### PR TITLE
REGRESSION (272706@main): TestWebKitAPI.PDF.PrintSize is failing on Intel

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.mm
@@ -34,7 +34,7 @@
 
 namespace WebKit {
 
-static void appendValuesInPDFNameSubtreeToVector(RetainPtr<CGPDFDictionaryRef> subtree, Vector<RetainPtr<CGPDFObjectRef>>& values)
+static void appendValuesInPDFNameSubtreeToVector(RetainPtr<CGPDFDictionaryRef> subtree, Vector<CGPDFObjectRef>& values)
 {
     CGPDFArrayRef names = nullptr;
     if (CGPDFDictionaryGetArray(subtree.get(), "Names", &names)) {
@@ -80,12 +80,12 @@ static void getAllScriptsInPDFDocument(RetainPtr<CGPDFDocumentRef> pdfDocument, 
         return;
 
     // The names are arbitrary. We are only interested in the values.
-    Vector<RetainPtr<CGPDFObjectRef>> objects;
+    Vector<CGPDFObjectRef> objects;
     appendValuesInPDFNameSubtreeToVector(javaScriptNameTree, objects);
 
     for (auto object : objects) {
         CGPDFDictionaryRef javaScriptAction = nullptr;
-        if (!CGPDFObjectGetValue(object.get(), kCGPDFObjectTypeDictionary, &javaScriptAction))
+        if (!CGPDFObjectGetValue(object, kCGPDFObjectTypeDictionary, &javaScriptAction))
             continue;
 
         // A JavaScript action must have an action type of "JavaScript".


### PR DESCRIPTION
#### c6d8b99f59c25be18018634dc25fff0d66022287
<pre>
REGRESSION (272706@main): TestWebKitAPI.PDF.PrintSize is failing on Intel
<a href="https://bugs.webkit.org/show_bug.cgi?id=267403">https://bugs.webkit.org/show_bug.cgi?id=267403</a>
<a href="https://rdar.apple.com/120837366">rdar://120837366</a>

Reviewed by Richard Robinson, Megan Gardner and Aditya Keerthi.

* Source/WebKit/WebProcess/Plugins/PDF/PDFScriptEvaluator.mm:
(WebKit::appendValuesInPDFNameSubtreeToVector):
(WebKit::getAllScriptsInPDFDocument):
No matter how much we might want to use RetainPtr everywhere, some types just
aren&apos;t refcounted. Despite looking a lot like a refcounted CF type, CGPDFObjectRef
is one such type. Thus, it&apos;s best to not try to call -retain on it, or you
might crash. Or, humorously, if you&apos;re on arm64, not crash, but you&apos;ve still
made a mistake.

Un-do this overuse of RetainPtr.

Canonical link: <a href="https://commits.webkit.org/272930@main">https://commits.webkit.org/272930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e018299b06b7f784949383d3c8868e67b88754fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36209 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30472 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29576 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9102 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9189 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37534 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30482 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35329 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7281 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33216 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11105 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7776 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9911 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10097 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->