### PR TITLE
[WGSL] shader,execution,expression,call,builtin,bitcast:f32_to_vec2h:* is failing

### DIFF
--- a/Source/WebGPU/WGSL/ConstantValue.h
+++ b/Source/WebGPU/WGSL/ConstantValue.h
@@ -173,15 +173,12 @@ std::optional<To> convertFloat(From value)
 
     static To max;
     static To lowest;
-    static To min;
     if constexpr (std::is_floating_point<To>::value) {
         max = std::numeric_limits<To>::max();
         lowest = std::numeric_limits<To>::lowest();
-        min = std::numeric_limits<To>::min();
     } else {
         max = 0x1.ffcp15;
         lowest = -max;
-        min = 0x1.0p-14;
     }
 
     if (value > max)
@@ -190,8 +187,6 @@ std::optional<To> convertFloat(From value)
         return std::nullopt;
     if (std::isnan(value))
         return std::nullopt;
-    if (std::abs(value) < min)
-        return { 0 };
 
     return { value };
 }


### PR DESCRIPTION
#### 4d4013fbe281f1cb7e43d9aa24e44df97ff985c5
<pre>
[WGSL] shader,execution,expression,call,builtin,bitcast:f32_to_vec2h:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=267335">https://bugs.webkit.org/show_bug.cgi?id=267335</a>
<a href="https://rdar.apple.com/120783750">rdar://120783750</a>

Reviewed by Mike Wyrzykowski.

We were checking that float values are not below FLT_MIN, but that seems to be
causing some test failures.

* Source/WebGPU/WGSL/ConstantValue.h:
(WGSL::convertFloat):

Canonical link: <a href="https://commits.webkit.org/272896@main">https://commits.webkit.org/272896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9dd1bb4597acdf6ab754415ef24c47c9b28c195d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36003 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30336 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9291 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29470 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8935 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9067 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37333 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30308 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35185 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7130 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33052 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10938 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7750 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9771 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9910 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->