### PR TITLE
Wheel event doesn't get fired on an element that has been reinserted after document.open

### DIFF
--- a/LayoutTests/fast/events/touch/ios/touch-event-after-document-open-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-after-document-open-expected.txt
@@ -1,0 +1,8 @@
+This tests triggering touch event on an element after document.open. The element should receive touch event.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS didFireTouchStartEvent is true
+PASS didFireTouchEndEvent is true
+

--- a/LayoutTests/fast/events/touch/ios/touch-event-after-document-open.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-after-document-open.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+<script>
+
+jsTestIsAsync = true;
+
+let didFireTouchStartEvent = false;
+let didFireTouchEndEvent = false;
+
+description('This tests triggering touch event on an element after document.open. The element should receive touch event.')
+
+window.addEventListener('load', async () => {
+    let target = document.getElementById('target');
+    target.style = 'width: 200px; height: 200px; background-color: silver; margin:20px;'
+    let description = document.getElementById('description');
+    let console2 = document.getElementById('console');
+
+    target.addEventListener('touchstart', (event) => didFireTouchStartEvent = true, false);
+    target.addEventListener('touchend', (event) => didFireTouchEndEvent = true, false);
+    target.remove();
+
+    document.open();
+    document.write('<!DOCTYPE html><head><body>');
+    document.close();
+    document.body.append(target, description, console2);
+
+    await UIHelper.ensurePresentationUpdate();
+    await UIHelper.activateElement(target);
+
+    shouldBeTrue('didFireTouchStartEvent');
+    shouldBeTrue('didFireTouchEndEvent');
+
+    finishJSTest();
+
+    // FIXME: This shouldn't be necessary but somehow it is.
+    if (window.testRunner)
+        testRunner.notifyDone();
+}, false);
+</script>
+</head>
+<body>
+    <div id="target"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/fast/events/wheel/wheel-event-after-document-open-expected.txt
+++ b/LayoutTests/fast/events/wheel/wheel-event-after-document-open-expected.txt
@@ -1,0 +1,10 @@
+This tests triggering wheel scroll on an element after document.open. The element should receive wheel event.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS didFireWheelEvent is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/wheel/wheel-event-after-document-open.html
+++ b/LayoutTests/fast/events/wheel/wheel-event-after-document-open.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+
+jsTestIsAsync = true;
+
+async function testScroll()
+{
+    await UIHelper.ensurePresentationUpdate();
+    await UIHelper.mouseWheelScrollAt(100, 100);
+
+    shouldBeTrue('didFireWheelEvent');
+
+    finishJSTest();
+}
+
+let didFireWheelEvent = false;
+
+description('This tests triggering wheel scroll on an element after document.open. The element should receive wheel event.')
+
+window.addEventListener('load', () => {
+    let target = document.getElementById('target');
+    target.style = 'width: 200px; height: 200px; background-color: silver; margin:20px;'
+    let description = document.getElementById('description');
+    let console = document.getElementById('console');
+
+    target.addEventListener('wheel', (event) => {
+        event.preventDefault();
+        didFireWheelEvent = true;
+    }, false);
+    target.remove();
+
+    setTimeout(async () => {
+        document.open();
+        document.write('<!DOCTYPE html><head><body>');
+        document.close();
+        document.body.append(target, description, console);
+
+        await testScroll();                
+    }, 100);
+
+}, false);
+</script>
+</head>
+<body>
+    <div id="target"></div>
+    <div id="console"></div>
+    <script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -2115,6 +2115,7 @@ webkit.org/b/250610 fast/events/wheel/wheelevent-in-text-node.html [ Skip ]
 webkit.org/b/250610 fast/scrolling/rtl-scrollbars-listbox-scroll.html [ Skip ]
 webkit.org/b/250610 scrollbars/scroll-rtl-or-bt-layer.html [ Skip ]
 webkit.org/b/250610 fast/events/wheel/wheel-event-destroys-overflow.html [ Skip ]
+webkit.org/b/250610 fast/events/wheel/wheel-event-after-document-open.html [ Skip ]
 
 # Missing glyph symbol is not rendered properly.
 webkit.org/b/140252 fast/css/line-height-determined-by-primary-font.html [ Failure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1228,6 +1228,7 @@ webkit.org/b/173419 fast/events/wheel/platform-wheelevent-paging-y-in-non-scroll
 webkit.org/b/173419 fast/events/wheel/platform-wheelevent-paging-y-in-non-scrolling-page.html [ Failure ]
 webkit.org/b/173419 fast/events/wheel/platform-wheelevent-paging-y-in-scrolling-div.html [ Failure ]
 webkit.org/b/173419 fast/events/wheel/platform-wheelevent-paging-y-in-scrolling-page.html [ Failure ]
+webkit.org/b/173419 fast/events/wheel/wheel-event-after-document-open.html [ Skip ]
 webkit.org/b/173419 fast/events/wheel/wheel-event-destroys-frame.html [ Timeout Pass ]
 webkit.org/b/173419 fast/events/wheel/wheel-event-destroys-overflow.html [ Timeout Pass ]
 webkit.org/b/173419 fast/events/wheel/wheelevent-basic.html [ Failure Timeout ]

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2931,18 +2931,9 @@ void Document::removeAllEventListeners()
 
     protectedReportingScope()->removeAllObservers();
 
-#if ENABLE(IOS_TOUCH_EVENTS)
-    clearTouchEventHandlersAndListeners();
-#endif
     // FIXME: What about disconnected nodes.
     for (RefPtr node = firstChild(); node; node = NodeTraversal::next(*node))
         node->removeAllEventListeners();
-
-#if ENABLE(TOUCH_EVENTS)
-    m_touchEventTargets = nullptr;
-#endif
-    m_wheelEventTargets = nullptr;
-    invalidateEventListenerRegions();
 }
 
 void Document::suspendDeviceMotionAndOrientationUpdates()

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -507,6 +507,7 @@ public:
 
     WEBCORE_EXPORT bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) override;
     bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions&) override;
+    void removeAllEventListeners() override;
 
     using EventTarget::dispatchEvent;
     void dispatchEvent(Event&) override;


### PR DESCRIPTION
#### a39166fd0ab3b6d329a33075ef2ddbfdcd0ca89f
<pre>
Wheel event doesn&apos;t get fired on an element that has been reinserted after document.open
<a href="https://bugs.webkit.org/show_bug.cgi?id=267399">https://bugs.webkit.org/show_bug.cgi?id=267399</a>

Reviewed by Wenson Hsieh.

The bug was caused by Document::removeAllEventListeners falsely assuming that all wheel and touch
event listeners from all nodes associated with this document are removed. This is not the case.
Document::removeAllEventListeners does not remove any event listeners from disconnected nodes.

Fixed the bug by relying on newly added Node::removeAllEventListeners to remove itself from
Document&apos;s maps of wheel and touch event listeners instead of clearing them all in
Document::removeAllEventListeners. Node::removeAllEventListeners won&apos;t be called on any
disconnected nodes and they would remain in the document&apos;s maps.

An alternative approach is for Document to keep track of only connected Nodes which have touch
and wheel event listeners but this will involve adding code to Node::insertedIntoAncestor and
Node::removedFromAncestor to add or remove nodes from Document&apos;s maps. We opt not to adopt this
approach since it incurs runtime cost of O(k) where k is the maximum number of event listeners.

* LayoutTests/fast/events/touch/ios/touch-event-after-document-open-expected.txt: Added.
* LayoutTests/fast/events/touch/ios/touch-event-after-document-open.html: Added.
* LayoutTests/fast/events/wheel/wheel-event-after-document-open-expected.txt: Added.
* LayoutTests/fast/events/wheel/wheel-event-after-document-open.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::removeAllEventListeners):
* Source/WebCore/dom/Node.cpp:
(WebCore::didRemoveEventListenerOfType): Extracted from tryRemoveEventListener.
(WebCore::tryRemoveEventListener): Deleted.
(WebCore::Node::removeEventListener):
(WebCore::Node::removeAllEventListeners): Added.
* Source/WebCore/dom/Node.h:

Canonical link: <a href="https://commits.webkit.org/272960@main">https://commits.webkit.org/272960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a63369224066b29ea5543cfbeb6d4f0813858aa0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36350 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30588 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29662 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9204 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9301 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37673 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30620 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35429 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33316 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11222 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29753 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10025 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4345 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10228 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->