### PR TITLE
Web Inspector: When there is a UA override on Safari, choosing a UA override in Develop Menu is not working

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3006,7 +3006,7 @@ String FrameLoader::userAgent(const URL& url) const
 
     InspectorInstrumentation::applyUserAgentOverride(protectedFrame(), userAgent);
 
-    if (userAgent.isEmpty())
+    if (userAgent.isEmpty() || m_client->hasCustomUserAgent())
         userAgent = m_client->userAgent(url);
     
     verifyUserAgent(userAgent);

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -258,6 +258,7 @@ public:
     virtual void updateCachedDocumentLoader(DocumentLoader&) = 0;
     virtual void setTitle(const StringWithDirection&, const URL&) = 0;
 
+    virtual bool hasCustomUserAgent() const { return false; }
     virtual String userAgent(const URL&) const = 0;
 
     virtual String overrideContentSecurityPolicy() const { return String(); }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4547,7 +4547,7 @@ void WebPageProxy::didSuspendAfterProcessSwap()
     ASSERT_NOT_REACHED();
 }
 
-void WebPageProxy::setUserAgent(String&& userAgent)
+void WebPageProxy::setUserAgent(String&& userAgent, IsCustomUserAgent isCustomUserAgent)
 {
     if (m_userAgent == userAgent)
         return;
@@ -4560,6 +4560,7 @@ void WebPageProxy::setUserAgent(String&& userAgent)
     if (!hasRunningProcess())
         return;
     send(Messages::WebPage::SetUserAgent(m_userAgent));
+    send(Messages::WebPage::SetHasCustomUserAgent(isCustomUserAgent == IsCustomUserAgent::Yes));
 }
 
 void WebPageProxy::setApplicationNameForUserAgent(const String& applicationName)
@@ -4586,7 +4587,7 @@ void WebPageProxy::setCustomUserAgent(const String& customUserAgent)
         return;
     }
 
-    setUserAgent(String { m_customUserAgent });
+    setUserAgent(String { m_customUserAgent }, IsCustomUserAgent::Yes);
 }
 
 void WebPageProxy::resumeActiveDOMObjectsAndAnimations()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2346,7 +2346,8 @@ private:
     void resetState(ResetStateReason);
     void resetStateAfterProcessExited(ProcessTerminationReason);
 
-    void setUserAgent(String&&);
+    enum class IsCustomUserAgent : bool { No, Yes };
+    void setUserAgent(String&&, IsCustomUserAgent = IsCustomUserAgent::No);
 
     // IPC::MessageSender
     bool sendMessage(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>) final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1454,6 +1454,13 @@ void WebLocalFrameLoaderClient::setTitle(const StringWithDirection& title, const
     webPage->send(Messages::WebPageProxy::DidUpdateHistoryTitle(title.string, url.string(), m_frame->frameID()));
 }
 
+bool WebLocalFrameLoaderClient::hasCustomUserAgent() const
+{
+    if (RefPtr webPage = m_frame->page())
+        return webPage->hasCustomUserAgent();
+    return false;
+}
+
 String WebLocalFrameLoaderClient::userAgent(const URL& url) const
 {
     RefPtr webPage = m_frame->page();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -202,7 +202,8 @@ private:
     void updateCachedDocumentLoader(WebCore::DocumentLoader&) final;
 
     void setTitle(const WebCore::StringWithDirection&, const URL&) final;
-    
+
+    bool hasCustomUserAgent() const final;
     String userAgent(const URL&) const final;
 
     String overrideContentSecurityPolicy() const final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4030,6 +4030,11 @@ void WebPage::setUserAgent(const String& userAgent)
         m_page->userAgentChanged();
 }
 
+void WebPage::setHasCustomUserAgent(bool hasCustomUserAgent)
+{
+    m_hasCustomUserAgent = hasCustomUserAgent;
+}
+
 void WebPage::suspendActiveDOMObjectsAndAnimations()
 {
     m_page->suspendActiveDOMObjectsAndAnimations();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -537,6 +537,7 @@ public:
     void show();
     String userAgent(const URL&) const;
     String platformUserAgent(const URL&) const;
+    bool hasCustomUserAgent() const { return m_hasCustomUserAgent; }
     WebCore::KeyboardUIMode keyboardUIMode();
 
     bool hoverSupportedByPrimaryPointingDevice() const;
@@ -1907,6 +1908,7 @@ private:
 #endif
 
     void setUserAgent(const String&);
+    void setHasCustomUserAgent(bool);
     void setCustomTextEncodingName(const String&);
     void suspendActiveDOMObjectsAndAnimations();
     void resumeActiveDOMObjectsAndAnimations();
@@ -2180,6 +2182,7 @@ private:
     RefPtr<WebPageGroupProxy> m_pageGroup;
 
     String m_userAgent;
+    bool m_hasCustomUserAgent { false };
 
     DrawingAreaType m_drawingAreaType;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -264,6 +264,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     PreferencesDidChangeDuringDOMPrintOperation(struct WebKit::WebPreferencesStore store) AllowedWhenWaitingForSyncReplyDuringUnboundedIPC
 
     SetUserAgent(String userAgent)
+    SetHasCustomUserAgent(bool hasCustomUserAgent)
     SetCustomTextEncodingName(String encodingName)
 
     SuspendActiveDOMObjectsAndAnimations()


### PR DESCRIPTION
#### 65e9ef262a036ce065c7ccb94a9e6bf4ae057529
<pre>
Web Inspector: When there is a UA override on Safari, choosing a UA override in Develop Menu is not working
<a href="https://bugs.webkit.org/show_bug.cgi?id=265575">https://bugs.webkit.org/show_bug.cgi?id=265575</a>
<a href="https://rdar.apple.com/118981832">rdar://118981832</a>

Reviewed by Wenson Hsieh.

`FrameLoader` does not consult `WebLocalFrameLoaderClient` for the UA
string if the client app adjusts the UA for a website using the
site-specific quirk mechanism, culprit to this line:

```
    // From FrameLoader::userAgent()
    if (userAgent.isEmpty())
        userAgent = m_client-&gt;userAgent(url);
```

Unfortunately, `WebLocalFrameLoaderClient` consults the `WebPage` for
the UA string, so that is the only source of truth for any potential UA
overrides, such as the UA override from Safari&apos;s develop menu.

This commit introduces a bit more fidelity in the UA resolution logic in
`FrameLoader::userAgent`, such that we initially respect any
site-specific quirks, but also take into account the possibility that
the client has overriden the user agent. We relay this information down
to `FrameLoader` by introducing an IPC message to the WebPage which
tells it that a custom UA string has been set. If that is the case, we
respect `WebLocalFrameLoaderClient` for the UA string even in the
presence of a site-specific quirk.

This commit also adds a new test case to exercise this change in the
`WebpagePreferences` API test suite, as well as refactoring some code in
said test file for more sane UA constants management.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::userAgent const):
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setUserAgent):
(WebKit::WebPageProxy::setCustomUserAgent):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::hasCustomUserAgent const):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setHasCustomUserAgent):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::hasCustomUserAgent const):
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:
(-[CustomUserAgentDelegate _webView:decidePolicyForNavigationAction:preferences:userInfo:decisionHandler:]):
(-[CustomJavaScriptUserAgentDelegate webView:decidePolicyForNavigationAction:preferences:decisionHandler:]):

Canonical link: <a href="https://commits.webkit.org/273001@main">https://commits.webkit.org/273001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad1bffc9e4ac7ed1476417366186fa4010b047d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33848 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36470 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34902 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29737 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30176 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9293 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9398 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30197 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37782 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30724 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35510 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7464 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33400 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11315 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7812 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/10104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10329 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->