### PR TITLE
Use Sudo When Pruning coresymbolicationd Cache

### DIFF
--- a/Tools/Scripts/delete-if-too-large
+++ b/Tools/Scripts/delete-if-too-large
@@ -48,7 +48,7 @@ def main():
 
         if directorySize >= tenGigabytesInKiloBytes:
             print(f'{directory} is {directorySize}K in size. Deleting') 
-            subprocess.call(['rm','-rf', directoryPath])
+            subprocess.call(['sudo', 'rm','-rf', directoryPath])
             print(f'Deleted {directory}')
         else:
             print(f'{directory} is {directorySize}K in size. Doing nothing') 


### PR DESCRIPTION
#### 6fe2994a53cf90840f31bfb54e66d8f5788773fe
<pre>
Use Sudo When Pruning coresymbolicationd Cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=267382">https://bugs.webkit.org/show_bug.cgi?id=267382</a>
<a href="https://rdar.apple.com/120814769">rdar://120814769</a>

Reviewed by Jonathan Bedard.

As a follow up to <a href="https://bugs.webkit.org/show_bug.cgi?id=267053">https://bugs.webkit.org/show_bug.cgi?id=267053</a> , sudo should be used when pruning the coresymbolicationd cache.

* Tools/Scripts/delete-if-too-large:
(main):

Canonical link: <a href="https://commits.webkit.org/273306@main">https://commits.webkit.org/273306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecd8d5d98eadade6209d42cca6546f18e27cf143

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36138 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30425 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34552 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29546 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/33990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29895 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9048 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9232 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37460 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30528 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35282 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9283 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33157 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11042 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8026 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9867 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10032 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->