### PR TITLE
[Filters] Enable CoreGraphics color matrix filter

### DIFF
--- a/LayoutTests/css3/filters/effect-grayscale.html
+++ b/LayoutTests/css3/filters/effect-grayscale.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-2500">
+    <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-32633">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
     <script>

--- a/LayoutTests/css3/filters/effect-sepia.html
+++ b/LayoutTests/css3/filters/effect-sepia.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-2500">
+    <meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-34979">
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
     <script>

--- a/LayoutTests/fast/filter-image/background-filter-image.html
+++ b/LayoutTests/fast/filter-image/background-filter-image.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>This tests that background images with filters scale properly.</title>
+<meta name="fuzzy" content="maxDifference=0-33; totalPixels=0-9754" />
 <script>
 	if (window.internals)
     	internals.settings.setCoreImageAcceleratedFilterRenderEnabled(false);

--- a/LayoutTests/fast/filter-image/filter-image.html
+++ b/LayoutTests/fast/filter-image/filter-image.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-5000" />
 <style>
 div {
     width: 50px;

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
@@ -124,8 +124,7 @@ OptionSet<FilterRenderingMode> FEColorMatrix::supportedFilterRenderingModes() co
     if (FEColorMatrixCoreImageApplier::supportsCoreImageRendering(*this))
         modes.add(FilterRenderingMode::Accelerated);
 #endif
-    // FIXME: Ensure the correctness of the CG ColorMatrix filter (http://webkit.org/b/243816).
-#if 0 && HAVE(CGSTYLE_COLORMATRIX_BLUR)
+#if HAVE(CGSTYLE_COLORMATRIX_BLUR)
     if (m_type == FECOLORMATRIX_TYPE_MATRIX)
         modes.add(FilterRenderingMode::GraphicsContext);
 #endif


### PR DESCRIPTION
#### 727f5586dc34ce5d21b7a5ab61cd9d35389de504
<pre>
[Filters] Enable CoreGraphics color matrix filter
<a href="https://bugs.webkit.org/show_bug.cgi?id=267354">https://bugs.webkit.org/show_bug.cgi?id=267354</a>
<a href="https://rdar.apple.com/120795573">rdar://120795573</a>

Reviewed by Simon Fraser.

Apply the ColorMatrix CGStyle style when it is available to draw the color matrix
filter. Fix the failed tests by adjusting the pixel tolerance.

* LayoutTests/css3/filters/effect-grayscale.html:
* LayoutTests/css3/filters/effect-sepia.html:
* LayoutTests/fast/filter-image/background-filter-image.html:
* LayoutTests/fast/filter-image/filter-image.html:
* Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp:
(WebCore::FEColorMatrix::supportedFilterRenderingModes const):

Canonical link: <a href="https://commits.webkit.org/272891@main">https://commits.webkit.org/272891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c93b8dccb981cd4dcf55965b8fd0f0f3d343a86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36118 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30417 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9425 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29540 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29888 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9039 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37440 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30410 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30224 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35275 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33151 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29570 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7747 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9860 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10014 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->