### PR TITLE
[Wasm-GC] Align limits with final values

### DIFF
--- a/JSTests/wasm/gc/limits.js
+++ b/JSTests/wasm/gc/limits.js
@@ -1,0 +1,79 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+function testLimits() {
+    // 1,000,000 recursion group size, at the limit.
+    assert.throws(
+        () => new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x87\x80\x80\x80\x00\x01\x4e\xC0\x84\x3D\x00\x00")),
+        WebAssembly.CompileError,
+        "WebAssembly.Module doesn't parse at byte 20: 0th Type is non-Func, non-Struct, and non-Array 0 (evaluating 'new WebAssembly.Module(buffer)'"
+    );
+
+    // 1,000,001 recursion group size, above limit.
+    assert.throws(
+        () => new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x87\x80\x80\x80\x00\x01\x4e\xC1\x84\x3D\x00\x00")),
+        WebAssembly.CompileError,
+        "WebAssembly.Module doesn't parse at byte 19: number of types for recursion group at position 0 is too big 1000001 maximum 1000000 (evaluating 'new WebAssembly.Module(buffer)"
+    );
+
+    // 63 depth subtype, at limit.
+    compile(`
+      (module
+        (type (sub (struct)))    (type (sub 0 (struct)))  (type (sub 1 (struct)))  (type (sub 2 (struct)))
+        (type (sub 3 (struct)))  (type (sub 4 (struct)))  (type (sub 5 (struct)))  (type (sub 6 (struct)))
+        (type (sub 7 (struct)))  (type (sub 8 (struct)))  (type (sub 9 (struct)))  (type (sub 10 (struct)))
+        (type (sub 11 (struct))) (type (sub 12 (struct))) (type (sub 13 (struct))) (type (sub 14 (struct)))
+        (type (sub 15 (struct))) (type (sub 16 (struct))) (type (sub 17 (struct))) (type (sub 18 (struct)))
+        (type (sub 19 (struct))) (type (sub 20 (struct))) (type (sub 21 (struct))) (type (sub 22 (struct)))
+        (type (sub 23 (struct))) (type (sub 24 (struct))) (type (sub 25 (struct))) (type (sub 26 (struct)))
+        (type (sub 27 (struct))) (type (sub 28 (struct))) (type (sub 29 (struct))) (type (sub 30 (struct)))
+        (type (sub 31 (struct))) (type (sub 32 (struct))) (type (sub 33 (struct))) (type (sub 34 (struct)))
+        (type (sub 35 (struct))) (type (sub 36 (struct))) (type (sub 37 (struct))) (type (sub 38 (struct)))
+        (type (sub 39 (struct))) (type (sub 40 (struct))) (type (sub 41 (struct))) (type (sub 42 (struct)))
+        (type (sub 43 (struct))) (type (sub 44 (struct))) (type (sub 45 (struct))) (type (sub 46 (struct)))
+        (type (sub 47 (struct))) (type (sub 48 (struct))) (type (sub 49 (struct))) (type (sub 50 (struct)))
+        (type (sub 51 (struct))) (type (sub 52 (struct))) (type (sub 53 (struct))) (type (sub 54 (struct)))
+        (type (sub 55 (struct))) (type (sub 56 (struct))) (type (sub 57 (struct))) (type (sub 58 (struct)))
+        (type (sub 59 (struct))) (type (sub 60 (struct))) (type (sub 61 (struct))) (type (sub 62 (struct)))
+      )
+    `);
+
+    assert.throws(
+        () => compile(`
+          (module
+            (type (sub (struct)))    (type (sub 0 (struct)))  (type (sub 1 (struct)))  (type (sub 2 (struct)))
+            (type (sub 3 (struct)))  (type (sub 4 (struct)))  (type (sub 5 (struct)))  (type (sub 6 (struct)))
+            (type (sub 7 (struct)))  (type (sub 8 (struct)))  (type (sub 9 (struct)))  (type (sub 10 (struct)))
+            (type (sub 11 (struct))) (type (sub 12 (struct))) (type (sub 13 (struct))) (type (sub 14 (struct)))
+            (type (sub 15 (struct))) (type (sub 16 (struct))) (type (sub 17 (struct))) (type (sub 18 (struct)))
+            (type (sub 19 (struct))) (type (sub 20 (struct))) (type (sub 21 (struct))) (type (sub 22 (struct)))
+            (type (sub 23 (struct))) (type (sub 24 (struct))) (type (sub 25 (struct))) (type (sub 26 (struct)))
+            (type (sub 27 (struct))) (type (sub 28 (struct))) (type (sub 29 (struct))) (type (sub 30 (struct)))
+            (type (sub 31 (struct))) (type (sub 32 (struct))) (type (sub 33 (struct))) (type (sub 34 (struct)))
+            (type (sub 35 (struct))) (type (sub 36 (struct))) (type (sub 37 (struct))) (type (sub 38 (struct)))
+            (type (sub 39 (struct))) (type (sub 40 (struct))) (type (sub 41 (struct))) (type (sub 42 (struct)))
+            (type (sub 43 (struct))) (type (sub 44 (struct))) (type (sub 45 (struct))) (type (sub 46 (struct)))
+            (type (sub 47 (struct))) (type (sub 48 (struct))) (type (sub 49 (struct))) (type (sub 50 (struct)))
+            (type (sub 51 (struct))) (type (sub 52 (struct))) (type (sub 53 (struct))) (type (sub 54 (struct)))
+            (type (sub 55 (struct))) (type (sub 56 (struct))) (type (sub 57 (struct))) (type (sub 58 (struct)))
+            (type (sub 59 (struct))) (type (sub 60 (struct))) (type (sub 61 (struct))) (type (sub 62 (struct)))
+            (type (sub 63 (struct)))
+          )
+        `),
+        WebAssembly.CompileError,
+        "WebAssembly.Module doesn't parse at byte 339: subtype depth for Type section's 64th signature exceeded the limits of 63"
+    );
+}
+
+testLimits();

--- a/JSTests/wasm/gc/rec.js
+++ b/JSTests/wasm/gc/rec.js
@@ -39,6 +39,13 @@ function testRecDeclaration() {
     "WebAssembly.Module doesn't parse at byte 20: can't get array's element Type"
   );
 
+  // Test a zero-length recursion group.
+  assert.throws(
+    () => new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x8a\x80\x80\x80\x00\x01\x4e\x80\x80\x80\x80\0xC0")),
+    WebAssembly.CompileError,
+    "WebAssembly.Module doesn't parse at byte 14: parsing ended before the end of Type section (evaluating 'new WebAssembly.Module(buffer)"
+  );
+
   /*
    *  Test invalid index in a recursion group with more than one type.
    *

--- a/Source/JavaScriptCore/wasm/WasmLimits.h
+++ b/Source/JavaScriptCore/wasm/WasmLimits.h
@@ -46,8 +46,10 @@ constexpr size_t maxGlobals = 1000000;
 constexpr size_t maxDataSegments = 100000;
 constexpr size_t maxStructFieldCount = 10000;
 constexpr size_t maxArrayNewFixedArgs = 10000;
-constexpr size_t maxRecursionGroupCount = 10000;
+constexpr size_t maxRecursionGroupCount = 1000000;
+constexpr size_t maxNumberOfRecursionGroups = 1000000;
 constexpr size_t maxSubtypeSupertypeCount = 1;
+constexpr size_t maxSubtypeDepth = 63;
 
 constexpr size_t maxStringSize = 100000;
 constexpr size_t maxModuleSize = 1024 * 1024 * 1024;


### PR DESCRIPTION
#### 936310fbceb1f58b4182e481df2116a7a52ed15c
<pre>
[Wasm-GC] Align limits with final values
<a href="https://bugs.webkit.org/show_bug.cgi?id=267245">https://bugs.webkit.org/show_bug.cgi?id=267245</a>

Reviewed by Justin Michaud.

Adds several implementation limits that were missing or added recently (max
number of rec groups, max recgroup size, and max subtyping depth).

Also fix an issue with zero length recursion groups uncovered by the tests.

* JSTests/wasm/gc/limits.js: Added.
(module):
(testLimits):
* JSTests/wasm/gc/rec.js:
(testRecDeclaration):
* Source/JavaScriptCore/wasm/WasmLimits.h:
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseType):
(JSC::Wasm::SectionParser::parseRecursionGroup):

Canonical link: <a href="https://commits.webkit.org/272921@main">https://commits.webkit.org/272921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/babb4a097e6a92fe4dc61501bea540fb06f7ad79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36053 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30372 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29500 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29837 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8982 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29830 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37382 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/28553 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30175 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35228 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/33417 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33097 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/10983 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/39893 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7770 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9816 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8368 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9956 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->