### PR TITLE
REGRESSION (266610@main): Catalyst WKWebView does not dispatch `contextmenu` on right click

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKMouseInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKMouseInteraction.mm
@@ -82,6 +82,15 @@
     [_interaction _updateMouseTouches:touches];
 }
 
+#if PLATFORM(MACCATALYST)
+
+- (UIEventButtonMask)_defaultAllowedMouseButtons
+{
+    return UIEventButtonMaskPrimary | UIEventButtonMaskSecondary;
+}
+
+#endif
+
 @end
 
 @implementation WKMouseInteraction {


### PR DESCRIPTION
#### 2b9a29c2569d82a81a7e2f23ab45e9ac52a78b3e
<pre>
REGRESSION (266610@main): Catalyst WKWebView does not dispatch `contextmenu` on right click
<a href="https://bugs.webkit.org/show_bug.cgi?id=267361">https://bugs.webkit.org/show_bug.cgi?id=267361</a>
<a href="https://rdar.apple.com/119634050">rdar://119634050</a>

Reviewed by Megan Gardner and Tim Horton.

After my refactoring in 266610@main, we no longer dispatch `contextmenu` events when right clicking
in Mac Catalyst `WKWebView`. This is because UIKit&apos;s gesture environment skips over the new
`WKMouseTouchGestureRecognizer` when delivering events to all gesture recognizers on the window,
which in turn means that `-[WKMouseTouchGestureRecognizer touchesBegan:withEvent:]` never gets
triggered and we don&apos;t dispatch any mouse (or context menu) events to the page.

This is due to UIKit having a Catalyst-specific codepath that returns `NO` in the case where the
pointer is not the primary button. Previously, we avoided this by overriding
`-_shouldReceiveTouch:forEvent:recognizerView:` and returning `YES` in the case of pointer touches.
Since the new `WKMouseTouchGestureRecognizer` doesn&apos;t use any SPI or IPI, this bypass no longer
works.

To address this, simply override the IPI method `-_defaultAllowedMouseButtons` to return both
primary and secondary mouse buttons to restore shipping behavior.

* Source/WebKit/UIProcess/ios/WKMouseInteraction.mm:
(-[WKMouseTouchGestureRecognizer _defaultAllowedMouseButtons]):

Canonical link: <a href="https://commits.webkit.org/272883@main">https://commits.webkit.org/272883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e5039d1defb565f1d72f26b7d4eb0659ad66b0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36096 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30405 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29526 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9018 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37420 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30392 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/30207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35260 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33147 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11019 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7739 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9848 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/9996 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->