### PR TITLE
Web Inspector: Replace the audit tests to rem instead of px

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/AuditNavigationSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/AuditNavigationSidebarPanel.css
@@ -65,7 +65,7 @@
     left: 0;
     z-index: calc(var(--z-index-popover) + 1);
     padding: 8px;
-    font-size: 13px;
+    font-size: 0.8rem;
     text-align: center;
     color: var(--text-color-secondary);
 }

--- a/Source/WebInspectorUI/UserInterface/Views/AuditTestCaseContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/AuditTestCaseContentView.css
@@ -107,7 +107,7 @@
     display: inline-block;
     min-width: var(--metadata-width);
     margin-inline-start: var(--audit-test-horizontal-space);
-    font-size: 12px;
+    font-size: 0.75rem;
     text-align: center;
     font-weight: bold;
 }
@@ -144,7 +144,7 @@
 
 .content-view.audit-test-case > section table > tr > td:first-child {
     font-family: -webkit-system-font, sans-serif;
-    font-size: 11px;
+    font-size: 0.7rem;
     font-variant-numeric: tabular-nums;
     text-align: end;
     vertical-align: top;

--- a/Source/WebInspectorUI/UserInterface/Views/AuditTestContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/AuditTestContentView.css
@@ -34,11 +34,11 @@
 }
 
 .content-view-container > .content-view.audit-test > header h1 {
-    font-size: 2em;
+    font-size: 2rem;
 }
 
 .content-view-container > .content-view.audit-test > header p {
-    font-size: 1.25em;
+    font-size: 1.25rem;
     opacity: 0.85;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/AuditTestGroupContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/AuditTestGroupContentView.css
@@ -69,7 +69,7 @@
 }
 
 .content-view.audit-test-group > header > .information > p {
-    font-size: 1.25em;
+    font-size: 1.25rem;
 }
 
 .content-view.audit-test-group > header > nav {
@@ -130,7 +130,7 @@
 .content-view.audit-test-group > header > .percentage-pass {
     width: var(--metadata-width);
     margin-inline-start: var(--audit-test-horizontal-space);
-    font-size: 16px;
+    font-size: 1rem;
     text-align: center;
     font-weight: bold;
     /* FIXME: Use CSS4 color blend functions once they're available. */
@@ -138,7 +138,7 @@
 }
 
 .content-view.audit-test-group > header > .percentage-pass > span {
-    font-size: 24px;
+    font-size: 1.5rem;
     /* FIXME: Use CSS4 color blend functions once they're available. */
     color: hsla(0, 0%, 0%, 0.65);
 }


### PR DESCRIPTION
#### a4db951c083c0e1adc555a91b7402cc92faf315f
<pre>
Web Inspector: Replace the audit tests to rem instead of px
<a href="https://bugs.webkit.org/show_bug.cgi?id=267311">https://bugs.webkit.org/show_bug.cgi?id=267311</a>

Reviewed by NOBODY (OOPS!).

Replace px with rem for `font-size` in the audit tests.

* Source/WebInspectorUI/UserInterface/Views/AuditNavigationSidebarPanel.css:
(.content-view.tab.audit .content-view &gt; .audit-version):
* Source/WebInspectorUI/UserInterface/Views/AuditTestCaseContentView.css:
(.content-view.audit-test-case &gt; header &gt; .metadata &gt; .duration):
(.content-view.audit-test-case &gt; section table &gt; tr &gt; td:first-child):
* Source/WebInspectorUI/UserInterface/Views/AuditTestContentView.css:
(.content-view-container &gt; .content-view.audit-test &gt; header h1):
(.content-view-container &gt; .content-view.audit-test &gt; header p):
* Source/WebInspectorUI/UserInterface/Views/AuditTestGroupContentView.css:
(.content-view.audit-test-group &gt; header &gt; .information &gt; p):
(.content-view.audit-test-group &gt; header &gt; .percentage-pass):
(.content-view.audit-test-group &gt; header &gt; .percentage-pass &gt; span):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4db951c083c0e1adc555a91b7402cc92faf315f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40097 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33462 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31850 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32932 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12078 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12042 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33618 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41362 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34037 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37941 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12621 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36108 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14062 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13023 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->