### PR TITLE
Safari periodically erasing LocalStorage and IndexedDB for all websites

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -377,7 +377,7 @@ void NetworkStorageManager::spaceGrantedForOrigin(const WebCore::ClientOrigin& o
     if (m_totalUsage)
         m_totalUsage = *m_totalUsage + amount;
 
-    if (!m_totalUsage || *m_totalUsage > m_totalQuota)
+    if (!m_totalUsage || *m_totalUsage > *m_totalQuota)
         schedulePerformEviction();
 }
 
@@ -484,7 +484,8 @@ void NetworkStorageManager::performEviction(HashMap<WebCore::SecurityOriginData,
     assertIsCurrent(workQueue());
 
     m_isEvictionScheduled = false;
-    if (!m_totalQuota || !m_totalUsage || *m_totalUsage <= m_totalQuota)
+    ASSERT(m_totalQuota);
+    if (!m_totalUsage || *m_totalUsage <= *m_totalQuota)
         return;
 
     Vector<std::pair<WebCore::SecurityOriginData, AccessRecord>> sortedOriginRecords;
@@ -496,7 +497,7 @@ void NetworkStorageManager::performEviction(HashMap<WebCore::SecurityOriginData,
     });
 
     uint64_t deletedOriginCount = 0;
-    while (!sortedOriginRecords.isEmpty() && *m_totalUsage > m_totalQuota) {
+    while (!sortedOriginRecords.isEmpty() && *m_totalUsage > *m_totalQuota) {
         auto [topOrigin, record] = sortedOriginRecords.takeLast();
         if (record.isActive || valueOrDefault(record.isPersisted))
             continue;
@@ -512,7 +513,7 @@ void NetworkStorageManager::performEviction(HashMap<WebCore::SecurityOriginData,
     }
 
     UNUSED_PARAM(deletedOriginCount);
-    RELEASE_LOG(Storage, "%p - NetworkStorageManager::performEviction evicts %" PRIu64 " origins, current usage %" PRIu64 ", total quota %" PRIu64, this, deletedOriginCount, valueOrDefault(m_totalUsage), m_totalQuota);
+    RELEASE_LOG(Storage, "%p - NetworkStorageManager::performEviction evicts %" PRIu64 " origins, current usage %" PRIu64 ", total quota %" PRIu64, this, deletedOriginCount, valueOrDefault(m_totalUsage), *m_totalQuota);
 }
 
 OriginQuotaManager::Parameters NetworkStorageManager::originQuotaManagerParameters(const WebCore::ClientOrigin& origin)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -266,7 +266,7 @@ private:
     std::optional<uint64_t> m_standardVolumeCapacity;
     std::optional<uint64_t> m_volumeCapacityOverride;
     std::optional<uint64_t> m_totalUsage;
-    uint64_t m_totalQuota;
+    std::optional<uint64_t> m_totalQuota;
     bool m_isEvictionScheduled { false };
     UnifiedOriginStorageLevel m_unifiedOriginStorageLevel;
     IPC::Connection::UniqueID m_parentConnection;


### PR DESCRIPTION
#### cc8a261932c7e35fa313249d0d2d173874c0dcdb
<pre>
Safari periodically erasing LocalStorage and IndexedDB for all websites
<a href="https://bugs.webkit.org/show_bug.cgi?id=266559">https://bugs.webkit.org/show_bug.cgi?id=266559</a>
<a href="https://rdar.apple.com/119818267">rdar://119818267</a>

Reviewed by Sihui Liu.

Data eviction will delete website data for all origins if the total disk usage exceeds the total quota.
`m_totalQuota` is set in `NetworkStorageManager::spaceGrantedForOrigin()`, and will only be set if
`m_totalQuota` is zero. However, `m_totalQuota` is never initialized, so it&apos;s possible for it to have a
non-zero value which is less than the current disk usage. This situation prevents the variable from ever
being initialized in `NetworkStorageManager::spaceGrantedForOrigin()` and results in the deletion of all
website data.

This change addresses the issue by making `m_totalQuota` optional, ensuring the value is always null when
`NetworkStorageManager::spaceGrantedForOrigin()` is initially called.

* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::spaceGrantedForOrigin):
(WebKit::NetworkStorageManager::performEviction):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:

Canonical link: <a href="https://commits.webkit.org/272951@main">https://commits.webkit.org/272951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddad802a35cf538e110bffa82d7501587decf44f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36161 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30441 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29559 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9068 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9163 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37489 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30434 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35295 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7248 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33171 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11064 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9883 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4340 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10056 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->