### PR TITLE
[JSC] DataIC DirectCall

### DIFF
--- a/Source/JavaScriptCore/bytecode/CallLinkInfoBase.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfoBase.cpp
@@ -43,6 +43,9 @@ void CallLinkInfoBase::unlink(VM& vm)
         static_cast<PolymorphicCallNode*>(this)->unlinkImpl(vm);
         break;
 #endif
+    case CallSiteType::DirectCall:
+        static_cast<DirectCallLinkInfo*>(this)->unlinkImpl(vm);
+        break;
     case CallSiteType::CachedCall:
         static_cast<CachedCall*>(this)->unlinkImpl(vm);
         break;

--- a/Source/JavaScriptCore/bytecode/CallLinkInfoBase.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfoBase.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CallMode.h"
 #include "JSCPtrTag.h"
 #include <wtf/CodePtr.h>
 #include <wtf/SentinelLinkedList.h>
@@ -55,8 +56,67 @@ public:
 #if ENABLE(JIT)
         PolymorphicCallNode,
 #endif
+        DirectCall,
         CachedCall,
     };
+
+    enum CallType : uint8_t {
+        None,
+        Call,
+        CallVarargs,
+        Construct,
+        ConstructVarargs,
+        TailCall,
+        TailCallVarargs,
+        DirectCall,
+        DirectConstruct,
+        DirectTailCall
+    };
+
+    static CallMode callModeFor(CallType callType)
+    {
+        switch (callType) {
+        case Call:
+        case CallVarargs:
+        case DirectCall:
+            return CallMode::Regular;
+        case TailCall:
+        case TailCallVarargs:
+        case DirectTailCall:
+            return CallMode::Tail;
+        case Construct:
+        case ConstructVarargs:
+        case DirectConstruct:
+            return CallMode::Construct;
+        case None:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    static bool isDirect(CallType callType)
+    {
+        switch (callType) {
+        case DirectCall:
+        case DirectTailCall:
+        case DirectConstruct:
+            return true;
+        case Call:
+        case CallVarargs:
+        case TailCall:
+        case TailCallVarargs:
+        case Construct:
+        case ConstructVarargs:
+            return false;
+        case None:
+            RELEASE_ASSERT_NOT_REACHED();
+            return false;
+        }
+
+        RELEASE_ASSERT_NOT_REACHED();
+        return false;
+    }
 
     explicit CallLinkInfoBase(CallSiteType callSiteType)
         : m_callSiteType(callSiteType)

--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
@@ -140,10 +140,6 @@ CallLinkStatus CallLinkStatus::computeFor(
 CallLinkStatus CallLinkStatus::computeFromCallLinkInfo(
     const ConcurrentJSLocker&, CallLinkInfo& callLinkInfo)
 {
-    // We cannot tell you anything about direct calls.
-    if (callLinkInfo.isDirect())
-        return CallLinkStatus();
-    
     if (callLinkInfo.clearedByGC() || callLinkInfo.clearedByVirtual())
         return takesSlowPath();
     

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -1574,6 +1574,8 @@ void CodeBlock::finalizeJITInlineCaches()
     if (JSC::JITCode::isOptimizingJIT(jitType())) {
         for (auto* callLinkInfo : m_jitCode->dfgCommon()->m_callLinkInfos)
             callLinkInfo->visitWeak(vm());
+        for (auto* callLinkInfo : m_jitCode->dfgCommon()->m_directCallLinkInfos)
+            callLinkInfo->visitWeak(vm());
         if (auto* jitData = dfgJITData()) {
             for (auto& callLinkInfo : jitData->callLinkInfos())
                 callLinkInfo.visitWeak(vm());

--- a/Source/JavaScriptCore/bytecode/Repatch.h
+++ b/Source/JavaScriptCore/bytecode/Repatch.h
@@ -85,7 +85,7 @@ void repatchCheckPrivateBrand(JSGlobalObject*, CodeBlock*, JSObject*, CacheableI
 void repatchSetPrivateBrand(JSGlobalObject*, CodeBlock*, JSObject*, Structure*, CacheableIdentifier, StructureStubInfo&);
 void repatchInstanceOf(JSGlobalObject*, CodeBlock*, JSValue, JSValue prototype, StructureStubInfo&, bool wasFound);
 void linkMonomorphicCall(VM&, CallFrame*, CallLinkInfo&, CodeBlock*, JSObject* callee, CodePtr<JSEntryPtrTag>);
-void linkDirectCall(CallFrame*, OptimizingCallLinkInfo&, CodeBlock*, CodePtr<JSEntryPtrTag>);
+void linkDirectCall(CallFrame*, DirectCallLinkInfo&, CodeBlock*, CodePtr<JSEntryPtrTag>);
 void unlinkCall(VM&, CallLinkInfo&);
 void linkPolymorphicCall(JSGlobalObject*, JSCell*, CallFrame*, CallLinkInfo&, CallVariant);
 void resetGetBy(CodeBlock*, StructureStubInfo&, GetByKind);

--- a/Source/JavaScriptCore/bytecode/RepatchInlines.h
+++ b/Source/JavaScriptCore/bytecode/RepatchInlines.h
@@ -104,8 +104,6 @@ ALWAYS_INLINE UGPRPair linkFor(CallFrame* calleeFrame, JSGlobalObject* globalObj
     CodeSpecializationKind kind = callLinkInfo->specializationKind();
     NativeCallFrameTracer tracer(vm, callFrame);
 
-    RELEASE_ASSERT(!callLinkInfo->isDirect());
-
     JSValue calleeAsValue = calleeFrame->guaranteedJSValueCallee();
     JSCell* calleeAsFunctionCell = getJSFunction(calleeAsValue);
     if (!calleeAsFunctionCell) {

--- a/Source/JavaScriptCore/dfg/DFGCommonData.h
+++ b/Source/JavaScriptCore/dfg/DFGCommonData.h
@@ -132,6 +132,7 @@ public:
     FixedVector<std::unique_ptr<BoyerMooreHorspoolTable<uint8_t>>> m_stringSearchTable8;
     Bag<StructureStubInfo> m_stubInfos;
     Bag<OptimizingCallLinkInfo> m_callLinkInfos;
+    Bag<DirectCallLinkInfo> m_directCallLinkInfos;
     Yarr::YarrBoyerMooreData m_boyerMooreData;
     
     ScratchBuffer* catchOSREntryBuffer;

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -289,13 +289,6 @@ void JITCompiler::link(LinkBuffer& linkBuffer)
                 linkBuffer.locationOf<JSInternalPtrTag>(record.doneLocation));
         }, record.info);
     }
-    
-    for (auto& record : m_jsDirectCalls) {
-        auto& info = *record.info;
-        info.setCodeLocations(
-            linkBuffer.locationOf<JSInternalPtrTag>(record.slowPath),
-            CodeLocationLabel<JSInternalPtrTag>());
-    }
 
     if (m_graph.m_plan.isUnlinked()) {
         m_jitCode->m_unlinkedCallLinkInfos = FixedVector<UnlinkedCallLinkInfo>(m_unlinkedCallLinkInfos.size());

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.h
@@ -255,11 +255,6 @@ public:
         m_jsCalls.append(JSCallRecord(slowPathStart, doneLocation, info));
     }
     
-    void addJSDirectCall(Label slowPath, OptimizingCallLinkInfo* info)
-    {
-        m_jsDirectCalls.append(JSDirectCallRecord(slowPath, info));
-    }
-    
     void addWeakReference(JSCell* target)
     {
         m_graph.m_plan.weakReferences().addLazily(target);
@@ -441,17 +436,6 @@ protected:
         CompileTimeCallLinkInfo info;
     };
     
-    struct JSDirectCallRecord {
-        JSDirectCallRecord(Label slowPath, OptimizingCallLinkInfo* info)
-            : slowPath(slowPath)
-            , info(info)
-        {
-        }
-        
-        Label slowPath;
-        OptimizingCallLinkInfo* info;
-    };
-    
     Vector<InlineCacheWrapper<JITGetByIdGenerator>, 4> m_getByIds;
     Vector<InlineCacheWrapper<JITGetByIdWithThisGenerator>, 4> m_getByIdsWithThis;
     Vector<InlineCacheWrapper<JITGetByValGenerator>, 4> m_getByVals;
@@ -465,7 +449,6 @@ protected:
     Vector<InlineCacheWrapper<JITInstanceOfGenerator>, 4> m_instanceOfs;
     Vector<InlineCacheWrapper<JITPrivateBrandAccessGenerator>, 4> m_privateBrandAccesses;
     Vector<JSCallRecord, 4> m_jsCalls;
-    Vector<JSDirectCallRecord, 4> m_jsDirectCalls;
     SegmentedVector<OSRExitCompilationInfo, 4> m_exitCompilationInfo;
     Vector<Vector<Label>> m_exitSiteLabels;
     Vector<DFG::OSREntryData> m_osrEntry;

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4264,7 +4264,7 @@ JSC_DEFINE_JIT_OPERATION(operationThrowStaticError, void, (JSGlobalObject* globa
     scope.throwException(globalObject, createError(globalObject, static_cast<ErrorTypeWithExtension>(errorType), errorMessage));
 }
 
-JSC_DEFINE_JIT_OPERATION(operationLinkDirectCall, void, (OptimizingCallLinkInfo* callLinkInfo, JSFunction* callee))
+JSC_DEFINE_JIT_OPERATION(operationLinkDirectCall, void, (DirectCallLinkInfo* callLinkInfo, JSFunction* callee))
 {
     JSGlobalObject* globalObject = callee->globalObject();
     VM& vm = globalObject->vm();
@@ -4273,25 +4273,9 @@ JSC_DEFINE_JIT_OPERATION(operationLinkDirectCall, void, (OptimizingCallLinkInfo*
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     CodeSpecializationKind kind = callLinkInfo->specializationKind();
-    
-    RELEASE_ASSERT(callLinkInfo->isDirect());
-    
-    // This would happen if the executable died during GC but the CodeBlock did not die. That should
-    // not happen because the CodeBlock should have a weak reference to any executable it uses for
-    // this purpose.
-    RELEASE_ASSERT(callLinkInfo->executable());
-    
-    // Having a CodeBlock indicates that this is linked. We shouldn't be taking this path if it's
-    // linked.
-    RELEASE_ASSERT(!callLinkInfo->codeBlock());
-    
-    // We just don't support this yet.
-    RELEASE_ASSERT(!callLinkInfo->isVarargs());
-    
-    ExecutableBase* executable = callLinkInfo->executable();
-    RELEASE_ASSERT(callee->executable() == callLinkInfo->executable());
 
     JSScope* scope = callee->scopeUnchecked();
+    ExecutableBase* executable = callee->executable();
 
     // FIXME: Support wasm IC.
     // https://bugs.webkit.org/show_bug.cgi?id=220339
@@ -4308,13 +4292,13 @@ JSC_DEFINE_JIT_OPERATION(operationLinkDirectCall, void, (OptimizingCallLinkInfo*
         functionExecutable->prepareForExecution<FunctionExecutable>(vm, callee, scope, kind, codeBlock);
         RETURN_IF_EXCEPTION(throwScope, void());
 
-        unsigned argumentStackSlots = callLinkInfo->maxArgumentCountIncludingThisForDirectCall();
+        unsigned argumentStackSlots = callLinkInfo->maxArgumentCountIncludingThis();
         if (argumentStackSlots < static_cast<size_t>(codeBlock->numParameters()))
             codePtr = functionExecutable->entrypointFor(kind, MustCheckArity);
         else
             codePtr = functionExecutable->entrypointFor(kind, ArityCheckNotRequired);
     }
-    
+
     linkDirectCall(callFrame, *callLinkInfo, codeBlock, codePtr);
 }
 

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -48,6 +48,7 @@ class JSWeakMap;
 class JSWeakSet;
 class NativeExecutable;
 class OptimizingCallLinkInfo;
+class DirectCallLinkInfo;
 struct UnlinkedStringJumpTable;
 
 namespace DFG {
@@ -367,7 +368,7 @@ JSC_DECLARE_JIT_OPERATION(operationNewRawObject, char*, (VM*, Structure*, int32_
 JSC_DECLARE_JIT_OPERATION(operationNewObjectWithButterfly, JSCell*, (VM*, Structure*, Butterfly*));
 JSC_DECLARE_JIT_OPERATION(operationNewObjectWithButterflyWithIndexingHeaderAndVectorLength, JSCell*, (VM*, Structure*, unsigned length, Butterfly*));
 
-JSC_DECLARE_JIT_OPERATION(operationLinkDirectCall, void, (OptimizingCallLinkInfo*, JSFunction*));
+JSC_DECLARE_JIT_OPERATION(operationLinkDirectCall, void, (DirectCallLinkInfo*, JSFunction*));
 
 JSC_DECLARE_JIT_OPERATION(operationDateGetFullYear, EncodedJSValue, (VM*, DateInstance*));
 JSC_DECLARE_JIT_OPERATION(operationDateGetUTCFullYear, EncodedJSValue, (VM*, DateInstance*));


### PR DESCRIPTION
#### ff0942f6169fc201aafeed7a3aa722a65a990747
<pre>
[JSC] DataIC DirectCall
<a href="https://bugs.webkit.org/show_bug.cgi?id=267398">https://bugs.webkit.org/show_bug.cgi?id=267398</a>
<a href="https://rdar.apple.com/120827744">rdar://120827744</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/bytecode/CallLinkInfo.cpp:
(JSC::DirectCallLinkInfo::unlinkImpl):
(JSC::DirectCallLinkInfo::visitWeak):
(JSC::DirectCallLinkInfo::emitDirectFastPath):
(JSC::DirectCallLinkInfo::emitDirectTailCallFastPath):
(JSC::DirectCallLinkInfo::setCallTarget):
(JSC::DirectCallLinkInfo::setMaxArgumentCountIncludingThis):
(JSC::OptimizingCallLinkInfo::emitDirectFastPath): Deleted.
(JSC::OptimizingCallLinkInfo::emitDirectTailCallFastPath): Deleted.
(JSC::OptimizingCallLinkInfo::initializeDirectCall): Deleted.
(JSC::OptimizingCallLinkInfo::setDirectCallTarget): Deleted.
(JSC::OptimizingCallLinkInfo::initializeDirectCallRepatch): Deleted.
(JSC::OptimizingCallLinkInfo::setDirectCallMaxArgumentCountIncludingThis): Deleted.
* Source/JavaScriptCore/bytecode/CallLinkInfo.h:
(JSC::CallLinkInfo::isDirect const):
(JSC::CallLinkInfo::callModeFor): Deleted.
(JSC::CallLinkInfo::isDirect): Deleted.
* Source/JavaScriptCore/bytecode/CallLinkInfoBase.cpp:
(JSC::CallLinkInfoBase::unlink):
* Source/JavaScriptCore/bytecode/CallLinkInfoBase.h:
(JSC::CallLinkInfoBase::callModeFor):
(JSC::CallLinkInfoBase::isDirect):
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::finalizeJITInlineCaches):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::revertCall):
(JSC::linkDirectCall):
* Source/JavaScriptCore/bytecode/Repatch.h:
* Source/JavaScriptCore/dfg/DFGCommonData.h:
* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
(JSC::DFG::JITCompiler::link):
* Source/JavaScriptCore/dfg/DFGJITCompiler.h:
(JSC::DFG::JITCompiler::addJSDirectCall): Deleted.
(JSC::DFG::JITCompiler::JSDirectCallRecord::JSDirectCallRecord): Deleted.
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff0942f6169fc201aafeed7a3aa722a65a990747

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36182 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30454 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9494 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10491 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29927 "Found 79 new API test failures: TestWebKitAPI.WKInspectorExtensionHost.UnregisterExtension, TestWebKitAPI.VideoControlsManager.VideoControlsManagerSingleSmallAutoplayingVideo, TestWebKitAPI.GPUProcess.ExitsUnderMemoryPressureGetUserMediaVideoCase, TestWebKitAPI.WebKit.ManagedMSEHasMediaStreamingActivity, TestWebKitAPI.WKInspectorExtension.CanEvaluateScriptInExtensionTab, TestWebKitAPI.WKInspectorDelegate.InspectorConfiguration, TestWebKitAPI.AVFoundationPref.PrefTest, TestWebKitAPI.WebKit.NavigateDuringGetUserMediaPrompt, TestWebKitAPI.WebKit.MSEHasMediaStreamingActivity, TestWebKitAPI.WebKit.ManagedMSEHasMediaStreamingActivityWithPolicy ... (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9081 "Found 4 new API test failures: /TestWebKit:WebKit.UserMediaBasic, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /TestWebKit:WebKit.EnumerateDevicesCrash, /TestWebKit:WebKit.OnDeviceChangeCrash (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9252 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29931 "Found 60 new test failures: accessibility/ARIA-reflection.html, accessibility/ancestor-computation.html, accessibility/aria-hidden-hides-all-elements.html, accessibility/mac/aria-grouping-roles.html, accessibility/mac/malformed-table.html, accessibility/mac/media-role-descriptions.html, accessibility/mac/value-change/value-change-user-info-textarea.html, accessibility/text-marker/media-emits-object-replacement.html, accessibility/text-marker/text-marker-previous-next.html, animations/keyframes-rule.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37509 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/28626 "Found 39764 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_includes.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort2.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_splice_515632.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/bug56026_nested.js.default, ChakraCore.yaml/ChakraCore/test/Bugs/deserializationbug339404.js.default, ChakraCore.yaml/ChakraCore/test/EH/oos2.js.default, ChakraCore.yaml/ChakraCore/test/EH/so.js.default, ChakraCore.yaml/ChakraCore/test/Error/NativeErrors.js.default, ChakraCore.yaml/ChakraCore/test/Function/argumentsResolution.js.default ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30559 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30264 "Found 60 new test failures: accessibility/ancestor-computation.html, accessibility/aria-hidden-hides-all-elements.html, accessibility/aria-table-hierarchy.html, accessibility/aria-visible-element-roles.html, accessibility/canvas-fallback-content-2.html, accessibility/custom-elements/table.html, accessibility/display-contents/element-roles.html, accessibility/mac/aria-grouping-roles.html, accessibility/mac/malformed-table.html, accessibility/mac/mathml-elements.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35311 "Failure limit exceed. At least found 350 new test failures: accessibility/aria-hidden-hides-all-elements.html, accessibility/aria-visible-element-roles.html, accessibility/canvas-fallback-content.html, accessibility/media-controls.html, animations/keyframes-rule.html, animations/unprefixed-keyframes-rule.html, animations/unprefixed-properties.html, animations/unprefixed-shorthand.html, compositing/geometry/clipped-video-controller.html, compositing/reflections/video-mask-reflection-crash.html ... (failure)") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/33523 "Found 2 new JSC stress test failures: stress/tail-call-many-arguments.js.ftl-eager-no-cjit-b3o1, stress/v8-earley-boyer-strict.js.ftl-eager-no-cjit-b3o1 (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9312 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7259 "Found 60 new test failures: editing/selection/move-by-word-visually-inline-block-positioned-element.html, editing/selection/move-by-word-visually-mac.html, editing/selection/move-by-word-visually-multi-line.html, editing/selection/move-by-word-visually-multi-space.html, editing/selection/move-by-word-visually-single-space-inline-element.html, editing/selection/move-by-word-visually-single-space-one-element.html, fast/inline/unexpected-line-wrap-with-calc.html, fast/selectors/text-field-selection-window-inactive-stroke-color.html, http/tests/inspector/network/fetch-response-body-304.html, http/tests/inspector/network/intercept-request-properties.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33191 "Found 10 new API test failures: /TestWebKit:WebKit.OnDeviceChangeCrash, /TestWebKit:WebKit.EnumerateDevicesCrash, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/popup-event-signal, /TestWebKit:WebKit.UserMediaBasic, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/custom-container-destroyed, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mouse-target, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/default, /WebKitGTK/TestContextMenu:/webkit/WebKitWebView/context-menu-key, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11080 "Built successfully") | | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/40033 "Hash ff0942f6 for PR 22646 does not build (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9896 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/40033 "Hash ff0942f6 for PR 22646 does not build (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10074 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->