### PR TITLE
Remove PropertyCascade::PropertyType::VariableReference

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -496,10 +496,6 @@ bool RenderStyle::inheritedEqual(const RenderStyle& other) const
         && m_rareInheritedData == other.m_rareInheritedData;
 }
 
-bool RenderStyle::inheritedCustomPropertiesEqual(const RenderStyle& other) const
-{
-    return m_rareInheritedData->customProperties == other.m_rareInheritedData->customProperties;
-}
 
 bool RenderStyle::fastPathInheritedEqual(const RenderStyle& other) const
 {

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1724,7 +1724,6 @@ public:
     const AtomString& hyphenString() const;
 
     bool inheritedEqual(const RenderStyle&) const;
-    bool inheritedCustomPropertiesEqual(const RenderStyle&) const;
     bool fastPathInheritedEqual(const RenderStyle&) const;
     bool nonFastPathInheritedEqual(const RenderStyle&) const;
 

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -100,15 +100,15 @@ bool MatchedDeclarationsCache::Entry::isUsableAfterHighPriorityProperties(const 
     return CSSPrimitiveValue::equalForLengthResolution(style, *renderStyle);
 }
 
-unsigned MatchedDeclarationsCache::computeHash(const MatchResult& matchResult)
+unsigned MatchedDeclarationsCache::computeHash(const MatchResult& matchResult, const StyleCustomPropertyData& inheritedCustomProperties)
 {
     if (!matchResult.isCacheable)
         return 0;
 
-    return WTF::computeHash(matchResult);
+    return WTF::computeHash(matchResult, &inheritedCustomProperties);
 }
 
-const MatchedDeclarationsCache::Entry* MatchedDeclarationsCache::find(unsigned hash, const MatchResult& matchResult)
+const MatchedDeclarationsCache::Entry* MatchedDeclarationsCache::find(unsigned hash, const MatchResult& matchResult, const StyleCustomPropertyData& inheritedCustomProperties)
 {
     if (!hash)
         return nullptr;
@@ -119,6 +119,9 @@ const MatchedDeclarationsCache::Entry* MatchedDeclarationsCache::find(unsigned h
 
     auto& entry = it->value;
     if (matchResult != entry.matchResult)
+        return nullptr;
+
+    if (&entry.parentRenderStyle->inheritedCustomProperties() != &inheritedCustomProperties)
         return nullptr;
 
     return &entry;

--- a/Source/WebCore/style/MatchedDeclarationsCache.h
+++ b/Source/WebCore/style/MatchedDeclarationsCache.h
@@ -43,7 +43,7 @@ public:
     ~MatchedDeclarationsCache();
 
     static bool isCacheable(const Element&, const RenderStyle&, const RenderStyle& parentStyle);
-    static unsigned computeHash(const MatchResult&);
+    static unsigned computeHash(const MatchResult&, const StyleCustomPropertyData& inheritedCustomProperties);
 
     struct Entry {
         MatchResult matchResult;
@@ -54,7 +54,7 @@ public:
         bool isUsableAfterHighPriorityProperties(const RenderStyle&) const;
     };
 
-    const Entry* find(unsigned hash, const MatchResult&);
+    const Entry* find(unsigned hash, const MatchResult&, const StyleCustomPropertyData& inheritedCustomProperties);
     void add(const RenderStyle&, const RenderStyle& parentStyle, const RenderStyle* userAgentAppearanceStyle, unsigned hash, const MatchResult&);
     void remove(unsigned hash);
 

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -241,11 +241,6 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
             if (propertyID >= firstDeferredProperty && m_lastIndexForDeferred)
                 return true;
 
-            if (m_includedProperties.contains(PropertyType::VariableReference)) {
-                if (current.value()->hasVariableReferences())
-                    return true;
-            }
-
             return false;
         }();
 

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -43,9 +43,8 @@ public:
         NonInherited = 1 << 0,
         Inherited = 1 << 1,
         ExplicitlyInherited = 1 << 2,
-        VariableReference = 1 << 3,
-        AfterAnimation = 1 << 4,
-        AfterTransition = 1 << 5
+        AfterAnimation = 1 << 3,
+        AfterTransition = 1 << 4
     };
     static constexpr OptionSet<PropertyType> allProperties() { return { PropertyType::NonInherited,  PropertyType::Inherited }; }
 


### PR DESCRIPTION
#### 2f6959fb1324843c1d0d16153ff806cf57d899e8
<pre>
Remove PropertyCascade::PropertyType::VariableReference
<a href="https://bugs.webkit.org/show_bug.cgi?id=267447">https://bugs.webkit.org/show_bug.cgi?id=267447</a>
<a href="https://rdar.apple.com/120892359">rdar://120892359</a>

Reviewed by Ryosuke Niwa.

We have an optimization where the cascade only applies properties containing variable references.
This doesn&apos;t seem to be helpful in practice so remove it.

* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::inheritedCustomPropertiesEqual const): Deleted.

This was only needed for this optimization.

* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::computeHash):
(WebCore::Style::MatchedDeclarationsCache::find):
* Source/WebCore/style/MatchedDeclarationsCache.h:
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::addMatch):
* Source/WebCore/style/PropertyCascade.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::applyMatchedProperties):

Canonical link: <a href="https://commits.webkit.org/272963@main">https://commits.webkit.org/272963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2312bfd7add7ccb26f76a9d43c7a73c148df7511

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36357 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30594 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9667 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29670 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30084 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9212 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9309 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37680 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30628 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35437 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9449 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33327 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11228 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7790 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->