### PR TITLE
EventTarget shouldn't have a special case for wheel events

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2934,6 +2934,7 @@ void Document::removeAllEventListeners()
 #if ENABLE(IOS_TOUCH_EVENTS)
     clearTouchEventHandlersAndListeners();
 #endif
+    // FIXME: What about disconnected nodes.
     for (RefPtr node = firstChild(); node; node = NodeTraversal::next(*node))
         node->removeAllEventListeners();
 
@@ -2941,6 +2942,7 @@ void Document::removeAllEventListeners()
     m_touchEventTargets = nullptr;
 #endif
     m_wheelEventTargets = nullptr;
+    invalidateEventListenerRegions();
 }
 
 void Document::suspendDeviceMotionAndOrientationUpdates()

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -224,7 +224,6 @@ private:
     virtual void derefEventTarget() = 0;
 
     void innerInvokeEventListeners(Event&, EventListenerVector, EventInvokePhase);
-    void invalidateEventListenerRegions();
 };
 
 inline bool EventTarget::hasEventListeners() const

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2064,9 +2064,10 @@ bool LocalDOMWindow::addEventListener(const AtomString& eventType, Ref<EventList
     auto typeInfo = eventNames.typeInfoForEvent(eventType);
     if (document) {
         document->didAddEventListenersOfType(eventType);
-        if (typeInfo.isInCategory(EventCategory::Wheel))
+        if (typeInfo.isInCategory(EventCategory::Wheel)) {
             document->didAddWheelEventHandler(*document);
-        else if (isTouchRelatedEventType(typeInfo, *document))
+            document->invalidateEventListenerRegions();
+        } else if (isTouchRelatedEventType(typeInfo, *document))
             document->didAddTouchEventHandler(*document);
         else if (eventType == eventNames.storageEvent)
             didAddStorageEventListener(*this);
@@ -2319,9 +2320,10 @@ bool LocalDOMWindow::removeEventListener(const AtomString& eventType, EventListe
     auto typeInfo = eventNames.typeInfoForEvent(eventType);
     if (document) {
         document->didRemoveEventListenersOfType(eventType);
-        if (typeInfo.isInCategory(EventCategory::Wheel))
+        if (typeInfo.isInCategory(EventCategory::Wheel)) {
             document->didRemoveWheelEventHandler(*document);
-        else if (isTouchRelatedEventType(typeInfo, *document))
+            document->invalidateEventListenerRegions();
+        } else if (isTouchRelatedEventType(typeInfo, *document))
             document->didRemoveTouchEventHandler(*document);
     }
 


### PR DESCRIPTION
#### 167dc5118a3f6228a19df40e673ea0a6d03b9bec
<pre>
EventTarget shouldn&apos;t have a special case for wheel events
<a href="https://bugs.webkit.org/show_bug.cgi?id=267383">https://bugs.webkit.org/show_bug.cgi?id=267383</a>

Reviewed by Yusuke Suzuki.

Move the code to invalidate event regions for wheel events from EventTarget to DOMWindow and Node.
Note that Node::removeAllEventListeners is only called when Document::removeAllEventListeners is
called in Document::~Document or Document::open so clearing it in Document::removeAllEventListeners
is sufficient.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::removeAllEventListeners):
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::addEventListener):
(WebCore::EventTarget::removeEventListener):
(WebCore::EventTarget::removeAllEventListeners):
(WebCore::EventTarget::invalidateEventListenerRegions): Deleted.
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::tryAddEventListener):
(WebCore::tryRemoveEventListener):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::addEventListener):
(WebCore::LocalDOMWindow::removeEventListener):

Canonical link: <a href="https://commits.webkit.org/272895@main">https://commits.webkit.org/272895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4d260e37f420102520a2674bfe8b3148f983acd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36158 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30439 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9471 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34016 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10364 "Found 1 new test failure: imported/blink/fast/text/international-iteration-simple-text.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9062 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37486 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30431 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30245 "Found 1 new test failure: compositing/updates/animation-non-composited.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35294 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9297 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7246 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33170 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11062 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9881 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4306 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->