### PR TITLE
Keep reducing use of downcast<>() in rendering code

### DIFF
--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -396,10 +396,8 @@ bool RenderEmbeddedObject::nodeAtPoint(const HitTestRequest& request, HitTestRes
 
 bool RenderEmbeddedObject::scroll(ScrollDirection direction, ScrollGranularity granularity, unsigned, Element**, RenderBox*, const IntPoint&)
 {
-    if (!is<PluginViewBase>(widget()))
-        return false;
-
-    return downcast<PluginViewBase>(*widget()).scroll(direction, granularity);
+    RefPtr pluginView = dynamicDowncast<PluginViewBase>(widget());
+    return pluginView && pluginView->scroll(direction, granularity);
 }
 
 bool RenderEmbeddedObject::logicalScroll(ScrollLogicalDirection direction, ScrollGranularity granularity, unsigned stepCount, Element** stopElement)
@@ -423,13 +421,13 @@ void RenderEmbeddedObject::handleUnavailablePluginIndicatorEvent(Event* event)
     if (!shouldUnavailablePluginMessageBeButton(page(), m_pluginUnavailabilityReason))
         return;
 
-    if (!is<MouseEvent>(*event))
+    RefPtr mouseEvent = dynamicDowncast<MouseEvent>(*event);
+    if (!mouseEvent)
         return;
 
-    Ref mouseEvent = downcast<MouseEvent>(*event);
     Ref element = downcast<HTMLPlugInElement>(frameOwnerElement());
     if (mouseEvent->type() == eventNames().mousedownEvent && mouseEvent->button() == MouseButton::Left) {
-        m_mouseDownWasInUnavailablePluginIndicator = isInUnavailablePluginIndicator(mouseEvent);
+        m_mouseDownWasInUnavailablePluginIndicator = isInUnavailablePluginIndicator(*mouseEvent);
         if (m_mouseDownWasInUnavailablePluginIndicator) {
             frame().eventHandler().setCapturingMouseEventsElement(element.copyRef());
             element->setIsCapturingMouseEvents(true);
@@ -443,14 +441,14 @@ void RenderEmbeddedObject::handleUnavailablePluginIndicatorEvent(Event* event)
             element->setIsCapturingMouseEvents(false);
             setUnavailablePluginIndicatorIsPressed(false);
         }
-        if (m_mouseDownWasInUnavailablePluginIndicator && isInUnavailablePluginIndicator(mouseEvent)) {
+        if (m_mouseDownWasInUnavailablePluginIndicator && isInUnavailablePluginIndicator(*mouseEvent)) {
             page().chrome().client().unavailablePluginButtonClicked(element.get(), m_pluginUnavailabilityReason);
         }
         m_mouseDownWasInUnavailablePluginIndicator = false;
         event->setDefaultHandled();
     }
     if (mouseEvent->type() == eventNames().mousemoveEvent) {
-        setUnavailablePluginIndicatorIsPressed(m_mouseDownWasInUnavailablePluginIndicator && isInUnavailablePluginIndicator(mouseEvent));
+        setUnavailablePluginIndicatorIsPressed(m_mouseDownWasInUnavailablePluginIndicator && isInUnavailablePluginIndicator(*mouseEvent));
         mouseEvent->setDefaultHandled();
     }
 }

--- a/Source/WebCore/rendering/RenderFragmentContainer.cpp
+++ b/Source/WebCore/rendering/RenderFragmentContainer.cpp
@@ -496,14 +496,12 @@ void RenderFragmentContainer::addVisualOverflowForBox(const RenderBox* box, cons
 
 LayoutRect RenderFragmentContainer::visualOverflowRectForBox(const RenderBoxModelObject& box) const
 {
-    if (is<RenderInline>(box)) {
-        const RenderInline& inlineBox = downcast<RenderInline>(box);
-        return inlineBox.linesVisualOverflowBoundingBoxInFragment(this);
-    }
+    if (CheckedPtr inlineBox = dynamicDowncast<RenderInline>(box))
+        return inlineBox->linesVisualOverflowBoundingBoxInFragment(this);
 
-    if (is<RenderBox>(box)) {
+    if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(box)) {
         RefPtr<RenderOverflow> overflow;
-        ensureOverflowForBox(&downcast<RenderBox>(box), overflow, true);
+        ensureOverflowForBox(renderBox.get(), overflow, true);
 
         ASSERT(overflow);
         return overflow->visualOverflowRect();

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -76,10 +76,10 @@ void RenderFragmentedFlow::styleDidChange(StyleDifference diff, const RenderStyl
 
 void RenderFragmentedFlow::removeFlowChildInfo(RenderElement& child)
 {
-    if (is<RenderBlockFlow>(child))
-        removeLineFragmentInfo(downcast<RenderBlockFlow>(child));
-    if (is<RenderBox>(child))
-        removeRenderBoxFragmentInfo(downcast<RenderBox>(child));
+    if (CheckedPtr blockFlow = dynamicDowncast<RenderBlockFlow>(child))
+        removeLineFragmentInfo(*blockFlow);
+    if (CheckedPtr box = dynamicDowncast<RenderBox>(child))
+        removeRenderBoxFragmentInfo(*box);
 }
 
 void RenderFragmentedFlow::removeFragmentFromThread(RenderFragmentContainer& renderFragmentContainer)
@@ -841,8 +841,8 @@ LayoutUnit RenderFragmentedFlow::offsetFromLogicalTopOfFirstFragment(const Rende
         if (!containerBlock)
             return 0;
         LayoutPoint currentBlockLocation = currentBlock->location();
-        if (is<RenderTableCell>(*currentBlock)) {
-            if (auto* section = downcast<RenderTableCell>(*currentBlock).section())
+        if (auto* cell = dynamicDowncast<RenderTableCell>(*currentBlock)) {
+            if (auto* section = cell->section())
                 currentBlockLocation.moveBy(section->location());
         }
 

--- a/Source/WebCore/rendering/RenderFrame.cpp
+++ b/Source/WebCore/rendering/RenderFrame.cpp
@@ -52,8 +52,8 @@ FrameEdgeInfo RenderFrame::edgeInfo() const
 
 void RenderFrame::updateFromElement()
 {
-    if (is<RenderFrameSet>(parent()))
-        downcast<RenderFrameSet>(*parent()).notifyFrameEdgeInfoChanged();
+    if (CheckedPtr frameSet = dynamicDowncast<RenderFrameSet>(parent()))
+        frameSet->notifyFrameEdgeInfoChanged();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderFrameSet.cpp
+++ b/Source/WebCore/rendering/RenderFrameSet.cpp
@@ -399,8 +399,8 @@ void RenderFrameSet::computeEdgeInfo()
     for (size_t r = 0; r < rows; ++r) {
         for (size_t c = 0; c < cols; ++c) {
             FrameEdgeInfo edgeInfo;
-            if (is<RenderFrameSet>(*child))
-                edgeInfo = downcast<RenderFrameSet>(*child).edgeInfo();
+            if (auto* frameSet = dynamicDowncast<RenderFrameSet>(*child))
+                edgeInfo = frameSet->edgeInfo();
             else
                 edgeInfo = downcast<RenderFrame>(*child).edgeInfo();
             fillFromEdgeInfo(edgeInfo, r, c);

--- a/Source/WebCore/rendering/RenderHighlight.cpp
+++ b/Source/WebCore/rendering/RenderHighlight.cpp
@@ -76,11 +76,11 @@ RenderObject* RenderRangeIterator::next()
 
 void RenderRangeIterator::checkForSpanner()
 {
-    if (!is<RenderMultiColumnSpannerPlaceholder>(m_current))
+    CheckedPtr placeholder = dynamicDowncast<RenderMultiColumnSpannerPlaceholder>(m_current);
+    if (!placeholder)
         return;
-    auto& placeholder = downcast<RenderMultiColumnSpannerPlaceholder>(*m_current);
-    m_spannerStack.append(&placeholder);
-    m_current = placeholder.spanner();
+    m_spannerStack.append(placeholder.get());
+    m_current = placeholder->spanner();
 }
 
 static RenderObject* rendererAfterOffset(const RenderObject& renderer, unsigned offset)

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -772,10 +772,8 @@ LayoutUnit RenderImage::minimumReplacedHeight() const
 
 RefPtr<HTMLMapElement> RenderImage::imageMap() const
 {
-    auto* imageElement = element();
-    if (!imageElement || !is<HTMLImageElement>(imageElement))
-        return nullptr;
-    return downcast<HTMLImageElement>(imageElement)->associatedMapElement();
+    auto* imageElement = dynamicDowncast<HTMLImageElement>(element());
+    return imageElement ? imageElement->associatedMapElement() : nullptr;
 }
 
 bool RenderImage::nodeAtPoint(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction hitTestAction)

--- a/Source/WebCore/rendering/RenderImageResource.cpp
+++ b/Source/WebCore/rendering/RenderImageResource.cpp
@@ -110,8 +110,8 @@ LayoutSize RenderImageResource::imageSize(float multiplier, CachedImage::SizeTyp
     if (!m_cachedImage)
         return LayoutSize();
     LayoutSize size = m_cachedImage->imageSizeForRenderer(m_renderer.get(), multiplier, type);
-    if (is<RenderImage>(m_renderer))
-        size.scale(downcast<RenderImage>(*m_renderer).imageDevicePixelRatio());
+    if (auto* renderImage = dynamicDowncast<RenderImage>(m_renderer.get()))
+        size.scale(renderImage->imageDevicePixelRatio());
     return size;
 }
 


### PR DESCRIPTION
#### cc946a62ba6acfcb8db041aafaf3fb9a1b50782e
<pre>
Keep reducing use of downcast&lt;&gt;() in rendering code
<a href="https://bugs.webkit.org/show_bug.cgi?id=267437">https://bugs.webkit.org/show_bug.cgi?id=267437</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::RenderEmbeddedObject::scroll):
(WebCore::RenderEmbeddedObject::handleUnavailablePluginIndicatorEvent):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::computeChildIntrinsicLogicalWidths const):
(WebCore::RenderFlexibleBox::cachedChildIntrinsicContentLogicalHeight const):
(WebCore::RenderFlexibleBox::computeMainAxisExtentForChild):
(WebCore::RenderFlexibleBox::constructFlexItem):
(WebCore::RenderFlexibleBox::childHasPercentHeightDescendants const):
(WebCore::RenderFlexibleBox::applyStretchAlignmentToChild):
* Source/WebCore/rendering/RenderFragmentContainer.cpp:
(WebCore::RenderFragmentContainer::visualOverflowRectForBox const):
* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
(WebCore::RenderFragmentedFlow::removeFlowChildInfo):
(WebCore::RenderFragmentedFlow::offsetFromLogicalTopOfFirstFragment const):
* Source/WebCore/rendering/RenderFrame.cpp:
(WebCore::RenderFrame::updateFromElement):
* Source/WebCore/rendering/RenderFrameSet.cpp:
(WebCore::RenderFrameSet::computeEdgeInfo):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::cacheBaselineAlignedChildren):
(WebCore::insertIntoGrid):
(WebCore::RenderGrid::layoutGridItems):
(WebCore::RenderGrid::layoutMasonryItems):
(WebCore::RenderGrid::alignSelfForChild const):
(WebCore::RenderGrid::justifySelfForChild const):
(WebCore::RenderGrid::applySubgridStretchAlignmentToChildIfNeeded):
(WebCore::RenderGrid::isSubgrid const):
(WebCore::RenderGrid::isSubgridInParentDirection const):
(WebCore::RenderGrid::gridSpanForChild const):
* Source/WebCore/rendering/RenderHighlight.cpp:
(WebCore::RenderRangeIterator::checkForSpanner):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::imageMap const):
* Source/WebCore/rendering/RenderImageResource.cpp:
(WebCore::RenderImageResource::imageSize const):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::updateStyleOfAnonymousBlockContinuations):
(WebCore::RenderInline::boundingRects const):
(WebCore::RenderInline::clippedOverflowRect const):
(WebCore::RenderInline::offsetFromContainer const):
(WebCore::RenderInline::mapLocalToContainer const):
(WebCore::RenderInline::addFocusRingRects const):
(WebCore::isEmptyInline):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::enclosingScrollableLayer const):
(WebCore::RenderLayer::overflowControlsRects const):
(WebCore::RenderLayer::paintLayerWithEffects):
(WebCore::RenderLayer::computeClipPath const):
(WebCore::RenderLayer::setupClipPath):
(WebCore::RenderLayer::calculateClipRects const):

Canonical link: <a href="https://commits.webkit.org/272975@main">https://commits.webkit.org/272975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9684acfdcab6f904c0a60117a9e84c172b37e220

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36339 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30577 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29654 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30067 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9196 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9290 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37662 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30608 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35420 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7375 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33308 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11211 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10014 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4351 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10217 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->