### PR TITLE
Use ASCIILiteral instead of `const char*` for Supplementable key

### DIFF
--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -29,6 +29,7 @@
 #include <type_traits>
 #include <wtf/ASCIICType.h>
 #include <wtf/Forward.h>
+#include <wtf/HashFunctions.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/SuperFastHash.h>
 
@@ -122,6 +123,12 @@ struct ASCIILiteralHash {
 template<typename T> struct DefaultHash;
 template<> struct DefaultHash<ASCIILiteral> : ASCIILiteralHash { };
 
+struct ASCIILiteralPtrHash {
+    static unsigned hash(const ASCIILiteral& key) { return IntHash<uintptr_t>::hash(reinterpret_cast<uintptr_t>(key.characters())); }
+    static bool equal(const ASCIILiteral& a, const ASCIILiteral& b) { return a.characters() == b.characters(); }
+    static constexpr bool safeToCompareToEmptyOrDeleted = false;
+};
+
 inline namespace StringLiterals {
 
 constexpr ASCIILiteral operator"" _s(const char* characters, size_t n)
@@ -139,4 +146,5 @@ constexpr ASCIILiteral operator"" _s(const char* characters, size_t n)
 
 } // namespace WTF
 
+using WTF::ASCIILiteralPtrHash;
 using namespace WTF::StringLiterals;

--- a/Source/WebCore/Modules/async-clipboard/NavigatorClipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/NavigatorClipboard.cpp
@@ -62,9 +62,9 @@ NavigatorClipboard* NavigatorClipboard::from(Navigator& navigator)
     return supplement;
 }
 
-const char* NavigatorClipboard::supplementName()
+ASCIILiteral NavigatorClipboard::supplementName()
 {
-    return "NavigatorClipboard";
+    return "NavigatorClipboard"_s;
 }
 
 }

--- a/Source/WebCore/Modules/async-clipboard/NavigatorClipboard.h
+++ b/Source/WebCore/Modules/async-clipboard/NavigatorClipboard.h
@@ -44,7 +44,7 @@ public:
 
 private:
     static NavigatorClipboard* from(Navigator&);
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     RefPtr<Clipboard> m_clipboard;
     Navigator& m_navigator;

--- a/Source/WebCore/Modules/audiosession/NavigatorAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/NavigatorAudioSession.cpp
@@ -60,9 +60,9 @@ NavigatorAudioSession* NavigatorAudioSession::from(Navigator& navigator)
     return supplement;
 }
 
-const char* NavigatorAudioSession::supplementName()
+ASCIILiteral NavigatorAudioSession::supplementName()
 {
-    return "NavigatorAudioSession";
+    return "NavigatorAudioSession"_s;
 }
 
 }

--- a/Source/WebCore/Modules/audiosession/NavigatorAudioSession.h
+++ b/Source/WebCore/Modules/audiosession/NavigatorAudioSession.h
@@ -45,7 +45,7 @@ public:
 
 private:
     static NavigatorAudioSession* from(Navigator&);
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     RefPtr<DOMAudioSession> m_audioSession;
 };

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -62,9 +62,9 @@ NavigatorBeacon* NavigatorBeacon::from(Navigator& navigator)
     return supplement;
 }
 
-const char* NavigatorBeacon::supplementName()
+ASCIILiteral NavigatorBeacon::supplementName()
 {
-    return "NavigatorBeacon";
+    return "NavigatorBeacon"_s;
 }
 
 void NavigatorBeacon::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.h
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.h
@@ -53,7 +53,7 @@ public:
 private:
     ExceptionOr<bool> sendBeacon(Document&, const String& url, std::optional<FetchBody::Init>&&);
 
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&) final;
     void logError(const ResourceError&);

--- a/Source/WebCore/Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp
+++ b/Source/WebCore/Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp
@@ -49,7 +49,7 @@ public:
     DOMCacheStorage* caches() const;
 
 private:
-    static const char* supplementName() { return "DOMWindowCaches"; }
+    static ASCIILiteral supplementName() { return "DOMWindowCaches"_s; }
 
     mutable RefPtr<DOMCacheStorage> m_caches;
 };
@@ -64,7 +64,7 @@ public:
     DOMCacheStorage* caches() const;
 
 private:
-    static const char* supplementName() { return "WorkerGlobalScopeCaches"; }
+    static ASCIILiteral supplementName() { return "WorkerGlobalScopeCaches"_s; }
 
     WorkerGlobalScope& m_scope;
     mutable RefPtr<DOMCacheStorage> m_caches;

--- a/Source/WebCore/Modules/contact-picker/NavigatorContacts.cpp
+++ b/Source/WebCore/Modules/contact-picker/NavigatorContacts.cpp
@@ -62,9 +62,9 @@ NavigatorContacts* NavigatorContacts::from(Navigator& navigator)
     return supplement;
 }
 
-const char* NavigatorContacts::supplementName()
+ASCIILiteral NavigatorContacts::supplementName()
 {
-    return "NavigatorContacts";
+    return "NavigatorContacts"_s;
 }
 
 }

--- a/Source/WebCore/Modules/contact-picker/NavigatorContacts.h
+++ b/Source/WebCore/Modules/contact-picker/NavigatorContacts.h
@@ -44,7 +44,7 @@ public:
 
 private:
     static NavigatorContacts* from(Navigator&);
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     RefPtr<ContactsManager> m_contactsManager;
     Navigator& m_navigator;

--- a/Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.h
+++ b/Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.h
@@ -49,7 +49,7 @@ public:
 
 private:
     static NavigatorCookieConsent& from(Navigator&);
-    static const char* supplementName() { return "NavigatorCookieConsent"; }
+    static ASCIILiteral supplementName() { return "NavigatorCookieConsent"_s; }
 
     void requestCookieConsent(RequestCookieConsentOptions&&, Ref<DeferredPromise>&&);
 

--- a/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.cpp
@@ -39,9 +39,9 @@ NavigatorCredentials::NavigatorCredentials() = default;
 
 NavigatorCredentials::~NavigatorCredentials() = default;
 
-const char* NavigatorCredentials::supplementName()
+ASCIILiteral NavigatorCredentials::supplementName()
 {
-    return "NavigatorCredentials";
+    return "NavigatorCredentials"_s;
 }
 
 CredentialsContainer* NavigatorCredentials::credentials(WeakPtr<Document, WeakPtrImplWithEventTargetData>&& document)

--- a/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.h
+++ b/Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.h
@@ -49,7 +49,7 @@ private:
     CredentialsContainer* credentials(WeakPtr<Document, WeakPtrImplWithEventTargetData>&&);
 
     static NavigatorCredentials* from(Navigator*);
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     RefPtr<CredentialsContainer> m_credentialsContainer;
 };

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp
@@ -37,9 +37,9 @@
 
 namespace WebCore {
 
-const char* MediaKeySystemController::supplementName()
+ASCIILiteral MediaKeySystemController::supplementName()
 {
-    return "MediaKeySystemController";
+    return "MediaKeySystemController"_s;
 }
 
 MediaKeySystemController* MediaKeySystemController::from(Page* page)

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.h
@@ -44,7 +44,7 @@ public:
 
     void logRequestMediaKeySystemDenial(Document&);
 
-    WEBCORE_EXPORT static const char* supplementName();
+    WEBCORE_EXPORT static ASCIILiteral supplementName();
     static MediaKeySystemController* from(Page*);
 
 private:

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -50,9 +50,9 @@ NavigatorGamepad::~NavigatorGamepad()
     GamepadManager::singleton().unregisterNavigator(*this);
 }
 
-const char* NavigatorGamepad::supplementName()
+ASCIILiteral NavigatorGamepad::supplementName()
 {
-    return "NavigatorGamepad";
+    return "NavigatorGamepad"_s;
 }
 
 NavigatorGamepad* NavigatorGamepad::from(Navigator& navigator)

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
@@ -56,7 +56,7 @@ public:
     Ref<Gamepad> gamepadFromPlatformGamepad(PlatformGamepad&);
 
 private:
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     void gamepadsBecameVisible();
 

--- a/Source/WebCore/Modules/geolocation/GeolocationController.cpp
+++ b/Source/WebCore/Modules/geolocation/GeolocationController.cpp
@@ -173,9 +173,9 @@ void GeolocationController::stopUpdatingIfNecessary()
     m_isUpdating = false;
 }
 
-const char* GeolocationController::supplementName()
+ASCIILiteral GeolocationController::supplementName()
 {
-    return "GeolocationController";
+    return "GeolocationController"_s;
 }
 
 void provideGeolocationTo(Page* page, GeolocationClient& client)

--- a/Source/WebCore/Modules/geolocation/GeolocationController.h
+++ b/Source/WebCore/Modules/geolocation/GeolocationController.h
@@ -61,7 +61,7 @@ public:
 
     GeolocationClient& client() { return m_client; }
 
-    WEBCORE_EXPORT static const char* supplementName();
+    WEBCORE_EXPORT static ASCIILiteral supplementName();
     static GeolocationController* from(Page* page) { return static_cast<GeolocationController*>(Supplement<Page>::from(page, supplementName())); }
 
     void revokeAuthorizationToken(const String&);

--- a/Source/WebCore/Modules/geolocation/NavigatorGeolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/NavigatorGeolocation.cpp
@@ -41,9 +41,9 @@ NavigatorGeolocation::NavigatorGeolocation(Navigator& navigator)
 
 NavigatorGeolocation::~NavigatorGeolocation() = default;
 
-const char* NavigatorGeolocation::supplementName()
+ASCIILiteral NavigatorGeolocation::supplementName()
 {
-    return "NavigatorGeolocation";
+    return "NavigatorGeolocation"_s;
 }
 
 NavigatorGeolocation* NavigatorGeolocation::from(Navigator& navigator)

--- a/Source/WebCore/Modules/geolocation/NavigatorGeolocation.h
+++ b/Source/WebCore/Modules/geolocation/NavigatorGeolocation.h
@@ -44,7 +44,7 @@ public:
 #endif // PLATFORM(IOS_FAMILY)
 
 private:
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     mutable RefPtr<Geolocation> m_geolocation;
     Navigator& m_navigator;

--- a/Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp
@@ -49,7 +49,7 @@ public:
     IDBFactory* indexedDB();
 
 private:
-    static const char* supplementName() { return "DOMWindowIndexedDatabase"; }
+    static ASCIILiteral supplementName() { return "DOMWindowIndexedDatabase"_s; }
 
     RefPtr<IDBFactory> m_idbFactory;
 };
@@ -64,7 +64,7 @@ public:
     IDBFactory* indexedDB();
 
 private:
-    static const char* supplementName() { return "WorkerGlobalScopeIndexedDatabase"; }
+    static ASCIILiteral supplementName() { return "WorkerGlobalScopeIndexedDatabase"_s; }
 
     RefPtr<IDBFactory> m_idbFactory;
     Ref<IDBClient::IDBConnectionProxy> m_connectionProxy;

--- a/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.cpp
@@ -38,9 +38,9 @@ NavigatorMediaCapabilities::NavigatorMediaCapabilities()
 
 NavigatorMediaCapabilities::~NavigatorMediaCapabilities() = default;
 
-const char* NavigatorMediaCapabilities::supplementName()
+ASCIILiteral NavigatorMediaCapabilities::supplementName()
 {
-    return "NavigatorMediaCapabilities";
+    return "NavigatorMediaCapabilities"_s;
 }
 
 NavigatorMediaCapabilities& NavigatorMediaCapabilities::from(Navigator& navigator)

--- a/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.h
+++ b/Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.h
@@ -43,7 +43,7 @@ public:
 
     MediaCapabilities& mediaCapabilities() const;
 private:
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     mutable Ref<MediaCapabilities> m_mediaCapabilities;
 };

--- a/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp
@@ -38,9 +38,9 @@ WorkerNavigatorMediaCapabilities::WorkerNavigatorMediaCapabilities()
 
 WorkerNavigatorMediaCapabilities::~WorkerNavigatorMediaCapabilities() = default;
 
-const char* WorkerNavigatorMediaCapabilities::supplementName()
+ASCIILiteral WorkerNavigatorMediaCapabilities::supplementName()
 {
-    return "WorkerNavigatorMediaCapabilities";
+    return "WorkerNavigatorMediaCapabilities"_s;
 }
 
 WorkerNavigatorMediaCapabilities& WorkerNavigatorMediaCapabilities::from(WorkerNavigator& navigator)

--- a/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.h
+++ b/Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.h
@@ -43,7 +43,7 @@ public:
 
     MediaCapabilities& mediaCapabilities() const;
 private:
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     mutable Ref<MediaCapabilities> m_mediaCapabilities;
 };

--- a/Source/WebCore/Modules/mediasession/NavigatorMediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/NavigatorMediaSession.cpp
@@ -64,9 +64,9 @@ NavigatorMediaSession* NavigatorMediaSession::from(Navigator& navigator)
     return supplement;
 }
 
-const char* NavigatorMediaSession::supplementName()
+ASCIILiteral NavigatorMediaSession::supplementName()
 {
-    return "NavigatorMediaSession";
+    return "NavigatorMediaSession"_s;
 }
 
 }

--- a/Source/WebCore/Modules/mediasession/NavigatorMediaSession.h
+++ b/Source/WebCore/Modules/mediasession/NavigatorMediaSession.h
@@ -46,7 +46,7 @@ public:
 
 private:
     static NavigatorMediaSession* from(Navigator&);
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     RefPtr<MediaSession> m_mediaSession;
     Navigator& m_navigator;

--- a/Source/WebCore/Modules/mediastream/NavigatorMediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/NavigatorMediaDevices.cpp
@@ -70,9 +70,9 @@ MediaDevices* NavigatorMediaDevices::mediaDevices() const
     return m_mediaDevices.get();
 }
 
-const char* NavigatorMediaDevices::supplementName()
+ASCIILiteral NavigatorMediaDevices::supplementName()
 {
-    return "NavigatorMediaDevices";
+    return "NavigatorMediaDevices"_s;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/NavigatorMediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/NavigatorMediaDevices.h
@@ -51,7 +51,7 @@ public:
     MediaDevices* mediaDevices() const;
 
 private:
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     mutable RefPtr<MediaDevices> m_mediaDevices;
 };

--- a/Source/WebCore/Modules/mediastream/UserMediaController.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaController.cpp
@@ -35,9 +35,9 @@
 
 namespace WebCore {
 
-const char* UserMediaController::supplementName()
+ASCIILiteral UserMediaController::supplementName()
 {
-    return "UserMediaController";
+    return "UserMediaController"_s;
 }
 
 UserMediaController::UserMediaController(UserMediaClient* client)

--- a/Source/WebCore/Modules/mediastream/UserMediaController.h
+++ b/Source/WebCore/Modules/mediastream/UserMediaController.h
@@ -56,7 +56,7 @@ public:
     void logGetDisplayMediaDenial(Document&);
     void logEnumerateDevicesDenial(Document&);
 
-    WEBCORE_EXPORT static const char* supplementName();
+    WEBCORE_EXPORT static ASCIILiteral supplementName();
     static UserMediaController* from(Page* page) { return static_cast<UserMediaController*>(Supplement<Page>::from(page, supplementName())); }
 
 private:

--- a/Source/WebCore/Modules/notifications/NotificationController.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationController.cpp
@@ -51,9 +51,9 @@ NotificationClient* NotificationController::clientFrom(Page& page)
     return &controller->client();
 }
 
-const char* NotificationController::supplementName()
+ASCIILiteral NotificationController::supplementName()
 {
-    return "NotificationController";
+    return "NotificationController"_s;
 }
 
 void provideNotification(Page* page, NotificationClient* client)

--- a/Source/WebCore/Modules/notifications/NotificationController.h
+++ b/Source/WebCore/Modules/notifications/NotificationController.h
@@ -40,7 +40,7 @@ public:
     explicit NotificationController(NotificationClient*);
     ~NotificationController();
 
-    WEBCORE_EXPORT static const char* supplementName();
+    WEBCORE_EXPORT static ASCIILiteral supplementName();
     static NotificationController* from(Page* page) { return static_cast<NotificationController*>(Supplement<Page>::from(page, supplementName())); }
     WEBCORE_EXPORT static NotificationClient* clientFrom(Page&);
 

--- a/Source/WebCore/Modules/permissions/NavigatorPermissions.cpp
+++ b/Source/WebCore/Modules/permissions/NavigatorPermissions.cpp
@@ -61,9 +61,9 @@ NavigatorPermissions& NavigatorPermissions::from(Navigator& navigator)
     return *supplement;
 }
 
-const char* NavigatorPermissions::supplementName()
+ASCIILiteral NavigatorPermissions::supplementName()
 {
-    return "NavigatorPermissions";
+    return "NavigatorPermissions"_s;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/permissions/NavigatorPermissions.h
+++ b/Source/WebCore/Modules/permissions/NavigatorPermissions.h
@@ -42,7 +42,7 @@ public:
 
 private:
     static NavigatorPermissions& from(Navigator&);
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     RefPtr<Permissions> m_permissions;
     Navigator& m_navigator;

--- a/Source/WebCore/Modules/permissions/WorkerNavigatorPermissions.cpp
+++ b/Source/WebCore/Modules/permissions/WorkerNavigatorPermissions.cpp
@@ -61,9 +61,9 @@ WorkerNavigatorPermissions& WorkerNavigatorPermissions::from(WorkerNavigator& na
     return *supplement;
 }
 
-const char* WorkerNavigatorPermissions::supplementName()
+ASCIILiteral WorkerNavigatorPermissions::supplementName()
 {
-    return "WorkerNavigatorPermissions";
+    return "WorkerNavigatorPermissions"_s;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/permissions/WorkerNavigatorPermissions.h
+++ b/Source/WebCore/Modules/permissions/WorkerNavigatorPermissions.h
@@ -42,7 +42,7 @@ public:
 
 private:
     static WorkerNavigatorPermissions& from(WorkerNavigator&);
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     RefPtr<Permissions> m_permissions;
     WorkerNavigator& m_navigator;

--- a/Source/WebCore/Modules/pictureinpicture/DocumentPictureInPicture.h
+++ b/Source/WebCore/Modules/pictureinpicture/DocumentPictureInPicture.h
@@ -48,7 +48,7 @@ public:
     static DocumentPictureInPicture* from(Document&);
 
 private:
-    static const char* supplementName() { return "DocumentPictureInPicture"; };
+    static ASCIILiteral supplementName() { return "DocumentPictureInPicture"_s; };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
@@ -73,7 +73,7 @@ public:
 #endif
 
 private:
-    static const char* supplementName() { return "HTMLVideoElementPictureInPicture"; }
+    static ASCIILiteral supplementName() { return "HTMLVideoElementPictureInPicture"_s; }
 
     bool m_autoPictureInPicture { false };
     bool m_disablePictureInPicture { false };

--- a/Source/WebCore/Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp
+++ b/Source/WebCore/Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp
@@ -64,9 +64,9 @@ ServiceWorkerRegistrationPushAPI* ServiceWorkerRegistrationPushAPI::from(Service
     return supplement;
 }
 
-const char* ServiceWorkerRegistrationPushAPI::supplementName()
+ASCIILiteral ServiceWorkerRegistrationPushAPI::supplementName()
 {
-    return "ServiceWorkerRegistrationPushAPI";
+    return "ServiceWorkerRegistrationPushAPI"_s;
 }
 
 }

--- a/Source/WebCore/Modules/push-api/ServiceWorkerRegistrationPushAPI.h
+++ b/Source/WebCore/Modules/push-api/ServiceWorkerRegistrationPushAPI.h
@@ -44,7 +44,7 @@ public:
 
 private:
     static ServiceWorkerRegistrationPushAPI* from(ServiceWorkerRegistration&);
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     ServiceWorkerRegistration& m_serviceWorkerRegistration;
     std::unique_ptr<PushManager> m_pushManager;

--- a/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp
@@ -49,9 +49,9 @@ NavigatorScreenWakeLock* NavigatorScreenWakeLock::from(Navigator& navigator)
     return supplement;
 }
 
-const char* NavigatorScreenWakeLock::supplementName()
+ASCIILiteral NavigatorScreenWakeLock::supplementName()
 {
-    return "NavigatorScreenWakeLock";
+    return "NavigatorScreenWakeLock"_s;
 }
 
 WakeLock& NavigatorScreenWakeLock::wakeLock(Navigator& navigator)

--- a/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.h
+++ b/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.h
@@ -46,7 +46,7 @@ public:
 private:
     WakeLock& wakeLock();
 
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     RefPtr<WakeLock> m_wakeLock;
     Navigator& m_navigator;

--- a/Source/WebCore/Modules/speech/LocalDOMWindowSpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/LocalDOMWindowSpeechSynthesis.cpp
@@ -45,9 +45,9 @@ LocalDOMWindowSpeechSynthesis::LocalDOMWindowSpeechSynthesis(LocalDOMWindow* win
 
 LocalDOMWindowSpeechSynthesis::~LocalDOMWindowSpeechSynthesis() = default;
 
-const char* LocalDOMWindowSpeechSynthesis::supplementName()
+ASCIILiteral LocalDOMWindowSpeechSynthesis::supplementName()
 {
-    return "LocalDOMWindowSpeechSynthesis";
+    return "LocalDOMWindowSpeechSynthesis"_s;
 }
 
 // static

--- a/Source/WebCore/Modules/speech/LocalDOMWindowSpeechSynthesis.h
+++ b/Source/WebCore/Modules/speech/LocalDOMWindowSpeechSynthesis.h
@@ -46,7 +46,7 @@ public:
     
 private:
     SpeechSynthesis* speechSynthesis();
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
     
     RefPtr<SpeechSynthesis> m_speechSynthesis;
 };

--- a/Source/WebCore/Modules/webdriver/NavigatorWebDriver.cpp
+++ b/Source/WebCore/Modules/webdriver/NavigatorWebDriver.cpp
@@ -37,9 +37,9 @@ NavigatorWebDriver::NavigatorWebDriver() = default;
 
 NavigatorWebDriver::~NavigatorWebDriver() = default;
 
-const char* NavigatorWebDriver::supplementName()
+ASCIILiteral NavigatorWebDriver::supplementName()
 {
-    return "NavigatorWebDriver";
+    return "NavigatorWebDriver"_s;
 }
 
 bool NavigatorWebDriver::isControlledByAutomation(const Navigator& navigator)

--- a/Source/WebCore/Modules/webdriver/NavigatorWebDriver.h
+++ b/Source/WebCore/Modules/webdriver/NavigatorWebDriver.h
@@ -40,7 +40,7 @@ public:
     static NavigatorWebDriver* from(Navigator*);
     static bool webdriver(const Navigator&);
 private:
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
     static bool isControlledByAutomation(const Navigator&);
 };
 

--- a/Source/WebCore/Modules/webxr/NavigatorWebXR.cpp
+++ b/Source/WebCore/Modules/webxr/NavigatorWebXR.cpp
@@ -43,13 +43,18 @@ WebXRSystem& NavigatorWebXR::xr(Navigator& navigatorObject)
 
 NavigatorWebXR& NavigatorWebXR::from(Navigator& navigator)
 {
-    auto* supplement = static_cast<NavigatorWebXR*>(Supplement<Navigator>::from(&navigator, "NavigatorWebXR"));
+    auto* supplement = static_cast<NavigatorWebXR*>(Supplement<Navigator>::from(&navigator, supplementName()));
     if (!supplement) {
         auto newSupplement = makeUnique<NavigatorWebXR>();
         supplement = newSupplement.get();
-        provideTo(&navigator, "NavigatorWebXR", WTFMove(newSupplement));
+        provideTo(&navigator, supplementName(), WTFMove(newSupplement));
     }
     return *supplement;
+}
+
+ASCIILiteral NavigatorWebXR::supplementName()
+{
+    return "NavigatorWebXR"_s;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/NavigatorWebXR.h
+++ b/Source/WebCore/Modules/webxr/NavigatorWebXR.h
@@ -44,6 +44,8 @@ public:
     WEBCORE_EXPORT static NavigatorWebXR& from(Navigator&);
 
 private:
+    static ASCIILiteral supplementName();
+
     RefPtr<WebXRSystem> m_xr;
 };
 

--- a/Source/WebCore/css/DOMCSSPaintWorklet.cpp
+++ b/Source/WebCore/css/DOMCSSPaintWorklet.cpp
@@ -54,9 +54,9 @@ DOMCSSPaintWorklet* DOMCSSPaintWorklet::from(DOMCSSNamespace& css)
     return supplement;
 }
 
-const char* DOMCSSPaintWorklet::supplementName()
+ASCIILiteral DOMCSSPaintWorklet::supplementName()
 {
-    return "DOMCSSPaintWorklet";
+    return "DOMCSSPaintWorklet"_s;
 }
 
 // FIXME: Get rid of this override and rely on the standard-compliant Worklet::addModule() instead.

--- a/Source/WebCore/css/DOMCSSPaintWorklet.h
+++ b/Source/WebCore/css/DOMCSSPaintWorklet.h
@@ -68,7 +68,7 @@ public:
 
 private:
     static DOMCSSPaintWorklet* from(DOMCSSNamespace&);
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
+++ b/Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp
@@ -106,9 +106,9 @@ DOMCSSRegisterCustomProperty* DOMCSSRegisterCustomProperty::from(DOMCSSNamespace
     return supplement;
 }
 
-const char* DOMCSSRegisterCustomProperty::supplementName()
+ASCIILiteral DOMCSSRegisterCustomProperty::supplementName()
 {
-    return "DOMCSSRegisterCustomProperty";
+    return "DOMCSSRegisterCustomProperty"_s;
 }
 
 }

--- a/Source/WebCore/css/DOMCSSRegisterCustomProperty.h
+++ b/Source/WebCore/css/DOMCSSRegisterCustomProperty.h
@@ -44,7 +44,7 @@ public:
 
 private:
     static DOMCSSRegisterCustomProperty* from(DOMCSSNamespace&);
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 };
 
 }

--- a/Source/WebCore/css/typedom/CSSNumericFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericFactory.cpp
@@ -44,9 +44,9 @@ CSSNumericFactory* CSSNumericFactory::from(DOMCSSNamespace& css)
     return supplement;
 }
 
-const char* CSSNumericFactory::supplementName()
+ASCIILiteral CSSNumericFactory::supplementName()
 {
-    return "CSSNumericFactory";
+    return "CSSNumericFactory"_s;
 }
 
 }

--- a/Source/WebCore/css/typedom/CSSNumericFactory.h
+++ b/Source/WebCore/css/typedom/CSSNumericFactory.h
@@ -128,7 +128,7 @@ public:
 
 private:
     static CSSNumericFactory* from(DOMCSSNamespace&);
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DeviceMotionController.cpp
+++ b/Source/WebCore/dom/DeviceMotionController.cpp
@@ -80,9 +80,9 @@ RefPtr<Event> DeviceMotionController::getLastEvent()
     return DeviceMotionEvent::create(eventNames().devicemotionEvent, lastMotion.get());
 }
 
-const char* DeviceMotionController::supplementName()
+ASCIILiteral DeviceMotionController::supplementName()
 {
-    return "DeviceMotionController";
+    return "DeviceMotionController"_s;
 }
 
 DeviceMotionController* DeviceMotionController::from(Page* page)

--- a/Source/WebCore/dom/DeviceMotionController.h
+++ b/Source/WebCore/dom/DeviceMotionController.h
@@ -53,7 +53,7 @@ public:
     bool hasLastData() override;
     RefPtr<Event> getLastEvent() override;
 
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
     static DeviceMotionController* from(Page*);
     static bool isActiveAt(Page*);
 };

--- a/Source/WebCore/dom/DeviceOrientationController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationController.cpp
@@ -82,9 +82,9 @@ RefPtr<Event> DeviceOrientationController::getLastEvent()
 
 #endif // PLATFORM(IOS_FAMILY)
 
-const char* DeviceOrientationController::supplementName()
+ASCIILiteral DeviceOrientationController::supplementName()
 {
-    return "DeviceOrientationController";
+    return "DeviceOrientationController"_s;
 }
 
 DeviceOrientationController* DeviceOrientationController::from(Page* page)

--- a/Source/WebCore/dom/DeviceOrientationController.h
+++ b/Source/WebCore/dom/DeviceOrientationController.h
@@ -54,7 +54,7 @@ public:
     RefPtr<Event> getLastEvent() override;
 #endif
 
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
     static DeviceOrientationController* from(Page*);
     static bool isActiveAt(Page*);
 };

--- a/Source/WebCore/dom/DocumentStorageAccess.cpp
+++ b/Source/WebCore/dom/DocumentStorageAccess.cpp
@@ -62,9 +62,9 @@ DocumentStorageAccess* DocumentStorageAccess::from(Document& document)
     return supplement;
 }
 
-const char* DocumentStorageAccess::supplementName()
+ASCIILiteral DocumentStorageAccess::supplementName()
 {
-    return "DocumentStorageAccess";
+    return "DocumentStorageAccess"_s;
 }
 
 void DocumentStorageAccess::hasStorageAccess(Document& document, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/DocumentStorageAccess.h
+++ b/Source/WebCore/dom/DocumentStorageAccess.h
@@ -85,7 +85,7 @@ private:
     void requestStorageAccessQuirk(RegistrableDomain&& requestingDomain, CompletionHandler<void(StorageAccessWasGranted)>&&);
 
     static DocumentStorageAccess* from(Document&);
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
     bool hasFrameSpecificStorageAccess() const;
     void setWasExplicitlyDeniedFrameSpecificStorageAccess() { ++m_numberOfTimesExplicitlyDeniedFrameSpecificStorageAccess; };
     bool isAllowedToRequestStorageAccess() { return m_numberOfTimesExplicitlyDeniedFrameSpecificStorageAccess < maxNumberOfTimesExplicitlyDeniedStorageAccess; };

--- a/Source/WebCore/html/NavigatorUserActivation.cpp
+++ b/Source/WebCore/html/NavigatorUserActivation.cpp
@@ -60,9 +60,9 @@ NavigatorUserActivation* NavigatorUserActivation::from(Navigator& navigator)
     return supplement;
 }
 
-const char* NavigatorUserActivation::supplementName()
+ASCIILiteral NavigatorUserActivation::supplementName()
 {
-    return "NavigatorUserActivation";
+    return "NavigatorUserActivation"_s;
 }
 
 }

--- a/Source/WebCore/html/NavigatorUserActivation.h
+++ b/Source/WebCore/html/NavigatorUserActivation.h
@@ -44,7 +44,7 @@ public:
 
 private:
     static NavigatorUserActivation* from(Navigator&);
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     Ref<UserActivation> m_userActivation;
 };

--- a/Source/WebCore/page/NavigatorIsLoggedIn.cpp
+++ b/Source/WebCore/page/NavigatorIsLoggedIn.cpp
@@ -42,9 +42,9 @@ NavigatorIsLoggedIn* NavigatorIsLoggedIn::from(Navigator& navigator)
     return supplement;
 }
 
-const char* NavigatorIsLoggedIn::supplementName()
+ASCIILiteral NavigatorIsLoggedIn::supplementName()
 {
-    return "NavigatorIsLoggedIn";
+    return "NavigatorIsLoggedIn"_s;
 }
 
 void NavigatorIsLoggedIn::setLoggedIn(Navigator& navigator, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/page/NavigatorIsLoggedIn.h
+++ b/Source/WebCore/page/NavigatorIsLoggedIn.h
@@ -49,7 +49,7 @@ private:
     void isLoggedIn(Ref<DeferredPromise>&&);
     
     static NavigatorIsLoggedIn* from(Navigator&);
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     Navigator& m_navigator;
 };

--- a/Source/WebCore/testing/InternalSettings.cpp
+++ b/Source/WebCore/testing/InternalSettings.cpp
@@ -142,9 +142,9 @@ private:
     RefPtr<InternalSettings> m_internalSettings;
 };
 
-const char* InternalSettings::supplementName()
+ASCIILiteral InternalSettings::supplementName()
 {
-    return "InternalSettings";
+    return "InternalSettings"_s;
 }
 
 InternalSettings* InternalSettings::from(Page* page)

--- a/Source/WebCore/testing/InternalSettings.h
+++ b/Source/WebCore/testing/InternalSettings.h
@@ -126,7 +126,7 @@ private:
     explicit InternalSettings(Page*);
 
     Settings& settings() const;
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     class Backup {
     public:

--- a/Source/WebCore/workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.cpp
+++ b/Source/WebCore/workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.cpp
@@ -70,9 +70,9 @@ ServiceWorkerRegistrationBackgroundFetchAPI& ServiceWorkerRegistrationBackground
     return *supplement;
 }
 
-const char* ServiceWorkerRegistrationBackgroundFetchAPI::supplementName()
+ASCIILiteral ServiceWorkerRegistrationBackgroundFetchAPI::supplementName()
 {
-    return "ServiceWorkerRegistrationBackgroundFetchAPI";
+    return "ServiceWorkerRegistrationBackgroundFetchAPI"_s;
 }
 
 }

--- a/Source/WebCore/workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.h
+++ b/Source/WebCore/workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.h
@@ -46,7 +46,7 @@ public:
 
 private:
     static ServiceWorkerRegistrationBackgroundFetchAPI& from(ServiceWorkerRegistration&);
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     ServiceWorkerRegistration& m_serviceWorkerRegistration;
     RefPtr<BackgroundFetchManager> m_backgroundFetchManager;

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
@@ -43,9 +43,9 @@
 namespace WebKit {
 using namespace WebCore;
 
-const char* WebCookieManager::supplementName()
+ASCIILiteral WebCookieManager::supplementName()
 {
-    return "WebCookieManager";
+    return "WebCookieManager"_s;
 }
 
 WebCookieManager::WebCookieManager(NetworkProcess& process)

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
@@ -56,7 +56,7 @@ public:
     WebCookieManager(NetworkProcess&);
     ~WebCookieManager();
 
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     void setHTTPCookieAcceptPolicy(PAL::SessionID, WebCore::HTTPCookieAcceptPolicy, CompletionHandler<void()>&&);
 

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp
@@ -36,9 +36,9 @@
 
 namespace WebKit {
 
-const char* LegacyCustomProtocolManager::supplementName()
+ASCIILiteral LegacyCustomProtocolManager::supplementName()
 {
-    return "LegacyCustomProtocolManager";
+    return "LegacyCustomProtocolManager"_s;
 }
 
 LegacyCustomProtocolManager::LegacyCustomProtocolManager(NetworkProcess& networkProcess)

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
@@ -60,7 +60,7 @@ class LegacyCustomProtocolManager : public NetworkProcessSupplement, public IPC:
 public:
     explicit LegacyCustomProtocolManager(NetworkProcess&);
 
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     void registerScheme(const String&);
     void unregisterScheme(const String&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -60,6 +60,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/text/ASCIILiteral.h>
 
 #if USE(RUNNINGBOARD)
 #include "WebSQLiteDatabaseTracker.h"
@@ -537,7 +538,7 @@ private:
     mutable String m_uiProcessBundleIdentifier;
     DownloadManager m_downloadManager;
 
-    typedef HashMap<const char*, std::unique_ptr<NetworkProcessSupplement>, PtrHash<const char*>> NetworkProcessSupplementMap;
+    using NetworkProcessSupplementMap = HashMap<ASCIILiteral, std::unique_ptr<NetworkProcessSupplement>, ASCIILiteralPtrHash>;
     NetworkProcessSupplementMap m_supplements;
 
     HashSet<PAL::SessionID> m_sessionsControlledByAutomation;

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
@@ -40,7 +40,7 @@ public:
     LaunchServicesDatabaseObserver(NetworkProcess&);
     virtual ~LaunchServicesDatabaseObserver();
 
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
 private:
     void startObserving(OSObjectPtr<xpc_connection_t>);

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
@@ -51,9 +51,9 @@ LaunchServicesDatabaseObserver::LaunchServicesDatabaseObserver(NetworkProcess&)
 #endif
 }
 
-const char* LaunchServicesDatabaseObserver::supplementName()
+ASCIILiteral LaunchServicesDatabaseObserver::supplementName()
 {
-    return "LaunchServicesDatabaseObserverSupplement";
+    return "LaunchServicesDatabaseObserverSupplement"_s;
 }
 
 void LaunchServicesDatabaseObserver::startObserving(OSObjectPtr<xpc_connection_t> connection)

--- a/Source/WebKit/Shared/Authentication/AuthenticationManager.cpp
+++ b/Source/WebKit/Shared/Authentication/AuthenticationManager.cpp
@@ -49,9 +49,9 @@ static bool canCoalesceChallenge(const WebCore::AuthenticationChallenge& challen
     return challenge.protectionSpace().authenticationScheme() != ProtectionSpace::AuthenticationScheme::ServerTrustEvaluationRequested;
 }
 
-const char* AuthenticationManager::supplementName()
+ASCIILiteral AuthenticationManager::supplementName()
 {
-    return "AuthenticationManager";
+    return "AuthenticationManager"_s;
 }
 
 AuthenticationManager::AuthenticationManager(NetworkProcess& process)

--- a/Source/WebKit/Shared/Authentication/AuthenticationManager.h
+++ b/Source/WebKit/Shared/Authentication/AuthenticationManager.h
@@ -70,7 +70,7 @@ public:
     explicit AuthenticationManager(NetworkProcess&);
     ~AuthenticationManager();
 
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     void didReceiveAuthenticationChallenge(PAL::SessionID, WebPageProxyIdentifier, const WebCore::SecurityOriginData* , const WebCore::AuthenticationChallenge&, NegotiatedLegacyTLS, ChallengeCompletionHandler&&);
     void didReceiveAuthenticationChallenge(IPC::MessageSender& download, const WebCore::AuthenticationChallenge&, ChallengeCompletionHandler&&);

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -43,9 +43,9 @@
 namespace WebKit {
 using namespace WebCore;
 
-const char* WebNotificationManagerProxy::supplementName()
+ASCIILiteral WebNotificationManagerProxy::supplementName()
 {
-    return "WebNotificationManagerProxy";
+    return "WebNotificationManagerProxy"_s;
 }
 
 Ref<WebNotificationManagerProxy> WebNotificationManagerProxy::create(WebProcessPool* processPool)

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h
@@ -55,8 +55,7 @@ class WebsiteDataStore;
 
 class WebNotificationManagerProxy : public API::ObjectImpl<API::Object::Type::NotificationManager>, public WebContextSupplement {
 public:
-
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     static Ref<WebNotificationManagerProxy> create(WebProcessPool*);
 

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
@@ -46,9 +46,9 @@ static inline Ref<WebProcessProxy> connectionToWebProcessProxy(const IPC::Connec
     return static_cast<WebProcessProxy&>(*connection.client());
 }
 
-const char* WebGeolocationManagerProxy::supplementName()
+ASCIILiteral WebGeolocationManagerProxy::supplementName()
 {
-    return "WebGeolocationManagerProxy";
+    return "WebGeolocationManagerProxy"_s;
 }
 
 Ref<WebGeolocationManagerProxy> WebGeolocationManagerProxy::create(WebProcessPool* processPool)

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.h
@@ -55,7 +55,7 @@ class WebGeolocationManagerProxy : public API::ObjectImpl<API::Object::Type::Geo
 #endif
 {
 public:
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     static Ref<WebGeolocationManagerProxy> create(WebProcessPool*);
     ~WebGeolocationManagerProxy();

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -54,6 +54,7 @@
 #include <wtf/RefCounter.h>
 #include <wtf/RefPtr.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/text/ASCIILiteral.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
@@ -699,7 +700,7 @@ private:
     bool m_memorySamplerEnabled { false };
     double m_memorySamplerInterval { 1400.0 };
 
-    typedef HashMap<const char*, RefPtr<WebContextSupplement>, PtrHash<const char*>> WebContextSupplementMap;
+    using WebContextSupplementMap = HashMap<ASCIILiteral, RefPtr<WebContextSupplement>, ASCIILiteralPtrHash>;
     WebContextSupplementMap m_supplements;
 
 #if USE(SOUP)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
@@ -50,9 +50,9 @@ void RemoteCDMFactory::registerFactory(Vector<CDMFactory*>& factories)
     factories.append(this);
 }
 
-const char* RemoteCDMFactory::supplementName()
+ASCIILiteral RemoteCDMFactory::supplementName()
 {
-    return "RemoteCDMFactory";
+    return "RemoteCDMFactory"_s;
 }
 
 GPUProcessConnection& RemoteCDMFactory::gpuProcessConnection()

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
@@ -60,7 +60,7 @@ public:
     explicit RemoteCDMFactory(WebProcess&);
     virtual ~RemoteCDMFactory();
 
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     GPUProcessConnection& gpuProcessConnection();
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
@@ -65,9 +65,9 @@ void RemoteLegacyCDMFactory::registerFactory()
     );
 }
 
-const char* RemoteLegacyCDMFactory::supplementName()
+ASCIILiteral RemoteLegacyCDMFactory::supplementName()
 {
-    return "RemoteLegacyCDMFactory";
+    return "RemoteLegacyCDMFactory"_s;
 }
 
 GPUProcessConnection& RemoteLegacyCDMFactory::gpuProcessConnection()

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
@@ -66,7 +66,7 @@ public:
 
     void registerFactory();
 
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     GPUProcessConnection& gpuProcessConnection();
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp
@@ -75,9 +75,9 @@ void RemoteMediaEngineConfigurationFactory::registerFactory()
     MediaEngineConfigurationFactory::installFactory({ WTFMove(createDecodingConfiguration), WTFMove(createEncodingConfiguration) });
 }
 
-const char* RemoteMediaEngineConfigurationFactory::supplementName()
+ASCIILiteral RemoteMediaEngineConfigurationFactory::supplementName()
 {
-    return "RemoteMediaEngineConfigurationFactory";
+    return "RemoteMediaEngineConfigurationFactory"_s;
 }
 
 GPUProcessConnection& RemoteMediaEngineConfigurationFactory::gpuProcessConnection()

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h
@@ -54,7 +54,7 @@ public:
 
     void registerFactory();
 
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     GPUProcessConnection& gpuProcessConnection();
 

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
@@ -48,9 +48,9 @@ static RegistrableDomain registrableDomainForPage(WebPage& page)
     return RegistrableDomain { document->url() };
 }
 
-const char* WebGeolocationManager::supplementName()
+ASCIILiteral WebGeolocationManager::supplementName()
 {
-    return "WebGeolocationManager";
+    return "WebGeolocationManager"_s;
 }
 
 WebGeolocationManager::WebGeolocationManager(WebProcess& process)

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h
@@ -51,7 +51,7 @@ public:
     explicit WebGeolocationManager(WebProcess&);
     ~WebGeolocationManager();
 
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     void registerWebPage(WebPage&, const String& authorizationToken, bool needsHighAccuracy);
     void unregisterWebPage(WebPage&);

--- a/Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.cpp
+++ b/Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.cpp
@@ -40,9 +40,9 @@ void WebMediaKeyStorageManager::setWebsiteDataStore(const WebProcessDataStorePar
     m_mediaKeyStorageDirectory = parameters.mediaKeyStorageDirectory;
 }
 
-const char* WebMediaKeyStorageManager::supplementName()
+ASCIILiteral WebMediaKeyStorageManager::supplementName()
 {
-    return "WebMediaKeyStorageManager";
+    return "WebMediaKeyStorageManager"_s;
 }
 
 String WebMediaKeyStorageManager::mediaKeyStorageDirectoryForOrigin(const SecurityOriginData& originData)

--- a/Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.h
+++ b/Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.h
@@ -45,7 +45,7 @@ public:
     explicit WebMediaKeyStorageManager(WebProcess&) { }
     virtual ~WebMediaKeyStorageManager() { }
 
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     const String& mediaKeyStorageDirectory() const { return m_mediaKeyStorageDirectory; }
     String mediaKeyStorageDirectoryForOrigin(const WebCore::SecurityOriginData&);

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -93,9 +93,9 @@ template<typename U> static bool sendNotificationMessageWithAsyncReply(U&& messa
 }
 #endif // ENABLE(NOTIFICATIONS)
 
-const char* WebNotificationManager::supplementName()
+ASCIILiteral WebNotificationManager::supplementName()
 {
-    return "WebNotificationManager";
+    return "WebNotificationManager"_s;
 }
 
 WebNotificationManager::WebNotificationManager(WebProcess& process)

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
@@ -56,7 +56,7 @@ public:
     explicit WebNotificationManager(WebProcess&);
     ~WebNotificationManager();
 
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
     
     bool show(WebCore::NotificationData&&, RefPtr<WebCore::NotificationResources>&&, WebPage*, CompletionHandler<void()>&&);
     void cancel(WebCore::NotificationData&&, WebPage*);

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -49,6 +49,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/RefCounter.h>
 #include <wtf/WeakHashMap.h>
+#include <wtf/text/ASCIILiteral.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
 
@@ -687,7 +688,7 @@ private:
 
     HashMap<WebCore::FrameIdentifier, WeakPtr<WebFrame>> m_frameMap;
 
-    typedef HashMap<const char*, std::unique_ptr<WebProcessSupplement>, PtrHash<const char*>> WebProcessSupplementMap;
+    using WebProcessSupplementMap = HashMap<ASCIILiteral, std::unique_ptr<WebProcessSupplement>, ASCIILiteralPtrHash>;
     WebProcessSupplementMap m_supplements;
 
     TextCheckerState m_textCheckerState;

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
@@ -47,9 +47,9 @@ AudioSessionRoutingArbitrator::AudioSessionRoutingArbitrator(WebProcess& process
 
 AudioSessionRoutingArbitrator::~AudioSessionRoutingArbitrator() = default;
 
-const char* AudioSessionRoutingArbitrator::supplementName()
+ASCIILiteral AudioSessionRoutingArbitrator::supplementName()
 {
-    return "AudioSessionRoutingArbitrator";
+    return "AudioSessionRoutingArbitrator"_s;
 }
 
 void AudioSessionRoutingArbitrator::beginRoutingArbitrationWithCategory(AudioSession::CategoryType category, CompletionHandler<void(RoutingArbitrationError, DefaultRouteChanged)>&& callback)

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
@@ -43,7 +43,7 @@ public:
     explicit AudioSessionRoutingArbitrator(WebProcess&);
     virtual ~AudioSessionRoutingArbitrator();
 
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     using WeakValueType = WebCore::AudioSessionRoutingArbitrationClient;
 

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
@@ -63,9 +63,9 @@ UserMediaCaptureManager::~UserMediaCaptureManager()
     m_remoteCaptureSampleManager.stopListeningForIPC();
 }
 
-const char* UserMediaCaptureManager::supplementName()
+ASCIILiteral UserMediaCaptureManager::supplementName()
 {
-    return "UserMediaCaptureManager";
+    return "UserMediaCaptureManager"_s;
 }
 
 void UserMediaCaptureManager::setupCaptureProcesses(bool shouldCaptureAudioInUIProcess, bool shouldCaptureAudioInGPUProcess, bool shouldCaptureVideoInUIProcess, bool shouldCaptureVideoInGPUProcess, bool shouldCaptureDisplayInUIProcess, bool shouldCaptureDisplayInGPUProcess, bool shouldUseGPUProcessRemoteFrames)

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
@@ -52,7 +52,7 @@ public:
     explicit UserMediaCaptureManager(WebProcess&);
     ~UserMediaCaptureManager();
 
-    static const char* supplementName();
+    static ASCIILiteral supplementName();
 
     void didReceiveMessageFromGPUProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
     void setupCaptureProcesses(bool shouldCaptureAudioInUIProcess, bool shouldCaptureAudioInGPUProcess, bool shouldCaptureVideoInUIProcess, bool shouldCaptureVideoInGPUProcess, bool shouldCaptureDisplayInUIProcess, bool shouldCaptureDisplayInGPUProcess, bool shouldUseGPUProcessRemoteFrames);

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h
@@ -49,7 +49,7 @@ public:
     explicit UserMediaCaptureManager(WebProcess&);
     ~UserMediaCaptureManager();
 
-    static const char* supplementName() { return "UserMediaCaptureManager"; }
+    static ASCIILiteral supplementName() { return "UserMediaCaptureManager"_s; }
 
 private:
     // IPC::MessageReceiver


### PR DESCRIPTION
#### 67e8a2009c5394a9dd03bc78614a938df568b6c9
<pre>
Use ASCIILiteral instead of `const char*` for Supplementable key
<a href="https://bugs.webkit.org/show_bug.cgi?id=267431">https://bugs.webkit.org/show_bug.cgi?id=267431</a>

Reviewed by Geoffrey Garen.

It makes string lifetime clearer.

* Source/WTF/wtf/text/ASCIILiteral.h:
(WTF::ASCIILiteralPtrHash::hash):
(WTF::ASCIILiteralPtrHash::equal):
* Source/WebCore/Modules/async-clipboard/NavigatorClipboard.cpp:
(WebCore::NavigatorClipboard::supplementName):
* Source/WebCore/Modules/async-clipboard/NavigatorClipboard.h:
* Source/WebCore/Modules/audiosession/NavigatorAudioSession.cpp:
(WebCore::NavigatorAudioSession::supplementName):
* Source/WebCore/Modules/audiosession/NavigatorAudioSession.h:
* Source/WebCore/Modules/beacon/NavigatorBeacon.cpp:
(WebCore::NavigatorBeacon::supplementName):
* Source/WebCore/Modules/beacon/NavigatorBeacon.h:
* Source/WebCore/Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp:
(WebCore::DOMWindowCaches::supplementName):
(WebCore::WorkerGlobalScopeCaches::supplementName):
* Source/WebCore/Modules/contact-picker/NavigatorContacts.cpp:
(WebCore::NavigatorContacts::supplementName):
* Source/WebCore/Modules/contact-picker/NavigatorContacts.h:
* Source/WebCore/Modules/cookie-consent/NavigatorCookieConsent.h:
* Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.cpp:
(WebCore::NavigatorCredentials::supplementName):
* Source/WebCore/Modules/credentialmanagement/NavigatorCredentials.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp:
(WebCore::MediaKeySystemController::supplementName):
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.h:
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::supplementName):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.h:
* Source/WebCore/Modules/geolocation/GeolocationController.cpp:
(WebCore::GeolocationController::supplementName):
* Source/WebCore/Modules/geolocation/GeolocationController.h:
* Source/WebCore/Modules/geolocation/NavigatorGeolocation.cpp:
(WebCore::NavigatorGeolocation::supplementName):
* Source/WebCore/Modules/geolocation/NavigatorGeolocation.h:
* Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp:
(WebCore::DOMWindowIndexedDatabase::supplementName):
(WebCore::WorkerGlobalScopeIndexedDatabase::supplementName):
* Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.cpp:
(WebCore::NavigatorMediaCapabilities::supplementName):
* Source/WebCore/Modules/mediacapabilities/NavigatorMediaCapabilities.h:
* Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.cpp:
(WebCore::WorkerNavigatorMediaCapabilities::supplementName):
* Source/WebCore/Modules/mediacapabilities/WorkerNavigatorMediaCapabilities.h:
* Source/WebCore/Modules/mediasession/NavigatorMediaSession.cpp:
(WebCore::NavigatorMediaSession::supplementName):
* Source/WebCore/Modules/mediasession/NavigatorMediaSession.h:
* Source/WebCore/Modules/mediastream/NavigatorMediaDevices.cpp:
(WebCore::NavigatorMediaDevices::supplementName):
* Source/WebCore/Modules/mediastream/NavigatorMediaDevices.h:
* Source/WebCore/Modules/mediastream/UserMediaController.cpp:
(WebCore::UserMediaController::supplementName):
* Source/WebCore/Modules/mediastream/UserMediaController.h:
* Source/WebCore/Modules/notifications/NotificationController.cpp:
(WebCore::NotificationController::supplementName):
* Source/WebCore/Modules/notifications/NotificationController.h:
* Source/WebCore/Modules/permissions/NavigatorPermissions.cpp:
(WebCore::NavigatorPermissions::supplementName):
* Source/WebCore/Modules/permissions/NavigatorPermissions.h:
* Source/WebCore/Modules/permissions/WorkerNavigatorPermissions.cpp:
(WebCore::WorkerNavigatorPermissions::supplementName):
* Source/WebCore/Modules/permissions/WorkerNavigatorPermissions.h:
* Source/WebCore/Modules/pictureinpicture/DocumentPictureInPicture.h:
(WebCore::DocumentPictureInPicture::supplementName):
* Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h:
(WebCore::HTMLVideoElementPictureInPicture::supplementName):
* Source/WebCore/Modules/push-api/ServiceWorkerRegistrationPushAPI.cpp:
(WebCore::ServiceWorkerRegistrationPushAPI::supplementName):
* Source/WebCore/Modules/push-api/ServiceWorkerRegistrationPushAPI.h:
* Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp:
(WebCore::NavigatorScreenWakeLock::supplementName):
* Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.h:
* Source/WebCore/Modules/speech/LocalDOMWindowSpeechSynthesis.cpp:
(WebCore::LocalDOMWindowSpeechSynthesis::supplementName):
* Source/WebCore/Modules/speech/LocalDOMWindowSpeechSynthesis.h:
* Source/WebCore/Modules/webdriver/NavigatorWebDriver.cpp:
(WebCore::NavigatorWebDriver::supplementName):
* Source/WebCore/Modules/webdriver/NavigatorWebDriver.h:
* Source/WebCore/css/DOMCSSPaintWorklet.cpp:
(WebCore::DOMCSSPaintWorklet::supplementName):
* Source/WebCore/css/DOMCSSPaintWorklet.h:
* Source/WebCore/css/DOMCSSRegisterCustomProperty.cpp:
(WebCore::DOMCSSRegisterCustomProperty::supplementName):
* Source/WebCore/css/DOMCSSRegisterCustomProperty.h:
* Source/WebCore/css/typedom/CSSNumericFactory.cpp:
(WebCore::CSSNumericFactory::supplementName):
* Source/WebCore/css/typedom/CSSNumericFactory.h:
* Source/WebCore/dom/DeviceMotionController.cpp:
(WebCore::DeviceMotionController::supplementName):
* Source/WebCore/dom/DeviceMotionController.h:
* Source/WebCore/dom/DeviceOrientationController.cpp:
(WebCore::DeviceOrientationController::supplementName):
* Source/WebCore/dom/DeviceOrientationController.h:
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::DocumentStorageAccess::supplementName):
* Source/WebCore/dom/DocumentStorageAccess.h:
* Source/WebCore/html/NavigatorUserActivation.cpp:
(WebCore::NavigatorUserActivation::supplementName):
* Source/WebCore/html/NavigatorUserActivation.h:
* Source/WebCore/page/NavigatorIsLoggedIn.cpp:
(WebCore::NavigatorIsLoggedIn::supplementName):
* Source/WebCore/page/NavigatorIsLoggedIn.h:
* Source/WebCore/platform/Supplementable.h:
(WebCore::Supplement::provideTo):
(WebCore::Supplement::from):
(WebCore::Supplementable::provideSupplement):
(WebCore::Supplementable::removeSupplement):
(WebCore::Supplementable::requireSupplement):
* Source/WebCore/testing/InternalSettings.cpp:
(WebCore::InternalSettings::supplementName):
* Source/WebCore/testing/InternalSettings.h:
* Source/WebCore/workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.cpp:
(WebCore::ServiceWorkerRegistrationBackgroundFetchAPI::supplementName):
* Source/WebCore/workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.h:
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp:
(WebKit::WebCookieManager::supplementName):
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h:
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.cpp:
(WebKit::LegacyCustomProtocolManager::supplementName):
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h:
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h:
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm:
(WebKit::LaunchServicesDatabaseObserver::supplementName):
* Source/WebKit/Shared/Authentication/AuthenticationManager.cpp:
(WebKit::AuthenticationManager::supplementName):
* Source/WebKit/Shared/Authentication/AuthenticationManager.h:
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::WebNotificationManagerProxy::supplementName):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h:
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp:
(WebKit::WebGeolocationManagerProxy::supplementName):
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp:
(WebKit::RemoteCDMFactory::supplementName):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp:
(WebKit::RemoteLegacyCDMFactory::supplementName):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp:
(WebKit::RemoteMediaEngineConfigurationFactory::supplementName):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h:
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp:
(WebKit::WebGeolocationManager::supplementName):
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h:
* Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.cpp:
(WebKit::WebMediaKeyStorageManager::supplementName):
* Source/WebKit/WebProcess/MediaCache/WebMediaKeyStorageManager.h:
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
(WebKit::WebNotificationManager::supplementName):
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.h:
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp:
(WebKit::AudioSessionRoutingArbitrator::supplementName):
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp:
(WebKit::UserMediaCaptureManager::supplementName):
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h:
* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h:
(WebKit::UserMediaCaptureManager::supplementName):

Canonical link: <a href="https://commits.webkit.org/272955@main">https://commits.webkit.org/272955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a569410b851d90519b03929064f54e4fbf1b746d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36336 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/30574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34769 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9647 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10535 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30063 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9193 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37659 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/28721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30603 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30397 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35417 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/33663 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/33305 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11208 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/40187 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/10011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8411 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4344 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->