### PR TITLE
[MSE][GStreamer] Dimension SourceBuffer size limit for all possible track types before init segment received

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -315,7 +315,10 @@ size_t SourceBufferPrivateGStreamer::platformMaximumBufferSize() const
     });
 
     // If any track type size isn't specified, we consider that it has no limit and the values from the
-    // element have to be used. Otherwise, the track limits are accumulative.
+    // element have to be used. Otherwise, the track limits are accumulative. If everything is specified
+    // but there's no track (eg: because we're processing an init segment that we don't know yet which
+    // kind of track(s) is going to generate) we assume that the 3 kind of tracks might appear (audio,
+    // video, text) and use all the accumulated limits at once to make room for any possible outcome.
     do {
         bool hasVideo = false;
         bool hasAudio = false;
@@ -338,19 +341,19 @@ size_t SourceBufferPrivateGStreamer::platformMaximumBufferSize() const
             }
         }
 
-        if (hasVideo) {
+        if (hasVideo || m_tracks.empty()) {
             if (maxBufferSizeVideo)
                 bufferSize += maxBufferSizeVideo;
             else
                 break;
         }
-        if (hasAudio) {
+        if (hasAudio || m_tracks.empty()) {
             if (maxBufferSizeAudio)
                 bufferSize += maxBufferSizeAudio;
             else
                 break;
         }
-        if (hasText) {
+        if (hasText || m_tracks.empty()) {
             if (maxBufferSizeText)
                 bufferSize += maxBufferSizeText;
             else


### PR DESCRIPTION
#### 71e98e40411520b4980a0b1d9f7aeccb52b369f4
<pre>
[MSE][GStreamer] Dimension SourceBuffer size limit for all possible track types before init segment received
<a href="https://bugs.webkit.org/show_bug.cgi?id=267417">https://bugs.webkit.org/show_bug.cgi?id=267417</a>

Reviewed by Philippe Normand.

SourceBuffer has separate max size limits for video, audio and text, but it has to parse the
init segment first to know if there are any video, audio or text tracks. At the very first
appendBuffer() there are not tracks parsed yet, so platformMaximumBufferSize() returns 0 (as
no tracks are there), and the limit is taken from MediaElementSession as audio limit 15MB as
no video track is present.

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1261">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1261</a>

Inspired by the work of Andrzej Surdej &lt;Andrzej_Surdej@comcast.com&gt;.

This patch adjusts the platform limits for WPE so that they account for the possibility of
any (or even all) of the possible track types appearing when processing the init segment.

* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::platformMaximumBufferSize const): Accumulate all the audio, video, text maximum sizes when no tracks have been detected yet.

Canonical link: <a href="https://commits.webkit.org/273039@main">https://commits.webkit.org/273039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc26ceb573d0d396ac970523eaf3b104feef0ea9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36417 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30643 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29712 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30137 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9255 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9363 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37735 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30478 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35476 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33367 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11278 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7840 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10076 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10288 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->