### PR TITLE
Reduce use of downcast<>() in rendering code even more

### DIFF
--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -81,18 +81,18 @@ void RenderLayerFilters::updateReferenceFilterClients(const FilterOperations& op
     removeReferenceFilterClients();
 
     for (auto& operation : operations.operations()) {
-        if (!is<ReferenceFilterOperation>(*operation))
+        RefPtr referenceOperation = dynamicDowncast<ReferenceFilterOperation>(*operation);
+        if (!referenceOperation)
             continue;
 
-        auto& referenceOperation = downcast<ReferenceFilterOperation>(*operation);
-        auto* documentReference = referenceOperation.cachedSVGDocumentReference();
+        auto* documentReference = referenceOperation->cachedSVGDocumentReference();
         if (auto* cachedSVGDocument = documentReference ? documentReference->document() : nullptr) {
             // Reference is external; wait for notifyFinished().
             cachedSVGDocument->addClient(*this);
             m_externalSVGReferences.append(cachedSVGDocument);
         } else {
             // Reference is internal; add layer as a client so we can trigger filter repaint on SVG attribute change.
-            RefPtr filterElement = m_layer.renderer().document().getElementById(referenceOperation.fragment());
+            RefPtr filterElement = m_layer.renderer().document().getElementById(referenceOperation->fragment());
             if (!filterElement)
                 continue;
             CheckedPtr renderer = dynamicDowncast<LegacyRenderSVGResourceFilter>(filterElement->renderer());

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -492,18 +492,19 @@ void RenderListBox::paintItemForeground(PaintInfo& paintInfo, const LayoutPoint&
         return;
 
     String itemText;
-    bool isOptionElement = is<HTMLOptionElement>(*listItemElement);
-    if (isOptionElement)
-        itemText = downcast<HTMLOptionElement>(*listItemElement).textIndentedToRespectGroupLabel();
-    else if (is<HTMLOptGroupElement>(*listItemElement))
-        itemText = downcast<HTMLOptGroupElement>(*listItemElement).groupLabelText();
+    RefPtr optionElement = dynamicDowncast<HTMLOptionElement>(*listItemElement);
+    RefPtr optGroupElement = dynamicDowncast<HTMLOptGroupElement>(*listItemElement);
+    if (optionElement)
+        itemText = optionElement->textIndentedToRespectGroupLabel();
+    else if (optGroupElement)
+        itemText = optGroupElement->groupLabelText();
     itemText = applyTextTransform(style(), itemText, ' ');
 
     if (itemText.isNull())
         return;
 
     Color textColor = itemStyle->visitedDependentColorWithColorFilter(CSSPropertyColor);
-    if (isOptionElement && downcast<HTMLOptionElement>(*listItemElement).selected()) {
+    if (optionElement && optionElement->selected()) {
         if (frame().selection().isFocusedAndActive() && document().focusedElement() == &selectElement())
             textColor = theme().activeListBoxSelectionForegroundColor(styleColorOptions());
         // Honor the foreground color for disabled items
@@ -528,7 +529,7 @@ void RenderListBox::paintItemForeground(PaintInfo& paintInfo, const LayoutPoint&
         paintInfo.context().translate(-rotationOrigin);
     }
 
-    if (is<HTMLOptGroupElement>(*listItemElement)) {
+    if (optGroupElement) {
         auto description = itemFont.fontDescription();
         description.setWeight(description.bolderWeight());
         itemFont = FontCascade(WTFMove(description), itemFont);
@@ -548,7 +549,7 @@ void RenderListBox::paintItemBackground(PaintInfo& paintInfo, const LayoutPoint&
         return;
 
     Color backColor;
-    if (is<HTMLOptionElement>(*listItemElement) && downcast<HTMLOptionElement>(*listItemElement).selected()) {
+    if (auto* option = dynamicDowncast<HTMLOptionElement>(*listItemElement); option && option->selected()) {
         if (frame().selection().isFocusedAndActive() && document().focusedElement() == &selectElement())
             backColor = theme().activeListBoxSelectionBackgroundColor(styleColorOptions());
         else

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -113,7 +113,8 @@ bool isHTMLListElement(const Node& node)
 static Element* enclosingList(const RenderListItem& listItem)
 {
     auto& element = listItem.element();
-    auto* parent = is<PseudoElement>(element) ? downcast<PseudoElement>(element).hostElement() : element.parentElement();
+    auto* pseudoElement = dynamicDowncast<PseudoElement>(element);
+    auto* parent = pseudoElement ? pseudoElement->hostElement() : element.parentElement();
     for (auto* ancestor = parent; ancestor; ancestor = ancestor->parentElement()) {
         if (isHTMLListElement(*ancestor) || (ancestor->renderer() && ancestor->renderer()->shouldApplyStyleContainment()))
             return ancestor;
@@ -136,13 +137,12 @@ static RenderListItem* nextListItemHelper(const Element& list, const Element& el
     };
     advance();
     while (current) {
-        auto* renderer = current->renderer();
-        if (!is<RenderListItem>(renderer)) {
+        auto* item = dynamicDowncast<RenderListItem>(current->renderer());
+        if (!item) {
             advance();
             continue;
         }
-        auto& item = downcast<RenderListItem>(*renderer);
-        auto* otherList = enclosingList(item);
+        auto* otherList = enclosingList(*item);
         if (!otherList) {
             advance();
             continue;
@@ -150,7 +150,7 @@ static RenderListItem* nextListItemHelper(const Element& list, const Element& el
 
         // This item is part of our current list, so it's what we're looking for.
         if (&list == otherList)
-            return &item;
+            return item;
 
         // We found ourself inside another list; skip the rest of its contents.
         current = ElementTraversal::nextIncludingPseudoSkippingChildren(*current, &list);
@@ -177,13 +177,12 @@ static RenderListItem* previousListItem(const Element& list, const RenderListIte
     };
     advance();
     while (current) {
-        auto* renderer = current->renderer();
-        if (!is<RenderListItem>(renderer)) {
+        auto* item = dynamicDowncast<RenderListItem>(current->renderer());
+        if (!item) {
             advance();
             continue;
         }
-        auto& item = downcast<RenderListItem>(*renderer);
-        auto* otherList = enclosingList(item);
+        auto* otherList = enclosingList(*item);
         if (!otherList) {
             advance();
             continue;
@@ -191,7 +190,7 @@ static RenderListItem* previousListItem(const Element& list, const RenderListIte
 
         // This item is part of our current list, so we found what we're looking for.
         if (&list == otherList)
-            return &item;
+            return item;
 
         // We found ourself inside another list; skip the rest of its contents by
         // advancing to it. However, since the list itself might be a list item,
@@ -354,10 +353,9 @@ void RenderListItem::updateListMarkerNumbers()
         return;
 
     bool isInReversedOrderedList = false;
-    if (is<HTMLOListElement>(*list)) {
-        auto& orderedList = downcast<HTMLOListElement>(*list);
-        orderedList.itemCountChanged();
-        isInReversedOrderedList = orderedList.isReversed();
+    if (RefPtr orderedList = dynamicDowncast<HTMLOListElement>(*list)) {
+        orderedList->itemCountChanged();
+        isInReversedOrderedList = orderedList->isReversed();
     }
 
     // If an item has been marked for update before, we know that all following items have, too.
@@ -370,8 +368,8 @@ void RenderListItem::updateListMarkerNumbers()
 
 bool RenderListItem::isInReversedOrderedList() const
 {
-    auto* list = enclosingList(*this);
-    return is<HTMLOListElement>(list) && downcast<HTMLOListElement>(*list).isReversed();
+    auto* list = dynamicDowncast<HTMLOListElement>(enclosingList(*this));
+    return list && list->isReversed();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -248,13 +248,11 @@ void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
 RenderBox* RenderListMarker::parentBox(RenderBox& box)
 {
     ASSERT(m_listItem);
-    auto* fragmentedFlow = m_listItem->enclosingFragmentedFlow();
-    if (!is<RenderMultiColumnFlow>(fragmentedFlow))
+    CheckedPtr multiColumnFlow = dynamicDowncast<RenderMultiColumnFlow>(m_listItem->enclosingFragmentedFlow());
+    if (!multiColumnFlow)
         return box.parentBox();
-    auto* placeholder = downcast<RenderMultiColumnFlow>(*fragmentedFlow).findColumnSpannerPlaceholder(&box);
-    if (!placeholder)
-        return box.parentBox();
-    return placeholder->parentBox();
+    auto* placeholder = multiColumnFlow->findColumnSpannerPlaceholder(&box);
+    return placeholder ? placeholder->parentBox() : box.parentBox();
 };
 
 void RenderListMarker::addOverflowFromListMarker()
@@ -338,11 +336,11 @@ void RenderListMarker::addOverflowFromListMarker()
             markerAncestor = parentBox(*markerAncestor);
             if (markerAncestor->hasNonVisibleOverflow())
                 propagateVisualOverflow = false;
-            if (is<RenderBlock>(*markerAncestor)) {
+            if (CheckedPtr markerAncestorBlock = dynamicDowncast<RenderBlock>(*markerAncestor)) {
                 if (propagateVisualOverflow)
-                    downcast<RenderBlock>(*markerAncestor).addVisualOverflow(markerRect);
+                    markerAncestorBlock->addVisualOverflow(markerRect);
                 if (propagateLayoutOverflow)
-                    downcast<RenderBlock>(*markerAncestor).addLayoutOverflow(markerRect);
+                    markerAncestorBlock->addLayoutOverflow(markerRect);
             }
             if (markerAncestor->hasNonVisibleOverflow())
                 propagateLayoutOverflow = false;

--- a/Source/WebCore/rendering/RenderMarquee.cpp
+++ b/Source/WebCore/rendering/RenderMarquee.cpp
@@ -73,9 +73,8 @@ RenderMarquee::~RenderMarquee() = default;
 int RenderMarquee::marqueeSpeed() const
 {
     int result = m_layer->renderer().style().marqueeSpeed();
-    Element* element = m_layer->renderer().element();
-    if (is<HTMLMarqueeElement>(element))
-        result = std::max(result, downcast<HTMLMarqueeElement>(*element).minimumDelay());
+    if (auto* marquee = dynamicDowncast<HTMLMarqueeElement>(m_layer->renderer().element()))
+        result = std::max(result, marquee->minimumDelay());
     return result;
 }
 

--- a/Source/WebCore/rendering/RenderMeter.cpp
+++ b/Source/WebCore/rendering/RenderMeter.cpp
@@ -46,8 +46,8 @@ HTMLMeterElement* RenderMeter::meterElement() const
 {
     ASSERT(element());
 
-    if (is<HTMLMeterElement>(*element()))
-        return downcast<HTMLMeterElement>(element());
+    if (auto* meterElement = dynamicDowncast<HTMLMeterElement>(*element()))
+        return meterElement;
 
     ASSERT(element()->shadowHost());
     return downcast<HTMLMeterElement>(element()->shadowHost());

--- a/Source/WebCore/rendering/RenderMultiColumnFlow.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnFlow.cpp
@@ -62,8 +62,8 @@ ASCIILiteral RenderMultiColumnFlow::renderName() const
 RenderMultiColumnSet* RenderMultiColumnFlow::firstMultiColumnSet() const
 {
     for (RenderObject* sibling = nextSibling(); sibling; sibling = sibling->nextSibling()) {
-        if (is<RenderMultiColumnSet>(*sibling))
-            return downcast<RenderMultiColumnSet>(sibling);
+        if (auto* multiColumnSet = dynamicDowncast<RenderMultiColumnSet>(*sibling))
+            return multiColumnSet;
     }
     return nullptr;
 }
@@ -73,8 +73,8 @@ RenderMultiColumnSet* RenderMultiColumnFlow::lastMultiColumnSet() const
     ASSERT(multiColumnBlockFlow());
 
     for (RenderObject* sibling = multiColumnBlockFlow()->lastChild(); sibling; sibling = sibling->previousSibling()) {
-        if (is<RenderMultiColumnSet>(*sibling))
-            return downcast<RenderMultiColumnSet>(sibling);
+        if (auto* multiColumnSet = dynamicDowncast<RenderMultiColumnSet>(*sibling))
+            return multiColumnSet;
     }
     return nullptr;
 }
@@ -116,9 +116,9 @@ void RenderMultiColumnFlow::layout()
     m_inLayout = true;
     m_lastSetWorkedOn = nullptr;
     if (RenderBox* first = firstColumnSetOrSpanner()) {
-        if (is<RenderMultiColumnSet>(*first)) {
-            m_lastSetWorkedOn = downcast<RenderMultiColumnSet>(first);
-            m_lastSetWorkedOn->beginFlow(this);
+        if (CheckedPtr multiColumnSet = dynamicDowncast<RenderMultiColumnSet>(*first)) {
+            m_lastSetWorkedOn = multiColumnSet.get();
+            multiColumnSet->beginFlow(this);
         }
     }
     RenderFragmentedFlow::layout();
@@ -155,22 +155,23 @@ void RenderMultiColumnFlow::willBeRemovedFromTree(IsInternalMove isInternalMove)
 
 void RenderMultiColumnFlow::fragmentedFlowDescendantBoxLaidOut(RenderBox* descendant)
 {
-    if (!is<RenderMultiColumnSpannerPlaceholder>(*descendant))
+    CheckedPtr placeholder = dynamicDowncast<RenderMultiColumnSpannerPlaceholder>(*descendant);
+    if (!placeholder)
         return;
-    auto& placeholder = downcast<RenderMultiColumnSpannerPlaceholder>(*descendant);
-    RenderBlock* container = placeholder.containingBlock();
 
-    for (RenderBox* prev = previousColumnSetOrSpannerSiblingOf(placeholder.spanner()); prev; prev = previousColumnSetOrSpannerSiblingOf(prev)) {
-        if (is<RenderMultiColumnSet>(*prev)) {
-            downcast<RenderMultiColumnSet>(*prev).endFlow(container, placeholder.logicalTop());
+    CheckedPtr container = placeholder->containingBlock();
+
+    for (RenderBox* prev = previousColumnSetOrSpannerSiblingOf(placeholder->spanner()); prev; prev = previousColumnSetOrSpannerSiblingOf(prev)) {
+        if (CheckedPtr multiColumnSet = dynamicDowncast<RenderMultiColumnSet>(*prev)) {
+            multiColumnSet->endFlow(container.get(), placeholder->logicalTop());
             break;
         }
     }
 
-    for (RenderBox* next = nextColumnSetOrSpannerSiblingOf(placeholder.spanner()); next; next = nextColumnSetOrSpannerSiblingOf(next)) {
-        if (is<RenderMultiColumnSet>(*next)) {
-            m_lastSetWorkedOn = downcast<RenderMultiColumnSet>(next);
-            m_lastSetWorkedOn->beginFlow(container);
+    for (RenderBox* next = nextColumnSetOrSpannerSiblingOf(placeholder->spanner()); next; next = nextColumnSetOrSpannerSiblingOf(next)) {
+        if (CheckedPtr multiColumnSet = dynamicDowncast<RenderMultiColumnSet>(*next)) {
+            m_lastSetWorkedOn = multiColumnSet.get();
+            multiColumnSet->beginFlow(container.get());
             break;
         }
     }
@@ -292,8 +293,8 @@ LayoutSize RenderMultiColumnFlow::offsetFromContainer(RenderElement& enclosingCo
         translatedPhysicalPoint.moveBy(fragment->topLeftLocation());
     
     LayoutSize offset(translatedPhysicalPoint.x(), translatedPhysicalPoint.y());
-    if (is<RenderBox>(enclosingContainer))
-        offset -= toLayoutSize(downcast<RenderBox>(enclosingContainer).scrollPosition());
+    if (auto* enclosingBox = dynamicDowncast<RenderBox>(enclosingContainer))
+        offset -= toLayoutSize(enclosingBox->scrollPosition());
     return offset;
 }
     

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -55,8 +55,8 @@ RenderMultiColumnSet::RenderMultiColumnSet(RenderFragmentedFlow& fragmentedFlow,
 RenderMultiColumnSet* RenderMultiColumnSet::nextSiblingMultiColumnSet() const
 {
     for (RenderObject* sibling = nextSibling(); sibling; sibling = sibling->nextSibling()) {
-        if (is<RenderMultiColumnSet>(*sibling))
-            return downcast<RenderMultiColumnSet>(sibling);
+        if (auto multiColumnSet = dynamicDowncast<RenderMultiColumnSet>(*sibling))
+            return multiColumnSet;
     }
     return nullptr;
 }
@@ -64,8 +64,8 @@ RenderMultiColumnSet* RenderMultiColumnSet::nextSiblingMultiColumnSet() const
 RenderMultiColumnSet* RenderMultiColumnSet::previousSiblingMultiColumnSet() const
 {
     for (RenderObject* sibling = previousSibling(); sibling; sibling = sibling->previousSibling()) {
-        if (is<RenderMultiColumnSet>(*sibling))
-            return downcast<RenderMultiColumnSet>(sibling);
+        if (auto* multiColumnSet = dynamicDowncast<RenderMultiColumnSet>(*sibling))
+            return multiColumnSet;
     }
     return nullptr;
 }


### PR DESCRIPTION
#### 58b06b535af534c669ff32e4eb9a73f9ae857ffb
<pre>
Reduce use of downcast&lt;&gt;() in rendering code even more
<a href="https://bugs.webkit.org/show_bug.cgi?id=267426">https://bugs.webkit.org/show_bug.cgi?id=267426</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::RenderLayerBacking):
(WebCore::clippingLayerBox):
(WebCore::RenderLayerBacking::updateChildrenTransformAndAnchorPoint):
(WebCore::RenderLayerBacking::updateBackdropFiltersGeometry):
(WebCore::RenderLayerBacking::updateAfterWidgetResize):
(WebCore::RenderLayerBacking::updateConfiguration):
(WebCore::RenderLayerBacking::computeParentGraphicsLayerRect const):
(WebCore::RenderLayerBacking::updateContentsRects):
(WebCore::isCompositedPlugin):
(WebCore::RenderLayerBacking::containsPaintedContent const):
(WebCore::RenderLayerBacking::isDirectlyCompositedImage const):
(WebCore::RenderLayerBacking::isUnscaledBitmapOnly const):
(WebCore::RenderLayerBacking::contentsBox const):
(WebCore::RenderLayerBacking::backgroundBoxForSimpleContainerPainting const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::frameHostingNodeForFrame):
(WebCore::RenderLayerCompositor::updateBacking):
(WebCore::RenderLayerCompositor::computeClippingScopes const):
(WebCore::RenderLayerCompositor::requiresCompositingForTransform const):
(WebCore::RenderLayerCompositor::requiresCompositingForVideo const):
(WebCore::RenderLayerCompositor::requiresCompositingForFrame const):
(WebCore::RenderLayerCompositor::isLayerForIFrameWithScrollCoordinatedContents const):
(WebCore::RenderLayerCompositor::parentRelativeScrollableRect const):
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::updateReferenceFilterClients):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::updateLayerTransform):
(WebCore::RenderLayerModelObject::computeVisibleRectsInSVGContainer const):
(WebCore::RenderLayerModelObject::svgClipperResourceFromStyle const):
(WebCore::RenderLayerModelObject::svgMaskerResourceFromStyle const):
(WebCore::RenderLayerModelObject::svgFillPaintServerResourceFromStyle const):
(WebCore::RenderLayerModelObject::svgStrokePaintServerResourceFromStyle const):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::scrollsOverflow const):
(WebCore::RenderLayerScrollableArea::availableContentSizeChanged):
(WebCore::RenderLayerScrollableArea::overflowControlsRects const):
(WebCore::RenderLayerScrollableArea::createScrollbar):
(WebCore::RenderLayerScrollableArea::updateScrollbarsAfterLayout):
* Source/WebCore/rendering/RenderLayoutState.cpp:
(WebCore::RenderLayoutState::computeOffsets):
(WebCore::RenderLayoutState::computePaginationInformation):
* Source/WebCore/rendering/RenderLineBoxList.cpp:
(WebCore::RenderLineBoxList::rangeIntersectsRect const):
(WebCore::RenderLineBoxList::dirtyLinesFromChangedChild):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::paintItemForeground):
(WebCore::RenderListBox::paintItemBackground):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::enclosingList):
(WebCore::nextListItemHelper):
(WebCore::previousListItem):
(WebCore::RenderListItem::updateListMarkerNumbers):
(WebCore::RenderListItem::isInReversedOrderedList const):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::parentBox):
(WebCore::RenderListMarker::addOverflowFromListMarker):
* Source/WebCore/rendering/RenderMarquee.cpp:
(WebCore::RenderMarquee::marqueeSpeed const):
* Source/WebCore/rendering/RenderMenuList.cpp:
(WebCore::selectedOptionCount):
(RenderMenuList::updateOptionsWidth):
(RenderMenuList::setTextFromOption):
(RenderMenuList::didUpdateActiveOption):
(RenderMenuList::itemText const):
(RenderMenuList::itemIsSelected const):
* Source/WebCore/rendering/RenderMeter.cpp:
(WebCore::RenderMeter::meterElement const):
* Source/WebCore/rendering/RenderMultiColumnFlow.cpp:
(WebCore::RenderMultiColumnFlow::firstMultiColumnSet const):
(WebCore::RenderMultiColumnFlow::lastMultiColumnSet const):
(WebCore::RenderMultiColumnFlow::layout):
(WebCore::RenderMultiColumnFlow::fragmentedFlowDescendantBoxLaidOut):
(WebCore::RenderMultiColumnFlow::offsetFromContainer const):
* Source/WebCore/rendering/RenderMultiColumnSet.cpp:
(WebCore::RenderMultiColumnSet::nextSiblingMultiColumnSet const):
(WebCore::RenderMultiColumnSet::previousSiblingMultiColumnSet const):

Canonical link: <a href="https://commits.webkit.org/272943@main">https://commits.webkit.org/272943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e67c594df4678c6dabc5466d62228a5069b73fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36279 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30535 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14810 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29619 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30012 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9152 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9247 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37605 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30553 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35377 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33262 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11167 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4330 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->