### PR TITLE
[WGSL] Add abstract overloads to conversion functions

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -737,9 +737,22 @@ CONSTANT_FUNCTION(BitwiseShiftRight)
 // Constructors
 
 CONSTANT_CONSTRUCTOR(Bool, bool)
-CONSTANT_CONSTRUCTOR(I32, int32_t)
 CONSTANT_CONSTRUCTOR(F32, float)
 CONSTANT_CONSTRUCTOR(F16, half)
+
+CONSTANT_FUNCTION(I32)
+{
+    if (arguments.size()) {
+        if (auto* abstractInt = std::get_if<int64_t>(&arguments[0])) {
+            auto result = convertInteger<int32_t>(*abstractInt);
+            if (result)
+                return { *result };
+            return makeUnexpected(makeString("value ", String::number(*abstractInt), " cannot be represented as 'i32'"));
+        }
+    }
+
+    return { constantConstructor<int32_t>(resultType, arguments) };
+}
 
 CONSTANT_FUNCTION(U32)
 {

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -297,7 +297,7 @@ constructor :bool, {
     must_use: true,
     const: true,
 
-    [T < ConcreteScalar].(T) => bool,
+    [T < Scalar].(T) => bool,
 }
 
 # 16.1.2.3.
@@ -305,7 +305,7 @@ constructor :f16, {
     must_use: true,
     const: true,
 
-    [T < ConcreteScalar].(T) => f16,
+    [T < Scalar].(T) => f16,
 }
 
 # 16.1.2.4.
@@ -313,7 +313,7 @@ constructor :f32, {
     must_use: true,
     const: true,
 
-    [T < ConcreteScalar].(T) => f32,
+    [T < Scalar].(T) => f32,
 }
 
 # 16.1.2.5.
@@ -321,7 +321,7 @@ constructor :i32, {
     must_use: true,
     const: true,
 
-    [T < ConcreteScalar].(T) => i32,
+    [T < Scalar].(T) => i32,
 }
 
 # 16.1.2.6 - 14: matCxR
@@ -347,8 +347,7 @@ constructor :u32, {
     must_use: true,
     const: true,
 
-    [T < ConcreteScalar].(T) => u32,
-    [].(abstract_int) => u32,
+    [T < Scalar].(T) => u32,
 }
 
 # 16.1.2.17.


### PR DESCRIPTION
#### d1b0136693a04998832b590d39e85877856dc743
<pre>
[WGSL] Add abstract overloads to conversion functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=267336">https://bugs.webkit.org/show_bug.cgi?id=267336</a>
<a href="https://rdar.apple.com/120783899">rdar://120783899</a>

Reviewed by Mike Wyrzykowski.

There were several CTS tests failing because they relied on directly converting
abstract floats to concrete integers. This behavior didn&apos;t match the spec, but
the spec is now being updated to match the CTS instead[1].

[1]: <a href="https://github.com/gpuweb/gpuweb/pull/4449">https://github.com/gpuweb/gpuweb/pull/4449</a>

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):
* Source/WebGPU/WGSL/TypeDeclarations.rb:

Canonical link: <a href="https://commits.webkit.org/272894@main">https://commits.webkit.org/272894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bffe948d0e82c898d4a1683cd1260b0d5fd1745

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36006 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30339 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29474 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29796 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8939 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9085 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37336 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30127 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35188 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7131 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33055 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10941 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7751 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9774 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9913 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->