### PR TITLE
[WPE] WPE Platform: wrong usage reported in DMABuf buffer formats under wayland

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -106,6 +106,17 @@ struct DMABufFeedback {
     ~DMABufFeedback() = default;
 
     struct Tranche {
+        Tranche() = default;
+        ~Tranche() = default;
+        Tranche(const Tranche&) = delete;
+        Tranche& operator=(const Tranche&) = delete;
+        Tranche(Tranche&& other)
+            : flags(other.flags)
+            , formats(WTFMove(other.formats))
+        {
+            other.flags = 0;
+        }
+
         uint32_t flags { 0 };
         Vector<uint16_t> formats;
     };


### PR DESCRIPTION
#### 75f18bf8d6d7395cb6cbf94d9c6dbdb6cfa4330e
<pre>
[WPE] WPE Platform: wrong usage reported in DMABuf buffer formats under wayland
<a href="https://bugs.webkit.org/show_bug.cgi?id=267406">https://bugs.webkit.org/show_bug.cgi?id=267406</a>

Reviewed by Alejandro G. Castro.

When there&apos;s more than one tranche, the flags for the next tranches are
added to the previous one. This is because we are using std::move with
the Tranche struct without defining a move constructor, so the flags
member is not set to 0 after the move.

* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(DMABufFeedback::Tranche::Tranche): Define a move constructor and make it non copyable.

Canonical link: <a href="https://commits.webkit.org/272911@main">https://commits.webkit.org/272911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ba24d26733a4911d44f0b17e7c3f7d9a2ebc66a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36220 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30481 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9533 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29582 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34078 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/10424 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29958 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9111 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37545 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30492 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/30292 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35337 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7292 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33222 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11116 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9922 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4308 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10108 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->