### PR TITLE
WebPaymentCoordinatorProxy should not send IPC to WebProcess when the connection is null

### DIFF
--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp
@@ -292,6 +292,7 @@ bool WebPaymentCoordinatorProxy::canBegin() const
 #if ENABLE(APPLE_PAY_COUPON_CODE)
     case State::CouponCodeChanged:
 #endif
+    case State::Deactivating:
         return false;
     }
 }
@@ -312,6 +313,7 @@ bool WebPaymentCoordinatorProxy::canCancel() const
 
     case State::Completing:
     case State::Idle:
+    case State::Deactivating:
         return false;
     }
 }
@@ -332,6 +334,7 @@ bool WebPaymentCoordinatorProxy::canCompletePayment() const
 #if ENABLE(APPLE_PAY_COUPON_CODE)
     case State::CouponCodeChanged:
 #endif
+    case State::Deactivating:
         return false;
     }
 }
@@ -352,8 +355,15 @@ bool WebPaymentCoordinatorProxy::canAbort() const
 
     case State::Completing:
     case State::Idle:
+    case State::Deactivating:
         return false;
     }
+}
+
+void WebPaymentCoordinatorProxy::webProcessExited()
+{
+    if (m_state != State::Idle)
+        m_state = State::Deactivating;
 }
 
 void WebPaymentCoordinatorProxy::didReachFinalState(WebCore::PaymentSessionError&& error)

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
@@ -73,7 +73,6 @@ namespace WebKit {
 
 class PaymentSetupConfiguration;
 class PaymentSetupFeatures;
-class WebPageProxy;
 
 class WebPaymentCoordinatorProxy
     : public IPC::MessageReceiver
@@ -106,6 +105,8 @@ public:
     friend class NetworkConnectionToWebProcess;
     explicit WebPaymentCoordinatorProxy(Client&);
     ~WebPaymentCoordinatorProxy();
+
+    void webProcessExited();
 
 private:
     // IPC::MessageReceiver
@@ -176,7 +177,7 @@ private:
     Client& m_client;
     std::optional<WebCore::PageIdentifier> m_destinationID;
 
-    enum class State {
+    enum class State : uint16_t {
         // Idle - Nothing's happening.
         Idle,
 
@@ -202,6 +203,10 @@ private:
         // CouponCodeChanged - Dispatching the couponcodechanged event and waiting for a reply.
         CouponCodeChanged,
 #endif
+
+        // Deactivating - Could not complete the payment and is about to idle.
+        // Currently only transitions here when the web process terminates while the payment coordinator is active.
+        Deactivating,
 
         // Completing - Completing the payment and waiting for presenterDidFinish to be called.
         Completing,

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9466,7 +9466,7 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
 #endif
 
 #if ENABLE(APPLE_PAY)
-    internals().paymentCoordinator = nullptr;
+    resetPaymentCoordinator(resetStateReason);
 #endif
 
 #if USE(SYSTEM_PREVIEW)
@@ -12357,6 +12357,21 @@ void WebPageProxy::setPrivateClickMeasurementAppBundleIDForTesting(const String&
 {
     websiteDataStore().protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAppBundleIDForTesting(m_websiteDataStore->sessionID(), appBundleIDForTesting), WTFMove(completionHandler));
 }
+
+#if ENABLE(APPLE_PAY)
+
+void WebPageProxy::resetPaymentCoordinator(ResetStateReason resetStateReason)
+{
+    if (!internals().paymentCoordinator)
+        return;
+
+    if (resetStateReason == ResetStateReason::WebProcessExited)
+        internals().paymentCoordinator->webProcessExited();
+
+    internals().paymentCoordinator = nullptr;
+}
+
+#endif // ENABLE(APPLE_PAY)
 
 #if ENABLE(SPEECH_SYNTHESIS)
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2338,7 +2338,7 @@ private:
 
     bool suspendCurrentPageIfPossible(API::Navigation&, RefPtr<WebFrameProxy>&& mainFrame, ProcessSwapRequestedByClient, ShouldDelayClosingUntilFirstLayerFlush);
 
-    enum class ResetStateReason {
+    enum class ResetStateReason : uint8_t {
         PageInvalidated,
         WebProcessExited,
         NavigationSwap,
@@ -2821,6 +2821,10 @@ private:
 
 #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)
     void didAccessWindowProxyPropertyViaOpenerForFrame(WebCore::FrameIdentifier, const WebCore::SecurityOriginData&, WebCore::WindowProxyProperty);
+#endif
+
+#if ENABLE(APPLE_PAY)
+    void resetPaymentCoordinator(ResetStateReason);
 #endif
 
 #if ENABLE(SPEECH_SYNTHESIS)


### PR DESCRIPTION
#### 133a77cf0f1d2a39311aabd462fef0fe36752060
<pre>
WebPaymentCoordinatorProxy should not send IPC to WebProcess when the connection is null
<a href="https://bugs.webkit.org/show_bug.cgi?id=267321">https://bugs.webkit.org/show_bug.cgi?id=267321</a>
<a href="https://rdar.apple.com/120772845">rdar://120772845</a>

Reviewed by Wenson Hsieh.

It is possible for WebPaymentCoordinatorProxy to send IPC messages to the
WP when the connection is null. This can happen when a WP terminates while
a payment sheet is showing, and since the proxy will be alive, it will end
up sending a DidCancelPaymentSession message in its destructor.
Unfortunately, this causes the UI process to terminate, which is a bad
user experience for client users (like Safari).

This patch provides nuance to WebPaymentCoordinatorProxy&apos;s state machine
so that it can distinguish between successful versus unsuccessful
payment sheet presentation. We do so by introducing the Deactivating
state, which we transition into when the proxy has to be reset because
the corresponding WP has terminated. In this state, we can&apos;t begin,
cancel, complete, or abort payments. The former pair of inabilities
ensures that the proxy does not send the culprit IPC when it is being
destructed.

Note that it is OK for us to skip out on sending DidCancelPaymentSession
when the proxy is being reset because there is no WP to respond to it
regardless.

* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp:
(WebKit::WebPaymentCoordinatorProxy::canBegin const):
(WebKit::WebPaymentCoordinatorProxy::canCancel const):
(WebKit::WebPaymentCoordinatorProxy::canCompletePayment const):
(WebKit::WebPaymentCoordinatorProxy::canAbort const):
(WebKit::WebPaymentCoordinatorProxy::webProcessExited):

Public state transition method that
WebPageProxy::resetPaymentCoordinator can call into.

* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::resetState):
(WebKit::WebPageProxy::resetPaymentCoordinator):
* Source/WebKit/UIProcess/WebPageProxy.h:

Add a resetPaymentCoordinator method since we are doing a little more
than nulling it out now. Also, drive-by fix to provide a more
representative backing type for the ResetStateReason enumeration.

Canonical link: <a href="https://commits.webkit.org/273018@main">https://commits.webkit.org/273018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d74f53f8dd56d406c0dccda482ca6d1dc3eb1a99

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12734 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36573 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30760 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29810 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30276 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9379 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9482 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37881 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30829 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35591 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9610 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7548 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33487 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11401 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7822 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->