### PR TITLE
[iOS] [scroll-anchoring] Software keyboard overlaps input field on webauthn.io

### DIFF
--- a/LayoutTests/fast/scrolling/ios/scroll-anchoring-momentum-scroll.html
+++ b/LayoutTests/fast/scrolling/ios/scroll-anchoring-momentum-scroll.html
@@ -39,7 +39,7 @@ async function runTest()
     document.querySelector("#block1").style.height = "200px";
     await UIHelper.waitForTargetScrollAnimationToSettle(document.scrollingElement);
     shouldBeGreaterThan("document.scrollingElement.scrollTop", "900");
-   finishJSTest();
+    finishJSTest();
 }
 </script>
 </html>

--- a/LayoutTests/fast/scrolling/ios/scroll-anchoring-when-revealing-focused-element-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/scroll-anchoring-when-revealing-focused-element-expected.txt
@@ -1,0 +1,10 @@
+Verifies that we scroll to avoid obscuring the focused element with the software keyboard, when scroll anchoring is enabled. To run the test manually, focus the text field without a hardware keyboard attached and check that the text field is visible
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS distanceToTopOfKeyboard is > distanceToBottomOfTextField
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Scroll Anchor Element
+

--- a/LayoutTests/fast/scrolling/ios/scroll-anchoring-when-revealing-focused-element.html
+++ b/LayoutTests/fast/scrolling/ios/scroll-anchoring-when-revealing-focused-element.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true focusStartsInputSessionPolicy=allow ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<style>
+body, html {
+    width: 100%;
+    margin: 0;
+}
+
+body {
+    height: 5000px;
+}
+
+input {
+    font-size: 18px;
+    position: absolute;
+    width: 100%;
+    top: 85vh;
+    overflow-anchor: none;
+}
+
+#content-above-anchor {
+    width: 100%;
+}
+
+#scroll-anchor {
+    width: 100%;
+    height: 100px;
+    font-weight: bold;
+    line-height: 100px;
+    color: white;
+    background: tomato;
+    text-align: center;
+}
+
+#description, #console {
+    overflow-anchor: none;
+    position: absolute;
+    top: 0;
+}
+</style>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<p id="console"></p>
+<div id="content-above-anchor"></div>
+<div id="scroll-anchor">Scroll Anchor Element</div>
+<input placeholder="Focus me" />
+<script>
+jsTestIsAsync = true;
+finalContentAboveAnchorHeight = 25;
+const contentAboveAnchor = document.getElementById("content-above-anchor");
+
+addEventListener("load", async () => {
+    description("Verifies that we scroll to avoid obscuring the focused element with the software keyboard, when scroll anchoring is enabled. To run the test manually, focus the text field without a hardware keyboard attached and check that the text field is visible");
+
+    let textField = document.querySelector("input");
+    textField.addEventListener("focus", async function() {
+        while (true) {
+            const currentHeight = parseInt(getComputedStyle(contentAboveAnchor).height);
+            contentAboveAnchor.style.height = `${currentHeight + 1}px`;
+            if (currentHeight >= finalContentAboveAnchorHeight)
+                return;
+            await UIHelper.renderingUpdate();
+        }
+    }, { once: true });
+
+    document.scrollingElement.scrollTo(0, 10);
+    if (!window.testRunner)
+        return;
+
+    await UIHelper.setObscuredInsets(59, 0, 134, 0);
+    await UIHelper.setHardwareKeyboardAttached(false);
+    await UIHelper.beginInteractiveObscuredInsetsChange();
+
+    textField.focus();
+
+    await UIHelper.waitForKeyboardToShow();
+    await UIHelper.endInteractiveObscuredInsetsChange();
+
+    distanceToTopOfKeyboard = innerHeight - (await UIHelper.inputViewBounds()).height;
+    distanceToBottomOfTextField = textField.offsetTop + textField.offsetHeight - pageYOffset;
+    shouldBeGreaterThan("distanceToTopOfKeyboard", "distanceToBottomOfTextField");
+
+    textField.blur();
+    await UIHelper.waitForKeyboardToHide();
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1708,6 +1708,36 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static beginInteractiveObscuredInsetsChange()
+    {
+        if (!this.isWebKit2() || !this.isIOSFamily())
+            return Promise.resolve();
+
+        return new Promise(resolve => {
+            testRunner.runUIScript("uiController.beginInteractiveObscuredInsetsChange()", resolve);
+        });
+    }
+
+    static endInteractiveObscuredInsetsChange()
+    {
+        if (!this.isWebKit2() || !this.isIOSFamily())
+            return Promise.resolve();
+
+        return new Promise(resolve => {
+            testRunner.runUIScript("uiController.endInteractiveObscuredInsetsChange()", resolve);
+        });
+    }
+
+    static setObscuredInsets(top, right, bottom, left)
+    {
+        if (!this.isWebKit2() || !this.isIOSFamily())
+            return Promise.resolve();
+
+        return new Promise(resolve => {
+            testRunner.runUIScript(`uiController.setObscuredInsets(${top}, ${right}, ${bottom}, ${left})`, resolve);
+        });
+    }
+
     static rotateDevice(orientationName, animatedResize = false)
     {
         if (!this.isWebKit2() || !this.isIOSFamily())

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1740,6 +1740,11 @@ void LocalFrameView::setLayoutViewportOverrideRect(std::optional<LayoutRect> rec
     m_layoutViewportOverrideRect = rect;
     LayoutRect newRect = layoutViewportRect();
 
+    if (oldRect != newRect) {
+        invalidateScrollAnchoringElement();
+        updateScrollAnchoringElement();
+    }
+
     // Triggering layout on height changes is necessary to make bottom-fixed elements behave correctly.
     if (oldRect.height() != newRect.height())
         layoutTriggering = TriggerLayoutOrNot::Yes;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
@@ -86,6 +86,7 @@
 
 - (void)_setDeviceHasAGXCompilerServiceForTesting;
 
+- (void)_resetObscuredInsetsForTesting;
 - (BOOL)_hasResizeAssertion;
 - (void)_simulateSelectionStart;
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -447,6 +447,12 @@ static void dumpUIView(TextStream& ts, UIView *view)
         _page->setDeviceHasAGXCompilerServiceForTesting();
 }
 
+- (void)_resetObscuredInsetsForTesting
+{
+    if (self._haveSetObscuredInsets)
+        [self _resetObscuredInsets];
+}
+
 - (BOOL)_hasResizeAssertion
 {
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -291,6 +291,10 @@ interface UIScriptController {
 
     undefined setScrollViewKeyboardAvoidanceEnabled(boolean enabled);
 
+    undefined beginInteractiveObscuredInsetsChange();
+    undefined endInteractiveObscuredInsetsChange();
+    undefined setObscuredInsets(double top, double right, double bottom, double left);
+
     undefined becomeFirstResponder();
     undefined resignFirstResponder();
     readonly attribute boolean isPresentingModally;

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -106,6 +106,10 @@ public:
     
     virtual void setSafeAreaInsets(double, double, double, double) { notImplemented(); }
 
+    virtual void beginInteractiveObscuredInsetsChange() { notImplemented(); }
+    virtual void endInteractiveObscuredInsetsChange() { notImplemented(); }
+    virtual void setObscuredInsets(double, double, double, double) { notImplemented(); }
+
     // View Parenting and Visibility
 
     virtual void becomeFirstResponder() { notImplemented(); }

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -348,6 +348,7 @@ bool TestController::platformResetStateToConsistentValues(const TestOptions& opt
         webView.usesSafariLikeRotation = NO;
         webView.overrideSafeAreaInsets = UIEdgeInsetsZero;
         [webView _clearOverrideLayoutParameters];
+        [webView _resetObscuredInsetsForTesting];
         [webView _clearInterfaceOrientationOverride];
         [webView setAllowedMenuActions:nil];
         webView._dragInteractionPolicy = dragInteractionPolicy(options);

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -175,6 +175,10 @@ private:
     void setDidEndScrollingCallback(JSValueRef) override;
     void clearAllCallbacks() override;
 
+    void beginInteractiveObscuredInsetsChange() final;
+    void endInteractiveObscuredInsetsChange() final;
+    void setObscuredInsets(double top, double right, double bottom, double left) final;
+
     bool suppressSoftwareKeyboard() const final;
     void setSuppressSoftwareKeyboard(bool) final;
 

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -1324,6 +1324,21 @@ void UIScriptControllerIOS::setSafeAreaInsets(double top, double right, double b
     webView().overrideSafeAreaInsets = insets;
 }
 
+void UIScriptControllerIOS::beginInteractiveObscuredInsetsChange()
+{
+    [webView() _beginInteractiveObscuredInsetsChange];
+}
+
+void UIScriptControllerIOS::setObscuredInsets(double top, double right, double bottom, double left)
+{
+    webView()._obscuredInsets = UIEdgeInsetsMake(top, left, bottom, right);
+}
+
+void UIScriptControllerIOS::endInteractiveObscuredInsetsChange()
+{
+    [webView() _endInteractiveObscuredInsetsChange];
+}
+
 void UIScriptControllerIOS::beginBackSwipe(JSValueRef callback)
 {
     [webView() _beginBackSwipeForTesting];


### PR DESCRIPTION
#### 184aa40be65f3f0c946f78c44009078fc492cb2c
<pre>
[iOS] [scroll-anchoring] Software keyboard overlaps input field on webauthn.io
<a href="https://bugs.webkit.org/show_bug.cgi?id=267440">https://bugs.webkit.org/show_bug.cgi?id=267440</a>
<a href="https://rdar.apple.com/120753568">rdar://120753568</a>

Reviewed by Simon Fraser.

It&apos;s possible for scroll anchoring to cause the scroll position to jump to the previously anchored
element, when scrolling to reveal the focused element on top of the software keyboard on iOS. This
scrolling (driven by `-_zoomToCenter:atScale:animated:` in the UI process) is bookended in Safari by
calls to `-_(begin|end)InteractiveObscuredInsetsChange` while the keyboard is showing, which puts us
in unstable state and also passes `ViewportRectStability::ChangingObscuredInsetsInteractively` into
`AsyncScrollingCoordinator::reconcileScrollingState`. This, in turn, means we&apos;ll skip setting the
layout viewport override rect when syncing the scroll position.

This isn&apos;t normally an issue, because we&apos;ll eventually update the layout viewport once we end
interactive obscured inset changes. However, in the context of scroll anchoring, the fact that the
scroll position is updated but the layout viewport rect isn&apos;t (when reconciling scrolling state)
means that it&apos;s possible for the scroll anchoring controller to adjust the layout viewport rect in
the following codepath during layout:

```
void LocalFrameView::updateLayoutViewport()
{
    …
    if (m_layoutViewportOverrideRect) {
        if (currentScrollType() == ScrollType::Programmatic) {
            LOG_WITH_STREAM(Scrolling, stream &lt;&lt; &quot;computing new override layout viewport because of programmatic scrolling&quot;);
            LayoutPoint newOrigin = computeLayoutViewportOrigin(visualViewportRect(), minStableLayoutViewportOrigin(), maxStableLayoutViewportOrigin(), layoutViewport, StickToDocumentBounds);
            setLayoutViewportOverrideRect(LayoutRect(newOrigin, m_layoutViewportOverrideRect.value().size()));
        }
        layoutOrVisualViewportChanged();
        return;
    }
```

..._without_ having properly invalidated and updated the current scroll anchor. In turn, this makes
it possible for us to compare the layout viewport after accounting for the keyboard scrolling amount
against a stale `m_lastOffsetForAnchorElement`, causing the adjustment to overcompensate and jump
back up to the top of the page in the middle of the keyboard scrolling animation.

To fix this, we simply invalidate the anchor element on `ScrollAnchoringController` (along with the
stale `m_lastOffsetForAnchorElement`) when the layout viewport changes.

* LayoutTests/fast/scrolling/ios/scroll-anchoring-momentum-scroll.html:

Drive-by fix: indentation.

* LayoutTests/fast/scrolling/ios/scroll-anchoring-when-revealing-focused-element-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/scroll-anchoring-when-revealing-focused-element.html: Added.

Add a new layout test that fails without this fix. While it doesn&apos;t precisely simulate the bug as it
appears on webauthn.io, it exercises the same root cause by repeatedly triggering scroll anchoring
adjustment while scrolling to reveal the focused element with the software keyboard, all in the
scope of interactive obscured inset changes.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.beginInteractiveObscuredInsetsChange):
(window.UIHelper.endInteractiveObscuredInsetsChange):
(window.UIHelper.setObscuredInsets):

Add new `UIHelper` methods to allow layout tests to adjust the obscured insets in the same way that
Safari does when showing the software keyboard.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::setLayoutViewportOverrideRect):

See comments above for more detail.

* Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _resetObscuredInsetsForTesting]):

Add a testing hook to reset the web view&apos;s obscured insets; used when resetting state in between
layout tests.

* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::beginInteractiveObscuredInsetsChange):
(WTR::UIScriptController::endInteractiveObscuredInsetsChange):
(WTR::UIScriptController::setObscuredInsets):

Add boilerplate code to implement the new script controller helper methods.

* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::TestController::platformResetStateToConsistentValues):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::beginInteractiveObscuredInsetsChange):
(WTR::UIScriptControllerIOS::setObscuredInsets):
(WTR::UIScriptControllerIOS::endInteractiveObscuredInsetsChange):

Canonical link: <a href="https://commits.webkit.org/272957@main">https://commits.webkit.org/272957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f5479ec94db0939b633569bb71770cd121ad651

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36338 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30576 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9649 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29652 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9194 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9288 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37661 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30400 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35419 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33307 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11210 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29741 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7787 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/10013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10216 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->