### PR TITLE
Make direct atomic inline children move for align-content on blocks.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-012-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-012-expected.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<title>CSS Box Alignment: align-content on large block container</title>
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#align-block">
+<link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
+
+<style title="Needed for automation; delete to review/debug">
+  @import "https://wpt.live/fonts/ahem.css";
+  html { font: 15px/1 Ahem; max-width: 800px;  }
+</style>
+
+<style>
+  .test { height: 3em; margin: 0.5em 1.25em; box-sizing: border-box;
+          /* show bounds of test box without interfering with margin-collapsing */
+          border-left: solid blue 5px;
+          /* ensure bullet follows first line */
+          display: list-item;
+          /* don't wrap, as that will throw off the reference */
+          white-space: nowrap; }
+
+  /* cram into 800x600 */
+  html { max-height: 600px; columns: 3 }
+  .wrapper { break-inside: avoid; border: solid 2px gray; }
+
+  /* predictability */
+  input { height: 4px; margin: 0; vertical-align: 4px; }
+  img { height: 8px }</style>
+
+<body>
+<div class="wrapper">
+  <div class="test" style="" title="start">
+    STRT
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="padding-top: 1em" title="center">
+    CNTR
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="padding-top: 2em" title="end">
+    ENDD
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="" title="baseline">
+    BSLN
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="padding-top: 2em" title="last baseline">
+    LBSL
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="" title="flex-start">
+    FSTR
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="padding-top: 2em" title="flex-end">
+    FEND
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="" title="unsafe start">
+    USTR
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="padding-top: 1em" title="unsafe center">
+    UCNT
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="padding-top: 2em" title="unsafe end">
+    UEND
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="" title="safe start">
+    SSTR
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="padding-top: 1em" title="safe center">
+    SCNT
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="padding-top: 2em" title="safe end">
+    SEND
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="padding-top: 1em" title="space-evenly">
+    SEVN
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="" title="space-between">
+    SBTW
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="padding-top: 1em" title="space-around">
+    SARN
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="" title="normal">
+    NRML
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+
+<p>
+  <button onclick="document.querySelector('style[title]').xContent = 'html { font-size: 12px; }'">Show Text</button>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-012.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-012.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<title>CSS Box Alignment: align-content on large block container</title>
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#align-block">
+<link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
+
+<style title="Needed for automation; delete to review/debug">
+  @import "https://wpt.live/fonts/ahem.css";
+  html { font: 15px/1 Ahem; max-width: 800px;  }
+</style>
+
+<style>
+  .test { height: 3em; margin: 0.5em 1.25em;
+          /* show bounds of test box without interfering with margin-collapsing */
+          border-left: solid blue 5px;
+          /* ensure bullet follows first line */
+          display: list-item;
+          /* don't wrap, as that will throw off the reference */
+          white-space: nowrap; }
+
+  /* cram into 800x600 */
+  html { max-height: 600px; columns: 3 }
+  .wrapper { break-inside: avoid; border: solid 2px gray; }
+
+  /* predictability */
+  input { height: 4px; margin: 0; vertical-align: 4px; }
+  img { height: 8px }
+</style>
+
+<body>
+<div class="wrapper">
+  <div class="test" style="align-content: start" title="start">
+    STRT
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="align-content: center" title="center">
+    CNTR
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="align-content: end" title="end">
+    ENDD
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="align-content: baseline" title="baseline">
+    BSLN
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="align-content: last baseline" title="last baseline">
+    LBSL
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="align-content: flex-start" title="flex-start">
+    FSTR
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="align-content: flex-end" title="flex-end">
+    FEND
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="align-content: unsafe start" title="unsafe start">
+    USTR
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="align-content: unsafe center" title="unsafe center">
+    UCNT
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="align-content: unsafe end" title="unsafe end">
+    UEND
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="align-content: safe start" title="safe start">
+    SSTR
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="align-content: safe center" title="safe center">
+    SCNT
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="align-content: safe end" title="safe end">
+    SEND
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="align-content: space-evenly" title="space-evenly">
+    SEVN
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="align-content: space-between" title="space-between">
+    SBTW
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="align-content: space-around" title="space-around">
+    SARN
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+<div class="wrapper">
+  <div class="test" style="align-content: normal" title="normal">
+    NRML
+    <input type=checkbox>
+    <img src='../../support/swatch-orange.png'>
+    <span>
+      x
+      <input type=checkbox>
+      <img src='../../support/swatch-orange.png'>
+    </div>
+  </div>
+</div>
+
+<p>
+  <button onclick="document.querySelector('style[title]').xContent = 'html { font-size: 12px; }'">Show Text</button>
+</body>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -1003,11 +1003,18 @@ void LineLayout::shiftLinesBy(LayoutUnit blockShift)
     for (auto& line : m_inlineContent->displayContent().lines)
         line.moveInBlockDirection(blockShift, isHorizontalWritingMode);
 
+    LayoutUnit deltaX = isHorizontalWritingMode ? 0_lu : blockShift;
+    LayoutUnit deltaY = isHorizontalWritingMode ? blockShift : 0_lu;
     for (auto& box : m_inlineContent->displayContent().boxes) {
         if (isHorizontalWritingMode)
             box.moveVertically(blockShift);
         else
             box.moveHorizontally(blockShift);
+
+        if (box.isAtomicInlineLevelBox()) {
+            CheckedRef renderer = downcast<RenderBox>(m_boxTree.rendererForLayoutBox(box.layoutBox()));
+            renderer->move(deltaX, deltaY);
+        }
     }
 
     for (auto& object : m_boxTree.renderers()) {


### PR DESCRIPTION
#### 01412a0f52c64ba8fdd1c0f3885e44196c29c5d5
<pre>
Make direct atomic inline children move for align-content on blocks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267360">https://bugs.webkit.org/show_bug.cgi?id=267360</a>
<a href="https://rdar.apple.com/120802276">rdar://120802276</a>

Reviewed by Alan Baradlay.

Moves the RenderBox of atomic inlines, not just their InlineDisplay::Box.

* LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-012-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-012.html: Added.
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::shiftLinesBy): Move RenderBoxes associated with moved InlineDisplay::Boxes.

Canonical link: <a href="https://commits.webkit.org/273003@main">https://commits.webkit.org/273003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/162cb5b00836e15570d68796d931f2e3d02ded68

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36454 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30668 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29730 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10638 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30163 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9284 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37766 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30709 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30501 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35498 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33386 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29845 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7813 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10097 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->