### PR TITLE
[git-webkit] Move merge-back clones into Internal Tools milestones

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py
@@ -143,6 +143,11 @@ MILESTONES = [
         tentpoles=['Scrolling', 'SVG'],
         isCategoryRequired=True,
     ), dict(
+        name='Internal Tools - October',
+        categories=['Test Development', 'Tentpole Feature Work', 'Escape / Regression in the Build'],
+        events=['Week 1', 'Week 2', 'Week 3', 'Week 4', 'Convergence'],
+        tentpoles=['Scrolling', 'SVG'],
+    ),  dict(
         name='Future',
         categories=['Test Development', 'Tentpole TBD', 'Escape / Regression in the Build'],
     ),

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clone.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clone.py
@@ -181,6 +181,9 @@ class Clone(Command):
             sys.stderr.write("Failed to find milestone matching '{}'\n".format(args.milestone))
             return 255
 
+        if merge_back:
+            milestone = milestones.get('Internal Tools - {}'.format(milestone.name), milestone)
+
         milestone_association = raw_issue.milestone_associations(milestone)
 
         def pick_attr(name, plural, default=None):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py
@@ -156,7 +156,7 @@ class TestClone(testing.PathTestCase):
             tracker = radar.Tracker()
             raw_issue = tracker.client.radar_for_id(4)
 
-            self.assertEqual(raw_issue.milestone.name, 'October')
+            self.assertEqual(raw_issue.milestone.name, 'Internal Tools - October')
             self.assertEqual(raw_issue.category.name, 'Tentpole Feature Work')
             self.assertIsNone(raw_issue.event)
             self.assertIsNone(raw_issue.tentpole)
@@ -165,5 +165,5 @@ class TestClone(testing.PathTestCase):
         self.assertEqual(
             captured.stdout.getvalue(),
             "Created '[merge-back] rdar://4 Example issue 1'\n"
-            'Moved clone to October and into Analyze: Prepare\n',
+            'Moved clone to Internal Tools - October and into Analyze: Prepare\n',
         )


### PR DESCRIPTION
#### 058ed67c11acff252e2464e358922035d4680cfe
<pre>
[git-webkit] Move merge-back clones into Internal Tools milestones
<a href="https://bugs.webkit.org/show_bug.cgi?id=267307">https://bugs.webkit.org/show_bug.cgi?id=267307</a>
<a href="https://rdar.apple.com/120754949">rdar://120754949</a>

Reviewed by Ryan Haddad.

Move merge-back clones into Internal Tools milestones, if possible.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py: Add tools milestone.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clone.py:
(Clone.main): Move merge-back clones to Internal Tools milestone
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py:
(TestClone.test_merge_back):

Canonical link: <a href="https://commits.webkit.org/272852@main">https://commits.webkit.org/272852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0576b236f1bdd0751d884a4e635ff0182e48b6e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12145 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36000 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30333 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29472 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33848 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10240 "Found 1 new test failure: webrtc/audio-samplerate-change.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8937 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/33648 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9065 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29776 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37330 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30306 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35182 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33049 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/33259 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10936 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9769 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4282 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9908 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->