### PR TITLE
REGRESSION (268069@main): [iOS] Rotating from landscape to portrait causes date picker to run off screen

### DIFF
--- a/LayoutTests/fast/forms/ios/dismiss-date-picker-on-rotation-expected.txt
+++ b/LayoutTests/fast/forms/ios/dismiss-date-picker-on-rotation-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that rotation dismisses a presented date picker.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Presented date picker
+PASS Dismissed date picker on rotation
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/dismiss-date-picker-on-rotation.html
+++ b/LayoutTests/fast/forms/ios/dismiss-date-picker-on-rotation.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<input type="date"></input>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that rotation dismisses a presented date picker.");
+
+    await UIHelper.activateElement(document.querySelector("input"));
+    await UIHelper.waitForContextMenuToShow();
+    testPassed("Presented date picker");
+
+    await UIHelper.rotateDevice("landscape-right");
+    await UIHelper.ensurePresentationUpdate();
+
+    await UIHelper.waitForContextMenuToHide();
+    testPassed("Dismissed date picker on rotation");
+
+    await UIHelper.rotateDevice("portrait");
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm
@@ -179,11 +179,16 @@
     RELEASE_ASSERT(hitTestedToAccessoryView);
 }
 
-- (void)dismissDatePicker
+- (void)dismissDatePickerAnimated:(BOOL)animated
 {
-    [self.presentingViewController dismissViewControllerAnimated:YES completion:[strongSelf = retainPtr(self)] {
+    [self.presentingViewController dismissViewControllerAnimated:animated completion:[strongSelf = retainPtr(self)] {
         [strongSelf _dispatchPopoverControllerDidDismissIfNeeded];
     }];
+}
+
+- (void)dismissDatePicker
+{
+    [self dismissDatePickerAnimated:YES];
 }
 
 - (void)viewDidLoad
@@ -221,6 +226,14 @@
     }
 
     [self _scaleDownToFitHeightIfNeeded];
+}
+
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
+{
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+
+    if (!self.isBeingPresented && !self.isBeingDismissed)
+        [self dismissDatePickerAnimated:NO];
 }
 
 - (void)_scaleDownToFitHeightIfNeeded


### PR DESCRIPTION
#### ea28020d4d412557991fa342390443d323a3805a
<pre>
REGRESSION (268069@main): [iOS] Rotating from landscape to portrait causes date picker to run off screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=267397">https://bugs.webkit.org/show_bug.cgi?id=267397</a>
<a href="https://rdar.apple.com/118972687">rdar://118972687</a>

Reviewed by Wenson Hsieh.

268069@main modified date picker presentation to use
`UIPopoverPresentationController`, rather than `_UIDatePickerOverlayPresentation`.

`_UIDatePickerOverlayPresentation` automatically handled dismissing the picker
on rotation and view size changes, but `UIPopoverPresentationController` does not.
This results in the date picker being presented at an incorrect location after
rotation, as the view remains presented, and the old layout information is still
used.

Fix by explicitly dismissing the picker on rotation and view size changes, matching
system date/time pickers.

* LayoutTests/fast/forms/ios/dismiss-date-picker-on-rotation-expected.txt: Added.
* LayoutTests/fast/forms/ios/dismiss-date-picker-on-rotation.html: Added.
* Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm:
(-[WKDatePickerPopoverController dismissDatePickerAnimated:]):
(-[WKDatePickerPopoverController dismissDatePicker]):
(-[WKDatePickerPopoverController viewWillTransitionToSize:withTransitionCoordinator:]):

Only dismiss the date picker if it is already presented by checking for
`isBeingPresented` and `isBeingDismissed`.

Canonical link: <a href="https://commits.webkit.org/272922@main">https://commits.webkit.org/272922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb3e021cb409cfac7c37adecbddc826e11d09bd4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36176 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30451 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9488 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29564 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34033 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9076 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9173 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37503 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30259 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35305 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7256 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33184 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11074 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29614 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7771 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9893 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->