### PR TITLE
[WGSL] shader,execution,expression,call,builtin,unpack2x16unorm:* is failing

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -1616,7 +1616,7 @@ CONSTANT_FUNCTION(Unpack2x16unorm)
 {
     UNUSED_PARAM(resultType);
     auto argument = std::get<uint32_t>(arguments[0]);
-    auto packed = bitwise_cast<std::array<int16_t, 2>>(argument);
+    auto packed = bitwise_cast<std::array<uint16_t, 2>>(argument);
     ConstantVector result(2);
     for (unsigned i = 0; i < 2; ++i) {
         auto e = static_cast<float>(packed[i]);


### PR DESCRIPTION
#### 5d9c9738a866e2001259b0241e9e4929b78f3db0
<pre>
[WGSL] shader,execution,expression,call,builtin,unpack2x16unorm:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=267346">https://bugs.webkit.org/show_bug.cgi?id=267346</a>
<a href="https://rdar.apple.com/120784740">rdar://120784740</a>

Reviewed by Mike Wyrzykowski.

There was a typo and the packed value was being converted to two `int16_t`s instead
of `uint16_t`s.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/272905@main">https://commits.webkit.org/272905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01391affa9028cde5ee1e791145f8ee40b0e8396

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36017 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30350 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9305 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29486 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29849 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8951 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9108 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37347 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30361 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35199 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9201 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7144 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33066 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10952 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7760 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9785 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9924 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->