### PR TITLE
[GStreamer][WebRTC] Missing support for parameter-less setLocalDescription()

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1892,7 +1892,7 @@ webkit.org/b/264803 fast/mediastream/mediastreamtrack-video-resize-event.html [ 
 # Adding transceivers without tracks is broken.
 webkit.org/b/265865 imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation.html [ Skip ]
 
-# [GStreamer][WebRTC] Missing support for non-trickle ICE handshake
+# Times out waiting for DTLS transport setup. Some bug related with data-channel, pending investigation.
 webkit.org/b/265860 imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https.html [ Skip ]
 
 # Pass Slow Failure with GStreamer 1.23. Skip (too many bugs) with GStreamer 1.22.
@@ -2064,6 +2064,8 @@ webrtc/video-vp8-videorange.html [ Skip ]
 # tests unexpected timeouts.
 imported/w3c/web-platform-tests/webrtc/ [ Skip ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-canTrickleIceCandidates.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-parameterless.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addIceCandidate-timing.https.html [ Pass ]
 
 # GStreamerRtpReceiverBackend::getSynchronizationSources() unimplemented.
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-captureTimestamp.html [ Skip ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-parameterless.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-parameterless.https-expected.txt
@@ -1,0 +1,17 @@
+
+Harness Error (TIMEOUT), message = null
+
+PASS Parameterless SLD() in 'stable' goes to 'have-local-offer'
+PASS Parameterless SLD() in 'stable' sets pendingLocalDescription
+FAIL Parameterless SLD() in 'stable' assigns transceiver.mid assert_not_equals: got disallowed value null
+PASS Parameterless SLD() in 'have-remote-offer' goes to 'stable'
+PASS Parameterless SLD() in 'have-remote-offer' sets currentLocalDescription
+TIMEOUT Parameterless SLD() in 'have-remote-offer' sets transceiver.currentDirection Test timed out
+NOTRUN Parameterless SLD() uses [[LastCreatedOffer]] if it is still valid
+NOTRUN Parameterless SLD() uses [[LastCreatedAnswer]] if it is still valid
+NOTRUN Parameterless SLD() rejects with InvalidStateError if already closed
+NOTRUN Parameterless SLD() never settles if closed while pending
+NOTRUN Parameterless SLD() in a full O/A exchange succeeds
+NOTRUN Parameterless SRD() rejects with TypeError.
+NOTRUN RTCSessionDescription constructed without type throws TypeError
+


### PR DESCRIPTION
#### 274953f826fda3160e7f955ed548b0da35f6f71d
<pre>
[GStreamer][WebRTC] Missing support for parameter-less setLocalDescription()
<a href="https://bugs.webkit.org/show_bug.cgi?id=265860">https://bugs.webkit.org/show_bug.cgi?id=265860</a>

Reviewed by Xabier Rodriguez-Calvar.

Minimal support for parameter-less setLocalDescription() calls, by creating the offer or answer
ourselves. Ideally this should be done by webrtcbin, but until then, we workaround the issue.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-parameterless.https-expected.txt: Added.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::fetchDescription):
(WebCore::GStreamerMediaEndpoint::doSetLocalDescription):
(WebCore::GStreamerMediaEndpoint::setDescription):
(WebCore::GStreamerMediaEndpoint::configureAndLinkSource):
(WebCore::GStreamerMediaEndpoint::requestPad):
(WebCore::GStreamerMediaEndpoint::initiate):
(WebCore::GStreamerMediaEndpoint::onIceGatheringChange):
(WebCore::GStreamerMediaEndpoint::onIceCandidate):

Canonical link: <a href="https://commits.webkit.org/272968@main">https://commits.webkit.org/272968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c57347fbfa3cd493108d9f95172569ae0decc29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36379 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30609 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9686 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29688 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30105 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9230 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37699 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30648 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30444 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35454 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7401 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/33343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11247 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10048 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4348 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10254 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->