### PR TITLE
REGRESSION(272844@main): [ wk2 ] imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-GC.https.html is consistently failing.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-GC.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-GC.https.html
@@ -40,15 +40,11 @@ promise_test(async t => {
     const start = performance.now();
     const width = destVideo.videoWidth;
     const height = destVideo.videoHeight;
-    const resizeEvent = new Promise(r => destVideo.onresize = r);
     while (destVideo.videoWidth == width && destVideo.videoHeight == height) {
       if (performance.now() - start > 5000) {
         throw new Error("Timeout waiting for video size change");
       }
-      await Promise.race([
-        resizeEvent,
-        new Promise(r => setTimeout(r, 50)),
-      ]);
+      await new Promise(r => t.step_timeout(r, 50));
     }
   };
 

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -884,5 +884,3 @@ webkit.org/b/262157 imported/w3c/web-platform-tests/css/css-contain/content-visi
 webkit.org/b/261314 [ Debug ] fast/mediastream/captureStream/canvas3d.html [ Pass Failure ]
 
 webkit.org/b/265700 webrtc/multi-video.html [ Pass Failure ]
-
-webkit.org/b/267355 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-GC.https.html [ Pass Failure ]


### PR DESCRIPTION
#### 87194aeb6d38425a3f7f3da731272c39008010dd
<pre>
REGRESSION(272844@main): [ wk2 ] imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-GC.https.html is consistently failing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267355">https://bugs.webkit.org/show_bug.cgi?id=267355</a>
<a href="https://rdar.apple.com/120798707">rdar://120798707</a>

Reviewed by Eric Carlson.

The previous try to fix the flakiness was not taking into account the case of resize event firing to handle the transition from (0,0) to (160,160).
If it fires while onVideoChange is running, onVideoChange would spin as resizeEvent promise would not be recomputed and stay resolved.

We simply remove the resize event check and only rely on the setTimeout check which has the same frequency as the video frame emition by the canvas.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-GC.https.html:
* LayoutTests/platform/wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/272990@main">https://commits.webkit.org/272990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63a0641ad1fdb503f3f91019baeb473d5fffe13a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36375 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30606 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29685 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30101 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9227 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9326 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37695 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30644 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30439 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35450 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33340 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29777 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7807 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10045 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10250 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->