### PR TITLE
Add IPC::Message

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -830,190 +830,192 @@ void GPUConnectionToWebProcess::setMediaOverridesForTesting(MediaOverridesForTes
 #endif
 }
 
-bool GPUConnectionToWebProcess::dispatchMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+bool GPUConnectionToWebProcess::dispatchMessage(IPC::Connection& connection, IPC::Message& message)
 {
+    const auto messageReceiverName = message.messageReceiverName();
 #if ENABLE(WEB_AUDIO)
-    if (decoder.messageReceiverName() == Messages::RemoteAudioDestinationManager::messageReceiverName()) {
-        remoteAudioDestinationManager().didReceiveMessageFromWebProcess(connection, decoder);
+    if (messageReceiverName == Messages::RemoteAudioDestinationManager::messageReceiverName()) {
+        remoteAudioDestinationManager().didReceiveMessageFromWebProcess(connection, message);
         return true;
     }
 #endif
 #if ENABLE(VIDEO)
-    if (decoder.messageReceiverName() == Messages::RemoteMediaPlayerManagerProxy::messageReceiverName()) {
-        remoteMediaPlayerManagerProxy().didReceiveMessageFromWebProcess(connection, decoder);
+    if (messageReceiverName == Messages::RemoteMediaPlayerManagerProxy::messageReceiverName()) {
+        remoteMediaPlayerManagerProxy().didReceiveMessageFromWebProcess(connection, message);
         return true;
     }
-    if (decoder.messageReceiverName() == Messages::RemoteMediaPlayerProxy::messageReceiverName()) {
-        remoteMediaPlayerManagerProxy().didReceivePlayerMessage(connection, decoder);
+    if (messageReceiverName == Messages::RemoteMediaPlayerProxy::messageReceiverName()) {
+        remoteMediaPlayerManagerProxy().didReceivePlayerMessage(connection, message);
         return true;
     }
-    if (decoder.messageReceiverName() == Messages::RemoteMediaResourceManager::messageReceiverName()) {
-        remoteMediaResourceManager().didReceiveMessage(connection, decoder);
-        return true;
-    }
-#endif
-#if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
-    if (decoder.messageReceiverName() == Messages::UserMediaCaptureManagerProxy::messageReceiverName()) {
-        userMediaCaptureManagerProxy().didReceiveMessageFromGPUProcess(connection, decoder);
-        return true;
-    }
-    if (decoder.messageReceiverName() == Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::messageReceiverName()) {
-        audioMediaStreamTrackRendererInternalUnitManager().didReceiveMessage(connection, decoder);
+    if (messageReceiverName == Messages::RemoteMediaResourceManager::messageReceiverName()) {
+        remoteMediaResourceManager().didReceiveMessage(connection, message);
         return true;
     }
 #endif
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
-    if (decoder.messageReceiverName() == Messages::RemoteMediaRecorderManager::messageReceiverName()) {
-        mediaRecorderManager().didReceiveMessageFromWebProcess(connection, decoder);
+    if (messageReceiverName == Messages::UserMediaCaptureManagerProxy::messageReceiverName()) {
+        userMediaCaptureManagerProxy().didReceiveMessageFromGPUProcess(connection, message);
         return true;
     }
-    if (decoder.messageReceiverName() == Messages::RemoteMediaRecorder::messageReceiverName()) {
-        mediaRecorderManager().didReceiveRemoteMediaRecorderMessage(connection, decoder);
+    if (messageReceiverName == Messages::RemoteAudioMediaStreamTrackRendererInternalUnitManager::messageReceiverName()) {
+        audioMediaStreamTrackRendererInternalUnitManager().didReceiveMessage(connection, message);
+        return true;
+    }
+#endif
+#if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
+    if (messageReceiverName == Messages::RemoteMediaRecorderManager::messageReceiverName()) {
+        mediaRecorderManager().didReceiveMessageFromWebProcess(connection, message);
+        return true;
+    }
+    if (messageReceiverName == Messages::RemoteMediaRecorder::messageReceiverName()) {
+        mediaRecorderManager().didReceiveRemoteMediaRecorderMessage(connection, message);
         return true;
     }
 #endif
 #if ENABLE(ENCRYPTED_MEDIA)
-    if (decoder.messageReceiverName() == Messages::RemoteCDMFactoryProxy::messageReceiverName()) {
-        cdmFactoryProxy().didReceiveMessageFromWebProcess(connection, decoder);
+    if (messageReceiverName == Messages::RemoteCDMFactoryProxy::messageReceiverName()) {
+        cdmFactoryProxy().didReceiveMessageFromWebProcess(connection, message);
         return true;
     }
 
-    if (decoder.messageReceiverName() == Messages::RemoteCDMProxy::messageReceiverName()) {
-        cdmFactoryProxy().didReceiveCDMMessage(connection, decoder);
+    if (messageReceiverName == Messages::RemoteCDMProxy::messageReceiverName()) {
+        cdmFactoryProxy().didReceiveCDMMessage(connection, message);
         return true;
     }
 
-    if (decoder.messageReceiverName() == Messages::RemoteCDMInstanceProxy::messageReceiverName()) {
-        cdmFactoryProxy().didReceiveCDMInstanceMessage(connection, decoder);
+    if (messageReceiverName == Messages::RemoteCDMInstanceProxy::messageReceiverName()) {
+        cdmFactoryProxy().didReceiveCDMInstanceMessage(connection, message);
         return true;
     }
 
-    if (decoder.messageReceiverName() == Messages::RemoteCDMInstanceSessionProxy::messageReceiverName()) {
-        cdmFactoryProxy().didReceiveCDMInstanceSessionMessage(connection, decoder);
+    if (messageReceiverName == Messages::RemoteCDMInstanceSessionProxy::messageReceiverName()) {
+        cdmFactoryProxy().didReceiveCDMInstanceSessionMessage(connection, message);
         return true;
     }
 #endif
 #if USE(AUDIO_SESSION)
-    if (decoder.messageReceiverName() == Messages::RemoteAudioSessionProxy::messageReceiverName()) {
-        audioSessionProxy().didReceiveMessage(connection, decoder);
+    if (messageReceiverName == Messages::RemoteAudioSessionProxy::messageReceiverName()) {
+        audioSessionProxy().didReceiveMessage(connection, message);
         return true;
     }
 #endif
 #if PLATFORM(IOS_FAMILY)
-    if (decoder.messageReceiverName() == Messages::RemoteMediaSessionHelperProxy::messageReceiverName()) {
-        mediaSessionHelperProxy().didReceiveMessageFromWebProcess(connection, decoder);
+    if (messageReceiverName == Messages::RemoteMediaSessionHelperProxy::messageReceiverName()) {
+        mediaSessionHelperProxy().didReceiveMessageFromWebProcess(connection, message);
         return true;
     }
 #endif
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    if (decoder.messageReceiverName() == Messages::RemoteLegacyCDMFactoryProxy::messageReceiverName()) {
-        legacyCdmFactoryProxy().didReceiveMessageFromWebProcess(connection, decoder);
+    if (messageReceiverName == Messages::RemoteLegacyCDMFactoryProxy::messageReceiverName()) {
+        legacyCdmFactoryProxy().didReceiveMessageFromWebProcess(connection, message);
         return true;
     }
 
-    if (decoder.messageReceiverName() == Messages::RemoteLegacyCDMProxy::messageReceiverName()) {
-        legacyCdmFactoryProxy().didReceiveCDMMessage(connection, decoder);
+    if (messageReceiverName == Messages::RemoteLegacyCDMProxy::messageReceiverName()) {
+        legacyCdmFactoryProxy().didReceiveCDMMessage(connection, message);
         return true;
     }
 
-    if (decoder.messageReceiverName() == Messages::RemoteLegacyCDMSessionProxy::messageReceiverName()) {
-        legacyCdmFactoryProxy().didReceiveCDMSessionMessage(connection, decoder);
+    if (messageReceiverName == Messages::RemoteLegacyCDMSessionProxy::messageReceiverName()) {
+        legacyCdmFactoryProxy().didReceiveCDMSessionMessage(connection, message);
         return true;
     }
 #endif
-    if (decoder.messageReceiverName() == Messages::RemoteMediaEngineConfigurationFactoryProxy::messageReceiverName()) {
-        mediaEngineConfigurationFactoryProxy().didReceiveMessageFromWebProcess(connection, decoder);
+    if (messageReceiverName == Messages::RemoteMediaEngineConfigurationFactoryProxy::messageReceiverName()) {
+        mediaEngineConfigurationFactoryProxy().didReceiveMessageFromWebProcess(connection, message);
         return true;
     }
 #if HAVE(AVASSETREADER)
-    if (decoder.messageReceiverName() == Messages::RemoteImageDecoderAVFProxy::messageReceiverName()) {
-        imageDecoderAVFProxy().didReceiveMessage(connection, decoder);
+    if (messageReceiverName == Messages::RemoteImageDecoderAVFProxy::messageReceiverName()) {
+        imageDecoderAVFProxy().didReceiveMessage(connection, message);
         return true;
     }
 #endif
 #if ENABLE(WEBGL)
-    if (decoder.messageReceiverName() == Messages::RemoteGraphicsContextGL::messageReceiverName()) {
+    if (messageReceiverName == Messages::RemoteGraphicsContextGL::messageReceiverName()) {
         // Skip messages for already removed receivers.
         return true;
     }
 #endif
 
-    if (decoder.messageReceiverName() == Messages::RemoteRemoteCommandListenerProxy::messageReceiverName()) {
+    if (messageReceiverName == Messages::RemoteRemoteCommandListenerProxy::messageReceiverName()) {
         if (m_remoteRemoteCommandListener)
-            m_remoteRemoteCommandListener->didReceiveMessage(connection, decoder);
+            m_remoteRemoteCommandListener->didReceiveMessage(connection, message);
         return true;
     }
 #if ENABLE(IPC_TESTING_API)
-    if (decoder.messageReceiverName() == Messages::IPCTester::messageReceiverName()) {
-        m_ipcTester.didReceiveMessage(connection, decoder);
+    if (messageReceiverName == Messages::IPCTester::messageReceiverName()) {
+        m_ipcTester.didReceiveMessage(connection, message);
         return true;
     }
 #endif
 
-    return messageReceiverMap().dispatchMessage(connection, decoder);
+    return messageReceiverMap().dispatchMessage(connection, message);
 }
 
-bool GPUConnectionToWebProcess::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool GPUConnectionToWebProcess::dispatchSyncMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& replyEncoder)
 {
+    const auto messageReceiverName = message.messageReceiverName();
 #if ENABLE(VIDEO)
-    if (decoder.messageReceiverName() == Messages::RemoteMediaPlayerManagerProxy::messageReceiverName()) {
-        return remoteMediaPlayerManagerProxy().didReceiveSyncMessageFromWebProcess(connection, decoder, replyEncoder);
+    if (messageReceiverName == Messages::RemoteMediaPlayerManagerProxy::messageReceiverName()) {
+        return remoteMediaPlayerManagerProxy().didReceiveSyncMessageFromWebProcess(connection, message, replyEncoder);
     }
-    if (decoder.messageReceiverName() == Messages::RemoteMediaPlayerProxy::messageReceiverName()) {
-        return remoteMediaPlayerManagerProxy().didReceiveSyncPlayerMessage(connection, decoder, replyEncoder);
+    if (messageReceiverName == Messages::RemoteMediaPlayerProxy::messageReceiverName()) {
+        return remoteMediaPlayerManagerProxy().didReceiveSyncPlayerMessage(connection, message, replyEncoder);
     }
 #endif
 #if ENABLE(ENCRYPTED_MEDIA)
-    if (decoder.messageReceiverName() == Messages::RemoteCDMFactoryProxy::messageReceiverName()) {
-        return cdmFactoryProxy().didReceiveSyncMessageFromWebProcess(connection, decoder, replyEncoder);
+    if (messageReceiverName == Messages::RemoteCDMFactoryProxy::messageReceiverName()) {
+        return cdmFactoryProxy().didReceiveSyncMessageFromWebProcess(connection, message, replyEncoder);
     }
 
-    if (decoder.messageReceiverName() == Messages::RemoteCDMProxy::messageReceiverName()) {
-        return cdmFactoryProxy().didReceiveSyncCDMMessage(connection, decoder, replyEncoder);
+    if (messageReceiverName == Messages::RemoteCDMProxy::messageReceiverName()) {
+        return cdmFactoryProxy().didReceiveSyncCDMMessage(connection, message, replyEncoder);
     }
 
-    if (decoder.messageReceiverName() == Messages::RemoteCDMInstanceProxy::messageReceiverName()) {
-        return cdmFactoryProxy().didReceiveSyncCDMInstanceMessage(connection, decoder, replyEncoder);
+    if (messageReceiverName == Messages::RemoteCDMInstanceProxy::messageReceiverName()) {
+        return cdmFactoryProxy().didReceiveSyncCDMInstanceMessage(connection, message, replyEncoder);
     }
 
-    if (decoder.messageReceiverName() == Messages::RemoteCDMInstanceSessionProxy::messageReceiverName()) {
-        return cdmFactoryProxy().didReceiveSyncCDMInstanceSessionMessage(connection, decoder, replyEncoder);
+    if (messageReceiverName == Messages::RemoteCDMInstanceSessionProxy::messageReceiverName()) {
+        return cdmFactoryProxy().didReceiveSyncCDMInstanceSessionMessage(connection, message, replyEncoder);
     }
 #endif
 #if USE(AUDIO_SESSION)
-    if (decoder.messageReceiverName() == Messages::RemoteAudioSessionProxy::messageReceiverName()) {
-        return audioSessionProxy().didReceiveSyncMessage(connection, decoder, replyEncoder);
+    if (messageReceiverName == Messages::RemoteAudioSessionProxy::messageReceiverName()) {
+        return audioSessionProxy().didReceiveSyncMessage(connection, message, replyEncoder);
     }
 #endif
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    if (decoder.messageReceiverName() == Messages::RemoteLegacyCDMFactoryProxy::messageReceiverName()) {
-        return legacyCdmFactoryProxy().didReceiveSyncMessageFromWebProcess(connection, decoder, replyEncoder);
+    if (messageReceiverName == Messages::RemoteLegacyCDMFactoryProxy::messageReceiverName()) {
+        return legacyCdmFactoryProxy().didReceiveSyncMessageFromWebProcess(connection, message, replyEncoder);
     }
 
-    if (decoder.messageReceiverName() == Messages::RemoteLegacyCDMProxy::messageReceiverName()) {
-        return legacyCdmFactoryProxy().didReceiveSyncCDMMessage(connection, decoder, replyEncoder);
+    if (messageReceiverName == Messages::RemoteLegacyCDMProxy::messageReceiverName()) {
+        return legacyCdmFactoryProxy().didReceiveSyncCDMMessage(connection, message, replyEncoder);
     }
 
-    if (decoder.messageReceiverName() == Messages::RemoteLegacyCDMSessionProxy::messageReceiverName()) {
-        return legacyCdmFactoryProxy().didReceiveSyncCDMSessionMessage(connection, decoder, replyEncoder);
+    if (messageReceiverName == Messages::RemoteLegacyCDMSessionProxy::messageReceiverName()) {
+        return legacyCdmFactoryProxy().didReceiveSyncCDMSessionMessage(connection, message, replyEncoder);
     }
 #endif
 #if HAVE(AVASSETREADER)
-    if (decoder.messageReceiverName() == Messages::RemoteImageDecoderAVFProxy::messageReceiverName()) {
-        return imageDecoderAVFProxy().didReceiveSyncMessage(connection, decoder, replyEncoder);
+    if (messageReceiverName == Messages::RemoteImageDecoderAVFProxy::messageReceiverName()) {
+        return imageDecoderAVFProxy().didReceiveSyncMessage(connection, message, replyEncoder);
     }
 #endif
 #if ENABLE(WEBGL)
-    if (decoder.messageReceiverName() == Messages::RemoteGraphicsContextGL::messageReceiverName())
+    if (messageReceiverName == Messages::RemoteGraphicsContextGL::messageReceiverName())
         // Skip messages for already removed receivers.
         return true;
 #endif
 #if ENABLE(IPC_TESTING_API)
-    if (decoder.messageReceiverName() == Messages::IPCTester::messageReceiverName()) {
-        return m_ipcTester.didReceiveSyncMessage(connection, decoder, replyEncoder);
+    if (messageReceiverName == Messages::IPCTester::messageReceiverName()) {
+        return m_ipcTester.didReceiveSyncMessage(connection, message, replyEncoder);
     }
 #endif
-    return messageReceiverMap().dispatchSyncMessage(connection, decoder, replyEncoder);
+    return messageReceiverMap().dispatchSyncMessage(connection, message, replyEncoder);
 }
 
 const String& GPUConnectionToWebProcess::mediaCacheDirectory() const

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -325,11 +325,11 @@ private:
     // IPC::Connection::Client
     void didClose(IPC::Connection&) final;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) final;
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
-    bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool dispatchMessage(IPC::Connection&, IPC::Message&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
 
     // NowPlayingManager::Client
     void didReceiveRemoteControlCommand(WebCore::PlatformMediaSession::RemoteControlCommandType, const WebCore::PlatformMediaSession::RemoteCommandArgument&) final;

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -105,17 +105,17 @@ GPUProcess::~GPUProcess()
 {
 }
 
-void GPUProcess::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void GPUProcess::didReceiveMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (messageReceiverMap().dispatchMessage(connection, decoder))
+    if (messageReceiverMap().dispatchMessage(connection, message))
         return;
 
-    if (decoder.messageReceiverName() == Messages::AuxiliaryProcess::messageReceiverName()) {
-        AuxiliaryProcess::didReceiveMessage(connection, decoder);
+    if (message.messageReceiverName() == Messages::AuxiliaryProcess::messageReceiverName()) {
+        AuxiliaryProcess::didReceiveMessage(connection, message);
         return;
     }
 
-    didReceiveGPUProcessMessage(connection, decoder);
+    didReceiveGPUProcessMessage(connection, message);
 }
 
 void GPUProcess::createGPUConnectionToWebProcess(WebCore::ProcessIdentifier identifier, PAL::SessionID sessionID, IPC::Connection::Handle&& connectionHandle, GPUProcessConnectionParameters&& parameters, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -143,8 +143,8 @@ private:
     bool canExitUnderMemoryPressure() const;
 
     // IPC::Connection::Client
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    void didReceiveGPUProcessMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
+    void didReceiveGPUProcessMessage(IPC::Connection&, IPC::Message&);
 
     // Message Handlers
     void initializeGPUProcess(GPUProcessCreationParameters&&);

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h
@@ -70,7 +70,7 @@ private:
 
     WebCore::ShapeDetection::BarcodeDetector& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void detect(WebCore::RenderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedBarcode>&&)>&&);
 

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h
@@ -69,7 +69,7 @@ private:
 
     WebCore::ShapeDetection::FaceDetector& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void detect(WebCore::RenderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&&);
 

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h
@@ -69,7 +69,7 @@ private:
 
     WebCore::ShapeDetection::TextDetector& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void detect(WebCore::RenderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedText>&&)>&&);
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -154,7 +154,7 @@ private:
     }
 
     void startListeningForIPC();
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
     SharedVideoFrameReader& sharedVideoFrameReader();

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -87,7 +87,7 @@ public:
     ~RemoteGraphicsContextGL() override;
     void stopListeningForIPC(Ref<RemoteGraphicsContextGL>&& refFromConnection);
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 #if PLATFORM(MAC)
     void displayWasReconfigured();
 #endif

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
@@ -59,7 +59,7 @@ private:
     IPC::StreamConnectionWorkQueue& workQueue() const;
 
     // IPC::StreamMessageReceiver
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     // Messages
     void getPixelBuffer(WebCore::PixelBufferFormat, WebCore::IntRect srcRect, CompletionHandler<void()>&&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h
@@ -65,7 +65,7 @@ private:
     IPC::StreamConnectionWorkQueue& workQueue() const;
 
     // IPC::StreamMessageReceiver
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     // Messages
     void updateConfiguration(const WebCore::FloatSize&, WebCore::RenderingMode, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormat);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -96,7 +96,7 @@ public:
 
     RemoteResourceCache& remoteResourceCache() { return m_remoteResourceCache; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     // Runs Function in RemoteRenderingBackend task queue.
     void dispatch(Function<void()>&&);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
@@ -74,7 +74,7 @@ private:
 
     WebCore::WebGPU::Adapter& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void requestDevice(const WebGPU::DeviceDescriptor&, WebGPUIdentifier, WebGPUIdentifier queueIdentifier, CompletionHandler<void(WebGPU::SupportedFeatures&&, WebGPU::SupportedLimits&&)>&&);
     void destruct();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
@@ -70,7 +70,7 @@ private:
 
     WebCore::WebGPU::BindGroup& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void setLabel(String&&);
     void destruct();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
@@ -70,7 +70,7 @@ private:
 
     WebCore::WebGPU::BindGroupLayout& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void setLabel(String&&);
     void destruct();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
@@ -75,7 +75,7 @@ private:
 
     WebCore::WebGPU::Buffer& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> sizeForMap, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     void mapAsync(WebCore::WebGPU::MapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> sizeForMap, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
@@ -70,7 +70,7 @@ private:
 
     WebCore::WebGPU::CommandBuffer& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void setLabel(String&&);
     void destruct();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
@@ -77,7 +77,7 @@ private:
 
     WebCore::WebGPU::CommandEncoder& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void beginRenderPass(const WebGPU::RenderPassDescriptor&, WebGPUIdentifier);
     void beginComputePass(const std::optional<WebGPU::ComputePassDescriptor>&, WebGPUIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
@@ -83,7 +83,7 @@ private:
 
     WebCore::WebGPU::CompositorIntegration& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
     void destruct();
     void paintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier, uint32_t, CompletionHandler<void()>&&);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
@@ -71,7 +71,7 @@ private:
 
     WebCore::WebGPU::ComputePassEncoder& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void setPipeline(WebGPUIdentifier);
     void dispatch(WebCore::WebGPU::Size32 workgroupCountX, WebCore::WebGPU::Size32 workgroupCountY = 1, WebCore::WebGPU::Size32 workgroupCountZ = 1);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
@@ -70,7 +70,7 @@ private:
 
     WebCore::WebGPU::ComputePipeline& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void getBindGroupLayout(uint32_t index, WebGPUIdentifier);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -110,7 +110,7 @@ private:
 
     WebCore::WebGPU::Device& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void destroy();
     void destruct();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
@@ -70,7 +70,7 @@ private:
 
     WebCore::WebGPU::ExternalTexture& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void setLabel(String&&);
     void destruct();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -105,7 +105,7 @@ private:
         return m_streamConnection->send(std::forward<T>(message), m_identifier);
     }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void requestAdapter(const WebGPU::RequestAdapterOptions&, WebGPUIdentifier, CompletionHandler<void(std::optional<RemoteGPURequestAdapterResponse>&&)>&&);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
@@ -70,7 +70,7 @@ private:
 
     WebCore::WebGPU::PipelineLayout& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void setLabel(String&&);
     void destruct();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
@@ -71,7 +71,7 @@ private:
 
     WebCore::WebGPU::PresentationContext& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void configure(const WebGPU::CanvasConfiguration&);
     void unconfigure();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h
@@ -70,7 +70,7 @@ private:
 
     WebCore::WebGPU::QuerySet& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void destroy();
     void destruct();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
@@ -79,7 +79,7 @@ private:
 
     WebCore::WebGPU::Queue& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void submit(Vector<WebGPUIdentifier>&&);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
@@ -70,7 +70,7 @@ private:
 
     WebCore::WebGPU::RenderBundle& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void setLabel(String&&);
     void destruct();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
@@ -73,7 +73,7 @@ private:
 
     WebCore::WebGPU::RenderBundleEncoder& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void setPipeline(WebGPUIdentifier);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
@@ -73,7 +73,7 @@ private:
 
     WebCore::WebGPU::RenderPassEncoder& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void setPipeline(WebGPUIdentifier);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
@@ -70,7 +70,7 @@ private:
 
     WebCore::WebGPU::RenderPipeline& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void getBindGroupLayout(uint32_t index, WebGPUIdentifier);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
@@ -70,7 +70,7 @@ private:
 
     WebCore::WebGPU::Sampler& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void setLabel(String&&);
     void destruct();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
@@ -73,7 +73,7 @@ private:
 
     WebCore::WebGPU::ShaderModule& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void compilationInfo(CompletionHandler<void(Vector<WebGPU::CompilationMessage>&&)>&&);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
@@ -71,7 +71,7 @@ private:
 
     WebCore::WebGPU::Texture& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void createView(const std::optional<WebGPU::TextureViewDescriptor>&, WebGPUIdentifier);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
@@ -70,7 +70,7 @@ private:
 
     WebCore::WebGPU::TextureView& backing() { return m_backing; }
 
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 
     void setLabel(String&&);
     void destruct();

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
@@ -56,12 +56,12 @@ public:
     RemoteAudioDestinationManager(GPUConnectionToWebProcess&);
     ~RemoteAudioDestinationManager();
 
-    void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
+    void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Message& message) { didReceiveMessage(connection, message); }
 
     bool allowsExitUnderMemoryPressure() const;
 
 private:
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
     void createAudioDestination(RemoteAudioDestinationIdentifier, const String& inputDeviceId, uint32_t numberOfInputChannels, uint32_t numberOfOutputChannels, float sampleRate, float hardwareSampleRate, IPC::Semaphore&& renderSemaphore, SharedMemoryHandle&&);
     void deleteAudioDestination(RemoteAudioDestinationIdentifier);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -64,8 +64,8 @@ public:
     void endInterruption(WebCore::AudioSession::MayResume);
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     GPUConnectionToWebProcess& gpuConnectionToWebProcess() const { return m_gpuConnection; }
 

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
@@ -90,42 +90,42 @@ void RemoteCDMFactoryProxy::supportsKeySystem(const String& keySystem, Completio
     completion(factoryForKeySystem(keySystem));
 }
 
-void RemoteCDMFactoryProxy::didReceiveCDMMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void RemoteCDMFactoryProxy::didReceiveCDMMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (auto* proxy = m_proxies.get(ObjectIdentifier<RemoteCDMIdentifierType>(decoder.destinationID())))
-        proxy->didReceiveMessage(connection, decoder);
+    if (auto* proxy = m_proxies.get(ObjectIdentifier<RemoteCDMIdentifierType>(message.destinationID)))
+        proxy->didReceiveMessage(connection, message);
 }
 
-void RemoteCDMFactoryProxy::didReceiveCDMInstanceMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void RemoteCDMFactoryProxy::didReceiveCDMInstanceMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (auto* instance = m_instances.get(ObjectIdentifier<RemoteCDMInstanceIdentifierType>(decoder.destinationID())))
-        instance->didReceiveMessage(connection, decoder);
+    if (auto* instance = m_instances.get(ObjectIdentifier<RemoteCDMInstanceIdentifierType>(message.destinationID)))
+        instance->didReceiveMessage(connection, message);
 }
 
-void RemoteCDMFactoryProxy::didReceiveCDMInstanceSessionMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void RemoteCDMFactoryProxy::didReceiveCDMInstanceSessionMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (auto* session = m_sessions.get(ObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>(decoder.destinationID())))
-        session->didReceiveMessage(connection, decoder);
+    if (auto* session = m_sessions.get(ObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>(message.destinationID)))
+        session->didReceiveMessage(connection, message);
 }
 
-bool RemoteCDMFactoryProxy::didReceiveSyncCDMMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
+bool RemoteCDMFactoryProxy::didReceiveSyncCDMMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& encoder)
 {
-    if (auto* proxy = m_proxies.get(ObjectIdentifier<RemoteCDMIdentifierType>(decoder.destinationID())))
-        return proxy->didReceiveSyncMessage(connection, decoder, encoder);
+    if (auto* proxy = m_proxies.get(ObjectIdentifier<RemoteCDMIdentifierType>(message.destinationID)))
+        return proxy->didReceiveSyncMessage(connection, message, encoder);
     return false;
 }
 
-bool RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
+bool RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& encoder)
 {
-    if (auto* instance = m_instances.get(ObjectIdentifier<RemoteCDMInstanceIdentifierType>(decoder.destinationID())))
-        return instance->didReceiveSyncMessage(connection, decoder, encoder);
+    if (auto* instance = m_instances.get(ObjectIdentifier<RemoteCDMInstanceIdentifierType>(message.destinationID)))
+        return instance->didReceiveSyncMessage(connection, message, encoder);
     return false;
 }
 
-bool RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceSessionMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
+bool RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceSessionMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& encoder)
 {
-    if (auto* session = m_sessions.get(ObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>(decoder.destinationID())))
-        return session->didReceiveSyncMessage(connection, decoder, encoder);
+    if (auto* session = m_sessions.get(ObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>(message.destinationID)))
+        return session->didReceiveSyncMessage(connection, message, encoder);
     return false;
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
@@ -52,14 +52,14 @@ public:
 
     void clear();
 
-    void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
-    bool didReceiveSyncMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder) { return didReceiveSyncMessage(connection, decoder, encoder); }
-    void didReceiveCDMMessage(IPC::Connection&, IPC::Decoder&);
-    void didReceiveCDMInstanceMessage(IPC::Connection&, IPC::Decoder&);
-    void didReceiveCDMInstanceSessionMessage(IPC::Connection&, IPC::Decoder&);
-    bool didReceiveSyncCDMMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
-    bool didReceiveSyncCDMInstanceMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
-    bool didReceiveSyncCDMInstanceSessionMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Message& message) { didReceiveMessage(connection, message); }
+    bool didReceiveSyncMessageFromWebProcess(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& encoder) { return didReceiveSyncMessage(connection, message, encoder); }
+    void didReceiveCDMMessage(IPC::Connection&, IPC::Message&);
+    void didReceiveCDMInstanceMessage(IPC::Connection&, IPC::Message&);
+    void didReceiveCDMInstanceSessionMessage(IPC::Connection&, IPC::Message&);
+    bool didReceiveSyncCDMMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
+    bool didReceiveSyncCDMInstanceMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
+    bool didReceiveSyncCDMInstanceSessionMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
 
     void addProxy(const RemoteCDMIdentifier&, std::unique_ptr<RemoteCDMProxy>&&);
     void removeProxy(const RemoteCDMIdentifier&);
@@ -82,8 +82,8 @@ public:
 private:
     friend class GPUProcessConnection;
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     // Messages
     void createCDM(const String& keySystem, CompletionHandler<void(RemoteCDMIdentifier&&, RemoteCDMConfiguration&&)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
@@ -74,8 +74,8 @@ private:
 #endif
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     using SuccessValue = WebCore::CDMInstance::SuccessValue;
     using AllowDistinctiveIdentifiers = WebCore::CDMInstance::AllowDistinctiveIdentifiers;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
@@ -52,7 +52,7 @@ private:
     RemoteCDMInstanceSessionProxy(WeakPtr<RemoteCDMProxy>&&, Ref<WebCore::CDMInstanceSession>&&, uint64_t logIdentifier, RemoteCDMInstanceSessionIdentifier);
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // Types
     using KeyGroupingStrategy = WebCore::CDMInstanceSession::KeyGroupingStrategy;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
@@ -72,8 +72,8 @@ private:
     RemoteCDMProxy(RemoteCDMFactoryProxy&, std::unique_ptr<WebCore::CDMPrivate>&&, UniqueRef<RemoteCDMConfiguration>&&);
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     // Messages
     void getSupportedConfiguration(WebCore::CDMKeySystemConfiguration&&, WebCore::CDMPrivate::LocalStorageAccess, CompletionHandler<void(std::optional<WebCore::CDMKeySystemConfiguration>)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h
@@ -51,8 +51,8 @@ public:
     virtual ~RemoteImageDecoderAVFProxy() = default;
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     bool allowsExitUnderMemoryPressure() const;
 

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
@@ -92,29 +92,29 @@ void RemoteLegacyCDMFactoryProxy::supportsKeySystem(const String& keySystem, std
         completion(LegacyCDM::supportsKeySystem(keySystem));
 }
 
-void RemoteLegacyCDMFactoryProxy::didReceiveCDMMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void RemoteLegacyCDMFactoryProxy::didReceiveCDMMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (auto* proxy = m_proxies.get(ObjectIdentifier<RemoteLegacyCDMIdentifierType>(decoder.destinationID())))
-        proxy->didReceiveMessage(connection, decoder);
+    if (auto* proxy = m_proxies.get(ObjectIdentifier<RemoteLegacyCDMIdentifierType>(message.destinationID)))
+        proxy->didReceiveMessage(connection, message);
 }
 
-void RemoteLegacyCDMFactoryProxy::didReceiveCDMSessionMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void RemoteLegacyCDMFactoryProxy::didReceiveCDMSessionMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (auto* session = m_sessions.get(ObjectIdentifier<RemoteLegacyCDMSessionIdentifierType>(decoder.destinationID())))
-        session->didReceiveMessage(connection, decoder);
+    if (auto* session = m_sessions.get(ObjectIdentifier<RemoteLegacyCDMSessionIdentifierType>(message.destinationID)))
+        session->didReceiveMessage(connection, message);
 }
 
-bool RemoteLegacyCDMFactoryProxy::didReceiveSyncCDMMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
+bool RemoteLegacyCDMFactoryProxy::didReceiveSyncCDMMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& encoder)
 {
-    if (auto* proxy = m_proxies.get(ObjectIdentifier<RemoteLegacyCDMIdentifierType>(decoder.destinationID())))
-        return proxy->didReceiveSyncMessage(connection, decoder, encoder);
+    if (auto* proxy = m_proxies.get(ObjectIdentifier<RemoteLegacyCDMIdentifierType>(message.destinationID)))
+        return proxy->didReceiveSyncMessage(connection, message, encoder);
     return false;
 }
 
-bool RemoteLegacyCDMFactoryProxy::didReceiveSyncCDMSessionMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
+bool RemoteLegacyCDMFactoryProxy::didReceiveSyncCDMSessionMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& encoder)
 {
-    if (auto* session = m_sessions.get(ObjectIdentifier<RemoteLegacyCDMSessionIdentifierType>(decoder.destinationID())))
-        return session->didReceiveSyncMessage(connection, decoder, encoder);
+    if (auto* session = m_sessions.get(ObjectIdentifier<RemoteLegacyCDMSessionIdentifierType>(message.destinationID)))
+        return session->didReceiveSyncMessage(connection, message, encoder);
     return false;
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
@@ -50,12 +50,12 @@ public:
 
     void clear();
 
-    void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
-    bool didReceiveSyncMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder) { return didReceiveSyncMessage(connection, decoder, encoder); }
-    void didReceiveCDMMessage(IPC::Connection&, IPC::Decoder&);
-    void didReceiveCDMSessionMessage(IPC::Connection&, IPC::Decoder&);
-    bool didReceiveSyncCDMMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
-    bool didReceiveSyncCDMSessionMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Message& message) { didReceiveMessage(connection, message); }
+    bool didReceiveSyncMessageFromWebProcess(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& encoder) { return didReceiveSyncMessage(connection, message, encoder); }
+    void didReceiveCDMMessage(IPC::Connection&, IPC::Message&);
+    void didReceiveCDMSessionMessage(IPC::Connection&, IPC::Message&);
+    bool didReceiveSyncCDMMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
+    bool didReceiveSyncCDMSessionMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
 
     void addProxy(RemoteLegacyCDMIdentifier, std::unique_ptr<RemoteLegacyCDMProxy>&&);
     void removeProxy(RemoteLegacyCDMIdentifier);
@@ -75,8 +75,8 @@ public:
 private:
     friend class GPUProcessConnection;
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     // Messages
     void createCDM(const String& keySystem, std::optional<WebCore::MediaPlayerIdentifier>&&, CompletionHandler<void(RemoteLegacyCDMIdentifier&&)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
@@ -51,8 +51,8 @@ private:
     RemoteLegacyCDMProxy(WeakPtr<RemoteLegacyCDMFactoryProxy>&&, WebCore::MediaPlayerIdentifier&&, std::unique_ptr<WebCore::LegacyCDM>&&);
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     // Messages
     using SupportsMIMETypeCallback = CompletionHandler<void(bool)>;

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
@@ -64,8 +64,8 @@ private:
     RemoteLegacyCDMSessionProxy(RemoteLegacyCDMFactoryProxy&, uint64_t logIdentifier, RemoteLegacyCDMSessionIdentifier, WebCore::LegacyCDM&);
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     // LegacyCDMSessionClient
     void sendMessage(Uint8Array*, String destinationURL) final;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.h
@@ -41,12 +41,12 @@ public:
     RemoteMediaEngineConfigurationFactoryProxy();
     virtual ~RemoteMediaEngineConfigurationFactoryProxy();
 
-    void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
+    void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Message& message) { didReceiveMessage(connection, message); }
 
 private:
     friend class GPUProcessConnection;
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // Messages
     void createDecodingConfiguration(WebCore::MediaDecodingConfiguration&&, CompletionHandler<void(WebCore::MediaCapabilitiesDecodingInfo&&)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
@@ -133,18 +133,18 @@ void RemoteMediaPlayerManagerProxy::supportsKeySystem(MediaPlayerEnums::MediaEng
     completionHandler(result);
 }
 
-void RemoteMediaPlayerManagerProxy::didReceivePlayerMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void RemoteMediaPlayerManagerProxy::didReceivePlayerMessage(IPC::Connection& connection, IPC::Message& message)
 {
     ASSERT(RunLoop::isMain());
-    if (auto* player = m_proxies.get(ObjectIdentifier<MediaPlayerIdentifierType>(decoder.destinationID())))
-        player->didReceiveMessage(connection, decoder);
+    if (auto* player = m_proxies.get(ObjectIdentifier<MediaPlayerIdentifierType>(message.destinationID)))
+        player->didReceiveMessage(connection, message);
 }
 
-bool RemoteMediaPlayerManagerProxy::didReceiveSyncPlayerMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
+bool RemoteMediaPlayerManagerProxy::didReceiveSyncPlayerMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& encoder)
 {
     ASSERT(RunLoop::isMain());
-    if (auto* player = m_proxies.get(ObjectIdentifier<MediaPlayerIdentifierType>(decoder.destinationID())))
-        return player->didReceiveSyncMessage(connection, decoder, encoder);
+    if (auto* player = m_proxies.get(ObjectIdentifier<MediaPlayerIdentifierType>(message.destinationID)))
+        return player->didReceiveSyncMessage(connection, message, encoder);
     return false;
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
@@ -59,10 +59,10 @@ public:
     Logger& logger();
 #endif
 
-    void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
-    bool didReceiveSyncMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder) { return didReceiveSyncMessage(connection, decoder, encoder); }
-    void didReceivePlayerMessage(IPC::Connection&, IPC::Decoder&);
-    bool didReceiveSyncPlayerMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Message& message) { didReceiveMessage(connection, message); }
+    bool didReceiveSyncMessageFromWebProcess(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& encoder) { return didReceiveSyncMessage(connection, message, encoder); }
+    void didReceivePlayerMessage(IPC::Connection&, IPC::Message&);
+    bool didReceiveSyncPlayerMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
 
     RefPtr<WebCore::MediaPlayer> mediaPlayer(const WebCore::MediaPlayerIdentifier&);
 
@@ -70,8 +70,8 @@ public:
 
 private:
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     void createMediaPlayer(WebCore::MediaPlayerIdentifier, WebCore::MediaPlayerEnums::MediaEngineIdentifier, RemoteMediaPlayerProxyConfiguration&&);
     void deleteMediaPlayer(WebCore::MediaPlayerIdentifier);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -131,8 +131,8 @@ public:
     void errorLog(CompletionHandler<void(String)>&&);
 #endif
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
 
     void getConfiguration(RemoteMediaPlayerConfiguration&);
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h
@@ -61,7 +61,7 @@ public:
     void removeMediaResource(RemoteMediaResourceIdentifier);
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
 private:
     void responseReceived(RemoteMediaResourceIdentifier, const WebCore::ResourceResponse&, bool, CompletionHandler<void(WebCore::ShouldContinuePolicyCheck)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h
@@ -75,8 +75,8 @@ public:
 
 private:
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     using AddSourceBufferCallback = CompletionHandler<void(WebCore::MediaSourcePrivate::AddStatus, std::optional<RemoteSourceBufferIdentifier>)>;
     void addSourceBuffer(const WebCore::ContentType&, AddSourceBufferCallback&&);

--- a/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.h
@@ -58,7 +58,7 @@ public:
     RemoteRemoteCommandListenerIdentifier identifier() const { return m_identifier; }
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
 private:
     RemoteRemoteCommandListenerProxy(GPUConnectionToWebProcess&, RemoteRemoteCommandListenerIdentifier&&);

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -76,8 +76,8 @@ private:
     void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode) final;
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     void setActive(bool);
     void canSwitchToType(const WebCore::ContentType&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
@@ -60,8 +60,8 @@ private:
     explicit RemoteVideoFrameObjectHeap(Ref<IPC::Connection>&&);
 
     // IPC::MessageReceiver overrides.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     // Messages.
     void releaseVideoFrame(RemoteVideoFrameWriteReference&&);

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
@@ -42,13 +42,13 @@ public:
     RemoteMediaSessionHelperProxy(GPUConnectionToWebProcess&);
     virtual ~RemoteMediaSessionHelperProxy();
 
-    void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
+    void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Message& message) { didReceiveMessage(connection, message); }
 
     void overridePresentingApplicationPIDIfNeeded();
 
 private:
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // Messages
     void startMonitoringWirelessRoutes();

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
@@ -81,7 +81,7 @@ private:
     WorkQueue& workQueue() const { return m_queue; }
 
     // IPC::WorkQueueMessageReceiver overrides.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     void createDecoder(VideoDecoderIdentifier, VideoCodecType, const String& codecString, bool useRemoteFrames, bool enableAdditionalLogging, CompletionHandler<void(bool)>&&);
     void releaseDecoder(VideoDecoderIdentifier);

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
@@ -53,7 +53,7 @@ public:
     explicit RemoteAudioMediaStreamTrackRendererInternalUnitManager(GPUConnectionToWebProcess&);
     ~RemoteAudioMediaStreamTrackRendererInternalUnitManager();
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
     bool hasUnits() { return !m_units.isEmpty(); }
     class Unit;

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h
@@ -61,7 +61,7 @@ public:
     unsigned audioBitRate() const { return m_writer->audioBitRate(); }
     unsigned videoBitRate() const { return m_writer->videoBitRate(); }
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
 private:
     RemoteMediaRecorder(GPUConnectionToWebProcess&, MediaRecorderIdentifier, Ref<WebCore::MediaRecorderPrivateWriter>&&, bool recordAudio);

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorderManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorderManager.cpp
@@ -47,10 +47,10 @@ RemoteMediaRecorderManager::~RemoteMediaRecorderManager()
 {
 }
 
-void RemoteMediaRecorderManager::didReceiveRemoteMediaRecorderMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void RemoteMediaRecorderManager::didReceiveRemoteMediaRecorderMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (auto* recorder = m_recorders.get(ObjectIdentifier<MediaRecorderIdentifierType>(decoder.destinationID())))
-        recorder->didReceiveMessage(connection, decoder);
+    if (auto* recorder = m_recorders.get(ObjectIdentifier<MediaRecorderIdentifierType>(message.destinationID)))
+        recorder->didReceiveMessage(connection, message);
 }
 
 void RemoteMediaRecorderManager::createRecorder(MediaRecorderIdentifier identifier, bool recordAudio, bool recordVideo, const MediaRecorderPrivateOptions& options, CompletionHandler<void(std::optional<ExceptionData>&&, String&&, unsigned, unsigned)>&& completionHandler)

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorderManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorderManager.h
@@ -53,14 +53,14 @@ public:
     explicit RemoteMediaRecorderManager(GPUConnectionToWebProcess&);
     ~RemoteMediaRecorderManager();
 
-    void didReceiveRemoteMediaRecorderMessage(IPC::Connection&, IPC::Decoder&);
-    void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
+    void didReceiveRemoteMediaRecorderMessage(IPC::Connection&, IPC::Message&);
+    void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Message& message) { didReceiveMessage(connection, message); }
 
     bool allowsExitUnderMemoryPressure() const;
 
 private:
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
     void createRecorder(MediaRecorderIdentifier, bool recordAudio, bool recordVideo, const WebCore::MediaRecorderPrivateOptions&, CompletionHandler<void(std::optional<WebCore::ExceptionData>&&, String&&, unsigned, unsigned)>&&);
     void releaseRecorder(MediaRecorderIdentifier);
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -60,7 +60,7 @@ public:
     void initialize(bool hideRootLayer, WebCore::IntSize, bool shouldMaintainAspectRatio, LayerInitializationCallback&&);
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     CGRect bounds() const;
     void updateBoundsAndPosition(CGRect, std::optional<WTF::MachSendRight>&&);

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
@@ -63,15 +63,15 @@ void RemoteSampleBufferDisplayLayerManager::close()
     });
 }
 
-bool RemoteSampleBufferDisplayLayerManager::dispatchMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+bool RemoteSampleBufferDisplayLayerManager::dispatchMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (!decoder.destinationID())
+    if (!message.destinationID)
         return false;
 
-    auto identifier = ObjectIdentifier<SampleBufferDisplayLayerIdentifierType>(decoder.destinationID());
+    auto identifier = ObjectIdentifier<SampleBufferDisplayLayerIdentifierType>(message.destinationID);
     Locker lock(m_layersLock);
     if (auto* layer = m_layers.get(identifier))
-        layer->didReceiveMessage(connection, decoder);
+        layer->didReceiveMessage(connection, message);
     return true;
 }
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.h
@@ -69,9 +69,9 @@ private:
     void startListeningForIPC();
 
     // IPC::WorkQueueMessageReceiver overrides.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
-    bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
+    bool dispatchMessage(IPC::Connection&, IPC::Message&);
 
     using LayerCreationCallback = CompletionHandler<void(std::optional<LayerHostingContextID>)>&&;
     void createLayer(SampleBufferDisplayLayerIdentifier, bool hideRootLayer, WebCore::IntSize, bool shouldMaintainAspectRatio, LayerCreationCallback);

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
@@ -70,7 +70,7 @@ private:
     Ref<NetworkProcess> protectedProcess();
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     void getHostnamesWithCookies(PAL::SessionID, CompletionHandler<void(Vector<String>&&)>&&);
 

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
@@ -85,7 +85,7 @@ private:
     void initialize(const NetworkProcessCreationParameters&) override;
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     void didFailWithError(LegacyCustomProtocolID, const WebCore::ResourceError&);
     void didLoadData(LegacyCustomProtocolID, const IPC::DataReference&);

--- a/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.h
+++ b/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.h
@@ -45,7 +45,7 @@ public:
 
     void removeConnection(IPC::Connection&);
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
     void registerChannel(IPC::Connection&, const WebCore::ClientOrigin&, const String& name);
     void unregisterChannel(IPC::Connection&, const WebCore::ClientOrigin&, const String& name);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -236,14 +236,14 @@ private:
     WebCore::NetworkStorageSession* storageSession();
 
     // IPC::Connection::Client
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) override;
     void didClose(IPC::Connection&) override;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) override;
 
     // Message handlers.
-    void didReceiveNetworkConnectionToWebProcessMessage(IPC::Connection&, IPC::Decoder&);
-    bool didReceiveSyncNetworkConnectionToWebProcessMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    void didReceiveNetworkConnectionToWebProcessMessage(IPC::Connection&, IPC::Message&);
+    bool didReceiveSyncNetworkConnectionToWebProcessMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
 
     void scheduleResourceLoad(NetworkResourceLoadParameters&&, std::optional<NetworkResourceLoadIdentifier> existingLoaderToResume);
     void performSynchronousLoad(NetworkResourceLoadParameters&&, CompletionHandler<void(const WebCore::ResourceError&, const WebCore::ResourceResponse, Vector<uint8_t>&&)>&&);

--- a/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h
+++ b/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h
@@ -35,6 +35,7 @@
 namespace IPC {
 class Connection;
 class Decoder;
+struct Message;
 }
 
 namespace WebKit {
@@ -46,7 +47,7 @@ public:
     NetworkContentRuleListManager(NetworkProcess&);
     ~NetworkContentRuleListManager();
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
     using BackendCallback = CompletionHandler<void(WebCore::ContentExtensions::ContentExtensionsBackend&)>;
     void contentExtensionsBackend(UserContentControllerIdentifier, BackendCallback&&);

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -247,7 +247,7 @@ ResourceError NetworkLoadChecker::validateResponse(const ResourceRequest& reques
 
 auto NetworkLoadChecker::accessControlErrorForValidationHandler(String&& message) -> RequestOrRedirectionTripletOrError
 {
-    return ResourceError { String { }, 0, m_url, WTFMove(message), ResourceError::Type::AccessControl };
+    return ResourceError { String { }, 0, m_url, message, ResourceError::Type::AccessControl };
 }
 
 void NetworkLoadChecker::checkRequest(ResourceRequest&& request, ContentSecurityPolicyClient* client, ValidationHandler&& handler)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -429,7 +429,7 @@ public:
 private:
     void platformInitializeNetworkProcess(const NetworkProcessCreationParameters&);
 
-    void didReceiveNetworkProcessMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveNetworkProcessMessage(IPC::Connection&, IPC::Message&);
 
     void terminate() override;
     void platformTerminate();
@@ -444,8 +444,8 @@ private:
     bool shouldTerminate() override;
 
     // IPC::Connection::Client
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) override;
     void didClose(IPC::Connection&) override;
 
     // DownloadManager::Client
@@ -456,7 +456,7 @@ private:
     AuthenticationManager& downloadsAuthenticationManager() override;
 
     // Message Handlers
-    bool didReceiveSyncNetworkProcessMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool didReceiveSyncNetworkProcessMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
     void initializeNetworkProcess(NetworkProcessCreationParameters&&, CompletionHandler<void()>&&);
     void createNetworkConnectionToWebProcess(WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&,  CompletionHandler<void(std::optional<IPC::Connection::Handle>&&, WebCore::HTTPCookieAcceptPolicy)>&&);
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -103,7 +103,7 @@ public:
     void transferToNewWebProcess(NetworkConnectionToWebProcess&, const NetworkResourceLoadParameters&);
 
     // Message handlers.
-    void didReceiveNetworkResourceLoaderMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveNetworkResourceLoaderMessage(IPC::Connection&, IPC::Message&);
 
     void continueWillSendRequest(WebCore::ResourceRequest&&, bool isAllowedToAskUserForCredentials, CompletionHandler<void(WebCore::ResourceRequest&&)>&&);
 

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
@@ -66,7 +66,7 @@ public:
     NetworkSocketChannel(NetworkConnectionToWebProcess&, NetworkSession*, const WebCore::ResourceRequest&, const String& protocol, WebCore::WebSocketIdentifier, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections>, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy);
     ~NetworkSocketChannel();
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
     friend class WebSocketTask;
 

--- a/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
@@ -65,7 +65,7 @@ bool Connection::performSendWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&& 
     return true;
 }
 
-bool Connection::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&& encoder, CompletionHandler<void(IPC::Decoder*)>&& completionHandler) const
+bool Connection::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&& encoder, CompletionHandler<void(IPC::Message*)>&& completionHandler) const
 {
     auto dictionary = messageDictionaryFromEncoder(WTFMove(encoder));
     Daemon::Connection::sendWithReply(dictionary.get(), [completionHandler = WTFMove(completionHandler)] (xpc_object_t reply) mutable {
@@ -78,8 +78,20 @@ bool Connection::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IP
         size_t dataSize { 0 };
         const uint8_t* data = static_cast<const uint8_t *>(xpc_dictionary_get_data(reply, WebPushD::protocolEncodedMessageKey, &dataSize));
         auto decoder = IPC::Decoder::create({ data, dataSize }, { });
-
-        completionHandler(decoder.get());
+        if (!decoder)
+            return completionHandler(nullptr);
+        auto messageFlags = decoder->decode<OptionSet<IPC::MessageFlags>>();
+        if (!messageFlags)
+            return completionHandler(nullptr);
+        auto destinationID = decoder->decode<uint64_t>();
+        if (!destinationID)
+            return completionHandler(nullptr);
+        IPC::Message message {
+            makeUniqueRefFromNonNullUniquePtr(WTFMove(decoder)),
+            *destinationID,
+            *messageFlags
+        };
+        completionHandler(&message);
     });
 
     return true;

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
@@ -76,7 +76,7 @@ private:
     IPC::Connection* messageSenderConnection() const final { return nullptr; }
     uint64_t messageSenderDestinationID() const final { return 0; }
     bool performSendWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&&) const final;
-    bool performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&&, CompletionHandler<void(IPC::Decoder*)>&&) const final;
+    bool performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&&, CompletionHandler<void(IPC::Message*)>&&) const final;
 };
 
 } // namespace WebPushD

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDebugInfo.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDebugInfo.cpp
@@ -47,7 +47,7 @@ DebugInfo::Message DebugInfo::Message::isolatedCopy() const &
 
 DebugInfo::Message DebugInfo::Message::isolatedCopy() &&
 {
-    return { messageLevel, WTFMove(message).isolatedCopy() };
+    return { messageLevel, message.isolatedCopy() };
 }
 
 } // namespace WebKit::PCM

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
@@ -83,7 +83,7 @@ private:
     void dispatch(Function<void()>&&) final;
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     template<typename Message> bool sendToServiceWorker(Message&&);
     void didFailDownload(std::optional<WebCore::ResourceError>&& = { });

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -73,7 +73,7 @@ public:
 
     void start(WebSWServerToContextConnection&);
     void cancelFromClient();
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
     void continueDidReceiveFetchResponse();
     void continueFetchTaskWith(WebCore::ResourceRequest&&);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -339,7 +339,7 @@ void WebSWServerConnection::postMessageToServiceWorker(ServiceWorkerIdentifier d
     // It's possible this specific worker cannot be re-run (e.g. its registration has been removed)
     server().runServiceWorkerIfNecessary(destinationIdentifier, [destinationIdentifier, message = WTFMove(message), sourceData = WTFMove(*sourceData)](auto* contextConnection) mutable {
         if (contextConnection)
-            sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::PostMessageToServiceWorker { destinationIdentifier, WTFMove(message), WTFMove(sourceData) });
+            sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::PostMessageToServiceWorker { destinationIdentifier, message, WTFMove(sourceData) });
     });
 }
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -78,7 +78,7 @@ public:
 
     IPC::Connection& ipcConnection() const { return m_contentConnection.get(); }
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     NetworkSession* session();
     PAL::SessionID sessionID() const;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -291,13 +291,13 @@ void WebSWServerToContextConnection::startFetch(ServiceWorkerFetchTask& task)
     task.start(*this);
 }
 
-void WebSWServerToContextConnection::didReceiveFetchTaskMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void WebSWServerToContextConnection::didReceiveFetchTaskMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    auto iterator = m_ongoingFetches.find(ObjectIdentifier<FetchIdentifierType>(decoder.destinationID()));
+    auto iterator = m_ongoingFetches.find(ObjectIdentifier<FetchIdentifierType>(message.destinationID));
     if (iterator == m_ongoingFetches.end())
         return;
 
-    iterator->value->didReceiveMessage(connection, decoder);
+    iterator->value->didReceiveMessage(connection, message);
 }
 
 void WebSWServerToContextConnection::registerFetch(ServiceWorkerFetchTask& task)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -64,12 +64,12 @@ public:
     IPC::Connection& ipcConnection() const;
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     void startFetch(ServiceWorkerFetchTask&);
     void cancelFetch(WebCore::SWServerConnectionIdentifier, WebCore::FetchIdentifier, WebCore::ServiceWorkerIdentifier);
 
-    void didReceiveFetchTaskMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveFetchTaskMessage(IPC::Connection&, IPC::Message&);
 
     void setThrottleState(bool isThrottleable);
     bool isThrottleable() const { return m_isThrottleable; }

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
@@ -62,7 +62,7 @@ public:
     NetworkSession* session();
     WebCore::ProcessIdentifier webProcessIdentifier() const { return m_webProcessIdentifier; }
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     void fetchScriptInClient(const WebSharedWorker&, WebCore::SharedWorkerObjectIdentifier, CompletionHandler<void(WebCore::WorkerFetchResult&&, WebCore::WorkerInitializationData&&)>&&);
     void notifyWorkerObjectOfLoadCompletion(WebCore::SharedWorkerObjectIdentifier, const WebCore::ResourceError&);

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
@@ -70,7 +70,7 @@ public:
 
     const HashMap<WebCore::ProcessIdentifier, HashSet<WebCore::SharedWorkerObjectIdentifier>>& sharedWorkerObjects() const { return m_sharedWorkerObjects; }
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     void addSharedWorkerObject(WebCore::SharedWorkerObjectIdentifier);
     void removeSharedWorkerObject(WebCore::SharedWorkerObjectIdentifier);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -142,8 +142,8 @@ private:
 #endif
 
     // IPC::MessageReceiver (implemented by generated code)
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>& replyEncoder);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>& replyEncoder);
 
     // Message handlers for FileSystem.
     void persisted(const WebCore::ClientOrigin&, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h
@@ -48,6 +48,7 @@
 namespace IPC {
 class Connection;
 class Decoder;
+struct Message;
 }
 
 namespace PAL {
@@ -67,7 +68,7 @@ public:
     NetworkMDNSRegister(NetworkConnectionToWebProcess&);
     ~NetworkMDNSRegister();
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
 #if ENABLE_MDNS
     void closeAndForgetService(DNSServiceRef);

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
@@ -42,6 +42,7 @@ ALLOW_COMMA_END
 namespace IPC {
 class Connection;
 class Decoder;
+struct Message;
 }
 
 namespace WebKit {
@@ -53,7 +54,7 @@ public:
     explicit NetworkRTCMonitor(NetworkRTCProvider& rtcProvider) : m_rtcProvider(rtcProvider) { }
     ~NetworkRTCMonitor();
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
     void stopUpdating();
     bool isStarted() const { return m_isStarted; }
     NetworkRTCProvider& rtcProvider() { return m_rtcProvider; }

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
@@ -86,7 +86,7 @@ public:
     }
     ~NetworkRTCProvider();
 
-    void didReceiveNetworkRTCMonitorMessage(IPC::Connection& connection, IPC::Decoder& decoder) { m_rtcMonitor.didReceiveMessage(connection, decoder); }
+    void didReceiveNetworkRTCMonitorMessage(IPC::Connection& connection, IPC::Message& message) { m_rtcMonitor.didReceiveMessage(connection, message); }
 
     class Socket {
     public:
@@ -145,7 +145,7 @@ private:
     void dispatch(Function<void()>&&) final;
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     static rtc::ProxyInfo proxyInfoFromSession(const RTCNetwork::SocketAddress&, NetworkSession&);
 

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h
@@ -48,7 +48,7 @@ private:
     RTCDataChannelRemoteManagerProxy();
 
     // IPC::WorkQueueMessageReceiver overrides.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // To source
     void sendData(WebCore::RTCDataChannelIdentifier, bool isRaw, const IPC::DataReference&);

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -67,7 +67,7 @@ public:
     void receiveIncomingUnidirectionalStream();
     void receiveBidirectionalStream();
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 private:
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;

--- a/Source/WebKit/Platform/IPC/Decoder.h
+++ b/Source/WebKit/Platform/IPC/Decoder.h
@@ -73,7 +73,7 @@ public:
     static std::unique_ptr<Decoder> create(DataReference buffer, Vector<Attachment>&&);
     using BufferDeallocator = Function<void(DataReference)>;
     static std::unique_ptr<Decoder> create(DataReference buffer, BufferDeallocator&&, Vector<Attachment>&&);
-    Decoder(DataReference stream, uint64_t destinationID);
+    Decoder(DataReference stream);
 
     ~Decoder();
 
@@ -83,21 +83,7 @@ public:
     Decoder& operator=(const Decoder&) = delete;
     Decoder& operator=(Decoder&&) = delete;
 
-    ReceiverName messageReceiverName() const { return receiverName(m_messageName); }
     MessageName messageName() const { return m_messageName; }
-    uint64_t destinationID() const { return m_destinationID; }
-    bool matches(const ReceiverMatcher& matcher) const { return matcher.matches(messageReceiverName(), destinationID()); }
-
-    bool isSyncMessage() const { return messageIsSync(messageName()); }
-    ShouldDispatchWhenWaitingForSyncReply shouldDispatchMessageWhenWaitingForSyncReply() const;
-    bool isAllowedWhenWaitingForSyncReply() const { return messageAllowedWhenWaitingForSyncReply(messageName()) || m_isAllowedWhenWaitingForSyncReplyOverride; }
-    bool isAllowedWhenWaitingForUnboundedSyncReply() const { return messageAllowedWhenWaitingForUnboundedSyncReply(messageName()); }
-#if ENABLE(IPC_TESTING_API)
-    bool hasSyncMessageDeserializationFailure() const;
-#endif
-    bool shouldUseFullySynchronousModeForTesting() const;
-    bool shouldMaintainOrderingWithAsyncMessages() const;
-    void setIsAllowedWhenWaitingForSyncReplyOverride(bool value) { m_isAllowedWhenWaitingForSyncReplyOverride = value; }
 
 #if PLATFORM(MAC)
     void setImportanceAssertion(ImportanceAssertion&&);
@@ -200,8 +186,6 @@ private:
 
     Vector<Attachment> m_attachments;
 
-    OptionSet<MessageFlags> m_messageFlags;
-    bool m_isAllowedWhenWaitingForSyncReplyOverride { false };
     MessageName m_messageName { MessageName::Invalid };
 
 #if PLATFORM(MAC)
@@ -210,8 +194,6 @@ private:
 #if PLATFORM(COCOA)
     HashSet<ClassStructPtr> m_allowedClasses;
 #endif
-
-    uint64_t m_destinationID;
 };
 
 inline bool alignedBufferIsLargeEnoughToContain(size_t bufferSize, const size_t alignedBufferPosition, size_t bytesNeeded)

--- a/Source/WebKit/Platform/IPC/Encoder.cpp
+++ b/Source/WebKit/Platform/IPC/Encoder.cpp
@@ -161,21 +161,21 @@ void Encoder::reserve(size_t size)
 
 void Encoder::encodeHeader()
 {
-    *this << defaultMessageFlags;
     *this << m_messageName;
+    *this << defaultMessageFlags;
     *this << m_destinationID;
 }
 
 OptionSet<MessageFlags>& Encoder::messageFlags()
 {
     // FIXME: We should probably pass an OptionSet<MessageFlags> into the Encoder constructor instead of encoding defaultMessageFlags then using this to change it later.
-    static_assert(sizeof(OptionSet<MessageFlags>::StorageType) == 1, "Encoder uses the first byte of the buffer for message flags.");
-    return *reinterpret_cast<OptionSet<MessageFlags>*>(buffer());
+    static_assert(sizeof(OptionSet<MessageFlags>::StorageType) == 1, "Encoder uses the third byte of the buffer for message flags.");
+    return *reinterpret_cast<OptionSet<MessageFlags>*>(buffer() + sizeof(m_messageName));
 }
 
 const OptionSet<MessageFlags>& Encoder::messageFlags() const
 {
-    return *reinterpret_cast<OptionSet<MessageFlags>*>(buffer());
+    return *reinterpret_cast<OptionSet<MessageFlags>*>(buffer() + sizeof(m_messageName));
 }
 
 uint8_t* Encoder::grow(size_t alignment, size_t size)

--- a/Source/WebKit/Platform/IPC/JSIPCBinding.h
+++ b/Source/WebKit/Platform/IPC/JSIPCBinding.h
@@ -162,13 +162,13 @@ std::optional<JSC::JSValue> putJSValueForDecodeArgumentInArray(JSC::JSGlobalObje
 }
 
 template<typename T>
-static std::optional<JSC::JSValue> jsValueForDecodedArguments(JSC::JSGlobalObject* globalObject, IPC::Decoder& decoder)
+static std::optional<JSC::JSValue> jsValueForDecodedArguments(JSC::JSGlobalObject* globalObject, IPC::Message& message)
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     auto* array = JSC::constructEmptyArray(globalObject, nullptr);
     RETURN_IF_EXCEPTION(scope, JSC::JSValue());
     T* dummyArguments = nullptr;
-    return putJSValueForDecodeArgumentInArray<>(globalObject, decoder, array, 0, dummyArguments);
+    return putJSValueForDecodeArgumentInArray<>(globalObject, message.decoder, array, 0, dummyArguments);
 }
 
 // The bindings implementation will call the function templates below to decode a message.
@@ -180,9 +180,9 @@ static std::optional<JSC::JSValue> jsValueForDecodedArguments(JSC::JSGlobalObjec
 // to know all the message argument types, and need to be recompiled only when the message itself
 // changes.
 template<MessageName>
-std::optional<JSC::JSValue> jsValueForDecodedMessage(JSC::JSGlobalObject*, IPC::Decoder&);
+std::optional<JSC::JSValue> jsValueForDecodedMessage(JSC::JSGlobalObject*, IPC::Message&);
 template<MessageName>
-std::optional<JSC::JSValue> jsValueForDecodedMessageReply(JSC::JSGlobalObject*, IPC::Decoder&);
+std::optional<JSC::JSValue> jsValueForDecodedMessageReply(JSC::JSGlobalObject*, IPC::Message&);
 
 }
 

--- a/Source/WebKit/Platform/IPC/MessageArgumentDescriptions.h
+++ b/Source/WebKit/Platform/IPC/MessageArgumentDescriptions.h
@@ -40,11 +40,12 @@ class JSValue;
 namespace IPC {
 
 class Decoder;
+struct Message;
 
 #if ENABLE(IPC_TESTING_API)
 
-std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject*, MessageName, Decoder&);
-std::optional<JSC::JSValue> jsValueForReplyArguments(JSC::JSGlobalObject*, MessageName, Decoder&);
+std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject*, MessageName, Message&);
+std::optional<JSC::JSValue> jsValueForReplyArguments(JSC::JSGlobalObject*, MessageName, Message&);
 
 Vector<ASCIILiteral> serializedIdentifiers();
 

--- a/Source/WebKit/Platform/IPC/MessageFlags.h
+++ b/Source/WebKit/Platform/IPC/MessageFlags.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/EnumTraits.h>
+
 namespace IPC {
 
 enum class MessageFlags : uint8_t {

--- a/Source/WebKit/Platform/IPC/MessageObserver.h
+++ b/Source/WebKit/Platform/IPC/MessageObserver.h
@@ -34,6 +34,7 @@ namespace IPC {
 
 class Decoder;
 class Encoder;
+struct Message;
 
 enum class SendOption : uint8_t;
 
@@ -41,7 +42,7 @@ class MessageObserver : public CanMakeWeakPtr<MessageObserver> {
 public:
     virtual ~MessageObserver() = default;
     virtual void willSendMessage(const Encoder&, OptionSet<SendOption>) = 0;
-    virtual void didReceiveMessage(const Decoder&) = 0;
+    virtual void didReceiveMessage(const Message&) = 0;
 };
 
 }

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueue.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueue.h
@@ -30,14 +30,14 @@
 namespace IPC {
 
 class Connection;
-class Decoder;
+struct Message;
 
 class MessageReceiveQueue {
 public:
     virtual ~MessageReceiveQueue() = default;
     // Called with Connection incoming message lock held.
     // May be called from multiple threads.
-    virtual void enqueueMessage(Connection&, UniqueRef<Decoder>&&) = 0;
+    virtual void enqueueMessage(Connection&, Message&&) = 0;
 };
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h
@@ -32,6 +32,7 @@
 
 namespace IPC {
 
+struct Message;
 enum class ReceiverName : uint8_t;
 
 class MessageReceiveQueueMap {
@@ -39,16 +40,13 @@ public:
     MessageReceiveQueueMap() = default;
     ~MessageReceiveQueueMap() = default;
 
-    static bool isValidMessage(const Decoder& message)
-    {
-        return QueueMap::isValidKey(std::make_pair(static_cast<uint8_t>(message.messageReceiverName()), message.destinationID()));
-    }
+    static bool isValidMessage(const Message&);
 
     void add(MessageReceiveQueue& queue, const ReceiverMatcher& matcher) { addImpl(StoreType(&queue), matcher); }
     void add(std::unique_ptr<MessageReceiveQueue>&& queue, const ReceiverMatcher& matcher) { addImpl(StoreType(WTFMove(queue)), matcher); }
     void remove(const ReceiverMatcher&);
 
-    MessageReceiveQueue* get(const Decoder&) const;
+    MessageReceiveQueue* get(const Message&) const;
 private:
     using StoreType = std::variant<MessageReceiveQueue*, std::unique_ptr<MessageReceiveQueue>>;
     void addImpl(StoreType&&, const ReceiverMatcher&);

--- a/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiveQueues.h
@@ -27,6 +27,8 @@
 
 #include "Connection.h"
 #include "MessageReceiveQueue.h"
+
+#include "Message.h"
 #include "WorkQueueMessageReceiver.h"
 
 namespace IPC {
@@ -41,10 +43,10 @@ public:
     }
     ~FunctionDispatcherQueue() final = default;
 
-    void enqueueMessage(Connection& connection, UniqueRef<Decoder>&& message) final
+    void enqueueMessage(Connection& connection, Message&& message) final
     {
         m_dispatcher.dispatch([connection = Ref { connection }, message = WTFMove(message), &receiver = m_receiver]() mutable {
-            connection->dispatchMessageReceiverMessage(receiver, WTFMove(message));
+            connection->dispatchMessageReceiverMessage(receiver, message);
         });
     }
 private:
@@ -62,10 +64,10 @@ public:
     }
     ~WorkQueueMessageReceiverQueue() final = default;
 
-    void enqueueMessage(Connection& connection, UniqueRef<Decoder>&& message) final
+    void enqueueMessage(Connection& connection, Message&& message) final
     {
         m_queue->dispatch([connection = Ref { connection }, message = WTFMove(message), receiver = m_receiver]() mutable {
-            connection->dispatchMessageReceiverMessage(receiver.get(), WTFMove(message));
+            connection->dispatchMessageReceiverMessage(receiver.get(), message);
         });
     }
 private:

--- a/Source/WebKit/Platform/IPC/MessageReceiver.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiver.h
@@ -33,6 +33,7 @@ namespace IPC {
 class Connection;
 class Decoder;
 class Encoder;
+struct Message;
 
 class MessageReceiver : public CanMakeWeakPtr<MessageReceiver> {
 public:
@@ -41,17 +42,17 @@ public:
         ASSERT(!m_messageReceiverMapCount);
     }
 
-    virtual void didReceiveMessage(Connection&, Decoder&)
+    virtual void didReceiveMessage(Connection&, Message&)
     {
         ASSERT_NOT_REACHED();
     }
 
-    virtual void didReceiveMessageWithReplyHandler(Decoder&, Function<void(UniqueRef<IPC::Encoder>&&)>&&)
+    virtual void didReceiveMessageWithReplyHandler(Message&, Function<void(UniqueRef<IPC::Encoder>&&)>&&)
     {
         ASSERT_NOT_REACHED();
     }
 
-    virtual bool didReceiveSyncMessage(Connection&, Decoder&, UniqueRef<Encoder>&)
+    virtual bool didReceiveSyncMessage(Connection&, Message&, UniqueRef<Encoder>&)
     {
         ASSERT_NOT_REACHED();
         return false;

--- a/Source/WebKit/Platform/IPC/MessageReceiverMap.h
+++ b/Source/WebKit/Platform/IPC/MessageReceiverMap.h
@@ -51,8 +51,8 @@ public:
 
     void invalidate();
 
-    bool dispatchMessage(Connection&, Decoder&);
-    bool dispatchSyncMessage(Connection&, Decoder&, UniqueRef<Encoder>&);
+    bool dispatchMessage(Connection&, Message&);
+    bool dispatchSyncMessage(Connection&, Message&, UniqueRef<Encoder>&);
 
 private:
     // Message receivers that don't require a destination ID.

--- a/Source/WebKit/Platform/IPC/MessageSender.cpp
+++ b/Source/WebKit/Platform/IPC/MessageSender.cpp
@@ -54,7 +54,7 @@ bool MessageSender::performSendWithoutUsingIPCConnection(UniqueRef<Encoder>&&) c
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-bool MessageSender::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<Encoder>&&, CompletionHandler<void(Decoder*)>&&) const
+bool MessageSender::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<Encoder>&&, CompletionHandler<void(Message*)>&&) const
 {
     // Senders that use sendWithAsyncReplyWithoutUsingIPCConnection(T&& message, C&& completionHandler) must also override this.
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebKit/Platform/IPC/MessageSender.h
+++ b/Source/WebKit/Platform/IPC/MessageSender.h
@@ -37,6 +37,7 @@ enum class SendOption : uint8_t;
 enum class SendSyncOption : uint8_t;
 struct AsyncReplyIDType;
 struct ConnectionAsyncReplyHandler;
+struct Message;
 template<typename> struct ConnectionSendSyncResult;
 using AsyncReplyID = AtomicObjectIdentifier<AsyncReplyIDType>;
 
@@ -74,7 +75,7 @@ public:
     virtual bool performSendWithoutUsingIPCConnection(UniqueRef<Encoder>&&) const;
 
     template<typename T, typename C> inline bool sendWithAsyncReplyWithoutUsingIPCConnection(T&& message, C&& completionHandler) const;
-    virtual bool performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<Encoder>&&, CompletionHandler<void(Decoder*)>&&) const;
+    virtual bool performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<Encoder>&&, CompletionHandler<void(Message*)>&&) const;
 
     virtual bool sendMessage(UniqueRef<Encoder>&&, OptionSet<SendOption>);
 

--- a/Source/WebKit/Platform/IPC/MessageSenderInlines.h
+++ b/Source/WebKit/Platform/IPC/MessageSenderInlines.h
@@ -73,9 +73,9 @@ template<typename MessageType, typename C> inline bool MessageSender::sendWithAs
     auto encoder = makeUniqueRef<IPC::Encoder>(MessageType::name(), messageSenderDestinationID());
     encoder.get() << std::forward<MessageType>(message).arguments();
 
-    auto asyncHandler = [completionHandler = std::forward<C>(completionHandler)] (Decoder* decoder) mutable {
-        if (decoder && decoder->isValid())
-            Connection::callReply<MessageType>(*decoder, WTFMove(completionHandler));
+    auto asyncHandler = [completionHandler = std::forward<C>(completionHandler)] (Message* message) mutable {
+        if (message && message->decoder->isValid())
+            Connection::callReply<MessageType>(*message, WTFMove(completionHandler));
         else
             Connection::cancelReply<MessageType>(WTFMove(completionHandler));
     };

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -35,14 +35,14 @@ StreamClientConnection::DedicatedConnectionClient::DedicatedConnectionClient(Con
 {
 }
 
-void StreamClientConnection::DedicatedConnectionClient::didReceiveMessage(Connection& connection, Decoder& decoder)
+void StreamClientConnection::DedicatedConnectionClient::didReceiveMessage(Connection& connection, Message& message)
 {
-    m_receiver.didReceiveMessage(connection, decoder);
+    m_receiver.didReceiveMessage(connection, message);
 }
 
-bool StreamClientConnection::DedicatedConnectionClient::didReceiveSyncMessage(Connection& connection, Decoder& decoder, UniqueRef<Encoder>& replyEncoder)
+bool StreamClientConnection::DedicatedConnectionClient::didReceiveSyncMessage(Connection& connection, Message& message, UniqueRef<Encoder>& replyEncoder)
 {
-    return m_receiver.didReceiveSyncMessage(connection, decoder, replyEncoder);
+    return m_receiver.didReceiveSyncMessage(connection, message, replyEncoder);
 }
 
 void StreamClientConnection::DedicatedConnectionClient::didClose(Connection& connection)

--- a/Source/WebKit/Platform/IPC/StreamMessageReceiver.h
+++ b/Source/WebKit/Platform/IPC/StreamMessageReceiver.h
@@ -31,12 +31,13 @@ namespace IPC {
 
 class StreamServerConnection;
 class Decoder;
+struct Message;
 
 class StreamMessageReceiver : public ThreadSafeRefCounted<StreamMessageReceiver> {
 public:
     virtual ~StreamMessageReceiver() { }
 
-    virtual void didReceiveStreamMessage(StreamServerConnection&, Decoder&) = 0;
+    virtual void didReceiveStreamMessage(StreamServerConnection&, Message&) = 0;
 };
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -65,7 +65,7 @@ struct StreamServerConnectionParameters {
 //  * Sends the replies back to the client via the stream or normal Connection fallback.
 //
 // Receiver template contract:
-//   void didReceiveStreamMessage(StreamServerConnection&, Decoder&);
+//   void didReceiveStreamMessage(StreamServerConnection&, Message&);
 //
 // The StreamServerConnection does not trust the StreamClientConnection.
 class StreamServerConnection final : public ThreadSafeRefCounted<StreamServerConnection>, private MessageReceiveQueue, private Connection::Client {
@@ -110,17 +110,17 @@ private:
     StreamServerConnection(Ref<Connection>, StreamServerConnectionBuffer&&);
 
     // MessageReceiveQueue
-    void enqueueMessage(Connection&, UniqueRef<Decoder>&&) final;
+    void enqueueMessage(Connection&, Message&&) final;
 
     // Connection::Client
-    void didReceiveMessage(Connection&, Decoder&) final;
-    bool didReceiveSyncMessage(Connection&, Decoder&, UniqueRef<Encoder>&) final;
+    void didReceiveMessage(Connection&, Message&) final;
+    bool didReceiveSyncMessage(Connection&, Message&, UniqueRef<Encoder>&) final;
     void didClose(Connection&) final;
     void didReceiveInvalidMessage(Connection&, MessageName) final;
 
-    bool processSetStreamDestinationID(Decoder&&, RefPtr<StreamMessageReceiver>& currentReceiver);
-    bool dispatchStreamMessage(Decoder&&, StreamMessageReceiver&);
-    bool dispatchOutOfStreamMessage(Decoder&&);
+    bool processSetStreamDestinationID(Message&, RefPtr<StreamMessageReceiver>& currentReceiver);
+    bool dispatchStreamMessage(Message&, StreamMessageReceiver&);
+    bool dispatchOutOfStreamMessage(Message&);
 
     using WakeUpClient = StreamServerConnectionBuffer::WakeUpClient;
     const Ref<IPC::Connection> m_connection;
@@ -128,7 +128,7 @@ private:
     StreamServerConnectionBuffer m_buffer;
 
     Lock m_outOfStreamMessagesLock;
-    Deque<UniqueRef<Decoder>> m_outOfStreamMessages WTF_GUARDED_BY_LOCK(m_outOfStreamMessagesLock);
+    Deque<Message> m_outOfStreamMessages WTF_GUARDED_BY_LOCK(m_outOfStreamMessagesLock);
 
     bool m_isDispatchingStreamMessage { false };
     Lock m_receiversLock;

--- a/Source/WebKit/Platform/Sources.txt
+++ b/Source/WebKit/Platform/Sources.txt
@@ -12,6 +12,7 @@ Platform/IPC/Decoder.cpp
 Platform/IPC/Encoder.cpp
 Platform/IPC/IPCUtilities.cpp
 Platform/IPC/JSIPCBinding.cpp
+Platform/IPC/Message.cpp
 Platform/IPC/MessageReceiveQueueMap.cpp
 Platform/IPC/MessageReceiverMap.cpp
 Platform/IPC/MessageSender.cpp

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -151,287 +151,287 @@ namespace IPC {
 
 #if ENABLE(IPC_TESTING_API)
 
-std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObject, MessageName name, Decoder& decoder)
+std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObject, MessageName name, Message& message)
 {
     switch (name) {
     case MessageName::TestWithSuperclass_LoadURL:
-        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_LoadURL>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_LoadURL>(globalObject, message);
 #if ENABLE(TEST_FEATURE)
     case MessageName::TestWithSuperclass_TestAsyncMessage:
-        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessage>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessage>(globalObject, message);
     case MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments:
-        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments>(globalObject, message);
     case MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments:
-        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments>(globalObject, message);
     case MessageName::TestWithSuperclass_TestAsyncMessageWithConnection:
-        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithConnection>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithConnection>(globalObject, message);
 #endif
     case MessageName::TestWithSuperclass_TestSyncMessage:
-        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestSyncMessage>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestSyncMessage>(globalObject, message);
     case MessageName::TestWithSuperclass_TestSynchronousMessage:
-        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestSynchronousMessage>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestSynchronousMessage>(globalObject, message);
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
     case MessageName::TestWithLegacyReceiver_LoadURL:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_LoadURL>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_LoadURL>(globalObject, message);
 #if ENABLE(TOUCH_EVENTS)
     case MessageName::TestWithLegacyReceiver_LoadSomething:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_LoadSomething>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_LoadSomething>(globalObject, message);
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
     case MessageName::TestWithLegacyReceiver_TouchEvent:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TouchEvent>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TouchEvent>(globalObject, message);
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
     case MessageName::TestWithLegacyReceiver_AddEvent:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_AddEvent>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_AddEvent>(globalObject, message);
 #endif
 #if ENABLE(TOUCH_EVENTS)
     case MessageName::TestWithLegacyReceiver_LoadSomethingElse:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_LoadSomethingElse>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_LoadSomethingElse>(globalObject, message);
 #endif
     case MessageName::TestWithLegacyReceiver_DidReceivePolicyDecision:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_DidReceivePolicyDecision>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_DidReceivePolicyDecision>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_Close:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_Close>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_Close>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_PreferencesDidChange:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_PreferencesDidChange>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_PreferencesDidChange>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_SendDoubleAndFloat:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_SendDoubleAndFloat>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_SendDoubleAndFloat>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_SendInts:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_SendInts>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_SendInts>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_CreatePlugin:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_CreatePlugin>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_CreatePlugin>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_RunJavaScriptAlert:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_RunJavaScriptAlert>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_RunJavaScriptAlert>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_GetPlugins:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_GetPlugins>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_GetPlugins>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_GetPluginProcessConnection:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_GetPluginProcessConnection>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_GetPluginProcessConnection>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_TestMultipleAttributes:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TestMultipleAttributes>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TestMultipleAttributes>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_TestParameterAttributes:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TestParameterAttributes>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TestParameterAttributes>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_TemplateTest:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TemplateTest>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TemplateTest>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_SetVideoLayerID:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_SetVideoLayerID>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_SetVideoLayerID>(globalObject, message);
 #if PLATFORM(MAC)
     case MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_InterpretKeyEvent:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_InterpretKeyEvent>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_InterpretKeyEvent>(globalObject, message);
 #endif
 #if ENABLE(DEPRECATED_FEATURE)
     case MessageName::TestWithLegacyReceiver_DeprecatedOperation:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_DeprecatedOperation>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_DeprecatedOperation>(globalObject, message);
 #endif
 #if ENABLE(FEATURE_FOR_TESTING)
     case MessageName::TestWithLegacyReceiver_ExperimentalOperation:
-        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_ExperimentalOperation>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_ExperimentalOperation>(globalObject, message);
 #endif
 #endif
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
     case MessageName::TestWithoutAttributes_LoadURL:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_LoadURL>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_LoadURL>(globalObject, message);
 #if ENABLE(TOUCH_EVENTS)
     case MessageName::TestWithoutAttributes_LoadSomething:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_LoadSomething>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_LoadSomething>(globalObject, message);
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
     case MessageName::TestWithoutAttributes_TouchEvent:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TouchEvent>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TouchEvent>(globalObject, message);
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
     case MessageName::TestWithoutAttributes_AddEvent:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_AddEvent>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_AddEvent>(globalObject, message);
 #endif
 #if ENABLE(TOUCH_EVENTS)
     case MessageName::TestWithoutAttributes_LoadSomethingElse:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_LoadSomethingElse>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_LoadSomethingElse>(globalObject, message);
 #endif
     case MessageName::TestWithoutAttributes_DidReceivePolicyDecision:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_DidReceivePolicyDecision>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_DidReceivePolicyDecision>(globalObject, message);
     case MessageName::TestWithoutAttributes_Close:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_Close>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_Close>(globalObject, message);
     case MessageName::TestWithoutAttributes_PreferencesDidChange:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_PreferencesDidChange>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_PreferencesDidChange>(globalObject, message);
     case MessageName::TestWithoutAttributes_SendDoubleAndFloat:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_SendDoubleAndFloat>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_SendDoubleAndFloat>(globalObject, message);
     case MessageName::TestWithoutAttributes_SendInts:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_SendInts>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_SendInts>(globalObject, message);
     case MessageName::TestWithoutAttributes_CreatePlugin:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_CreatePlugin>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_CreatePlugin>(globalObject, message);
     case MessageName::TestWithoutAttributes_RunJavaScriptAlert:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_RunJavaScriptAlert>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_RunJavaScriptAlert>(globalObject, message);
     case MessageName::TestWithoutAttributes_GetPlugins:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_GetPlugins>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_GetPlugins>(globalObject, message);
     case MessageName::TestWithoutAttributes_GetPluginProcessConnection:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_GetPluginProcessConnection>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_GetPluginProcessConnection>(globalObject, message);
     case MessageName::TestWithoutAttributes_TestMultipleAttributes:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TestMultipleAttributes>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TestMultipleAttributes>(globalObject, message);
     case MessageName::TestWithoutAttributes_TestParameterAttributes:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TestParameterAttributes>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TestParameterAttributes>(globalObject, message);
     case MessageName::TestWithoutAttributes_TemplateTest:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TemplateTest>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TemplateTest>(globalObject, message);
     case MessageName::TestWithoutAttributes_SetVideoLayerID:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_SetVideoLayerID>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_SetVideoLayerID>(globalObject, message);
 #if PLATFORM(MAC)
     case MessageName::TestWithoutAttributes_DidCreateWebProcessConnection:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_DidCreateWebProcessConnection>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_DidCreateWebProcessConnection>(globalObject, message);
     case MessageName::TestWithoutAttributes_InterpretKeyEvent:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_InterpretKeyEvent>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_InterpretKeyEvent>(globalObject, message);
 #endif
 #if ENABLE(DEPRECATED_FEATURE)
     case MessageName::TestWithoutAttributes_DeprecatedOperation:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_DeprecatedOperation>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_DeprecatedOperation>(globalObject, message);
 #endif
 #if ENABLE(FEATURE_FOR_TESTING)
     case MessageName::TestWithoutAttributes_ExperimentalOperation:
-        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_ExperimentalOperation>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutAttributes_ExperimentalOperation>(globalObject, message);
 #endif
 #endif
     case MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgument:
-        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgument>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgument>(globalObject, message);
     case MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply:
-        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply>(globalObject, message);
     case MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument:
-        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument>(globalObject, message);
     case MessageName::TestWithoutUsingIPCConnection_MessageWithArgument:
-        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgument>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgument>(globalObject, message);
     case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply:
-        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply>(globalObject, message);
     case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument:
-        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument>(globalObject, message);
 #if PLATFORM(COCOA)
     case MessageName::TestWithIfMessage_LoadURL:
-        return jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(globalObject, message);
 #endif
 #if PLATFORM(GTK)
     case MessageName::TestWithIfMessage_LoadURL:
-        return jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(globalObject, message);
 #endif
     case MessageName::TestWithSemaphore_SendSemaphore:
-        return jsValueForDecodedMessage<MessageName::TestWithSemaphore_SendSemaphore>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithSemaphore_SendSemaphore>(globalObject, message);
     case MessageName::TestWithSemaphore_ReceiveSemaphore:
-        return jsValueForDecodedMessage<MessageName::TestWithSemaphore_ReceiveSemaphore>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithSemaphore_ReceiveSemaphore>(globalObject, message);
     case MessageName::TestWithImageData_SendImageData:
-        return jsValueForDecodedMessage<MessageName::TestWithImageData_SendImageData>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithImageData_SendImageData>(globalObject, message);
     case MessageName::TestWithImageData_ReceiveImageData:
-        return jsValueForDecodedMessage<MessageName::TestWithImageData_ReceiveImageData>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithImageData_ReceiveImageData>(globalObject, message);
     case MessageName::TestWithStream_SendString:
-        return jsValueForDecodedMessage<MessageName::TestWithStream_SendString>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithStream_SendString>(globalObject, message);
     case MessageName::TestWithStream_SendStringAsync:
-        return jsValueForDecodedMessage<MessageName::TestWithStream_SendStringAsync>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithStream_SendStringAsync>(globalObject, message);
     case MessageName::TestWithStream_SendStringSync:
-        return jsValueForDecodedMessage<MessageName::TestWithStream_SendStringSync>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithStream_SendStringSync>(globalObject, message);
     case MessageName::TestWithStream_CallWithIdentifier:
-        return jsValueForDecodedMessage<MessageName::TestWithStream_CallWithIdentifier>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithStream_CallWithIdentifier>(globalObject, message);
 #if PLATFORM(COCOA)
     case MessageName::TestWithStream_SendMachSendRight:
-        return jsValueForDecodedMessage<MessageName::TestWithStream_SendMachSendRight>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithStream_SendMachSendRight>(globalObject, message);
     case MessageName::TestWithStream_ReceiveMachSendRight:
-        return jsValueForDecodedMessage<MessageName::TestWithStream_ReceiveMachSendRight>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithStream_ReceiveMachSendRight>(globalObject, message);
     case MessageName::TestWithStream_SendAndReceiveMachSendRight:
-        return jsValueForDecodedMessage<MessageName::TestWithStream_SendAndReceiveMachSendRight>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithStream_SendAndReceiveMachSendRight>(globalObject, message);
 #endif
     case MessageName::TestWithStreamBatched_SendString:
-        return jsValueForDecodedMessage<MessageName::TestWithStreamBatched_SendString>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithStreamBatched_SendString>(globalObject, message);
     case MessageName::TestWithStreamBuffer_SendStreamBuffer:
-        return jsValueForDecodedMessage<MessageName::TestWithStreamBuffer_SendStreamBuffer>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithStreamBuffer_SendStreamBuffer>(globalObject, message);
 #if USE(AVFOUNDATION)
     case MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer:
-        return jsValueForDecodedMessage<MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer>(globalObject, message);
     case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer:
-        return jsValueForDecodedMessage<MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer>(globalObject, message);
 #endif
     case MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection:
-        return jsValueForDecodedMessage<MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection>(globalObject, message);
     case MessageName::TestWithEnabledIf_AlwaysEnabled:
-        return jsValueForDecodedMessage<MessageName::TestWithEnabledIf_AlwaysEnabled>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithEnabledIf_AlwaysEnabled>(globalObject, message);
     case MessageName::TestWithEnabledIf_OnlyEnabledIfFeatureEnabled:
-        return jsValueForDecodedMessage<MessageName::TestWithEnabledIf_OnlyEnabledIfFeatureEnabled>(globalObject, decoder);
+        return jsValueForDecodedMessage<MessageName::TestWithEnabledIf_OnlyEnabledIfFeatureEnabled>(globalObject, message);
     default:
         break;
     }
     return std::nullopt;
 }
 
-std::optional<JSC::JSValue> jsValueForReplyArguments(JSC::JSGlobalObject* globalObject, MessageName name, Decoder& decoder)
+std::optional<JSC::JSValue> jsValueForReplyArguments(JSC::JSGlobalObject* globalObject, MessageName name, Message& message)
 {
     switch (name) {
 #if ENABLE(TEST_FEATURE)
     case MessageName::TestWithSuperclass_TestAsyncMessage:
-        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessage>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessage>(globalObject, message);
     case MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments:
-        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments>(globalObject, message);
     case MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments:
-        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments>(globalObject, message);
     case MessageName::TestWithSuperclass_TestAsyncMessageWithConnection:
-        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithConnection>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithConnection>(globalObject, message);
 #endif
     case MessageName::TestWithSuperclass_TestSyncMessage:
-        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestSyncMessage>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestSyncMessage>(globalObject, message);
     case MessageName::TestWithSuperclass_TestSynchronousMessage:
-        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestSynchronousMessage>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestSynchronousMessage>(globalObject, message);
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
     case MessageName::TestWithLegacyReceiver_CreatePlugin:
-        return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_CreatePlugin>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_CreatePlugin>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_RunJavaScriptAlert:
-        return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_RunJavaScriptAlert>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_RunJavaScriptAlert>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_GetPlugins:
-        return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_GetPlugins>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_GetPlugins>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_GetPluginProcessConnection:
-        return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_GetPluginProcessConnection>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_GetPluginProcessConnection>(globalObject, message);
     case MessageName::TestWithLegacyReceiver_TestMultipleAttributes:
-        return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_TestMultipleAttributes>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_TestMultipleAttributes>(globalObject, message);
 #if PLATFORM(MAC)
     case MessageName::TestWithLegacyReceiver_InterpretKeyEvent:
-        return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_InterpretKeyEvent>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_InterpretKeyEvent>(globalObject, message);
 #endif
 #endif
 #if (ENABLE(WEBKIT2) && (NESTED_MASTER_CONDITION || MASTER_OR && MASTER_AND))
     case MessageName::TestWithoutAttributes_CreatePlugin:
-        return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_CreatePlugin>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_CreatePlugin>(globalObject, message);
     case MessageName::TestWithoutAttributes_RunJavaScriptAlert:
-        return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_RunJavaScriptAlert>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_RunJavaScriptAlert>(globalObject, message);
     case MessageName::TestWithoutAttributes_GetPlugins:
-        return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_GetPlugins>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_GetPlugins>(globalObject, message);
     case MessageName::TestWithoutAttributes_GetPluginProcessConnection:
-        return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_GetPluginProcessConnection>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_GetPluginProcessConnection>(globalObject, message);
     case MessageName::TestWithoutAttributes_TestMultipleAttributes:
-        return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_TestMultipleAttributes>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_TestMultipleAttributes>(globalObject, message);
 #if PLATFORM(MAC)
     case MessageName::TestWithoutAttributes_InterpretKeyEvent:
-        return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_InterpretKeyEvent>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_InterpretKeyEvent>(globalObject, message);
 #endif
 #endif
     case MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply:
-        return jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply>(globalObject, message);
     case MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument:
-        return jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument>(globalObject, message);
     case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply:
-        return jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply>(globalObject, message);
     case MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument:
-        return jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument>(globalObject, message);
     case MessageName::TestWithSemaphore_ReceiveSemaphore:
-        return jsValueForDecodedMessageReply<MessageName::TestWithSemaphore_ReceiveSemaphore>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithSemaphore_ReceiveSemaphore>(globalObject, message);
     case MessageName::TestWithImageData_ReceiveImageData:
-        return jsValueForDecodedMessageReply<MessageName::TestWithImageData_ReceiveImageData>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithImageData_ReceiveImageData>(globalObject, message);
     case MessageName::TestWithStream_SendStringAsync:
-        return jsValueForDecodedMessageReply<MessageName::TestWithStream_SendStringAsync>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithStream_SendStringAsync>(globalObject, message);
     case MessageName::TestWithStream_SendStringSync:
-        return jsValueForDecodedMessageReply<MessageName::TestWithStream_SendStringSync>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithStream_SendStringSync>(globalObject, message);
     case MessageName::TestWithStream_CallWithIdentifier:
-        return jsValueForDecodedMessageReply<MessageName::TestWithStream_CallWithIdentifier>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithStream_CallWithIdentifier>(globalObject, message);
 #if PLATFORM(COCOA)
     case MessageName::TestWithStream_ReceiveMachSendRight:
-        return jsValueForDecodedMessageReply<MessageName::TestWithStream_ReceiveMachSendRight>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithStream_ReceiveMachSendRight>(globalObject, message);
     case MessageName::TestWithStream_SendAndReceiveMachSendRight:
-        return jsValueForDecodedMessageReply<MessageName::TestWithStream_SendAndReceiveMachSendRight>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithStream_SendAndReceiveMachSendRight>(globalObject, message);
 #endif
 #if USE(AVFOUNDATION)
     case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer:
-        return jsValueForDecodedMessageReply<MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer>(globalObject, decoder);
+        return jsValueForDecodedMessageReply<MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer>(globalObject, message);
 #endif
     default:
         break;

--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp
@@ -28,8 +28,8 @@
 #if USE(AVFOUNDATION)
 #include "ArgumentCodersCF.h" // NOLINT
 #endif
-#include "Decoder.h" // NOLINT
 #include "HandleMessage.h" // NOLINT
+#include "Message.h" // NOLINT
 #include "TestWithCVPixelBufferMessages.h" // NOLINT
 #if USE(AVFOUNDATION)
 #include <WebCore/CVUtilities.h> // NOLINT
@@ -44,22 +44,22 @@
 
 namespace WebKit {
 
-void TestWithCVPixelBuffer::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void TestWithCVPixelBuffer::didReceiveMessage(IPC::Connection& connection, IPC::Message&& message)
 {
     Ref protectedThis { *this };
 #if USE(AVFOUNDATION)
-    if (decoder.messageName() == Messages::TestWithCVPixelBuffer::SendCVPixelBuffer::name())
-        return IPC::handleMessage<Messages::TestWithCVPixelBuffer::SendCVPixelBuffer>(connection, decoder, this, &TestWithCVPixelBuffer::sendCVPixelBuffer);
-    if (decoder.messageName() == Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer::name())
-        return IPC::handleMessageAsync<Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer>(connection, decoder, this, &TestWithCVPixelBuffer::receiveCVPixelBuffer);
+    if (message.messageName() == Messages::TestWithCVPixelBuffer::SendCVPixelBuffer::name())
+        return IPC::handleMessage<Messages::TestWithCVPixelBuffer::SendCVPixelBuffer>(connection, WTFMove(message), this, &TestWithCVPixelBuffer::sendCVPixelBuffer);
+    if (message.messageName() == Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer::name())
+        return IPC::handleMessageAsync<Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer>(connection, WTFMove(message), this, &TestWithCVPixelBuffer::receiveCVPixelBuffer);
 #endif
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(message);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(message.messageName()), message.destinationID);
 }
 
 } // namespace WebKit
@@ -69,17 +69,17 @@ void TestWithCVPixelBuffer::didReceiveMessage(IPC::Connection& connection, IPC::
 namespace IPC {
 
 #if USE(AVFOUNDATION)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithCVPixelBuffer::SendCVPixelBuffer::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithCVPixelBuffer::SendCVPixelBuffer::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer::ReplyArguments>(globalObject, message);
 }
 #endif
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp
@@ -26,8 +26,8 @@
 #include "TestWithEnabledIf.h"
 
 #include "ArgumentCoders.h" // NOLINT
-#include "Decoder.h" // NOLINT
 #include "HandleMessage.h" // NOLINT
+#include "Message.h" // NOLINT
 #include "TestWithEnabledIfMessages.h" // NOLINT
 #include <wtf/text/WTFString.h> // NOLINT
 
@@ -37,20 +37,20 @@
 
 namespace WebKit {
 
-void TestWithEnabledIf::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void TestWithEnabledIf::didReceiveMessage(IPC::Connection& connection, IPC::Message&& message)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithEnabledIf::AlwaysEnabled::name())
-        return IPC::handleMessage<Messages::TestWithEnabledIf::AlwaysEnabled>(connection, decoder, this, &TestWithEnabledIf::alwaysEnabled);
-    if (decoder.messageName() == Messages::TestWithEnabledIf::OnlyEnabledIfFeatureEnabled::name() && featureEnabled())
-        return IPC::handleMessage<Messages::TestWithEnabledIf::OnlyEnabledIfFeatureEnabled>(connection, decoder, this, &TestWithEnabledIf::onlyEnabledIfFeatureEnabled);
+    if (message.messageName() == Messages::TestWithEnabledIf::AlwaysEnabled::name())
+        return IPC::handleMessage<Messages::TestWithEnabledIf::AlwaysEnabled>(connection, WTFMove(message), this, &TestWithEnabledIf::alwaysEnabled);
+    if (message.messageName() == Messages::TestWithEnabledIf::OnlyEnabledIfFeatureEnabled::name() && featureEnabled())
+        return IPC::handleMessage<Messages::TestWithEnabledIf::OnlyEnabledIfFeatureEnabled>(connection, WTFMove(message), this, &TestWithEnabledIf::onlyEnabledIfFeatureEnabled);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(message);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(message.messageName()), message.destinationID);
 }
 
 } // namespace WebKit
@@ -59,13 +59,13 @@ void TestWithEnabledIf::didReceiveMessage(IPC::Connection& connection, IPC::Deco
 
 namespace IPC {
 
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithEnabledIf_AlwaysEnabled>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithEnabledIf_AlwaysEnabled>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithEnabledIf::AlwaysEnabled::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithEnabledIf::AlwaysEnabled::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithEnabledIf_OnlyEnabledIfFeatureEnabled>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithEnabledIf_OnlyEnabledIfFeatureEnabled>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithEnabledIf::OnlyEnabledIfFeatureEnabled::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithEnabledIf::OnlyEnabledIfFeatureEnabled::Arguments>(globalObject, message);
 }
 
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp
@@ -28,8 +28,8 @@
 #if PLATFORM(COCOA) || PLATFORM(GTK)
 #include "ArgumentCoders.h" // NOLINT
 #endif
-#include "Decoder.h" // NOLINT
 #include "HandleMessage.h" // NOLINT
+#include "Message.h" // NOLINT
 #include "TestWithIfMessageMessages.h" // NOLINT
 #if PLATFORM(COCOA) || PLATFORM(GTK)
 #include <wtf/text/WTFString.h> // NOLINT
@@ -41,24 +41,24 @@
 
 namespace WebKit {
 
-void TestWithIfMessage::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void TestWithIfMessage::didReceiveMessage(IPC::Connection& connection, IPC::Message&& message)
 {
     Ref protectedThis { *this };
 #if PLATFORM(COCOA)
-    if (decoder.messageName() == Messages::TestWithIfMessage::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithIfMessage::LoadURL>(connection, decoder, this, &TestWithIfMessage::loadURL);
+    if (message.messageName() == Messages::TestWithIfMessage::LoadURL::name())
+        return IPC::handleMessage<Messages::TestWithIfMessage::LoadURL>(connection, WTFMove(message), this, &TestWithIfMessage::loadURL);
 #endif
 #if PLATFORM(GTK)
-    if (decoder.messageName() == Messages::TestWithIfMessage::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithIfMessage::LoadURL>(connection, decoder, this, &TestWithIfMessage::loadURL);
+    if (message.messageName() == Messages::TestWithIfMessage::LoadURL::name())
+        return IPC::handleMessage<Messages::TestWithIfMessage::LoadURL>(connection, WTFMove(message), this, &TestWithIfMessage::loadURL);
 #endif
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(message);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(message.messageName()), message.destinationID);
 }
 
 } // namespace WebKit
@@ -68,15 +68,15 @@ void TestWithIfMessage::didReceiveMessage(IPC::Connection& connection, IPC::Deco
 namespace IPC {
 
 #if PLATFORM(COCOA)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithIfMessage::LoadURL::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithIfMessage::LoadURL::Arguments>(globalObject, message);
 }
 #endif
 #if PLATFORM(GTK)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithIfMessage_LoadURL>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithIfMessage::LoadURL::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithIfMessage::LoadURL::Arguments>(globalObject, message);
 }
 #endif
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp
@@ -26,8 +26,8 @@
 #include "TestWithImageData.h"
 
 #include "ArgumentCoders.h" // NOLINT
-#include "Decoder.h" // NOLINT
 #include "HandleMessage.h" // NOLINT
+#include "Message.h" // NOLINT
 #include "TestWithImageDataMessages.h" // NOLINT
 #include "WebCoreArgumentCoders.h" // NOLINT
 #include <WebCore/ImageData.h> // NOLINT
@@ -39,20 +39,20 @@
 
 namespace WebKit {
 
-void TestWithImageData::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void TestWithImageData::didReceiveMessage(IPC::Connection& connection, IPC::Message&& message)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithImageData::SendImageData::name())
-        return IPC::handleMessage<Messages::TestWithImageData::SendImageData>(connection, decoder, this, &TestWithImageData::sendImageData);
-    if (decoder.messageName() == Messages::TestWithImageData::ReceiveImageData::name())
-        return IPC::handleMessageAsync<Messages::TestWithImageData::ReceiveImageData>(connection, decoder, this, &TestWithImageData::receiveImageData);
+    if (message.messageName() == Messages::TestWithImageData::SendImageData::name())
+        return IPC::handleMessage<Messages::TestWithImageData::SendImageData>(connection, WTFMove(message), this, &TestWithImageData::sendImageData);
+    if (message.messageName() == Messages::TestWithImageData::ReceiveImageData::name())
+        return IPC::handleMessageAsync<Messages::TestWithImageData::ReceiveImageData>(connection, WTFMove(message), this, &TestWithImageData::receiveImageData);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(message);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(message.messageName()), message.destinationID);
 }
 
 } // namespace WebKit
@@ -61,17 +61,17 @@ void TestWithImageData::didReceiveMessage(IPC::Connection& connection, IPC::Deco
 
 namespace IPC {
 
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithImageData_SendImageData>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithImageData_SendImageData>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithImageData::SendImageData::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithImageData::SendImageData::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithImageData_ReceiveImageData>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithImageData_ReceiveImageData>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithImageData::ReceiveImageData::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithImageData::ReceiveImageData::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithImageData_ReceiveImageData>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithImageData_ReceiveImageData>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithImageData::ReceiveImageData::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithImageData::ReceiveImageData::ReplyArguments>(globalObject, message);
 }
 
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp
@@ -31,7 +31,6 @@
 #include "ArgumentCodersDarwin.h" // NOLINT
 #endif
 #include "Connection.h" // NOLINT
-#include "Decoder.h" // NOLINT
 #if ENABLE(DEPRECATED_FEATURE) || ENABLE(FEATURE_FOR_TESTING)
 #include "DummyType.h" // NOLINT
 #endif
@@ -39,6 +38,7 @@
 #include "GestureTypes.h" // NOLINT
 #endif
 #include "HandleMessage.h" // NOLINT
+#include "Message.h" // NOLINT
 #include "Plugin.h" // NOLINT
 #include "TestWithLegacyReceiverMessages.h" // NOLINT
 #include "WebCoreArgumentCoders.h" // NOLINT
@@ -68,87 +68,87 @@
 
 namespace WebKit {
 
-void TestWithLegacyReceiver::didReceiveTestWithLegacyReceiverMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void TestWithLegacyReceiver::didReceiveTestWithLegacyReceiverMessage(IPC::Connection& connection, IPC::Message&& message)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::LoadURL>(connection, decoder, this, &TestWithLegacyReceiver::loadURL);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::LoadURL::name())
+        return IPC::handleMessage<Messages::TestWithLegacyReceiver::LoadURL>(connection, WTFMove(message), this, &TestWithLegacyReceiver::loadURL);
 #if ENABLE(TOUCH_EVENTS)
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::LoadSomething::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::LoadSomething>(connection, decoder, this, &TestWithLegacyReceiver::loadSomething);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::LoadSomething::name())
+        return IPC::handleMessage<Messages::TestWithLegacyReceiver::LoadSomething>(connection, WTFMove(message), this, &TestWithLegacyReceiver::loadSomething);
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::TouchEvent::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::TouchEvent>(connection, decoder, this, &TestWithLegacyReceiver::touchEvent);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::TouchEvent::name())
+        return IPC::handleMessage<Messages::TestWithLegacyReceiver::TouchEvent>(connection, WTFMove(message), this, &TestWithLegacyReceiver::touchEvent);
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::AddEvent::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::AddEvent>(connection, decoder, this, &TestWithLegacyReceiver::addEvent);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::AddEvent::name())
+        return IPC::handleMessage<Messages::TestWithLegacyReceiver::AddEvent>(connection, WTFMove(message), this, &TestWithLegacyReceiver::addEvent);
 #endif
 #if ENABLE(TOUCH_EVENTS)
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::LoadSomethingElse::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::LoadSomethingElse>(connection, decoder, this, &TestWithLegacyReceiver::loadSomethingElse);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::LoadSomethingElse::name())
+        return IPC::handleMessage<Messages::TestWithLegacyReceiver::LoadSomethingElse>(connection, WTFMove(message), this, &TestWithLegacyReceiver::loadSomethingElse);
 #endif
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::DidReceivePolicyDecision::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::DidReceivePolicyDecision>(connection, decoder, this, &TestWithLegacyReceiver::didReceivePolicyDecision);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::Close::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::Close>(connection, decoder, this, &TestWithLegacyReceiver::close);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::PreferencesDidChange::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::PreferencesDidChange>(connection, decoder, this, &TestWithLegacyReceiver::preferencesDidChange);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::SendDoubleAndFloat::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::SendDoubleAndFloat>(connection, decoder, this, &TestWithLegacyReceiver::sendDoubleAndFloat);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::SendInts::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::SendInts>(connection, decoder, this, &TestWithLegacyReceiver::sendInts);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::CreatePlugin::name())
-        return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::CreatePlugin>(connection, decoder, this, &TestWithLegacyReceiver::createPlugin);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::RunJavaScriptAlert::name())
-        return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::RunJavaScriptAlert>(connection, decoder, this, &TestWithLegacyReceiver::runJavaScriptAlert);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::GetPlugins::name())
-        return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::GetPlugins>(connection, decoder, this, &TestWithLegacyReceiver::getPlugins);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::TestParameterAttributes::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::TestParameterAttributes>(connection, decoder, this, &TestWithLegacyReceiver::testParameterAttributes);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::TemplateTest::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::TemplateTest>(connection, decoder, this, &TestWithLegacyReceiver::templateTest);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::SetVideoLayerID::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::SetVideoLayerID>(connection, decoder, this, &TestWithLegacyReceiver::setVideoLayerID);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::DidReceivePolicyDecision::name())
+        return IPC::handleMessage<Messages::TestWithLegacyReceiver::DidReceivePolicyDecision>(connection, WTFMove(message), this, &TestWithLegacyReceiver::didReceivePolicyDecision);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::Close::name())
+        return IPC::handleMessage<Messages::TestWithLegacyReceiver::Close>(connection, WTFMove(message), this, &TestWithLegacyReceiver::close);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::PreferencesDidChange::name())
+        return IPC::handleMessage<Messages::TestWithLegacyReceiver::PreferencesDidChange>(connection, WTFMove(message), this, &TestWithLegacyReceiver::preferencesDidChange);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::SendDoubleAndFloat::name())
+        return IPC::handleMessage<Messages::TestWithLegacyReceiver::SendDoubleAndFloat>(connection, WTFMove(message), this, &TestWithLegacyReceiver::sendDoubleAndFloat);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::SendInts::name())
+        return IPC::handleMessage<Messages::TestWithLegacyReceiver::SendInts>(connection, WTFMove(message), this, &TestWithLegacyReceiver::sendInts);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::CreatePlugin::name())
+        return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::CreatePlugin>(connection, WTFMove(message), this, &TestWithLegacyReceiver::createPlugin);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::RunJavaScriptAlert::name())
+        return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::RunJavaScriptAlert>(connection, WTFMove(message), this, &TestWithLegacyReceiver::runJavaScriptAlert);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::GetPlugins::name())
+        return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::GetPlugins>(connection, WTFMove(message), this, &TestWithLegacyReceiver::getPlugins);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::TestParameterAttributes::name())
+        return IPC::handleMessage<Messages::TestWithLegacyReceiver::TestParameterAttributes>(connection, WTFMove(message), this, &TestWithLegacyReceiver::testParameterAttributes);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::TemplateTest::name())
+        return IPC::handleMessage<Messages::TestWithLegacyReceiver::TemplateTest>(connection, WTFMove(message), this, &TestWithLegacyReceiver::templateTest);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::SetVideoLayerID::name())
+        return IPC::handleMessage<Messages::TestWithLegacyReceiver::SetVideoLayerID>(connection, WTFMove(message), this, &TestWithLegacyReceiver::setVideoLayerID);
 #if PLATFORM(MAC)
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection>(connection, decoder, this, &TestWithLegacyReceiver::didCreateWebProcessConnection);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::InterpretKeyEvent::name())
-        return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::InterpretKeyEvent>(connection, decoder, this, &TestWithLegacyReceiver::interpretKeyEvent);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection::name())
+        return IPC::handleMessage<Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection>(connection, WTFMove(message), this, &TestWithLegacyReceiver::didCreateWebProcessConnection);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::InterpretKeyEvent::name())
+        return IPC::handleMessageAsync<Messages::TestWithLegacyReceiver::InterpretKeyEvent>(connection, WTFMove(message), this, &TestWithLegacyReceiver::interpretKeyEvent);
 #endif
 #if ENABLE(DEPRECATED_FEATURE)
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::DeprecatedOperation::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::DeprecatedOperation>(connection, decoder, this, &TestWithLegacyReceiver::deprecatedOperation);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::DeprecatedOperation::name())
+        return IPC::handleMessage<Messages::TestWithLegacyReceiver::DeprecatedOperation>(connection, WTFMove(message), this, &TestWithLegacyReceiver::deprecatedOperation);
 #endif
 #if ENABLE(FEATURE_FOR_TESTING)
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::ExperimentalOperation::name())
-        return IPC::handleMessage<Messages::TestWithLegacyReceiver::ExperimentalOperation>(connection, decoder, this, &TestWithLegacyReceiver::experimentalOperation);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::ExperimentalOperation::name())
+        return IPC::handleMessage<Messages::TestWithLegacyReceiver::ExperimentalOperation>(connection, WTFMove(message), this, &TestWithLegacyReceiver::experimentalOperation);
 #endif
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(message);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(message.messageName()), message.destinationID);
 }
 
-bool TestWithLegacyReceiver::didReceiveSyncTestWithLegacyReceiverMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool TestWithLegacyReceiver::didReceiveSyncTestWithLegacyReceiverMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& replyEncoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::GetPluginProcessConnection::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithLegacyReceiver::GetPluginProcessConnection>(connection, decoder, replyEncoder, this, &TestWithLegacyReceiver::getPluginProcessConnection);
-    if (decoder.messageName() == Messages::TestWithLegacyReceiver::TestMultipleAttributes::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithLegacyReceiver::TestMultipleAttributes>(connection, decoder, replyEncoder, this, &TestWithLegacyReceiver::testMultipleAttributes);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::GetPluginProcessConnection::name())
+        return IPC::handleMessageSynchronous<Messages::TestWithLegacyReceiver::GetPluginProcessConnection>(connection, WTFMove(message), replyEncoder, this, &TestWithLegacyReceiver::getPluginProcessConnection);
+    if (message.messageName() == Messages::TestWithLegacyReceiver::TestMultipleAttributes::name())
+        return IPC::handleMessageSynchronous<Messages::TestWithLegacyReceiver::TestMultipleAttributes>(connection, WTFMove(message), replyEncoder, this, &TestWithLegacyReceiver::testMultipleAttributes);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(message);
     UNUSED_PARAM(replyEncoder);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
         return false;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(message.messageName()), message.destinationID);
     return false;
 }
 
@@ -158,130 +158,130 @@ bool TestWithLegacyReceiver::didReceiveSyncTestWithLegacyReceiverMessage(IPC::Co
 
 namespace IPC {
 
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_LoadURL>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_LoadURL>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::LoadURL::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::LoadURL::Arguments>(globalObject, message);
 }
 #if ENABLE(TOUCH_EVENTS)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_LoadSomething>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_LoadSomething>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::LoadSomething::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::LoadSomething::Arguments>(globalObject, message);
 }
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TouchEvent>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TouchEvent>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::TouchEvent::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::TouchEvent::Arguments>(globalObject, message);
 }
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_AddEvent>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_AddEvent>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::AddEvent::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::AddEvent::Arguments>(globalObject, message);
 }
 #endif
 #if ENABLE(TOUCH_EVENTS)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_LoadSomethingElse>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_LoadSomethingElse>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::LoadSomethingElse::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::LoadSomethingElse::Arguments>(globalObject, message);
 }
 #endif
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_DidReceivePolicyDecision>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_DidReceivePolicyDecision>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::DidReceivePolicyDecision::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::DidReceivePolicyDecision::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_Close>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_Close>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::Close::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::Close::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_PreferencesDidChange>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_PreferencesDidChange>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::PreferencesDidChange::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::PreferencesDidChange::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_SendDoubleAndFloat>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_SendDoubleAndFloat>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::SendDoubleAndFloat::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::SendDoubleAndFloat::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_SendInts>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_SendInts>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::SendInts::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::SendInts::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_CreatePlugin>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_CreatePlugin>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::CreatePlugin::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::CreatePlugin::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_CreatePlugin>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_CreatePlugin>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::CreatePlugin::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::CreatePlugin::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_RunJavaScriptAlert>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_RunJavaScriptAlert>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::RunJavaScriptAlert::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::RunJavaScriptAlert::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_RunJavaScriptAlert>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_RunJavaScriptAlert>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::RunJavaScriptAlert::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::RunJavaScriptAlert::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_GetPlugins>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_GetPlugins>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::GetPlugins::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::GetPlugins::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_GetPlugins>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_GetPlugins>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::GetPlugins::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::GetPlugins::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_GetPluginProcessConnection>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_GetPluginProcessConnection>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::GetPluginProcessConnection::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::GetPluginProcessConnection::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_GetPluginProcessConnection>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_GetPluginProcessConnection>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::GetPluginProcessConnection::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::GetPluginProcessConnection::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TestMultipleAttributes>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TestMultipleAttributes>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::TestMultipleAttributes::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::TestMultipleAttributes::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_TestMultipleAttributes>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_TestMultipleAttributes>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::TestMultipleAttributes::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::TestMultipleAttributes::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TestParameterAttributes>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TestParameterAttributes>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::TestParameterAttributes::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::TestParameterAttributes::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TemplateTest>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_TemplateTest>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::TemplateTest::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::TemplateTest::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_SetVideoLayerID>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_SetVideoLayerID>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::SetVideoLayerID::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::SetVideoLayerID::Arguments>(globalObject, message);
 }
 #if PLATFORM(MAC)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_InterpretKeyEvent>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_InterpretKeyEvent>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::InterpretKeyEvent::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::InterpretKeyEvent::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_InterpretKeyEvent>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithLegacyReceiver_InterpretKeyEvent>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::InterpretKeyEvent::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::InterpretKeyEvent::ReplyArguments>(globalObject, message);
 }
 #endif
 #if ENABLE(DEPRECATED_FEATURE)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_DeprecatedOperation>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_DeprecatedOperation>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::DeprecatedOperation::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::DeprecatedOperation::Arguments>(globalObject, message);
 }
 #endif
 #if ENABLE(FEATURE_FOR_TESTING)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_ExperimentalOperation>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithLegacyReceiver_ExperimentalOperation>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::ExperimentalOperation::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithLegacyReceiver::ExperimentalOperation::Arguments>(globalObject, message);
 }
 #endif
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp
@@ -25,9 +25,9 @@
 #include "config.h"
 #include "TestWithSemaphore.h"
 
-#include "Decoder.h" // NOLINT
 #include "HandleMessage.h" // NOLINT
 #include "IPCSemaphore.h" // NOLINT
+#include "Message.h" // NOLINT
 #include "TestWithSemaphoreMessages.h" // NOLINT
 
 #if ENABLE(IPC_TESTING_API)
@@ -36,20 +36,20 @@
 
 namespace WebKit {
 
-void TestWithSemaphore::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void TestWithSemaphore::didReceiveMessage(IPC::Connection& connection, IPC::Message&& message)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithSemaphore::SendSemaphore::name())
-        return IPC::handleMessage<Messages::TestWithSemaphore::SendSemaphore>(connection, decoder, this, &TestWithSemaphore::sendSemaphore);
-    if (decoder.messageName() == Messages::TestWithSemaphore::ReceiveSemaphore::name())
-        return IPC::handleMessageAsync<Messages::TestWithSemaphore::ReceiveSemaphore>(connection, decoder, this, &TestWithSemaphore::receiveSemaphore);
+    if (message.messageName() == Messages::TestWithSemaphore::SendSemaphore::name())
+        return IPC::handleMessage<Messages::TestWithSemaphore::SendSemaphore>(connection, WTFMove(message), this, &TestWithSemaphore::sendSemaphore);
+    if (message.messageName() == Messages::TestWithSemaphore::ReceiveSemaphore::name())
+        return IPC::handleMessageAsync<Messages::TestWithSemaphore::ReceiveSemaphore>(connection, WTFMove(message), this, &TestWithSemaphore::receiveSemaphore);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(message);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(message.messageName()), message.destinationID);
 }
 
 } // namespace WebKit
@@ -58,17 +58,17 @@ void TestWithSemaphore::didReceiveMessage(IPC::Connection& connection, IPC::Deco
 
 namespace IPC {
 
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSemaphore_SendSemaphore>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSemaphore_SendSemaphore>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithSemaphore::SendSemaphore::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithSemaphore::SendSemaphore::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSemaphore_ReceiveSemaphore>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSemaphore_ReceiveSemaphore>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithSemaphore::ReceiveSemaphore::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithSemaphore::ReceiveSemaphore::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSemaphore_ReceiveSemaphore>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSemaphore_ReceiveSemaphore>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithSemaphore::ReceiveSemaphore::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithSemaphore::ReceiveSemaphore::ReplyArguments>(globalObject, message);
 }
 
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp
@@ -26,8 +26,8 @@
 #include "TestWithStreamBatched.h"
 
 #include "ArgumentCoders.h" // NOLINT
-#include "Decoder.h" // NOLINT
 #include "HandleMessage.h" // NOLINT
+#include "Message.h" // NOLINT
 #include "TestWithStreamBatchedMessages.h" // NOLINT
 #include <wtf/text/WTFString.h> // NOLINT
 
@@ -37,17 +37,17 @@
 
 namespace WebKit {
 
-void TestWithStreamBatched::didReceiveStreamMessage(IPC::StreamServerConnection& connection, IPC::Decoder& decoder)
+void TestWithStreamBatched::didReceiveStreamMessage(IPC::StreamServerConnection& connection, IPC::Message&& message)
 {
-    if (decoder.messageName() == Messages::TestWithStreamBatched::SendString::name())
-        return IPC::handleMessage<Messages::TestWithStreamBatched::SendString>(connection.protectedConnection(), decoder, this, &TestWithStreamBatched::sendString);
-    UNUSED_PARAM(decoder);
+    if (message.messageName() == Messages::TestWithStreamBatched::SendString::name())
+        return IPC::handleMessage<Messages::TestWithStreamBatched::SendString>(connection.protectedConnection(), WTFMove(message), this, &TestWithStreamBatched::sendString);
+    UNUSED_PARAM(message);
     UNUSED_PARAM(connection);
 #if ENABLE(IPC_TESTING_API)
     if (connection.protectedConnection()->ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(message.messageName()), message.destinationID);
 }
 
 } // namespace WebKit
@@ -56,9 +56,9 @@ void TestWithStreamBatched::didReceiveStreamMessage(IPC::StreamServerConnection&
 
 namespace IPC {
 
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStreamBatched_SendString>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStreamBatched_SendString>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStreamBatched::SendString::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStreamBatched::SendString::Arguments>(globalObject, message);
 }
 
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp
@@ -25,8 +25,8 @@
 #include "config.h"
 #include "TestWithStreamBuffer.h"
 
-#include "Decoder.h" // NOLINT
 #include "HandleMessage.h" // NOLINT
+#include "Message.h" // NOLINT
 #include "StreamConnectionBuffer.h" // NOLINT
 #include "TestWithStreamBufferMessages.h" // NOLINT
 
@@ -36,18 +36,18 @@
 
 namespace WebKit {
 
-void TestWithStreamBuffer::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void TestWithStreamBuffer::didReceiveMessage(IPC::Connection& connection, IPC::Message&& message)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithStreamBuffer::SendStreamBuffer::name())
-        return IPC::handleMessage<Messages::TestWithStreamBuffer::SendStreamBuffer>(connection, decoder, this, &TestWithStreamBuffer::sendStreamBuffer);
+    if (message.messageName() == Messages::TestWithStreamBuffer::SendStreamBuffer::name())
+        return IPC::handleMessage<Messages::TestWithStreamBuffer::SendStreamBuffer>(connection, WTFMove(message), this, &TestWithStreamBuffer::sendStreamBuffer);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(message);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(message.messageName()), message.destinationID);
 }
 
 } // namespace WebKit
@@ -56,9 +56,9 @@ void TestWithStreamBuffer::didReceiveMessage(IPC::Connection& connection, IPC::D
 
 namespace IPC {
 
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStreamBuffer_SendStreamBuffer>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStreamBuffer_SendStreamBuffer>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStreamBuffer::SendStreamBuffer::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStreamBuffer::SendStreamBuffer::Arguments>(globalObject, message);
 }
 
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp
@@ -29,8 +29,8 @@
 #if PLATFORM(COCOA)
 #include "ArgumentCodersDarwin.h" // NOLINT
 #endif
-#include "Decoder.h" // NOLINT
 #include "HandleMessage.h" // NOLINT
+#include "Message.h" // NOLINT
 #include "TestWithStreamMessages.h" // NOLINT
 #if PLATFORM(COCOA)
 #include <wtf/MachSendRight.h> // NOLINT
@@ -43,33 +43,33 @@
 
 namespace WebKit {
 
-void TestWithStream::didReceiveStreamMessage(IPC::StreamServerConnection& connection, IPC::Decoder& decoder)
+void TestWithStream::didReceiveStreamMessage(IPC::StreamServerConnection& connection, IPC::Message&& message)
 {
-    if (decoder.messageName() == Messages::TestWithStream::SendString::name())
-        return IPC::handleMessage<Messages::TestWithStream::SendString>(connection.protectedConnection(), decoder, this, &TestWithStream::sendString);
-    if (decoder.messageName() == Messages::TestWithStream::SendStringAsync::name())
-        return IPC::handleMessageAsync<Messages::TestWithStream::SendStringAsync>(connection.protectedConnection(), decoder, this, &TestWithStream::sendStringAsync);
-    if (decoder.messageName() == Messages::TestWithStream::CallWithIdentifier::name())
-        return IPC::handleMessageAsyncWithReplyID<Messages::TestWithStream::CallWithIdentifier>(connection.protectedConnection(), decoder, this, &TestWithStream::callWithIdentifier);
+    if (message.messageName() == Messages::TestWithStream::SendString::name())
+        return IPC::handleMessage<Messages::TestWithStream::SendString>(connection.protectedConnection(), WTFMove(message), this, &TestWithStream::sendString);
+    if (message.messageName() == Messages::TestWithStream::SendStringAsync::name())
+        return IPC::handleMessageAsync<Messages::TestWithStream::SendStringAsync>(connection.protectedConnection(), WTFMove(message), this, &TestWithStream::sendStringAsync);
+    if (message.messageName() == Messages::TestWithStream::CallWithIdentifier::name())
+        return IPC::handleMessageAsyncWithReplyID<Messages::TestWithStream::CallWithIdentifier>(connection.protectedConnection(), WTFMove(message), this, &TestWithStream::callWithIdentifier);
 #if PLATFORM(COCOA)
-    if (decoder.messageName() == Messages::TestWithStream::SendMachSendRight::name())
-        return IPC::handleMessage<Messages::TestWithStream::SendMachSendRight>(connection.protectedConnection(), decoder, this, &TestWithStream::sendMachSendRight);
+    if (message.messageName() == Messages::TestWithStream::SendMachSendRight::name())
+        return IPC::handleMessage<Messages::TestWithStream::SendMachSendRight>(connection.protectedConnection(), WTFMove(message), this, &TestWithStream::sendMachSendRight);
 #endif
-    if (decoder.messageName() == Messages::TestWithStream::SendStringSync::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithStream::SendStringSync>(connection, decoder, this, &TestWithStream::sendStringSync);
+    if (message.messageName() == Messages::TestWithStream::SendStringSync::name())
+        return IPC::handleMessageSynchronous<Messages::TestWithStream::SendStringSync>(connection, WTFMove(message), this, &TestWithStream::sendStringSync);
 #if PLATFORM(COCOA)
-    if (decoder.messageName() == Messages::TestWithStream::ReceiveMachSendRight::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithStream::ReceiveMachSendRight>(connection, decoder, this, &TestWithStream::receiveMachSendRight);
-    if (decoder.messageName() == Messages::TestWithStream::SendAndReceiveMachSendRight::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithStream::SendAndReceiveMachSendRight>(connection, decoder, this, &TestWithStream::sendAndReceiveMachSendRight);
+    if (message.messageName() == Messages::TestWithStream::ReceiveMachSendRight::name())
+        return IPC::handleMessageSynchronous<Messages::TestWithStream::ReceiveMachSendRight>(connection, WTFMove(message), this, &TestWithStream::receiveMachSendRight);
+    if (message.messageName() == Messages::TestWithStream::SendAndReceiveMachSendRight::name())
+        return IPC::handleMessageSynchronous<Messages::TestWithStream::SendAndReceiveMachSendRight>(connection, WTFMove(message), this, &TestWithStream::sendAndReceiveMachSendRight);
 #endif
-    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(message);
     UNUSED_PARAM(connection);
 #if ENABLE(IPC_TESTING_API)
     if (connection.protectedConnection()->ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled stream message %s to %" PRIu64, IPC::description(message.messageName()), message.destinationID);
 }
 
 } // namespace WebKit
@@ -78,54 +78,54 @@ void TestWithStream::didReceiveStreamMessage(IPC::StreamServerConnection& connec
 
 namespace IPC {
 
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_SendString>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_SendString>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStream::SendString::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStream::SendString::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_SendStringAsync>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_SendStringAsync>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStream::SendStringAsync::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStream::SendStringAsync::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithStream_SendStringAsync>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithStream_SendStringAsync>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStream::SendStringAsync::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStream::SendStringAsync::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_SendStringSync>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_SendStringSync>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStream::SendStringSync::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStream::SendStringSync::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithStream_SendStringSync>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithStream_SendStringSync>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStream::SendStringSync::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStream::SendStringSync::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_CallWithIdentifier>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_CallWithIdentifier>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStream::CallWithIdentifier::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStream::CallWithIdentifier::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithStream_CallWithIdentifier>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithStream_CallWithIdentifier>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStream::CallWithIdentifier::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStream::CallWithIdentifier::ReplyArguments>(globalObject, message);
 }
 #if PLATFORM(COCOA)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_SendMachSendRight>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_SendMachSendRight>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStream::SendMachSendRight::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStream::SendMachSendRight::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_ReceiveMachSendRight>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_ReceiveMachSendRight>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStream::ReceiveMachSendRight::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStream::ReceiveMachSendRight::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithStream_ReceiveMachSendRight>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithStream_ReceiveMachSendRight>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStream::ReceiveMachSendRight::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStream::ReceiveMachSendRight::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_SendAndReceiveMachSendRight>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStream_SendAndReceiveMachSendRight>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStream::SendAndReceiveMachSendRight::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStream::SendAndReceiveMachSendRight::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithStream_SendAndReceiveMachSendRight>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithStream_SendAndReceiveMachSendRight>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStream::SendAndReceiveMachSendRight::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStream::SendAndReceiveMachSendRight::ReplyArguments>(globalObject, message);
 }
 #endif
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessageReceiver.cpp
@@ -25,8 +25,8 @@
 #include "config.h"
 #include "TestWithStreamServerConnectionHandle.h"
 
-#include "Decoder.h" // NOLINT
 #include "HandleMessage.h" // NOLINT
+#include "Message.h" // NOLINT
 #include "StreamServerConnection.h" // NOLINT
 #include "TestWithStreamServerConnectionHandleMessages.h" // NOLINT
 
@@ -36,18 +36,18 @@
 
 namespace WebKit {
 
-void TestWithStreamServerConnectionHandle::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void TestWithStreamServerConnectionHandle::didReceiveMessage(IPC::Connection& connection, IPC::Message&& message)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithStreamServerConnectionHandle::SendStreamServerConnection::name())
-        return IPC::handleMessage<Messages::TestWithStreamServerConnectionHandle::SendStreamServerConnection>(connection, decoder, this, &TestWithStreamServerConnectionHandle::sendStreamServerConnection);
+    if (message.messageName() == Messages::TestWithStreamServerConnectionHandle::SendStreamServerConnection::name())
+        return IPC::handleMessage<Messages::TestWithStreamServerConnectionHandle::SendStreamServerConnection>(connection, WTFMove(message), this, &TestWithStreamServerConnectionHandle::sendStreamServerConnection);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(message);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(message.messageName()), message.destinationID);
 }
 
 } // namespace WebKit
@@ -56,9 +56,9 @@ void TestWithStreamServerConnectionHandle::didReceiveMessage(IPC::Connection& co
 
 namespace IPC {
 
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithStreamServerConnectionHandle::SendStreamServerConnection::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithStreamServerConnectionHandle::SendStreamServerConnection::Arguments>(globalObject, message);
 }
 
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp
@@ -26,8 +26,8 @@
 #include "TestWithSuperclass.h"
 
 #include "ArgumentCoders.h" // NOLINT
-#include "Decoder.h" // NOLINT
 #include "HandleMessage.h" // NOLINT
+#include "Message.h" // NOLINT
 #include "TestClassName.h" // NOLINT
 #if ENABLE(TEST_FEATURE)
 #include "TestTwoStateEnum.h" // NOLINT
@@ -42,39 +42,39 @@
 
 namespace WebKit {
 
-void TestWithSuperclass::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void TestWithSuperclass::didReceiveMessage(IPC::Connection& connection, IPC::Message&& message)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithSuperclass::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithSuperclass::LoadURL>(connection, decoder, this, &TestWithSuperclass::loadURL);
+    if (message.messageName() == Messages::TestWithSuperclass::LoadURL::name())
+        return IPC::handleMessage<Messages::TestWithSuperclass::LoadURL>(connection, WTFMove(message), this, &TestWithSuperclass::loadURL);
 #if ENABLE(TEST_FEATURE)
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessage::name())
-        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessage>(connection, decoder, this, &TestWithSuperclass::testAsyncMessage);
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments::name())
-        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithNoArguments);
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::name())
-        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithMultipleArguments);
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithConnection::name())
-        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithConnection>(connection, decoder, this, &TestWithSuperclass::testAsyncMessageWithConnection);
+    if (message.messageName() == Messages::TestWithSuperclass::TestAsyncMessage::name())
+        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessage>(connection, WTFMove(message), this, &TestWithSuperclass::testAsyncMessage);
+    if (message.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments::name())
+        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments>(connection, WTFMove(message), this, &TestWithSuperclass::testAsyncMessageWithNoArguments);
+    if (message.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::name())
+        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments>(connection, WTFMove(message), this, &TestWithSuperclass::testAsyncMessageWithMultipleArguments);
+    if (message.messageName() == Messages::TestWithSuperclass::TestAsyncMessageWithConnection::name())
+        return IPC::handleMessageAsync<Messages::TestWithSuperclass::TestAsyncMessageWithConnection>(connection, WTFMove(message), this, &TestWithSuperclass::testAsyncMessageWithConnection);
 #endif
-    WebPageBase::didReceiveMessage(connection, decoder);
+    WebPageBase::didReceiveMessage(connection, WTFMove(message));
 }
 
-bool TestWithSuperclass::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool TestWithSuperclass::didReceiveSyncMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& replyEncoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestSyncMessage::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithSuperclass::TestSyncMessage>(connection, decoder, replyEncoder, this, &TestWithSuperclass::testSyncMessage);
-    if (decoder.messageName() == Messages::TestWithSuperclass::TestSynchronousMessage::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithSuperclass::TestSynchronousMessage>(connection, decoder, replyEncoder, this, &TestWithSuperclass::testSynchronousMessage);
+    if (message.messageName() == Messages::TestWithSuperclass::TestSyncMessage::name())
+        return IPC::handleMessageSynchronous<Messages::TestWithSuperclass::TestSyncMessage>(connection, WTFMove(message), replyEncoder, this, &TestWithSuperclass::testSyncMessage);
+    if (message.messageName() == Messages::TestWithSuperclass::TestSynchronousMessage::name())
+        return IPC::handleMessageSynchronous<Messages::TestWithSuperclass::TestSynchronousMessage>(connection, WTFMove(message), replyEncoder, this, &TestWithSuperclass::testSynchronousMessage);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(message);
     UNUSED_PARAM(replyEncoder);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
         return false;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(message.messageName()), message.destinationID);
     return false;
 }
 
@@ -84,59 +84,59 @@ bool TestWithSuperclass::didReceiveSyncMessage(IPC::Connection& connection, IPC:
 
 namespace IPC {
 
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclass_LoadURL>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclass_LoadURL>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithSuperclass::LoadURL::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithSuperclass::LoadURL::Arguments>(globalObject, message);
 }
 #if ENABLE(TEST_FEATURE)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessage>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestAsyncMessage::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestAsyncMessage::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessage>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestAsyncMessage::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestAsyncMessage::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithConnection>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestAsyncMessageWithConnection>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestAsyncMessageWithConnection::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestAsyncMessageWithConnection::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithConnection>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestAsyncMessageWithConnection>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestAsyncMessageWithConnection::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestAsyncMessageWithConnection::ReplyArguments>(globalObject, message);
 }
 #endif
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestSyncMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestSyncMessage>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestSyncMessage::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestSyncMessage::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestSyncMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestSyncMessage>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestSyncMessage::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestSyncMessage::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestSynchronousMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithSuperclass_TestSynchronousMessage>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestSynchronousMessage::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestSynchronousMessage::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestSynchronousMessage>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithSuperclass_TestSynchronousMessage>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestSynchronousMessage::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithSuperclass::TestSynchronousMessage::ReplyArguments>(globalObject, message);
 }
 
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp
@@ -31,7 +31,6 @@
 #include "ArgumentCodersDarwin.h" // NOLINT
 #endif
 #include "Connection.h" // NOLINT
-#include "Decoder.h" // NOLINT
 #if ENABLE(DEPRECATED_FEATURE) || ENABLE(FEATURE_FOR_TESTING)
 #include "DummyType.h" // NOLINT
 #endif
@@ -39,6 +38,7 @@
 #include "GestureTypes.h" // NOLINT
 #endif
 #include "HandleMessage.h" // NOLINT
+#include "Message.h" // NOLINT
 #include "Plugin.h" // NOLINT
 #include "TestWithoutAttributesMessages.h" // NOLINT
 #include "WebCoreArgumentCoders.h" // NOLINT
@@ -68,87 +68,87 @@
 
 namespace WebKit {
 
-void TestWithoutAttributes::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void TestWithoutAttributes::didReceiveMessage(IPC::Connection& connection, IPC::Message&& message)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithoutAttributes::LoadURL::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::LoadURL>(connection, decoder, this, &TestWithoutAttributes::loadURL);
+    if (message.messageName() == Messages::TestWithoutAttributes::LoadURL::name())
+        return IPC::handleMessage<Messages::TestWithoutAttributes::LoadURL>(connection, WTFMove(message), this, &TestWithoutAttributes::loadURL);
 #if ENABLE(TOUCH_EVENTS)
-    if (decoder.messageName() == Messages::TestWithoutAttributes::LoadSomething::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::LoadSomething>(connection, decoder, this, &TestWithoutAttributes::loadSomething);
+    if (message.messageName() == Messages::TestWithoutAttributes::LoadSomething::name())
+        return IPC::handleMessage<Messages::TestWithoutAttributes::LoadSomething>(connection, WTFMove(message), this, &TestWithoutAttributes::loadSomething);
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
-    if (decoder.messageName() == Messages::TestWithoutAttributes::TouchEvent::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::TouchEvent>(connection, decoder, this, &TestWithoutAttributes::touchEvent);
+    if (message.messageName() == Messages::TestWithoutAttributes::TouchEvent::name())
+        return IPC::handleMessage<Messages::TestWithoutAttributes::TouchEvent>(connection, WTFMove(message), this, &TestWithoutAttributes::touchEvent);
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
-    if (decoder.messageName() == Messages::TestWithoutAttributes::AddEvent::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::AddEvent>(connection, decoder, this, &TestWithoutAttributes::addEvent);
+    if (message.messageName() == Messages::TestWithoutAttributes::AddEvent::name())
+        return IPC::handleMessage<Messages::TestWithoutAttributes::AddEvent>(connection, WTFMove(message), this, &TestWithoutAttributes::addEvent);
 #endif
 #if ENABLE(TOUCH_EVENTS)
-    if (decoder.messageName() == Messages::TestWithoutAttributes::LoadSomethingElse::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::LoadSomethingElse>(connection, decoder, this, &TestWithoutAttributes::loadSomethingElse);
+    if (message.messageName() == Messages::TestWithoutAttributes::LoadSomethingElse::name())
+        return IPC::handleMessage<Messages::TestWithoutAttributes::LoadSomethingElse>(connection, WTFMove(message), this, &TestWithoutAttributes::loadSomethingElse);
 #endif
-    if (decoder.messageName() == Messages::TestWithoutAttributes::DidReceivePolicyDecision::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::DidReceivePolicyDecision>(connection, decoder, this, &TestWithoutAttributes::didReceivePolicyDecision);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::Close::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::Close>(connection, decoder, this, &TestWithoutAttributes::close);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::PreferencesDidChange::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::PreferencesDidChange>(connection, decoder, this, &TestWithoutAttributes::preferencesDidChange);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::SendDoubleAndFloat::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::SendDoubleAndFloat>(connection, decoder, this, &TestWithoutAttributes::sendDoubleAndFloat);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::SendInts::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::SendInts>(connection, decoder, this, &TestWithoutAttributes::sendInts);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::CreatePlugin::name())
-        return IPC::handleMessageAsync<Messages::TestWithoutAttributes::CreatePlugin>(connection, decoder, this, &TestWithoutAttributes::createPlugin);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::RunJavaScriptAlert::name())
-        return IPC::handleMessageAsync<Messages::TestWithoutAttributes::RunJavaScriptAlert>(connection, decoder, this, &TestWithoutAttributes::runJavaScriptAlert);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::GetPlugins::name())
-        return IPC::handleMessageAsync<Messages::TestWithoutAttributes::GetPlugins>(connection, decoder, this, &TestWithoutAttributes::getPlugins);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::TestParameterAttributes::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::TestParameterAttributes>(connection, decoder, this, &TestWithoutAttributes::testParameterAttributes);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::TemplateTest::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::TemplateTest>(connection, decoder, this, &TestWithoutAttributes::templateTest);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::SetVideoLayerID::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::SetVideoLayerID>(connection, decoder, this, &TestWithoutAttributes::setVideoLayerID);
+    if (message.messageName() == Messages::TestWithoutAttributes::DidReceivePolicyDecision::name())
+        return IPC::handleMessage<Messages::TestWithoutAttributes::DidReceivePolicyDecision>(connection, WTFMove(message), this, &TestWithoutAttributes::didReceivePolicyDecision);
+    if (message.messageName() == Messages::TestWithoutAttributes::Close::name())
+        return IPC::handleMessage<Messages::TestWithoutAttributes::Close>(connection, WTFMove(message), this, &TestWithoutAttributes::close);
+    if (message.messageName() == Messages::TestWithoutAttributes::PreferencesDidChange::name())
+        return IPC::handleMessage<Messages::TestWithoutAttributes::PreferencesDidChange>(connection, WTFMove(message), this, &TestWithoutAttributes::preferencesDidChange);
+    if (message.messageName() == Messages::TestWithoutAttributes::SendDoubleAndFloat::name())
+        return IPC::handleMessage<Messages::TestWithoutAttributes::SendDoubleAndFloat>(connection, WTFMove(message), this, &TestWithoutAttributes::sendDoubleAndFloat);
+    if (message.messageName() == Messages::TestWithoutAttributes::SendInts::name())
+        return IPC::handleMessage<Messages::TestWithoutAttributes::SendInts>(connection, WTFMove(message), this, &TestWithoutAttributes::sendInts);
+    if (message.messageName() == Messages::TestWithoutAttributes::CreatePlugin::name())
+        return IPC::handleMessageAsync<Messages::TestWithoutAttributes::CreatePlugin>(connection, WTFMove(message), this, &TestWithoutAttributes::createPlugin);
+    if (message.messageName() == Messages::TestWithoutAttributes::RunJavaScriptAlert::name())
+        return IPC::handleMessageAsync<Messages::TestWithoutAttributes::RunJavaScriptAlert>(connection, WTFMove(message), this, &TestWithoutAttributes::runJavaScriptAlert);
+    if (message.messageName() == Messages::TestWithoutAttributes::GetPlugins::name())
+        return IPC::handleMessageAsync<Messages::TestWithoutAttributes::GetPlugins>(connection, WTFMove(message), this, &TestWithoutAttributes::getPlugins);
+    if (message.messageName() == Messages::TestWithoutAttributes::TestParameterAttributes::name())
+        return IPC::handleMessage<Messages::TestWithoutAttributes::TestParameterAttributes>(connection, WTFMove(message), this, &TestWithoutAttributes::testParameterAttributes);
+    if (message.messageName() == Messages::TestWithoutAttributes::TemplateTest::name())
+        return IPC::handleMessage<Messages::TestWithoutAttributes::TemplateTest>(connection, WTFMove(message), this, &TestWithoutAttributes::templateTest);
+    if (message.messageName() == Messages::TestWithoutAttributes::SetVideoLayerID::name())
+        return IPC::handleMessage<Messages::TestWithoutAttributes::SetVideoLayerID>(connection, WTFMove(message), this, &TestWithoutAttributes::setVideoLayerID);
 #if PLATFORM(MAC)
-    if (decoder.messageName() == Messages::TestWithoutAttributes::DidCreateWebProcessConnection::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::DidCreateWebProcessConnection>(connection, decoder, this, &TestWithoutAttributes::didCreateWebProcessConnection);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::InterpretKeyEvent::name())
-        return IPC::handleMessageAsync<Messages::TestWithoutAttributes::InterpretKeyEvent>(connection, decoder, this, &TestWithoutAttributes::interpretKeyEvent);
+    if (message.messageName() == Messages::TestWithoutAttributes::DidCreateWebProcessConnection::name())
+        return IPC::handleMessage<Messages::TestWithoutAttributes::DidCreateWebProcessConnection>(connection, WTFMove(message), this, &TestWithoutAttributes::didCreateWebProcessConnection);
+    if (message.messageName() == Messages::TestWithoutAttributes::InterpretKeyEvent::name())
+        return IPC::handleMessageAsync<Messages::TestWithoutAttributes::InterpretKeyEvent>(connection, WTFMove(message), this, &TestWithoutAttributes::interpretKeyEvent);
 #endif
 #if ENABLE(DEPRECATED_FEATURE)
-    if (decoder.messageName() == Messages::TestWithoutAttributes::DeprecatedOperation::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::DeprecatedOperation>(connection, decoder, this, &TestWithoutAttributes::deprecatedOperation);
+    if (message.messageName() == Messages::TestWithoutAttributes::DeprecatedOperation::name())
+        return IPC::handleMessage<Messages::TestWithoutAttributes::DeprecatedOperation>(connection, WTFMove(message), this, &TestWithoutAttributes::deprecatedOperation);
 #endif
 #if ENABLE(FEATURE_FOR_TESTING)
-    if (decoder.messageName() == Messages::TestWithoutAttributes::ExperimentalOperation::name())
-        return IPC::handleMessage<Messages::TestWithoutAttributes::ExperimentalOperation>(connection, decoder, this, &TestWithoutAttributes::experimentalOperation);
+    if (message.messageName() == Messages::TestWithoutAttributes::ExperimentalOperation::name())
+        return IPC::handleMessage<Messages::TestWithoutAttributes::ExperimentalOperation>(connection, WTFMove(message), this, &TestWithoutAttributes::experimentalOperation);
 #endif
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(message);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
         return;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(message.messageName()), message.destinationID);
 }
 
-bool TestWithoutAttributes::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool TestWithoutAttributes::didReceiveSyncMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& replyEncoder)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithoutAttributes::GetPluginProcessConnection::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithoutAttributes::GetPluginProcessConnection>(connection, decoder, replyEncoder, this, &TestWithoutAttributes::getPluginProcessConnection);
-    if (decoder.messageName() == Messages::TestWithoutAttributes::TestMultipleAttributes::name())
-        return IPC::handleMessageSynchronous<Messages::TestWithoutAttributes::TestMultipleAttributes>(connection, decoder, replyEncoder, this, &TestWithoutAttributes::testMultipleAttributes);
+    if (message.messageName() == Messages::TestWithoutAttributes::GetPluginProcessConnection::name())
+        return IPC::handleMessageSynchronous<Messages::TestWithoutAttributes::GetPluginProcessConnection>(connection, WTFMove(message), replyEncoder, this, &TestWithoutAttributes::getPluginProcessConnection);
+    if (message.messageName() == Messages::TestWithoutAttributes::TestMultipleAttributes::name())
+        return IPC::handleMessageSynchronous<Messages::TestWithoutAttributes::TestMultipleAttributes>(connection, WTFMove(message), replyEncoder, this, &TestWithoutAttributes::testMultipleAttributes);
     UNUSED_PARAM(connection);
-    UNUSED_PARAM(decoder);
+    UNUSED_PARAM(message);
     UNUSED_PARAM(replyEncoder);
 #if ENABLE(IPC_TESTING_API)
     if (connection.ignoreInvalidMessageForTesting())
         return false;
 #endif // ENABLE(IPC_TESTING_API)
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(decoder.messageName()), decoder.destinationID());
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled synchronous message %s to %" PRIu64, description(message.messageName()), message.destinationID);
     return false;
 }
 
@@ -158,130 +158,130 @@ bool TestWithoutAttributes::didReceiveSyncMessage(IPC::Connection& connection, I
 
 namespace IPC {
 
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_LoadURL>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_LoadURL>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::LoadURL::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::LoadURL::Arguments>(globalObject, message);
 }
 #if ENABLE(TOUCH_EVENTS)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_LoadSomething>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_LoadSomething>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::LoadSomething::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::LoadSomething::Arguments>(globalObject, message);
 }
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION || SOME_OTHER_MESSAGE_CONDITION))
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TouchEvent>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TouchEvent>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::TouchEvent::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::TouchEvent::Arguments>(globalObject, message);
 }
 #endif
 #if (ENABLE(TOUCH_EVENTS) && (NESTED_MESSAGE_CONDITION && SOME_OTHER_MESSAGE_CONDITION))
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_AddEvent>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_AddEvent>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::AddEvent::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::AddEvent::Arguments>(globalObject, message);
 }
 #endif
 #if ENABLE(TOUCH_EVENTS)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_LoadSomethingElse>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_LoadSomethingElse>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::LoadSomethingElse::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::LoadSomethingElse::Arguments>(globalObject, message);
 }
 #endif
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_DidReceivePolicyDecision>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_DidReceivePolicyDecision>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::DidReceivePolicyDecision::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::DidReceivePolicyDecision::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_Close>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_Close>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::Close::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::Close::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_PreferencesDidChange>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_PreferencesDidChange>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::PreferencesDidChange::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::PreferencesDidChange::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_SendDoubleAndFloat>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_SendDoubleAndFloat>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::SendDoubleAndFloat::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::SendDoubleAndFloat::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_SendInts>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_SendInts>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::SendInts::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::SendInts::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_CreatePlugin>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_CreatePlugin>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::CreatePlugin::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::CreatePlugin::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_CreatePlugin>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_CreatePlugin>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::CreatePlugin::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::CreatePlugin::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_RunJavaScriptAlert>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_RunJavaScriptAlert>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::RunJavaScriptAlert::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::RunJavaScriptAlert::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_RunJavaScriptAlert>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_RunJavaScriptAlert>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::RunJavaScriptAlert::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::RunJavaScriptAlert::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_GetPlugins>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_GetPlugins>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::GetPlugins::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::GetPlugins::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_GetPlugins>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_GetPlugins>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::GetPlugins::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::GetPlugins::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_GetPluginProcessConnection>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_GetPluginProcessConnection>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::GetPluginProcessConnection::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::GetPluginProcessConnection::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_GetPluginProcessConnection>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_GetPluginProcessConnection>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::GetPluginProcessConnection::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::GetPluginProcessConnection::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TestMultipleAttributes>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TestMultipleAttributes>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::TestMultipleAttributes::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::TestMultipleAttributes::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_TestMultipleAttributes>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_TestMultipleAttributes>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::TestMultipleAttributes::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::TestMultipleAttributes::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TestParameterAttributes>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TestParameterAttributes>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::TestParameterAttributes::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::TestParameterAttributes::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TemplateTest>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_TemplateTest>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::TemplateTest::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::TemplateTest::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_SetVideoLayerID>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_SetVideoLayerID>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::SetVideoLayerID::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::SetVideoLayerID::Arguments>(globalObject, message);
 }
 #if PLATFORM(MAC)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_DidCreateWebProcessConnection>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_DidCreateWebProcessConnection>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::DidCreateWebProcessConnection::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::DidCreateWebProcessConnection::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_InterpretKeyEvent>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_InterpretKeyEvent>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::InterpretKeyEvent::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::InterpretKeyEvent::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_InterpretKeyEvent>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutAttributes_InterpretKeyEvent>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::InterpretKeyEvent::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::InterpretKeyEvent::ReplyArguments>(globalObject, message);
 }
 #endif
 #if ENABLE(DEPRECATED_FEATURE)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_DeprecatedOperation>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_DeprecatedOperation>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::DeprecatedOperation::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::DeprecatedOperation::Arguments>(globalObject, message);
 }
 #endif
 #if ENABLE(FEATURE_FOR_TESTING)
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_ExperimentalOperation>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutAttributes_ExperimentalOperation>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::ExperimentalOperation::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutAttributes::ExperimentalOperation::Arguments>(globalObject, message);
 }
 #endif
 

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp
@@ -26,8 +26,8 @@
 #include "TestWithoutUsingIPCConnection.h"
 
 #include "ArgumentCoders.h" // NOLINT
-#include "Decoder.h" // NOLINT
 #include "HandleMessage.h" // NOLINT
+#include "Message.h" // NOLINT
 #include "TestWithoutUsingIPCConnectionMessages.h" // NOLINT
 #include <wtf/text/WTFString.h> // NOLINT
 
@@ -37,23 +37,23 @@
 
 namespace WebKit {
 
-void TestWithoutUsingIPCConnection::didReceiveMessageWithReplyHandler(IPC::Decoder& decoder, Function<void(UniqueRef<IPC::Encoder>&&)>&& replyHandler)
+void TestWithoutUsingIPCConnection::didReceiveMessageWithReplyHandler(IPC::Message&& message, Function<void(UniqueRef<IPC::Encoder>&&)>&& replyHandler)
 {
     Ref protectedThis { *this };
-    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgument::name())
-        return IPC::handleMessageWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgument>(decoder, this, &TestWithoutUsingIPCConnection::messageWithoutArgument);
-    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply::name())
-        return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithoutArgumentAndEmptyReply);
-    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument::name())
-        return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithoutArgumentAndReplyWithArgument);
-    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgument::name())
-        return IPC::handleMessageWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgument>(decoder, this, &TestWithoutUsingIPCConnection::messageWithArgument);
-    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply::name())
-        return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndEmptyReply);
-    if (decoder.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::name())
-        return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument>(decoder, WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndReplyWithArgument);
-    UNUSED_PARAM(decoder);
-    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+    if (message.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgument::name())
+        return IPC::handleMessageWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgument>(WTFMove(message), this, &TestWithoutUsingIPCConnection::messageWithoutArgument);
+    if (message.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply::name())
+        return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply>(WTFMove(message), WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithoutArgumentAndEmptyReply);
+    if (message.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument::name())
+        return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument>(WTFMove(message), WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithoutArgumentAndReplyWithArgument);
+    if (message.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgument::name())
+        return IPC::handleMessageWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgument>(WTFMove(message), this, &TestWithoutUsingIPCConnection::messageWithArgument);
+    if (message.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply::name())
+        return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply>(WTFMove(message), WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndEmptyReply);
+    if (message.messageName() == Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::name())
+        return IPC::handleMessageAsyncWithoutUsingIPCConnection<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument>(WTFMove(message), WTFMove(replyHandler), this, &TestWithoutUsingIPCConnection::messageWithArgumentAndReplyWithArgument);
+    UNUSED_PARAM(message);
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(message.messageName()), message.destinationID);
 }
 
 } // namespace WebKit
@@ -62,45 +62,45 @@ void TestWithoutUsingIPCConnection::didReceiveMessageWithReplyHandler(IPC::Decod
 
 namespace IPC {
 
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgument>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgument>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgument::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgument::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndEmptyReply::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithoutArgumentAndReplyWithArgument::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgument>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgument>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithArgument::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithArgument::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndEmptyReply::ReplyArguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::Arguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::Arguments>(globalObject, message);
 }
-template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessageReply<MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument>(JSC::JSGlobalObject* globalObject, Message& message)
 {
-    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::ReplyArguments>(globalObject, decoder);
+    return jsValueForDecodedArguments<Messages::TestWithoutUsingIPCConnection::MessageWithArgumentAndReplyWithArgument::ReplyArguments>(globalObject, message);
 }
 
 }

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h
@@ -61,7 +61,7 @@ private:
     virtual uint64_t messageDestinationID() = 0;
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // Message handlers
     void invokeMethod(const RemoteObjectInvocation&);

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
@@ -109,8 +109,8 @@ public:
 
 private:
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) override;
 
     // IPC::MessageSender
     IPC::Connection* messageSenderConnection() const final;

--- a/Source/WebKit/Shared/Authentication/AuthenticationManager.h
+++ b/Source/WebKit/Shared/Authentication/AuthenticationManager.h
@@ -99,7 +99,7 @@ private:
 #endif
     
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     AuthenticationChallengeIdentifier addChallengeToChallengeMap(UniqueRef<Challenge>&&);
     bool shouldCoalesceChallenge(WebPageProxyIdentifier, AuthenticationChallengeIdentifier, const WebCore::AuthenticationChallenge&) const;

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -135,7 +135,7 @@ protected:
     static void stopNSRunLoop();
 #endif
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
 #if OS(LINUX)
     void didReceiveMemoryPressureEvent(bool isCritical);

--- a/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
@@ -84,7 +84,7 @@ void XPCEndpoint::sendEndpointToConnection(xpc_connection_t connection)
     xpc_dictionary_set_string(message.get(), xpcEndpointMessageNameKey(), xpcEndpointMessageName());
     xpc_dictionary_set_value(message.get(), xpcEndpointNameKey(), m_endpoint.get());
 
-    xpc_connection_send_message(connection, message.get());
+    xpc_connection_send_message(connection, WTFMove(message).get());
 }
 
 OSObjectPtr<xpc_endpoint_t> XPCEndpoint::endpoint() const

--- a/Source/WebKit/Shared/IPCConnectionTester.h
+++ b/Source/WebKit/Shared/IPCConnectionTester.h
@@ -52,8 +52,8 @@ private:
     void initialize();
 
     // IPC::Connection::Client overrides.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
     void didClose(IPC::Connection&) final;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) final;
 

--- a/Source/WebKit/Shared/IPCStreamTester.h
+++ b/Source/WebKit/Shared/IPCStreamTester.h
@@ -50,7 +50,7 @@ public:
     void stopListeningForIPC(Ref<IPCStreamTester>&& refFromConnection);
 
     // IPC::StreamMessageReceiver overrides.
-    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
+    void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Message&) final;
 private:
     IPCStreamTester(IPCStreamTesterIdentifier, IPC::StreamServerConnection::Handle&&, bool ignoreInvalidMessageForTesting);
     ~IPCStreamTester();

--- a/Source/WebKit/Shared/IPCStreamTesterProxy.h
+++ b/Source/WebKit/Shared/IPCStreamTesterProxy.h
@@ -43,7 +43,7 @@ namespace WebKit {
 class IPCStreamTesterProxy final : public IPC::MessageReceiver {
 public:
     // IPC::MessageReceiver overrides.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 private:
     IPCStreamTesterProxy() = default;
     ~IPCStreamTesterProxy() = default;

--- a/Source/WebKit/Shared/IPCTester.cpp
+++ b/Source/WebKit/Shared/IPCTester.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(IPC_TESTING_API)
 #include "Connection.h"
 #include "Decoder.h"
+#include "Message.h"
 #include "IPCConnectionTester.h"
 #include "IPCStreamTester.h"
 #include "IPCTesterMessages.h"
@@ -81,7 +82,12 @@ static int sendTestMessage(IPC::DataReference buffer, void* context)
     BinarySemaphore semaphore;
     auto decoder = IPC::Decoder::create(buffer, [&semaphore] (IPC::DataReference) { semaphore.signal(); }, { }); // NOLINT
     if (decoder) {
-        testedConnection->dispatchIncomingMessageForTesting(makeUniqueRefFromNonNullUniquePtr(WTFMove(decoder)));
+        IPC::Message message {
+            makeUniqueRefFromNonNullUniquePtr(WTFMove(decoder)),
+            0,
+            { }
+        };
+        testedConnection->dispatchIncomingMessageForTesting(WTFMove(message));
         semaphore.wait();
     }
     return 0;

--- a/Source/WebKit/Shared/IPCTester.h
+++ b/Source/WebKit/Shared/IPCTester.h
@@ -57,8 +57,8 @@ public:
     ~IPCTester();
 
     // IPC::MessageReceiver overrides.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 private:
     // Messages.
     void startMessageTesting(IPC::Connection&, String&& driverName);

--- a/Source/WebKit/Shared/IPCTesterReceiver.h
+++ b/Source/WebKit/Shared/IPCTesterReceiver.h
@@ -42,7 +42,7 @@ public:
     ~IPCTesterReceiver() = default;
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 private:
     // Messages
     void asyncMessage(uint32_t, CompletionHandler<void(uint32_t)>&&);

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
@@ -48,7 +48,7 @@ public:
     virtual void pageWasNotifiedOfNotificationPermission() = 0;
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebConnection.h
+++ b/Source/WebKit/Shared/WebConnection.h
@@ -52,7 +52,7 @@ protected:
 
     // IPC::MessageReceiver
     // Implemented in generated WebConnectionMessageReceiver.cpp
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // Mesage handling implementation functions.
     void handleMessage(const String& messageName, const UserData& messageBody);

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -129,7 +129,7 @@ RefPtr<WebProcessPool> WebAutomationSession::protectedProcessPool() const
 
 void WebAutomationSession::dispatchMessageFromRemote(String&& message)
 {
-    m_backendDispatcher->dispatch(WTFMove(message));
+    m_backendDispatcher->dispatch(message);
 }
 
 void WebAutomationSession::connect(Inspector::FrontendChannel& channel, bool isAutomaticConnection, bool immediatelyPause)

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -255,7 +255,7 @@ private:
     void hideWindowForPage(WebPageProxy&, WTF::CompletionHandler<void()>&&);
 
     // IPC::MessageReceiver (Implemented by generated code in WebAutomationSessionMessageReceiver.cpp).
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
     // Called by WebAutomationSession messages.
     void didEvaluateJavaScriptFunction(uint64_t callbackID, const String& result, const String& errorType);

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -252,8 +252,8 @@ bool AuxiliaryProcessProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, Optio
 
     if (asyncReplyHandler && canSendMessage() && shouldStartProcessThrottlerActivity == ShouldStartProcessThrottlerActivity::Yes) {
         auto completionHandler = WTFMove(asyncReplyHandler->completionHandler);
-        asyncReplyHandler->completionHandler = [activity = throttler().backgroundActivity({ }), completionHandler = WTFMove(completionHandler)](IPC::Decoder* decoder) mutable {
-            completionHandler(decoder);
+        asyncReplyHandler->completionHandler = [activity = throttler().backgroundActivity({ }), completionHandler = WTFMove(completionHandler)](IPC::Message* message) mutable {
+            completionHandler(message);
         };
     }
 
@@ -306,14 +306,14 @@ void AuxiliaryProcessProxy::removeMessageReceiver(IPC::ReceiverName messageRecei
     m_messageReceiverMap.removeMessageReceiver(messageReceiverName);
 }
 
-bool AuxiliaryProcessProxy::dispatchMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+bool AuxiliaryProcessProxy::dispatchMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    return m_messageReceiverMap.dispatchMessage(connection, decoder);
+    return m_messageReceiverMap.dispatchMessage(connection, message);
 }
 
-bool AuxiliaryProcessProxy::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool AuxiliaryProcessProxy::dispatchSyncMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& replyEncoder)
 {
-    return m_messageReceiverMap.dispatchSyncMessage(connection, decoder, replyEncoder);
+    return m_messageReceiverMap.dispatchSyncMessage(connection, message, replyEncoder);
 }
 
 void AuxiliaryProcessProxy::didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier connectionIdentifier)

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -200,8 +200,8 @@ protected:
     // ProcessLauncher::Client
     void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier) override;
 
-    bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool dispatchMessage(IPC::Connection&, IPC::Message&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
 
     void logInvalidMessage(IPC::Connection&, IPC::MessageName);
     virtual ASCIILiteral processName() const = 0;

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -200,7 +200,7 @@ private:
     friend class VideoPresentationManagerProxy;
 
     explicit PlaybackSessionManagerProxy(WebPageProxy&);
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     typedef std::tuple<RefPtr<PlaybackSessionModelContext>, RefPtr<WebCore::PlatformPlaybackSessionInterface>> ModelInterfaceTuple;
     ModelInterfaceTuple createModelAndInterface(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
@@ -80,13 +80,13 @@ public:
 
     void setOrientation(WebCore::IntDegrees);
 
-    void didReceiveMessageFromGPUProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
+    void didReceiveMessageFromGPUProcess(IPC::Connection& connection, IPC::Message& message) { didReceiveMessage(connection, message); }
 
     bool hasSourceProxies() const;
 
 private:
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     using CreateSourceCallback = CompletionHandler<void(const WebCore::CaptureSourceError&, const WebCore::RealtimeMediaSourceSettings&, const WebCore::RealtimeMediaSourceCapabilities&)>;
     void createMediaSourceForCaptureDeviceWithConstraints(WebCore::RealtimeMediaSourceIdentifier, const WebCore::CaptureDevice& deviceID, WebCore::MediaDeviceHashSalts&&, const WebCore::MediaConstraints&, bool shouldUseGPUProcessRemoteFrames, WebCore::PageIdentifier, CreateSourceCallback&&);

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -199,7 +199,7 @@ private:
     friend class VideoPresentationModelContext;
 
     explicit VideoPresentationManagerProxy(WebPageProxy&, PlaybackSessionManagerProxy&);
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     typedef std::tuple<RefPtr<VideoPresentationModelContext>, RefPtr<WebCore::PlatformVideoFullscreenInterface>> ModelInterfaceTuple;
     ModelInterfaceTuple createModelAndInterface(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -712,7 +712,7 @@ void WebPasteboardProxy::testIPCSharedMemory(IPC::Connection& connection, const 
     }
 
     String message = { static_cast<char*>(sharedMemoryBuffer->data()), static_cast<unsigned>(sharedMemoryBuffer->size()) };
-    completionHandler(sharedMemoryBuffer->size(), WTFMove(message));
+    completionHandler(sharedMemoryBuffer->size(), message);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -124,7 +124,7 @@ private:
     explicit DownloadProxy(DownloadProxyMap&, WebsiteDataStore&, API::DownloadClient&, const WebCore::ResourceRequest&, const FrameInfoData&, WebPageProxy*);
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     DownloadProxyMap& m_downloadProxyMap;
     RefPtr<WebsiteDataStore> m_dataStore;

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -129,7 +129,7 @@ public:
     virtual void viewWillEndLiveResize() { };
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // IPC::MessageSender
     bool sendMessage(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>) final;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -638,7 +638,7 @@ private:
     void fireWindowsEventIfNeeded(WebExtensionEventListenerType, std::optional<WebExtensionWindowParameters>);
 
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     WebExtensionContextIdentifier m_identifier;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -133,7 +133,7 @@ public:
 
 private:
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     void addProcessPool(WebProcessPool&);
     void removeProcessPool(WebProcessPool&);

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -150,7 +150,7 @@ private:
     void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier) override;
 
     // IPC::Connection::Client
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
     void didClose(IPC::Connection&) override;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) override;
 

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
@@ -128,7 +128,7 @@ private:
     RefPtr<WebPageProxy> protectedInspectorPage();
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // RemoteWebInspectorUIProxy messages.
     void frontendLoaded();

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h
@@ -53,7 +53,7 @@ public:
     virtual ~WebInspectorUIExtensionControllerProxy();
 
     // Implemented in generated WebInspectorUIExtensionControllerProxyMessageReceiver.cpp
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // API.
     void registerExtension(const Inspector::ExtensionID&, const String& extensionBundleIdentifier, const String& displayName, WTF::CompletionHandler<void(Expected<RefPtr<API::InspectorExtension>, Inspector::ExtensionError>)>&&);

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -214,7 +214,7 @@ private:
     void closeFrontendPageAndWindow();
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // Inspector::FrontendChannel
     void sendMessageToFrontend(const String& message) override;

--- a/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp
@@ -81,7 +81,7 @@ void WebPageDebuggable::disconnect(FrontendChannel& channel)
 
 void WebPageDebuggable::dispatchMessageFromRemote(String&& message)
 {
-    m_page.inspectorController().dispatchMessageFromFrontend(WTFMove(message));
+    m_page.inspectorController().dispatchMessageFromFrontend(message);
 }
 
 void WebPageDebuggable::setIndicating(bool indicating)

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
@@ -76,7 +76,7 @@ private:
     Ref<WebProcessProxy> protectedProcess();
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // Messages
     void beginRoutingArbitrationWithCategory(WebCore::AudioSession::CategoryType, ArbitrationCallback&&);

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
@@ -62,7 +62,7 @@ private:
     explicit RemoteMediaSessionCoordinatorProxy(WebPageProxy&, Ref<MediaSessionCoordinatorProxyPrivate>&&);
 
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // Receivers.
     void join(MediaSessionCommandCompletionHandler&&);

--- a/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h
+++ b/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h
@@ -68,7 +68,7 @@ private:
     Ref<NetworkProcessProxy> protectedProcess();
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     WeakRef<NetworkProcessProxy> m_networkProcessProxy;
 };

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -449,20 +449,20 @@ void NetworkProcessProxy::networkProcessDidTerminate(ProcessTerminationReason re
     m_dataTasks.clear();
 }
 
-void NetworkProcessProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void NetworkProcessProxy::didReceiveMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (dispatchMessage(connection, decoder))
+    if (dispatchMessage(connection, message))
         return;
 
-    didReceiveNetworkProcessProxyMessage(connection, decoder);
+    didReceiveNetworkProcessProxyMessage(connection, message);
 }
 
-bool NetworkProcessProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool NetworkProcessProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& replyEncoder)
 {
-    if (dispatchSyncMessage(connection, decoder, replyEncoder))
+    if (dispatchSyncMessage(connection, message, replyEncoder))
         return true;
 
-    return didReceiveSyncNetworkProcessProxyMessage(connection, decoder, replyEncoder);
+    return didReceiveSyncNetworkProcessProxyMessage(connection, message, replyEncoder);
 }
 
 void NetworkProcessProxy::didClose(IPC::Connection& connection)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -346,17 +346,17 @@ private:
     void terminate() final;
 
     // IPC::Connection::Client
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) override;
     void didClose(IPC::Connection&) override;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) override;
-    bool didReceiveSyncNetworkProcessProxyMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool didReceiveSyncNetworkProcessProxyMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
 
     // ResponsivenessTimer::Client
     void didBecomeUnresponsive() final;
 
     // Message handlers
-    void didReceiveNetworkProcessProxyMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveNetworkProcessProxyMessage(IPC::Connection&, IPC::Message&);
     void didReceiveAuthenticationChallenge(PAL::SessionID, WebPageProxyIdentifier, const std::optional<WebCore::SecurityOriginData>&, WebCore::AuthenticationChallenge&&, bool, AuthenticationChallengeIdentifier);
     void negotiatedLegacyTLS(WebPageProxyIdentifier);
     void didNegotiateModernTLS(WebPageProxyIdentifier, const URL&);

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -577,165 +577,165 @@ void ProvisionalPageProxy::unfreezeLayerTreeDueToSwipeAnimation()
     send(Messages::WebPage::UnfreezeLayerTreeDueToSwipeAnimation());
 }
 
-void ProvisionalPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void ProvisionalPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    ASSERT(decoder.messageReceiverName() == Messages::WebPageProxy::messageReceiverName());
+    ASSERT(message.messageReceiverName() == Messages::WebPageProxy::messageReceiverName());
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidStartProgress::name()
-        || decoder.messageName() == Messages::WebPageProxy::DidChangeProgress::name()
-        || decoder.messageName() == Messages::WebPageProxy::DidFinishProgress::name()
-        || decoder.messageName() == Messages::WebPageProxy::SetNetworkRequestsInProgress::name()
-        || decoder.messageName() == Messages::WebPageProxy::WillGoToBackForwardListItem::name()
+    if (message.messageName() == Messages::WebPageProxy::DidStartProgress::name()
+        || message.messageName() == Messages::WebPageProxy::DidChangeProgress::name()
+        || message.messageName() == Messages::WebPageProxy::DidFinishProgress::name()
+        || message.messageName() == Messages::WebPageProxy::SetNetworkRequestsInProgress::name()
+        || message.messageName() == Messages::WebPageProxy::WillGoToBackForwardListItem::name()
 #if USE(QUICK_LOOK)
-        || decoder.messageName() == Messages::WebPageProxy::DidStartLoadForQuickLookDocumentInMainFrame::name()
-        || decoder.messageName() == Messages::WebPageProxy::DidFinishLoadForQuickLookDocumentInMainFrame::name()
+        || message.messageName() == Messages::WebPageProxy::DidStartLoadForQuickLookDocumentInMainFrame::name()
+        || message.messageName() == Messages::WebPageProxy::DidFinishLoadForQuickLookDocumentInMainFrame::name()
 #endif
-        || decoder.messageName() == Messages::WebPageProxy::CreateInspectorTarget::name()
-        || decoder.messageName() == Messages::WebPageProxy::DestroyInspectorTarget::name()
-        || decoder.messageName() == Messages::WebPageProxy::SendMessageToInspectorFrontend::name()
+        || message.messageName() == Messages::WebPageProxy::CreateInspectorTarget::name()
+        || message.messageName() == Messages::WebPageProxy::DestroyInspectorTarget::name()
+        || message.messageName() == Messages::WebPageProxy::SendMessageToInspectorFrontend::name()
 #if PLATFORM(GTK) || PLATFORM(WPE)
-        || decoder.messageName() == Messages::WebPageProxy::DidInitiateLoadForResource::name()
-        || decoder.messageName() == Messages::WebPageProxy::DidSendRequestForResource::name()
-        || decoder.messageName() == Messages::WebPageProxy::DidReceiveResponseForResource::name()
+        || message.messageName() == Messages::WebPageProxy::DidInitiateLoadForResource::name()
+        || message.messageName() == Messages::WebPageProxy::DidSendRequestForResource::name()
+        || message.messageName() == Messages::WebPageProxy::DidReceiveResponseForResource::name()
 #endif
         )
     {
-        m_page->didReceiveMessage(connection, decoder);
+        m_page->didReceiveMessage(connection, message);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidDestroyNavigation::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidDestroyNavigation>(connection, decoder, this, &ProvisionalPageProxy::didDestroyNavigation);
+    if (message.messageName() == Messages::WebPageProxy::DidDestroyNavigation::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::DidDestroyNavigation>(connection, message, this, &ProvisionalPageProxy::didDestroyNavigation);
         return;
     }
 
 #if PLATFORM(COCOA)
-    if (decoder.messageName() == Messages::WebPageProxy::RegisterWebProcessAccessibilityToken::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::RegisterWebProcessAccessibilityToken>(connection, decoder, this, &ProvisionalPageProxy::registerWebProcessAccessibilityToken);
+    if (message.messageName() == Messages::WebPageProxy::RegisterWebProcessAccessibilityToken::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::RegisterWebProcessAccessibilityToken>(connection, message, this, &ProvisionalPageProxy::registerWebProcessAccessibilityToken);
         return;
     }
 #endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
-    if (decoder.messageName() == Messages::WebPageProxy::BindAccessibilityTree::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::BindAccessibilityTree>(connection, decoder, this, &ProvisionalPageProxy::bindAccessibilityTree);
+    if (message.messageName() == Messages::WebPageProxy::BindAccessibilityTree::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::BindAccessibilityTree>(connection, message, this, &ProvisionalPageProxy::bindAccessibilityTree);
         return;
     }
 #endif
 
-    if (decoder.messageName() == Messages::WebPageProxy::BackForwardAddItem::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::BackForwardAddItem>(connection, decoder, this, &ProvisionalPageProxy::backForwardAddItem);
+    if (message.messageName() == Messages::WebPageProxy::BackForwardAddItem::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::BackForwardAddItem>(connection, message, this, &ProvisionalPageProxy::backForwardAddItem);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::LogDiagnosticMessageFromWebProcess::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::LogDiagnosticMessageFromWebProcess>(connection, decoder, this, &ProvisionalPageProxy::logDiagnosticMessageFromWebProcess);
+    if (message.messageName() == Messages::WebPageProxy::LogDiagnosticMessageFromWebProcess::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::LogDiagnosticMessageFromWebProcess>(connection, message, this, &ProvisionalPageProxy::logDiagnosticMessageFromWebProcess);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::LogDiagnosticMessageWithEnhancedPrivacyFromWebProcess::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::LogDiagnosticMessageWithEnhancedPrivacyFromWebProcess>(connection, decoder, this, &ProvisionalPageProxy::logDiagnosticMessageWithEnhancedPrivacyFromWebProcess);
+    if (message.messageName() == Messages::WebPageProxy::LogDiagnosticMessageWithEnhancedPrivacyFromWebProcess::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::LogDiagnosticMessageWithEnhancedPrivacyFromWebProcess>(connection, message, this, &ProvisionalPageProxy::logDiagnosticMessageWithEnhancedPrivacyFromWebProcess);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::LogDiagnosticMessageWithValueDictionaryFromWebProcess::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::LogDiagnosticMessageWithValueDictionaryFromWebProcess>(connection, decoder, this, &ProvisionalPageProxy::logDiagnosticMessageWithValueDictionaryFromWebProcess);
+    if (message.messageName() == Messages::WebPageProxy::LogDiagnosticMessageWithValueDictionaryFromWebProcess::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::LogDiagnosticMessageWithValueDictionaryFromWebProcess>(connection, message, this, &ProvisionalPageProxy::logDiagnosticMessageWithValueDictionaryFromWebProcess);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::StartURLSchemeTask::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::StartURLSchemeTask>(connection, decoder, this, &ProvisionalPageProxy::startURLSchemeTask);
+    if (message.messageName() == Messages::WebPageProxy::StartURLSchemeTask::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::StartURLSchemeTask>(connection, message, this, &ProvisionalPageProxy::startURLSchemeTask);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DecidePolicyForNavigationActionAsync::name()) {
-        IPC::handleMessageAsync<Messages::WebPageProxy::DecidePolicyForNavigationActionAsync>(connection, decoder, this, &ProvisionalPageProxy::decidePolicyForNavigationActionAsync);
+    if (message.messageName() == Messages::WebPageProxy::DecidePolicyForNavigationActionAsync::name()) {
+        IPC::handleMessageAsync<Messages::WebPageProxy::DecidePolicyForNavigationActionAsync>(connection, message, this, &ProvisionalPageProxy::decidePolicyForNavigationActionAsync);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DecidePolicyForResponse::name()) {
-        IPC::handleMessageAsync<Messages::WebPageProxy::DecidePolicyForResponse>(connection, decoder, this, &ProvisionalPageProxy::decidePolicyForResponse);
+    if (message.messageName() == Messages::WebPageProxy::DecidePolicyForResponse::name()) {
+        IPC::handleMessageAsync<Messages::WebPageProxy::DecidePolicyForResponse>(connection, message, this, &ProvisionalPageProxy::decidePolicyForResponse);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidChangeProvisionalURLForFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidChangeProvisionalURLForFrame>(connection, decoder, this, &ProvisionalPageProxy::didChangeProvisionalURLForFrame);
+    if (message.messageName() == Messages::WebPageProxy::DidChangeProvisionalURLForFrame::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::DidChangeProvisionalURLForFrame>(connection, message, this, &ProvisionalPageProxy::didChangeProvisionalURLForFrame);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidNavigateWithNavigationData::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidNavigateWithNavigationData>(connection, decoder, this, &ProvisionalPageProxy::didNavigateWithNavigationData);
+    if (message.messageName() == Messages::WebPageProxy::DidNavigateWithNavigationData::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::DidNavigateWithNavigationData>(connection, message, this, &ProvisionalPageProxy::didNavigateWithNavigationData);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidPerformClientRedirect::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidPerformClientRedirect>(connection, decoder, this, &ProvisionalPageProxy::didPerformClientRedirect);
+    if (message.messageName() == Messages::WebPageProxy::DidPerformClientRedirect::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::DidPerformClientRedirect>(connection, message, this, &ProvisionalPageProxy::didPerformClientRedirect);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidCreateMainFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidCreateMainFrame>(connection, decoder, this, &ProvisionalPageProxy::didCreateMainFrame);
+    if (message.messageName() == Messages::WebPageProxy::DidCreateMainFrame::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::DidCreateMainFrame>(connection, message, this, &ProvisionalPageProxy::didCreateMainFrame);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidStartProvisionalLoadForFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidStartProvisionalLoadForFrame>(connection, decoder, this, &ProvisionalPageProxy::didStartProvisionalLoadForFrame);
+    if (message.messageName() == Messages::WebPageProxy::DidStartProvisionalLoadForFrame::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::DidStartProvisionalLoadForFrame>(connection, message, this, &ProvisionalPageProxy::didStartProvisionalLoadForFrame);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidFailProvisionalLoadForFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidFailProvisionalLoadForFrame>(connection, decoder, this, &ProvisionalPageProxy::didFailProvisionalLoadForFrame);
+    if (message.messageName() == Messages::WebPageProxy::DidFailProvisionalLoadForFrame::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::DidFailProvisionalLoadForFrame>(connection, message, this, &ProvisionalPageProxy::didFailProvisionalLoadForFrame);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidCommitLoadForFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidCommitLoadForFrame>(connection, decoder, this, &ProvisionalPageProxy::didCommitLoadForFrame);
+    if (message.messageName() == Messages::WebPageProxy::DidCommitLoadForFrame::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::DidCommitLoadForFrame>(connection, message, this, &ProvisionalPageProxy::didCommitLoadForFrame);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidReceiveServerRedirectForProvisionalLoadForFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidReceiveServerRedirectForProvisionalLoadForFrame>(connection, decoder, this, &ProvisionalPageProxy::didReceiveServerRedirectForProvisionalLoadForFrame);
+    if (message.messageName() == Messages::WebPageProxy::DidReceiveServerRedirectForProvisionalLoadForFrame::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::DidReceiveServerRedirectForProvisionalLoadForFrame>(connection, message, this, &ProvisionalPageProxy::didReceiveServerRedirectForProvisionalLoadForFrame);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidPerformServerRedirect::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidPerformServerRedirect>(connection, decoder, this, &ProvisionalPageProxy::didPerformServerRedirect);
+    if (message.messageName() == Messages::WebPageProxy::DidPerformServerRedirect::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::DidPerformServerRedirect>(connection, message, this, &ProvisionalPageProxy::didPerformServerRedirect);
         return;
     }
 
 #if USE(QUICK_LOOK)
-    if (decoder.messageName() == Messages::WebPageProxy::RequestPasswordForQuickLookDocumentInMainFrame::name()) {
-        IPC::handleMessageAsync<Messages::WebPageProxy::RequestPasswordForQuickLookDocumentInMainFrame>(connection, decoder, this, &ProvisionalPageProxy::requestPasswordForQuickLookDocumentInMainFrame);
+    if (message.messageName() == Messages::WebPageProxy::RequestPasswordForQuickLookDocumentInMainFrame::name()) {
+        IPC::handleMessageAsync<Messages::WebPageProxy::RequestPasswordForQuickLookDocumentInMainFrame>(connection, message, this, &ProvisionalPageProxy::requestPasswordForQuickLookDocumentInMainFrame);
         return;
     }
 #endif
 
 #if ENABLE(CONTENT_FILTERING)
-    if (decoder.messageName() == Messages::WebPageProxy::ContentFilterDidBlockLoadForFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::ContentFilterDidBlockLoadForFrame>(connection, decoder, this, &ProvisionalPageProxy::contentFilterDidBlockLoadForFrame);
+    if (message.messageName() == Messages::WebPageProxy::ContentFilterDidBlockLoadForFrame::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::ContentFilterDidBlockLoadForFrame>(connection, message, this, &ProvisionalPageProxy::contentFilterDidBlockLoadForFrame);
         return;
     }
 #endif
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
-    if (decoder.messageName() == Messages::WebPageProxy::DidCreateContextInWebProcessForVisibilityPropagation::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidCreateContextInWebProcessForVisibilityPropagation>(connection, decoder, this, &ProvisionalPageProxy::didCreateContextInWebProcessForVisibilityPropagation);
+    if (message.messageName() == Messages::WebPageProxy::DidCreateContextInWebProcessForVisibilityPropagation::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::DidCreateContextInWebProcessForVisibilityPropagation>(connection, message, this, &ProvisionalPageProxy::didCreateContextInWebProcessForVisibilityPropagation);
         return;
     }
 #endif
 
-    LOG(ProcessSwapping, "Unhandled message %s from provisional process", description(decoder.messageName()));
+    LOG(ProcessSwapping, "Unhandled message %s from provisional process", description(message.messageName()));
 }
 
-bool ProvisionalPageProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool ProvisionalPageProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& replyEncoder)
 {
-    if (decoder.messageName() == Messages::WebPageProxy::BackForwardGoToItem::name())
-        return IPC::handleMessageSynchronous<Messages::WebPageProxy::BackForwardGoToItem>(connection, decoder, replyEncoder, this, &ProvisionalPageProxy::backForwardGoToItem);
+    if (message.messageName() == Messages::WebPageProxy::BackForwardGoToItem::name())
+        return IPC::handleMessageSynchronous<Messages::WebPageProxy::BackForwardGoToItem>(connection, message, replyEncoder, this, &ProvisionalPageProxy::backForwardGoToItem);
 
-    if (decoder.messageName() == Messages::WebPageProxy::DecidePolicyForNavigationActionSync::name())
-        return IPC::handleMessageSynchronous<Messages::WebPageProxy::DecidePolicyForNavigationActionSync>(connection, decoder, replyEncoder, this, &ProvisionalPageProxy::decidePolicyForNavigationActionSync);
+    if (message.messageName() == Messages::WebPageProxy::DecidePolicyForNavigationActionSync::name())
+        return IPC::handleMessageSynchronous<Messages::WebPageProxy::DecidePolicyForNavigationActionSync>(connection, message, replyEncoder, this, &ProvisionalPageProxy::decidePolicyForNavigationActionSync);
 
-    return m_page->didReceiveSyncMessage(connection, decoder, replyEncoder);
+    return m_page->didReceiveSyncMessage(connection, message, replyEncoder);
 }
 
 IPC::Connection* ProvisionalPageProxy::messageSenderConnection() const

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -135,8 +135,8 @@ private:
     RefPtr<WebFrameProxy> protectedMainFrame() const;
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     // IPC::MessageSender
     IPC::Connection* messageSenderConnection() const final;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -120,7 +120,7 @@ private:
     void removeRemotePageDrawingAreaProxy(RemotePageDrawingAreaProxy&) final;
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // Message handlers
     // FIXME(site-isolation): We really want a Connection parameter to all of these (including

--- a/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp
@@ -51,16 +51,16 @@ RemotePageDrawingAreaProxy::~RemotePageDrawingAreaProxy()
         m_drawingArea->removeRemotePageDrawingAreaProxy(*this);
 }
 
-void RemotePageDrawingAreaProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void RemotePageDrawingAreaProxy::didReceiveMessage(IPC::Connection& connection, IPC::Message& message)
 {
     if (m_drawingArea)
-        m_drawingArea->didReceiveMessage(connection, decoder);
+        m_drawingArea->didReceiveMessage(connection, message);
 }
 
-bool RemotePageDrawingAreaProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
+bool RemotePageDrawingAreaProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& encoder)
 {
     if (m_drawingArea)
-        return m_drawingArea->didReceiveSyncMessage(connection, decoder, encoder);
+        return m_drawingArea->didReceiveSyncMessage(connection, message, encoder);
     ASSERT_NOT_REACHED();
     return false;
 }

--- a/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
@@ -43,8 +43,8 @@ public:
     WebProcessProxy& process() { return m_process; }
 
 private:
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     WeakPtr<DrawingAreaProxy> m_drawingArea;
     DrawingAreaIdentifier m_identifier;

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -112,40 +112,40 @@ RemotePageProxy::~RemotePageProxy()
         m_page->removeRemotePageProxy(m_domain);
 }
 
-void RemotePageProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void RemotePageProxy::didReceiveMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (decoder.messageName() == Messages::WebPageProxy::DecidePolicyForResponse::name()) {
-        IPC::handleMessageAsync<Messages::WebPageProxy::DecidePolicyForResponse>(connection, decoder, this, &RemotePageProxy::decidePolicyForResponse);
+    if (message.messageName() == Messages::WebPageProxy::DecidePolicyForResponse::name()) {
+        IPC::handleMessageAsync<Messages::WebPageProxy::DecidePolicyForResponse>(connection, message, this, &RemotePageProxy::decidePolicyForResponse);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidCommitLoadForFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidCommitLoadForFrame>(connection, decoder, this, &RemotePageProxy::didCommitLoadForFrame);
+    if (message.messageName() == Messages::WebPageProxy::DidCommitLoadForFrame::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::DidCommitLoadForFrame>(connection, message, this, &RemotePageProxy::didCommitLoadForFrame);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DecidePolicyForNavigationActionAsync::name()) {
-        IPC::handleMessageAsync<Messages::WebPageProxy::DecidePolicyForNavigationActionAsync>(connection, decoder, this, &RemotePageProxy::decidePolicyForNavigationActionAsync);
+    if (message.messageName() == Messages::WebPageProxy::DecidePolicyForNavigationActionAsync::name()) {
+        IPC::handleMessageAsync<Messages::WebPageProxy::DecidePolicyForNavigationActionAsync>(connection, message, this, &RemotePageProxy::decidePolicyForNavigationActionAsync);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidChangeProvisionalURLForFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidChangeProvisionalURLForFrame>(connection, decoder, this, &RemotePageProxy::didChangeProvisionalURLForFrame);
+    if (message.messageName() == Messages::WebPageProxy::DidChangeProvisionalURLForFrame::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::DidChangeProvisionalURLForFrame>(connection, message, this, &RemotePageProxy::didChangeProvisionalURLForFrame);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidFailProvisionalLoadForFrame::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidFailProvisionalLoadForFrame>(connection, decoder, this, &RemotePageProxy::didFailProvisionalLoadForFrame);
+    if (message.messageName() == Messages::WebPageProxy::DidFailProvisionalLoadForFrame::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::DidFailProvisionalLoadForFrame>(connection, message, this, &RemotePageProxy::didFailProvisionalLoadForFrame);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::HandleMessage::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::HandleMessage>(connection, decoder, this, &RemotePageProxy::handleMessage);
+    if (message.messageName() == Messages::WebPageProxy::HandleMessage::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::HandleMessage>(connection, message, this, &RemotePageProxy::handleMessage);
         return;
     }
 
     if (m_page)
-        m_page->didReceiveMessage(connection, decoder);
+        m_page->didReceiveMessage(connection, message);
 }
 
 void RemotePageProxy::handleMessage(const String& messageName, const WebKit::UserData& messageBody)
@@ -204,13 +204,13 @@ void RemotePageProxy::didChangeProvisionalURLForFrame(WebCore::FrameIdentifier f
     m_page->didChangeProvisionalURLForFrameShared(m_process.copyRef(), frameID, navigationID, WTFMove(url));
 }
 
-bool RemotePageProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder)
+bool RemotePageProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& encoder)
 {
-    if (decoder.messageName() == Messages::WebPageProxy::DecidePolicyForNavigationActionSync::name())
-        return IPC::handleMessageSynchronous<Messages::WebPageProxy::DecidePolicyForNavigationActionSync>(connection, decoder, encoder, this, &RemotePageProxy::decidePolicyForNavigationActionSync);
+    if (message.messageName() == Messages::WebPageProxy::DecidePolicyForNavigationActionSync::name())
+        return IPC::handleMessageSynchronous<Messages::WebPageProxy::DecidePolicyForNavigationActionSync>(connection, message, encoder, this, &RemotePageProxy::decidePolicyForNavigationActionSync);
 
     if (m_page)
-        return m_page->didReceiveSyncMessage(connection, decoder, encoder);
+        return m_page->didReceiveSyncMessage(connection, message, encoder);
 
     return false;
 }

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -92,8 +92,8 @@ public:
 
 private:
     RemotePageProxy(WebPageProxy&, WebProcessProxy&, const WebCore::RegistrableDomain&, WebPageProxyMessageReceiverRegistration*);
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
     void decidePolicyForResponse(FrameInfoData&&, uint64_t navigationID, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, const String& downloadAttribute, CompletionHandler<void(PolicyDecision&&)>&&);
     void didCommitLoadForFrame(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, uint64_t navigationID, const String& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, const WebCore::CertificateInfo&, bool usedLegacyTLS, bool privateRelayed, bool containsPluginDocument, WebCore::HasInsecureContent, WebCore::MouseEventPolicy, const UserData&);
     void decidePolicyForNavigationActionAsync(FrameInfoData&&, uint64_t navigationID, NavigationActionData&&, FrameInfoData&& originatingFrameInfo, std::optional<WebPageProxyIdentifier> originatingPageID, const WebCore::ResourceRequest& originalRequest, WebCore::ResourceRequest&&, IPC::FormDataReference&& requestBody, CompletionHandler<void(PolicyDecision&&)>&&);

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h
@@ -64,7 +64,7 @@ private:
 #endif
 
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // IPC::MessageSender.
     IPC::Connection* messageSenderConnection() const final;

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.h
@@ -72,7 +72,7 @@ private:
     void sendUpdate(const WebCore::SpeechRecognitionUpdate&);
 
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // IPC::MessageSender.
     IPC::Connection* messageSenderConnection() const final;

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -273,32 +273,32 @@ WebPageProxy& SuspendedPageProxy::page() const
     return m_page.get();
 }
 
-void SuspendedPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void SuspendedPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    ASSERT(decoder.messageReceiverName() == Messages::WebPageProxy::messageReceiverName());
+    ASSERT(message.messageReceiverName() == Messages::WebPageProxy::messageReceiverName());
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidSuspendAfterProcessSwap::name()) {
+    if (message.messageName() == Messages::WebPageProxy::DidSuspendAfterProcessSwap::name()) {
         didProcessRequestToSuspend(SuspensionState::Suspended);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidFailToSuspendAfterProcessSwap::name()) {
+    if (message.messageName() == Messages::WebPageProxy::DidFailToSuspendAfterProcessSwap::name()) {
         didProcessRequestToSuspend(SuspensionState::FailedToSuspend);
         return;
     }
 
-    if (decoder.messageName() == Messages::WebPageProxy::DidDestroyNavigation::name()) {
-        IPC::handleMessage<Messages::WebPageProxy::DidDestroyNavigation>(connection, decoder, this, &SuspendedPageProxy::didDestroyNavigation);
+    if (message.messageName() == Messages::WebPageProxy::DidDestroyNavigation::name()) {
+        IPC::handleMessage<Messages::WebPageProxy::DidDestroyNavigation>(connection, message, this, &SuspendedPageProxy::didDestroyNavigation);
         return;
     }
 
 #if !LOG_DISABLED
-    if (!messageNamesToIgnoreWhileSuspended().contains(decoder.messageName()))
-        LOG(ProcessSwapping, "SuspendedPageProxy received unexpected WebPageProxy message '%s'", description(decoder.messageName()));
+    if (!messageNamesToIgnoreWhileSuspended().contains(message.messageName()))
+        LOG(ProcessSwapping, "SuspendedPageProxy received unexpected WebPageProxy message '%s'", description(message.messageName()));
 #endif
 }
 
-bool SuspendedPageProxy::didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&)
+bool SuspendedPageProxy::didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&)
 {
     return false;
 }

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -101,8 +101,8 @@ private:
     void didDestroyNavigation(uint64_t navigationID);
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     template<typename T> void sendToAllProcesses(T&&);
 

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -120,7 +120,7 @@ public:
 
 private:
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     void didPostMessage(WebPageProxyIdentifier, FrameInfoData&&, uint64_t messageHandlerID, const IPC::DataReference&, CompletionHandler<void(IPC::DataReference&&, const String&)>&&);
 

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -205,7 +205,7 @@ public:
 
 private:
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     static ViewGestureController* controllerForGesture(WebPageProxyIdentifier, GestureID);
 

--- a/Source/WebKit/UIProcess/VisitedLinkStore.h
+++ b/Source/WebKit/UIProcess/VisitedLinkStore.h
@@ -55,7 +55,7 @@ public:
 
 private:
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // SharedStringHashStore::Client
     void didInvalidateSharedMemory() final;

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
@@ -86,7 +86,7 @@ private:
     using QueryCompletionHandler = CompletionHandler<void(bool)>;
 
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // Receivers.
     void makeCredential(WebCore::FrameIdentifier, FrameInfoData&&, Vector<uint8_t>&& hash, WebCore::PublicKeyCredentialCreationOptions&&, RequestCompletionHandler&&);

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -112,8 +112,8 @@ private:
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame);
     void callCloseCompletionHandlers();
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) override;
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.h
@@ -82,7 +82,7 @@ private:
     void derefWebContextSupplement() override;
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // IPC messages.
     void startUpdating(IPC::Connection&, const WebCore::RegistrableDomain&, WebPageProxyIdentifier, const String& authorizationToken, bool enableHighAccuracy);

--- a/Source/WebKit/UIProcess/WebLockRegistryProxy.h
+++ b/Source/WebKit/UIProcess/WebLockRegistryProxy.h
@@ -46,7 +46,7 @@ public:
     ~WebLockRegistryProxy();
 
     void processDidExit();
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
 private:
     // IPC Message handlers.

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1982,8 +1982,8 @@ public:
 
     // IPC::MessageReceiver
     // Implemented in generated WebPageProxyMessageReceiver.cpp
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     void requestStorageSpace(WebCore::FrameIdentifier, const String& originIdentifier, const String& databaseName, const String& displayName, uint64_t currentQuota, uint64_t currentOriginUsage, uint64_t currentDatabaseUsage, uint64_t expectedUsage, WTF::CompletionHandler<void(uint64_t)>&&);
 

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.h
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.h
@@ -79,8 +79,8 @@ public:
 private:
     WebPasteboardProxy();
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) override;
 
     WebProcessProxy* webProcessProxyForConnection(IPC::Connection&) const;
 

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.h
@@ -48,7 +48,7 @@ public:
     ~WebPermissionControllerProxy();
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
 private:
     RefPtr<WebPageProxy> mostReasonableWebPageProxy(const WebCore::SecurityOriginData&, WebCore::PermissionQuerySource) const;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1516,14 +1516,14 @@ void WebProcessPool::removeMessageReceiver(IPC::ReceiverName messageReceiverName
     m_messageReceiverMap.removeMessageReceiver(messageReceiverName, destinationID);
 }
 
-bool WebProcessPool::dispatchMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+bool WebProcessPool::dispatchMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    return m_messageReceiverMap.dispatchMessage(connection, decoder);
+    return m_messageReceiverMap.dispatchMessage(connection, message);
 }
 
-bool WebProcessPool::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool WebProcessPool::dispatchSyncMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& replyEncoder)
 {
-    return m_messageReceiverMap.dispatchSyncMessage(connection, decoder, replyEncoder);
+    return m_messageReceiverMap.dispatchSyncMessage(connection, message, replyEncoder);
 }
 
 void WebProcessPool::setEnhancedAccessibility(bool flag)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -194,8 +194,8 @@ public:
         removeMessageReceiver(messageReceiverName, destinationID.toUInt64());
     }
 
-    bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool dispatchMessage(IPC::Connection&, IPC::Message&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
 
     void initializeClient(const WKContextClientBase*);
     void setInjectedBundleClient(std::unique_ptr<API::InjectedBundleClient>&&);
@@ -573,8 +573,8 @@ private:
 
     // IPC::MessageReceiver.
     // Implemented in generated WebProcessPoolMessageReceiver.cpp
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) override;
 
     bool usesSingleWebProcess() const { return m_configuration->usesSingleWebProcess(); }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -562,8 +562,8 @@ private:
 
     // IPC::Connection::Client
     friend class WebConnectionToWebProcess;
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) override;
     void didClose(IPC::Connection&) final;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) override;
 
@@ -574,8 +574,8 @@ private:
     void didChangeIsResponsive() override;
 
     // Implemented in generated WebProcessProxyMessageReceiver.cpp
-    void didReceiveWebProcessProxyMessage(IPC::Connection&, IPC::Decoder&);
-    bool didReceiveSyncWebProcessProxyMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    void didReceiveWebProcessProxyMessage(IPC::Connection&, IPC::Message&);
+    bool didReceiveSyncWebProcessProxyMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
 
     bool canTerminateAuxiliaryProcess();
 

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
@@ -45,8 +45,8 @@ public:
     ~WebScreenOrientationManagerProxy();
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
 
     void unlockIfNecessary();
 

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -63,7 +63,7 @@ private:
     static PlatformXRCoordinator* xrCoordinator();
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // Message handlers
     void enumerateImmersiveXRDevices(CompletionHandler<void(Vector<XRDeviceInfo>&&)>&&);

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.h
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.h
@@ -52,7 +52,7 @@ public:
 
 private:
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     void didCollectGeometryForSmartMagnificationGesture(WebCore::FloatPoint origin, WebCore::FloatRect renderRect, WebCore::FloatRect visibleContentBounds, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale);
     void scrollToRect(WebCore::FloatPoint origin, WebCore::FloatRect targetRect);

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h
@@ -52,7 +52,7 @@ private:
     void motionChanged(double, double, double, double, double, double, std::optional<double>, std::optional<double>, std::optional<double>) final;
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     WebPageProxy& m_page;
 };

--- a/Source/WebKit/UIProcess/mac/SecItemShimProxy.h
+++ b/Source/WebKit/UIProcess/mac/SecItemShimProxy.h
@@ -47,8 +47,8 @@ private:
     ~SecItemShimProxy();
 
     // IPC::Connection::MessageReceiver overrides.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) override;
 
     void secItemRequest(IPC::Connection&, const SecItemRequestData&, CompletionHandler<void(std::optional<SecItemResponseData>&&)>&&);
     void secItemRequestSync(IPC::Connection&, const SecItemRequestData&, CompletionHandler<void(std::optional<SecItemResponseData>&&)>&&);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1415,6 +1415,7 @@
 		57FD318722B35170008D0E8B /* WKSOAuthorizationDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 57FD317122B35148008D0E8B /* WKSOAuthorizationDelegate.h */; };
 		57FE686D2604827800BF45E4 /* _WKAuthenticatorAttachment.h in Headers */ = {isa = PBXBuildFile; fileRef = 57FE686C2604827800BF45E4 /* _WKAuthenticatorAttachment.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		57FE688C260ABB3D00BF45E4 /* PrivateClickMeasurementNetworkLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 57FE688A260ABB3D00BF45E4 /* PrivateClickMeasurementNetworkLoader.h */; };
+		5C0C2B692B4CE4F3004473B0 /* Message.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C0C2B682B4CE4F3004473B0 /* Message.h */; };
 		5C121E842410208D00486F9B /* FrameTreeNodeData.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C121E8324101F7000486F9B /* FrameTreeNodeData.h */; };
 		5C121E89241029C900486F9B /* _WKFrameTreeNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C121E882410290D00486F9B /* _WKFrameTreeNode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5C139DA629DB82E500D5117B /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* WebKit.framework */; };
@@ -5739,6 +5740,8 @@
 		5C046A1C290B26CF00FF7820 /* TextTrackPrivateRemoteConfiguration.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = TextTrackPrivateRemoteConfiguration.serialization.in; sourceTree = "<group>"; };
 		5C05FDF227AB4FA5003A2487 /* PrivateRelayed.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrivateRelayed.h; sourceTree = "<group>"; };
 		5C0A10C1235241A30053E2CA /* NetworkSchemeRegistry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkSchemeRegistry.cpp; sourceTree = "<group>"; };
+		5C0C2B682B4CE4F3004473B0 /* Message.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Message.h; sourceTree = "<group>"; };
+		5C0C2B6A2B4E6B00004473B0 /* Message.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Message.cpp; sourceTree = "<group>"; };
 		5C121E8324101F7000486F9B /* FrameTreeNodeData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FrameTreeNodeData.h; sourceTree = "<group>"; };
 		5C121E852410276F00486F9B /* APIFrameTreeNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APIFrameTreeNode.h; sourceTree = "<group>"; };
 		5C121E862410290D00486F9B /* _WKFrameTreeNode.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKFrameTreeNode.mm; sourceTree = "<group>"; };
@@ -9150,6 +9153,8 @@
 				7B9FC5AB28A3B440007570E7 /* IPCUtilities.h */,
 				9BF5EC6325410E9900984E77 /* JSIPCBinding.cpp */,
 				9B47908E253151CC00EC11AB /* JSIPCBinding.h */,
+				5C0C2B6A2B4E6B00004473B0 /* Message.cpp */,
+				5C0C2B682B4CE4F3004473B0 /* Message.h */,
 				9B47908C25314D8300EC11AB /* MessageArgumentDescriptions.h */,
 				1AC4C82816B876A90069DCCD /* MessageFlags.h */,
 				7BDD9DDA28D205C6004CDF48 /* MessageObserver.h */,
@@ -15583,6 +15588,7 @@
 				A15799B72584433200528236 /* MediaTrackReader.h in Headers */,
 				93E799DB276121080074008A /* MemoryStorageArea.h in Headers */,
 				51933DEF1965EB31008AC3EA /* MenuUtilities.h in Headers */,
+				5C0C2B692B4CE4F3004473B0 /* Message.h in Headers */,
 				9B47908D25314D8300EC11AB /* MessageArgumentDescriptions.h in Headers */,
 				1AC4C82916B876A90069DCCD /* MessageFlags.h in Headers */,
 				7BDD9DDC28D205C6004CDF48 /* MessageObserver.h in Headers */,

--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h
@@ -84,7 +84,7 @@ private:
     void endApplePaySetup() final;
 
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // IPC::MessageSender.
     IPC::Connection* messageSenderConnection() const final;

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
@@ -69,7 +69,7 @@ private:
     void ensureObserverForFrame(WebFrame&);
 
     // Implemented in generated WebAutomationSessionProxyMessageReceiver.cpp
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // Called by WebAutomationSessionProxy messages
     void evaluateJavaScriptFunction(WebCore::PageIdentifier, std::optional<WebCore::FrameIdentifier>, const String& function, Vector<String> arguments, bool expectsImplicitCallbackArgument, std::optional<double> callbackTimeout, uint64_t callbackID);

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
@@ -34,6 +34,7 @@ namespace IPC {
 class Connection;
 class Decoder;
 class Encoder;
+struct Message;
 }
 
 namespace WebKit {
@@ -46,7 +47,7 @@ public:
 
     ~WebCacheStorageConnection();
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
     void networkProcessConnectionClosed();
 
 private:

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
@@ -30,6 +30,10 @@
 #include <WebCore/IDBConnectionToServer.h>
 #include <WebCore/ProcessIdentifier.h>
 
+namespace IPC {
+struct Message;
+}
+
 namespace WebKit {
 
 class WebIDBResult;
@@ -42,7 +46,7 @@ public:
     WebCore::IDBClient::IDBConnectionToServer& coreConnectionToServer();
     WebCore::IDBConnectionIdentifier identifier() const final;
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
     void connectionToServerLost();
 
 private:

--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
@@ -139,7 +139,7 @@ void MediaKeySystemPermissionRequestManager::mediaKeySystemWasDenied(MediaKeySys
     if (!request)
         return;
 
-    request->deny(WTFMove(message));
+    request->deny(message);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -168,7 +168,7 @@ private:
     void dispatchWindowsEvent(WebExtensionEventListenerType, const std::optional<WebExtensionWindowParameters>&);
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     WebExtensionContextIdentifier m_identifier;
     URL m_baseURL;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
@@ -74,7 +74,7 @@ private:
     explicit WebExtensionControllerProxy(const WebExtensionControllerParameters&);
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
 #if PLATFORM(COCOA)
     void load(const WebExtensionContextParameters&);

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -149,9 +149,9 @@ void WebFullScreenManager::setPIPStandbyElement(WebCore::HTMLVideoElement* pipSt
 #endif
 }
 
-void WebFullScreenManager::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void WebFullScreenManager::didReceiveMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    didReceiveWebFullScreenManagerMessage(connection, decoder);
+    didReceiveWebFullScreenManagerMessage(connection, message);
 }
 
 bool WebFullScreenManager::supportsFullScreen(bool withKeyboard)

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -39,6 +39,7 @@
 namespace IPC {
 class Connection;
 class Decoder;
+struct Message;
 }
 
 namespace WebCore {
@@ -60,7 +61,7 @@ public:
 
     void invalidate();
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
     bool supportsFullScreen(bool withKeyboard);
     void enterFullScreenForElement(WebCore::Element*);
@@ -92,7 +93,7 @@ protected:
     void setFullscreenAutoHideDuration(Seconds);
     void setFullscreenControlsHidden(bool);
 
-    void didReceiveWebFullScreenManagerMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveWebFullScreenManagerMessage(IPC::Connection&, IPC::Message&);
 
     WebCore::IntRect m_initialFrame;
     WebCore::IntRect m_finalFrame;

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -224,62 +224,63 @@ RemoteAudioSourceProviderManager& GPUProcessConnection::audioSourceProviderManag
 }
 #endif
 
-bool GPUProcessConnection::dispatchMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+bool GPUProcessConnection::dispatchMessage(IPC::Connection& connection, IPC::Message& message)
 {
+    const auto messageReceiverName = message.messageReceiverName();
 #if ENABLE(VIDEO)
-    if (decoder.messageReceiverName() == Messages::MediaPlayerPrivateRemote::messageReceiverName()) {
-        WebProcess::singleton().remoteMediaPlayerManager().didReceivePlayerMessage(connection, decoder);
+    if (messageReceiverName == Messages::MediaPlayerPrivateRemote::messageReceiverName()) {
+        WebProcess::singleton().remoteMediaPlayerManager().didReceivePlayerMessage(connection, message);
         return true;
     }
 #endif
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
-    if (decoder.messageReceiverName() == Messages::UserMediaCaptureManager::messageReceiverName()) {
+    if (messageReceiverName == Messages::UserMediaCaptureManager::messageReceiverName()) {
         if (auto* captureManager = WebProcess::singleton().supplement<UserMediaCaptureManager>())
-            captureManager->didReceiveMessageFromGPUProcess(connection, decoder);
+            captureManager->didReceiveMessageFromGPUProcess(connection, message);
         return true;
     }
 
-    if (decoder.messageReceiverName() == Messages::SampleBufferDisplayLayer::messageReceiverName()) {
-        sampleBufferDisplayLayerManager().didReceiveLayerMessage(connection, decoder);
+    if (messageReceiverName == Messages::SampleBufferDisplayLayer::messageReceiverName()) {
+        sampleBufferDisplayLayerManager().didReceiveLayerMessage(connection, message);
         return true;
     }
 #endif // PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
 
 #if ENABLE(ENCRYPTED_MEDIA)
-    if (decoder.messageReceiverName() == Messages::RemoteCDMInstanceSession::messageReceiverName()) {
-        WebProcess::singleton().cdmFactory().didReceiveSessionMessage(connection, decoder);
+    if (messageReceiverName == Messages::RemoteCDMInstanceSession::messageReceiverName()) {
+        WebProcess::singleton().cdmFactory().didReceiveSessionMessage(connection, message);
         return true;
     }
 #endif
-    if (messageReceiverMap().dispatchMessage(connection, decoder))
+    if (messageReceiverMap().dispatchMessage(connection, message))
         return true;
 
 #if USE(AUDIO_SESSION)
-    if (decoder.messageReceiverName() == Messages::RemoteAudioSession::messageReceiverName()) {
+    if (messageReceiverName == Messages::RemoteAudioSession::messageReceiverName()) {
         RELEASE_LOG_ERROR(Media, "The RemoteAudioSession object has beed destroyed");
         return true;
     }
 #endif
 
 #if ENABLE(MEDIA_SOURCE)
-    if (decoder.messageReceiverName() == Messages::MediaSourcePrivateRemote::messageReceiverName()) {
+    if (messageReceiverName == Messages::MediaSourcePrivateRemote::messageReceiverName()) {
         RELEASE_LOG_ERROR(Media, "The MediaSourcePrivateRemote object has beed destroyed");
         return true;
     }
 
-    if (decoder.messageReceiverName() == Messages::SourceBufferPrivateRemote::messageReceiverName()) {
+    if (messageReceiverName == Messages::SourceBufferPrivateRemote::messageReceiverName()) {
         RELEASE_LOG_ERROR(Media, "The SourceBufferPrivateRemote object has beed destroyed");
         return true;
     }
 #endif
 
-    if (decoder.messageReceiverName() == Messages::RemoteAudioHardwareListener::messageReceiverName()) {
+    if (messageReceiverName == Messages::RemoteAudioHardwareListener::messageReceiverName()) {
         RELEASE_LOG_ERROR(Media, "The RemoteAudioHardwareListener object has beed destroyed");
         return true;
     }
 
-    if (decoder.messageReceiverName() == Messages::RemoteRemoteCommandListener::messageReceiverName()) {
+    if (messageReceiverName == Messages::RemoteRemoteCommandListener::messageReceiverName()) {
         RELEASE_LOG_ERROR(Media, "The RemoteRemoteCommandListener object has beed destroyed");
         return true;
     }
@@ -287,9 +288,9 @@ bool GPUProcessConnection::dispatchMessage(IPC::Connection& connection, IPC::Dec
     return false;
 }
 
-bool GPUProcessConnection::dispatchSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool GPUProcessConnection::dispatchSyncMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& replyEncoder)
 {
-    return messageReceiverMap().dispatchSyncMessage(connection, decoder, replyEncoder);
+    return messageReceiverMap().dispatchSyncMessage(connection, message, replyEncoder);
 }
 
 void GPUProcessConnection::didInitialize(std::optional<GPUProcessConnectionInfo>&& info)

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
@@ -129,12 +129,12 @@ private:
 
     // IPC::Connection::Client
     void didClose(IPC::Connection&) override;
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) final;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) override;
 
-    bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool dispatchMessage(IPC::Connection&, IPC::Message&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
 
     // Messages.
     void didReceiveRemoteCommand(WebCore::PlatformMediaSession::RemoteControlCommandType, const WebCore::PlatformMediaSession::RemoteCommandArgument&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -66,7 +66,7 @@ public:
     ~RemoteGraphicsContextGLProxy();
 
     // IPC::Connection::Client overrides.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
     void didClose(IPC::Connection&) final;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) final { }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -62,7 +62,7 @@ public:
     void backingStoreWillChange();
     std::unique_ptr<WebCore::SerializedImageBuffer> sinkIntoSerializedImageBuffer() final;
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
     // Messages
     void didCreateBackend(std::optional<ImageBufferBackendHandle>);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -455,19 +455,19 @@ void RemoteRenderingBackendProxy::didPaintLayers()
     m_remoteResourceCacheProxy.didPaintLayers();
 }
 
-bool RemoteRenderingBackendProxy::dispatchMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+bool RemoteRenderingBackendProxy::dispatchMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (decoder.messageReceiverName() == Messages::RemoteImageBufferProxy::messageReceiverName()) {
-        auto imageBuffer = m_remoteResourceCacheProxy.cachedImageBuffer(RenderingResourceIdentifier { decoder.destinationID() });
+    if (message.messageReceiverName() == Messages::RemoteImageBufferProxy::messageReceiverName()) {
+        auto imageBuffer = m_remoteResourceCacheProxy.cachedImageBuffer(RenderingResourceIdentifier { message.destinationID });
         if (imageBuffer)
-            imageBuffer->didReceiveMessage(connection, decoder);
+            imageBuffer->didReceiveMessage(connection, message);
         // Messages to already removed instances are ok.
         return true;
     }
     return false;
 }
 
-bool RemoteRenderingBackendProxy::dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&)
+bool RemoteRenderingBackendProxy::dispatchSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&)
 {
     return false;
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -92,8 +92,8 @@ public:
     bool isCached(const WebCore::ImageBuffer&) const;
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) override;
 
     // Messages to be sent.
     RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormat, OptionSet<WebCore::ImageBufferOptions>);
@@ -179,8 +179,8 @@ private:
     void disconnectGPUProcess();
     void ensureGPUProcessConnection();
 
-    bool dispatchMessage(IPC::Connection&, IPC::Decoder&);
-    bool dispatchSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool dispatchMessage(IPC::Connection&, IPC::Message&);
+    bool dispatchSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
 
     // Returns std::nullopt if no update is needed or allocation failed.
     // Returns handle if that should be sent to the receiver process.

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -76,7 +76,7 @@ private:
     RemoteGPUProxy& operator=(RemoteGPUProxy&&) = delete;
 
     // IPC::Connection::Client
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
     void didClose(IPC::Connection&) final;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) final { }
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -94,7 +94,7 @@ public:
     void ref() final { RefCounted::ref(); }
     void deref() final { RefCounted::deref(); }
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     WebCore::MediaPlayerEnums::MediaEngineIdentifier remoteEngineIdentifier() const { return m_remoteEngineIdentifier; }
     WebCore::MediaPlayerIdentifier identifier() const final { return m_id; }

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h
@@ -91,7 +91,7 @@ public:
 private:
     MediaSourcePrivateRemote(GPUProcessConnection&, RemoteMediaSourceIdentifier, RemoteMediaPlayerMIMETypeCache&, const MediaPlayerPrivateRemote&, WebCore::MediaSourcePrivateClient&);
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
     void mediaSourcePrivateShuttingDown(CompletionHandler<void()>&&);
     bool isGPURunning() const { return !m_shutdown && m_gpuProcessConnection.get(); }
     void bufferedChanged(const WebCore::PlatformTimeRanges&) final;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h
@@ -59,7 +59,7 @@ private:
     explicit RemoteAudioHardwareListener(WebCore::AudioHardwareListener::Client&);
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // GPUProcessConnection::Client
     void gpuProcessConnectionDidClose(GPUProcessConnection&) final;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -62,7 +62,7 @@ private:
     IPC::Connection& ensureConnection();
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // Messages
     void configurationChanged(RemoteAudioSessionConfiguration&&);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
@@ -49,7 +49,7 @@ public:
     void addProvider(Ref<RemoteAudioSourceProvider>&&);
     void removeProvider(WebCore::MediaPlayerIdentifier);
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
 private:
     RemoteAudioSourceProviderManager();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
@@ -94,10 +94,10 @@ void RemoteCDMFactory::removeInstance(RemoteCDMInstanceIdentifier identifier)
     gpuProcessConnection().connection().send(Messages::RemoteCDMFactoryProxy::RemoveInstance(identifier), { });
 }
 
-void RemoteCDMFactory::didReceiveSessionMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void RemoteCDMFactory::didReceiveSessionMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (auto session = m_sessions.get(ObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>(decoder.destinationID())))
-        session->didReceiveMessage(connection, decoder);
+    if (auto session = m_sessions.get(ObjectIdentifier<RemoteCDMInstanceSessionIdentifierType>(message.destinationID)))
+        session->didReceiveMessage(connection, message);
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
@@ -42,6 +42,7 @@ class Settings;
 namespace IPC {
 class Connection;
 class Decoder;
+struct Message;
 }
 
 namespace WebKit {
@@ -66,7 +67,7 @@ public:
 
     void registerFactory(Vector<WebCore::CDMFactory*>&);
 
-    void didReceiveSessionMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveSessionMessage(IPC::Connection&, IPC::Message&);
 
     void addSession(RemoteCDMInstanceSession&);
     void removeSession(RemoteCDMInstanceSessionIdentifier);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.h
@@ -46,7 +46,7 @@ private:
     RemoteCDMInstance(WeakPtr<RemoteCDMFactory>&&, RemoteCDMInstanceIdentifier&&, RemoteCDMInstanceConfiguration&&);
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // Messages
     void unrequestedInitializationDataReceived(const String&, Ref<WebCore::SharedBuffer>&&);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h
@@ -55,7 +55,7 @@ private:
 #endif
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // Messages
     void updateKeyStatuses(KeyStatusVector&&);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
@@ -66,7 +66,7 @@ private:
     // GPUProcessConnection::Client.
     void gpuProcessConnectionDidClose(GPUProcessConnection&) final;
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
     void encodedDataStatusChanged(const WebCore::ImageDecoderIdentifier&, size_t frameCount, const WebCore::IntSize&, bool hasTrack);
 
     HashMap<WebCore::ImageDecoderIdentifier, WeakPtr<RemoteImageDecoderAVF>> m_remoteImageDecoders;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
@@ -162,7 +162,7 @@ void RemoteLegacyCDMSession::sendMessage(RefPtr<SharedBuffer>&& message, const S
         return;
     }
 
-    m_client->sendMessage(convertToUint8Array(WTFMove(message)).get(), destinationURL);
+    m_client->sendMessage(convertToUint8Array(message).get(), destinationURL);
 }
 
 void RemoteLegacyCDMSession::sendError(WebCore::LegacyCDMSessionClient::MediaKeyErrorCode errorCode, uint32_t systemCode)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.h
@@ -48,7 +48,7 @@ public:
     ~RemoteLegacyCDMSession();
 
     // MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     const RemoteLegacyCDMSessionIdentifier& identifier() const { return m_identifier; }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h
@@ -58,7 +58,7 @@ public:
 
     GPUProcessConnection& gpuProcessConnection();
 
-    void didReceiveSessionMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveSessionMessage(IPC::Connection&, IPC::Message&);
 
 private:
     void createDecodingConfiguration(WebCore::MediaDecodingConfiguration&&, WebCore::MediaEngineConfigurationFactory::DecodingConfigurationCallback&&);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -229,10 +229,10 @@ bool RemoteMediaPlayerManager::supportsKeySystem(MediaPlayerEnums::MediaEngineId
     return false;
 }
 
-void RemoteMediaPlayerManager::didReceivePlayerMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void RemoteMediaPlayerManager::didReceivePlayerMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (const auto& player = m_players.get(ObjectIdentifier<MediaPlayerIdentifierType>(decoder.destinationID())))
-        player->didReceiveMessage(connection, decoder);
+    if (const auto& player = m_players.get(ObjectIdentifier<MediaPlayerIdentifierType>(message.destinationID)))
+        player->didReceiveMessage(connection, message);
 }
 
 void RemoteMediaPlayerManager::setUseGPUProcess(bool useGPUProcess)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
@@ -57,7 +57,7 @@ public:
 
     GPUProcessConnection& gpuProcessConnection();
 
-    void didReceivePlayerMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceivePlayerMessage(IPC::Connection&, IPC::Message&);
 
     void deleteRemoteMediaPlayer(WebCore::MediaPlayerIdentifier);
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h
@@ -58,7 +58,7 @@ public:
 
 private:
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // GPUProcessConnection::Client
     void gpuProcessConnectionDidClose(GPUProcessConnection&) final;

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -109,7 +109,7 @@ private:
     Ref<SamplesPromise> bufferedSamplesForTrackId(TrackID) final;
     Ref<SamplesPromise> enqueuedSamplesForTrackID(TrackID) final;
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
     void sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegmentInfo&&, CompletionHandler<void(WebCore::MediaPromise::Result&&)>&&);
     void takeOwnershipOfMemory(WebKit::SharedMemory::Handle&&);
     void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&);

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h
@@ -58,7 +58,7 @@ public:
 
 private:
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // GPUProcessConnection::Client
     void gpuProcessConnectionDidClose(GPUProcessConnection&) final;

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -158,7 +158,7 @@ public:
 
     CVPixelBufferPoolRef pixelBufferPool(size_t width, size_t height, OSType);
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     void setVP9VTBSupport(bool supportVP9VTB) { m_supportVP9VTB = supportVP9VTB; }
     bool supportVP9VTB() const { return m_supportVP9VTB; }

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h
@@ -72,7 +72,7 @@ private:
     explicit RemoteVideoFrameObjectHeapProxyProcessor(GPUProcessConnection&);
     void initialize();
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // Messages
     void setSharedVideoFrameSemaphore(IPC::Semaphore&&);

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
@@ -49,7 +49,7 @@ public:
 
     SampleBufferDisplayLayerIdentifier identifier() const { return m_identifier; }
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     WebCore::LayerHostingContextID hostingContextID() const final { return m_hostingContextID.value_or(0); }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp
@@ -34,10 +34,10 @@
 namespace WebKit {
 using namespace WebCore;
 
-void SampleBufferDisplayLayerManager::didReceiveLayerMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void SampleBufferDisplayLayerManager::didReceiveLayerMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (auto* layer = m_layers.get(ObjectIdentifier<SampleBufferDisplayLayerIdentifierType>(decoder.destinationID())).get())
-        layer->didReceiveMessage(connection, decoder);
+    if (auto* layer = m_layers.get(ObjectIdentifier<SampleBufferDisplayLayerIdentifierType>(message.destinationID)).get())
+        layer->didReceiveMessage(connection, message);
 }
 
 RefPtr<WebCore::SampleBufferDisplayLayer> SampleBufferDisplayLayerManager::createLayer(WebCore::SampleBufferDisplayLayer::Client& client)

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.h
@@ -41,7 +41,7 @@ public:
     void addLayer(SampleBufferDisplayLayer&);
     void removeLayer(SampleBufferDisplayLayer&);
 
-    void didReceiveLayerMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveLayerMessage(IPC::Connection&, IPC::Message&);
     RefPtr<WebCore::SampleBufferDisplayLayer> createLayer(WebCore::SampleBufferDisplayLayer::Client&);
 
 private:

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h
@@ -59,7 +59,7 @@ public:
 
 private:
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     void didChangePosition(const WebCore::RegistrableDomain&, const WebCore::GeolocationPositionData&);
     void didFailToDeterminePosition(const WebCore::RegistrableDomain&, const String& errorMessage);

--- a/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.h
+++ b/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.h
@@ -59,7 +59,7 @@ public:
     ~RemoteWebInspectorUI();
 
     // Implemented in generated RemoteWebInspectorUIMessageReceiver.cpp
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // Called by RemoteWebInspectorUI messages
     void initialize(DebuggableInfoData&&, const String& backendCommandsURL);

--- a/Source/WebKit/WebProcess/Inspector/WebInspector.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspector.h
@@ -46,7 +46,7 @@ public:
     void updateDockingAvailability();
 
     // Implemented in generated WebInspectorMessageReceiver.cpp
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // IPC::Connection::Client
     void didClose(IPC::Connection&) override { close(); }

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.h
@@ -43,7 +43,7 @@ public:
     
 private:
     // IPC::MessageReceiver overrides.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
     
     void notifyNeedDebuggerBreak();
     

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
@@ -63,7 +63,7 @@ public:
     static void enableFrontendFeatures(WebPage&);
 
     // Implemented in generated WebInspectorUIMessageReceiver.cpp
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // IPC::Connection::Client
     void didClose(IPC::Connection&) override { /* Do nothing, the inspected page process may have crashed and may be getting replaced. */ }

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h
@@ -61,7 +61,7 @@ public:
     ~WebInspectorUIExtensionController();
 
     // Implemented in generated WebInspectorUIExtensionControllerMessageReceiver.cpp
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // WebInspectorUIExtensionController IPC messages.
     void registerExtension(const Inspector::ExtensionID&, const String& extensionBundleIdentifier, const String& displayName, CompletionHandler<void(Expected<void, Inspector::ExtensionError>)>&&);

--- a/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h
+++ b/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h
@@ -51,7 +51,7 @@ private:
     explicit RemoteMediaSessionCoordinator(WebPage&, const String&);
 
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // MessageReceivers.
     void seekSessionToTime(double, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -95,111 +95,114 @@ NetworkProcessConnection::~NetworkProcessConnection()
     m_connection->invalidate();
 }
 
-void NetworkProcessConnection::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void NetworkProcessConnection::didReceiveMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (decoder.messageReceiverName() == Messages::WebResourceLoader::messageReceiverName()) {
-        if (auto* webResourceLoader = WebProcess::singleton().webLoaderStrategy().webResourceLoaderForIdentifier(AtomicObjectIdentifier<WebCore::ResourceLoader>(decoder.destinationID())))
-            webResourceLoader->didReceiveWebResourceLoaderMessage(connection, decoder);
+    const auto messageReceiverName = message.messageReceiverName();
+
+    if (messageReceiverName == Messages::WebResourceLoader::messageReceiverName()) {
+        if (auto* webResourceLoader = WebProcess::singleton().webLoaderStrategy().webResourceLoaderForIdentifier(AtomicObjectIdentifier<WebCore::ResourceLoader>(message.destinationID)))
+            webResourceLoader->didReceiveWebResourceLoaderMessage(connection, message);
         return;
     }
-    if (decoder.messageReceiverName() == Messages::WebBroadcastChannelRegistry::messageReceiverName()) {
-        WebProcess::singleton().broadcastChannelRegistry().didReceiveMessage(connection, decoder);
+    if (messageReceiverName == Messages::WebBroadcastChannelRegistry::messageReceiverName()) {
+        WebProcess::singleton().broadcastChannelRegistry().didReceiveMessage(connection, message);
         return;
     }
-    if (decoder.messageReceiverName() == Messages::WebSocketChannel::messageReceiverName()) {
-        WebProcess::singleton().webSocketChannelManager().didReceiveMessage(connection, decoder);
+    if (messageReceiverName == Messages::WebSocketChannel::messageReceiverName()) {
+        WebProcess::singleton().webSocketChannelManager().didReceiveMessage(connection, message);
         return;
     }
-    if (decoder.messageReceiverName() == Messages::WebPage::messageReceiverName()) {
-        if (auto* webPage = WebProcess::singleton().webPage(ObjectIdentifier<PageIdentifierType>(decoder.destinationID())))
-            webPage->didReceiveWebPageMessage(connection, decoder);
+    if (messageReceiverName == Messages::WebPage::messageReceiverName()) {
+        if (auto* webPage = WebProcess::singleton().webPage(ObjectIdentifier<PageIdentifierType>(message.destinationID)))
+            webPage->didReceiveWebPageMessage(connection, message);
         return;
     }
-    if (decoder.messageReceiverName() == Messages::StorageAreaMap::messageReceiverName()) {
-        if (auto storageAreaMap = WebProcess::singleton().storageAreaMap(ObjectIdentifier<StorageAreaMapIdentifierType>(decoder.destinationID())))
-            storageAreaMap->didReceiveMessage(connection, decoder);
+    if (messageReceiverName == Messages::StorageAreaMap::messageReceiverName()) {
+        if (auto storageAreaMap = WebProcess::singleton().storageAreaMap(ObjectIdentifier<StorageAreaMapIdentifierType>(message.destinationID)))
+            storageAreaMap->didReceiveMessage(connection, message);
         return;
     }
-    if (decoder.messageReceiverName() == Messages::WebFileSystemStorageConnection::messageReceiverName()) {
-        WebProcess::singleton().fileSystemStorageConnection().didReceiveMessage(connection, decoder);
+    if (messageReceiverName == Messages::WebFileSystemStorageConnection::messageReceiverName()) {
+        WebProcess::singleton().fileSystemStorageConnection().didReceiveMessage(connection, message);
         return;
     }
-    if (decoder.messageReceiverName() == Messages::WebTransportSession::messageReceiverName()) {
-        if (auto* webTransportSession = WebProcess::singleton().webTransportSession(WebTransportSessionIdentifier(decoder.destinationID())))
-            webTransportSession->didReceiveMessage(connection, decoder);
+    if (messageReceiverName == Messages::WebTransportSession::messageReceiverName()) {
+        if (auto* webTransportSession = WebProcess::singleton().webTransportSession(WebTransportSessionIdentifier(message.destinationID)))
+            webTransportSession->didReceiveMessage(connection, message);
         return;
     }
 
 #if USE(LIBWEBRTC)
-    if (decoder.messageReceiverName() == Messages::WebRTCMonitor::messageReceiverName()) {
+    if (messageReceiverName == Messages::WebRTCMonitor::messageReceiverName()) {
         auto& network = WebProcess::singleton().libWebRTCNetwork();
         if (network.isActive())
-            network.monitor().didReceiveMessage(connection, decoder);
+            network.monitor().didReceiveMessage(connection, message);
         else
             RELEASE_LOG_ERROR(WebRTC, "Received WebRTCMonitor message while libWebRTCNetwork is not active");
         return;
     }
-    if (decoder.messageReceiverName() == Messages::WebRTCResolver::messageReceiverName()) {
+    if (messageReceiverName == Messages::WebRTCResolver::messageReceiverName()) {
         auto& network = WebProcess::singleton().libWebRTCNetwork();
         if (network.isActive())
-            network.resolver(AtomicObjectIdentifier<LibWebRTCResolverIdentifierType>(decoder.destinationID())).didReceiveMessage(connection, decoder);
+            network.resolver(AtomicObjectIdentifier<LibWebRTCResolverIdentifierType>(message.destinationID)).didReceiveMessage(connection, message);
         else
             RELEASE_LOG_ERROR(WebRTC, "Received WebRTCResolver message while libWebRTCNetwork is not active");
         return;
     }
 #endif
 
-    if (decoder.messageReceiverName() == Messages::WebIDBConnectionToServer::messageReceiverName()) {
+    if (messageReceiverName == Messages::WebIDBConnectionToServer::messageReceiverName()) {
         if (m_webIDBConnection)
-            m_webIDBConnection->didReceiveMessage(connection, decoder);
+            m_webIDBConnection->didReceiveMessage(connection, message);
         return;
     }
 
-    if (decoder.messageReceiverName() == Messages::WebSWClientConnection::messageReceiverName()) {
-        serviceWorkerConnection().didReceiveMessage(connection, decoder);
+    if (messageReceiverName == Messages::WebSWClientConnection::messageReceiverName()) {
+        serviceWorkerConnection().didReceiveMessage(connection, message);
         return;
     }
-    if (decoder.messageReceiverName() == Messages::WebSWContextManagerConnection::messageReceiverName()) {
+    if (messageReceiverName == Messages::WebSWContextManagerConnection::messageReceiverName()) {
         ASSERT(SWContextManager::singleton().connection());
         if (auto* contextManagerConnection = SWContextManager::singleton().connection())
-            static_cast<WebSWContextManagerConnection&>(*contextManagerConnection).didReceiveMessage(connection, decoder);
+            static_cast<WebSWContextManagerConnection&>(*contextManagerConnection).didReceiveMessage(connection, message);
         return;
     }
-    if (decoder.messageReceiverName() == Messages::WebSharedWorkerObjectConnection::messageReceiverName()) {
-        sharedWorkerConnection().didReceiveMessage(connection, decoder);
+    if (messageReceiverName == Messages::WebSharedWorkerObjectConnection::messageReceiverName()) {
+        sharedWorkerConnection().didReceiveMessage(connection, message);
         return;
     }
-    if (decoder.messageReceiverName() == Messages::WebSharedWorkerContextManagerConnection::messageReceiverName()) {
+    if (messageReceiverName == Messages::WebSharedWorkerContextManagerConnection::messageReceiverName()) {
         ASSERT(SharedWorkerContextManager::singleton().connection());
         if (auto* contextManagerConnection = SharedWorkerContextManager::singleton().connection())
-            static_cast<WebSharedWorkerContextManagerConnection&>(*contextManagerConnection).didReceiveMessage(connection, decoder);
+            static_cast<WebSharedWorkerContextManagerConnection&>(*contextManagerConnection).didReceiveMessage(connection, message);
         return;
     }
 
 #if ENABLE(APPLE_PAY_REMOTE_UI)
-    if (decoder.messageReceiverName() == Messages::WebPaymentCoordinator::messageReceiverName()) {
-        if (auto webPage = WebProcess::singleton().webPage(ObjectIdentifier<PageIdentifierType>(decoder.destinationID())))
-            webPage->paymentCoordinator()->didReceiveMessage(connection, decoder);
+    if (messageReceiverName == Messages::WebPaymentCoordinator::messageReceiverName()) {
+        if (auto webPage = WebProcess::singleton().webPage(ObjectIdentifier<PageIdentifierType>(message.destinationID)))
+            webPage->paymentCoordinator()->didReceiveMessage(connection, message);
         return;
     }
 #endif
 
-    didReceiveNetworkProcessConnectionMessage(connection, decoder);
+    didReceiveNetworkProcessConnectionMessage(connection, message);
 }
 
-bool NetworkProcessConnection::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool NetworkProcessConnection::didReceiveSyncMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& replyEncoder)
 {
-    if (decoder.messageReceiverName() == Messages::WebSWContextManagerConnection::messageReceiverName()) {
+    const auto messageReceiverName = message.messageReceiverName();
+    if (messageReceiverName == Messages::WebSWContextManagerConnection::messageReceiverName()) {
         ASSERT(SWContextManager::singleton().connection());
         if (auto* contextManagerConnection = SWContextManager::singleton().connection())
-            return static_cast<WebSWContextManagerConnection&>(*contextManagerConnection).didReceiveSyncMessage(connection, decoder, replyEncoder);
+            return static_cast<WebSWContextManagerConnection&>(*contextManagerConnection).didReceiveSyncMessage(connection, message, replyEncoder);
         return false;
     }
 
 #if ENABLE(APPLE_PAY_REMOTE_UI)
-    if (decoder.messageReceiverName() == Messages::WebPaymentCoordinator::messageReceiverName()) {
-        if (auto webPage = WebProcess::singleton().webPage(ObjectIdentifier<PageIdentifierType>(decoder.destinationID())))
-            return webPage->paymentCoordinator()->didReceiveSyncMessage(connection, decoder, replyEncoder);
+    if (messageReceiverName == Messages::WebPaymentCoordinator::messageReceiverName()) {
+        if (auto webPage = WebProcess::singleton().webPage(ObjectIdentifier<PageIdentifierType>(message.destinationID)))
+            return webPage->paymentCoordinator()->didReceiveSyncMessage(connection, message, replyEncoder);
         return false;
     }
 #endif

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
@@ -68,7 +68,7 @@ public:
     Ref<IPC::Connection> protectedConnection() { return m_connection; }
     IPC::Connection& connection() { return m_connection.get(); }
 
-    void didReceiveNetworkProcessConnectionMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveNetworkProcessConnectionMessage(IPC::Connection&, IPC::Message&);
 
     void writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&&);
 
@@ -98,8 +98,8 @@ private:
     NetworkProcessConnection(IPC::Connection::Identifier, WebCore::HTTPCookieAcceptPolicy);
 
     // IPC::Connection::Client
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) override;
     void didClose(IPC::Connection&) override;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) override;
 

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.h
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.h
@@ -71,7 +71,7 @@ public:
 
     ~WebResourceLoader();
 
-    void didReceiveWebResourceLoaderMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveWebResourceLoaderMessage(IPC::Connection&, IPC::Message&);
 
     WebCore::ResourceLoader* resourceLoader() const { return m_coreLoader.get(); }
 

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.h
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.h
@@ -53,7 +53,7 @@ public:
     static Ref<WebSocketChannel> create(WebPageProxyIdentifier, WebCore::Document&, WebCore::WebSocketChannelClient&);
     ~WebSocketChannel();
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
     void networkProcessCrashed();
 

--- a/Source/WebKit/WebProcess/Network/WebSocketChannelManager.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannelManager.cpp
@@ -44,11 +44,11 @@ void WebSocketChannelManager::networkProcessCrashed()
         channel->networkProcessCrashed();
 }
 
-void WebSocketChannelManager::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void WebSocketChannelManager::didReceiveMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    auto iterator = m_channels.find(AtomicObjectIdentifier<WebCore::WebSocketIdentifierType>(decoder.destinationID()));
+    auto iterator = m_channels.find(AtomicObjectIdentifier<WebCore::WebSocketIdentifierType>(message.destinationID));
     if (iterator != m_channels.end())
-        iterator->value->didReceiveMessage(connection, decoder);
+        iterator->value->didReceiveMessage(connection, message);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/WebSocketChannelManager.h
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannelManager.h
@@ -49,7 +49,7 @@ public:
     WebSocketChannelManager() = default;
 
     void networkProcessCrashed();
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
     void addChannel(WebSocketChannel&);
     void removeChannel(WebSocketChannel& channel) { m_channels.remove(channel.identifier() ); }

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.h
@@ -61,7 +61,7 @@ public:
     void deref() const final { ThreadSafeRefCounted::deref(); }
 
     // MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 private:
     WebTransportSession(WebTransportSessionIdentifier);
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
@@ -84,7 +84,7 @@ private:
 
 #if USE(LIBWEBRTC)
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 #endif
 
 #if USE(LIBWEBRTC)

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
@@ -158,7 +158,7 @@ void RTCDataChannelRemoteManager::receiveData(WebCore::RTCDataChannelIdentifier 
 
 void RTCDataChannelRemoteManager::detectError(WebCore::RTCDataChannelIdentifier handlerIdentifier, WebCore::RTCErrorDetailType detail, String&& message)
 {
-    postTaskToHandler(handlerIdentifier, [detail, message = WTFMove(message)](auto& handler) mutable {
+    postTaskToHandler(handlerIdentifier, [detail, message = message](auto& handler) mutable {
         handler.didDetectError(WebCore::RTCError::create(detail, WTFMove(message)));
     });
 }

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h
@@ -49,7 +49,7 @@ private:
     void initialize();
 
     // IPC::MessageReceiver overrides.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // Messages
     void sendData(WebCore::RTCDataChannelIdentifier, bool isRaw, const IPC::DataReference&);

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h
@@ -35,6 +35,7 @@
 namespace IPC {
 class Connection;
 class Decoder;
+struct Message;
 }
 
 namespace WebKit {
@@ -57,7 +58,7 @@ public:
     void stopUpdating();
 
     void networkProcessCrashed();
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
     bool didReceiveNetworkList() const { return m_didReceiveNetworkList; }
     const Vector<RTCNetwork>& networkList() const { return m_networkList; }

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h
@@ -34,6 +34,7 @@
 namespace IPC {
 class Connection;
 class Decoder;
+struct Message;
 }
 
 namespace WebKit {
@@ -45,7 +46,7 @@ class WebRTCResolver {
 public:
     WebRTCResolver(LibWebRTCSocketFactory&, LibWebRTCResolverIdentifier);
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
 private:
     void setResolvedAddress(const Vector<RTCNetwork::IPAddress>&);

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
@@ -77,7 +77,7 @@ private:
 
     // IPC::MessageReceiver
     // Implemented in generated WebNotificationManagerMessageReceiver.cpp
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
     
     void didShowNotification(const WTF::UUID& notificationID);
     void didClickNotification(const WTF::UUID& notificationID);

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
@@ -53,7 +53,7 @@ private:
     void stop(WebCore::RealtimeMediaSourceIdentifier);
 
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // IPC::MessageSender.
     IPC::Connection* messageSenderConnection() const final;

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -120,7 +120,7 @@ void WebSWClientConnection::postMessageToServiceWorker(ServiceWorkerIdentifier d
     for (auto& port : message.transferredPorts)
         WebMessagePortChannelProvider::singleton().messagePortSentToRemote(port.first);
 
-    send(Messages::WebSWServerConnection::PostMessageToServiceWorker { destinationIdentifier, WTFMove(message), sourceIdentifier });
+    send(Messages::WebSWServerConnection::PostMessageToServiceWorker { destinationIdentifier, message, sourceIdentifier });
 }
 
 void WebSWClientConnection::registerServiceWorkerClient(const ClientOrigin& clientOrigin, WebCore::ServiceWorkerClientData&& data, const std::optional<WebCore::ServiceWorkerRegistrationIdentifier>& controllingServiceWorkerRegistrationIdentifier, String&& userAgent)

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.h
@@ -59,7 +59,7 @@ public:
     void removeServiceWorkerRegistrationInServer(WebCore::ServiceWorkerRegistrationIdentifier) final;
 
     void disconnectedFromWebProcess();
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     bool mayHaveServiceWorkerRegisteredForOrigin(const WebCore::SecurityOriginData&) const final;
 

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
@@ -66,7 +66,7 @@ public:
     static Ref<WebSWContextManagerConnection> create(Ref<IPC::Connection>&& connection, WebCore::RegistrableDomain&& registrableDomain, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, PageGroupIdentifier pageGroupID, WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier pageID, const WebPreferencesStore& store, RemoteWorkerInitializationData&& initializationData) { return adoptRef(*new WebSWContextManagerConnection(WTFMove(connection), WTFMove(registrableDomain), serviceWorkerPageIdentifier, pageGroupID, webPageProxyID, pageID, store, WTFMove(initializationData))); }
     ~WebSWContextManagerConnection();
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     WebCore::PageIdentifier pageIdentifier() const final { return m_pageID; }
 

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.h
@@ -56,7 +56,7 @@ public:
     void postErrorToWorkerObject(WebCore::SharedWorkerIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, bool isErrorEvent) final;
     void sharedWorkerTerminated(WebCore::SharedWorkerIdentifier) final;
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
 private:
     // IPC Messages.

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.h
@@ -36,7 +36,7 @@ public:
     static Ref<WebSharedWorkerObjectConnection> create() { return adoptRef(*new WebSharedWorkerObjectConnection); }
     ~WebSharedWorkerObjectConnection();
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
 private:
     WebSharedWorkerObjectConnection();

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.h
@@ -89,7 +89,7 @@ private:
 #endif
 
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     void removeContentWorlds(const Vector<ContentWorldIdentifier>&);
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/RemoteWebLockRegistry.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/RemoteWebLockRegistry.h
@@ -48,7 +48,7 @@ public:
     void clientIsGoingAway(PAL::SessionID, const WebCore::ClientOrigin&, WebCore::ScriptExecutionContextIdentifier) final;
 
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
 private:
     explicit RemoteWebLockRegistry(WebProcess&);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.h
@@ -53,7 +53,7 @@ public:
 
     void networkProcessCrashed();
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
 private:
     WebBroadcastChannelRegistry() = default;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.h
@@ -54,7 +54,7 @@ private:
     void deviceMotionChanged(double, double, double, double, double, double, std::optional<double>, std::optional<double>, std::optional<double>) final;
 
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     WeakPtr<WebPage> m_page;
     WebCore::PageIdentifier m_pageIdentifier;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h
@@ -67,7 +67,7 @@ class WebFileSystemStorageConnection final : public WebCore::FileSystemStorageCo
 public:
     static Ref<WebFileSystemStorageConnection> create(Ref<IPC::Connection>&&);
     void connectionClosed();
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
 private:
     explicit WebFileSystemStorageConnection(Ref<IPC::Connection>&&);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
@@ -111,7 +111,7 @@ void WebMessagePortChannelProvider::postMessageToRemote(MessageWithMessagePorts&
 {
     auto iterator = m_inProcessPortMessages.find(remoteTarget);
     if (iterator != m_inProcessPortMessages.end()) {
-        iterator->value.append(WTFMove(message));
+        iterator->value.append(message);
         WebProcess::singleton().messagesAvailableForPort(remoteTarget);
         return;
     }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h
@@ -50,7 +50,7 @@ public:
     ~WebPermissionController();
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
 private:
     explicit WebPermissionController(WebProcess&);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h
@@ -40,7 +40,7 @@ public:
     ~WebScreenOrientationManager();
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
 private:
     void orientationDidChange(WebCore::ScreenOrientationType);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.h
@@ -61,7 +61,7 @@ private:
     void invalidate(WebCore::SpeechRecognitionConnectionClientIdentifier);
 
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // IPC::MessageSender.
     IPC::Connection* messageSenderConnection() const final;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h
@@ -57,7 +57,7 @@ public:
 
 private:
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     struct RangeAndOffset {
         WebCore::SimpleRange range;

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -201,7 +201,7 @@ protected:
 
 private:
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // Message handlers.
     // FIXME: These should be pure virtual.

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -103,7 +103,7 @@ public:
 
 private:
     // IPC::MessageReceiver overrides.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // Message handlers
     void wheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -398,7 +398,7 @@ void RemoteLayerTreeDrawingArea::updateRendering()
 
     Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree message(transactions);
     auto commitEncoder = makeUniqueRef<IPC::Encoder>(Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree::name(), m_identifier.toUInt64());
-    commitEncoder.get() << WTFMove(message).arguments();
+    commitEncoder.get() << message.arguments();
 
     Vector<std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher>> flushers;
     for (auto& transaction : transactions)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
@@ -83,7 +83,7 @@ private:
     void startMonitoringWheelEvents(bool clearLatchingState) final;
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
     
     // Respond to UI process changes.
     void scrollPositionChangedForNode(WebCore::ScrollingNodeID, const WebCore::FloatPoint& scrollPosition, std::optional<WebCore::FloatPoint> layoutViewportOrigin, bool syncLayerPosition, CompletionHandler<void()>&&);

--- a/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.h
+++ b/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.h
@@ -51,7 +51,7 @@ public:
 
 private:
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     // Message handlers.
     void collectGeometryForSmartMagnificationGesture(WebCore::FloatPoint gestureLocationInViewCoordinates);

--- a/Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.h
@@ -49,7 +49,7 @@ public:
 
 private:
     // IPC::MessageReceiver overrides.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     void visibleContentRectUpdate(WebCore::PageIdentifier, const VisibleContentRectUpdateInfo&);
 

--- a/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.h
+++ b/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.h
@@ -45,7 +45,7 @@ private:
     void addVisitedLink(WebCore::Page&, WebCore::SharedStringHash) override;
 
     // IPC::MessageReceiver.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     void setVisitedLinkTable(SharedMemory::Handle&&);
     void visitedLinkStateChanged(const Vector<WebCore::SharedStringHash>&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5796,39 +5796,40 @@ bool WebPage::windowAndWebPageAreFocused() const
     return isVisible() && m_page->focusController().isFocused() && m_page->focusController().isActive();
 }
 
-void WebPage::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void WebPage::didReceiveMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (decoder.messageReceiverName() == Messages::WebInspector::messageReceiverName()) {
+    const auto messageReceiverName = message.messageReceiverName();
+    if (messageReceiverName == Messages::WebInspector::messageReceiverName()) {
         if (WebInspector* inspector = this->inspector())
-            inspector->didReceiveMessage(connection, decoder);
+            inspector->didReceiveMessage(connection, message);
         return;
     }
 
-    if (decoder.messageReceiverName() == Messages::WebInspectorUI::messageReceiverName()) {
+    if (messageReceiverName == Messages::WebInspectorUI::messageReceiverName()) {
         if (WebInspectorUI* inspectorUI = this->inspectorUI())
-            inspectorUI->didReceiveMessage(connection, decoder);
+            inspectorUI->didReceiveMessage(connection, message);
         return;
     }
 
-    if (decoder.messageReceiverName() == Messages::RemoteWebInspectorUI::messageReceiverName()) {
+    if (messageReceiverName == Messages::RemoteWebInspectorUI::messageReceiverName()) {
         if (RemoteWebInspectorUI* remoteInspectorUI = this->remoteInspectorUI())
-            remoteInspectorUI->didReceiveMessage(connection, decoder);
+            remoteInspectorUI->didReceiveMessage(connection, message);
         return;
     }
 
 #if ENABLE(FULLSCREEN_API)
-    if (decoder.messageReceiverName() == Messages::WebFullScreenManager::messageReceiverName()) {
-        fullScreenManager()->didReceiveMessage(connection, decoder);
+    if (messageReceiverName == Messages::WebFullScreenManager::messageReceiverName()) {
+        fullScreenManager()->didReceiveMessage(connection, message);
         return;
     }
 #endif
 
-    didReceiveWebPageMessage(connection, decoder);
+    didReceiveWebPageMessage(connection, message);
 }
 
-bool WebPage::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool WebPage::didReceiveSyncMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& replyEncoder)
 {
-    return didReceiveSyncWebPageMessage(connection, decoder, replyEncoder);
+    return didReceiveSyncWebPageMessage(connection, message, replyEncoder);
 }
 
 #if ENABLE(ASYNC_SCROLLING)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -579,8 +579,8 @@ public:
     WebOpenPanelResultListener* activeOpenPanelResultListener() const { return m_activeOpenPanelResultListener.get(); }
     void setActiveOpenPanelResultListener(Ref<WebOpenPanelResultListener>&&);
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) override;
 
     // -- InjectedBundle methods
 #if ENABLE(CONTEXT_MENUS)
@@ -1447,7 +1447,7 @@ public:
 
     bool isSuspended() const { return m_isSuspended; }
 
-    void didReceiveWebPageMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveWebPageMessage(IPC::Connection&, IPC::Message&);
 
     template<typename T>
     SendSyncResult<T> sendSyncWithDelayedReply(T&& message, OptionSet<IPC::SendSyncOption> sendSyncOptions = { })
@@ -1704,7 +1704,7 @@ private:
 
     void getPlatformEditorStateCommon(const WebCore::LocalFrame&, EditorState&) const;
 
-    bool didReceiveSyncWebPageMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
+    bool didReceiveSyncWebPageMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&);
 
     void updateSizeForCSSDefaultViewportUnits();
     void updateSizeForCSSSmallViewportUnits();

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -911,43 +911,44 @@ void WebProcess::terminate()
     AuxiliaryProcess::terminate();
 }
 
-bool WebProcess::didReceiveSyncMessage(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& replyEncoder)
+bool WebProcess::didReceiveSyncMessage(IPC::Connection& connection, IPC::Message& message, UniqueRef<IPC::Encoder>& replyEncoder)
 {
-    if (messageReceiverMap().dispatchSyncMessage(connection, decoder, replyEncoder))
+    if (messageReceiverMap().dispatchSyncMessage(connection, message, replyEncoder))
         return true;
     return false;
 }
 
-void WebProcess::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+void WebProcess::didReceiveMessage(IPC::Connection& connection, IPC::Message& message)
 {
-    if (messageReceiverMap().dispatchMessage(connection, decoder))
+    if (messageReceiverMap().dispatchMessage(connection, message))
         return;
 
-    if (decoder.messageReceiverName() == Messages::WebProcess::messageReceiverName()) {
-        didReceiveWebProcessMessage(connection, decoder);
-        return;
-    }
-
-    if (decoder.messageReceiverName() == Messages::AuxiliaryProcess::messageReceiverName()) {
-        AuxiliaryProcess::didReceiveMessage(connection, decoder);
+    const auto messageReceiverName = message.messageReceiverName();
+    if (messageReceiverName == Messages::WebProcess::messageReceiverName()) {
+        didReceiveWebProcessMessage(connection, message);
         return;
     }
 
-    if (decoder.messageReceiverName() == Messages::WebSWContextManagerConnection::messageReceiverName()) {
+    if (messageReceiverName == Messages::AuxiliaryProcess::messageReceiverName()) {
+        AuxiliaryProcess::didReceiveMessage(connection, message);
+        return;
+    }
+
+    if (messageReceiverName == Messages::WebSWContextManagerConnection::messageReceiverName()) {
         ASSERT(SWContextManager::singleton().connection());
         if (auto* contextManagerConnection = SWContextManager::singleton().connection())
-            static_cast<WebSWContextManagerConnection&>(*contextManagerConnection).didReceiveMessage(connection, decoder);
+            static_cast<WebSWContextManagerConnection&>(*contextManagerConnection).didReceiveMessage(connection, message);
         return;
     }
 
-    if (decoder.messageReceiverName() == Messages::WebSharedWorkerContextManagerConnection::messageReceiverName()) {
+    if (messageReceiverName == Messages::WebSharedWorkerContextManagerConnection::messageReceiverName()) {
         ASSERT(SharedWorkerContextManager::singleton().connection());
         if (auto* contextManagerConnection = SharedWorkerContextManager::singleton().connection())
-            static_cast<WebSharedWorkerContextManagerConnection&>(*contextManagerConnection).didReceiveMessage(connection, decoder);
+            static_cast<WebSharedWorkerContextManagerConnection&>(*contextManagerConnection).didReceiveMessage(connection, message);
         return;
     }
 
-    LOG_ERROR("Unhandled web process message '%s' (destination: %" PRIu64 " pid: %d)", description(decoder.messageName()), decoder.destinationID(), static_cast<int>(getCurrentProcessID()));
+    LOG_ERROR("Unhandled web process message '%s' (destination: %" PRIu64 " pid: %d)", description(message.messageName()), message.destinationID, static_cast<int>(getCurrentProcessID()));
 }
 
 void WebProcess::didClose(IPC::Connection& connection)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -590,12 +590,12 @@ private:
 
     // IPC::Connection::Client
     friend class WebConnectionToUIProcess;
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) override;
     void didClose(IPC::Connection&) final;
 
     // Implemented in generated WebProcessMessageReceiver.cpp
-    void didReceiveWebProcessMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveWebProcessMessage(IPC::Connection&, IPC::Message&);
 
 #if PLATFORM(MAC)
     void scrollerStylePreferenceChanged(bool useOverlayScrollbars);

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
@@ -65,7 +65,7 @@ public:
     bool contains(const String& key);
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     const WebCore::SecurityOrigin& securityOrigin() const { return m_securityOrigin.get(); }
     StorageAreaMapIdentifier identifier() const { return m_identifier; }

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
@@ -57,7 +57,7 @@ private:
     RefPtr<XRDeviceProxy> deviceByIdentifier(XRDeviceIdentifier);
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // Message handlers
     void sessionDidEnd(XRDeviceIdentifier);

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -101,7 +101,7 @@ public:
 
     void invalidate();
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     void setUpPlaybackControlsManager(WebCore::HTMLMediaElement&);
     void clearPlaybackControlsManager();

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h
@@ -66,7 +66,7 @@ public:
     void setVideoFrameObjectHeapProxy(RefPtr<RemoteVideoFrameObjectHeapProxy>&&);
 
     // IPC::WorkQueueMessageReceiver overrides.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveMessage(IPC::Connection&, IPC::Message&);
 
 private:
     // Messages

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
@@ -54,7 +54,7 @@ public:
 
     static const char* supplementName();
 
-    void didReceiveMessageFromGPUProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
+    void didReceiveMessageFromGPUProcess(IPC::Connection& connection, IPC::Message& message) { didReceiveMessage(connection, message); }
     void setupCaptureProcesses(bool shouldCaptureAudioInUIProcess, bool shouldCaptureAudioInGPUProcess, bool shouldCaptureVideoInUIProcess, bool shouldCaptureVideoInGPUProcess, bool shouldCaptureDisplayInUIProcess, bool shouldCaptureDisplayInGPUProcess, bool shouldUseGPUProcessRemoteFrames);
 
     void addSource(Ref<RemoteRealtimeAudioSource>&&);
@@ -119,7 +119,7 @@ private:
     };
 
     // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) final;
 
     // Messages::UserMediaCaptureManager
     void sourceStopped(WebCore::RealtimeMediaSourceIdentifier, bool didFail);

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -133,7 +133,7 @@ public:
 
     bool hasVideoPlayingInPictureInPicture() const;
 
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveMessage(IPC::Connection&, IPC::Message&) override;
 
     void setupRemoteLayerHosting(WebCore::HTMLVideoElement&);
     void willRemoveLayerForID(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -87,7 +87,7 @@ public:
     void broadcastDebugMessage(const String&);
     void sendDebugMessage(const String&);
 
-    void didReceiveMessageWithReplyHandler(IPC::Decoder&, Function<void(UniqueRef<IPC::Encoder>&&)>&&) override;
+    void didReceiveMessageWithReplyHandler(IPC::Message&, Function<void(UniqueRef<IPC::Encoder>&&)>&&) override;
 
 private:
     PushClientConnection(xpc_connection_t);

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
@@ -78,7 +78,7 @@ private:
     void sendAuditToken();
 
     bool performSendWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&&) const final;
-    bool performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&&, CompletionHandler<void(IPC::Decoder*)>&&) const final;
+    bool performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IPC::Encoder>&&, CompletionHandler<void(IPC::Message*)>&&) const final;
     IPC::Connection* messageSenderConnection() const final { return nullptr; }
     uint64_t messageSenderDestinationID() const final { return 0; }
 

--- a/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp
@@ -96,8 +96,7 @@ public:
 
     std::unique_ptr<IPC::Decoder> createDecoder() const
     {
-        auto decoder = makeUnique<IPC::Decoder>(IPC::DataReference { m_impl->buffer.data(), m_impl->buffer.size() }, 0);
-        return decoder;
+        return makeUnique<IPC::Decoder>(IPC::DataReference { m_impl->buffer.data(), m_impl->buffer.size() });
     }
 
 private:

--- a/Tools/TestWebKitAPI/Tests/IPC/EventTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/EventTests.cpp
@@ -82,9 +82,9 @@ TEST_P(EventTestABBA, SerializeAndSignal)
     runLoop->dispatch([&] {
         ASSERT_TRUE(openB());
 
-        bClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
-            decoder.decode<uint64_t>();
-            auto signal = decoder.decode<IPC::Signal>();
+        bClient().setAsyncMessageHandler([&] (IPC::Message& message) -> bool {
+            message.decoder->decode<uint64_t>();
+            auto signal = message.decoder->decode<IPC::Signal>();
             signal->signal();
 
             b()->invalidate();
@@ -107,10 +107,10 @@ TEST_P(EventTestABBA, InterruptOnDestruct)
     runLoop->dispatch([&] {
         ASSERT_TRUE(openB());
 
-        bClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
-            decoder.decode<uint64_t>();
+        bClient().setAsyncMessageHandler([&] (IPC::Message& message) -> bool {
+            message.decoder->decode<uint64_t>();
             {
-                auto signal = decoder.decode<IPC::Signal>();
+                auto signal = message.decoder->decode<IPC::Signal>();
             }
 
             b()->invalidate();

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h
@@ -105,21 +105,21 @@ public:
     }
 
     // Handler returns false if the message should be just recorded.
-    void setAsyncMessageHandler(Function<bool(IPC::Decoder&)>&& handler)
+    void setAsyncMessageHandler(Function<bool(IPC::Message&)>&& handler)
     {
         m_asyncMessageHandler = WTFMove(handler);
     }
 
     // IPC::Connection::Client overrides.
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder& decoder) override
+    void didReceiveMessage(IPC::Connection&, IPC::Message& message) override
     {
-        if (m_asyncMessageHandler && m_asyncMessageHandler(decoder))
+        if (m_asyncMessageHandler && m_asyncMessageHandler(message))
             return;
-        m_messages.append({ decoder.messageName(), decoder.destinationID() });
+        m_messages.append({ message.messageName(), message.destinationID });
         m_continueWaitForMessage = true;
     }
 
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Message&, UniqueRef<IPC::Encoder>&) override
     {
         return false;
     }
@@ -139,7 +139,7 @@ private:
     std::optional<IPC::MessageName> m_didReceiveInvalidMessage;
     Deque<MessageInfo> m_messages;
     bool m_continueWaitForMessage { false };
-    Function<bool(IPC::Decoder&)> m_asyncMessageHandler;
+    Function<bool(IPC::Message&)> m_asyncMessageHandler;
 };
 
 enum class ConnectionTestDirection {

--- a/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
@@ -59,7 +59,7 @@ private:
 
             auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
             xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, testMessageFromEndpoint);
-            xpc_connection_send_message(connection, message.get());
+            xpc_connection_send_message(connection, WTFMove(message).get());
         }
     }
 };


### PR DESCRIPTION
#### a0746c8e37e8189970807d6b1e35c0862c6dea1e
<pre>
Add IPC::Message
<a href="https://bugs.webkit.org/show_bug.cgi?id=267433">https://bugs.webkit.org/show_bug.cgi?id=267433</a>

Reviewed by NOBODY (OOPS!).

This begins separating Decoder from metadata associated with the message.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::dispatchMessage):
(WebKit::GPUConnectionToWebProcess::dispatchSyncMessage):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::didReceiveMessage):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h:
* Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h:
* Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h:
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h:
(WebKit::RemoteAudioDestinationManager::didReceiveMessageFromWebProcess):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp:
(WebKit::RemoteCDMFactoryProxy::didReceiveCDMMessage):
(WebKit::RemoteCDMFactoryProxy::didReceiveCDMInstanceMessage):
(WebKit::RemoteCDMFactoryProxy::didReceiveCDMInstanceSessionMessage):
(WebKit::RemoteCDMFactoryProxy::didReceiveSyncCDMMessage):
(WebKit::RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceMessage):
(WebKit::RemoteCDMFactoryProxy::didReceiveSyncCDMInstanceSessionMessage):
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.h:
* Source/WebKit/GPUProcess/media/RemoteImageDecoderAVFProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp:
(WebKit::RemoteLegacyCDMFactoryProxy::didReceiveCDMMessage):
(WebKit::RemoteLegacyCDMFactoryProxy::didReceiveCDMSessionMessage):
(WebKit::RemoteLegacyCDMFactoryProxy::didReceiveSyncCDMMessage):
(WebKit::RemoteLegacyCDMFactoryProxy::didReceiveSyncCDMSessionMessage):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaEngineConfigurationFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp:
(WebKit::RemoteMediaPlayerManagerProxy::didReceivePlayerMessage):
(WebKit::RemoteMediaPlayerManagerProxy::didReceiveSyncPlayerMessage):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h:
(WebKit::RemoteMediaPlayerManagerProxy::didReceiveMessageFromWebProcess):
(WebKit::RemoteMediaPlayerManagerProxy::didReceiveSyncMessageFromWebProcess):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteRemoteCommandListenerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h:
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h:
(WebKit::RemoteMediaSessionHelperProxy::didReceiveMessageFromWebProcess):
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h:
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h:
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorderManager.cpp:
(WebKit::RemoteMediaRecorderManager::didReceiveRemoteMediaRecorderMessage):
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorderManager.h:
(WebKit::RemoteMediaRecorderManager::didReceiveMessageFromWebProcess):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h:
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp:
(WebKit::RemoteSampleBufferDisplayLayerManager::dispatchMessage):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.h:
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h:
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h:
* Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::didReceiveMessage):
(WebKit::NetworkConnectionToWebProcess::didReceiveSyncMessage):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::accessControlErrorForValidationHandler):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::didReceiveMessage):
(WebKit::NetworkProcess::didReceiveSyncMessage):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/NetworkSocketChannel.h:
* Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm:
(WebKit::WebPushD::Connection::performSendWithAsyncReplyWithoutUsingIPCConnection const):
* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDebugInfo.cpp:
(WebKit::PCM::DebugInfo::Message::isolatedCopy):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::postMessageToServiceWorker):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::didReceiveFetchTaskMessage):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h:
(WebKit::NetworkRTCProvider::didReceiveNetworkRTCMonitorMessage):
* Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::SyncMessageState::enqueueMatchingMessages):
(IPC::Connection::SyncMessageState::processIncomingMessage):
(IPC::Connection::SyncMessageState::dispatchMessages):
(IPC::Connection::enqueueMatchingMessagesToMessageReceiveQueue):
(IPC::Connection::dispatchMessageReceiverMessage):
(IPC::Connection::sendMessage):
(IPC::Connection::waitForMessage):
(IPC::Connection::sendSyncMessage):
(IPC::Connection::waitForSyncReply):
(IPC::Connection::processIncomingSyncReply):
(IPC::Connection::processIncomingMessage):
(IPC::Connection::hasIncomingSyncMessage):
(IPC::Connection::dispatchIncomingMessageForTesting):
(IPC::Connection::dispatchSyncMessage):
(IPC::Connection::enqueueIncomingMessage):
(IPC::Connection::dispatchNonSyncMessage):
(IPC::Connection::dispatchMessage):
(IPC::Connection::dispatchOneIncomingMessage):
(IPC::Connection::dispatchIncomingMessages):
(IPC::CompletionHandler&lt;void):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendSync):
(IPC::Connection::waitForAndDispatchImmediately):
(IPC::Connection::waitForAsyncReplyAndDispatchImmediately):
(IPC::Connection::waitForMessageForTesting):
(IPC::Connection::makeAsyncReplyHandler):
(IPC::Connection::callReply):
* Source/WebKit/Platform/IPC/Decoder.cpp:
(IPC::Decoder::Decoder):
(IPC::Decoder::unwrapForTesting):
(IPC::Decoder::shouldDispatchMessageWhenWaitingForSyncReply const): Deleted.
(IPC::Decoder::shouldUseFullySynchronousModeForTesting const): Deleted.
(IPC::Decoder::shouldMaintainOrderingWithAsyncMessages const): Deleted.
(IPC::Decoder::hasSyncMessageDeserializationFailure const): Deleted.
* Source/WebKit/Platform/IPC/Decoder.h:
(IPC::Decoder::messageName const):
(IPC::Decoder::messageReceiverName const): Deleted.
(IPC::Decoder::destinationID const): Deleted.
(IPC::Decoder::matches const): Deleted.
(IPC::Decoder::isSyncMessage const): Deleted.
(IPC::Decoder::isAllowedWhenWaitingForSyncReply const): Deleted.
(IPC::Decoder::isAllowedWhenWaitingForUnboundedSyncReply const): Deleted.
(IPC::Decoder::setIsAllowedWhenWaitingForSyncReplyOverride): Deleted.
* Source/WebKit/Platform/IPC/Encoder.cpp:
(IPC::Encoder::encodeHeader):
(IPC::Encoder::messageFlags):
(IPC::Encoder::messageFlags const):
* Source/WebKit/Platform/IPC/HandleMessage.h:
(IPC::handleMessage):
(IPC::handleMessageWithoutUsingIPCConnection):
(IPC::handleMessageSynchronous):
(IPC::handleMessageAsync):
(IPC::handleMessageAsyncWithoutUsingIPCConnection):
(IPC::handleMessageAsyncWithReplyID):
* Source/WebKit/Platform/IPC/JSIPCBinding.h:
(IPC::jsValueForDecodedArguments):
* Source/WebKit/Platform/IPC/Message.cpp: Copied from Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp.
(IPC::Message::messageName const):
(IPC::Message::matches const):
(IPC::Message::shouldDispatchMessageWhenWaitingForSyncReply const):
(IPC::Message::shouldUseFullySynchronousModeForTesting const):
(IPC::Message::shouldMaintainOrderingWithAsyncMessages const):
(IPC::Message::hasSyncMessageDeserializationFailure const):
* Source/WebKit/Platform/IPC/Message.h: Copied from Source/WebKit/Platform/IPC/MessageObserver.h.
(IPC::Message::messageReceiverName const):
(IPC::Message::isSyncMessage const):
(IPC::Message::isAllowedWhenWaitingForSyncReply const):
(IPC::Message::isAllowedWhenWaitingForUnboundedSyncReply const):
* Source/WebKit/Platform/IPC/MessageArgumentDescriptions.h:
* Source/WebKit/Platform/IPC/MessageFlags.h:
* Source/WebKit/Platform/IPC/MessageObserver.h:
* Source/WebKit/Platform/IPC/MessageReceiveQueue.h:
* Source/WebKit/Platform/IPC/MessageReceiveQueueMap.cpp:
(IPC::MessageReceiveQueueMap::isValidMessage):
(IPC::MessageReceiveQueueMap::get const):
* Source/WebKit/Platform/IPC/MessageReceiveQueueMap.h:
(IPC::MessageReceiveQueueMap::isValidMessage): Deleted.
* Source/WebKit/Platform/IPC/MessageReceiveQueues.h:
* Source/WebKit/Platform/IPC/MessageReceiver.h:
(IPC::MessageReceiver::didReceiveMessage):
(IPC::MessageReceiver::didReceiveMessageWithReplyHandler):
(IPC::MessageReceiver::didReceiveSyncMessage):
* Source/WebKit/Platform/IPC/MessageReceiverMap.cpp:
(IPC::MessageReceiverMap::dispatchMessage):
(IPC::MessageReceiverMap::dispatchSyncMessage):
* Source/WebKit/Platform/IPC/MessageReceiverMap.h:
* Source/WebKit/Platform/IPC/MessageSender.cpp:
(IPC::MessageSender::performSendWithAsyncReplyWithoutUsingIPCConnection const):
* Source/WebKit/Platform/IPC/MessageSender.h:
* Source/WebKit/Platform/IPC/MessageSenderInlines.h:
(IPC::MessageSender::sendWithAsyncReplyWithoutUsingIPCConnection const):
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::DedicatedConnectionClient::didReceiveMessage):
(IPC::StreamClientConnection::DedicatedConnectionClient::didReceiveSyncMessage):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::trySendSyncStream):
* Source/WebKit/Platform/IPC/StreamMessageReceiver.h:
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::enqueueMessage):
(IPC::StreamServerConnection::didReceiveMessage):
(IPC::StreamServerConnection::didReceiveSyncMessage):
(IPC::StreamServerConnection::dispatchStreamMessages):
(IPC::StreamServerConnection::processSetStreamDestinationID):
(IPC::StreamServerConnection::dispatchStreamMessage):
(IPC::StreamServerConnection::dispatchOutOfStreamMessage):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::Connection::receiveSourceEventHandler):
* Source/WebKit/Platform/Sources.txt:
* Source/WebKit/Scripts/webkit/messages.py:
(async_message_statement):
(sync_message_statement):
(generate_message_handler):
(generate_js_value_conversion_function):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::jsValueForArguments):
(IPC::jsValueForReplyArguments):
* Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessageReceiver.cpp:
(WebKit::TestWithCVPixelBuffer::didReceiveMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithCVPixelBuffer_SendCVPixelBuffer&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithEnabledIfMessageReceiver.cpp:
(WebKit::TestWithEnabledIf::didReceiveMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithEnabledIf_AlwaysEnabled&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithEnabledIf_OnlyEnabledIfFeatureEnabled&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessageReceiver.cpp:
(WebKit::TestWithIfMessage::didReceiveMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithIfMessage_LoadURL&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessageReceiver.cpp:
(WebKit::TestWithImageData::didReceiveMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithImageData_SendImageData&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithImageData_ReceiveImageData&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithImageData_ReceiveImageData&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessageReceiver.cpp:
(WebKit::TestWithLegacyReceiver::didReceiveTestWithLegacyReceiverMessage):
(WebKit::TestWithLegacyReceiver::didReceiveSyncTestWithLegacyReceiverMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_LoadURL&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_LoadSomething&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_TouchEvent&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_AddEvent&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_LoadSomethingElse&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_DidReceivePolicyDecision&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_Close&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_PreferencesDidChange&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_SendDoubleAndFloat&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_SendInts&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_CreatePlugin&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithLegacyReceiver_CreatePlugin&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_RunJavaScriptAlert&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithLegacyReceiver_RunJavaScriptAlert&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_GetPlugins&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithLegacyReceiver_GetPlugins&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_GetPluginProcessConnection&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithLegacyReceiver_GetPluginProcessConnection&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_TestMultipleAttributes&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithLegacyReceiver_TestMultipleAttributes&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_TestParameterAttributes&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_TemplateTest&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_SetVideoLayerID&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_DidCreateWebProcessConnection&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_InterpretKeyEvent&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithLegacyReceiver_InterpretKeyEvent&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_DeprecatedOperation&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithLegacyReceiver_ExperimentalOperation&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessageReceiver.cpp:
(WebKit::TestWithSemaphore::didReceiveMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithSemaphore_SendSemaphore&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithSemaphore_ReceiveSemaphore&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithSemaphore_ReceiveSemaphore&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessageReceiver.cpp:
(WebKit::TestWithStreamBatched::didReceiveStreamMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithStreamBatched_SendString&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessageReceiver.cpp:
(WebKit::TestWithStreamBuffer::didReceiveMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithStreamBuffer_SendStreamBuffer&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessageReceiver.cpp:
(WebKit::TestWithStream::didReceiveStreamMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithStream_SendString&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithStream_SendStringAsync&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithStream_SendStringAsync&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithStream_SendStringSync&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithStream_SendStringSync&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithStream_CallWithIdentifier&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithStream_CallWithIdentifier&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithStream_SendMachSendRight&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithStream_ReceiveMachSendRight&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithStream_ReceiveMachSendRight&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithStream_SendAndReceiveMachSendRight&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithStream_SendAndReceiveMachSendRight&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessageReceiver.cpp:
(WebKit::TestWithStreamServerConnectionHandle::didReceiveMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessageReceiver.cpp:
(WebKit::TestWithSuperclass::didReceiveMessage):
(WebKit::TestWithSuperclass::didReceiveSyncMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithSuperclass_LoadURL&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithSuperclass_TestAsyncMessage&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithSuperclass_TestAsyncMessage&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithSuperclass_TestAsyncMessageWithNoArguments&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArguments&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithSuperclass_TestAsyncMessageWithConnection&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithSuperclass_TestAsyncMessageWithConnection&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithSuperclass_TestSyncMessage&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithSuperclass_TestSyncMessage&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithSuperclass_TestSynchronousMessage&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithSuperclass_TestSynchronousMessage&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessageReceiver.cpp:
(WebKit::TestWithoutAttributes::didReceiveMessage):
(WebKit::TestWithoutAttributes::didReceiveSyncMessage):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_LoadURL&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_LoadSomething&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_TouchEvent&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_AddEvent&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_LoadSomethingElse&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_DidReceivePolicyDecision&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_Close&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_PreferencesDidChange&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_SendDoubleAndFloat&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_SendInts&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_CreatePlugin&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithoutAttributes_CreatePlugin&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_RunJavaScriptAlert&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithoutAttributes_RunJavaScriptAlert&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_GetPlugins&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithoutAttributes_GetPlugins&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_GetPluginProcessConnection&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithoutAttributes_GetPluginProcessConnection&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_TestMultipleAttributes&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithoutAttributes_TestMultipleAttributes&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_TestParameterAttributes&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_TemplateTest&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_SetVideoLayerID&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_DidCreateWebProcessConnection&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_InterpretKeyEvent&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithoutAttributes_InterpretKeyEvent&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_DeprecatedOperation&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutAttributes_ExperimentalOperation&gt;):
* Source/WebKit/Scripts/webkit/tests/TestWithoutUsingIPCConnectionMessageReceiver.cpp:
(WebKit::TestWithoutUsingIPCConnection::didReceiveMessageWithReplyHandler):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgument&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndEmptyReply&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithoutArgumentAndReplyWithArgument&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithArgument&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndEmptyReply&gt;):
(IPC::jsValueForDecodedMessage&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument&gt;):
(IPC::jsValueForDecodedMessageReply&lt;MessageName::TestWithoutUsingIPCConnection_MessageWithArgumentAndReplyWithArgument&gt;):
* Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h:
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h:
* Source/WebKit/Shared/Authentication/AuthenticationManager.h:
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/Shared/Cocoa/XPCEndpoint.mm:
(WebKit::XPCEndpoint::sendEndpointToConnection):
* Source/WebKit/Shared/IPCConnectionTester.h:
* Source/WebKit/Shared/IPCStreamTester.h:
* Source/WebKit/Shared/IPCStreamTesterProxy.h:
* Source/WebKit/Shared/IPCTester.cpp:
* Source/WebKit/Shared/IPCTester.h:
* Source/WebKit/Shared/IPCTesterReceiver.h:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h:
* Source/WebKit/Shared/WebConnection.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::dispatchMessageFromRemote):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::sendMessage):
(WebKit::AuxiliaryProcessProxy::dispatchMessage):
(WebKit::AuxiliaryProcessProxy::dispatchSyncMessage):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h:
(WebKit::UserMediaCaptureManagerProxy::didReceiveMessageFromGPUProcess):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::testIPCSharedMemory):
* Source/WebKit/UIProcess/Downloads/DownloadProxy.h:
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp:
(WebKit::WebPageDebuggable::dispatchMessageFromRemote):
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h:
* Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::didReceiveMessage):
(WebKit::NetworkProcessProxy::didReceiveSyncMessage):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::didReceiveMessage):
(WebKit::ProvisionalPageProxy::didReceiveSyncMessage):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp:
(WebKit::RemotePageDrawingAreaProxy::didReceiveMessage):
(WebKit::RemotePageDrawingAreaProxy::didReceiveSyncMessage):
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::didReceiveMessage):
(WebKit::RemotePageProxy::didReceiveSyncMessage):
* Source/WebKit/UIProcess/RemotePageProxy.h:
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSourceManager.h:
* Source/WebKit/UIProcess/SpeechRecognitionServer.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::didReceiveMessage):
(WebKit::SuspendedPageProxy::didReceiveSyncMessage):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/VisitedLinkStore.h:
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.h:
* Source/WebKit/UIProcess/WebLockRegistryProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPasteboardProxy.h:
* Source/WebKit/UIProcess/WebPermissionControllerProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::dispatchMessage):
(WebKit::WebProcessPool::dispatchSyncMessage):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shouldSendPendingMessage):
(WebKit::WebProcessProxy::didReceiveMessage):
(WebKit::WebProcessProxy::didReceiveSyncMessage):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:
* Source/WebKit/UIProcess/ios/SmartMagnificationController.h:
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.h:
* Source/WebKit/UIProcess/mac/SecItemShimProxy.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h:
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h:
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h:
* Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp:
(WebKit::MediaKeySystemPermissionRequestManager::mediaKeySystemWasDenied):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::didReceiveMessage):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::dispatchMessage):
(WebKit::GPUProcessConnection::dispatchSyncMessage):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::dispatchMessage):
(WebKit::RemoteRenderingBackendProxy::dispatchSyncMessage):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp:
(WebKit::RemoteCDMFactory::didReceiveSessionMessage):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstance.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h:
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp:
(WebKit::RemoteLegacyCDMSession::sendMessage):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::didReceivePlayerMessage):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.h:
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h:
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.cpp:
(WebKit::SampleBufferDisplayLayerManager::didReceiveLayerMessage):
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayerManager.h:
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h:
* Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.h:
* Source/WebKit/WebProcess/Inspector/WebInspector.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorInterruptDispatcher.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h:
* Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::didReceiveMessage):
(WebKit::NetworkProcessConnection::didReceiveSyncMessage):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.h:
* Source/WebKit/WebProcess/Network/WebResourceLoader.h:
* Source/WebKit/WebProcess/Network/WebSocketChannel.h:
* Source/WebKit/WebProcess/Network/WebSocketChannelManager.cpp:
(WebKit::WebSocketChannelManager::didReceiveMessage):
* Source/WebKit/WebProcess/Network/WebSocketChannelManager.h:
* Source/WebKit/WebProcess/Network/WebTransportSession.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h:
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp:
(WebKit::RTCDataChannelRemoteManager::detectError):
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h:
* Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.h:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.h:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h:
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.h:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h:
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
(WebKit::WebSWClientConnection::postMessageToServiceWorker):
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.h:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.h:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.h:
* Source/WebKit/WebProcess/WebCoreSupport/RemoteWebLockRegistry.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebDeviceOrientationUpdateProvider.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp:
(WebKit::WebMessagePortChannelProvider::postMessageToRemote):
* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::sendMessageWithJSArguments):
(WebKit::IPCTestingAPI::sendSyncMessageWithJSArguments):
(WebKit::IPCTestingAPI::waitForMessageWithJSArguments):
(WebKit::IPCTestingAPI::JSIPCConnection::didReceiveMessage):
(WebKit::IPCTestingAPI::JSIPCConnection::didReceiveSyncMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendSyncMessage):
(WebKit::IPCTestingAPI::jsResultFromReplyMessage):
(WebKit::IPCTestingAPI::JSMessageListener::didReceiveMessage):
(WebKit::IPCTestingAPI::JSMessageListener::willSendMessage):
(WebKit::IPCTestingAPI::JSMessageListener::jsDescriptionFromDecoder):
(WebKit::IPCTestingAPI::jsResultFromReplyDecoder): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.h:
* Source/WebKit/WebProcess/WebPage/ViewUpdateDispatcher.h:
* Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didReceiveMessage):
(WebKit::WebPage::didReceiveSyncMessage):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::didReceiveSyncMessage):
(WebKit::WebProcess::didReceiveMessage):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h:
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.h:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h:
(WebKit::UserMediaCaptureManager::didReceiveMessageFromGPUProcess):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/webpushd/PushClientConnection.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::connectionEventHandler):
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h:
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::performSendWithAsyncReplyWithoutUsingIPCConnection const):
* Tools/TestWebKitAPI/Tests/IPC/ArgumentCoderTests.cpp:
(TestWebKitAPI::ArgumentCoderEncoderDecoderTest&lt;IPC::StreamConnectionEncoder&gt;::createDecoder const):
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/IPC/EventTests.cpp:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(SerializationTestSender::performSendWithAsyncReplyWithoutUsingIPCConnection const):
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h:
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
* Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::WebPushXPCConnectionMessageSender::performSendWithAsyncReplyWithoutUsingIPCConnection const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0746c8e37e8189970807d6b1e35c0862c6dea1e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33703 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35634 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36318 "Hash a0746c8e for PR 22683 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30560 "Hash a0746c8e for PR 22683 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34751 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9631 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/36318 "Hash a0746c8e for PR 22683 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34180 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10520 "Found 60 new test failures: accessibility/accessibility-node-reparent.html, accessibility/ancestor-computation.html, accessibility/announcement-notification.html, accessibility/aria-checked-mixed-value.html, accessibility/aria-current-state-changed-notification.html, accessibility/aria-describedby-on-input.html, accessibility/aria-description.html, accessibility/aria-invalid.html, accessibility/aria-labelledby-targeting-slot.html, accessibility/aria-modal-with-text-crash.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30044 "815 api tests failed or timed out") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/36318 "Hash a0746c8e for PR 22683 does not build (failure)") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/33980 "Found 1 webkitpy python3 test failure: webkit.messages_unittest.GeneratedFileContentsTest.test_receiver") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9275 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html, imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html, imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor.any.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor.any.worker.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-in-worker.worker.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30055 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37641 "Hash a0746c8e for PR 22683 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30606 "Found 3102 new API test failures: TestWebKitAPI.ServiceWorkers.ParallelProcessLaunch, TestWebKitAPI.AVFoundationPref.PrefTest, TestWebKitAPI.DragAndDropTests.WebViewRemovedFromViewHierarchyDuringDrag, TestWebKitAPI.WebpagePreferences.ExtensionPageContentBlockers, TestWebKitAPI.WKWebExtensionAPIExtension.GetViewsFromBackgroundPage, TestWebKitAPI.ProcessSwap.CrossSiteBlankTargetNoOpener, TestWebKitAPI.DocumentEditingContext.CharacterRectConsistency, TestWebKitAPI.EditorStateTests.ParagraphBoundary, TestWebKitAPI.QuickLook.LegacyQuickLookContent, TestWebKitAPI.WebKit.RelaxThirdPartyCookieBlocking ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30377 "Found 60 new test failures: accessibility/content-editable-as-textarea.html, accessibility/date-input-aria-label-and-value.html, accessibility/empty-text-under-element-cached.html, accessibility/ignored-textfield-still-accessible.html, accessibility/mac/canvas.html, accessibility/mac/caret-browsing-arrow-nav.html, accessibility/mac/value-change/value-change-user-info-textarea.html, accessibility/mac/value-change/value-change-user-info-textfield.html, animations/animation-direction-normal.html, animations/animation-direction-reverse.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/37641 "Hash a0746c8e for PR 22683 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9414 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7361 "Found 60 new test failures: accessibility/ARIA-reflection.html, accessibility/accessibility-crash-focused-element-change.html, accessibility/accessibility-crash-setattribute.html, accessibility/accessibility-crash-with-dynamic-inline-content.html, accessibility/custom-elements/autocomplete.html, accessibility/custom-elements/controls-shadow.html, accessibility/custom-elements/controls.html, accessibility/custom-elements/current.html, accessibility/display-contents/aria-grid.html, accessibility/display-contents/aria-hidden.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/37641 "Hash a0746c8e for PR 22683 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11194 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/9997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->