### PR TITLE
REGRESSION(272844@main): [GStreamer][Debug] ASSERTION FAILED: isMainThread() in WebCore::MediaStreamTrackPrivate::source()

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1031,16 +1031,13 @@ webkit.org/b/254522 media/video-volume.html [ Pass Failure ]
 webkit.org/b/254525 http/tests/media/video-throttled-load-metadata.html [ Pass Failure ]
 media/video-seek-to-current-time.html [ Failure ]
 
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/213699 http/wpt/mediarecorder/mimeType.html [ Failure ]
+webkit.org/b/213699 http/wpt/mediarecorder/mimeType.html [ Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/mute-tracks.html [ Failure Crash ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/213699 http/wpt/mediarecorder/video-rotation.html [ Failure ]
+webkit.org/b/213699 http/wpt/mediarecorder/video-rotation.html [ Failure ]
 webkit.org/b/213699 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-mimetype.html [ Pass Timeout ]
 webkit.org/b/213699 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-no-sink.https.html [ Failure ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/213699 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-peerconnection.https.html [ Failure ]
-#webkit.org/b/213699 http/wpt/mediarecorder/set-srcObject-MediaStream-Blob.html [ Pass Failure ]
+webkit.org/b/213699 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-peerconnection.https.html [ Failure ]
+webkit.org/b/213699 http/wpt/mediarecorder/set-srcObject-MediaStream-Blob.html [ Pass Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-audio-bitrate.html [ Pass Failure ]
 webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable.html [ Timeout Failure ]
 
@@ -1225,6 +1222,8 @@ webkit.org/b/264708 media/media-source/media-webm-opus-partial-abort.html [ Pass
 webkit.org/b/265205 imported/w3c/web-platform-tests/media-source/mediasource-remove-preserves-currentTime.html [ Pass Crash ]
 
 webkit.org/b/265206 media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html [ Pass Crash ]
+
+media/now-playing-status-for-video-conference-web-page.html [ Pass Timeout ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of GStreamer-related bugs
@@ -1851,8 +1850,7 @@ webkit.org/b/251106 webgl/2.0.y/conformance/offscreencanvas/methods-worker.html 
 webkit.org/b/251106 webgl/2.0.y/conformance/offscreencanvas/offscreencanvas-timer-query.html [ Pass Timeout ]
 
 # Fails when using two textures.
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/258296 webrtc/canvas-to-peer-connection.html [ Failure Timeout ]
+webkit.org/b/258296 webrtc/canvas-to-peer-connection.html [ Failure Timeout ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebGL-related bugs
@@ -1868,8 +1866,7 @@ webkit.org/b/79203 fast/mediastream/RTCPeerConnection-ice.html [ Failure Timeout
 webkit.org/b/79203 fast/mediastream/RTCPeerConnection-inspect-offer-bundlePolicy-bundle-only.html [ Failure Crash ]
 webkit.org/b/79203 fast/mediastream/RTCPeerConnection-stats.html [ Timeout Crash ]
 webkit.org/b/79203 fast/mediastream/video-srcObject-fit-fill.html [ Pass Timeout ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/230415 fast/mediastream/RTCPeerConnection-iceconnectionstatechange-event.html [ Timeout ]
+webkit.org/b/230415 fast/mediastream/RTCPeerConnection-iceconnectionstatechange-event.html [ Timeout ]
 webkit.org/b/187603 fast/mediastream/media-stream-track-source-failure.html [ Timeout Failure Pass ]
 
 webkit.org/b/264803 fast/mediastream/mediastreamtrack-video-resize-event.html [ Failure ]
@@ -1878,10 +1875,9 @@ webkit.org/b/264803 fast/mediastream/mediastreamtrack-video-resize-event.html [ 
 webkit.org/b/265865 imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation.html [ Skip ]
 
 # Requires video scaling adaptation.
-# Uncomment when webkit.org/b/267411 is fixed
-#webrtc/captureCanvas-webrtc-with-video-scaling-adaptation.html [ Failure ]
-#webrtc/video-maxBitrate.html [ Failure ]
-#webrtc/video-maxBitrate-vp8.html [ Failure ]
+webrtc/captureCanvas-webrtc-with-video-scaling-adaptation.html [ Failure ]
+webrtc/video-maxBitrate.html [ Failure ]
+webrtc/video-maxBitrate-vp8.html [ Failure ]
 
 # Times out waiting for DTLS transport setup. Some bug related with data-channel, pending investigation.
 webkit.org/b/265860 imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https.html [ Skip ]
@@ -1910,15 +1906,13 @@ fast/mediastream/get-user-media-constraints.html [ Failure ]
 fast/mediastream/get-user-media-ideal-constraints.html [ Failure ]
 fast/mediastream/mediastreamtrack-video-frameRate-clone-increasing.html [ Failure ]
 fast/mediastream/video-rotation.html [ Skip ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webrtc/video-rotation-no-cvo.html [ Failure Timeout ]
+webrtc/video-rotation-no-cvo.html [ Failure Timeout ]
 webrtc/video-rotation-black.html [ Crash Failure Pass Timeout ]
 
 # No AudioSession category handling in WPE/GTK ports.
 fast/mediastream/microphone-interruption-and-audio-session.html [ Skip ]
 
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/261329 webrtc/video-clone-track.html [ Failure ]
+webkit.org/b/261329 webrtc/video-clone-track.html [ Failure ]
 
 webkit.org/b/256758 fast/mediastream/captureStream/canvas3d.html [ Failure ]
 
@@ -1936,8 +1930,7 @@ webkit.org/b/187064 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-get
 
 webrtc/video-av1.html [ Skip ]
 
-# Uncomment when webkit.org/b/267411 is fixed
-#webrtc/h265.html [ Pass Timeout ]
+webrtc/h265.html [ Pass Timeout ]
 
 # GStreamer's DTLS agent currently generates RSA certificates only. DTLS 1.2 is not supported yet (AFAIK).
 webrtc/datachannel/dtls10.html [ Failure ]
@@ -1991,58 +1984,54 @@ webkit.org/b/235885 webrtc/libwebrtc/release-while-getting-stats.html [ Skip ]
 webrtc/video-replace-track.html [ Pass Failure Timeout Crash ]
 
 # GStreamerRtpSenderBackend::setMediaStreamIds() unimplemented.
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/235885 webrtc/video.html [ Failure ]
+webkit.org/b/235885 webrtc/video.html [ Skip ]
 
 # webrtcbin emits no ICE candidate stats for a PeerConnection managing only one data-channel.
 webkit.org/b/235885 webrtc/candidate-stats.html [ Failure ]
 webkit.org/b/262989 imported/w3c/web-platform-tests/webrtc-stats/getStats-remote-candidate-address.html [ Failure ]
 
 # Pending investigation.
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/235885 fast/mediastream/RTCPeerConnection-addIceCandidate.html [ Failure ]
-#webkit.org/b/235885 fast/mediastream/RTCPeerConnection-addTrack-reuse-sender.html [ Failure ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-addIceCandidate.html [ Failure ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-addTrack-reuse-sender.html [ Failure ]
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-local-pranswer.html [ Failure ]
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-remote-offer.html [ Failure ]
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-remote-pranswer.html [ Failure ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/235885 fast/mediastream/RTCPeerConnection-icecandidate-event.html [ Failure ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-icecandidate-event.html [ Failure ]
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-media-setup-callbacks-single-dialog.html [ Failure ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/235885 fast/mediastream/RTCPeerConnection-media-setup-two-dialogs.html [ Failure Timeout ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-media-setup-two-dialogs.html [ Failure Timeout ]
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-onnegotiationneeded.html [ Skip ] # Timeout.
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/235885 fast/mediastream/RTCPeerConnection-remotely-assigned-transceiver-mid.html [ Pass Failure Timeout ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-remotely-assigned-transceiver-mid.html [ Pass Failure Timeout ]
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-setLocalDescription-offer.html [ Failure ]
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpParameters-maxFramerate.html [ Failure ]
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-priority/RTCRtpParameters-encodings.html [ Failure ]
 webkit.org/b/235885 imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationPreference.html [ Failure ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/235885 webrtc/addTransceiver-then-addTrack.html [ Failure ]
+webkit.org/b/235885 webrtc/addTransceiver-then-addTrack.html [ Failure ]
 webkit.org/b/235885 webrtc/audio-video-element-playing.html [ Timeout ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/235885 webrtc/ephemeral-certificates-and-cnames.html [ Failure ]
+webkit.org/b/235885 webrtc/ephemeral-certificates-and-cnames.html [ Failure ]
 webkit.org/b/235885 webrtc/filtering-ice-candidate-after-reload.html [ Failure ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/235885 webrtc/peer-connection-track-end.html [ Failure ]
-#webkit.org/b/235885 webrtc/peerconnection-page-cache-long.html [ Timeout ]
-#webkit.org/b/235885 webrtc/peerconnection-page-cache.html [ Timeout ]
-#webkit.org/b/235885 webrtc/video-stats.html [ Failure ]
+webkit.org/b/235885 webrtc/peer-connection-track-end.html [ Failure ]
+webkit.org/b/235885 webrtc/peerconnection-page-cache.html [ Timeout ]
+webkit.org/b/235885 webrtc/video-stats.html [ Failure ]
 webkit.org/b/235885 webrtc/vp8-then-h264.html [ Failure Timeout Crash ]
 webkit.org/b/252878 fast/mediastream/mediastreamtrack-video-clone.html [ Crash Failure Timeout Pass ]
 webkit.org/b/213202 fast/mediastream/getUserMedia-grant-persistency3.html [ Failure Pass ]
 webkit.org/b/252878 fast/mediastream/video-mediastream-restricted-invisible-autoplay-not-allowed.html [ Pass Timeout ]
 webkit.org/b/252878 fast/mediastream/video-mediastream-restricted-invisible-autoplay-user-click.html [ Pass Timeout ]
 webkit.org/b/252878 http/tests/webrtc/video-mediastream-invisible-autoplay-detached.html [ Pass Timeout ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/187064 webrtc/video-addTrack.html [ Failure Pass Timeout ]
-#webkit.org/b/187064 webrtc/video-rotation.html [ Failure Timeout ]
-#webkit.org/b/187064 webrtc/video-with-data-channel.html [ Failure ]
+webkit.org/b/187064 webrtc/video-addTrack.html [ Failure Pass Timeout ]
+webkit.org/b/187064 webrtc/video-rotation.html [ Failure Timeout ]
+webkit.org/b/187064 webrtc/video-with-data-channel.html [ Failure ]
 webkit.org/b/177533 webrtc/video-interruption.html
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/229346 webkit.org/b/235885 webrtc/multi-audio.html [ Timeout Pass Failure ]
-#webkit.org/b/224074 webrtc/concurrentVideoPlayback2.html [ Timeout Pass ]
+webkit.org/b/229346 webkit.org/b/235885 webrtc/multi-audio.html [ Timeout Pass Failure ]
+webkit.org/b/224074 webrtc/concurrentVideoPlayback2.html [ Timeout Pass ]
 webkit.org/b/206656 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-removetrack.https.html [ Crash Failure Timeout ]
+webkit.org/b/257624 webrtc/video-mute.html [ Pass Timeout ]
+webkit.org/b/257624 webrtc/video-mute-vp8.html [ Pass Timeout ]
+webrtc/captureCanvas-webrtc.html [ Pass Timeout ]
+webkit.org/b/252878 webrtc/audio-peer-connection-webaudio.html [ Failure Pass Timeout ]
+webkit.org/b/252878 webrtc/audio-samplerate-change.html [ Pass Timeout ]
+webkit.org/b/252878 webrtc/datachannel/bufferedAmountLowThreshold-default.html [ Failure Pass ]
+webkit.org/b/252878 webrtc/video-h264.html [ Pass Timeout ]
 
 imported/w3c/web-platform-tests/mediacapture-streams/GUM-required-constraint-with-ideal-value.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-MediaElement-preload-none.https.html [ Pass Failure ]
@@ -2067,6 +2056,13 @@ imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-canTrickleIceCandidates
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-parameterless.https.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addIceCandidate-timing.https.html [ Pass ]
 
+# Missing support for ICE restarts
+webkit.org/b/235885 webrtc/peerconnection-page-cache-long.html [ Skip ]
+webrtc/datachannel/datachannel-page-cache-send.html [ Skip ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-explicit-rollback-iceGatheringState.html [ Skip ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-restartIce.https.html [ Skip ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-iceGatheringState.html [ Skip ]
+
 # GStreamerRtpReceiverBackend::getSynchronizationSources() unimplemented.
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-captureTimestamp.html [ Skip ]
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html [ Skip ]
@@ -2074,8 +2070,7 @@ webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/protocol/rtp-clockrat
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-senderCaptureTimeOffset.html [ Skip ]
 
 # GStreamerRtpSenderBackend::setParameters() unimplemented.
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/215005 webkit.org/b/218787 webrtc/h264-baseline.html [ Failure Timeout ]
+webkit.org/b/215005 webkit.org/b/218787 webrtc/h264-baseline.html [ Failure Timeout ]
 webkit.org/b/215007 webrtc/h264-high.html [ Failure Timeout ]
 
 # We don't support spatial encoding yet.
@@ -2092,9 +2087,7 @@ webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-ontonec
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-ontonechange.https.html [ Skip ]
 webkit.org/b/235885 webrtc/dtmf-gc.html [ Skip ]
 
-webkit.org/b/235885 webrtc/video-h264.html [ Slow ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/235885 webrtc/vp9.html [ Slow Failure ]
+webkit.org/b/235885 webrtc/vp9.html [ Slow Failure ]
 
 # Also skipped on mac, timing out because relying on MediaStream::onactive event which is not exposed.
 webkit.org/b/151344 fast/mediastream/MediaStream-add-ended-tracks.html [ Skip ]
@@ -3568,9 +3561,8 @@ webkit.org/b/252878 imported/w3c/web-platform-tests/service-workers/service-work
 webkit.org/b/252878 imported/w3c/web-platform-tests/wasm/webapi/instantiateStreaming.any.serviceworker.html [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/wasm/webapi/instantiateStreaming.any.sharedworker.html [ Failure Pass ]
 webkit.org/b/252878 loader/navigation-policy/should-open-external-urls/subframe-navigated-programatically-by-main-frame.html [ Failure Pass ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/252878 webrtc/multi-video.html [ Failure Pass Timeout ]
-#webkit.org/b/252878 webrtc/peer-connection-remote-audio-mute2.html [ Pass Timeout ]
+webkit.org/b/252878 webrtc/multi-video.html [ Failure Pass Timeout ]
+webkit.org/b/252878 webrtc/peer-connection-remote-audio-mute2.html [ Pass Timeout ]
 
 # Missing support for UIScriptController.paste()
 fast/forms/input-text-max-length-emojis.html [ Failure ]
@@ -3596,8 +3588,7 @@ webkit.org/b/257624 http/tests/workers/service/postmessage-after-terminating-hun
 webkit.org/b/257624 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-setmediakeys-to-multiple-video-elements.https.html [ Crash Pass ]
 webkit.org/b/257624 imported/w3c/web-platform-tests/navigation-timing/nav2_test_redirect_xserver.html [ Failure Pass ]
 webkit.org/b/257624 webanimations/accelerated-translate-animation-additional-animation-added-in-flight.html [ ImageOnlyFailure Pass ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/257624 webrtc/audio-replace-track.html [ Failure Pass Timeout ]
+webkit.org/b/257624 webrtc/audio-replace-track.html [ Failure Pass Timeout ]
 webkit.org/b/257624 webrtc/negotiatedneeded-event-addStream.html [ Failure Pass ]
 
 webkit.org/b/258162 fast/images/image-alt-text-vertical.html [ ImageOnlyFailure ]
@@ -3671,10 +3662,9 @@ webkit.org/b/261024 svg/custom/circle-move-invalidation.svg [ Failure ImageOnlyF
 webkit.org/b/261024 svg/custom/mouse-move-on-svg-container.xhtml [ Failure ImageOnlyFailure Pass ]
 webkit.org/b/261024 svg/custom/mouse-move-on-svg-root.xhtml [ Failure ImageOnlyFailure Pass ]
 webkit.org/b/261024 svg/text/small-fonts-in-html5.html [ Failure ImageOnlyFailure Pass ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/261024 webrtc/video-maxFramerate.html [ Pass Timeout ]
-#webkit.org/b/261024 webrtc/video-replace-muted-track.html [ Pass Timeout ]
-#webkit.org/b/261024 webrtc/video-unmute.html [ Pass Timeout ]
+webkit.org/b/261024 webrtc/video-maxFramerate.html [ Pass Timeout ]
+webkit.org/b/261024 webrtc/video-replace-muted-track.html [ Pass Timeout ]
+webkit.org/b/261024 webrtc/video-unmute.html [ Pass Timeout ]
 webkit.org/b/261024 webrtc/video-disabled-black.html [ Crash Pass ]
 
 # Initial css/compositing test import
@@ -3744,91 +3734,7 @@ webkit.org/b/266719 fast/canvas/offscreen-giant.html [ ImageOnlyFailure ]
 
 webkit.org/b/266713 webrtc/processIceTransportStateChange-gc.html [ Skip ]
 
-webkit.org/b/267411 fast/mediastream/RTCPeerConnection-addIceCandidate.html [ Failure Crash ]
-webkit.org/b/267411 fast/mediastream/RTCPeerConnection-addTransceiver.html [ Pass Crash ]
-webkit.org/b/267411 fast/mediastream/RTCPeerConnection-icecandidate-event.html [ Failure Crash ]
-webkit.org/b/267411 fast/mediastream/RTCPeerConnection-iceconnectionstatechange-event.html [ Timeout Crash ]
-webkit.org/b/267411 fast/mediastream/RTCPeerConnection-localDescription.html [ Pass Crash ]
-webkit.org/b/267411 fast/mediastream/RTCPeerConnection-media-setup-two-dialogs.html [ Failure Timeout Crash ]
-webkit.org/b/267411 fast/mediastream/RTCPeerConnection-remotely-assigned-transceiver-mid.html [ Pass Failure Timeout Crash ]
-webkit.org/b/267411 http/wpt/mediarecorder/MediaRecorder-multiple-start-stop.html [ Pass Crash ]
-webkit.org/b/267411 http/wpt/mediarecorder/MediaRecorder-video-bitrate.html [ Pass Crash ]
-webkit.org/b/267411 http/wpt/mediarecorder/MediaRecorder-video-h264-profiles.html [ Crash Pass Timeout Crash ]
-webkit.org/b/267411 http/wpt/mediarecorder/pause-recording-timeSlice.html [ Pass Crash ]
-webkit.org/b/267411 http/wpt/mediarecorder/pause-recording.html [ Pass Failure Crash ]
-webkit.org/b/267411 http/wpt/mediarecorder/set-srcObject-MediaStream-Blob.html [ Pass Failure Crash ]
-webkit.org/b/267411 http/wpt/mediarecorder/video-rotation.html [ Failure Crash ]
-webkit.org/b/267411 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-peerconnection.https.html [ Failure Crash ]
-webkit.org/b/267411 imported/w3c/web-platform-tests/webrtc-stats/outbound-rtp.https.html [ Pass Crash ]
-webkit.org/b/267411 media/now-playing-status-for-video-conference-web-page.html [ Pass Crash ]
-webkit.org/b/267411 fast/mediastream/RTCPeerConnection-inspect-offer.html [ Pass Crash ]
-webkit.org/b/267411 fast/mediastream/RTCPeerConnection-setRemoteDescription-offer.html [ Pass Crash ]
-webkit.org/b/267411 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-disabled-tracks.https.html [ Pass Crash ]
-webkit.org/b/267411 fast/mediastream/RTCPeerConnection-overloaded-operations.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/addTransceiver-then-addTrack.html [ Failure Crash ]
-webkit.org/b/267411 webrtc/audio-muted-stats.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/audio-peer-connection-g722.html [ Failure Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/audio-peer-connection-webaudio.html [ Failure Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/audio-replace-track.html [ Failure Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/audio-samplerate-change.html [ Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/canvas-to-peer-connection-2d.html [ Failure Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/captureCanvas-webrtc-software-h264-baseline.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/captureCanvas-webrtc-software-h264-high.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/captureCanvas-webrtc.html [ Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/clone-audio-track.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/concurrentVideoPlayback.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/concurrentVideoPlayback2.html [ Timeout Pass Crash ]
-webkit.org/b/267411 webrtc/connection-state.html [ Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/ephemeral-certificates-and-cnames.html [ Failure Crash ]
-webkit.org/b/267411 webrtc/h264-baseline.html [ Failure Timeout Crash ]
-webkit.org/b/267411 webrtc/h265.html [ Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/legacy-api.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/libwebrtc/descriptionGetters.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/msection-recycling.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/multi-audio.html [ Timeout Pass Failure Crash ]
-webkit.org/b/267411 webrtc/multi-video.html [ Failure Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/no-port-zero-in-upd-candidates.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/peer-connection-audio-mute2.html [ Failure Timeout Pass Crash ]
-webkit.org/b/267411 webrtc/canvas-to-peer-connection.html [ Failure Timeout Crash ]
-webkit.org/b/267411 webrtc/peer-connection-audio-mute.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/peer-connection-audio-unmute.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/peer-connection-createMediaStreamDestination.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/peer-connection-remote-audio-mute.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/peer-connection-remote-audio-mute2.html [ Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/peer-connection-track-end.html  [ Failure Crash ]
-webkit.org/b/267411 webrtc/peerconnection-page-cache-long.html  [ Timeout Crash ]
-webkit.org/b/267411 webrtc/peerconnection-page-cache.html [ Timeout Crash ]
-webkit.org/b/267411 webrtc/receiver-track-should-stay-live-even-if-receiver-is-inactive.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/release-after-getting-track.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/remoteAudio-never-played.html [ Pass Crash ]
-webkit.org/b/267411 fast/mediastream/RTCPeerConnection-createAnswer.html [ Pass Crash ]
-webkit.org/b/267411 http/wpt/mediarecorder/mimeType.html [ Failure Crash ]
-webkit.org/b/267411 webrtc/utf8-sdp.html [ Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/video-addTrack.html [ Failure Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/video-autoplay.html [ Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/video-clone-track.html [ Failure Crash ]
-webkit.org/b/267411 webrtc/video-getParameters.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/video-maxBitrate-vp8.html [ Failure Crash ]
-webkit.org/b/267411 webrtc/video-maxBitrate.html [ Failure Crash ]
-webkit.org/b/267411 webrtc/video-maxFramerate.html [ Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/video-mute-vp8.html [ Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/video-mute.html [ Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/video-receivers.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/video-remote-mute.html [ Failure Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/video-replace-muted-track.html [ Pass Timeout Crash ]
-webkit.org/b/267411 fast/mediastream/RTCPeerConnection-addTrack-reuse-sender.html [ Failure Crash ]
-webkit.org/b/267411 webrtc/captureCanvas-webrtc-with-video-scaling-adaptation.html [ Failure Crash ]
-webkit.org/b/267411 webrtc/libwebrtc/release-while-creating-offer.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/video-replace-track-to-null.html [ Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/video-rotation-no-cvo.html [ Failure Timeout Crash ]
-webkit.org/b/267411 webrtc/video-rotation.html [ Failure Timeout Crash ]
-webkit.org/b/267411 webrtc/video-stats.html [ Failure Crash ]
-webkit.org/b/267411 webrtc/video-unmute.html [ Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/video-with-data-channel.html [ Failure Crash ]
-webkit.org/b/267411 webrtc/video.html [ Failure Crash ]
-webkit.org/b/267411 webrtc/vp8-then-h264-gpu-process-crash.html [ Pass Timeout Crash ]
-webkit.org/b/267411 webrtc/vp9-profile2.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/vp9.html [ Failure Pass Timeout Crash ]
+webrtc/datachannel/multiple-connections.html [ Timeout ]
 
 # End: Common failures between GTK and WPE.
 

--- a/LayoutTests/platform/gtk-wayland/TestExpectations
+++ b/LayoutTests/platform/gtk-wayland/TestExpectations
@@ -30,8 +30,7 @@ webkit.org/b/217159 http/wpt/service-workers/file-upload.html [ Pass ]
 webkit.org/b/132262 [ Release ] http/tests/media/video-redirect.html [ Timeout Pass Crash ]
 
 # WebRTC
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/212892 webrtc/peer-connection-audio-mute2.html [ Failure Timeout Pass Crash ]
+webkit.org/b/212892 webrtc/peer-connection-audio-mute2.html [ Failure Timeout Pass Crash ]
 
 # Workers
 ## Crashing in X11, but also timing out in Wayland

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1415,7 +1415,6 @@ webkit.org/b/252878 fast/forms/form-control-element-crash.html [ Pass Timeout ]
 webkit.org/b/252878 fast/frames/exponential-frames.html [ Pass Timeout ]
 webkit.org/b/252878 fast/frames/lots-of-objects.html [ Pass Timeout ]
 webkit.org/b/252878 html5lib/webkit-resumer.html [ Pass Timeout ]
-# Uncomment when webkit.org/b/267411 is fixed
 webkit.org/b/252878 http/wpt/mediarecorder/MediaRecorder-video-h264-profiles.html [ Crash Pass Timeout ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/content-security-policy/reporting/report-multiple-violations-02.html [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/content-security-policy/webrtc/webrtc-blocked-unknown.html [ Failure ]
@@ -1616,13 +1615,6 @@ webkit.org/b/252878 inspector/debugger/breakpoints/resolved-dump-all-pause-locat
 webkit.org/b/252878 inspector/debugger/breakpoints/resolved-dump-each-line.html [ Failure Timeout Pass ]
 webkit.org/b/252878 js/weakref-finalizationregistry.html [ Pass Timeout ]
 webkit.org/b/252878 webaudio/audioworket-out-of-memory.html [ Pass Timeout ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/252878 webrtc/audio-peer-connection-webaudio.html [ Failure Pass Timeout ]
-#webkit.org/b/252878 webrtc/audio-samplerate-change.html [ Pass Timeout ]
-webkit.org/b/252878 webrtc/datachannel/bufferedAmountLowThreshold-default.html [ Failure Pass ]
-webkit.org/b/252878 webrtc/video-h264.html [ Pass Timeout ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/252878 webrtc/video-mute-vp8.html [ Pass Timeout ]
 
 # Flaky tests detected on May2023
 webkit.org/b/257624 compositing/reflections/mask-and-reflection.html [ ImageOnlyFailure Pass ]
@@ -1631,7 +1623,8 @@ webkit.org/b/257624 http/tests/frame-throttling/raf-throttle-in-cross-origin-sub
 webkit.org/b/257624 http/tests/security/video-cross-origin-caching.html [ Pass Timeout Crash ]
 webkit.org/b/257624 http/tests/websocket/tests/hybi/multiple-connections.html [ Pass Timeout ]
 webkit.org/b/257624 http/tests/websocket/tests/hybi/multiple-connections-limit.html [ Pass Timeout ]
-webkit.org/b/257624 http/wpt/cross-origin-opener-policy/header-parsing-with-report-to.https.html [ Failure Pass ]
+# Uncomment when webkit.org/b/266280 is fixed
+#webkit.org/b/257624 http/wpt/cross-origin-opener-policy/header-parsing-with-report-to.https.html [ Failure Pass ]
 webkit.org/b/257624 http/wpt/mediarecorder/pause-recording.html [ Crash Failure Pass ]
 webkit.org/b/257624 imported/blink/compositing/background-color/background-color-drawn-over-child.html [ ImageOnlyFailure Pass ]
 webkit.org/b/257624 imported/blink/fast/text/international/vertical-positioning-with-combining-marks.html [ Crash ImageOnlyFailure Pass ]
@@ -1662,10 +1655,9 @@ webkit.org/b/257624 imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-w
 webkit.org/b/257624 imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires.html [ Failure Pass ]
 webkit.org/b/257624 media/video-audio-session-mode.html [ Pass Timeout ]
 webkit.org/b/257624 webanimations/accelerated-animations-and-motion-path.html [ Failure Pass ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/257624 webrtc/connection-state.html [ Pass Timeout ]
-#webkit.org/b/257624 webrtc/video-autoplay.html [ Pass Timeout ]
-#webkit.org/b/257624 webrtc/video-replace-track-to-null.html [ Pass Timeout ]
+webkit.org/b/257624 webrtc/connection-state.html [ Pass Timeout ]
+webkit.org/b/257624 webrtc/video-autoplay.html [ Pass Timeout ]
+webkit.org/b/257624 webrtc/video-replace-track-to-null.html [ Pass Timeout ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Flaky tests
@@ -2557,8 +2549,7 @@ webkit.org/b/261024 webgl/2.0.y/conformance2/textures/webgl_canvas/tex-3d-r8-red
 webkit.org/b/261024 webgl/2.0.y/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html [ Pass Timeout ]
 webkit.org/b/261024 webgl/2.0.y/conformance/renderbuffers/framebuffer-state-restoration.html [ Pass Timeout ]
 webkit.org/b/261024 webgl/2.0.y/conformance/rendering/color-mask-preserved-during-implicit-clears.html [ Pass Timeout ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/261024 webrtc/utf8-sdp.html [ Pass Timeout ]
+webkit.org/b/261024 webrtc/utf8-sdp.html [ Pass Timeout ]
 
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-plus-filter.html [ ImageOnlyFailure ]
 
@@ -2591,8 +2582,7 @@ webkit.org/b/264680 inspector/heap/getPreview.html [ Failure Pass ]
 webkit.org/b/264680 media/video-seek-past-end-playing.html [ Pass Timeout ]
 webkit.org/b/264680 scrollbars/scrollbar-selectors.html [ Missing Pass Timeout ]
 webkit.org/b/264680 webanimations/accelerated-animation-opacity-animation-begin-time-after-scale-animation-ends.html [ ImageOnlyFailure Pass ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/264680 webrtc/peer-connection-audio-mute2.html [ Failure Pass Timeout ]
+webkit.org/b/264680 webrtc/peer-connection-audio-mute2.html [ Failure Pass Timeout ]
 
 webkit.org/b/266204 [ Debug ] imported/w3c/web-platform-tests/scroll-animations/css/animation-inactive-outside-range-test.html [ Crash ]
 [ Debug ] imported/w3c/web-platform-tests/scroll-animations/css/animation-fill-outside-range-test.html [ Crash ]

--- a/LayoutTests/platform/gtk/webrtc/canvas-to-peer-connection-2d-expected.txt
+++ b/LayoutTests/platform/gtk/webrtc/canvas-to-peer-connection-2d-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL draw: with2DContext promise_test: Unhandled rejection with value: "video.requestVideoFrameCallback timed out"
-

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -888,13 +888,11 @@ webkit.org/b/252878 perf/append-text-nodes-without-renderers.html [ Failure Pass
 webkit.org/b/252878 svg/as-image/svg-as-image-canvas.html [ ImageOnlyFailure Pass ]
 webkit.org/b/252878 webanimations/accelerated-animation-tiled-while-running.html [ Pass Timeout ]
 webkit.org/b/252878 webaudio/audioworklet-addModule-failure.html [ Pass Timeout ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/252878 webrtc/audio-peer-connection-g722.html [ Failure Pass Timeout ]
-#webkit.org/b/252878 webrtc/audio-peer-connection-webaudio.html [ Pass Timeout ]
+webkit.org/b/252878 webrtc/audio-peer-connection-g722.html [ Failure Pass Timeout ]
+webkit.org/b/252878 webrtc/audio-peer-connection-webaudio.html [ Pass Timeout ]
 webkit.org/b/252878 webrtc/datachannel/bufferedAmountLowThreshold-default.html [ Crash Failure Pass Timeout ]
 
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/187064 webkit.org/b/235885 webrtc/video-remote-mute.html [ Failure Pass Timeout ]
+webkit.org/b/187064 webkit.org/b/235885 webrtc/video-remote-mute.html [ Failure Pass Timeout ]
 
 webkit.org/b/265290 webrtc/datachannel/basic.html [ Pass Crash ]
 webkit.org/b/265290 webrtc/datachannel/binary.html [ Pass Crash ]
@@ -916,8 +914,7 @@ webkit.org/b/257624 fast/scrolling/scrolling-inside-scrolled-overflowarea.html [
 webkit.org/b/257624 fast/scrolling/sync-scroll-overscroll-behavior-element.html [ Failure Pass ]
 webkit.org/b/257624 fast/scrolling/sync-scroll-overscroll-behavior-unscrollable-element.html [ Failure Pass ]
 webkit.org/b/257624 http/tests/workers/service/postmessage-after-terminate.https.html [ Crash Pass ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/257624 http/wpt/mediarecorder/pause-recording.html [ Failure Pass ]
+webkit.org/b/257624 http/wpt/mediarecorder/pause-recording.html [ Failure Pass ]
 webkit.org/b/257624 imported/blink/compositing/squashing/attempting-to-squash-into-compositing-container.html [ ImageOnlyFailure Pass ]
 webkit.org/b/257624 imported/blink/compositing/video/video-controls-layer-creation-squashing.html [ ImageOnlyFailure Pass ]
 webkit.org/b/257624 imported/w3c/web-platform-tests/css/css-backgrounds/background-position/subpixel-position-center.tentative.html [ ImageOnlyFailure Pass ]
@@ -938,12 +935,8 @@ webkit.org/b/257624 webaudio/suspend-context-while-interrupted.html [ Pass Timeo
 webkit.org/b/257624 webgl/1.0.x/conformance/rendering/texture-switch-performance.html [ Failure Pass ]
 webkit.org/b/257624 webgl/2.0.y/conformance2/offscreencanvas/offscreencanvas-timer-query.html [ Pass Timeout ]
 webkit.org/b/257624 webgl/2.0.y/conformance/rendering/texture-switch-performance.html [ Failure Pass ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/257624 webrtc/canvas-to-peer-connection-2d.html [ Failure Pass Timeout ]
+webkit.org/b/257624 webrtc/canvas-to-peer-connection-2d.html [ Failure Pass Timeout ]
 webkit.org/b/257624 webrtc/video-h264.html [ Crash Pass Timeout ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webkit.org/b/257624 webrtc/video-mute.html [ Pass Timeout ]
-#webkit.org/b/257624 webrtc/video-mute-vp8.html [ Pass Timeout ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # 6. SLOW TESTS
@@ -1478,8 +1471,6 @@ imported/w3c/web-platform-tests/css/css-shapes/shape-outside-invalid-circle-000.
 imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/constants/001.html?wss [ Pass Timeout ]
 webgl/2.0.0/conformance/uniforms/out-of-bounds-uniform-array-access.html [ Pass Timeout ]
 webgl/2.0.y/conformance/reading/read-pixels-test.html [ Pass Timeout ]
-# Uncomment when webkit.org/b/267411 is fixed
-#webrtc/captureCanvas-webrtc.html [ Pass Timeout ]
 
 imported/blink/fast/text/international/vertical-positioning-with-combining-marks.html [ Pass ImageOnlyFailure ]
 imported/mozilla/svg/dynamic-small-object-scaled-up-02.svg [ Pass ImageOnlyFailure ]

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
@@ -114,6 +114,8 @@ private:
     void setReconfiguring(bool isReconfiguring) { m_isReconfiguring = isReconfiguring; }
     bool isReconfiguring() const { return m_isReconfiguring; }
 
+    void tearDown();
+
     Ref<GStreamerMediaEndpoint> m_endpoint;
     bool m_isLocalDescriptionSet { false };
     bool m_isRemoteDescriptionSet { false };

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
@@ -118,6 +118,16 @@ void GStreamerRtpSenderBackend::stopSource()
     });
 }
 
+void GStreamerRtpSenderBackend::tearDown()
+{
+    WTF::switchOn(m_source, [](Ref<RealtimeOutgoingVideoSourceGStreamer>& source) {
+        source->teardown();
+    }, [](Ref<RealtimeOutgoingAudioSourceGStreamer>& source) {
+        source->teardown();
+    }, [&](std::nullptr_t&) {
+    });
+}
+
 bool GStreamerRtpSenderBackend::replaceTrack(RTCRtpSender& sender, MediaStreamTrack* track)
 {
     GST_DEBUG_OBJECT(m_rtcSender.get(), "Replacing sender track with track %p", track);

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h
@@ -70,6 +70,7 @@ public:
     void takeSource(GStreamerRtpSenderBackend&);
 
     void stopSource();
+    void tearDown();
 
 private:
     bool replaceTrack(RTCRtpSender&, MediaStreamTrack*) final;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -153,6 +153,11 @@ ExceptionOr<void> GStreamerRtpTransceiverBackend::setCodecPreferences(const Vect
     return { };
 }
 
+void GStreamerRtpTransceiverBackend::tearDown()
+{
+    m_rtcTransceiver.clear();
+}
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.h
@@ -40,6 +40,8 @@ public:
 
     GstWebRTCRTPTransceiver* rtcTransceiver() { return m_rtcTransceiver.get(); }
 
+    void tearDown();
+
 private:
     RTCRtpTransceiverDirection direction() const final;
     std::optional<RTCRtpTransceiverDirection> currentDirection() const final;

--- a/Source/WebCore/platform/SourcesGStreamer.txt
+++ b/Source/WebCore/platform/SourcesGStreamer.txt
@@ -119,6 +119,7 @@ platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
 platform/mediastream/gstreamer/GStreamerCapturer.cpp
 platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.cpp
 platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp
+platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
 platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp @no-unify
 platform/mediastream/gstreamer/GStreamerMockDevice.cpp @no-unify
 platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp @no-unify

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
@@ -86,17 +86,16 @@ const GstMetaInfo* videoFrameMetadataGetInfo()
                 auto* frameMeta = VIDEO_FRAME_METADATA_CAST(meta);
                 destroyVideoFrameMetadataPrivate(frameMeta->priv);
             },
-            [](GstBuffer* buffer, GstMeta* meta, GstBuffer*, GQuark type, gpointer data) -> gboolean {
+            [](GstBuffer* buffer, GstMeta* meta, GstBuffer*, GQuark type, gpointer) -> gboolean {
                 if (!GST_META_TRANSFORM_IS_COPY(type))
-                    return FALSE;
-
-                auto transformCopy = reinterpret_cast<GstMetaTransformCopy*>(data);
-                if (!transformCopy->region)
                     return FALSE;
 
                 auto* frameMeta = VIDEO_FRAME_METADATA_CAST(meta);
                 auto [buf, copyMeta] = ensureVideoFrameMetadata(buffer);
                 copyMeta->priv->videoSampleMetadata = frameMeta->priv->videoSampleMetadata;
+
+                Locker frameMetaLocker { frameMeta->priv->lock };
+                Locker copyMetaLocker { copyMeta->priv->lock };
                 copyMeta->priv->processingTimes = frameMeta->priv->processingTimes;
                 return TRUE;
             });

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -1,0 +1,263 @@
+/*
+ *  Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "config.h"
+#include "GStreamerIncomingTrackProcessor.h"
+
+#if USE(GSTREAMER_WEBRTC)
+
+#include "GStreamerCommon.h"
+#include "GStreamerRegistryScanner.h"
+
+GST_DEBUG_CATEGORY(webkit_webrtc_incoming_track_processor_debug);
+#define GST_CAT_DEFAULT webkit_webrtc_incoming_track_processor_debug
+
+namespace WebCore {
+
+GStreamerIncomingTrackProcessor::GStreamerIncomingTrackProcessor(ThreadSafeWeakPtr<GStreamerMediaEndpoint>&& endPoint, GRefPtr<GstPad>&& pad)
+    : m_endPoint(WTFMove(endPoint))
+    , m_pad(WTFMove(pad))
+{
+    static std::once_flag debugRegisteredFlag;
+    std::call_once(debugRegisteredFlag, [] {
+        GST_DEBUG_CATEGORY_INIT(webkit_webrtc_incoming_track_processor_debug, "webkitwebrtcincomingtrackprocessor", 0, "WebKit WebRTC Incoming Track Processor");
+    });
+
+    m_data.mediaStreamBinName = makeString(GST_OBJECT_NAME(m_pad.get()));
+    m_bin = gst_bin_new(m_data.mediaStreamBinName.ascii().data());
+
+    auto caps = adoptGRef(gst_pad_get_current_caps(m_pad.get()));
+    if (!caps)
+        caps = adoptGRef(gst_pad_query_caps(m_pad.get(), nullptr));
+
+    GST_DEBUG_OBJECT(m_bin.get(), "Processing track with caps %" GST_PTR_FORMAT, caps.get());
+    m_data.type = doCapsHaveType(caps.get(), "audio") ? RealtimeMediaSource::Type::Audio : RealtimeMediaSource::Type::Video;
+    m_data.caps = WTFMove(caps);
+
+    g_object_get(m_pad.get(), "transceiver", &m_data.transceiver.outPtr(), nullptr);
+    retrieveMediaStreamAndTrackIdFromSDP();
+    m_data.mediaStreamId = mediaStreamIdFromPad();
+
+    if (!m_sdpMsIdAndTrackId.second.isEmpty())
+        m_data.trackId = m_sdpMsIdAndTrackId.second;
+
+    m_tee = gst_element_factory_make("tee", "tee");
+    g_object_set(m_tee.get(), "allow-not-linked", TRUE, nullptr);
+
+    auto trackProcessor = incomingTrackProcessor();
+    m_data.isUpstreamDecoding = m_isDecoding;
+
+    gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_tee.get(), trackProcessor.get(), nullptr);
+    auto sinkPad = adoptGRef(gst_element_get_static_pad(trackProcessor.get(), "sink"));
+    gst_element_add_pad(m_bin.get(), gst_ghost_pad_new("sink", sinkPad.get()));
+}
+
+String GStreamerIncomingTrackProcessor::mediaStreamIdFromPad()
+{
+    // Look-up the mediastream ID, using the msid attribute, fall back to pad name if there is no msid.
+    String mediaStreamId;
+    if (gstObjectHasProperty(m_pad.get(), "msid")) {
+        GUniqueOutPtr<char> msid;
+        g_object_get(m_pad.get(), "msid", &msid.outPtr(), nullptr);
+        if (msid) {
+            mediaStreamId = String::fromUTF8(msid.get());
+            GST_DEBUG_OBJECT(m_bin.get(), "msid set from pad msid property: %s", mediaStreamId.utf8().data());
+        }
+    }
+
+    if (!mediaStreamId.isEmpty())
+        return mediaStreamId;
+
+    if (!m_sdpMsIdAndTrackId.first.isEmpty()) {
+        GST_DEBUG_OBJECT(m_bin.get(), "msid set from SDP media msid attribute: '%s'", m_sdpMsIdAndTrackId.first.utf8().data());
+        return m_sdpMsIdAndTrackId.first;
+    }
+
+    GUniquePtr<gchar> name(gst_pad_get_name(m_pad.get()));
+    mediaStreamId = String::fromLatin1(name.get());
+    GST_DEBUG_OBJECT(m_bin.get(), "msid set from webrtcbin src pad name: %s", mediaStreamId.utf8().data());
+    return mediaStreamId;
+}
+
+void GStreamerIncomingTrackProcessor::retrieveMediaStreamAndTrackIdFromSDP()
+{
+    auto endPoint = m_endPoint.get();
+    if (!endPoint)
+        return;
+
+    GUniqueOutPtr<GstWebRTCSessionDescription> description;
+    g_object_get(endPoint->webrtcBin(), "remote-description", &description.outPtr(), nullptr);
+
+    unsigned mLineIndex;
+    g_object_get(m_data.transceiver.get(), "mlineindex", &mLineIndex, nullptr);
+    const auto media = gst_sdp_message_get_media(description->sdp, mLineIndex);
+    if (UNLIKELY(!media))
+        return;
+
+    const char* msidAttribute = gst_sdp_media_get_attribute_val(media, "msid");
+    if (!msidAttribute)
+        return;
+
+    GST_LOG_OBJECT(m_bin.get(), "SDP media msid attribute value: %s", msidAttribute);
+    auto components = String::fromUTF8(msidAttribute).split(' ');
+    if (components.size() != 2)
+        return;
+
+    m_sdpMsIdAndTrackId = { components[0], components[1] };
+}
+
+GRefPtr<GstElement> GStreamerIncomingTrackProcessor::incomingTrackProcessor()
+{
+    if (m_data.type == RealtimeMediaSource::Type::Audio)
+        return createParser();
+
+    bool forceEarlyVideoDecoding = !g_strcmp0(g_getenv("WEBKIT_GST_WEBRTC_FORCE_EARLY_VIDEO_DECODING"), "1");
+    GST_DEBUG_OBJECT(m_bin.get(), "Configuring for input caps: %" GST_PTR_FORMAT "%s", m_data.caps.get(), forceEarlyVideoDecoding ? " and early decoding" : "");
+    if (!forceEarlyVideoDecoding) {
+        auto structure = gst_caps_get_structure(m_data.caps.get(), 0);
+        ASSERT(gst_structure_has_name(structure, "application/x-rtp"));
+        auto encodingNameValue = makeString(gst_structure_get_string(structure, "encoding-name"));
+        auto mediaType = makeString("video/x-"_s, encodingNameValue.convertToASCIILowercase());
+        auto codecCaps = adoptGRef(gst_caps_new_empty_simple(mediaType.ascii().data()));
+
+        auto& scanner = GStreamerRegistryScanner::singleton();
+        if (scanner.areCapsSupported(GStreamerRegistryScanner::Configuration::Decoding, codecCaps, true)) {
+            GST_DEBUG_OBJECT(m_bin.get(), "Hardware video decoder detected, deferring decoding to the source client");
+            return createParser();
+        }
+    }
+
+    GST_DEBUG_OBJECT(m_bin.get(), "Preparing video decoder for depayloaded RTP packets");
+    GRefPtr<GstElement> decodebin = makeGStreamerElement("decodebin3", nullptr);
+    m_isDecoding = true;
+
+    m_queue = gst_element_factory_make("queue", nullptr);
+    m_fakeVideoSink = makeGStreamerElement("fakevideosink", nullptr);
+    g_object_set(m_fakeVideoSink.get(), "enable-last-sample", FALSE, nullptr);
+    gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_queue.get(), m_fakeVideoSink.get(), nullptr);
+    gst_element_link(m_queue.get(), m_fakeVideoSink.get());
+
+    g_signal_connect(decodebin.get(), "deep-element-added", G_CALLBACK(+[](GstBin*, GstBin*, GstElement* element, gpointer) {
+        auto elementClass = makeString(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
+        auto classifiers = elementClass.split('/');
+        if (!classifiers.contains("Depayloader"_s))
+            return;
+
+        configureVideoRTPDepayloader(element);
+    }), nullptr);
+
+    g_signal_connect(decodebin.get(), "element-added", G_CALLBACK(+[](GstBin*, GstElement* element, gpointer userData) {
+        auto elementClass = makeString(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
+        auto classifiers = elementClass.split('/');
+        if (!classifiers.contains("Decoder"_s) || !classifiers.contains("Video"_s))
+            return;
+
+        configureMediaStreamVideoDecoder(element);
+
+        auto pad = adoptGRef(gst_element_get_static_pad(element, "src"));
+        gst_pad_add_probe(pad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER | GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM), [](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
+            auto self = reinterpret_cast<GStreamerIncomingTrackProcessor*>(userData);
+            if (info->type & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM) {
+                auto event = GST_PAD_PROBE_INFO_EVENT(info);
+                if (GST_EVENT_TYPE(event) == GST_EVENT_CAPS) {
+                    GstCaps* caps;
+                    gst_event_parse_caps(event, &caps);
+                    self->m_videoSize = getVideoResolutionFromCaps(caps).value_or(FloatSize { 0, 0 });
+                }
+                return GST_PAD_PROBE_OK;
+            }
+            self->m_decodedVideoFrames++;
+            return GST_PAD_PROBE_OK;
+        }, userData, nullptr);
+    }), this);
+
+    g_signal_connect_swapped(decodebin.get(), "pad-added", G_CALLBACK(+[](GStreamerIncomingTrackProcessor* self, GstPad* pad) {
+        auto sinkPad = adoptGRef(gst_element_get_static_pad(self->m_tee.get(), "sink"));
+        gst_pad_link(pad, sinkPad.get());
+
+        gst_element_link(self->m_tee.get(), self->m_queue.get());
+        gst_element_sync_state_with_parent(self->m_tee.get());
+        gst_element_sync_state_with_parent(self->m_queue.get());
+        gst_element_sync_state_with_parent(self->m_fakeVideoSink.get());
+        self->trackReady();
+    }), this);
+    return decodebin;
+}
+
+GRefPtr<GstElement> GStreamerIncomingTrackProcessor::createParser()
+{
+    GRefPtr<GstElement> parsebin = makeGStreamerElement("parsebin", nullptr);
+    g_signal_connect(parsebin.get(), "element-added", G_CALLBACK(+[](GstBin*, GstElement* element, gpointer) {
+        auto elementClass = makeString(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
+        auto classifiers = elementClass.split('/');
+        if (!classifiers.contains("Depayloader"_s))
+            return;
+
+        configureVideoRTPDepayloader(element);
+    }), nullptr);
+
+    g_signal_connect_swapped(parsebin.get(), "pad-added", G_CALLBACK(+[](GStreamerIncomingTrackProcessor* self, GstPad* pad) {
+        auto sinkPad = adoptGRef(gst_element_get_static_pad(self->m_tee.get(), "sink"));
+        gst_pad_link(pad, sinkPad.get());
+        gst_element_sync_state_with_parent(self->m_tee.get());
+        self->trackReady();
+    }), this);
+    return parsebin;
+}
+
+void GStreamerIncomingTrackProcessor::trackReady()
+{
+    auto endPoint = m_endPoint.get();
+    if (!endPoint || endPoint->isStopped())
+        return;
+
+    m_isReady = true;
+    GST_DEBUG_OBJECT(m_bin.get(), "Track %s on pad %" GST_PTR_FORMAT " is ready", m_data.mediaStreamId.utf8().data(), m_pad.get());
+    callOnMainThread([endPoint = Ref { *endPoint }, this] {
+        if (endPoint->isStopped())
+            return;
+        endPoint->connectIncomingTrack(m_data);
+    });
+}
+
+const GstStructure* GStreamerIncomingTrackProcessor::stats()
+{
+    if (m_data.type == RealtimeMediaSource::Type::Audio)
+        return nullptr;
+
+    if (!m_isDecoding)
+        return nullptr;
+
+    m_stats.reset(gst_structure_new_empty("incoming-video-stats"));
+    uint64_t droppedVideoFrames = 0;
+    GUniqueOutPtr<GstStructure> stats;
+    g_object_get(m_fakeVideoSink.get(), "stats", &stats.outPtr(), nullptr);
+    if (!gst_structure_get_uint64(stats.get(), "dropped", &droppedVideoFrames))
+        return m_stats.get();
+
+    gst_structure_set(m_stats.get(), "frames-decoded", G_TYPE_UINT64, m_decodedVideoFrames, "frames-dropped", G_TYPE_UINT64, droppedVideoFrames, nullptr);
+    if (!m_videoSize.isZero())
+        gst_structure_set(m_stats.get(), "frame-width", G_TYPE_UINT, static_cast<unsigned>(m_videoSize.width()), "frame-height", G_TYPE_UINT, static_cast<unsigned>(m_videoSize.height()), nullptr);
+    return m_stats.get();
+}
+
+} // namespace WebCore
+
+#undef GST_CAT_DEFAULT
+
+#endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#pragma once
+
+#if USE(GSTREAMER_WEBRTC)
+
+#include "GStreamerMediaEndpoint.h"
+#include "GStreamerWebRTCCommon.h"
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class GStreamerIncomingTrackProcessor : public RefCounted<GStreamerIncomingTrackProcessor> {
+    WTF_MAKE_FAST_ALLOCATED;
+
+public:
+    static Ref<GStreamerIncomingTrackProcessor> create(ThreadSafeWeakPtr<GStreamerMediaEndpoint>&& endPoint, GRefPtr<GstPad>&& pad)
+    {
+        return adoptRef(*new GStreamerIncomingTrackProcessor(WTFMove(endPoint), WTFMove(pad)));
+    }
+    ~GStreamerIncomingTrackProcessor() = default;
+
+    GstElement* bin() const { return m_bin.get(); }
+    GstPad* pad() const { return m_pad.get(); }
+
+    const GstStructure* stats();
+
+    bool isDecoding() const { return m_isDecoding; }
+    bool isReady() const { return m_isReady; }
+    const String& trackId() const { return m_data.trackId; }
+
+private:
+    GStreamerIncomingTrackProcessor(ThreadSafeWeakPtr<GStreamerMediaEndpoint>&&, GRefPtr<GstPad>&&);
+
+    void retrieveMediaStreamAndTrackIdFromSDP();
+    String mediaStreamIdFromPad();
+
+    GRefPtr<GstElement> incomingTrackProcessor();
+    GRefPtr<GstElement> createParser();
+
+    void trackReady();
+
+    ThreadSafeWeakPtr<GStreamerMediaEndpoint> m_endPoint;
+    GRefPtr<GstPad> m_pad;
+    GRefPtr<GstElement> m_bin;
+    GRefPtr<GstElement> m_tee;
+    WebRTCTrackData m_data;
+
+    std::pair<String, String> m_sdpMsIdAndTrackId;
+
+    bool m_isDecoding { false };
+    FloatSize m_videoSize;
+    uint64_t m_decodedVideoFrames { 0 };
+    GRefPtr<GstElement> m_queue;
+    GRefPtr<GstElement> m_fakeVideoSink;
+    GUniquePtr<GstStructure> m_stats;
+    bool m_isReady { false };
+};
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCCommon.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCCommon.h
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#pragma once
+
+#if USE(GSTREAMER_WEBRTC)
+
+namespace WebCore {
+
+using WebRTCTrackData = struct _WebRTCTrackData {
+    String mediaStreamId;
+    String trackId;
+    String mediaStreamBinName;
+    GRefPtr<GstWebRTCRTPTransceiver> transceiver;
+    bool isUpstreamDecoding;
+    RealtimeMediaSource::Type type;
+    GRefPtr<GstCaps> caps;
+};
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp
@@ -38,9 +38,8 @@ RealtimeIncomingAudioSourceGStreamer::RealtimeIncomingAudioSourceGStreamer(AtomS
         GST_DEBUG_CATEGORY_INIT(webkit_webrtc_incoming_audio_debug, "webkitwebrtcincomingaudio", 0, "WebKit WebRTC incoming audio");
     });
     static Atomic<uint64_t> sourceCounter = 0;
-    gst_element_set_name(bin(), makeString("incoming-audio-source-", sourceCounter.exchangeAdd(1)).ascii().data());
-    GST_DEBUG_OBJECT(bin(), "New incoming audio source created");
-    start();
+    gst_element_set_name(bin(), makeString("incoming-audio-source-"_s, sourceCounter.exchangeAdd(1)).ascii().data());
+    GST_DEBUG_OBJECT(bin(), "New incoming audio source created with ID %s", persistentID().ascii().data());
 }
 
 RealtimeIncomingAudioSourceGStreamer::~RealtimeIncomingAudioSourceGStreamer()

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
@@ -23,7 +23,6 @@
 #include "RealtimeIncomingVideoSourceGStreamer.h"
 
 #include "GStreamerCommon.h"
-#include "GStreamerRegistryScanner.h"
 #include "GStreamerWebRTCUtils.h"
 #include "VideoFrameGStreamer.h"
 #include "VideoFrameMetadataGStreamer.h"
@@ -41,10 +40,16 @@ RealtimeIncomingVideoSourceGStreamer::RealtimeIncomingVideoSourceGStreamer(AtomS
         GST_DEBUG_CATEGORY_INIT(webkit_webrtc_incoming_video_debug, "webkitwebrtcincomingvideo", 0, "WebKit WebRTC incoming video");
     });
     static Atomic<uint64_t> sourceCounter = 0;
-    gst_element_set_name(bin(), makeString("incoming-video-source-", sourceCounter.exchangeAdd(1)).ascii().data());
-    GST_DEBUG_OBJECT(bin(), "New incoming video source created");
+    gst_element_set_name(bin(), makeString("incoming-video-source-"_s, sourceCounter.exchangeAdd(1)).ascii().data());
+    GST_DEBUG_OBJECT(bin(), "New incoming video source created with ID %s", persistentID().ascii().data());
+}
 
-    auto sinkPad = adoptGRef(gst_element_get_static_pad(bin(), "sink"));
+void RealtimeIncomingVideoSourceGStreamer::setUpstreamBin(const GRefPtr<GstElement>& bin)
+{
+    RealtimeIncomingSourceGStreamer::setUpstreamBin(bin);
+
+    auto tee = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_upstreamBin.get()), "tee"));
+    auto sinkPad = adoptGRef(gst_element_get_static_pad(tee.get(), "sink"));
     gst_pad_add_probe(sinkPad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER), [](GstPad*, GstPadProbeInfo* info, gpointer) -> GstPadProbeReturn {
         auto videoFrameTimeMetadata = std::make_optional<VideoFrameTimeMetadata>({ });
         videoFrameTimeMetadata->receiveTime = MonotonicTime::now().secondsSinceEpoch();
@@ -60,87 +65,6 @@ RealtimeIncomingVideoSourceGStreamer::RealtimeIncomingVideoSourceGStreamer(AtomS
         GST_PAD_PROBE_INFO_DATA(info) = buffer;
         return GST_PAD_PROBE_OK;
     }, nullptr, nullptr);
-
-    start();
-}
-
-void RealtimeIncomingVideoSourceGStreamer::configureForInputCaps(const GRefPtr<GstCaps>& caps)
-{
-    bool forceEarlyVideoDecoding = !g_strcmp0(g_getenv("WEBKIT_GST_WEBRTC_FORCE_EARLY_VIDEO_DECODING"), "1");
-    GST_DEBUG_OBJECT(bin(), "Configuring for input caps: %" GST_PTR_FORMAT "%s", caps.get(), forceEarlyVideoDecoding ? " and early decoding" : "");
-    if (!forceEarlyVideoDecoding) {
-        auto structure = gst_caps_get_structure(caps.get(), 0);
-        ASSERT(gst_structure_has_name(structure, "application/x-rtp"));
-        auto encodingNameValue = makeString(gst_structure_get_string(structure, "encoding-name"));
-        auto mediaType = makeString("video/x-"_s, encodingNameValue.convertToASCIILowercase());
-        auto codecCaps = adoptGRef(gst_caps_new_empty_simple(mediaType.ascii().data()));
-
-        auto& scanner = GStreamerRegistryScanner::singleton();
-        if (scanner.areCapsSupported(GStreamerRegistryScanner::Configuration::Decoding, codecCaps, true)) {
-            GST_DEBUG_OBJECT(bin(), "Hardware video decoder detected, deferring decoding to the source client");
-            createParser();
-            return;
-        }
-    }
-
-    GST_DEBUG_OBJECT(bin(), "Preparing video decoder for depayloaded RTP packets");
-    auto decodebin = makeGStreamerElement("decodebin3", nullptr);
-
-    g_signal_connect(decodebin, "deep-element-added", G_CALLBACK(+[](GstBin*, GstBin*, GstElement* element, gpointer) {
-        auto elementClass = makeString(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
-        auto classifiers = elementClass.split('/');
-        if (!classifiers.contains("Depayloader"_s))
-            return;
-
-        configureVideoRTPDepayloader(element);
-    }), nullptr);
-
-    g_signal_connect(decodebin, "element-added", G_CALLBACK(+[](GstBin*, GstElement* element, gpointer userData) {
-        auto elementClass = makeString(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
-        auto classifiers = elementClass.split('/');
-        if (!classifiers.contains("Decoder"_s) || !classifiers.contains("Video"_s))
-            return;
-
-        configureMediaStreamVideoDecoder(element);
-        auto pad = adoptGRef(gst_element_get_static_pad(element, "src"));
-        gst_pad_add_probe(pad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_BUFFER | GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM), [](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
-            auto self = reinterpret_cast<RealtimeIncomingVideoSourceGStreamer*>(userData);
-            if (info->type & GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM) {
-                auto event = GST_PAD_PROBE_INFO_EVENT(info);
-                if (GST_EVENT_TYPE(event) == GST_EVENT_CAPS) {
-                    GstCaps* caps;
-                    gst_event_parse_caps(event, &caps);
-                    self->m_videoSize = getVideoResolutionFromCaps(caps).value_or(FloatSize { 0, 0 });
-                }
-                return GST_PAD_PROBE_OK;
-            }
-            self->m_decodedVideoFrames++;
-            return GST_PAD_PROBE_OK;
-        }, userData, nullptr);
-    }), this);
-
-    g_signal_connect_swapped(decodebin, "pad-added", G_CALLBACK(+[](RealtimeIncomingVideoSourceGStreamer* source, GstPad* pad) {
-        auto sinkPad = adoptGRef(gst_element_get_static_pad(source->m_tee.get(), "sink"));
-        gst_pad_link(pad, sinkPad.get());
-
-        gst_element_sync_state_with_parent(source->m_tee.get());
-        gst_element_sync_state_with_parent(source->m_queue.get());
-        gst_element_sync_state_with_parent(source->m_fakeVideoSink.get());
-        GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(source->bin()), GST_DEBUG_GRAPH_SHOW_ALL, GST_OBJECT_NAME(source->bin()));
-    }), this);
-
-    m_queue = makeGStreamerElement("queue", nullptr);
-    m_fakeVideoSink = makeGStreamerElement("fakevideosink", nullptr);
-    g_object_set(m_fakeVideoSink.get(), "enable-last-sample", FALSE, nullptr);
-
-    gst_bin_add_many(GST_BIN_CAST(bin()), decodebin, m_queue.get(), m_fakeVideoSink.get(), nullptr);
-
-    gst_element_link_many(m_tee.get(), m_queue.get(), m_fakeVideoSink.get(), nullptr);
-    gst_element_sync_state_with_parent(m_queue.get());
-    gst_element_sync_state_with_parent(m_fakeVideoSink.get());
-
-    gst_element_link(m_valve.get(), decodebin);
-    m_isDecoding = true;
 }
 
 const RealtimeMediaSourceSettings& RealtimeIncomingVideoSourceGStreamer::settings()
@@ -204,19 +128,6 @@ void RealtimeIncomingVideoSourceGStreamer::dispatchSample(GRefPtr<GstSample>&& s
 const GstStructure* RealtimeIncomingVideoSourceGStreamer::stats()
 {
     m_stats.reset(gst_structure_new_empty("incoming-video-stats"));
-
-    if (m_isDecoding) {
-        uint64_t droppedVideoFrames = 0;
-        GUniqueOutPtr<GstStructure> stats;
-        g_object_get(m_fakeVideoSink.get(), "stats", &stats.outPtr(), nullptr);
-        if (!gst_structure_get_uint64(stats.get(), "dropped", &droppedVideoFrames))
-            return m_stats.get();
-
-        gst_structure_set(m_stats.get(), "frames-decoded", G_TYPE_UINT64, m_decodedVideoFrames, "frames-dropped", G_TYPE_UINT64, droppedVideoFrames, nullptr);
-        if (!m_videoSize.isZero())
-            gst_structure_set(m_stats.get(), "frame-width", G_TYPE_UINT, static_cast<unsigned>(m_videoSize.width()), "frame-height", G_TYPE_UINT, static_cast<unsigned>(m_videoSize.height()), nullptr);
-        return m_stats.get();
-    }
 
     forEachVideoFrameObserver([&](auto& observer) {
         auto stats = observer.queryAdditionalStats();

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.h
@@ -36,7 +36,7 @@ public:
 
     const GstStructure* stats();
 
-    void configureForInputCaps(const GRefPtr<GstCaps>&) final;
+    void setUpstreamBin(const GRefPtr<GstElement>&) final;
 
 protected:
     RealtimeIncomingVideoSourceGStreamer(AtomString&&);
@@ -53,12 +53,6 @@ private:
 
     std::optional<RealtimeMediaSourceSettings> m_currentSettings;
     GUniquePtr<GstStructure> m_stats;
-
-    bool m_isDecoding { false };
-    FloatSize m_videoSize;
-    uint64_t m_decodedVideoFrames { 0 };
-    GRefPtr<GstElement> m_queue;
-    GRefPtr<GstElement> m_fakeVideoSink;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -126,7 +126,7 @@ bool RealtimeOutgoingAudioSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
 
     auto preEncoderSinkPad = adoptGRef(gst_element_get_static_pad(m_preEncoderQueue.get(), "sink"));
     if (!gst_pad_is_linked(preEncoderSinkPad.get())) {
-        if (!gst_element_link_many(m_outgoingSource.get(), m_inputSelector.get(), m_audioconvert.get(), m_audioresample.get(), m_inputCapsFilter.get(), m_preEncoderQueue.get(), nullptr)) {
+        if (!gst_element_link_many(m_outgoingSource.get(), m_inputSelector.get(), m_liveSync.get(), m_audioconvert.get(), m_audioresample.get(), m_inputCapsFilter.get(), m_preEncoderQueue.get(), nullptr)) {
             GST_ERROR_OBJECT(m_bin.get(), "Unable to link outgoing source to pre-encoder queue");
             return false;
         }
@@ -204,6 +204,15 @@ void RealtimeOutgoingAudioSourceGStreamer::linkOutgoingSource()
 void RealtimeOutgoingAudioSourceGStreamer::setParameters(GUniquePtr<GstStructure>&& parameters)
 {
     m_parameters = WTFMove(parameters);
+}
+
+void RealtimeOutgoingAudioSourceGStreamer::teardown()
+{
+    RealtimeOutgoingMediaSourceGStreamer::teardown();
+    m_audioconvert.clear();
+    m_audioresample.clear();
+    m_inputCaps.clear();
+    m_inputCaps.clear();
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h
@@ -31,6 +31,7 @@ public:
 
     bool setPayloadType(const GRefPtr<GstCaps>&) final;
     void setParameters(GUniquePtr<GstStructure>&&) final;
+    void teardown() final;
 
 protected:
     explicit RealtimeOutgoingAudioSourceGStreamer(const RefPtr<UniqueSSRCGenerator>&, const String& mediaStreamId, MediaStreamTrack&);

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
@@ -53,7 +53,7 @@ public:
     GRefPtr<GstElement> bin() const { return m_bin; }
 
     virtual bool setPayloadType(const GRefPtr<GstCaps>&) { return false; }
-    virtual void teardown() { }
+    virtual void teardown();
 
     GUniquePtr<GstStructure> parameters();
     virtual void fillEncodingParameters(const GUniquePtr<GstStructure>&) { }
@@ -77,6 +77,7 @@ protected:
     std::optional<RealtimeMediaSourceSettings> m_initialSettings;
     GRefPtr<GstElement> m_bin;
     GRefPtr<GstElement> m_outgoingSource;
+    GRefPtr<GstElement> m_liveSync;
     GRefPtr<GstElement> m_inputSelector;
     GRefPtr<GstPad> m_fallbackPad;
     GRefPtr<GstElement> m_valve;

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
@@ -95,7 +95,13 @@ void RealtimeOutgoingVideoSourceGStreamer::updateStats(GstBuffer*)
 
 void RealtimeOutgoingVideoSourceGStreamer::teardown()
 {
+    RealtimeOutgoingMediaSourceGStreamer::teardown();
+    m_videoConvert.clear();
+    m_videoFlip.clear();
+    m_videoRate.clear();
+    m_frameRateCapsFilter.clear();
     stopUpdatingStats();
+    m_stats.reset();
 }
 
 bool RealtimeOutgoingVideoSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>& caps)
@@ -167,7 +173,7 @@ bool RealtimeOutgoingVideoSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
 
     auto encoderSinkPad = adoptGRef(gst_element_get_static_pad(m_encoder.get(), "sink"));
     if (!gst_pad_is_linked(encoderSinkPad.get())) {
-        if (!gst_element_link_many(m_outgoingSource.get(), m_inputSelector.get(), m_videoFlip.get(), nullptr)) {
+        if (!gst_element_link_many(m_outgoingSource.get(), m_inputSelector.get(), m_liveSync.get(), m_videoFlip.get(), nullptr)) {
             GST_ERROR_OBJECT(m_bin.get(), "Unable to link outgoing source to videoflip");
             return false;
         }


### PR DESCRIPTION
#### 4dab5e97eee362997bc251c68299d3e72d118181
<pre>
REGRESSION(272844@main): [GStreamer][Debug] ASSERTION FAILED: isMainThread() in WebCore::MediaStreamTrackPrivate::source()
<a href="https://bugs.webkit.org/show_bug.cgi?id=267411">https://bugs.webkit.org/show_bug.cgi?id=267411</a>

Reviewed by Xabier Rodriguez-Calvar.

Make sure we don&apos;t access the RealtimeMediaSource from non-main threads. Parsing and/or decoding on
incoming RTP packets is now done between the webrtcbin src pad and the incoming source bin. Thus,
track events are dispatched only when all parsers and/or decoders are ready, from the main thread.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk-wayland/TestExpectations:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/gtk/webrtc/canvas-to-peer-connection-2d-expected.txt: Removed.
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::initializePipeline):
(WebCore::GStreamerMediaEndpoint::teardownPipeline):
(WebCore::GStreamerMediaEndpoint::getStats):
(WebCore::GStreamerMediaEndpoint::connectIncomingTrack):
(WebCore::GStreamerMediaEndpoint::connectPad):
(WebCore::GStreamerMediaEndpoint::suspend):
(WebCore::GStreamerMediaEndpoint::resume):
(WebCore::GStreamerMediaEndpoint::addRemoteStream): Deleted.
(WebCore::GStreamerMediaEndpoint::startRemoteStream): Deleted.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
(WebCore::GStreamerMediaEndpoint::webrtcBin const):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::GStreamerPeerConnectionBackend::getStats):
(WebCore::GStreamerPeerConnectionBackend::tearDown):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp:
(WebCore::GStreamerRtpSenderBackend::tearDown):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp:
(WebCore::GStreamerRtpTransceiverBackend::tearDown):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.h:
* Source/WebCore/platform/SourcesGStreamer.txt:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp:
(videoFrameMetadataGetInfo):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp: Added.
(WebCore::GStreamerIncomingTrackProcessor::GStreamerIncomingTrackProcessor):
(WebCore::GStreamerIncomingTrackProcessor::mediaStreamIdFromPad):
(WebCore::GStreamerIncomingTrackProcessor::retrieveMediaStreamAndTrackIdFromSDP):
(WebCore::GStreamerIncomingTrackProcessor::incomingTrackProcessor):
(WebCore::GStreamerIncomingTrackProcessor::createParser):
(WebCore::GStreamerIncomingTrackProcessor::trackReady):
(WebCore::GStreamerIncomingTrackProcessor::stats):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.h: Added.
(WebCore::GStreamerIncomingTrackProcessor::create):
(WebCore::GStreamerIncomingTrackProcessor::bin const):
(WebCore::GStreamerIncomingTrackProcessor::pad const):
(WebCore::GStreamerIncomingTrackProcessor::isDecoding const):
(WebCore::GStreamerIncomingTrackProcessor::isReady const):
(WebCore::GStreamerIncomingTrackProcessor::trackId const):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCCommon.h: Added.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp:
(WebCore::RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer):
(WebCore::RealtimeIncomingSourceGStreamer::setUpstreamBin):
(WebCore::RealtimeIncomingSourceGStreamer::startProducingData):
(WebCore::RealtimeIncomingSourceGStreamer::stopProducingData):
(WebCore::RealtimeIncomingSourceGStreamer::registerClient):
(WebCore::RealtimeIncomingSourceGStreamer::unregisterClient):
(WebCore::RealtimeIncomingSourceGStreamer::unregisterClientLocked):
(WebCore::RealtimeIncomingSourceGStreamer::handleUpstreamQuery):
(WebCore::RealtimeIncomingSourceGStreamer::tearDown):
(WebCore::RealtimeIncomingSourceGStreamer::createParser): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h:
(WebCore::RealtimeIncomingSourceGStreamer::setIsUpstreamDecoding):
(WebCore::RealtimeIncomingSourceGStreamer::configureForInputCaps): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp:
(WebCore::RealtimeIncomingVideoSourceGStreamer::setUpstreamBin):
(WebCore::RealtimeIncomingVideoSourceGStreamer::stats):
(WebCore::RealtimeIncomingVideoSourceGStreamer::configureForInputCaps): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingAudioSourceGStreamer::setPayloadType):
(WebCore::RealtimeOutgoingAudioSourceGStreamer::teardown):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::RealtimeOutgoingMediaSourceGStreamer):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::~RealtimeOutgoingMediaSourceGStreamer):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::stopOutgoingSource):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::teardown):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::teardown): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingVideoSourceGStreamer::teardown):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::setPayloadType):

Canonical link: <a href="https://commits.webkit.org/273292@main">https://commits.webkit.org/273292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10b2ffa6f9a8bed7b9432b6094266cb4477e25c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35007 "Failed to checkout and rebase branch from PR 22668") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37085 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/37756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36166 "Failed to checkout and rebase branch from PR 22668") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10976 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/37756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35550 "Failed to checkout and rebase branch from PR 22668") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/11774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/37756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/31308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/31838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/31637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/39007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10485 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/8410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11018 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4501 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11350 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->