### PR TITLE
ImageBufferShareableBitmapBackend lacks ownership attribution

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -154,8 +154,6 @@ public:
 
     virtual ImageBufferBackendSharing* toBackendSharing() { return nullptr; }
 
-    virtual void setOwnershipIdentity(const ProcessIdentity&) { }
-
     const Parameters& parameters() { return m_parameters; }
 
     WEBCORE_EXPORT virtual String debugDescription() const = 0;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -152,6 +152,8 @@ unsigned ImageBufferIOSurfaceBackend::bytesPerRow() const
 void ImageBufferIOSurfaceBackend::transferToNewContext(const ImageBufferCreationContext& creationContext)
 {
     m_ioSurfacePool = creationContext.surfacePool;
+    if (creationContext.resourceOwner)
+        m_surface->setOwnershipIdentity(creationContext.resourceOwner);
 }
 
 void ImageBufferIOSurfaceBackend::invalidateCachedNativeImage()

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -115,19 +115,21 @@ void RemoteImageBuffer::putPixelBuffer(Ref<WebCore::PixelBuffer> pixelBuffer, We
 void RemoteImageBuffer::getShareableBitmap(WebCore::PreserveResolution preserveResolution, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    std::optional<ShareableBitmap::Handle> handle;
-    [&]() {
+    std::optional<ShareableBitmap::Handle> handle = [&]() -> std::optional<ShareableBitmap::Handle> {
         auto backendSize = m_imageBuffer->backendSize();
         auto logicalSize = m_imageBuffer->logicalSize();
         auto resultSize = preserveResolution == WebCore::PreserveResolution::Yes ? backendSize : m_imageBuffer->truncatedLogicalSize();
         auto bitmap = ShareableBitmap::create({ resultSize, m_imageBuffer->colorSpace() });
         if (!bitmap)
-            return;
+            return std::nullopt;
+        auto handle = bitmap->createHandle();
+        if (m_backend->resourceOwner())
+            handle->setOwnershipOfMemory(m_backend->resourceOwner(), MemoryLedger::Graphics);
         auto context = bitmap->createGraphicsContext();
         if (!context)
-            return;
+            return std::nullopt;
         context->drawImageBuffer(m_imageBuffer.get(), WebCore::FloatRect { { }, resultSize }, WebCore::FloatRect { { }, logicalSize }, { WebCore::CompositeOperator::Copy });
-        handle = bitmap->createHandle();
+        return handle;
     }();
     completionHandler(WTFMove(handle));
 }
@@ -135,20 +137,22 @@ void RemoteImageBuffer::getShareableBitmap(WebCore::PreserveResolution preserveR
 void RemoteImageBuffer::filteredNativeImage(Ref<WebCore::Filter> filter, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    std::optional<ShareableBitmap::Handle> handle;
-    [&]() {
+    std::optional<ShareableBitmap::Handle> handle = [&]() -> std::optional<ShareableBitmap::Handle> {
         auto image = m_imageBuffer->filteredNativeImage(filter);
         if (!image)
-            return;
+            return std::nullopt;
         auto imageSize = image->size();
         auto bitmap = ShareableBitmap::create({ imageSize, m_imageBuffer->colorSpace() });
         if (!bitmap)
-            return;
+            return std::nullopt;
+        auto handle = bitmap->createHandle();
+        if (m_backend->resourceOwner())
+            handle->setOwnershipOfMemory(m_backend->resourceOwner(), MemoryLedger::Graphics);
         auto context = bitmap->createGraphicsContext();
         if (!context)
-            return;
+            return std::nullopt;
         context->drawNativeImage(*image, WebCore::FloatRect { { }, imageSize }, WebCore::FloatRect { { }, imageSize });
-        handle = bitmap->createHandle();
+        return handle;
     }();
     completionHandler(WTFMove(handle));
 }

--- a/Source/WebKit/Platform/SharedMemory.h
+++ b/Source/WebKit/Platform/SharedMemory.h
@@ -78,8 +78,9 @@ public:
 
     size_t size() const { return m_size; }
 
-    // Take/Set ownership of the memory for jetsam purposes.
+    // Take ownership of the memory for process memory accounting purposes.
     void takeOwnershipOfMemory(MemoryLedger) const;
+    // Transfer ownership of the memory for process memory accounting purposes.
     void setOwnershipOfMemory(const WebCore::ProcessIdentity&, MemoryLedger) const;
 
 #if USE(UNIX_DOMAIN_SOCKETS)

--- a/Source/WebKit/Shared/ShareableBitmap.h
+++ b/Source/WebKit/Shared/ShareableBitmap.h
@@ -106,6 +106,8 @@ public:
 
     // Take ownership of the memory for process memory accounting purposes.
     void takeOwnershipOfMemory(MemoryLedger) const;
+    // Transfer ownership of the memory for process memory accounting purposes.
+    void setOwnershipOfMemory(const WebCore::ProcessIdentity&, MemoryLedger) const;
 
 private:
     friend struct IPC::ArgumentCoder<ShareableBitmapHandle, void>;
@@ -141,6 +143,8 @@ public:
     
     // Create a ReadOnly handle.
     std::optional<Handle> createReadOnlyHandle() const;
+
+    void setOwnershipOfMemory(const WebCore::ProcessIdentity&);
 
     WebCore::IntSize size() const { return m_configuration.size(); }
     WebCore::IntRect bounds() const { return WebCore::IntRect(WebCore::IntPoint(), size()); }
@@ -190,12 +194,12 @@ private:
     static void releaseSurfaceData(void* typelessBitmap);
 #endif
 
-#if USE(CG)
-    bool m_releaseBitmapContextDataCalled { false };
-#endif
-
     ShareableBitmapConfiguration m_configuration;
     Ref<SharedMemory> m_sharedMemory;
+#if USE(CG)
+    std::optional<SharedMemoryHandle> m_ownershipHandle;
+    bool m_releaseBitmapContextDataCalled : 1 { false };
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/ShareableBitmapHandle.cpp
+++ b/Source/WebKit/Shared/ShareableBitmapHandle.cpp
@@ -45,4 +45,10 @@ void ShareableBitmapHandle::takeOwnershipOfMemory(MemoryLedger ledger) const
     m_handle.takeOwnershipOfMemory(ledger);
 }
 
+void ShareableBitmapHandle::setOwnershipOfMemory(const WebCore::ProcessIdentity& identity, MemoryLedger ledger) const
+{
+    m_handle.setOwnershipOfMemory(identity, ledger);
+}
+
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/cairo/ShareableBitmapCairo.cpp
+++ b/Source/WebKit/Shared/cairo/ShareableBitmapCairo.cpp
@@ -111,4 +111,8 @@ RefPtr<Image> ShareableBitmap::createImage()
     return BitmapImage::create(WTFMove(surface));
 }
 
+void ShareableBitmap::setOwnershipOfMemory(const ProcessIdentity&)
+{
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/cg/ShareableBitmapCG.mm
+++ b/Source/WebKit/Shared/cg/ShareableBitmapCG.mm
@@ -268,4 +268,12 @@ RefPtr<Image> ShareableBitmap::createImage()
     return nullptr;
 }
 
+void ShareableBitmap::setOwnershipOfMemory(const ProcessIdentity& identity)
+{
+    m_ownershipHandle = m_sharedMemory->createHandle(SharedMemory::Protection::ReadWrite);
+    if (!m_ownershipHandle)
+        return;
+    m_ownershipHandle->setOwnershipOfMemory(identity, MemoryLedger::Graphics);
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
@@ -65,7 +65,7 @@ size_t ImageBufferShareableBitmapBackend::calculateMemoryCost(const Parameters& 
     return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters, parameters.backendSize));
 }
 
-std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBackend::create(const Parameters& parameters, const WebCore::ImageBufferCreationContext&)
+std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBackend::create(const Parameters& parameters, const ImageBufferCreationContext& creationContext)
 {
     ASSERT(parameters.pixelFormat == PixelFormat::BGRA8 || parameters.pixelFormat == PixelFormat::BGRX8);
 
@@ -76,7 +76,8 @@ std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBac
     auto bitmap = ShareableBitmap::create({ backendSize, parameters.colorSpace });
     if (!bitmap)
         return nullptr;
-
+    if (creationContext.resourceOwner)
+        bitmap->setOwnershipOfMemory(creationContext.resourceOwner);
     auto context = bitmap->createGraphicsContext();
     if (!context)
         return nullptr;
@@ -84,14 +85,9 @@ std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBac
     return makeUnique<ImageBufferShareableBitmapBackend>(parameters, bitmap.releaseNonNull(), WTFMove(context));
 }
 
-std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBackend::create(const Parameters& parameters, ImageBufferBackendHandle handle)
+std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBackend::create(const Parameters& parameters, ShareableBitmap::Handle handle)
 {
-    if (!std::holds_alternative<ShareableBitmap::Handle>(handle)) {
-        ASSERT_NOT_REACHED();
-        return nullptr;
-    }
-
-    auto bitmap = ShareableBitmap::create(WTFMove(std::get<ShareableBitmap::Handle>(handle)));
+    auto bitmap = ShareableBitmap::create(WTFMove(handle));
     if (!bitmap)
         return nullptr;
 
@@ -121,6 +117,12 @@ std::optional<ImageBufferBackendHandle> ImageBufferShareableBitmapBackend::creat
     return { };
 }
 
+void ImageBufferShareableBitmapBackend::transferToNewContext(const ImageBufferCreationContext& creationContext)
+{
+    if (creationContext.resourceOwner)
+        m_bitmap->setOwnershipOfMemory(creationContext.resourceOwner);
+}
+
 unsigned ImageBufferShareableBitmapBackend::bytesPerRow() const
 {
     return m_bitmap->bytesPerRow();
@@ -148,7 +150,7 @@ void ImageBufferShareableBitmapBackend::getPixelBuffer(const IntRect& srcRect, P
     ImageBufferBackend::getPixelBuffer(srcRect, m_bitmap->data(), destination);
 }
 
-void ImageBufferShareableBitmapBackend::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, WebCore::AlphaPremultiplication destFormat)
+void ImageBufferShareableBitmapBackend::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
 {
     ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, m_bitmap->data());
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
@@ -59,7 +59,7 @@ public:
     static size_t calculateMemoryCost(const Parameters&);
 
     static std::unique_ptr<ImageBufferShareableBitmapBackend> create(const Parameters&, const WebCore::ImageBufferCreationContext&);
-    static std::unique_ptr<ImageBufferShareableBitmapBackend> create(const Parameters&, ImageBufferBackendHandle);
+    static std::unique_ptr<ImageBufferShareableBitmapBackend> create(const Parameters&, ShareableBitmap::Handle);
 
     ImageBufferShareableBitmapBackend(const Parameters&, Ref<ShareableBitmap>&&, std::unique_ptr<WebCore::GraphicsContext>&&);
 
@@ -70,6 +70,7 @@ public:
 #if USE(CAIRO)
     RefPtr<cairo_surface_t> createCairoSurface() final;
 #endif
+    void transferToNewContext(const WebCore::ImageBufferCreationContext&) final;
 
     RefPtr<WebCore::NativeImage> copyNativeImage() final;
     RefPtr<WebCore::NativeImage> createNativeImageReference() final;

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
@@ -49,7 +49,8 @@ std::unique_ptr<ImageBufferShareableMappedIOSurfaceBitmapBackend> ImageBufferSha
     auto surface = IOSurface::create(creationContext.surfacePool, backendSize, parameters.colorSpace, IOSurface::Name::ImageBuffer, IOSurface::formatForPixelFormat(parameters.pixelFormat));
     if (!surface)
         return nullptr;
-
+    if (creationContext.resourceOwner)
+        surface->setOwnershipIdentity(creationContext.resourceOwner);
     auto lockAndContext = surface->createBitmapPlatformContext();
     if (!lockAndContext)
         return nullptr;
@@ -112,11 +113,6 @@ GraphicsContext& ImageBufferShareableMappedIOSurfaceBitmapBackend::context()
     m_context = makeUnique<GraphicsContextCG>(nullptr);
     applyBaseTransform(*m_context);
     return *m_context;
-}
-
-void ImageBufferShareableMappedIOSurfaceBitmapBackend::setOwnershipIdentity(const WebCore::ProcessIdentity& resourceOwner)
-{
-    m_surface->setOwnershipIdentity(resourceOwner);
 }
 
 unsigned ImageBufferShareableMappedIOSurfaceBitmapBackend::bytesPerRow() const

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
@@ -53,7 +53,6 @@ public:
     static constexpr bool isOriginAtBottomLeftCorner = true;
 
     std::optional<ImageBufferBackendHandle> createBackendHandle(SharedMemory::Protection = SharedMemory::Protection::ReadWrite) const final;
-    void setOwnershipIdentity(const WebCore::ProcessIdentity&) final;
     WebCore::GraphicsContext& context() final;
     bool originAtBottomLeftCorner() const override { return isOriginAtBottomLeftCorner; }
 private:


### PR DESCRIPTION
#### cab1c34e3f5de8eb66ddab429127b3127cd33f65
<pre>
ImageBufferShareableBitmapBackend lacks ownership attribution
<a href="https://bugs.webkit.org/show_bug.cgi?id=267266">https://bugs.webkit.org/show_bug.cgi?id=267266</a>
<a href="https://rdar.apple.com/problem/120707603">rdar://problem/120707603</a>

Reviewed by Matt Woodrow.

Add ShareableBitmap::setOwnershipOfMemory() to attribute the
ShareableBitmap to the owner process, currently always WP.

Use this when creating RemoteImageBuffer instances.
Use ShareableBitmap::Handle::takeOwnershipOfMemory() when receiving
the handles in WP.

Make some call sites of ShareableBitmap::create() more consistent.
The general pattern for marking the owner has to be:
- Use ShareableBitmap::setOwnershipOfMemory() in GPUP side immediately
  after creation.
- Use ShareableBitmap::Handle::takeOwnershipOfMemory() in WP side
  when receiving the handle. This is needed for the older macOS systems.

Remove unused ImageBuffer::setOwnershipIdentity() and similar methods.
Currently the ImageBuffer API contract is that the creator owns the
memory, and the internal implementation, in this case calls to
ShareableBitmap ensure it.

* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::setOwnershipIdentity): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::transferToNewContext):
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::getShareableBitmap):
(WebKit::RemoteImageBuffer::filteredNativeImage):
* Source/WebKit/Platform/SharedMemory.h:
* Source/WebKit/Shared/ShareableBitmap.h:
* Source/WebKit/Shared/ShareableBitmapHandle.cpp:
(WebKit::ShareableBitmapHandle::setOwnershipOfMemory const):
* Source/WebKit/Shared/cairo/ShareableBitmapCairo.cpp:
(WebKit::ShareableBitmap::setOwnershipIdentity):
* Source/WebKit/Shared/cg/ShareableBitmapCG.mm:
(WebKit::ShareableBitmap::setOwnershipIdentity):
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp:
(WebKit::ImageBufferShareableBitmapBackend::create):
(WebKit::ImageBufferShareableBitmapBackend::transferToNewContext):
(WebKit::BufferShareableBitmapBackend::bytesPerRow const):
(WebKit::ImageBufferShareableBitmapBackend::bytesPerRow const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::didCreateBackend):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp:
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::create):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::setOwnershipIdentity): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h:

Canonical link: <a href="https://commits.webkit.org/273123@main">https://commits.webkit.org/273123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f790ab7146af59605a67cd8924bb8b4aabe7868

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36198 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30467 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29572 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34056 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10407 "Found 1 new test failure: fast/loader/redirect-to-invalid-url-using-meta-refresh-calls-policy-delegate.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9093 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37523 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30474 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30278 "Found 2 new test failures: compositing/updates/animation-non-composited.html, mathml/scripts-removeChild.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35318 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33199 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11094 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7899 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9905 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10088 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->