### PR TITLE
[WGSL] shader,execution,expression,call,builtin,length:* is failing

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -1031,6 +1031,8 @@ CONSTANT_FUNCTION(Dot4I8Packed)
     return { { result } };
 }
 
+CONSTANT_FUNCTION(Sqrt);
+
 CONSTANT_FUNCTION(Length)
 {
     ASSERT(arguments.size() == 1);
@@ -1043,7 +1045,7 @@ CONSTANT_FUNCTION(Length)
         CALL(tmp, Multiply, resultType, { element, element });
         CALL_MOVE(result, Add, resultType, { result, tmp });
     }
-    return { { result } };
+    return constantSqrt(resultType, { result });
 }
 
 UNARY_OPERATION(Exp, Float, WRAP_STD(exp));
@@ -1345,8 +1347,6 @@ CONSTANT_FUNCTION(Reflect)
         return reflect.operator()<double>();
     RELEASE_ASSERT_NOT_REACHED();
 }
-
-CONSTANT_FUNCTION(Sqrt);
 
 CONSTANT_FUNCTION(Refract)
 {


### PR DESCRIPTION
#### 3c7ac2a67deb14ef6c8a1c69a7ce5612f58d6044
<pre>
[WGSL] shader,execution,expression,call,builtin,length:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=267338">https://bugs.webkit.org/show_bug.cgi?id=267338</a>
<a href="https://rdar.apple.com/120784047">rdar://120784047</a>

Reviewed by Mike Wyrzykowski.

We were missing a call to sqrt on the result of the constant function.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/272900@main">https://commits.webkit.org/272900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3062561ccebd27ab5471c0ad85b403294bdad0c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36008 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30341 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29477 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8942 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9094 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37338 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30339 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30129 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35191 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9192 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7135 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33058 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10943 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7753 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9776 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9915 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->