### PR TITLE
[ews] Improve error logging when passwords.json is missing

### DIFF
--- a/Tools/CISupport/build-webkit-org/master.cfg
+++ b/Tools/CISupport/build-webkit-org/master.cfg
@@ -20,9 +20,11 @@ def load_password(name, default=None):
     try:
         passwords = json.load(open('passwords.json'))
         return passwords.get(name, default)
+    except FileNotFoundError as e:
+        print(f'ERROR: passwords.json missing: {e}, using default value for {name}\n')
     except Exception as e:
-        print(f'Error in finding {name} in passwords.json')
-        return default
+        print(f'Error in finding {name} in passwords.json\n')
+    return default
 
 
 # This is work-around for https://bugs.webkit.org/show_bug.cgi?id=222361

--- a/Tools/CISupport/ews-app/ews/common/util.py
+++ b/Tools/CISupport/ews-app/ews/common/util.py
@@ -64,6 +64,8 @@ def load_password(name, default=None):
     try:
         passwords = json.load(open('passwords.json'))
         return passwords.get(name, default)
+    except FileNotFoundError as e:
+        _log.error('ERROR: passwords.json missing: {}, using default value for {}\n'.format(e, name))
     except Exception as e:
         _log.error('Error in finding {} in passwords.json'.format(name))
-        return default
+    return default

--- a/Tools/CISupport/ews-build/utils.py
+++ b/Tools/CISupport/ews-build/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,6 +30,8 @@ def load_password(name, default=None):
     try:
         passwords = json.load(open('passwords.json'))
         return passwords.get(name, default)
+    except FileNotFoundError as e:
+        print(f'ERROR: passwords.json missing: {e}, using default value for {name}\n')
     except Exception as e:
-        print(f'Error in finding {name} in passwords.json')
-        return default
+        print(f'Error in finding {name} in passwords.json\n')
+    return default


### PR DESCRIPTION
#### f9c1475ac7e327f474a5c2422aa2006f83bb0ee7
<pre>
[ews] Improve error logging when passwords.json is missing
<a href="https://bugs.webkit.org/show_bug.cgi?id=267407">https://bugs.webkit.org/show_bug.cgi?id=267407</a>

Reviewed by Jonathan Bedard.

When passwords.json is missing (e.g.: local testing), currently we log messages saying:
Error in finding {variable_name} in passwords.json
We should print more accurate message.

* Tools/CISupport/ews-build/utils.py:
(load_password):
* Tools/CISupport/build-webkit-org/master.cfg:
* Tools/CISupport/ews-app/ews/common/util.py:
(load_password):

Canonical link: <a href="https://commits.webkit.org/272915@main">https://commits.webkit.org/272915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a02fdfa8f3bb0c6c83eb73eba64cf9f9ed0280cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36245 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30504 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9558 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29598 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34103 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/10448 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/29981 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9131 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9212 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37570 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/30519 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/30311 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35356 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9359 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7314 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33241 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/33516 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11137 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9943 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4312 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10131 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->