### PR TITLE
[iOS] REGRESSION (266293@main): Video automatically pauses in fullscreen when youtube.com is open in multiple tabs

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -96,8 +96,11 @@ void RemoteAudioSessionProxy::tryToSetActive(bool active, SetActiveCompletion&& 
 {
     auto success = audioSessionManager().tryToSetActiveForProcess(*this, active);
     bool hasActiveChanged = success && m_active != active;
-    if (success)
+    if (success) {
         m_active = active;
+        if (m_active)
+            m_isInterrupted = false;
+    }
 
     completion(success);
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -138,30 +138,42 @@ void RemoteAudioSessionProxyManager::updatePreferredBufferSizeForProcess()
         AudioSession::sharedSession().setPreferredBufferSize(preferredBufferSize);
 }
 
+bool RemoteAudioSessionProxyManager::hasOtherActiveProxyThan(RemoteAudioSessionProxy& proxyToExclude)
+{
+    for (auto& proxy : m_proxies) {
+        if (proxy.isActive() && &proxy != &proxyToExclude)
+            return true;
+    }
+    return false;
+}
+
+bool RemoteAudioSessionProxyManager::hasActiveNotInterruptedProxy()
+{
+    for (auto& proxy : m_proxies) {
+        if (proxy.isActive() && !proxy.isInterrupted())
+            return true;
+    }
+    return false;
+}
+
 bool RemoteAudioSessionProxyManager::tryToSetActiveForProcess(RemoteAudioSessionProxy& proxy, bool active)
 {
     ASSERT(m_proxies.contains(proxy));
 
-    size_t activeProxyCount { 0 };
-    for (auto& otherProxy : m_proxies) {
-        if (otherProxy.isActive() && !otherProxy.isInterrupted())
-            ++activeProxyCount;
-    }
-
-    if (!active && activeProxyCount > 1) {
-        // This proxy wants to de-activate, but other proxies are still
-        // active. No-op, and return deactivation was sucessful.
-        return true;
-    }
-
     if (!active) {
+        if (hasOtherActiveProxyThan(proxy)) {
+            // This proxy wants to de-activate, but other proxies are still
+            // active. No-op, and return deactivation was sucessful.
+            return true;
+        }
+
         // This proxy wants to de-activate, and is the last remaining active
         // proxy. Deactivate the session, and return whether that deactivation
-        // was sucessful;
+        // was sucessful.
         return AudioSession::sharedSession().tryToSetActive(false);
     }
 
-    if (active && !activeProxyCount) {
+    if (!hasActiveNotInterruptedProxy()) {
         // This proxy and only this proxy wants to become active. Activate
         // the session, and return whether that activation was successful.
         return AudioSession::sharedSession().tryToSetActive(active);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
@@ -73,6 +73,9 @@ private:
     void sampleRateDidChange(const WebCore::AudioSession&) final;
     void configurationDidChange(const WebCore::AudioSession&);
 
+    bool hasOtherActiveProxyThan(RemoteAudioSessionProxy& proxyToExclude);
+    bool hasActiveNotInterruptedProxy();
+
     GPUProcess& m_gpuProcess;
     WeakHashSet<RemoteAudioSessionProxy> m_proxies;
 };


### PR DESCRIPTION
#### 7c93c4a37091a51eae4033f2421fb0aebd36aff4
<pre>
[iOS] REGRESSION (266293@main): Video automatically pauses in fullscreen when youtube.com is open in multiple tabs
<a href="https://bugs.webkit.org/show_bug.cgi?id=267451">https://bugs.webkit.org/show_bug.cgi?id=267451</a>
<a href="https://rdar.apple.com/118461093">rdar://118461093</a>

Reviewed by Eric Carlson.

As part of 266293@main, we changed the computation of active audio session proxies to include whether interrupted or not.
This ensured that we were activating the shared audio session in case where some audio sessions were active BUT interrupted.

This computation broke the deactivation of the shared audio session as we would end up in the case of two active audio session proxies,
but one of them, the one we want to deactivate, is interrupted.
In that case, we would wrongly deactivate the shared audio session, even though the second active audio session wants to continue playing audio.
We update this computation to only deactivate the shared audio session if there is no other active audio session proxy than the proxy we want to deactivate.

We introduce hasOtherActiveProxyThan and hasActiveNotInterruptedProxy routines to make the code clearer.
We update RemoteAudioSessionProxy::tryToSetActive to ensure its interrupted state is set back to false when activated.
This could happen in case the shared audio session is already enabled and we would just interrupt other audio session proxies.

Manually tested.

* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::tryToSetActive):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::hasOtherActiveProxyThan):
(WebKit::RemoteAudioSessionProxyManager::hasActiveNotInterruptedProxy):
(WebKit::RemoteAudioSessionProxyManager::tryToSetActiveForProcess):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h:

Canonical link: <a href="https://commits.webkit.org/273032@main">https://commits.webkit.org/273032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bec0e3d050857ca8f0ad94f3028f2e6f024ed60e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36384 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30614 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9691 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29693 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9236 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9337 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37704 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35459 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33351 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11251 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7834 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10052 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10259 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->