### PR TITLE
Update the version of MotionMark 1.3 used for perf testing

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/MotionMark1.3.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/MotionMark1.3.patch
@@ -16,8 +16,8 @@ index 1aa630356cff167ec370961d7256920a21d6c508..ef393bcdebc03d2aad9c52c3caef5ad0
              var suiteResults = self._suitesResults[suite.name] || {};
              suiteResults[test.name] = testData;
              self._suitesResults[suite.name] = suiteResults;
-diff --git a/tests/resources/main.js b/tests/resources/main.js
-index 212470bfb1b93e25db7966a2192b3ab84a1ace84..b90324994aa9be4e02de269e356d190c19f11292 100644
+diff --git a/MotionMark/tests/resources/main.js b/MotionMark/tests/resources/main.js
+index ca7f2a9783dcbaa9334d7c896981addce846a98a..f549cca8bc9260c224d5be271d16ed0ef1ad7057 100644
 --- a/tests/resources/main.js
 +++ b/tests/resources/main.js
 @@ -889,6 +889,8 @@ Benchmark = Utilities.createClass(

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.plan
@@ -1,7 +1,7 @@
 {
     "timeout": 1800,
     "count": 3,
-    "github_source": "https://github.com/webkit/MotionMark/tree/c52acd4c645780fd77cdbbd572750a5abfee1f7d/MotionMark",
+    "github_source": "https://github.com/webkit/MotionMark/tree/5d9c88136d59c11daf78d539c73e4e3e88c091ab/MotionMark",
     "webserver_benchmark_patch": "data/patches/webserver/MotionMark1.3.patch",
     "webdriver_benchmark_patch": "data/patches/webdriver/MotionMark1.3.patch",
     "signpost_patch": "data/patches/signposts/MotionMark1.3.patch",
@@ -106,7 +106,7 @@
         ]
     },
     "github_subtree": {
-        "url": "https://api.github.com/repos/WebKit/MotionMark/git/trees/2ccd8c3022e9e8c350a54947a0734bc3af8a43c4",
+        "url": "https://api.github.com/repos/WebKit/MotionMark/git/trees/c523d8ee72b4addf7107d0bbfabc34b479395a82",
         "tree": [
             {"path": "about.html", "mode": "100644", "type": "blob"},
             {"path": "developer.html", "mode": "100644", "type": "blob"},


### PR DESCRIPTION
#### a30be9ad6873fdd8bee60485591fe66db48bb72c
<pre>
Update the version of MotionMark 1.3 used for perf testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=267363">https://bugs.webkit.org/show_bug.cgi?id=267363</a>
<a href="https://rdar.apple.com/120803393">rdar://120803393</a>

Reviewed by Dewei Zhu.

Update the version of MotionMark to <a href="https://github.com/WebKit/MotionMark/commit/5d9c88136d59c11daf78d539c73e4e3e88c091ab.">https://github.com/WebKit/MotionMark/commit/5d9c88136d59c11daf78d539c73e4e3e88c091ab.</a>

* Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/MotionMark1.3.patch:
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.plan:

Canonical link: <a href="https://commits.webkit.org/272878@main">https://commits.webkit.org/272878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc21f7cc2eef76563d4eaebbc3e06faa1f79a49e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36075 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30392 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34424 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29513 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/8999 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/33723 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9121 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37403 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30199 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35248 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33120 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11004 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7738 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9978 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->