### PR TITLE
[webkitbugspy] Refactor mock data

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py
@@ -138,17 +138,15 @@ MILESTONES = [
         name='October',
         isProtected=True,
         protectedAccessGroups=['Managers', 'Integrators'],
-        categories=['Test Development', 'Tentpole Feature Work', 'Escape / Regression in the Build'],
-        events=['Week 1', 'Week 2', 'Week 3', 'Week 4', 'Convergence'],
-        tentpoles=['Scrolling', 'SVG'],
+        categories=['Testing', 'Feature', 'Regression', 'Important'],
+        events=['Week 1', 'Week 2', 'Week 3', 'Week 4', 'Week 5'],
         isCategoryRequired=True,
     ), dict(
         name='Internal Tools - October',
-        categories=['Test Development', 'Tentpole Feature Work', 'Escape / Regression in the Build'],
-        events=['Week 1', 'Week 2', 'Week 3', 'Week 4', 'Convergence'],
-        tentpoles=['Scrolling', 'SVG'],
+        categories=['Testing', 'Feature', 'Regression', 'Important'],
+        events=['Week 1', 'Week 2', 'Week 3', 'Week 4', 'Week 5'],
     ),  dict(
         name='Future',
-        categories=['Test Development', 'Tentpole TBD', 'Escape / Regression in the Build'],
+        categories=['Testing', 'TBD', 'Regression'],
     ),
 ]

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py
@@ -115,7 +115,7 @@ class TestClone(testing.PathTestCase):
             issues=bmocks.ISSUES,
             projects=bmocks.PROJECTS,
             milestones=bmocks.MILESTONES,
-        ), MockTerminal.input('3'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+        ), MockTerminal.input('2'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
 
             self.assertEqual(0, program.main(
                 args=('clone', 'rdar://1', '--reason', 'Cloning for an October branch', '--milestone', 'October', '--prompt'),
@@ -125,7 +125,7 @@ class TestClone(testing.PathTestCase):
             raw_issue = tracker.client.radar_for_id(4)
 
             self.assertEqual(raw_issue.milestone.name, 'October')
-            self.assertEqual(raw_issue.category.name, 'Test Development')
+            self.assertEqual(raw_issue.category.name, 'Important')
             self.assertIsNone(raw_issue.event)
             self.assertIsNone(raw_issue.tentpole)
 
@@ -133,16 +133,17 @@ class TestClone(testing.PathTestCase):
         self.assertEqual(
             captured.stdout.getvalue(),
             'Pick a category for your clone:\n'
-            '    1) Escape / Regression in the Build\n'
-            '    2) Tentpole Feature Work\n'
-            '    3) Test Development\n: \n'
+            '    1) Feature\n'
+            '    2) Important\n'
+            '    3) Regression\n'
+            '    4) Testing\n: \n'
             "Created 'rdar://4 Example issue 1'\n"
             'Moved clone to October and into Analyze: Prepare\n',
         )
 
     def test_merge_back(self):
         issues = [issue.copy() for issue in bmocks.ISSUES]
-        issues[0]['category'] = 'Tentpole Feature Work'
+        issues[0]['category'] = 'Important'
 
         with mocks.local.Git(self.path), mocks.local.Svn(), Environment(RADAR_USERNAME='tcontributor'), bmocks.Radar(
             issues=issues,
@@ -157,7 +158,7 @@ class TestClone(testing.PathTestCase):
             raw_issue = tracker.client.radar_for_id(4)
 
             self.assertEqual(raw_issue.milestone.name, 'Internal Tools - October')
-            self.assertEqual(raw_issue.category.name, 'Tentpole Feature Work')
+            self.assertEqual(raw_issue.category.name, 'Important')
             self.assertIsNone(raw_issue.event)
             self.assertIsNone(raw_issue.tentpole)
 


### PR DESCRIPTION
#### f568db0eb46f4e1095875a04cc2242777059ecc9
<pre>
[webkitbugspy] Refactor mock data
<a href="https://bugs.webkit.org/show_bug.cgi?id=267359">https://bugs.webkit.org/show_bug.cgi?id=267359</a>
<a href="https://rdar.apple.com/120802161">rdar://120802161</a>

Reviewed by Alexey Proskuryakov.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/data.py: Refactor mock data.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py:
(TestClone.test_prompt): Rebaseline test.
(TestClone.test_merge_back): Ditto.

Canonical link: <a href="https://commits.webkit.org/272864@main">https://commits.webkit.org/272864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d02a6cd11b5982ec2ae6f1fe2732fbeb4e4fc997

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36068 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/30385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9358 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33915 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29848 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8995 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/33714 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/29839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37396 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30369 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/30187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35240 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33110 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/33327 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/10997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4289 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9971 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->