### PR TITLE
[SVG2] Add support for the 'turn' unit in <angle>

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedEnumeration-SVGMarkerElement-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedEnumeration-SVGMarkerElement-expected.txt
@@ -2,6 +2,6 @@
 PASS Test SVGAnimatedEnumeration
 PASS Test SVGOrient
 PASS Test grad units
-FAIL Test turn units assert_equals: expected 360 but got 0
+PASS Test turn units
 FAIL Test auto-start-reverse Type error
 

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -134,8 +134,12 @@ constexpr inline float turn2deg(float t) { return t * degreesPerTurnFloat; }
 // Treat theses as conversions through the cannonical unit for angles, which is degrees.
 constexpr inline double rad2grad(double r) { return deg2grad(rad2deg(r)); }
 constexpr inline double grad2rad(double g) { return deg2rad(grad2deg(g)); }
+constexpr inline double turn2grad(double t) { return deg2grad(turn2deg(t)); }
+constexpr inline double grad2turn(double g) { return deg2turn(grad2deg(g)); }
 constexpr inline float rad2grad(float r) { return deg2grad(rad2deg(r)); }
 constexpr inline float grad2rad(float g) { return deg2rad(grad2deg(g)); }
+constexpr inline float turn2grad(float t) { return deg2grad(turn2deg(t)); }
+constexpr inline float grad2turn(float g) { return deg2turn(grad2deg(g)); }
 
 inline double roundTowardsPositiveInfinity(double value) { return std::floor(value + 0.5); }
 inline float roundTowardsPositiveInfinity(float value) { return std::floor(value + 0.5f); }

--- a/Source/WebCore/svg/SVGAngle.h
+++ b/Source/WebCore/svg/SVGAngle.h
@@ -56,6 +56,9 @@ public:
 
     SVGAngleValue::Type unitType() const
     {
+        // Per spec https://svgwg.org/svg2-draft/types.html#__svg__SVGAngle__SVG_ANGLETYPE_UNKNOWN
+        if (m_value.unitType() > SVGAngleValue::Type::SVG_ANGLETYPE_GRAD)
+            return SVGAngleValue::Type::SVG_ANGLETYPE_UNKNOWN;
         return m_value.unitType();
     }
 

--- a/Source/WebCore/svg/SVGAngleValue.cpp
+++ b/Source/WebCore/svg/SVGAngleValue.cpp
@@ -37,6 +37,8 @@ float SVGAngleValue::value() const
         return grad2deg(m_valueInSpecifiedUnits);
     case SVG_ANGLETYPE_RAD:
         return rad2deg(m_valueInSpecifiedUnits);
+    case SVG_ANGLETYPE_TURN:
+        return turn2deg(m_valueInSpecifiedUnits);
     case SVG_ANGLETYPE_UNSPECIFIED:
     case SVG_ANGLETYPE_UNKNOWN:
     case SVG_ANGLETYPE_DEG:
@@ -55,6 +57,9 @@ void SVGAngleValue::setValue(float value)
     case SVG_ANGLETYPE_RAD:
         m_valueInSpecifiedUnits = deg2rad(value);
         return;
+    case SVG_ANGLETYPE_TURN:
+        m_valueInSpecifiedUnits = deg2turn(value);
+        return;
     case SVG_ANGLETYPE_UNSPECIFIED:
     case SVG_ANGLETYPE_UNKNOWN:
     case SVG_ANGLETYPE_DEG:
@@ -71,6 +76,8 @@ String SVGAngleValue::valueAsString() const
         return makeString(m_valueInSpecifiedUnits, "deg");
     case SVG_ANGLETYPE_RAD:
         return makeString(m_valueInSpecifiedUnits, "rad");
+    case SVG_ANGLETYPE_TURN:
+        return makeString(m_valueInSpecifiedUnits, "turn");
     case SVG_ANGLETYPE_GRAD:
         return makeString(m_valueInSpecifiedUnits, "grad");
     case SVG_ANGLETYPE_UNSPECIFIED:
@@ -96,6 +103,8 @@ template<typename CharacterType> static inline SVGAngleValue::Type parseAngleTyp
     case 4:
         if (compareCharacters(buffer.position(), 'g', 'r', 'a', 'd'))
             return SVGAngleValue::SVG_ANGLETYPE_GRAD;
+        if (compareCharacters(buffer.position(), 't', 'u', 'r', 'n'))
+            return SVGAngleValue::SVG_ANGLETYPE_TURN;
         break;
     }
     return SVGAngleValue::SVG_ANGLETYPE_UNKNOWN;
@@ -142,6 +151,24 @@ ExceptionOr<void> SVGAngleValue::convertToSpecifiedUnits(unsigned short unitType
         return { };
 
     switch (m_unitType) {
+    case SVG_ANGLETYPE_TURN:
+        switch (unitType) {
+        case SVG_ANGLETYPE_GRAD:
+            m_valueInSpecifiedUnits = turn2grad(m_valueInSpecifiedUnits);
+            break;
+        case SVG_ANGLETYPE_UNSPECIFIED:
+        case SVG_ANGLETYPE_DEG:
+            m_valueInSpecifiedUnits = turn2deg(m_valueInSpecifiedUnits);
+            break;
+        case SVG_ANGLETYPE_RAD:
+            m_valueInSpecifiedUnits = deg2rad(turn2deg(m_valueInSpecifiedUnits));
+            break;
+        case SVG_ANGLETYPE_TURN:
+        case SVG_ANGLETYPE_UNKNOWN:
+            ASSERT_NOT_REACHED();
+            break;
+        }
+        break;
     case SVG_ANGLETYPE_RAD:
         switch (unitType) {
         case SVG_ANGLETYPE_GRAD:
@@ -150,6 +177,9 @@ ExceptionOr<void> SVGAngleValue::convertToSpecifiedUnits(unsigned short unitType
         case SVG_ANGLETYPE_UNSPECIFIED:
         case SVG_ANGLETYPE_DEG:
             m_valueInSpecifiedUnits = rad2deg(m_valueInSpecifiedUnits);
+            break;
+        case SVG_ANGLETYPE_TURN:
+            m_valueInSpecifiedUnits = deg2turn(rad2deg(m_valueInSpecifiedUnits));
             break;
         case SVG_ANGLETYPE_RAD:
         case SVG_ANGLETYPE_UNKNOWN:
@@ -166,6 +196,9 @@ ExceptionOr<void> SVGAngleValue::convertToSpecifiedUnits(unsigned short unitType
         case SVG_ANGLETYPE_DEG:
             m_valueInSpecifiedUnits = grad2deg(m_valueInSpecifiedUnits);
             break;
+        case SVG_ANGLETYPE_TURN:
+            m_valueInSpecifiedUnits = grad2turn(m_valueInSpecifiedUnits);
+            break;
         case SVG_ANGLETYPE_GRAD:
         case SVG_ANGLETYPE_UNKNOWN:
             ASSERT_NOT_REACHED();
@@ -181,6 +214,9 @@ ExceptionOr<void> SVGAngleValue::convertToSpecifiedUnits(unsigned short unitType
             break;
         case SVG_ANGLETYPE_GRAD:
             m_valueInSpecifiedUnits = deg2grad(m_valueInSpecifiedUnits);
+            break;
+        case SVG_ANGLETYPE_TURN:
+            m_valueInSpecifiedUnits = deg2turn(m_valueInSpecifiedUnits);
             break;
         case SVG_ANGLETYPE_UNSPECIFIED:
         case SVG_ANGLETYPE_DEG:

--- a/Source/WebCore/svg/SVGAngleValue.h
+++ b/Source/WebCore/svg/SVGAngleValue.h
@@ -30,11 +30,13 @@ class SVGAngleValue {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     enum Type {
+        // FIXME: Change the casing style of the enum type or naming of the Angle Value (webkit.org/b/269429).
         SVG_ANGLETYPE_UNKNOWN = 0,
         SVG_ANGLETYPE_UNSPECIFIED = 1,
         SVG_ANGLETYPE_DEG = 2,
         SVG_ANGLETYPE_RAD = 3,
-        SVG_ANGLETYPE_GRAD = 4
+        SVG_ANGLETYPE_GRAD = 4,
+        SVG_ANGLETYPE_TURN = 5
     };
 
     Type unitType() const { return m_unitType; }


### PR DESCRIPTION
#### 82c987e62f88df8ecd31f4526b688c0bbfdba45d
<pre>
[SVG2] Add support for the &apos;turn&apos; unit in &lt;angle&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=267180">https://bugs.webkit.org/show_bug.cgi?id=267180</a>
<a href="https://rdar.apple.com/120840743">rdar://120840743</a>

Reviewed by Anne van Kesteren.

This is adding the turn units to SVGAngle.
Note that the spec is saying that the IDL should not be modified.
<a href="https://svgwg.org/svg2-draft/types.html#__svg__SVGAngle__SVG_ANGLETYPE_UNKNOWN">https://svgwg.org/svg2-draft/types.html#__svg__SVGAngle__SVG_ANGLETYPE_UNKNOWN</a>
And new units should be considered with the SVG_ANGLETYPE_UNKNOWN.

* Source/WTF/wtf/MathExtras.h:
(turn2grad):
(grad2turn):
* Source/WebCore/svg/SVGAngle.h:
(WebCore::SVGAngle::unitType const):
* Source/WebCore/svg/SVGAngleValue.cpp:
(WebCore::SVGAngleValue::value const):
(WebCore::SVGAngleValue::setValue):
(WebCore::SVGAngleValue::valueAsString const):
(WebCore::parseAngleType):
(WebCore::SVGAngleValue::newValueSpecifiedUnits):
(WebCore::SVGAngleValue::convertToSpecifiedUnits):
* Source/WebCore/svg/SVGAngleValue.h:

Co-authored-by: Anne van Kesteren &lt;annevk@annevk.nl&gt;
Canonical link: <a href="https://commits.webkit.org/274778@main">https://commits.webkit.org/274778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/130e0201c49ca213c7f7aae2ecbc3b7ee998b191

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39901 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42445 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35803 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42208 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16242 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33259 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34502 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13803 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13827 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43724 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/33354 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36235 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35794 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39560 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39527 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37831 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16335 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46535 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8974 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16384 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9573 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15979 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->