### PR TITLE
[WGSL] shader,execution,expression,call,builtin,reflect:* is failing

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -1334,9 +1334,9 @@ CONSTANT_FUNCTION(Reflect)
 
     const auto& reflect = [&]<typename T>() -> ConstantResult {
         CALL(dot, Dot, elementType, { e2, e1 });
-        CALL(prod, Multiply, resultType, { dot, e2 });
-        CALL(doubleResult, Multiply, resultType, { static_cast<T>(2), e2 });
-        return constantMinus(resultType, { e1, doubleResult });
+        CALL(doubleResult, Multiply, resultType, { static_cast<T>(2), dot });
+        CALL(prod, Multiply, resultType, { doubleResult, e2 });
+        return constantMinus(resultType, { e1, prod });
     };
 
     if (primitive.kind == Types::Primitive::F32)


### PR DESCRIPTION
#### 9939b7d727fe6d50c2592e527b40d66670e7a98f
<pre>
[WGSL] shader,execution,expression,call,builtin,reflect:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=267342">https://bugs.webkit.org/show_bug.cgi?id=267342</a>
<a href="https://rdar.apple.com/120784326">rdar://120784326</a>

Reviewed by Mike Wyrzykowski.

There was a typo where the incorrect operand was used, which caused some of the
intermediate computations to be discarded.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/272901@main">https://commits.webkit.org/272901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5894f8cfb21d7459d9564288d308b4ab2a96e18f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36011 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30344 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29480 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10251 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8945 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9077 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37341 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30134 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35194 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33061 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10946 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7756 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9779 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9918 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->