### PR TITLE
Implement VideoTrackGenerator

### DIFF
--- a/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Frames get closed when written in a VideoTrackGenerator writable
+PASS Writable gets closed when writing a closed VideoFrame
+PASS Writable gets closed when writing something else than a VideoFrame
+PASS Track settings are updated according enqueued video frames
+PASS Track gets muted based on VideoTrackGenerator.muted
+

--- a/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.html
+++ b/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.js
+++ b/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.js
@@ -1,0 +1,122 @@
+// META: title=MediaStreamTrack processor and generator tests.
+importScripts("/resources/testharness.js");
+
+function makeOffscreenCanvasVideoFrame(width, height) {
+    let canvas = new OffscreenCanvas(width, height);
+    let ctx = canvas.getContext('2d');
+    ctx.fillStyle = 'rgba(50, 100, 150, 255)';
+    ctx.fillRect(0, 0, width, height);
+    return new VideoFrame(canvas, { timestamp: 1 });
+}
+
+promise_test(async (t) => {
+    const frame1 = makeOffscreenCanvasVideoFrame(100, 100);
+    t.add_cleanup(() => frame1.close());
+
+    const generator = new VideoTrackGenerator();
+    const writer = generator.writable.getWriter();
+    assert_equals(frame1.codedWidth, 100);
+    await writer.write(frame1);
+    assert_equals(frame1.codedWidth, 0);
+}, "Frames get closed when written in a VideoTrackGenerator writable");
+
+promise_test(async (t) => {
+    const frame1 = makeOffscreenCanvasVideoFrame(100, 100);
+    frame1.close();
+
+    const generator = new VideoTrackGenerator();
+    const writer = generator.writable.getWriter();
+    await promise_rejects_js(t, TypeError, writer.write(frame1));
+
+    await promise_rejects_js(t, TypeError, writer.closed);
+}, "Writable gets closed when writing a closed VideoFrame");
+
+promise_test(async (t) => {
+    const frame1 = makeOffscreenCanvasVideoFrame(100, 100);
+    frame1.close();
+
+    const generator = new VideoTrackGenerator();
+    const writer = generator.writable.getWriter();
+    await promise_rejects_js(t, TypeError, writer.write(generator));
+
+    await promise_rejects_js(t, TypeError, writer.closed);
+}, "Writable gets closed when writing something else than a VideoFrame");
+
+promise_test(async (t) => {
+    const frame1 = makeOffscreenCanvasVideoFrame(100, 100);
+    t.add_cleanup(() => frame1.close());
+
+    const generator = new VideoTrackGenerator();
+    const writer = generator.writable.getWriter();
+    let settings = generator.track.getSettings();
+    let capabilities = generator.track.getCapabilities();
+    assert_equals(settings.width, 0, "width 1");
+    assert_equals(settings.height, 0, "height 1");
+    assert_equals(capabilities.width.min, 0, "min width 1");
+    assert_equals(capabilities.width.max, 0, "max width 1");
+    assert_equals(capabilities.height.min, 0, "min height 1");
+    assert_equals(capabilities.height.max, 0, "max height 1");
+
+    await writer.write(frame1);
+
+    let counter = 0;
+    while (++counter < 100 && generator.track.getSettings().width !== 100)
+        await new Promise(resolve => t.step_timeout(resolve, 50));
+
+    settings = generator.track.getSettings();
+    capabilities = generator.track.getCapabilities();
+    assert_equals(settings.width, 100, "width 2");
+    assert_equals(settings.height, 100, "height 2");
+    assert_equals(capabilities.width.min, 0, "min width 2");
+    assert_equals(capabilities.width.max, 100, "max width 2");
+    assert_equals(capabilities.height.min, 0, "min height 2");
+    assert_equals(capabilities.height.max, 100, "max height 2");
+
+    const frame2 = makeOffscreenCanvasVideoFrame(200, 200);
+    t.add_cleanup(() => frame2.close());
+
+    await writer.write(frame2);
+
+    counter = 0;
+    while (++counter < 100 && generator.track.getSettings().width !== 200)
+        await new Promise(resolve => t.step_timeout(resolve, 50));
+
+    settings = generator.track.getSettings();
+    capabilities = generator.track.getCapabilities();
+    assert_equals(settings.width, 200, "width 3");
+    assert_equals(settings.height, 200, "height 3");
+    assert_equals(capabilities.width.min, 0, "min width 3");
+    assert_equals(capabilities.width.max, 200, "max width 3");
+    assert_equals(capabilities.height.min, 0, "min height 3");
+    assert_equals(capabilities.height.max, 200, "max height 3");
+
+    const frame3 = makeOffscreenCanvasVideoFrame(100, 200);
+    t.add_cleanup(() => frame3.close());
+
+    await writer.write(frame3);
+
+    counter = 0;
+    while (++counter < 100 && generator.track.getSettings().width !== 100)
+        await new Promise(resolve => t.step_timeout(resolve, 50));
+
+    settings = generator.track.getSettings();
+    capabilities = generator.track.getCapabilities();
+    assert_equals(settings.width, 100, "width 4");
+    assert_equals(settings.height, 200, "height 4");
+    assert_equals(capabilities.width.min, 0, "min width 4");
+    assert_equals(capabilities.width.max, 200, "max width 4");
+    assert_equals(capabilities.height.min, 0, "min height 4");
+    assert_equals(capabilities.height.max, 200, "max height 4");
+}, "Track settings are updated according enqueued video frames");
+
+
+promise_test(async (t) => {
+    const generator = new VideoTrackGenerator();
+    generator.muted = true;
+    await new Promise(resolve => generator.track.onmute = resolve);
+
+    generator.muted = false;
+    await new Promise(resolve => generator.track.onunmute = resolve);
+}, "Track gets muted based on VideoTrackGenerator.muted");
+
+done();

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.worker-expected.txt
@@ -14,12 +14,12 @@ PASS VideoTrackGenerator interface object name
 PASS VideoTrackGenerator interface: existence and properties of interface prototype object
 PASS VideoTrackGenerator interface: existence and properties of interface prototype object's "constructor" property
 PASS VideoTrackGenerator interface: existence and properties of interface prototype object's @@unscopables property
-FAIL VideoTrackGenerator interface: attribute writable assert_true: The prototype object must have a property "writable" expected true got false
+PASS VideoTrackGenerator interface: attribute writable
 PASS VideoTrackGenerator interface: attribute muted
-FAIL VideoTrackGenerator interface: attribute track assert_true: The prototype object must have a property "track" expected true got false
+PASS VideoTrackGenerator interface: attribute track
 PASS VideoTrackGenerator must be primary interface of new VideoTrackGenerator()
 PASS Stringification of new VideoTrackGenerator()
-FAIL VideoTrackGenerator interface: new VideoTrackGenerator() must inherit property "writable" with the proper type assert_inherits: property "writable" not found in prototype chain
+PASS VideoTrackGenerator interface: new VideoTrackGenerator() must inherit property "writable" with the proper type
 PASS VideoTrackGenerator interface: new VideoTrackGenerator() must inherit property "muted" with the proper type
-FAIL VideoTrackGenerator interface: new VideoTrackGenerator() must inherit property "track" with the proper type assert_inherits: property "track" not found in prototype chain
+FAIL VideoTrackGenerator interface: new VideoTrackGenerator() must inherit property "track" with the proper type Right hand side of instanceof is not an object
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -646,7 +646,7 @@ void MediaStreamTrack::trackMutedChanged(MediaStreamTrackPrivate&)
 
     Function<void()> updateMuted = [this, muted = m_private->muted()] {
         RefPtr context = scriptExecutionContext();
-        if (!context || context ->activeDOMObjectsAreStopped())
+        if (!context || context->activeDOMObjectsAreStopped())
             return;
 
         if (m_muted == muted)
@@ -663,8 +663,8 @@ void MediaStreamTrack::trackMutedChanged(MediaStreamTrackPrivate&)
     configureTrackRendering();
 
     bool wasInterrupted = m_isInterrupted;
-    m_isInterrupted = m_private->source().interrupted();
-    if (isCaptureTrack() && wasInterrupted != m_isInterrupted && m_private->source().type() == RealtimeMediaSource::Type::Audio && context->settingsValues().muteCameraOnMicrophoneInterruptionEnabled)
+    m_isInterrupted = m_private->interrupted();
+    if (isCaptureTrack() && wasInterrupted != m_isInterrupted && m_private->type() == RealtimeMediaSource::Type::Audio && context->settingsValues().muteCameraOnMicrophoneInterruptionEnabled)
         updateVideoCaptureAccordingMicrophoneInterruption(*downcast<Document>(context), m_isInterrupted);
 }
 

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.idl
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.idl
@@ -31,7 +31,7 @@
 ] interface VideoTrackGenerator {
     [CallWith=CurrentScriptExecutionContext] constructor();
 
-    // readonly attribute WritableStream writable;
-    attribute boolean muted;
-    // readonly attribute MediaStreamTrack track;
+    readonly attribute WritableStream writable;
+    [CallWith=CurrentScriptExecutionContext] attribute boolean muted;
+    readonly attribute MediaStreamTrack track;
 };

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -136,6 +136,9 @@ public:
 
     friend class MediaStreamTrackPrivateSourceObserver;
 
+    void initializeSettings(RealtimeMediaSourceSettings&& settings) { m_settings = WTFMove(settings); }
+    void initializeCapabilities(RealtimeMediaSourceCapabilities&& capabilities) { m_capabilities = WTFMove(capabilities); }
+
 private:
     MediaStreamTrackPrivate(Ref<const Logger>&&, Ref<RealtimeMediaSource>&&, String&& id, std::function<void(Function<void()>&&)>&&);
 


### PR DESCRIPTION
#### b074e03b7fb3286fe2be9bdbe4bdcb4bf6bfc884
<pre>
Implement VideoTrackGenerator
<a href="https://bugs.webkit.org/show_bug.cgi?id=267319">https://bugs.webkit.org/show_bug.cgi?id=267319</a>
<a href="https://rdar.apple.com/120772003">rdar://120772003</a>

Reviewed by Eric Carlson.

We implement VideoTrackGenerator now that we can create a MediaStreamTrack out of main thread.
To allow posting tasks, we use ScriptExecutionContext::postTaskTo.
We implement the track source and the writable sink.
The writable sink is getting video frames and pushing them to the source.
The video frames are thus provided to media observer on the worker thread.

The IDL tests are not yet fully passing as we do not yet expose MediaStreamTrack to worker contexts.
We will do that when allowing to transfer MediaStreamTrack to workers.

* LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker-expected.txt: Added.
* LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.html: Added.
* LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.js: Added.
(makeOffscreenCanvasVideoFrame):
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.worker-expected.txt:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::trackMutedChanged):
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp:
(WebCore::VideoTrackGenerator::create):
(WebCore::VideoTrackGenerator::VideoTrackGenerator):
(WebCore::VideoTrackGenerator::setMuted):
(WebCore::VideoTrackGenerator::writable):
(WebCore::VideoTrackGenerator::track):
(WebCore::VideoTrackGenerator::Source::Source):
(WebCore::VideoTrackGenerator::Source::writeVideoFrame):
(WebCore::VideoTrackGenerator::Sink::Sink):
(WebCore::VideoTrackGenerator::Sink::write):
(WebCore::VideoTrackGenerator::Sink::close):
(WebCore::VideoTrackGenerator::Sink::error):
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.h:
(WebCore::VideoTrackGenerator::muted const):
(WebCore::VideoTrackGenerator::create): Deleted.
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.idl:
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h:

Canonical link: <a href="https://commits.webkit.org/272973@main">https://commits.webkit.org/272973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbbcddec77e67ff66280edfc61ea9bd04eb4e608

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36387 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30617 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29697 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9240 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37707 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30658 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35463 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33353 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11254 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29789 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7801 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10262 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->