### PR TITLE
GraphicsContextCG uses memory redundantly for bool fields

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -75,7 +75,7 @@ class GraphicsContext {
 public:
     // Indicates if draw operations read the sources such as NativeImage backing stores immediately
     // during draw operations.
-    enum class IsDeferred {
+    enum class IsDeferred : bool {
         No,
         Yes
     };
@@ -369,7 +369,6 @@ public:
     void releaseWindowsContext(HDC, const IntRect&, bool supportAlphaBlend); // The passed in HDC should be the one handed back by getWindowsContext.
 #endif
 
-    IsDeferred deferred() const { return m_isDeferred; }
 private:
     virtual void drawNativeImageInternal(NativeImage&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions = { }) = 0;
 
@@ -386,13 +385,12 @@ protected:
     Vector<FloatPoint> centerLineAndCutOffCorners(bool isVerticalLine, float cornerWidth, FloatPoint point1, FloatPoint point2) const;
 
     GraphicsContextState m_state;
-    const IsDeferred m_isDeferred;
-
 private:
     Vector<GraphicsContextState, 1> m_stack;
 
     unsigned m_transparencyLayerCount { 0 };
-    bool m_contentfulPaintDetected { false };
+    const IsDeferred m_isDeferred : 1; // NOLINT
+    bool m_contentfulPaintDetected : 1 { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1507,7 +1507,9 @@ bool GraphicsContextCG::canUseShadowBlur() const
 
 bool GraphicsContextCG::consumeHasDrawn()
 {
-    return std::exchange(m_hasDrawn, false);
+    bool hasDrawn = m_hasDrawn;
+    m_hasDrawn = false;
+    return hasDrawn;
 }
 
 }

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -152,12 +152,12 @@ private:
     CGContextRef contextForState() const;
 
     const RetainPtr<CGContextRef> m_cgContext;
-    const RenderingMode m_renderingMode;
-    const bool m_isLayerCGContext;
-    mutable bool m_userToDeviceTransformKnownToBeIdentity { false };
-    // Flag for pending draws. Start with true because we do not know what commands have been scheduled to the context.
-    bool m_hasDrawn { true };
     mutable std::optional<DestinationColorSpace> m_colorSpace;
+    const RenderingMode m_renderingMode : 1; // NOLINT
+    const bool m_isLayerCGContext : 1;
+    mutable bool m_userToDeviceTransformKnownToBeIdentity : 1 { false };
+    // Flag for pending draws. Start with true because we do not know what commands have been scheduled to the context.
+    bool m_hasDrawn : 1 { true };
 };
 
 CGAffineTransform getUserToBaseCTM(CGContextRef);


### PR DESCRIPTION
#### 10d7bc6d7f3c880c1205f0b6c693abdea4537fc9
<pre>
GraphicsContextCG uses memory redundantly for bool fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=267404">https://bugs.webkit.org/show_bug.cgi?id=267404</a>
<a href="https://rdar.apple.com/120837402">rdar://120837402</a>

Reviewed by Antti Koivisto.

Mark some of the held bools as bitfields and reorder.

Before:
Total byte size: 808
Total pad bytes: 61
Padding percentage: 7.55 %

After:
Total byte size: 800
Total pad bytes: 60
Padding percentage: 7.50 %

* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::deferred const): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::consumeHasDrawn):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:

Canonical link: <a href="https://commits.webkit.org/272965@main">https://commits.webkit.org/272965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa7fa1e7a5a00d8d09df4601e3f9b483e782677d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36210 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30473 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34638 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29578 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34068 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10416 "Found 3 new test failures: compositing/updates/animation-non-composited.html, fast/forms/state-restore-to-non-edited-controls.html, scrollingcoordinator/scrolling-tree/fixed-inside-frame.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9106 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9190 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29956 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37535 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30484 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30283 "Found 1 new test failure: fast/forms/state-restore-to-non-edited-controls.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35332 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7284 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33214 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11106 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7789 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9912 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10098 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->