### PR TITLE
[UnifiedPDF] Keyboard scrolling has no effect

### DIFF
--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -90,6 +90,7 @@ class PlatformWheelEvent;
 class RemoteFrame;
 class RenderBox;
 class RenderElement;
+class RenderEmbeddedObject;
 class RenderLayer;
 class RenderWidget;
 class ScrollableArea;
@@ -409,6 +410,7 @@ private:
     bool startKeyboardScrollAnimationOnRenderBoxLayer(ScrollDirection, ScrollGranularity, RenderBox*, bool isKeyRepeat);
     bool startKeyboardScrollAnimationOnRenderBoxAndItsAncestors(ScrollDirection, ScrollGranularity, RenderBox*, bool isKeyRepeat);
     bool startKeyboardScrollAnimationOnEnclosingScrollableContainer(ScrollDirection, ScrollGranularity, Node*, bool isKeyRepeat);
+    bool startKeyboardScrollAnimationOnPlugin(ScrollDirection, ScrollGranularity, RenderEmbeddedObject&, bool isKeyRepeat);
 
 #if ENABLE(DRAG_SUPPORT)
     bool handleMouseDraggedEvent(const MouseEventWithHitTestResults&, CheckDragHysteresis = ShouldCheckDragHysteresis);

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -147,7 +147,7 @@ public:
 
     Editor& editor() { return document()->editor(); }
     const Editor& editor() const { return document()->editor(); }
-    CheckedRef<Editor> checkedEditor();
+    WEBCORE_EXPORT CheckedRef<Editor> checkedEditor();
     CheckedRef<const Editor> checkedEditor() const;
 
     EventHandler& eventHandler() { return m_eventHandler; }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -184,8 +184,8 @@ private:
     bool handleMouseLeaveEvent(const WebMouseEvent&) override;
     bool handleContextMenuEvent(const WebMouseEvent&) override;
     bool handleKeyboardEvent(const WebKeyboardEvent&) override;
-    bool handleEditingCommand(StringView commandName) override;
-    bool isEditingCommandEnabled(StringView commandName) override;
+    bool handleEditingCommand(const String& commandName, const String& argument) override;
+    bool isEditingCommandEnabled(const String& commandName) override;
 
     String getSelectionString() const override;
     bool existingSelectionContainsPoint(const WebCore::FloatPoint&) const override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1834,7 +1834,7 @@ bool PDFPlugin::handleKeyboardEvent(const WebKeyboardEvent& event)
     return false;
 }
     
-bool PDFPlugin::handleEditingCommand(StringView commandName)
+bool PDFPlugin::handleEditingCommand(const String& commandName, const String&)
 {
     if (commandName == "copy"_s)
         [m_pdfLayerController copySelection];
@@ -1849,7 +1849,7 @@ bool PDFPlugin::handleEditingCommand(StringView commandName)
     return true;
 }
 
-bool PDFPlugin::isEditingCommandEnabled(StringView commandName)
+bool PDFPlugin::isEditingCommandEnabled(const String& commandName)
 {
     if (commandName == "copy"_s || commandName == "takeFindStringFromSelection"_s)
         return [m_pdfLayerController currentSelection];

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -128,8 +128,8 @@ public:
     virtual bool handleMouseLeaveEvent(const WebMouseEvent&) = 0;
     virtual bool handleContextMenuEvent(const WebMouseEvent&) = 0;
     virtual bool handleKeyboardEvent(const WebKeyboardEvent&) = 0;
-    virtual bool handleEditingCommand(StringView commandName) = 0;
-    virtual bool isEditingCommandEnabled(StringView commandName) = 0;
+    virtual bool handleEditingCommand(const String& commandName, const String& argument) = 0;
+    virtual bool isEditingCommandEnabled(const String& commandName) = 0;
 
     virtual String getSelectionString() const = 0;
     virtual bool existingSelectionContainsPoint(const WebCore::FloatPoint&) const = 0;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -122,8 +122,8 @@ private:
     bool handleMouseLeaveEvent(const WebMouseEvent&) override;
     bool handleContextMenuEvent(const WebMouseEvent&) override;
     bool handleKeyboardEvent(const WebKeyboardEvent&) override;
-    bool handleEditingCommand(StringView commandName) override;
-    bool isEditingCommandEnabled(StringView commandName) override;
+    bool handleEditingCommand(const String& commandName, const String& argument) override;
+    bool isEditingCommandEnabled(const String& commandName) override;
 
     enum class ContextMenuItemTag : uint8_t {
         OpenWithPreview,
@@ -212,6 +212,8 @@ private:
 
     // ScrollableArea
     bool requestScrollToPosition(const WebCore::ScrollPosition&, const WebCore::ScrollPositionChangeOptions& = WebCore::ScrollPositionChangeOptions::createProgrammatic()) override;
+    bool requestStartKeyboardScrollAnimation(const KeyboardScroll& scrollData) override;
+    bool requestStopKeyboardScrollAnimation(bool immediate) override;
 
     // HUD Actions.
 #if ENABLE(PDF_HUD)

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -642,12 +642,12 @@ void PluginView::handleEvent(Event& event)
         event.setDefaultHandled();
 }
 
-bool PluginView::handleEditingCommand(const String& commandName, const String&)
+bool PluginView::handleEditingCommand(const String& commandName, const String& argument)
 {
     if (!m_isInitialized)
         return false;
 
-    return m_plugin->handleEditingCommand(commandName);
+    return m_plugin->handleEditingCommand(commandName, argument);
 }
     
 bool PluginView::isEditingCommandEnabled(const String& commandName)


### PR DESCRIPTION
#### 657d45347d8c7eb8757b150eb473ab10fbb3c96f
<pre>
[UnifiedPDF] Keyboard scrolling has no effect
<a href="https://bugs.webkit.org/show_bug.cgi?id=267356">https://bugs.webkit.org/show_bug.cgi?id=267356</a>
<a href="https://rdar.apple.com/118414971">rdar://118414971</a>

Reviewed by Richard Robinson.

Because UnifiedPDFPlugin is somewhat odd in keeping its own ScrollableArea,
we have a small bit of plumbing to do to make keyboard scrolling work, as follows:

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::startKeyboardScrollAnimationOnDocument):
When we have no focused element, if the relevant document is a PluginDocument,
see if the plugin wants to handle keyboard scrolling.

(WebCore::EventHandler::startKeyboardScrollAnimationOnEnclosingScrollableContainer):
If the focused element is a plugin, see if the plugin wants to handle keyboard scrolling.

(WebCore::EventHandler::startKeyboardScrollAnimationOnPlugin):
For plugins with internal async scrollers, give the plugin a shot at keyboard scrolling.

* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/LocalFrame.h:

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::handleEditingCommand):
(WebKit::PDFPlugin::isEditingCommandEnabled):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
Fix the types of these methods to match their friends in WebPage.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::requestStartKeyboardScrollAnimation):
(WebKit::UnifiedPDFPlugin::requestStopKeyboardScrollAnimation):
Implement these ScrollableArea methods and forward them to the page&apos;s ScrollingCoordinator.

(WebKit::UnifiedPDFPlugin::handleEditingCommand):
(WebKit::UnifiedPDFPlugin::isEditingCommandEnabled):
Implement these editing commands and forward them to the page&apos;s Editor.
They&apos;ll come back around eventually.

* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::handleEditingCommand):
Pass the editing command argument along to the plugin for completeness&apos; sake.

Canonical link: <a href="https://commits.webkit.org/272872@main">https://commits.webkit.org/272872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb456a71cd56c38fba71f3eee0dd7a026a60b379

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33460 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36085 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30396 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9415 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29519 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9008 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37410 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30381 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/30203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35253 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9254 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33126 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11009 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7734 "") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4296 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->