### PR TITLE
Reduce use of CheckedRef for non-stack variables

### DIFF
--- a/Source/WebCore/css/parser/SizesAttributeParser.h
+++ b/Source/WebCore/css/parser/SizesAttributeParser.h
@@ -32,7 +32,7 @@
 #include "CSSParserTokenRange.h"
 #include "CSSPrimitiveValue.h"
 #include "MediaQuery.h"
-#include <wtf/CheckedRef.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -60,7 +60,7 @@ private:
 
     Ref<const Document> protectedDocument() const;
 
-    CheckedRef<const Document> m_document;
+    WeakRef<const Document, WeakPtrImplWithEventTargetData> m_document;
     Vector<MQ::MediaQueryResult> m_dynamicMediaQueryResults;
     float m_length { 0 };
     bool m_lengthWasSet { false };

--- a/Source/WebCore/dom/ConstantPropertyMap.h
+++ b/Source/WebCore/dom/ConstantPropertyMap.h
@@ -26,10 +26,10 @@
 
 #pragma once
 
-#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
 #include <wtf/Seconds.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
 
@@ -76,7 +76,7 @@ private:
 
     std::optional<Values> m_values;
 
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/CurrentScriptIncrementer.h
+++ b/Source/WebCore/dom/CurrentScriptIncrementer.h
@@ -28,9 +28,9 @@
 
 #pragma once
 
-#include <wtf/CheckedRef.h>
 #include "Document.h"
 #include "ScriptElement.h"
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -52,7 +52,7 @@ public:
 private:
     Ref<Document> protectedDocument() const { return m_document.get(); }
 
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DOMImplementation.h
+++ b/Source/WebCore/dom/DOMImplementation.h
@@ -26,7 +26,7 @@
 #include "ExceptionOr.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include "XMLDocument.h"
-#include <wtf/CheckedRef.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -50,7 +50,7 @@ public:
 private:
     Ref<Document> protectedDocument();
 
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.h
+++ b/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.h
@@ -30,7 +30,6 @@
 #include "DeviceOrientationOrMotionPermissionState.h"
 #include "ExceptionOr.h"
 #include "SecurityOriginData.h"
-#include <wtf/CheckedRef.h>
 #include <wtf/Function.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -49,7 +48,7 @@ public:
     void shouldAllowAccess(const Document&, Function<void(DeviceOrientationOrMotionPermissionState)>&&);
 
 private:
-    CheckedRef<Document> m_topDocument;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_topDocument;
     HashMap<SecurityOriginData, DeviceOrientationOrMotionPermissionState> m_accessStatePerOrigin;
 };
 

--- a/Source/WebCore/dom/DocumentFontLoader.h
+++ b/Source/WebCore/dom/DocumentFontLoader.h
@@ -29,8 +29,8 @@
 #include "CachedResourceHandle.h"
 #include "Document.h"
 #include "Timer.h"
-#include <wtf/CheckedRef.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -54,7 +54,7 @@ public:
 private:
     void fontLoadingTimerFired();
 
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     Timer m_fontLoadingTimer;
     Vector<CachedResourceHandle<CachedFont>> m_fontsToBeginLoading;
     bool m_isFontLoadingSuspended { false };

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -29,9 +29,9 @@
 #include "DocumentMarker.h"
 #include "Timer.h"
 #include <memory>
-#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -119,7 +119,7 @@ private:
     MarkerMap m_markers;
     // Provide a quick way to determine whether a particular marker type is absent without going through the map.
     OptionSet<DocumentMarker::Type> m_possiblyExistingMarkerTypes;
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 
     Timer m_fadeAnimationTimer;
 };

--- a/Source/WebCore/dom/DocumentStorageAccess.h
+++ b/Source/WebCore/dom/DocumentStorageAccess.h
@@ -27,7 +27,6 @@
 
 #include "RegistrableDomain.h"
 #include "Supplementable.h"
-#include <wtf/CheckedRef.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -35,6 +34,7 @@ namespace WebCore {
 class DeferredPromise;
 class Document;
 class UserGestureIndicator;
+class WeakPtrImplWithEventTargetData;
 
 enum class StorageAccessWasGranted : bool { No, Yes };
 
@@ -96,7 +96,7 @@ private:
 
     std::unique_ptr<UserGestureIndicator> m_temporaryUserGesture;
     
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 
     uint8_t m_numberOfTimesExplicitlyDeniedFrameSpecificStorageAccess = 0;
 

--- a/Source/WebCore/dom/ExtensionStyleSheets.h
+++ b/Source/WebCore/dom/ExtensionStyleSheets.h
@@ -33,6 +33,7 @@
 #include <wtf/RefPtr.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 #if ENABLE(CONTENT_EXTENSIONS)
@@ -83,7 +84,7 @@ public:
 private:
     Ref<Document> protectedDocument() const;
 
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 
     RefPtr<CSSStyleSheet> m_pageUserSheet;
 

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -32,7 +32,6 @@
 #include "GCReachableRef.h"
 #include "LayoutRect.h"
 #include "Page.h"
-#include <wtf/CheckedRef.h>
 #include <wtf/Deque.h>
 #include <wtf/WeakPtr.h>
 
@@ -113,7 +112,7 @@ private:
     Document& topDocument() { return m_topDocument ? *m_topDocument : document().topDocument(); }
     Ref<Document> protectedTopDocument();
 
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_topDocument;
 
     RefPtr<Element> fullscreenOrPendingElement() const { return m_fullscreenElement ? m_fullscreenElement : m_pendingFullscreenElement; }

--- a/Source/WebCore/dom/ScriptRunner.h
+++ b/Source/WebCore/dom/ScriptRunner.h
@@ -28,9 +28,9 @@
 
 #include "PendingScriptClient.h"
 #include "Timer.h"
-#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -63,7 +63,7 @@ private:
 
     void notifyFinished(PendingScript&) override;
 
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     Vector<Ref<PendingScript>> m_scriptsToExecuteInOrder;
     Vector<RefPtr<PendingScript>> m_scriptsToExecuteSoon; // http://www.whatwg.org/specs/web-apps/current-work/#set-of-scripts-that-will-execute-as-soon-as-possible
     HashSet<Ref<PendingScript>> m_pendingAsyncScripts;

--- a/Source/WebCore/dom/VisitedLinkState.h
+++ b/Source/WebCore/dom/VisitedLinkState.h
@@ -32,6 +32,7 @@
 #include "RenderStyleConstants.h"
 #include "SharedStringHash.h"
 #include <wtf/HashSet.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -49,7 +50,7 @@ public:
 private:
     InsideLink determineLinkStateSlowCase(const Element&);
 
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     HashSet<SharedStringHash, SharedStringHashHash> m_linksCheckedForVisitedState;
 };
 

--- a/Source/WebCore/editing/AlternativeTextController.h
+++ b/Source/WebCore/editing/AlternativeTextController.h
@@ -31,6 +31,7 @@
 #include "Position.h"
 #include <variant>
 #include <wtf/Noncopyable.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -139,7 +140,7 @@ private:
 
     void removeCorrectionIndicatorMarkers();
 
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
 #undef UNLESS_ENABLED

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -43,7 +43,7 @@
 #include "VisibleSelection.h"
 #include "WritingDirection.h"
 #include <memory>
-#include <wtf/CheckedRef.h>
+#include <wtf/WeakRef.h>
 
 #if PLATFORM(COCOA)
 OBJC_CLASS NSAttributedString;
@@ -660,7 +660,7 @@ private:
     void postTextStateChangeNotificationForCut(const String&, const VisibleSelection&);
 
     WeakPtr<EditorClient> m_client;
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     RefPtr<CompositeEditCommand> m_lastEditCommand;
     RefPtr<Text> m_compositionNode;
     unsigned m_compositionStart;

--- a/Source/WebCore/editing/SpellChecker.h
+++ b/Source/WebCore/editing/SpellChecker.h
@@ -32,6 +32,7 @@
 #include "Timer.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/Deque.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -95,7 +96,7 @@ private:
 
     Ref<Document> protectedDocument() const { return m_document.get(); }
 
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     TextCheckingRequestIdentifier m_lastRequestIdentifier;
     TextCheckingRequestIdentifier m_lastProcessedIdentifier;
 

--- a/Source/WebCore/html/parser/HTMLConstructionSite.h
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.h
@@ -227,7 +227,7 @@ private:
     // m_head has to be destroyed after destroying CheckedRef of m_document and m_attachmentRoot
     HTMLStackItem m_head;
 
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     
     // This is the root ContainerNode to which the parser attaches all newly
     // constructed nodes. It points to a DocumentFragment when parsing fragments

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -46,9 +46,9 @@
 #include "SecurityPolicy.h"
 #include "Settings.h"
 #include "SizesAttributeParser.h"
-#include <wtf/CheckedRef.h>
 #include <wtf/MainThread.h>
 #include <wtf/SortedArrayMap.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -405,7 +405,7 @@ private:
 
     Ref<Document> protectedDocument() const { return m_document.get(); }
 
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     TagId m_tagId;
     String m_urlToLoad;
     String m_srcSetAttribute;

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.h
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.h
@@ -28,7 +28,7 @@
 #include "CachedResource.h"
 #include "CachedResourceRequest.h"
 #include "ScriptType.h"
-#include <wtf/CheckedRef.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -90,7 +90,7 @@ public:
 private:
     Ref<Document> protectedDocument() const { return m_document.get(); }
 
-    CheckedRef<Document> m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 3b9cbf2ef6fb716c4ac446f327ba4c88ee134565
<pre>
Reduce use of CheckedRef for non-stack variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=267414">https://bugs.webkit.org/show_bug.cgi?id=267414</a>

Reviewed by Brent Fulgham.

This tested as performance neutral on Speedometer 2 &amp; 3.

* Source/WebCore/css/parser/SizesAttributeParser.h:
* Source/WebCore/dom/ConstantPropertyMap.h:
* Source/WebCore/dom/CurrentScriptIncrementer.h:
* Source/WebCore/dom/DOMImplementation.h:
* Source/WebCore/dom/DeviceOrientationAndMotionAccessController.h:
* Source/WebCore/dom/DocumentFontLoader.h:
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/dom/DocumentStorageAccess.h:
* Source/WebCore/dom/ExtensionStyleSheets.h:
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/dom/ScriptRunner.h:
* Source/WebCore/dom/VisitedLinkState.h:
* Source/WebCore/editing/AlternativeTextController.h:
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/SpellChecker.h:
* Source/WebCore/html/parser/HTMLConstructionSite.h:
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
* Source/WebCore/html/parser/HTMLResourcePreloader.h:

Canonical link: <a href="https://commits.webkit.org/272924@main">https://commits.webkit.org/272924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7e325ff1334b7ea1e4ec69e48d2f455cb639457

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36247 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30506 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9560 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29602 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10456 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/29985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9135 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/29993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37572 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30524 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/30315 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35360 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33245 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11139 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9945 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4317 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->