### PR TITLE
Enable warning flags that are on by default in open source clang-17

### DIFF
--- a/Configurations/CommonBase.xcconfig
+++ b/Configurations/CommonBase.xcconfig
@@ -55,7 +55,7 @@ OTHER_LDFLAGS = $(inherited) $(WK_COMMON_OTHER_LDFLAGS);
 WK_COMMON_OTHER_TAPI_FLAGS = -x objective-c++ -std=c++2a -fno-rtti $(WK_SANITIZER_OTHER_TAPI_FLAGS);
 OTHER_TAPI_FLAGS = $(inherited) $(WK_COMMON_OTHER_TAPI_FLAGS);
 
-WK_COMMON_WARNING_CFLAGS = -Wall -Wconditional-uninitialized -Wextra -Wformat=2 -Wundef;
+WK_COMMON_WARNING_CFLAGS = -Wall -Wc99-designator -Wconditional-uninitialized -Wextra -Wdeprecated-enum-enum-conversion -Wdeprecated-enum-float-conversion -Wenum-float-conversion -Wfinal-dtor-non-final-class -Wformat=2 -Wmisleading-indentation -Wreorder-init-list -Wundef;
 WARNING_CFLAGS = $(inherited) $(WK_COMMON_WARNING_CFLAGS);
 
 WK_LIBCPP_ASSERTIONS_CFLAGS = $(WK_LIBCPP_ASSERTIONS_CFLAGS_$(WK_PLATFORM_NAME));

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -8056,11 +8056,13 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
         return;
 
 #if HAVE(UI_ASYNC_TEXT_INTERACTION)
-    if (self.shouldUseAsyncInteractions)
+    if (self.shouldUseAsyncInteractions) {
         [_asyncSystemInputDelegate invalidateTextEntryContext];
-    else
+        return;
+    }
 #endif
-        [UIKeyboardImpl.activeInstance updateForChangedSelection];
+
+    [UIKeyboardImpl.activeInstance updateForChangedSelection];
 }
 
 - (void)_updateFocusedElementInformation:(const WebKit::FocusedElementInformation&)information

--- a/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
+++ b/Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm
@@ -56,7 +56,10 @@
         [view addInteraction:_asyncTextInteraction.get()];
     } else
 #endif // HAVE(UI_ASYNC_TEXT_INTERACTION)
+    {
         _textInteractionAssistant = adoptNS([[UIWKTextInteractionAssistant alloc] initWithView:view]);
+    }
+
     _view = view;
     return self;
 }


### PR DESCRIPTION
#### b30e5d409182c801fb31e20e53360472f1f67971
<pre>
Enable warning flags that are on by default in open source clang-17
<a href="https://bugs.webkit.org/show_bug.cgi?id=267387">https://bugs.webkit.org/show_bug.cgi?id=267387</a>
&lt;<a href="https://rdar.apple.com/120817888">rdar://120817888</a>&gt;

Reviewed by Alexey Proskuryakov.

* Configurations/CommonBase.xcconfig:
(WK_COMMON_WARNING_CFLAGS):
- Add warning flags that are enabled by default in open source clang-17
  to make sure they don&apos;t regress.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _updateInputContextAfterBlurringAndRefocusingElement]):
- Add early return to avoid warning.
* Source/WebKit/UIProcess/ios/WKTextInteractionWrapper.mm:
(-[WKTextInteractionWrapper initWithView:]):
- Add block to fix -Wmisleading-indentation warning.

Canonical link: <a href="https://commits.webkit.org/272978@main">https://commits.webkit.org/272978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/522733050986bd4a51e5e3c17562b40774b49fe4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36393 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30623 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9700 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29700 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30119 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9243 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9347 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37713 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30458 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35465 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7415 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33356 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11260 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10061 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4354 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10268 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->