### PR TITLE
Store fewer raw pointers in HashMaps in worker code

### DIFF
--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -59,9 +59,9 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(Worker);
 
 static Lock allWorkersLock;
-static HashMap<ScriptExecutionContextIdentifier, Worker*>& allWorkers() WTF_REQUIRES_LOCK(allWorkersLock)
+static HashMap<ScriptExecutionContextIdentifier, WeakRef<Worker, WeakPtrImplWithEventTargetData>>& allWorkers() WTF_REQUIRES_LOCK(allWorkersLock)
 {
-    static NeverDestroyed<HashMap<ScriptExecutionContextIdentifier, Worker*>> map;
+    static NeverDestroyed<HashMap<ScriptExecutionContextIdentifier, WeakRef<Worker, WeakPtrImplWithEventTargetData>>> map;
     return map;
 }
 
@@ -92,7 +92,7 @@ Worker::Worker(ScriptExecutionContext& context, JSC::RuntimeFlags runtimeFlags, 
     }
 
     Locker locker { allWorkersLock };
-    auto addResult = allWorkers().add(m_clientIdentifier, this);
+    auto addResult = allWorkers().add(m_clientIdentifier, *this);
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
 }
 

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -59,6 +59,10 @@ struct WorkerOptions;
 class Worker final : public AbstractWorker, public ActiveDOMObject, private WorkerScriptLoaderClient {
     WTF_MAKE_ISO_ALLOCATED(Worker);
 public:
+    using AbstractWorker::weakPtrFactory;
+    using AbstractWorker::WeakValueType;
+    using AbstractWorker::WeakPtrImplType;
+
     static ExceptionOr<Ref<Worker>> create(ScriptExecutionContext&, JSC::RuntimeFlags, const String& url, WorkerOptions&&);
     virtual ~Worker();
 

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -589,7 +589,7 @@ void ServiceWorkerContainer::addRegistration(ServiceWorkerRegistration& registra
     ASSERT(m_creationThread.ptr() == &Thread::current());
 
     ensureSWClientConnection().addServiceWorkerRegistrationInServer(registration.identifier());
-    m_registrations.add(registration.identifier(), &registration);
+    m_registrations.add(registration.identifier(), registration);
 }
 
 void ServiceWorkerContainer::removeRegistration(ServiceWorkerRegistration& registration)

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -154,7 +154,7 @@ private:
     HashMap<ServiceWorkerJobIdentifier, OngoingJob> m_jobMap;
 
     bool m_isStopped { false };
-    HashMap<ServiceWorkerRegistrationIdentifier, ServiceWorkerRegistration*> m_registrations;
+    HashMap<ServiceWorkerRegistrationIdentifier, WeakRef<ServiceWorkerRegistration, WeakPtrImplWithEventTargetData>> m_registrations;
 
 #if ASSERT_ENABLED
     Ref<Thread> m_creationThread { Thread::current() };

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -1389,7 +1389,7 @@ void SWServer::addContextConnection(SWServerToContextConnection& connection)
 
     ASSERT(!m_contextConnections.contains(connection.registrableDomain()));
 
-    m_contextConnections.add(connection.registrableDomain(), &connection);
+    m_contextConnections.add(connection.registrableDomain(), connection);
 
     contextConnectionCreated(connection);
 }
@@ -1407,6 +1407,11 @@ void SWServer::removeContextConnection(SWServerToContextConnection& connection)
     markAllWorkersForRegistrableDomainAsTerminated(registrableDomain);
     if (needsContextConnectionForRegistrableDomain(registrableDomain))
         createContextConnection(registrableDomain, serviceWorkerPageIdentifier);
+}
+
+SWServerToContextConnection* SWServer::contextConnectionForRegistrableDomain(const RegistrableDomain& domain)
+{
+    return m_contextConnections.get(domain);
 }
 
 void SWServer::createContextConnection(const RegistrableDomain& registrableDomain, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier)
@@ -1712,7 +1717,7 @@ void SWServer::setInspectable(ServiceWorkerIsInspectable inspectable)
 
     m_isInspectable = inspectable;
 
-    for (auto* connection : m_contextConnections.values())
+    for (auto& connection : m_contextConnections.values())
         connection->setInspectable(inspectable);
 }
 

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -235,7 +235,7 @@ public:
     WEBCORE_EXPORT void addContextConnection(SWServerToContextConnection&);
     WEBCORE_EXPORT void removeContextConnection(SWServerToContextConnection&);
 
-    SWServerToContextConnection* contextConnectionForRegistrableDomain(const RegistrableDomain& domain) { return m_contextConnections.get(domain); }
+    WEBCORE_EXPORT SWServerToContextConnection* contextConnectionForRegistrableDomain(const RegistrableDomain&);
     WEBCORE_EXPORT void createContextConnection(const RegistrableDomain&, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier);
 
     bool isImportCompleted() const { return m_importCompleted; }
@@ -354,7 +354,7 @@ private:
     bool m_isProcessTerminationDelayEnabled { true };
     Vector<CompletionHandler<void()>> m_clearCompletionCallbacks;
     Vector<Function<void(const HashSet<SecurityOriginData>&)>> m_getOriginsWithRegistrationsCallbacks;
-    HashMap<RegistrableDomain, SWServerToContextConnection*> m_contextConnections;
+    HashMap<RegistrableDomain, WeakRef<SWServerToContextConnection>> m_contextConnections;
 
     HashSet<RegistrableDomain> m_pendingConnectionDomains;
     Vector<CompletionHandler<void()>> m_importCompletedCallbacks;

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -36,6 +36,7 @@
 #include "ServiceWorkerIdentifier.h"
 #include "ServiceWorkerTypes.h"
 #include <wtf/URLHash.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -48,7 +49,7 @@ struct ServiceWorkerContextData;
 struct ServiceWorkerJobDataIdentifier;
 enum class WorkerThreadMode : bool;
 
-class SWServerToContextConnection {
+class SWServerToContextConnection: public CanMakeWeakPtr<SWServerToContextConnection> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT virtual ~SWServerToContextConnection();

--- a/Source/WebCore/workers/service/server/SWServerWorker.cpp
+++ b/Source/WebCore/workers/service/server/SWServerWorker.cpp
@@ -36,9 +36,9 @@
 
 namespace WebCore {
 
-HashMap<ServiceWorkerIdentifier, SWServerWorker*>& SWServerWorker::allWorkers()
+HashMap<ServiceWorkerIdentifier, WeakRef<SWServerWorker>>& SWServerWorker::allWorkers()
 {
-    static NeverDestroyed<HashMap<ServiceWorkerIdentifier, SWServerWorker*>> workers;
+    static NeverDestroyed<HashMap<ServiceWorkerIdentifier, WeakRef<SWServerWorker>>> workers;
     return workers;
 }
 
@@ -66,7 +66,7 @@ SWServerWorker::SWServerWorker(SWServer& server, SWServerRegistration& registrat
 {
     m_data.scriptURL.removeFragmentIdentifier();
 
-    auto result = allWorkers().add(identifier, this);
+    auto result = allWorkers().add(identifier, *this);
     ASSERT_UNUSED(result, result.isNewEntry);
 
     ASSERT(m_server->getRegistration(m_registrationKey) == &registration);

--- a/Source/WebCore/workers/service/server/SWServerWorker.h
+++ b/Source/WebCore/workers/service/server/SWServerWorker.h
@@ -54,7 +54,7 @@ struct ServiceWorkerJobDataIdentifier;
 enum class WorkerThreadMode : bool;
 enum class WorkerType : bool;
 
-class SWServerWorker : public RefCounted<SWServerWorker> {
+class SWServerWorker : public RefCounted<SWServerWorker>, public CanMakeWeakPtr<SWServerWorker> {
 public:
     template <typename... Args> static Ref<SWServerWorker> create(Args&&... args)
     {
@@ -112,7 +112,7 @@ public:
     bool isSkipWaitingFlagSet() const { return m_isSkipWaitingFlagSet; }
 
     WEBCORE_EXPORT static SWServerWorker* existingWorkerForIdentifier(ServiceWorkerIdentifier);
-    static HashMap<ServiceWorkerIdentifier, SWServerWorker*>& allWorkers();
+    static HashMap<ServiceWorkerIdentifier, WeakRef<SWServerWorker>>& allWorkers();
 
     const ServiceWorkerData& data() const { return m_data; }
     ServiceWorkerContextData contextData() const;

--- a/Source/WebCore/workers/shared/SharedWorker.cpp
+++ b/Source/WebCore/workers/shared/SharedWorker.cpp
@@ -50,10 +50,10 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(SharedWorker);
 #define SHARED_WORKER_RELEASE_LOG(fmt, ...) RELEASE_LOG(SharedWorker, "%p - [identifier=%" PUBLIC_LOG_STRING "] SharedWorker::" fmt, this, m_identifier.toString().utf8().data(), ##__VA_ARGS__)
 #define SHARED_WORKER_RELEASE_LOG_ERROR(fmt, ...) RELEASE_LOG_ERROR(SharedWorker, "%p - [identifier=%" PUBLIC_LOG_STRING "] SharedWorker::" fmt, this, m_identifier.toString().utf8().data(), ##__VA_ARGS__)
 
-static HashMap<SharedWorkerObjectIdentifier, SharedWorker*>& allSharedWorkers()
+static HashMap<SharedWorkerObjectIdentifier, WeakRef<SharedWorker, WeakPtrImplWithEventTargetData>>& allSharedWorkers()
 {
     ASSERT(isMainThread());
-    static NeverDestroyed<HashMap<SharedWorkerObjectIdentifier, SharedWorker*>> allSharedWorkers;
+    static NeverDestroyed<HashMap<SharedWorkerObjectIdentifier, WeakRef<SharedWorker, WeakPtrImplWithEventTargetData>>> allSharedWorkers;
     return allSharedWorkers;
 }
 
@@ -121,7 +121,7 @@ SharedWorker::SharedWorker(Document& document, const SharedWorkerKey& key, Ref<M
     , m_blobURLExtension({ m_key.url.protocolIsBlob() ? m_key.url : URL(), document.topOrigin().data() }) // Keep blob URL alive until the worker has finished loading.
 {
     SHARED_WORKER_RELEASE_LOG("SharedWorker:");
-    allSharedWorkers().add(m_identifier, this);
+    allSharedWorkers().add(m_identifier, *this);
 }
 
 SharedWorker::~SharedWorker()

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -53,9 +53,9 @@
 
 namespace WebCore {
 
-static HashMap<ScriptExecutionContextIdentifier, SharedWorkerThreadProxy*>& allSharedWorkerThreadProxies()
+static HashMap<ScriptExecutionContextIdentifier, WeakRef<SharedWorkerThreadProxy>>& allSharedWorkerThreadProxies()
 {
-    static MainThreadNeverDestroyed<HashMap<ScriptExecutionContextIdentifier, SharedWorkerThreadProxy*>> map;
+    static MainThreadNeverDestroyed<HashMap<ScriptExecutionContextIdentifier, WeakRef<SharedWorkerThreadProxy>>> map;
     return map;
 }
 
@@ -104,7 +104,7 @@ SharedWorkerThreadProxy::SharedWorkerThreadProxy(Ref<Page>&& page, SharedWorkerI
     , m_clientOrigin(clientOrigin)
 {
     ASSERT(!allSharedWorkerThreadProxies().contains(m_contextIdentifier));
-    allSharedWorkerThreadProxies().add(m_contextIdentifier, this);
+    allSharedWorkerThreadProxies().add(m_contextIdentifier, *this);
 
     static bool addedListener;
     if (!addedListener) {
@@ -214,7 +214,7 @@ void SharedWorkerThreadProxy::setResourceCachingDisabledByWebInspector(bool)
 
 void SharedWorkerThreadProxy::networkStateChanged(bool isOnLine)
 {
-    for (auto* proxy : allSharedWorkerThreadProxies().values())
+    for (auto& proxy : allSharedWorkerThreadProxies().values())
         proxy->notifyNetworkStateChange(isOnLine);
 }
 

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
@@ -44,7 +44,7 @@ class SharedWorkerThread;
 struct WorkerFetchResult;
 struct WorkerInitializationData;
 
-class SharedWorkerThreadProxy final : public ThreadSafeRefCounted<SharedWorkerThreadProxy>, public WorkerObjectProxy, public WorkerLoaderProxy, public WorkerDebuggerProxy, public WorkerBadgeProxy {
+class SharedWorkerThreadProxy final : public ThreadSafeRefCounted<SharedWorkerThreadProxy>, public WorkerObjectProxy, public WorkerLoaderProxy, public WorkerDebuggerProxy, public WorkerBadgeProxy, public CanMakeWeakPtr<SharedWorkerThreadProxy> {
 public:
     template<typename... Args> static Ref<SharedWorkerThreadProxy> create(Args&&... args) { return adoptRef(*new SharedWorkerThreadProxy(std::forward<Args>(args)...)); }
     WEBCORE_EXPORT ~SharedWorkerThreadProxy();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -58,6 +58,10 @@ class WebSWServerConnection;
 
 class WebSWServerToContextConnection final: public WebCore::SWServerToContextConnection, public IPC::MessageSender, public IPC::MessageReceiver {
 public:
+    using WebCore::SWServerToContextConnection::weakPtrFactory;
+    using WebCore::SWServerToContextConnection::WeakValueType;
+    using WebCore::SWServerToContextConnection::WeakPtrImplType;
+
     WebSWServerToContextConnection(NetworkConnectionToWebProcess&, WebPageProxyIdentifier, WebCore::RegistrableDomain&&, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, WebCore::SWServer&);
     ~WebSWServerToContextConnection();
 


### PR DESCRIPTION
#### e30eaca9b4f63f5540473ecd965682d0f09be5ef
<pre>
Store fewer raw pointers in HashMaps in worker code
<a href="https://bugs.webkit.org/show_bug.cgi?id=267435">https://bugs.webkit.org/show_bug.cgi?id=267435</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/workers/Worker.cpp:
(WebCore::WTF_REQUIRES_LOCK):
(WebCore::Worker::Worker):
(): Deleted.
* Source/WebCore/workers/Worker.h:
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::addRegistration):
* Source/WebCore/workers/service/ServiceWorkerContainer.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::addContextConnection):
(WebCore::SWServer::contextConnectionForRegistrableDomain):
(WebCore::SWServer::setInspectable):
* Source/WebCore/workers/service/server/SWServer.h:
(WebCore::SWServer::contextConnectionForRegistrableDomain): Deleted.
* Source/WebCore/workers/service/server/SWServerToContextConnection.h:
(WebCore::SWServerToContextConnection::identifier const): Deleted.
(WebCore::SWServerToContextConnection::shouldTerminateWhenPossible const): Deleted.
(WebCore::SWServerToContextConnection::registrableDomain const): Deleted.
(WebCore::SWServerToContextConnection::serviceWorkerPageIdentifier const): Deleted.
* Source/WebCore/workers/service/server/SWServerWorker.cpp:
(WebCore::SWServerWorker::allWorkers):
(WebCore::m_lastNavigationWasAppInitiated):
(): Deleted.
* Source/WebCore/workers/service/server/SWServerWorker.h:
* Source/WebCore/workers/shared/SharedWorker.cpp:
(WebCore::allSharedWorkers):
(): Deleted.
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::allSharedWorkerThreadProxies):
(WebCore::SharedWorkerThreadProxy::SharedWorkerThreadProxy):
(WebCore::SharedWorkerThreadProxy::networkStateChanged):
(): Deleted.
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:

Canonical link: <a href="https://commits.webkit.org/272976@main">https://commits.webkit.org/272976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4e6f9acfd3b67da799a83359063da7a7ba8e20d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36325 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30567 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29644 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9182 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9289 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37648 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30607 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35406 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7367 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33293 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11201 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10004 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4352 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->