### PR TITLE
Move MediaStreamTrack capture state handling to Document

### DIFF
--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -68,13 +68,11 @@ public:
         virtual void trackDidEnd() = 0;
     };
 
-    static Ref<MediaStreamTrack> create(ScriptExecutionContext&, Ref<MediaStreamTrackPrivate>&&);
+    enum class RegisterCaptureTrackToOwner : bool { No, Yes };
+    static Ref<MediaStreamTrack> create(ScriptExecutionContext&, Ref<MediaStreamTrackPrivate>&&, RegisterCaptureTrackToOwner = RegisterCaptureTrackToOwner::Yes);
     virtual ~MediaStreamTrack();
 
-    static void endCapture(Document&, MediaProducerMediaCaptureKind);
-
-    static MediaProducerMediaStateFlags captureState(Document&);
-    static void updateCaptureAccordingToMutedState(Document&);
+    static MediaProducerMediaStateFlags captureState(const RealtimeMediaSource&);
 
     virtual bool isCanvas() const { return false; }
 
@@ -177,7 +175,6 @@ private:
     explicit MediaStreamTrack(MediaStreamTrack&);
 
     void configureTrackRendering();
-    void updateToPageMutedState();
 
     // ActiveDOMObject API.
     void stop() final { stopTrack(); }
@@ -201,8 +198,6 @@ private:
     // PlatformMediaSession::AudioCaptureSource
     bool isCapturingAudio() const final;
     bool wantsToCaptureAudio() const final;
-
-    void updateVideoCaptureAccordingMicrophoneInterruption(Document&, bool);
 
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const final { return "MediaStreamTrack"; }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -194,6 +194,7 @@ class QualifiedName;
 class Quirks;
 class RTCNetworkManager;
 class Range;
+class RealtimeMediaSource;
 class Region;
 class RenderTreeBuilder;
 class RenderView;
@@ -1650,6 +1651,8 @@ public:
     void stopMediaCapture(MediaProducerMediaCaptureKind);
     void mediaStreamCaptureStateChanged();
     size_t activeMediaElementsWithMediaStreamCount() const { return m_activeMediaElementsWithMediaStreamCount; }
+    void addCaptureSource(Ref<RealtimeMediaSource>&&);
+    void updateVideoCaptureStateForMicrophoneInterruption(bool);
 #endif
 
 // FIXME: Find a better place for this functionality.
@@ -2014,6 +2017,11 @@ private:
 
     bool isObservingContentVisibilityTargets() const;
 
+#if ENABLE(MEDIA_STREAM)
+    void updateCaptureAccordingToMutedState();
+    MediaProducerMediaStateFlags computeCaptureState() const;
+#endif
+
     const Ref<const Settings> m_settings;
 
     UniqueRef<Quirks> m_quirks;
@@ -2343,6 +2351,8 @@ private:
 #if ENABLE(MEDIA_STREAM)
     String m_idHashSalt;
     size_t m_activeMediaElementsWithMediaStreamCount { 0 };
+    HashSet<Ref<RealtimeMediaSource>> m_captureSources;
+    bool m_isUpdatingCaptureAccordingToMutedState { false };
 #endif
 
     struct PendingScrollEventTargetList;

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -455,6 +455,12 @@ RealtimeMediaSource& MediaStreamTrackPrivate::source()
     return m_sourceObserver->source();
 }
 
+const RealtimeMediaSource& MediaStreamTrackPrivate::source() const
+{
+    ASSERT(isMainThread());
+    return m_sourceObserver->source();
+}
+
 RealtimeMediaSource& MediaStreamTrackPrivate::sourceForProcessor()
 {
     ASSERT(isOnCreationThread());

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -98,6 +98,7 @@ public:
     Ref<MediaStreamTrackPrivate> clone();
 
     WEBCORE_EXPORT RealtimeMediaSource& source();
+    const RealtimeMediaSource& source() const;
     RealtimeMediaSource& sourceForProcessor();
     bool hasSource(const RealtimeMediaSource*) const;
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -378,6 +378,9 @@ void RealtimeMediaSource::start()
     m_isProducingData = true;
     startProducingData();
 
+    if (m_registerOwnerCallback)
+        m_registerOwnerCallback(*this, false);
+
     if (!m_isProducingData)
         return;
 
@@ -426,10 +429,20 @@ void RealtimeMediaSource::end(Observer* callingObserver)
     m_isEnded = true;
     didEnd();
 
+    if (m_registerOwnerCallback)
+        m_registerOwnerCallback(*this, false);
+
     forEachObserver([&callingObserver](auto& observer) {
         if (&observer != callingObserver)
             observer.sourceStopped();
     });
+}
+
+void RealtimeMediaSource::registerOwnerCallback(OwnerCallback&& callback)
+{
+    ASSERT(isMainThread());
+    ASSERT(!m_registerOwnerCallback);
+    m_registerOwnerCallback = WTFMove(callback);
 }
 
 void RealtimeMediaSource::captureFailed()

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -277,6 +277,9 @@ public:
 
     virtual double facingModeFitnessScoreAdjustment() const { return 0; }
 
+    using OwnerCallback = std::function<void(RealtimeMediaSource&, bool isNewClonedSource)>;
+    void registerOwnerCallback(OwnerCallback&&);
+
 protected:
     RealtimeMediaSource(const CaptureDevice&, MediaDeviceHashSalts&& hashSalts = { }, PageIdentifier = { });
 
@@ -317,6 +320,8 @@ protected:
     void setPersistentId(const String&);
 
     bool hasSeveralVideoFrameObserversWithAdaptors() const { return m_videoFrameObserversWithAdaptors > 1; }
+
+    OwnerCallback m_registerOwnerCallback;
 
 private:
     virtual void startProducingData() { }

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
@@ -78,13 +78,18 @@ Ref<RealtimeMediaSource> RemoteRealtimeVideoSource::clone()
 
         clone = adoptRef(*new RemoteRealtimeVideoSource(proxy().clone(), MediaDeviceHashSalts { deviceIDHashSalts() }, manager(), pageIdentifier()));
 
+        clone->m_registerOwnerCallback = m_registerOwnerCallback;
         clone->setSettings(RealtimeMediaSourceSettings { settings() });
         clone->setCapabilities(RealtimeMediaSourceCapabilities { capabilities() });
 
         manager().addSource(*clone);
         manager().remoteCaptureSampleManager().addSource(*clone);
         proxy().createRemoteCloneSource(clone->identifier(), pageIdentifier());
+
+        bool isNewClonedSource = true;
+        clone->m_registerOwnerCallback(*clone, isNewClonedSource);
     });
+
     return clone.releaseNonNull();
 }
 


### PR DESCRIPTION
#### 31557cfb95e2fbd2e27f4ca6de470b2b91bf56e1
<pre>
Move MediaStreamTrack capture state handling to Document
<a href="https://bugs.webkit.org/show_bug.cgi?id=267325">https://bugs.webkit.org/show_bug.cgi?id=267325</a>
<a href="https://rdar.apple.com/120776008">rdar://120776008</a>

Reviewed by Jean-Yves Avenard and Eric Carlson.

MediaStreamTrack may be transferred from a document to a worker.
As per spec, transferring a track does not transfer the ownership of source.
This ensures UA capture states remain the same even if a track gets transferred.

To align with this and prepare track transfer, we are moving capture state handling to Document.
A document will own directly RealtimeMediaSource instead of going through MediaStreamTrack, since a transferred MediaStreamTrack gets closed.
We introduce the possibility for a Document to register itself as an owner of a RealtimeMediaSource.
The RealtimeMediaSource will notify the Document when it either starts or ends.
The Document updates its capture state based on this signal.

When the document goes away, it will stop all sources like would have been done previously with any remaining MediaStreamTrack.

We continue updating code to limit access to a MediaStreamTrack source.

* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::create):
(WebCore::MediaStreamTrack::MediaStreamTrack):
(WebCore::MediaStreamTrack::~MediaStreamTrack):
(WebCore::trackCaptureState):
(WebCore::MediaStreamTrack::mediaState const):
(WebCore::MediaStreamTrack::trackEnded):
(WebCore::MediaStreamTrack::trackMutedChanged):
(): Deleted.
(WebCore::sourceCaptureState): Deleted.
(WebCore::MediaStreamTrack::captureState): Deleted.
(WebCore::MediaStreamTrack::updateCaptureAccordingToMutedState): Deleted.
(WebCore::MediaStreamTrack::updateVideoCaptureAccordingMicrophoneInterruption): Deleted.
(WebCore::MediaStreamTrack::updateToPageMutedState): Deleted.
(WebCore::trackTypeForMediaProducerCaptureKind): Deleted.
(WebCore::MediaStreamTrack::endCapture): Deleted.
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
(WebCore::MediaStreamTrack::isDetached const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::commonTeardown):
(WebCore::Document::visibilityStateChanged):
(WebCore::captureSourceState):
(WebCore::Document::computeCaptureState const):
(WebCore::Document::updateIsPlayingMedia):
(WebCore::Document::pageMutedStateDidChange):
(WebCore::updateCaptureSourceToPageMutedState):
(WebCore::Document::addCaptureSource):
(WebCore::Document::captureSourceStateChanged):
(WebCore::Document::updateCaptureAccordingToMutedState):
(WebCore::trackTypeForMediaProducerCaptureKind):
(WebCore::Document::stopMediaCapture):
(WebCore::Document::updateVideoCaptureAccordingMicrophoneInterruption):
* Source/WebCore/dom/Document.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::start):
(WebCore::RealtimeMediaSource::end):
(WebCore::RealtimeMediaSource::registerOwnerCallback):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp:
(WebKit::RemoteRealtimeVideoSource::clone):

Canonical link: <a href="https://commits.webkit.org/273218@main">https://commits.webkit.org/273218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0586aac3e87c0a395c4edeeda049114b150e7125

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37447 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31370 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35903 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10667 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30317 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11498 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10050 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38712 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31557 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31352 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36161 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8131 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34135 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12057 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7966 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10776 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11120 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->