### PR TITLE
HTMLTagNames.in should list MathML and SVG elements with hyphen in its name

### DIFF
--- a/Source/WebCore/html/HTMLTagNames.in
+++ b/Source/WebCore/html/HTMLTagNames.in
@@ -142,3 +142,12 @@ video wrapperOnlyIfMediaIsAvailable, conditional=VIDEO, constructorNeedsCreatedB
 wbr interfaceName=HTMLWBRElement, JSInterfaceName=HTMLElement
 xmp interfaceName=HTMLPreElement
 noscript interfaceName=HTMLElement
+
+annotation-xml interfaceName=HTMLUnknownElement
+color-profile interfaceName=HTMLUnknownElement
+font-face interfaceName=HTMLUnknownElement
+font-face-format interfaceName=HTMLUnknownElement
+font-face-name interfaceName=HTMLUnknownElement
+font-face-src interfaceName=HTMLUnknownElement
+font-face-uri interfaceName=HTMLUnknownElement
+missing-glyph interfaceName=HTMLUnknownElement


### PR DESCRIPTION
#### 0993d23875f17c5b4dd76b392dcf7c80b907cdf6
<pre>
HTMLTagNames.in should list MathML and SVG elements with hyphen in its name
<a href="https://bugs.webkit.org/show_bug.cgi?id=267444">https://bugs.webkit.org/show_bug.cgi?id=267444</a>

Reviewed by Antti Koivisto.

This PR enlists MathML and SVG elements with hyphen in its name in HTMLTagNames.in so that
HTMLElementFactory::createKnownElement will create HTMLUnknownElement for those elements.

* Source/WebCore/dom/Document.cpp:
(WebCore::createUpgradeCandidateElement):
(WebCore::validateCustomElementNameWithoutCheckingStandardElementNames): Extracted from
Document::validateCustomElementName.
(WebCore::isStandardElementName): Ditto.
(WebCore::Document::validateCustomElementName):
* Source/WebCore/html/HTMLTagNames.in:

Canonical link: <a href="https://commits.webkit.org/272980@main">https://commits.webkit.org/272980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/137ddc48d7fd283d0f5bc0f8187c8d9d387b7f32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33747 "15 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36366 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30600 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29679 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9221 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37688 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30636 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35444 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33334 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11234 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10037 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4356 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->