### PR TITLE
Reduce use of downcast<>() in loader/

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1183,9 +1183,8 @@ void DocumentLoader::continueAfterContentPolicy(PolicyAction policy)
     if (m_response.isInHTTPFamily()) {
         int status = m_response.httpStatusCode(); // Status may be zero when loading substitute data, in particular from a WebArchive.
         if (status && (status < 200 || status >= 300)) {
-            auto* owner = m_frame->ownerElement();
-            if (is<HTMLObjectElement>(owner)) {
-                downcast<HTMLObjectElement>(*owner).renderFallbackContent();
+            if (RefPtr owner = dynamicDowncast<HTMLObjectElement>(m_frame->ownerElement())) {
+                owner->renderFallbackContent();
                 // object elements are no longer rendered after we fallback, so don't
                 // keep trying to process data from their load
                 cancelMainResourceLoad(frameLoader()->cancelledError(m_request));

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1116,7 +1116,8 @@ String FrameLoader::outgoingReferrer() const
     }
     if (!frame)
         return emptyString();
-    return is<LocalFrame>(*frame) ? downcast<LocalFrame>(*frame).loader().m_outgoingReferrer : emptyString();
+    auto* localFrame = dynamicDowncast<LocalFrame>(*frame);
+    return localFrame ? localFrame->loader().m_outgoingReferrer : emptyString();
 }
 
 String FrameLoader::outgoingOrigin() const
@@ -1251,10 +1252,10 @@ void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stat
     started();
 
     if (RefPtr ownerElement = m_frame->ownerElement()) {
-        CheckedPtr ownerRenderer = ownerElement->renderer();
+        CheckedPtr ownerRenderer = dynamicDowncast<RenderWidget>(ownerElement->renderer());
         RefPtr view = m_frame->view();
-        if (is<RenderWidget>(ownerRenderer.get()) && view)
-            downcast<RenderWidget>(*ownerRenderer).setWidget(WTFMove(view));
+        if (ownerRenderer && view)
+            ownerRenderer->setWidget(WTFMove(view));
     }
 
     // We need to scroll to the fragment whether or not a hash change occurred, since

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -257,7 +257,8 @@ void ResourceLoader::start()
     }
 #endif
 
-    RefPtr<SecurityOrigin> sourceOrigin = is<SubresourceLoader>(*this) ? downcast<SubresourceLoader>(*this).origin() : nullptr;
+    auto* subresourceLoader = dynamicDowncast<SubresourceLoader>(*this);
+    RefPtr<SecurityOrigin> sourceOrigin = subresourceLoader ? subresourceLoader->origin() : nullptr;
     if (!sourceOrigin && frameLoader()) {
         auto* document = frameLoader()->frame().document();
         sourceOrigin =  document ? &document->securityOrigin() : nullptr;

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -924,7 +924,6 @@ void SubresourceLoader::reportResourceTiming(const NetworkLoadMetrics& networkLo
     // Worker's Performance object.
     if (options().initiatorContext == InitiatorContext::Worker) {
         ASSERT(m_origin);
-        ASSERT(is<CachedRawResource>(*resource));
         downcast<CachedRawResource>(*resource).finishedTimingForWorkerLoad(WTFMove(resourceTiming));
         return;
     }

--- a/Source/WebCore/loader/WorkerThreadableLoader.cpp
+++ b/Source/WebCore/loader/WorkerThreadableLoader.cpp
@@ -154,8 +154,8 @@ WorkerThreadableLoader::MainThreadBridge::MainThreadBridge(ThreadableLoaderClien
     if (!optionsCopy->options.clientIdentifier)
         optionsCopy->options.clientIdentifier = globalScope.identifier().object();
 
-    if (is<WorkerGlobalScope>(globalScope))
-        InspectorInstrumentation::willSendRequest(downcast<WorkerGlobalScope>(globalScope), m_workerRequestIdentifier, request);
+    if (auto* workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(globalScope))
+        InspectorInstrumentation::willSendRequest(*workerGlobalScope, m_workerRequestIdentifier, request);
 
     if (!m_loaderProxy)
         return;
@@ -252,8 +252,8 @@ void WorkerThreadableLoader::MainThreadBridge::didReceiveResponse(ResourceLoader
         ASSERT(context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
         auto response = ResourceResponse::fromCrossThreadData(WTFMove(responseData));
         protectedWorkerClientWrapper->didReceiveResponse(identifier, response);
-        if (is<WorkerGlobalScope>(context))
-            InspectorInstrumentation::didReceiveResourceResponse(downcast<WorkerGlobalScope>(context), workerRequestIdentifier, response);
+        if (auto* globalScope = dynamicDowncast<WorkerGlobalScope>(context))
+            InspectorInstrumentation::didReceiveResourceResponse(*globalScope, workerRequestIdentifier, response);
     }, m_taskMode);
 }
 
@@ -262,8 +262,8 @@ void WorkerThreadableLoader::MainThreadBridge::didReceiveData(const SharedBuffer
     ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_contextIdentifier, [protectedWorkerClientWrapper = Ref { *m_workerClientWrapper }, workerRequestIdentifier = m_workerRequestIdentifier, buffer = Ref { data }] (ScriptExecutionContext& context) {
         ASSERT(context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
         protectedWorkerClientWrapper->didReceiveData(buffer);
-        if (is<WorkerGlobalScope>(context))
-            InspectorInstrumentation::didReceiveData(downcast<WorkerGlobalScope>(context), workerRequestIdentifier, buffer);
+        if (auto* globalScope = dynamicDowncast<WorkerGlobalScope>(context))
+            InspectorInstrumentation::didReceiveData(*globalScope, workerRequestIdentifier, buffer);
     }, m_taskMode);
 }
 
@@ -273,8 +273,8 @@ void WorkerThreadableLoader::MainThreadBridge::didFinishLoading(ResourceLoaderId
     ScriptExecutionContext::postTaskForModeToWorkerOrWorklet(m_contextIdentifier, [protectedWorkerClientWrapper = Ref { *m_workerClientWrapper }, workerRequestIdentifier = m_workerRequestIdentifier, metrics = metrics.isolatedCopy(), identifier] (ScriptExecutionContext& context) mutable {
         ASSERT(context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
         protectedWorkerClientWrapper->didFinishLoading(identifier, metrics);
-        if (is<WorkerGlobalScope>(context))
-            InspectorInstrumentation::didFinishLoading(downcast<WorkerGlobalScope>(context), workerRequestIdentifier, metrics);
+        if (auto* globalScope = dynamicDowncast<WorkerGlobalScope>(context))
+            InspectorInstrumentation::didFinishLoading(*globalScope, workerRequestIdentifier, metrics);
     }, m_taskMode);
 }
 
@@ -285,8 +285,8 @@ void WorkerThreadableLoader::MainThreadBridge::didFail(const ResourceError& erro
         ASSERT(context.isWorkerGlobalScope() || context.isWorkletGlobalScope());
         ThreadableLoader::logError(context, error, protectedWorkerClientWrapper->initiator());
         protectedWorkerClientWrapper->didFail(error);
-        if (is<WorkerGlobalScope>(context))
-            InspectorInstrumentation::didFailLoading(downcast<WorkerGlobalScope>(context), workerRequestIdentifier, error);
+        if (auto* globalScope = dynamicDowncast<WorkerGlobalScope>(context))
+            InspectorInstrumentation::didFailLoading(*globalScope, workerRequestIdentifier, error);
     }, m_taskMode);
 }
 
@@ -298,8 +298,8 @@ void WorkerThreadableLoader::MainThreadBridge::didFinishTiming(const ResourceTim
         ASSERT(!resourceTiming.initiatorType().isEmpty());
 
         // No need to notify clients, just add the performance timing entry.
-        if (is<WorkerGlobalScope>(context))
-            downcast<WorkerGlobalScope>(context).performance().addResourceTiming(WTFMove(resourceTiming));
+        if (auto* globalScope = dynamicDowncast<WorkerGlobalScope>(context))
+            globalScope->performance().addResourceTiming(WTFMove(resourceTiming));
     }, m_taskMode);
 }
 

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -546,10 +546,11 @@ static void addSubresourcesForAttachmentElementsIfNecessary(LocalFrame& frame, c
 
     Vector<String> identifiers;
     for (auto& node : nodes) {
-        if (!is<HTMLAttachmentElement>(node))
+        auto* attachment = dynamicDowncast<HTMLAttachmentElement>(node.get());
+        if (!attachment)
             continue;
 
-        auto uniqueIdentifier = downcast<HTMLAttachmentElement>(node.get()).uniqueIdentifier();
+        auto uniqueIdentifier = attachment->uniqueIdentifier();
         if (uniqueIdentifier.isEmpty())
             continue;
 
@@ -586,17 +587,16 @@ static HashMap<RefPtr<CSSStyleSheet>, String> addSubresourcesForCSSStyleSheetsIf
     HashMap<RefPtr<CSSStyleSheet>, String> relativeUniqueCSSStyleSheets;
     Ref documentStyleSheets = document->styleSheets();
     for (unsigned index = 0; index < documentStyleSheets->length(); ++index) {
-        RefPtr styleSheet = documentStyleSheets->item(index);
-        if (!is<CSSStyleSheet>(styleSheet))
+        RefPtr cssStyleSheet = dynamicDowncast<CSSStyleSheet>(documentStyleSheets->item(index));
+        if (!cssStyleSheet)
             continue;
 
-        auto& cssStyleSheet = downcast<CSSStyleSheet>(*styleSheet);
-        if (uniqueCSSStyleSheets.contains(&cssStyleSheet))
+        if (uniqueCSSStyleSheets.contains(cssStyleSheet.get()))
             continue;
 
         HashSet<RefPtr<CSSStyleSheet>> cssStyleSheets;
-        cssStyleSheets.add(&cssStyleSheet);
-        cssStyleSheet.getChildStyleSheets(cssStyleSheets);
+        cssStyleSheets.add(cssStyleSheet.get());
+        cssStyleSheet->getChildStyleSheets(cssStyleSheets);
         for (auto& currentCSSStyleSheet : cssStyleSheets) {
             bool isExternalStyleSheet = !currentCSSStyleSheet->href().isEmpty() || currentCSSStyleSheet->ownerRule();
             if (!isExternalStyleSheet)

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -684,8 +684,8 @@ void MemoryCache::adjustSize(bool live, long long delta)
 
 void MemoryCache::removeRequestFromSessionCaches(ScriptExecutionContext& context, const ResourceRequest& request)
 {
-    if (is<WorkerGlobalScope>(context)) {
-        auto* workerLoaderProxy = downcast<WorkerGlobalScope>(context).thread().workerLoaderProxy();
+    if (auto* globalScope = dynamicDowncast<WorkerGlobalScope>(context)) {
+        auto* workerLoaderProxy = globalScope->thread().workerLoaderProxy();
         if (!workerLoaderProxy)
             return;
         workerLoaderProxy->postTaskToLoader([request = request.isolatedCopy()] (ScriptExecutionContext& context) {


### PR DESCRIPTION
#### 5bfff50d340a414cc27893332843b66616a78350
<pre>
Reduce use of downcast&lt;&gt;() in loader/
<a href="https://bugs.webkit.org/show_bug.cgi?id=267394">https://bugs.webkit.org/show_bug.cgi?id=267394</a>

Reviewed by Brent Fulgham.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::continueAfterContentPolicy):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::outgoingReferrer const):
(WebCore::FrameLoader::loadInSameDocument):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::start):
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::requestObject):
(WebCore::FrameLoader::SubframeLoader::loadSubframe):
(WebCore::FrameLoader::SubframeLoader::loadPlugin):
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::reportResourceTiming):
* Source/WebCore/loader/ThreadableLoader.cpp:
(WebCore::ThreadableLoader::create):
(WebCore::ThreadableLoader::loadResourceSynchronously):
* Source/WebCore/loader/WorkerThreadableLoader.cpp:
(WebCore::m_contextIdentifier):
(WebCore::WorkerThreadableLoader::MainThreadBridge::didReceiveResponse):
(WebCore::WorkerThreadableLoader::MainThreadBridge::didReceiveData):
(WebCore::WorkerThreadableLoader::MainThreadBridge::didFinishLoading):
(WebCore::WorkerThreadableLoader::MainThreadBridge::didFail):
(WebCore::WorkerThreadableLoader::MainThreadBridge::didFinishTiming):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::addSubresourcesForAttachmentElementsIfNecessary):
(WebCore::addSubresourcesForCSSStyleSheetsIfNecessary):
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::setBodyDataFrom):
(WebCore::CachedImage::removeAllClientsWaitingForAsyncDecoding):
(WebCore::CachedImage::createImage):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestUserCSSStyleSheet):
(WebCore::isSVGImageCachedResource):
(WebCore::CachedResourceLoader::requestResource):
(WebCore::CachedResourceLoader::reloadImagesIfNotDeferred):
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::removeRequestFromSessionCaches):

Canonical link: <a href="https://commits.webkit.org/272926@main">https://commits.webkit.org/272926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b45a36b434875ea3f04062e2ec251a46c5756788

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36169 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30446 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29560 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29916 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9070 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9167 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37496 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30253 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35300 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33177 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11069 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9888 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4318 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10063 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->