### PR TITLE
[Wasm-GC] Fix write barrier bug in BBQ array.set

### DIFF
--- a/JSTests/wasm/gc/bug267381.js
+++ b/JSTests/wasm/gc/bug267381.js
@@ -1,0 +1,57 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true", "--useWebAssemblyExtendedConstantExpressions=true")
+
+import * as assert from "../assert.js";
+import { instantiate } from "./wast-wrapper.js";
+
+{
+  const m1 = instantiate(`
+    (module
+      (type (struct (field i32)))
+      (type (array (mut (ref null 0))))
+      (func (export "maker") (result (ref 1))
+        (array.new_default 1 (i32.const 5))))
+  `);
+
+  const arr = m1.exports.maker();
+  assert.isObject(arr);
+
+  // Do a GC to ensure the array is an old object.
+  gc();
+
+  const m2 = instantiate(`
+    (module
+      (type (struct (field i32)))
+      (type (array (mut (ref null 0))))
+      (func (export "set") (param (ref 1) i32)
+        (array.set 1 (local.get 0) (local.get 1) (struct.new 0 (i32.const 42))))
+      (func (export "get") (param (ref 1) i32) (result i32)
+        (struct.get 0 0 (array.get 1 (local.get 0) (local.get 1)))))
+  `);
+
+  for (var i = 0; i < 5; i++)
+    m2.exports.set(arr, i);
+
+  // Do an eden GC to test write barriers.
+  edenGC();
+
+  for (var i = 0; i < 5; i++)
+    assert.eq(m2.exports.get(arr, i), 42);
+}
+
+// Test array.new_fixed case.
+{
+  const m = instantiate(`
+    (module
+      (type (struct (field i32)))
+      (type (array (mut (ref null 0))))
+      (func (export "maker") (result (ref 1))
+        (array.new_fixed 1 2 (struct.new 0 (i32.const 42)) (struct.new 0 (i32.const 42))))
+      (func (export "get") (param (ref 1) i32) (result i32)
+        (struct.get 0 0 (array.get 1 (local.get 0) (local.get 1)))))
+  `);
+
+  const arr = m.exports.maker();
+  gc();
+  assert.eq(m.exports.get(arr, 0), 42);
+  assert.eq(m.exports.get(arr, 1), 42);
+}


### PR DESCRIPTION
#### 6decd847ff1762e7bc2a269e3a264192ed704c24
<pre>
[Wasm-GC] Fix write barrier bug in BBQ array.set
<a href="https://bugs.webkit.org/show_bug.cgi?id=267381">https://bugs.webkit.org/show_bug.cgi?id=267381</a>

Reviewed by Justin Michaud.

Fixes a bug in the patch for bug245405. The write barriers in these cases were
in the right place, but the condition to check for them was wrong (because BBQ
values use I64 type kind for Ref types). The condition now uses the type index
to look up the type.

* JSTests/wasm/gc/bug267381.js: Added.
(i.assert.eq.m2.exports):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::addArrayNewFixed):
(JSC::Wasm::BBQJIT::addArraySet):

Canonical link: <a href="https://commits.webkit.org/272923@main">https://commits.webkit.org/272923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42bddb3ea7877fab533c4480b72579e50751ebf1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36126 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30420 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29541 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29892 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9041 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9146 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37448 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/28594 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30412 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35277 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/33474 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7232 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33152 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11036 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/39970 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7773 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9862 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8382 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10022 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->