### PR TITLE
[GTK][WPE][Debug] imported/w3c/web-platform-tests/notifications/instance.https.html is a constant crash

### DIFF
--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.h
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.h
@@ -61,6 +61,8 @@ private:
 
         void cancel();
 
+        bool finished() const { return m_finished; }
+
     private:
         // ThreadableLoaderClient API.
         void didReceiveResponse(ResourceLoaderIdentifier, const ResourceResponse&) final;
@@ -68,6 +70,7 @@ private:
         void didFinishLoading(ResourceLoaderIdentifier, const NetworkLoadMetrics&) final;
         void didFail(const ResourceError&) final;
 
+        bool m_finished { false };
         SharedBufferBuilder m_buffer;
         RefPtr<BitmapImage> m_image;
         RefPtr<ThreadableLoader> m_loader;
@@ -77,6 +80,7 @@ private:
     void didFinishLoadingResource(ResourceLoader*);
 
     Notification& m_notification;
+    bool m_stopped { false };
     CompletionHandler<void(RefPtr<NotificationResources>&&)> m_completionHandler;
     HashSet<std::unique_ptr<ResourceLoader>> m_loaders;
     RefPtr<NotificationResources> m_resources;


### PR DESCRIPTION
#### 21c1140b536ca89bfc2c3feaa1e6404d11839160
<pre>
[GTK][WPE][Debug] imported/w3c/web-platform-tests/notifications/instance.https.html is a constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=267132">https://bugs.webkit.org/show_bug.cgi?id=267132</a>

Reviewed by Carlos Garcia Campos.

Currently, when `NotificationResourcesLoader` starts downloading
notification resources, we create a &quot;ResourceLoader&quot; per resource
(we only support the icon resource for now) and add it to the set of
running loaders `m_loaders`.

When a `ResourceLoader` finishes, we check if it was the last one
running. If yes, we run the `NotificationResourcesLoader`&apos;s completion
handler.

But in some circumstances (e.g. when the icon URL is bogus)
a `ResouceLoader` can execute its completion handler synchronously
during construction.

In this case, the `NotificationResourcesLoader`&apos;s completion handler
will be called from `didFinishLoadingResource()` because
`m_loaders.isEmpty()` since we haven&apos;t added the loader to the set yet.

To prevent it, this patch checks that `ResouceLoader` hasn&apos;t finished
yet before adding it to the set of running loaders.

* Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp:
(WebCore::NotificationResourcesLoader::start):
(WebCore::NotificationResourcesLoader::stop):
(WebCore::NotificationResourcesLoader::didFinishLoadingResource):
(WebCore::NotificationResourcesLoader::ResourceLoader::didFinishLoading):
(WebCore::NotificationResourcesLoader::ResourceLoader::didFail):
* Source/WebCore/Modules/notifications/NotificationResourcesLoader.h:

Canonical link: <a href="https://commits.webkit.org/272970@main">https://commits.webkit.org/272970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4629716c166719b9e597914ceca66f4590cbef90

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36215 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30476 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34643 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9528 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29579 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29950 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9107 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9192 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37540 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30486 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30310 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35333 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33226 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11111 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7797 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10103 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->