### PR TITLE
Fix running jsc tests on Windows (non-cygwin) after 272663@main

### DIFF
--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -2910,15 +2910,19 @@ def getStatusMap(map={})
         # ignore any stale results from a previous run).
         forEachRemote($remoteHosts, :dropOnFailure => true, :timeout => 8 * REMOTE_TIMEOUT) { |_, host|
             copyRemoteResultToHost(host)
-            File.open(getLocalRemoteResultPath(host) + STATUS_FILE).each do |line|
-                processStatusLine(map, line.strip)
+            File.open(getLocalRemoteResultPath(host) + STATUS_FILE) do |f|
+                f.each do |line|
+                    processStatusLine(map, line.strip)
+                end
             end
             clearLocalRemoteResults(host)
         }
     else
         Dir.chdir($runnerDir) {
-            File.open(STATUS_FILE).each do |line|
-                processStatusLine(map, line.strip)
+            File.open(STATUS_FILE) do |f|
+                f.each do |line|
+                    processStatusLine(map, line.strip)
+                end
             end
         }
     end

--- a/Tools/Scripts/webkitruby/jsc-stress-test-writer-ruby.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test-writer-ruby.rb
@@ -322,8 +322,8 @@ class Plan < BasePlan
         # guaranteed to be set; if it isn't, set the exit code to
         # something that's clearly invalid.
         <<-END_STATUS_COMMAND
-          File.open("#{statusFile}", "w") { |f|
-              f.puts("#{$runUniqueId} \#{status.nil? ? 999999999 : status.exitstatus} #{status_code}")
+          File.open("#{statusFile}", "a") { |f|
+              f.puts("#{@index} #{$runUniqueId} \#{status.nil? ? 999999999 : status.exitstatus} #{status_code}")
           }
         END_STATUS_COMMAND
     end
@@ -348,7 +348,7 @@ class Plan < BasePlan
     end
     
     def statusFile
-        "#{STATUS_FILE_PREFIX}#{@index}"
+        "#{STATUS_FILE}"
     end
 
     def writeRunScript(filename)


### PR DESCRIPTION
#### 55e44f92c5bb72f9ed33bbb571c531b738c38634
<pre>
Fix running jsc tests on Windows (non-cygwin) after 272663@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=267424">https://bugs.webkit.org/show_bug.cgi?id=267424</a>

Reviewed by Ryan Haddad.

Update the ruby writer to no longer use the removed variable name
for the &apos;prefix&apos; of the results name and to append results to that
file.

Change the reading to not use directly File.open().each as that
appears to not automatically close the file which causes issues
on Windows for later unlink attempts.

* Tools/Scripts/run-jsc-stress-tests:
* Tools/Scripts/webkitruby/jsc-stress-test-writer-ruby.rb:

Canonical link: <a href="https://commits.webkit.org/273028@main">https://commits.webkit.org/273028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d718f92881fe08445b1eeb88a7c56144f03ad130

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36273 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30529 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34701 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29615 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10478 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9148 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9239 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37599 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/28677 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30546 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35374 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/33610 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9383 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33259 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11161 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/40124 "Built successfully") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7799 "") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9966 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8401 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4379 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->