### PR TITLE
[JetStream2] Always instantiate Float32Array in the cost array of findOptimalSegmentationInternal.

### DIFF
--- a/PerformanceTests/JetStream2/worker/async-task.js
+++ b/PerformanceTests/JetStream2/worker/async-task.js
@@ -390,7 +390,7 @@ var Statistics = new (function () {
 
     function findOptimalSegmentationInternal(cost, previousNode, values, costMatrix, segmentCount)
     {
-        cost[0] = [0]; // The cost of segmenting single value is always 0.
+        cost[0] = new Float32Array([0]); // The cost of segmenting single value is always 0.
         previousNode[0] = [-1];
         for (var segmentStart = 0; segmentStart < values.length; segmentStart++) {
             var costOfOptimalSegmentationThatEndAtCurrentStart = cost[segmentStart];

--- a/PerformanceTests/JetStream2/worker/segmentation.js
+++ b/PerformanceTests/JetStream2/worker/segmentation.js
@@ -392,7 +392,7 @@ var Statistics = new (function () {
 
     function findOptimalSegmentationInternal(cost, previousNode, values, costMatrix, segmentCount)
     {
-        cost[0] = [0]; // The cost of segmenting single value is always 0.
+        cost[0] = new Float32Array([0]); // The cost of segmenting single value is always 0.
         previousNode[0] = [-1];
         for (var segmentStart = 0; segmentStart < values.length; segmentStart++) {
             var costOfOptimalSegmentationThatEndAtCurrentStart = cost[segmentStart];


### PR DESCRIPTION
#### a66c16294ae1466bf352116ef7fe008bd22eda9c
<pre>
[JetStream2] Always instantiate Float32Array in the cost array of findOptimalSegmentationInternal.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267436">https://bugs.webkit.org/show_bug.cgi?id=267436</a>

Reviewed by Yusuke Suzuki.

The cost array in findOptimalSegmentationInternal is always intended to be an array of Float32Array
but we were forgetting to instantiate Float32Array for the very first item in the array.

This PR makes it more consistent across the array.

* PerformanceTests/JetStream2/worker/async-task.js:
(Statistics.new.findOptimalSegmentationInternal):
* PerformanceTests/JetStream2/worker/segmentation.js:
(Statistics.new.findOptimalSegmentationInternal):

Canonical link: <a href="https://commits.webkit.org/273102@main">https://commits.webkit.org/273102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48e5b46916ffd320f7ebf726640d18d8b147c33d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36329 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30568 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29645 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30050 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9184 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9279 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37652 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30383 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35409 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33300 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11202 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10005 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4401 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->