### PR TITLE
[WGSL] shader,execution,expression,call,builtin,extractBits:* is failing

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -414,6 +414,19 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
         m_stringBuilder.append(m_indent, "}\n");
     }
 
+    if (m_callGraph.ast().usesExtractBits()) {
+        m_stringBuilder.append(m_indent, "template<typename T>\n");
+        m_stringBuilder.append(m_indent, "T __wgslExtractBits(T e, uint offset, uint count)\n");
+        m_stringBuilder.append(m_indent, "{\n");
+        {
+            IndentationScope scope(m_indent);
+            m_stringBuilder.append(m_indent, "auto o = min(offset, 32u);\n");
+            m_stringBuilder.append(m_indent, "auto c = min(count, 32u - o);\n");
+            m_stringBuilder.append(m_indent, "return extract_bits(e, o, c);\n");
+        }
+        m_stringBuilder.append(m_indent, "}\n");
+    }
+
     if (m_callGraph.ast().usesPackedStructs()) {
         m_callGraph.ast().clearUsesPackedStructs();
 
@@ -1865,7 +1878,7 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
             { "dpdy", "dfdy"_s },
             { "dpdyCoarse", "dfdy"_s },
             { "dpdyFine", "dfdy"_s },
-            { "extractBits", "extract_bits"_s },
+            { "extractBits", "__wgslExtractBits"_s },
             { "faceForward", "faceforward"_s },
             { "firstLeadingBit", "__wgslFirstLeadingBit"_s },
             { "firstTrailingBit", "__wgslFirstTrailingBit"_s },

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -1053,6 +1053,8 @@ void TypeChecker::visit(AST::CallExpression& call)
                 m_shaderModule.setUsesDot4I8Packed();
             else if (targetName == "dot4U8Packed"_s)
                 m_shaderModule.setUsesDot4U8Packed();
+            else if (targetName == "extractBits"_s)
+                m_shaderModule.setUsesExtractBits();
             target.m_inferredType = result;
             return;
         }

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -123,6 +123,9 @@ public:
     bool usesDot4U8Packed() const { return m_usesDot4U8Packed; }
     void setUsesDot4U8Packed() { m_usesDot4U8Packed = true; }
 
+    bool usesExtractBits() const { return m_usesExtractBits; }
+    void setUsesExtractBits() { m_usesExtractBits = true; }
+
     template<typename T>
     std::enable_if_t<std::is_base_of_v<AST::Node, T>, void> replace(T* current, T&& replacement)
     {
@@ -288,6 +291,7 @@ private:
     bool m_usesSampleIndex { false };
     bool m_usesDot4I8Packed { false };
     bool m_usesDot4U8Packed { false };
+    bool m_usesExtractBits { false };
     OptionSet<Extension> m_enabledExtensions;
     OptionSet<LanguageFeature> m_requiredFeatures;
     Configuration m_configuration;


### PR DESCRIPTION
#### 6d89eecb9b64ec244aeb840661fb8ad1ae5f1fb7
<pre>
[WGSL] shader,execution,expression,call,builtin,extractBits:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=267337">https://bugs.webkit.org/show_bug.cgi?id=267337</a>
<a href="https://rdar.apple.com/120783982">rdar://120783982</a>

Reviewed by Mike Wyrzykowski.

The runtime version of extractBits was failing because we directly generated
calls to Metal&apos;s extract_bits. Intead we need small wrapper function in order
to clamp the offset and count.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::usesExtractBits const):
(WGSL::ShaderModule::setUsesExtractBits):

Canonical link: <a href="https://commits.webkit.org/272897@main">https://commits.webkit.org/272897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34ebf4d0d4057e4c6413cd814b7ed8cdb20e2c7e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36007 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30340 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9295 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29476 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8941 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9070 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37337 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30311 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35190 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33057 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10942 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7752 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9775 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9914 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->