### PR TITLE
Crash returning non-string results in scripting.executeScript and tabs.executeScript.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in
@@ -40,7 +40,7 @@ struct WebKit::WebExtensionScriptInjectionParameters {
 
 struct WebKit::WebExtensionScriptInjectionResultParameters {
     std::optional<String> error;
-    std::optional<String> result;
+    std::optional<String> resultJSON;
     std::optional<WebKit::WebExtensionFrameIdentifier> frameID;
 }
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionScriptInjectionResultParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionScriptInjectionResultParameters.h
@@ -33,7 +33,7 @@ namespace WebKit {
 
 struct WebExtensionScriptInjectionResultParameters {
     std::optional<String> error;
-    std::optional<String> result;
+    std::optional<String> resultJSON;
     std::optional<WebExtensionFrameIdentifier> frameID;
 };
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -184,7 +184,7 @@ WebExtensionScriptInjectionResultParameters toInjectionResultParameters(id resul
     WebExtensionScriptInjectionResultParameters parameters;
 
     if (resultOfExecution)
-        parameters.result = resultOfExecution;
+        parameters.resultJSON = encodeJSONString(resultOfExecution, JSONOptions::FragmentsAllowed);
 
     if (info)
         parameters.frameID = toWebExtensionFrameIdentifier(info);

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
@@ -92,10 +92,8 @@ NSArray *toWebAPI(const Vector<WebExtensionScriptInjectionResultParameters>& par
     // tabs.executeScript() only returns an array of the injection result.
     if (returnExecutionResultOnly) {
         for (auto& parameters : parametersVector) {
-            if (parameters.result)
-                [results addObject:parameters.result.value()];
-            else
-                [results addObject:NSNull.null];
+            id result = parameters.resultJSON ? parseJSON(parameters.resultJSON.value(), JSONOptions::FragmentsAllowed) : nil;
+            [results addObject:result ?: NSNull.null];
         }
 
         return [results copy];
@@ -104,10 +102,8 @@ NSArray *toWebAPI(const Vector<WebExtensionScriptInjectionResultParameters>& par
     for (auto& parameters : parametersVector) {
         auto *result = [NSMutableDictionary dictionaryWithCapacity:3];
 
-        if (parameters.result)
-            result[@"result"] = parameters.result.value();
-        else
-            result[@"result"] = NSNull.null;
+        id value = parameters.resultJSON ? parseJSON(parameters.resultJSON.value(), JSONOptions::FragmentsAllowed) : nil;
+        result[@"result"] = value ?: NSNull.null;
 
         ASSERT(parameters.frameID);
         if (parameters.frameID)


### PR DESCRIPTION
#### 814028b389f8a6d2150fb632bda456dc6552f51f
<pre>
Crash returning non-string results in scripting.executeScript and tabs.executeScript.
<a href="https://webkit.org/b/267376">https://webkit.org/b/267376</a>
<a href="https://rdar.apple.com/119334188">rdar://119334188</a>

Reviewed by Brian Weinstein.

Treat the result of scripting.executeScript and tabs.executeScript as a JSON-serializable
value and encode and parse it as needed. Added new tests that confirms this works.

* Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionScriptInjectionResultParameters.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::toInjectionResultParameters):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
(WebKit::toWebAPI):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/272879@main">https://commits.webkit.org/272879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ca0d3c0ac094f06b19041dd9f24718f20a0b9c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36113 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/30415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9420 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9031 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37435 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30407 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/30221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35269 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33144 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11030 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4301 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10011 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->