### PR TITLE
Stop using CheckedPtr in RenderingResource::m_observers

### DIFF
--- a/Source/WebCore/platform/graphics/RenderingResource.h
+++ b/Source/WebCore/platform/graphics/RenderingResource.h
@@ -26,16 +26,15 @@
 #pragma once
 
 #include "RenderingResourceIdentifier.h"
-#include <wtf/CheckedPtr.h>
-#include <wtf/HashSet.h>
 #include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
 class RenderingResource
     : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RenderingResource> {
 public:
-    class Observer : public CanMakeCheckedPtr {
+    class Observer : public CanMakeWeakPtr<Observer> {
     public:
         virtual ~Observer() = default;
         virtual void releaseRenderingResource(RenderingResourceIdentifier) = 0;
@@ -47,8 +46,9 @@ public:
     {
         if (!hasValidRenderingResourceIdentifier())
             return;
+
         for (auto& observer : m_observers)
-            observer->releaseRenderingResource(renderingResourceIdentifier());
+            observer.releaseRenderingResource(renderingResourceIdentifier());
     }
 
     virtual bool isNativeImage() const { return false; }
@@ -75,13 +75,13 @@ public:
     void addObserver(Observer& observer)
     {
         ASSERT(hasValidRenderingResourceIdentifier());
-        m_observers.add(&observer);
+        m_observers.add(observer);
     }
 
     void removeObserver(Observer& observer)
     {
         ASSERT(hasValidRenderingResourceIdentifier());
-        m_observers.remove(&observer);
+        m_observers.remove(observer);
     }
 
 protected:
@@ -90,7 +90,7 @@ protected:
     {
     }
 
-    HashSet<CheckedPtr<Observer>> m_observers;
+    WeakHashSet<Observer> m_observers;
     std::optional<RenderingResourceIdentifier> m_renderingResourceIdentifier;
 };
 


### PR DESCRIPTION
#### 86d1981ef878451ea42fdaf4f6f5e98ac0923975
<pre>
Stop using CheckedPtr in RenderingResource::m_observers
<a href="https://bugs.webkit.org/show_bug.cgi?id=267365">https://bugs.webkit.org/show_bug.cgi?id=267365</a>

Reviewed by Darin Adler.

Stop using CheckedPtr in RenderingResource::m_observers. Per our recent smart
pointer guidelines, we restrict CheckedPtr/CheckedRef usage to stack variables.

Use a WeahHashSet instead.

* Source/WebCore/platform/graphics/RenderingResource.h:
(WebCore::RenderingResource::~RenderingResource):
(WebCore::RenderingResource::addObserver):
(WebCore::RenderingResource::removeObserver):

Canonical link: <a href="https://commits.webkit.org/272916@main">https://commits.webkit.org/272916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaeca97b91d68548b52e8d7211c1e1c0adb32501

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36093 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30402 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29532 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9026 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29860 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37417 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30209 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35257 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7203 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33130 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11016 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9845 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4313 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9993 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->