### PR TITLE
Unreviewed, address review feedback about 272926@main.

### DIFF
--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1505,7 +1505,7 @@ bool CachedResourceLoader::shouldDeferImageLoad(const URL& url) const
 void CachedResourceLoader::reloadImagesIfNotDeferred()
 {
     for (auto& resource : m_documentResources.values()) {
-        CachedResourceHandle image =  dynamicDowncast<CachedImage>(*resource);
+        CachedResourceHandle image = dynamicDowncast<CachedImage>(*resource);
         if (image && resource->stillNeedsLoad() && clientDefersImage(resource->url()) == ImageLoading::Immediate)
             image->load(*this);
     }


### PR DESCRIPTION
#### d07ed3d431f20c668b5cfc1440316606d6836a98
<pre>
Unreviewed, address review feedback about 272926@main.

* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::reloadImagesIfNotDeferred):

Canonical link: <a href="https://commits.webkit.org/272931@main">https://commits.webkit.org/272931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e206f6f9ca57b2c321e94e20afdcc865774c529c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33664 "Failed to checkout and rebase branch from PR 22673") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36280 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/30536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34711 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14811 "Failed to checkout and rebase branch from PR 22673") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/9593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/34140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/14811 "Failed to checkout and rebase branch from PR 22673") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/30007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/9153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/14811 "Failed to checkout and rebase branch from PR 22673") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/30016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/37606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/14811 "Failed to checkout and rebase branch from PR 22673") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/30339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/37606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/9593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/37606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/11168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/9973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4322 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/10164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->