### PR TITLE
[JSC] RegExp /u flag doesn't respect atomicity of surrogate pairs

### DIFF
--- a/JSTests/stress/regexp-unicode-dangling-surrogates.js
+++ b/JSTests/stress/regexp-unicode-dangling-surrogates.js
@@ -1,0 +1,190 @@
+// With verbose set to false, this test is successful if there is no output.  Set verbose to true to see expected matches.
+let verbose = false;
+
+function arrayToString(arr)
+{
+    let str = '';
+    arr.forEach(function(v, index) {
+        if (typeof v == "string")
+            str += "\"" + v + "\"";
+        else
+            str += v;
+
+        if (index != (arr.length - 1))
+            str += ',';
+      });
+  return str;
+}
+
+function objectToString(obj)
+{
+    let str = "";
+
+    firstEntry = true;
+
+    for (const [key, value] of Object.entries(obj)) {
+        if (!firstEntry)
+            str += ", ";
+
+        str += key + ": " + dumpValue(value);
+
+        firstEntry = false;
+    }
+    
+    return "{ " + str + " }";
+}
+
+function dumpValue(v)
+{
+    if (v === null)
+        return "<null>";
+
+    if (v === undefined)
+        return "<undefined>";
+
+    if (typeof v == "string")
+        return "\"" + v + "\"";
+
+    let str = "";
+
+    if (v.length)
+        str += arrayToString(v);
+
+    if (v.groups) {
+        groupStr = objectToString(v.groups);
+
+        if (str.length) {
+            if ( groupStr.length)
+                str += ", " + groupStr;
+        } else
+            str = groupStr;
+    }
+
+    return "[ " + str + " ]";
+}
+
+function compareArray(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected is null, actual is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected is not null, actual is null");
+        return false;
+    }
+
+    if (expected.length !== actual.length) {
+        print("### expected.length: " + expected.length + ", actual.length: " + actual.length);
+        return false;
+    }
+
+    for (var i = 0; i < expected.length; i++) {
+        if (expected[i] !== actual[i]) {
+            print("### expected[" + i + "]: \"" + expected[i] + "\" !== actual[" + i + "]: \"" + actual[i] + "\"");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function compareGroups(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected group is null, actual group is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected group is not null, actual group is null");
+        return false;
+    }
+
+    for (const key in expected) {
+        if (expected[key] !== actual[key]) {
+            print("### expected." + key + ": " + dumpValue(expected[key]) + " !== actual." + key + ": " + dumpValue(actual[key]));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+let testNumber = 0;
+
+function testRegExp(re, str, exp, groups)
+{
+    testNumber++;
+
+    if (groups)
+        exp.groups = groups;
+
+    let actual = re.exec(str);
+
+    let result = compareArray(exp, actual);;
+
+    if (exp && exp.groups) {
+        if (!compareGroups(exp.groups, actual.groups))
+            result = false;
+    }
+
+    if (result) {
+        if (verbose)
+            print(re.toString() + ".exec(" + dumpValue(str) + "), passed ", dumpValue(exp));
+    } else
+        print(re.toString() + ".exec(" + dumpValue(str) + "), FAILED test #" + testNumber + ", Expected ", dumpValue(exp), " got ", dumpValue(actual));
+}
+
+function testRegExpSyntaxError(reString, flags, expError)
+{
+    testNumber++;
+
+    try {
+        let re = new RegExp(reString, flags);
+        print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError);
+    } catch (e) {
+        if (e != expError)
+            print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\" got \"" + e + "\"");
+        else if (verbose)
+            print("/" + reString + "/" + flags + " passed, it threw \"" + expError + "\" as expected");
+    }
+}
+
+// Test 1
+testRegExp(/\uDC9A$/u, "a\u{1F49A}", null);
+testRegExp(/[\uDC9A|\uD83D]$/u, "a\u{1F49A}", null);
+testRegExp(/[\uDC9A|\uD83D]+$/u, "a\u{1F49A}", null);
+testRegExp(/[\uDC9A|\uD83D]+?$/u, "a\u{1F49A}", null);
+testRegExp(/\uDC9A$/u, "a\uDC9A", ["\uDC9A"]);
+
+// Test 6
+testRegExp(/[\uDC9A|\uD83D]$/u, "a\uD83D", ["\uD83D"]);
+testRegExp(/[\uDC9A|\uD83D]$/u, "a\uDC9A", ["\uDC9A"]);
+testRegExp(/[\uDC9A|\uD83D]$/u, "a\uDC9A\uD83D", ["\uD83D"]);
+testRegExp(/[\uDC9A|\uD83D]+$/u, "a\uD83D", ["\uD83D"]);
+testRegExp(/[\uDC9A|\uD83D]+$/u, "a\uDC9A", ["\uDC9A"]);
+
+// Test 11
+testRegExp(/[\uDC9A|\uD83D]+$/u, "a\uDC9A\uD83D", ["\uDC9A\uD83D"]);
+testRegExp(/[\uDC9A|\uD83D]+?$/u, "a\uD83D", ["\uD83D"]);
+testRegExp(/[\uDC9A|\uD83D]+?$/u, "a\uDC9A", ["\uDC9A"]);
+testRegExp(/[\uDC9A|\uD83D]+?$/u, "a\uDC9A\uD83D", ["\uDC9A\uD83D"]);
+testRegExp(/[^\u{1F49A}]/u, "a\u{1F49A}", ["a"]);
+
+// Test 16
+testRegExp(/[^\u{1F49A}]/u, "\u{1F49A}a", ["a"]);
+testRegExp(/(?<=(\u{1F49A}))a/u, "\u{1F49A}a", ["a", "\u{1F49A}"]);
+testRegExp(/(?<=(\u{1F49A}))./u, "\u{1F49A}a", ["a", "\u{1F49A}"]);
+testRegExp(/(?<=(\uDC9A))a/u, "\u{1F49A}a", null);
+testRegExp(/(?<=(\uD83D))./u, "\u{1F49A}a", null);
+
+// Test 21
+testRegExp(/(?<=(\uDC9A))./u, "\u{1F49A}a", null);

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -58,9 +58,6 @@ test/built-ins/Proxy/construct/return-not-object-throws-undefined-realm.js:
 test/built-ins/Proxy/construct/trap-is-not-callable-realm.js:
   default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
   strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/RegExp/prototype/Symbol.match/builtin-infer-unicode.js:
-  default: 'Test262Error: Expected SameValue(«�», «null») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«�», «null») to be true'
 test/built-ins/RegExp/prototype/Symbol.match/flags-tostring-error.js:
   default: 'Test262Error: Expected a CustomError but got a Test262Error'
   strict mode: 'Test262Error: Expected a CustomError but got a Test262Error'
@@ -79,15 +76,6 @@ test/built-ins/RegExp/prototype/Symbol.replace/get-flags-err.js:
 test/built-ins/RegExp/prototype/Symbol.replace/get-unicode-error.js:
   default: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
-test/built-ins/RegExp/prototype/Symbol.search/u-lastindex-advance.js:
-  default: 'Test262Error: Expected SameValue(«1», «-1») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«1», «-1») to be true'
-test/built-ins/RegExp/prototype/Symbol.split/u-lastindex-adv-thru-failure.js:
-  default: 'Test262Error: Expected SameValue(«2», «1») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«2», «1») to be true'
-test/built-ins/RegExp/prototype/exec/u-lastindex-adv.js:
-  default: 'Test262Error: Expected SameValue(«�», «null») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«�», «null») to be true'
 test/built-ins/RegExp/quantifier-integer-limit.js:
   default: 'SyntaxError: Invalid regular expression: number too large in {} quantifier'
   strict mode: 'SyntaxError: Invalid regular expression: number too large in {} quantifier'
@@ -1134,9 +1122,6 @@ test/language/import/import-assertions/json-value-string.js:
   module: "SyntaxError: Unexpected identifier 'assert'. Expected a ';' following a targeted import declaration."
 test/language/import/import-assertions/json-via-namespace.js:
   module: "SyntaxError: Unexpected identifier 'assert'. Expected a ';' following a targeted import declaration."
-test/language/literals/regexp/u-astral-char-class-invert.js:
-  default: 'Test262Error: Expected SameValue(«�», «null») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«�», «null») to be true'
 test/language/module-code/import-assertions/eval-gtbndng-indirect-faux-assertion.js:
   raw: "SyntaxError: Unexpected token '*'. import call expects one or two arguments."
 test/language/module-code/import-assertions/import-assertion-empty.js:

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -285,7 +285,8 @@ public:
                     return errorCodePoint;
                 next();
                 return U16_GET_SUPPLEMENTARY(result, input[p + 1]);
-            }
+            } else if (decodeSurrogatePairs && p > 0 && U16_IS_TRAIL(result) && U16_IS_LEAD(input[p - 1]))
+                return errorCodePoint;
             return result;
         }
 


### PR DESCRIPTION
#### 584a9a820ab2d2408314858daaccc8a9f01f6c56
<pre>
[JSC] RegExp /u flag doesn&apos;t respect atomicity of surrogate pairs
<a href="https://bugs.webkit.org/show_bug.cgi?id=267011">https://bugs.webkit.org/show_bug.cgi?id=267011</a>
<a href="https://rdar.apple.com/120391451">rdar://120391451</a>

Reviewed by Alexey Shvayka.

Fixed bug where a dangling surrogate in a pattern matches half a valid surrogate pair in a subject string.
Updated the reading of surrogates that when we read starting in the middle of a valid surrogate pair, we return an error
codepoint which we never match.  Updated backtracking for non-greedy character class matching to use the start index
as the appropriate index to reset when we fail to match, instead of doing math with the current match count.

Added a new test and updated the Test262 expections file.

* JSTests/stress/regexp-unicode-dangling-surrogates.js: Added.
(arrayToString):
(objectToString):
(dumpValue):
(compareArray):
(compareGroups):
(testRegExp):
(testRegExpSyntaxError):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::InputStream::readChecked):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/272928@main">https://commits.webkit.org/272928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83ab502628b38975d31879c38d3bf7e8376c1c24

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36135 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30423 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29544 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10354 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29893 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9045 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37457 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/28596 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30422 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35280 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/33478 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33155 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11040 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/39979 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7775 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9865 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8385 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10030 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->