### PR TITLE
Remove iframe layer when isolated iframe process crashes

### DIFF
--- a/LayoutTests/http/tests/site-isolation/iframe-process-termination-after-navigation-completed-expected.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-process-termination-after-navigation-completed-expected.html
@@ -1,0 +1,2 @@
+<body bgcolor=blue>
+</body>

--- a/LayoutTests/http/tests/site-isolation/iframe-process-termination-after-navigation-completed.html
+++ b/LayoutTests/http/tests/site-isolation/iframe-process-termination-after-navigation-completed.html
@@ -1,0 +1,8 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<body bgcolor=blue>
+<script>
+    if (window.testRunner) { testRunner.waitUntilDone() }
+    onload = ()=>{ setTimeout(()=>{ testRunner.notifyDone() }, 500) }
+</script>
+<iframe src="http://localhost:8000/site-isolation/resources/iframe-terminate-process-when-loaded.html?timeout=true" frameborder=0></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/iframe-terminate-process-when-loaded.html
+++ b/LayoutTests/http/tests/site-isolation/resources/iframe-terminate-process-when-loaded.html
@@ -1,2 +1,10 @@
-<script> onload = () => { window.internals.terminateWebContentProcess() } </script>
+<script> onload = () => {
+    if (window.location.search == "?timeout=true") {
+        setTimeout(()=>{
+            window.internals.terminateWebContentProcess()
+        }, 0)
+    } else {
+        window.internals.terminateWebContentProcess()
+    }
+} </script>
 <body style='background-color:green'/>

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -87,6 +87,7 @@ enum class WebKit::SwapBuffersDisplayRequirement : uint8_t {
 [LegacyPopulateFromEmptyConstructor] class WebKit::RemoteLayerTreeTransaction {
 {
     WebCore::PlatformLayerIdentifier m_rootLayerID;
+    WebCore::ProcessIdentifier m_processIdentifier;
     WebKit::ChangedLayers m_changedLayers;
 
     Markable<WebCore::LayerHostingContextIdentifier> m_remoteContextHostedIdentifier;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -39,6 +39,7 @@
 #include <WebCore/LayoutMilestone.h>
 #include <WebCore/MediaPlayerEnums.h>
 #include <WebCore/PlatformCALayer.h>
+#include <WebCore/ProcessIdentifier.h>
 #include <WebCore/ScrollTypes.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
@@ -125,6 +126,9 @@ public:
     void setCreatedLayers(Vector<LayerCreationProperties>);
     void setDestroyedLayerIDs(Vector<WebCore::PlatformLayerIdentifier>);
     void setLayerIDsWithNewlyUnreachableBackingStore(Vector<WebCore::PlatformLayerIdentifier>);
+
+    WebCore::ProcessIdentifier processIdentifier() const { return m_processIdentifier; }
+    void setProcessIdentifier(WebCore::ProcessIdentifier processIdentifier) { m_processIdentifier = processIdentifier; }
 
 #if !defined(NDEBUG) || !LOG_DISABLED
     String description() const;
@@ -248,6 +252,7 @@ private:
     friend struct IPC::ArgumentCoder<RemoteLayerTreeTransaction, void>;
 
     WebCore::PlatformLayerIdentifier m_rootLayerID;
+    WebCore::ProcessIdentifier m_processIdentifier;
     ChangedLayers m_changedLayers;
 
     Markable<WebCore::LayerHostingContextIdentifier> m_remoteContextHostedIdentifier;

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -33,6 +33,7 @@
 #include <WebCore/FloatRect.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/IntSize.h>
+#include <WebCore/ProcessIdentifier.h>
 #include <stdint.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RunLoop.h>
@@ -139,6 +140,8 @@ public:
 
     virtual void addRemotePageDrawingAreaProxy(RemotePageDrawingAreaProxy&) { }
     virtual void removeRemotePageDrawingAreaProxy(RemotePageDrawingAreaProxy&) { }
+
+    virtual void remotePageProcessCrashed(WebCore::ProcessIdentifier) { }
 
 protected:
     DrawingAreaProxy(DrawingAreaType, WebPageProxy&, WebProcessProxy&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -91,6 +91,7 @@ protected:
 
 private:
 
+    void remotePageProcessCrashed(WebCore::ProcessIdentifier) final;
     void sizeDidChange() final;
     void deviceScaleFactorDidChange() final;
     void windowKindDidChange() final;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -104,6 +104,12 @@ void RemoteLayerTreeDrawingAreaProxy::sizeDidChange()
     sendUpdateGeometry();
 }
 
+void RemoteLayerTreeDrawingAreaProxy::remotePageProcessCrashed(WebCore::ProcessIdentifier processIdentifier)
+{
+    if (m_remoteLayerTreeHost)
+        m_remoteLayerTreeHost->remotePageProcessCrashed(processIdentifier);
+}
+
 void RemoteLayerTreeDrawingAreaProxy::viewWillStartLiveResize()
 {
     if (auto scrollingCoordinator = m_webPageProxy->scrollingCoordinatorProxy())

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -29,6 +29,7 @@
 #include "RemoteLayerTreeNode.h"
 #include "RemoteLayerTreeTransaction.h"
 #include <WebCore/PlatformCALayer.h>
+#include <WebCore/ProcessIdentifier.h>
 #include <wtf/HashMap.h>
 #include <wtf/RetainPtr.h>
 
@@ -96,13 +97,15 @@ public:
     Seconds acceleratedTimelineTimeOrigin() const;
 #endif
 
+    void remotePageProcessCrashed(WebCore::ProcessIdentifier);
+
 private:
     void createLayer(const RemoteLayerTreeTransaction::LayerCreationProperties&);
     std::unique_ptr<RemoteLayerTreeNode> makeNode(const RemoteLayerTreeTransaction::LayerCreationProperties&);
 
     bool updateBannerLayers(const RemoteLayerTreeTransaction&);
 
-    void layerWillBeRemoved(WebCore::PlatformLayerIdentifier);
+    void layerWillBeRemoved(WebCore::ProcessIdentifier, WebCore::PlatformLayerIdentifier);
 
     RemoteLayerBackingStoreProperties::LayerContentsType layerContentsType() const;
 
@@ -111,6 +114,7 @@ private:
     HashMap<WebCore::PlatformLayerIdentifier, std::unique_ptr<RemoteLayerTreeNode>> m_nodes;
     HashMap<WebCore::LayerHostingContextIdentifier, WebCore::PlatformLayerIdentifier> m_hostingLayers;
     HashMap<WebCore::LayerHostingContextIdentifier, WebCore::PlatformLayerIdentifier> m_hostedLayers;
+    HashMap<WebCore::ProcessIdentifier, HashSet<WebCore::PlatformLayerIdentifier>> m_hostedLayersInProcess;
     HashMap<WebCore::PlatformLayerIdentifier, RetainPtr<WKAnimationDelegate>> m_animationDelegates;
 #if HAVE(AVKIT)
     HashMap<WebCore::PlatformLayerIdentifier, PlaybackSessionContextIdentifier> m_videoLayers;

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -89,8 +89,10 @@ void RemotePageProxy::injectPageIntoNewProcess()
     m_process->send(Messages::WebProcess::CreateWebPage(m_webPageID, WTFMove(parameters)), 0);
 }
 
-void RemotePageProxy::processDidTerminate()
+void RemotePageProxy::processDidTerminate(WebCore::ProcessIdentifier processIdentifier)
 {
+    if (m_page && m_page->drawingArea())
+        m_page->drawingArea()->remotePageProcessCrashed(processIdentifier);
     for (auto& frame : m_frames)
         frame.remoteProcessDidTerminate();
 }

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -31,6 +31,7 @@
 #include "WebProcessProxy.h"
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/PageIdentifier.h>
+#include <WebCore/ProcessIdentifier.h>
 #include <WebCore/RegistrableDomain.h>
 #include <wtf/WeakHashSet.h>
 
@@ -81,7 +82,7 @@ public:
     template<typename M, typename C> void sendWithAsyncReply(M&&, C&&, const ObjectIdentifierGenericBase&);
 
     void injectPageIntoNewProcess();
-    void processDidTerminate();
+    void processDidTerminate(WebCore::ProcessIdentifier);
 
     WebPageProxyMessageReceiverRegistration& messageReceiverRegistration() { return m_messageReceiverRegistration; }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1161,7 +1161,7 @@ void WebProcessProxy::processDidTerminateOrFailedToLaunch(ProcessTerminationReas
         page->dispatchProcessDidTerminate(reason);
 
     for (auto& remotePage : m_remotePages)
-        remotePage.processDidTerminate();
+        remotePage.processDidTerminate(coreProcessIdentifier());
 }
 
 void WebProcessProxy::didReceiveInvalidMessage(IPC::Connection& connection, IPC::MessageName messageName)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -367,6 +367,7 @@ void RemoteLayerTreeDrawingArea::updateRendering()
         rootLayer.layer->flushCompositingStateForThisLayerOnly();
 
         RemoteLayerTreeTransaction layerTransaction;
+        layerTransaction.setProcessIdentifier(WebCore::Process::identifier());
         layerTransaction.setTransactionID(transactionID);
         layerTransaction.setCallbackIDs(WTFMove(m_pendingCallbackIDs));
 


### PR DESCRIPTION
#### f898ec15e4717fb76ec1dca87773e423aeadb425
<pre>
Remove iframe layer when isolated iframe process crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=267362">https://bugs.webkit.org/show_bug.cgi?id=267362</a>

Reviewed by Tim Horton.

A little bookkeeping is needed to know what layers to remove when a process crashes, but not much.

* LayoutTests/http/tests/site-isolation/iframe-process-termination-after-navigation-completed-expected.html: Added.
* LayoutTests/http/tests/site-isolation/iframe-process-termination-after-navigation-completed.html: Added.
* LayoutTests/http/tests/site-isolation/resources/iframe-terminate-process-when-loaded.html:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
(WebKit::RemoteLayerTreeTransaction::processIdentifier const):
(WebKit::RemoteLayerTreeTransaction::setProcessIdentifier):
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
(WebKit::DrawingAreaProxy::remotePageProcessCrashed):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::remotePageProcessCrashed):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateLayerTree):
(WebKit::RemoteLayerTreeHost::layerWillBeRemoved):
(WebKit::RemoteLayerTreeHost::remotePageProcessCrashed):
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::processDidTerminate):
* Source/WebKit/UIProcess/RemotePageProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::processDidTerminateOrFailedToLaunch):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):

Canonical link: <a href="https://commits.webkit.org/272882@main">https://commits.webkit.org/272882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/449d072415caca3f27481b9ff8ac699ffc299555

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36073 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30390 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9403 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29510 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10307 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29856 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8996 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37401 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30376 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35242 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9248 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33112 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11002 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29525 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9833 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4302 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9976 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->