### PR TITLE
Remove PDFPluginHUDEnabled runtime switch

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4936,19 +4936,6 @@ PDFPluginEnabled:
       "PLATFORM(IOS_FAMILY)": false
       default: true
 
-PDFPluginHUDEnabled:
-  type: bool
-  status: embedder
-  condition: PLATFORM(COCOA)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebCore:
-      default: false
-
 PageAtRuleSupportEnabled:
   type: bool
   status: unstable

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFLayerControllerSPI.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFLayerControllerSPI.h
@@ -131,9 +131,6 @@ typedef NS_ENUM(NSInteger, PDFLayerControllerCursorType) {
 
 - (bool)keyDown:(NSEvent *)event;
 
-- (void)setHUDEnabled:(BOOL)enabled;
-- (BOOL)hudEnabled;
-
 - (CGRect)boundsForAnnotation:(PDFAnnotation *)annotation;
 - (void)activateNextAnnotation:(BOOL)previous;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -246,7 +246,6 @@ protected:
 #if ENABLE(PDF_HUD)
     void updatePDFHUDLocation();
     WebCore::IntRect frameForHUDInRootViewCoordinates() const;
-    bool hudEnabled() const;
 #endif
 
     SingleThreadWeakPtr<PluginView> m_view;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -255,7 +255,7 @@ void PDFPluginBase::geometryDidChange(const IntSize& pluginSize, const AffineTra
 void PDFPluginBase::visibilityDidChange(bool visible)
 {
 #if ENABLE(PDF_HUD)
-    if (!m_frame || !hudEnabled())
+    if (!m_frame)
         return;
     if (visible)
         m_frame->page()->createPDFHUD(*this, frameForHUDInRootViewCoordinates());
@@ -589,13 +589,6 @@ void PDFPluginBase::updatePDFHUDLocation()
 IntRect PDFPluginBase::frameForHUDInRootViewCoordinates() const
 {
     return convertFromPluginToRootView(IntRect(IntPoint(), size()));
-}
-
-bool PDFPluginBase::hudEnabled() const
-{
-    if (RefPtr page = this->page())
-        return page->settings().pdfPluginHUDEnabled();
-    return false;
 }
 
 #endif // ENABLE(PDF_HUD)


### PR DESCRIPTION
#### 69a709d1314e7630b38ea9b35cd4aba9e6659f4f
<pre>
Remove PDFPluginHUDEnabled runtime switch
<a href="https://bugs.webkit.org/show_bug.cgi?id=267367">https://bugs.webkit.org/show_bug.cgi?id=267367</a>
<a href="https://rdar.apple.com/120806855">rdar://120806855</a>

Reviewed by NOBODY (OOPS!).

It&apos;s been on on macOS for many years, and doesn&apos;t exist on iOS.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/WebProcess/Plugins/PDF/PDFLayerControllerSPI.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::visibilityDidChange):
(WebKit::PDFPluginBase::hudEnabled const): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69a709d1314e7630b38ea9b35cd4aba9e6659f4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36094 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30403 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29527 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9019 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9135 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37418 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/28581 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30208 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35261 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/33450 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9261 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7204 "Found 1 new test failure: compositing/plugins/pdf/pdf-in-embed-rounded-border.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33135 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11017 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/39938 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9846 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8375 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9994 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->