### PR TITLE
Reduce use of downcast<>() in Modules/

### DIFF
--- a/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.cpp
+++ b/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.cpp
@@ -43,9 +43,8 @@ namespace WebCore {
 
 ExceptionOr<Ref<BarcodeDetector>> BarcodeDetector::create(ScriptExecutionContext& scriptExecutionContext, const BarcodeDetectorOptions& barcodeDetectorOptions)
 {
-    if (is<Document>(scriptExecutionContext)) {
-        const auto& document = downcast<Document>(scriptExecutionContext);
-        const auto* page = document.page();
+    if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
+        RefPtr page = document->page();
         if (!page)
             return Exception { ExceptionCode::AbortError };
         auto backing = page->chrome().createBarcodeDetector(barcodeDetectorOptions.convertToBacking());
@@ -72,9 +71,8 @@ BarcodeDetector::~BarcodeDetector() = default;
 
 ExceptionOr<void> BarcodeDetector::getSupportedFormats(ScriptExecutionContext& scriptExecutionContext, GetSupportedFormatsPromise&& promise)
 {
-    if (is<Document>(scriptExecutionContext)) {
-        const auto& document = downcast<Document>(scriptExecutionContext);
-        const auto* page = document.page();
+    if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
+        RefPtr page = document->page();
         if (!page)
             return Exception { ExceptionCode::AbortError };
         page->chrome().getBarcodeDetectorSupportedFormats(([promise = WTFMove(promise)](Vector<ShapeDetection::BarcodeFormat>&& barcodeFormats) mutable {

--- a/Source/WebCore/Modules/ShapeDetection/FaceDetector.cpp
+++ b/Source/WebCore/Modules/ShapeDetection/FaceDetector.cpp
@@ -42,9 +42,8 @@ namespace WebCore {
 
 ExceptionOr<Ref<FaceDetector>> FaceDetector::create(ScriptExecutionContext& scriptExecutionContext, const FaceDetectorOptions& faceDetectorOptions)
 {
-    if (is<Document>(scriptExecutionContext)) {
-        const auto& document = downcast<Document>(scriptExecutionContext);
-        const auto* page = document.page();
+    if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
+        RefPtr page = document->page();
         if (!page)
             return Exception { ExceptionCode::AbortError };
         auto backing = page->chrome().createFaceDetector(faceDetectorOptions.convertToBacking());

--- a/Source/WebCore/Modules/ShapeDetection/TextDetector.cpp
+++ b/Source/WebCore/Modules/ShapeDetection/TextDetector.cpp
@@ -41,9 +41,8 @@ namespace WebCore {
 
 ExceptionOr<Ref<TextDetector>> TextDetector::create(ScriptExecutionContext& scriptExecutionContext)
 {
-    if (is<Document>(scriptExecutionContext)) {
-        const auto& document = downcast<Document>(scriptExecutionContext);
-        const auto* page = document.page();
+    if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
+        RefPtr page = document->page();
         if (!page)
             return Exception { ExceptionCode::AbortError };
         auto backing = page->chrome().createTextDetector();

--- a/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp
+++ b/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp
@@ -108,7 +108,7 @@ ApplePayAMSUIPaymentHandler::ApplePayAMSUIPaymentHandler(Document& document, con
 
 Document& ApplePayAMSUIPaymentHandler::document() const
 {
-    ASSERT(is<Document>(scriptExecutionContext()));
+    ASSERT(scriptExecutionContext());
     return downcast<Document>(*scriptExecutionContext());
 }
 

--- a/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
@@ -174,12 +174,10 @@ std::optional<Vector<Ref<SharedBuffer>>> InitDataRegistry::extractKeyIDsCenc(con
             return std::nullopt;
 
 #if HAVE(FAIRPLAYSTREAMING_CENC_INITDATA)
-        if (is<ISOFairPlayStreamingPsshBox>(*psshBox)) {
-            ISOFairPlayStreamingPsshBox& fpsPssh = downcast<ISOFairPlayStreamingPsshBox>(*psshBox);
-
-            FourCC scheme = fpsPssh.initDataBox().info().scheme();
+        if (auto* fpsPssh = dynamicDowncast<ISOFairPlayStreamingPsshBox>(*psshBox)) {
+            FourCC scheme = fpsPssh->initDataBox().info().scheme();
             if (CDMPrivateFairPlayStreaming::validFairPlayStreamingSchemes().contains(scheme)) {
-                for (const auto& request : fpsPssh.initDataBox().requests()) {
+                for (const auto& request : fpsPssh->initDataBox().requests()) {
                     auto& keyID = request.requestInfo().keyID();
                     keyIDs.append(SharedBuffer::create(keyID.data(), keyID.size()));
                 }

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -165,7 +165,8 @@ static inline std::optional<Exception> processInvalidSignal(ScriptExecutionConte
     ASCIILiteral message { "FetchRequestInit.signal should be undefined, null or an AbortSignal object. This will throw in a future release."_s };
     context.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, message);
 
-    if (is<Document>(context) && downcast<Document>(context).quirks().shouldIgnoreInvalidSignal())
+    RefPtr document = dynamicDowncast<Document>(context);
+    if (document && document->quirks().shouldIgnoreInvalidSignal())
         return { };
 
     RELEASE_LOG_ERROR(ResourceLoading, "FetchRequestInit.signal should be undefined, null or an AbortSignal object.");

--- a/Source/WebCore/Modules/highlight/AppHighlightStorage.cpp
+++ b/Source/WebCore/Modules/highlight/AppHighlightStorage.cpp
@@ -54,10 +54,7 @@ static constexpr unsigned textPreviewLength = 500;
 
 static RefPtr<Node> findNodeByPathIndex(const Node& parent, unsigned pathIndex, const String& nodeName)
 {
-    if (!is<ContainerNode>(parent))
-        return nullptr;
-
-    for (RefPtr child = downcast<ContainerNode>(parent).firstChild(); child; child = child->nextSibling()) {
+    for (RefPtr child = parent.firstChild(); child; child = child->nextSibling()) {
         if (nodeName != child->nodeName())
             continue;
 
@@ -80,7 +77,8 @@ static std::pair<RefPtr<Node>, size_t> findNodeStartingAtPathComponentIndex(cons
         if (!nextNode)
             return { nullptr, currentPathIndex };
 
-        if (is<CharacterData>(*nextNode) && downcast<CharacterData>(*nextNode).data() != component.textData)
+        auto* chararacterData = dynamicDowncast<CharacterData>(*nextNode);
+        if (chararacterData && chararacterData->data() != component.textData)
             return { nullptr, currentPathIndex };
 
         currentNode = WTFMove(nextNode);
@@ -183,10 +181,12 @@ static unsigned computePathIndex(const Node& node)
 
 static AppHighlightRangeData::NodePathComponent createNodePathComponent(const Node& node)
 {
+    auto* element = dynamicDowncast<Element>(node);
+    auto* characterData = dynamicDowncast<CharacterData>(node);
     return {
-        is<Element>(node) ? downcast<Element>(node).getIdAttribute().string() : nullString(),
+        element ? element->getIdAttribute().string() : nullString(),
         node.nodeName(),
-        is<CharacterData>(node) ? downcast<CharacterData>(node).data() : nullString(),
+        characterData ? characterData->data() : nullString(),
         computePathIndex(node)
     };
 }

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
@@ -469,8 +469,10 @@ void IDBDatabase::dispatchEvent(Event& event)
 
     EventTarget::dispatchEvent(event);
 
-    if (event.isVersionChangeEvent() && event.type() == m_eventNames.versionchangeEvent)
-        m_connectionProxy->didFireVersionChangeEvent(m_databaseConnectionIdentifier, downcast<IDBVersionChangeEvent>(event).requestIdentifier());
+    if (auto* versionChangeEvent = dynamicDowncast<IDBVersionChangeEvent>(event)) {
+        if (versionChangeEvent->type() == m_eventNames.versionchangeEvent)
+            m_connectionProxy->didFireVersionChangeEvent(m_databaseConnectionIdentifier, versionChangeEvent->requestIdentifier());
+    }
 }
 
 void IDBDatabase::didCreateIndexInfo(const IDBIndexInfo& info)

--- a/Source/WebCore/Modules/indexeddb/IDBFactory.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBFactory.cpp
@@ -48,11 +48,10 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(IDBFactory);
 static bool shouldThrowSecurityException(ScriptExecutionContext& context)
 {
     ASSERT(is<Document>(context) || context.isWorkerGlobalScope());
-    if (is<Document>(context)) {
-        Document& document = downcast<Document>(context);
-        if (!document.frame())
+    if (auto* document = dynamicDowncast<Document>(context)) {
+        if (!document->frame())
             return true;
-        if (!document.page())
+        if (!document->page())
             return true;
     }
 

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -348,8 +348,8 @@ ExceptionOr<Ref<IDBRequest>> IDBObjectStore::putOrAdd(JSGlobalObject& state, JSV
         return Exception { ExceptionCode::DataCloneError, "Failed to store record in an IDBObjectStore: An object could not be cloned."_s };
 
     bool privateBrowsingEnabled = false;
-    if (is<Document>(*context)) {
-        if (auto* page = downcast<Document>(*context).page())
+    if (auto* document = dynamicDowncast<Document>(*context)) {
+        if (auto* page = document->page())
             privateBrowsingEnabled = page->sessionID().isEphemeral();
     }
 

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
@@ -249,8 +249,8 @@ void MediaCapabilities::decodingInfo(ScriptExecutionContext& context, MediaDecod
         });
     };
 
-    if (is<Document>(context)) {
-        gatherDecodingInfo(downcast<Document>(context), WTFMove(configuration), WTFMove(callback));
+    if (RefPtr document = dynamicDowncast<Document>(context)) {
+        gatherDecodingInfo(*document, WTFMove(configuration), WTFMove(callback));
         return;
     }
 
@@ -306,8 +306,8 @@ void MediaCapabilities::encodingInfo(ScriptExecutionContext& context, MediaEncod
         });
     };
 
-    if (is<Document>(context)) {
-        gatherEncodingInfo(downcast<Document>(context), WTFMove(configuration), WTFMove(callback));
+    if (RefPtr document = dynamicDowncast<Document>(context)) {
+        gatherEncodingInfo(*document, WTFMove(configuration), WTFMove(callback));
         return;
     }
 

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -431,12 +431,11 @@ public:
     {
         ASSERT(event.type() == eventNames().contextmenuEvent);
 
-        RefPtr target = event.target();
-        if (!is<Node>(target.get()))
+        RefPtr target = dynamicDowncast<Node>(event.target());
+        if (!target)
             return;
-        Ref node = downcast<Node>(target.releaseNonNull());
 
-        auto* page = node->document().page();
+        auto* page = target->document().page();
         if (!page)
             return;
 
@@ -601,12 +600,8 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
 
                 if (RefPtr cues = textTrack->cues()) {
                     for (unsigned i = 0; i < cues->length(); ++i) {
-                        RefPtr cue = cues->item(i);
-                        if (!is<VTTCue>(cue.get()))
-                            continue;
-
-                        auto& vttCue = downcast<VTTCue>(*cue);
-                        chapterMenuItems.append(createMenuItem(RefPtr { &vttCue }, vttCue.text()));
+                        if (RefPtr vttCue = dynamicDowncast<VTTCue>(cues->item(i)))
+                            chapterMenuItems.append(createMenuItem(vttCue.copyRef(), vttCue->text()));
                     }
                 }
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -435,8 +435,8 @@ MediaProducerMediaStateFlags MediaStreamTrack::mediaState() const
     if (m_ended || !isCaptureTrack())
         return MediaProducer::IsNotPlaying;
 
-    RefPtr context = scriptExecutionContext();
-    if (!context || !is<Document>(context) || !downcast<Document>(context)->page())
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
+    if (!document || !document->page())
         return MediaProducer::IsNotPlaying;
 
     return sourceCaptureState(source());
@@ -530,7 +530,6 @@ void MediaStreamTrack::updateToPageMutedState()
     if (!context)
         return;
 
-    ASSERT(is<Document>(context));
     auto& document = downcast<Document>(*context);
     auto* page = document.page();
     if (!page)
@@ -691,11 +690,11 @@ void MediaStreamTrack::trackEnabledChanged(MediaStreamTrackPrivate&)
 
 void MediaStreamTrack::configureTrackRendering()
 {
-    RefPtr context = scriptExecutionContext();
-    if (!context || !is<Document>(context))
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
+    if (!document)
         return;
 
-    downcast<Document>(context)->updateIsPlayingMedia();
+    document->updateIsPlayingMedia();
 
     // 4.3.1
     // ... media from the source only flows when a MediaStreamTrack object is both unmuted and enabled

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -339,14 +339,14 @@ PlatformLayerIdentifier HTMLModelElement::platformLayerID()
     if (!page)
         return { };
 
-    if (!is<RenderLayerModelObject>(this->renderer()))
+    auto* renderLayerModelObject = dynamicDowncast<RenderLayerModelObject>(this->renderer());
+    if (!renderLayerModelObject)
         return { };
 
-    auto& renderLayerModelObject = downcast<RenderLayerModelObject>(*this->renderer());
-    if (!renderLayerModelObject.isComposited() || !renderLayerModelObject.layer() || !renderLayerModelObject.layer()->backing())
+    if (!renderLayerModelObject->isComposited() || !renderLayerModelObject->layer() || !renderLayerModelObject->layer()->backing())
         return { };
 
-    RefPtr graphicsLayer = renderLayerModelObject.layer()->backing()->graphicsLayer();
+    RefPtr graphicsLayer = renderLayerModelObject->layer()->backing()->graphicsLayer();
     if (!graphicsLayer)
         return { };
 
@@ -403,7 +403,6 @@ void HTMLModelElement::defaultEventHandler(Event& event)
     if (type != eventNames().mousedownEvent && type != eventNames().mousemoveEvent && type != eventNames().mouseupEvent)
         return;
 
-    ASSERT(is<MouseEvent>(event));
     auto& mouseEvent = downcast<MouseEvent>(event);
 
     if (mouseEvent.button() != MouseButton::Left)

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -60,12 +60,12 @@ SpeechSynthesis::SpeechSynthesis(ScriptExecutionContext& context)
     , m_restrictions(NoRestrictions)
     , m_speechSynthesisClient(nullptr)
 {
-    if (context.isDocument()) {
+    if (RefPtr document = dynamicDowncast<Document>(context)) {
 #if PLATFORM(IOS_FAMILY)
-        if (downcast<Document>(context).requiresUserGestureForAudioPlayback())
+        if (document->requiresUserGestureForAudioPlayback())
             m_restrictions = RequireUserGestureForSpeechStartRestriction;
 #endif
-        m_speechSynthesisClient = downcast<Document>(context).frame()->page()->speechSynthesisClient();
+        m_speechSynthesisClient = document->frame()->page()->speechSynthesisClient();
     }
 
     if (m_speechSynthesisClient) {

--- a/Source/WebCore/Modules/storage/StorageManager.cpp
+++ b/Source/WebCore/Modules/storage/StorageManager.cpp
@@ -74,15 +74,15 @@ static ExceptionOr<ConnectionInfo> connectionInfo(NavigatorBase* navigator)
     RefPtr origin = context->securityOrigin();
     ASSERT(origin);
 
-    if (is<Document>(context)) {
-        if (RefPtr connection = downcast<Document>(context)->storageConnection())
-            return ConnectionInfo { *connection, { context->topOrigin().data(), origin->data() } };
+    if (RefPtr document = dynamicDowncast<Document>(context)) {
+        if (RefPtr connection = document->storageConnection())
+            return ConnectionInfo { *connection, { document->topOrigin().data(), origin->data() } };
 
         return Exception { ExceptionCode::InvalidStateError, "Connection is invalid"_s };
     }
 
-    if (is<WorkerGlobalScope>(context))
-        return ConnectionInfo { downcast<WorkerGlobalScope>(context)->storageConnection(), { context->topOrigin().data(), origin->data() } };
+    if (RefPtr globalScope = dynamicDowncast<WorkerGlobalScope>(context))
+        return ConnectionInfo { globalScope->storageConnection(), { globalScope->topOrigin().data(), origin->data() } };
 
     return Exception { ExceptionCode::NotSupportedError };
 }

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -184,7 +184,8 @@ void WebLockManager::request(const String& name, Options&& options, Ref<WebLockG
         return;
     }
     auto& context = *scriptExecutionContext();
-    if ((is<Document>(context) && !downcast<Document>(context).isFullyActive())) {
+    auto* document = dynamicDowncast<Document>(context);
+    if (document && !document->isFullyActive()) {
         releasePromise->reject(ExceptionCode::InvalidStateError, "Responsible document is not fully active"_s);
         return;
     }
@@ -292,7 +293,8 @@ void WebLockManager::query(Ref<DeferredPromise>&& promise)
         return;
     }
     auto& context = *scriptExecutionContext();
-    if ((is<Document>(context) && !downcast<Document>(context).isFullyActive())) {
+    auto* document = dynamicDowncast<Document>(context);
+    if (document && !document->isFullyActive()) {
         promise->reject(ExceptionCode::InvalidStateError, "Responsible document is not fully active"_s);
         return;
     }

--- a/Source/WebCore/Modules/webaudio/AudioNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNode.cpp
@@ -205,8 +205,9 @@ ExceptionOr<void> AudioNode::connect(AudioNode& destination, unsigned outputInde
     if (!output->numberOfChannels())
         return Exception { ExceptionCode::InvalidAccessError, "Node has zero output channels"_s };
 
-    if (is<AudioContext>(context) && &destination == &context.destination() && !downcast<AudioContext>(context).destination().isConnected())
-        downcast<AudioContext>(context).defaultDestinationWillBecomeConnected();
+    RefPtr audioContext = dynamicDowncast<AudioContext>(context);
+    if (audioContext && &destination == &context.destination() && !audioContext->destination().isConnected())
+        audioContext->defaultDestinationWillBecomeConnected();
 
     input->connect(output);
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h
@@ -91,7 +91,11 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AudioWorkletGlobalScope)
-static bool isType(const WebCore::ScriptExecutionContext& context) { return is<WebCore::WorkletGlobalScope>(context) && downcast<WebCore::WorkletGlobalScope>(context).isAudioWorkletGlobalScope(); }
+static bool isType(const WebCore::ScriptExecutionContext& context)
+{
+    auto* workletGlobalScope = dynamicDowncast<WebCore::WorkletGlobalScope>(context);
+    return workletGlobalScope && workletGlobalScope->isAudioWorkletGlobalScope();
+}
 static bool isType(const WebCore::WorkletGlobalScope& context) { return context.isAudioWorkletGlobalScope(); }
 SPECIALIZE_TYPE_TRAITS_END()
 

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
@@ -56,7 +56,8 @@ OfflineAudioContext::OfflineAudioContext(Document& document, const OfflineAudioC
 
 ExceptionOr<Ref<OfflineAudioContext>> OfflineAudioContext::create(ScriptExecutionContext& context, const OfflineAudioContextOptions& options)
 {
-    if (!is<Document>(context))
+    auto* document = dynamicDowncast<Document>(context);
+    if (!document)
         return Exception { ExceptionCode::NotSupportedError, "OfflineAudioContext is only supported in Document contexts"_s };
     if (!options.numberOfChannels || options.numberOfChannels > maxNumberOfChannels)
         return Exception { ExceptionCode::NotSupportedError, "Number of channels is not in range"_s };
@@ -65,7 +66,7 @@ ExceptionOr<Ref<OfflineAudioContext>> OfflineAudioContext::create(ScriptExecutio
     if (!isSupportedSampleRate(options.sampleRate))
         return Exception { ExceptionCode::NotSupportedError, "sampleRate is not in range"_s };
 
-    auto audioContext = adoptRef(*new OfflineAudioContext(downcast<Document>(context), options));
+    Ref audioContext = adoptRef(*new OfflineAudioContext(*document, options));
     audioContext->suspendIfNeeded();
     return audioContext;
 }

--- a/Source/WebCore/Modules/webdatabase/DatabaseContext.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseContext.cpp
@@ -177,9 +177,8 @@ bool DatabaseContext::stopDatabases(DatabaseTaskSynchronizer* synchronizer)
 bool DatabaseContext::allowDatabaseAccess() const
 {
     RefPtr context = scriptExecutionContext();
-    if (is<Document>(*context)) {
-        auto& document = downcast<Document>(*context);
-        if (!document.page() || (document.page()->usesEphemeralSession() && !LegacySchemeRegistry::allowsDatabaseAccessInPrivateBrowsing(document.securityOrigin().protocol())))
+    if (RefPtr document = dynamicDowncast<Document>(*context)) {
+        if (!document->page() || (document->page()->usesEphemeralSession() && !LegacySchemeRegistry::allowsDatabaseAccessInPrivateBrowsing(document->securityOrigin().protocol())))
             return false;
         return true;
     }
@@ -191,10 +190,9 @@ bool DatabaseContext::allowDatabaseAccess() const
 void DatabaseContext::databaseExceededQuota(const String& name, DatabaseDetails details)
 {
     RefPtr context = scriptExecutionContext();
-    if (is<Document>(*context)) {
-        auto& document = downcast<Document>(*context);
-        if (Page* page = document.page())
-            page->chrome().client().exceededDatabaseQuota(*document.frame(), name, details);
+    if (RefPtr document = dynamicDowncast<Document>(*context)) {
+        if (RefPtr page = document->page())
+            page->chrome().client().exceededDatabaseQuota(*document->frame(), name, details);
         return;
     }
     ASSERT(context->isWorkerGlobalScope());

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
@@ -57,10 +57,9 @@ RefPtr<ThreadableWebSocketChannel> ThreadableWebSocketChannel::create(Document& 
 
 RefPtr<ThreadableWebSocketChannel> ThreadableWebSocketChannel::create(ScriptExecutionContext& context, WebSocketChannelClient& client, SocketProvider& provider)
 {
-    if (is<WorkerGlobalScope>(context)) {
-        WorkerGlobalScope& workerGlobalScope = downcast<WorkerGlobalScope>(context);
-        WorkerRunLoop& runLoop = workerGlobalScope.thread().runLoop();
-        return WorkerThreadableWebSocketChannel::create(workerGlobalScope, client, makeString("webSocketChannelMode", runLoop.createUniqueId()), provider);
+    if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(context)) {
+        WorkerRunLoop& runLoop = workerGlobalScope->thread().runLoop();
+        return WorkerThreadableWebSocketChannel::create(*workerGlobalScope, client, makeString("webSocketChannelMode", runLoop.createUniqueId()), provider);
     }
 
     return create(downcast<Document>(context), client, provider);

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -309,12 +309,11 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
         ResourceLoadObserver::shared().logWebSocketLoading(targetURL, mainFrameURL);
     });
 
-    if (is<Document>(context)) {
-        Document& document = downcast<Document>(context);
-        RefPtr frame = document.frame();
+    if (RefPtr document = dynamicDowncast<Document>(context)) {
+        RefPtr frame = document->frame();
         // FIXME: make the mixed content check equivalent to the non-document mixed content check currently in WorkerThreadableWebSocketChannel::Bridge::connect()
         // In particular we need to match the error messaging in the console and the inspector instrumentation. See WebSocketChannel::fail.
-        if (!frame || !MixedContentChecker::frameAndAncestorsCanRunInsecureContent(*frame, document.securityOrigin(), m_url)) {
+        if (!frame || !MixedContentChecker::frameAndAncestorsCanRunInsecureContent(*frame, document->securityOrigin(), m_url)) {
             failAsynchronously();
             return { };
         }

--- a/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp
@@ -410,7 +410,6 @@ void WorkerThreadableWebSocketChannel::Bridge::connect(const URL& url, const Str
 
     m_loaderProxy.postTaskToLoader([peer = m_peer, url = url.isolatedCopy(), protocol = protocol.isolatedCopy()](ScriptExecutionContext& context) {
         ASSERT(isMainThread());
-        ASSERT(context.isDocument());
         ASSERT(peer);
 
         auto& document = downcast<Document>(context);

--- a/Source/WebCore/Modules/webxr/WebXRBoundedReferenceSpace.h
+++ b/Source/WebCore/Modules/webxr/WebXRBoundedReferenceSpace.h
@@ -64,7 +64,11 @@ private:
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebXRBoundedReferenceSpace)
     static bool isType(const WebCore::WebXRReferenceSpace& element) { return element.isBoundedReferenceSpace(); }
-    static bool isType(const WebCore::WebXRSpace& element) { return is<WebCore::WebXRReferenceSpace>(element) && isType(downcast<WebCore::WebXRReferenceSpace>(element)); }
+    static bool isType(const WebCore::WebXRSpace& element)
+    {
+        auto* referenceSpace = dynamicDowncast<WebCore::WebXRReferenceSpace>(element);
+        return referenceSpace && isType(*referenceSpace);
+    }
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(WEBXR)

--- a/Source/WebCore/Modules/webxr/WebXRFrame.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRFrame.cpp
@@ -68,10 +68,11 @@ bool WebXRFrame::isOutsideNativeBoundsOfBoundedReferenceSpace(const WebXRSpace& 
 
 bool WebXRFrame::isLocalReferenceSpace(const WebXRSpace& space) const
 {
-    if (!is<WebXRReferenceSpace>(space))
+    auto* referenceSpace = dynamicDowncast<WebXRReferenceSpace>(space);
+    if (!referenceSpace)
         return false;
 
-    auto type = downcast<WebXRReferenceSpace>(space).type();
+    auto type = referenceSpace->type();
     if (type == XRReferenceSpaceType::Local || type == XRReferenceSpaceType::LocalFloor)
         return true;
 


### PR DESCRIPTION
#### 1ada299af123bdb34c2b267be68025a06ecae43b
<pre>
Reduce use of downcast&lt;&gt;() in Modules/
<a href="https://bugs.webkit.org/show_bug.cgi?id=267392">https://bugs.webkit.org/show_bug.cgi?id=267392</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/Modules/ShapeDetection/BarcodeDetector.cpp:
(WebCore::BarcodeDetector::create):
(WebCore::BarcodeDetector::getSupportedFormats):
* Source/WebCore/Modules/ShapeDetection/FaceDetector.cpp:
(WebCore::FaceDetector::create):
* Source/WebCore/Modules/ShapeDetection/TextDetector.cpp:
(WebCore::TextDetector::create):
* Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp:
(WebCore::ApplePayAMSUIPaymentHandler::document const):
* Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp:
(WebCore::InitDataRegistry::extractKeyIDsCenc):
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::processInvalidSignal):
* Source/WebCore/Modules/highlight/AppHighlightStorage.cpp:
(WebCore::findNodeByPathIndex):
(WebCore::findNodeStartingAtPathComponentIndex):
(WebCore::createNodePathComponent):
* Source/WebCore/Modules/indexeddb/IDBDatabase.cpp:
(WebCore::IDBDatabase::dispatchEvent):
* Source/WebCore/Modules/indexeddb/IDBFactory.cpp:
(WebCore::shouldThrowSecurityException):
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::putOrAdd):
* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp:
(WebCore::MediaCapabilities::decodingInfo):
(WebCore::MediaCapabilities::encodingInfo):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::showMediaControlsContextMenu):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::addSourceBuffer):
(WebCore::MediaSource::isTypeSupported):
(WebCore::MediaSource::createSourceBufferPrivate):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::mediaState const):
(WebCore::MediaStreamTrack::updateToPageMutedState):
(WebCore::MediaStreamTrack::configureTrackRendering):
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::platformLayerID):
(WebCore::HTMLModelElement::defaultEventHandler):
* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
(WebCore::SpeechSynthesis::SpeechSynthesis):
* Source/WebCore/Modules/storage/StorageManager.cpp:
(WebCore::connectionInfo):
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
(WebCore::WebLockManager::request):
(WebCore::WebLockManager::query):
* Source/WebCore/Modules/webaudio/AudioNode.cpp:
(WebCore::AudioNode::connect):
* Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h:
(isType):
* Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp:
(WebCore::OfflineAudioContext::create):
* Source/WebCore/Modules/webdatabase/DatabaseContext.cpp:
(WebCore::DatabaseContext::allowDatabaseAccess const):
(WebCore::DatabaseContext::databaseExceededQuota):
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp:
(WebCore::ThreadableWebSocketChannel::create):
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::connect):
* Source/WebCore/Modules/websockets/WorkerThreadableWebSocketChannel.cpp:
(WebCore::WorkerThreadableWebSocketChannel::Bridge::connect):
* Source/WebCore/Modules/webxr/WebXRBoundedReferenceSpace.h:
(isType):
* Source/WebCore/Modules/webxr/WebXRFrame.cpp:
(WebCore::WebXRFrame::isLocalReferenceSpace const):

Canonical link: <a href="https://commits.webkit.org/272920@main">https://commits.webkit.org/272920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be28f68e1b7d91070b3b2436502b431f2ad4dfce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33535 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36153 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30435 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34572 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29550 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29905 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9055 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37481 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30427 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35287 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9293 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33162 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11057 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9877 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4316 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10047 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->