### PR TITLE
Move approved WebGL extensions out of draft

### DIFF
--- a/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-default-expected.txt
+++ b/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-default-expected.txt
@@ -2,7 +2,7 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 22 PASS, 0 FAIL
+TEST COMPLETE: 18 PASS, 0 FAIL
 
 
 PASS webgl:EXT_blend_func_extended: Supported
@@ -11,14 +11,10 @@ PASS webgl:EXT_texture_mirror_clamp_to_edge: Supported
 PASS webgl:EXT_texture_mirror_clamp_to_edge: Has object.
 PASS webgl2:EXT_blend_func_extended: Supported
 PASS webgl2:EXT_blend_func_extended: Has object.
-PASS webgl2:EXT_conservative_depth: Supported
-PASS webgl2:EXT_conservative_depth: Has object.
 PASS webgl2:EXT_render_snorm: Supported
 PASS webgl2:EXT_render_snorm: Has object.
 PASS webgl2:EXT_texture_mirror_clamp_to_edge: Supported
 PASS webgl2:EXT_texture_mirror_clamp_to_edge: Has object.
-PASS webgl2:NV_shader_noperspective_interpolation: Supported
-PASS webgl2:NV_shader_noperspective_interpolation: Has object.
 PASS webgl2:OES_sample_variables: Supported
 PASS webgl2:OES_sample_variables: Has object.
 PASS webgl2:OES_shader_multisample_interpolation: Not supported

--- a/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-on-expected.txt
+++ b/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-on-expected.txt
@@ -2,7 +2,7 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 22 PASS, 0 FAIL
+TEST COMPLETE: 18 PASS, 0 FAIL
 
 
 PASS webgl:EXT_blend_func_extended: Supported
@@ -11,14 +11,10 @@ PASS webgl:EXT_texture_mirror_clamp_to_edge: Supported
 PASS webgl:EXT_texture_mirror_clamp_to_edge: Has object.
 PASS webgl2:EXT_blend_func_extended: Supported
 PASS webgl2:EXT_blend_func_extended: Has object.
-PASS webgl2:EXT_conservative_depth: Supported
-PASS webgl2:EXT_conservative_depth: Has object.
 PASS webgl2:EXT_render_snorm: Supported
 PASS webgl2:EXT_render_snorm: Has object.
 PASS webgl2:EXT_texture_mirror_clamp_to_edge: Supported
 PASS webgl2:EXT_texture_mirror_clamp_to_edge: Has object.
-PASS webgl2:NV_shader_noperspective_interpolation: Supported
-PASS webgl2:NV_shader_noperspective_interpolation: Has object.
 PASS webgl2:OES_sample_variables: Supported
 PASS webgl2:OES_sample_variables: Has object.
 PASS webgl2:OES_shader_multisample_interpolation: Not supported

--- a/LayoutTests/webgl/resources/webgl-draft-extensions-flag.js
+++ b/LayoutTests/webgl/resources/webgl-draft-extensions-flag.js
@@ -9,10 +9,8 @@ let currentDraftExtensions = {
     ],
     "webgl2" : [
         "EXT_blend_func_extended",
-        "EXT_conservative_depth",
         "EXT_render_snorm",
         "EXT_texture_mirror_clamp_to_edge",
-        "NV_shader_noperspective_interpolation",
         "OES_sample_variables",
         "OES_shader_multisample_interpolation",
         "WEBGL_draw_instanced_base_vertex_base_instance",

--- a/LayoutTests/webgl/webgl-draft-extensions-flag-default-expected.txt
+++ b/LayoutTests/webgl/webgl-draft-extensions-flag-default-expected.txt
@@ -2,7 +2,7 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 25 PASS, 0 FAIL
+TEST COMPLETE: 21 PASS, 0 FAIL
 
 
 PASS webgl:EXT_blend_func_extended: Supported
@@ -11,14 +11,10 @@ PASS webgl:EXT_texture_mirror_clamp_to_edge: Supported
 PASS webgl:EXT_texture_mirror_clamp_to_edge: Has object.
 PASS webgl2:EXT_blend_func_extended: Supported
 PASS webgl2:EXT_blend_func_extended: Has object.
-PASS webgl2:EXT_conservative_depth: Supported
-PASS webgl2:EXT_conservative_depth: Has object.
 PASS webgl2:EXT_render_snorm: Supported
 PASS webgl2:EXT_render_snorm: Has object.
 PASS webgl2:EXT_texture_mirror_clamp_to_edge: Supported
 PASS webgl2:EXT_texture_mirror_clamp_to_edge: Has object.
-PASS webgl2:NV_shader_noperspective_interpolation: Supported
-PASS webgl2:NV_shader_noperspective_interpolation: Has object.
 PASS webgl2:OES_sample_variables: Supported
 PASS webgl2:OES_sample_variables: Has object.
 PASS webgl2:OES_shader_multisample_interpolation: Supported

--- a/LayoutTests/webgl/webgl-draft-extensions-flag-off-expected.txt
+++ b/LayoutTests/webgl/webgl-draft-extensions-flag-off-expected.txt
@@ -2,16 +2,14 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 13 PASS, 0 FAIL
+TEST COMPLETE: 11 PASS, 0 FAIL
 
 
 PASS webgl:EXT_blend_func_extended: Not supported
 PASS webgl:EXT_texture_mirror_clamp_to_edge: Not supported
 PASS webgl2:EXT_blend_func_extended: Not supported
-PASS webgl2:EXT_conservative_depth: Not supported
 PASS webgl2:EXT_render_snorm: Not supported
 PASS webgl2:EXT_texture_mirror_clamp_to_edge: Not supported
-PASS webgl2:NV_shader_noperspective_interpolation: Not supported
 PASS webgl2:OES_sample_variables: Not supported
 PASS webgl2:OES_shader_multisample_interpolation: Not supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Not supported

--- a/LayoutTests/webgl/webgl-draft-extensions-flag-on-expected.txt
+++ b/LayoutTests/webgl/webgl-draft-extensions-flag-on-expected.txt
@@ -2,7 +2,7 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 25 PASS, 0 FAIL
+TEST COMPLETE: 21 PASS, 0 FAIL
 
 
 PASS webgl:EXT_blend_func_extended: Supported
@@ -11,14 +11,10 @@ PASS webgl:EXT_texture_mirror_clamp_to_edge: Supported
 PASS webgl:EXT_texture_mirror_clamp_to_edge: Has object.
 PASS webgl2:EXT_blend_func_extended: Supported
 PASS webgl2:EXT_blend_func_extended: Has object.
-PASS webgl2:EXT_conservative_depth: Supported
-PASS webgl2:EXT_conservative_depth: Has object.
 PASS webgl2:EXT_render_snorm: Supported
 PASS webgl2:EXT_render_snorm: Has object.
 PASS webgl2:EXT_texture_mirror_clamp_to_edge: Supported
 PASS webgl2:EXT_texture_mirror_clamp_to_edge: Has object.
-PASS webgl2:NV_shader_noperspective_interpolation: Supported
-PASS webgl2:NV_shader_noperspective_interpolation: Has object.
 PASS webgl2:OES_sample_variables: Supported
 PASS webgl2:OES_sample_variables: Has object.
 PASS webgl2:OES_shader_multisample_interpolation: Supported

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -2598,7 +2598,7 @@ std::optional<WebGLExtensionAny> WebGL2RenderingContext::getExtension(const Stri
     ENABLE_IF_REQUESTED(EXTClipControl, m_extClipControl, "EXT_clip_control"_s, EXTClipControl::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTColorBufferFloat, m_extColorBufferFloat, "EXT_color_buffer_float"_s, EXTColorBufferFloat::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTColorBufferHalfFloat, m_extColorBufferHalfFloat, "EXT_color_buffer_half_float"_s, EXTColorBufferHalfFloat::supported(*m_context));
-    ENABLE_IF_REQUESTED(EXTConservativeDepth, m_extConservativeDepth, "EXT_conservative_depth"_s, EXTConservativeDepth::supported(*m_context) && enableDraftExtensions);
+    ENABLE_IF_REQUESTED(EXTConservativeDepth, m_extConservativeDepth, "EXT_conservative_depth"_s, EXTConservativeDepth::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTDepthClamp, m_extDepthClamp, "EXT_depth_clamp"_s, EXTDepthClamp::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTDisjointTimerQueryWebGL2, m_extDisjointTimerQueryWebGL2, "EXT_disjoint_timer_query_webgl2"_s, EXTDisjointTimerQueryWebGL2::supported(*m_context) && scriptExecutionContext()->settingsValues().webGLTimerQueriesEnabled);
     ENABLE_IF_REQUESTED(EXTFloatBlend, m_extFloatBlend, "EXT_float_blend"_s, EXTFloatBlend::supported(*m_context));
@@ -2610,7 +2610,7 @@ std::optional<WebGLExtensionAny> WebGL2RenderingContext::getExtension(const Stri
     ENABLE_IF_REQUESTED(EXTTextureMirrorClampToEdge, m_extTextureMirrorClampToEdge, "EXT_texture_mirror_clamp_to_edge"_s, EXTTextureMirrorClampToEdge::supported(*m_context) && enableDraftExtensions);
     ENABLE_IF_REQUESTED(EXTTextureNorm16, m_extTextureNorm16, "EXT_texture_norm16"_s, EXTTextureNorm16::supported(*m_context));
     ENABLE_IF_REQUESTED(KHRParallelShaderCompile, m_khrParallelShaderCompile, "KHR_parallel_shader_compile"_s, KHRParallelShaderCompile::supported(*m_context));
-    ENABLE_IF_REQUESTED(NVShaderNoperspectiveInterpolation, m_nvShaderNoperspectiveInterpolation, "NV_shader_noperspective_interpolation"_s, NVShaderNoperspectiveInterpolation::supported(*m_context) && enableDraftExtensions);
+    ENABLE_IF_REQUESTED(NVShaderNoperspectiveInterpolation, m_nvShaderNoperspectiveInterpolation, "NV_shader_noperspective_interpolation"_s, NVShaderNoperspectiveInterpolation::supported(*m_context));
     ENABLE_IF_REQUESTED(OESDrawBuffersIndexed, m_oesDrawBuffersIndexed, "OES_draw_buffers_indexed"_s, OESDrawBuffersIndexed::supported(*m_context));
     ENABLE_IF_REQUESTED(OESSampleVariables, m_oesSampleVariables, "OES_sample_variables"_s, OESSampleVariables::supported(*m_context) && enableDraftExtensions);
     ENABLE_IF_REQUESTED(OESShaderMultisampleInterpolation, m_oesShaderMultisampleInterpolation, "OES_shader_multisample_interpolation"_s, OESShaderMultisampleInterpolation::supported(*m_context) && enableDraftExtensions);
@@ -2653,7 +2653,7 @@ std::optional<Vector<String>> WebGL2RenderingContext::getSupportedExtensions()
     APPEND_IF_SUPPORTED("EXT_clip_control", EXTClipControl::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_color_buffer_float", EXTColorBufferFloat::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_color_buffer_half_float", EXTColorBufferHalfFloat::supported(*m_context))
-    APPEND_IF_SUPPORTED("EXT_conservative_depth", EXTConservativeDepth::supported(*m_context) && enableDraftExtensions)
+    APPEND_IF_SUPPORTED("EXT_conservative_depth", EXTConservativeDepth::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_depth_clamp", EXTDepthClamp::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_disjoint_timer_query_webgl2", EXTDisjointTimerQueryWebGL2::supported(*m_context) && scriptExecutionContext()->settingsValues().webGLTimerQueriesEnabled)
     APPEND_IF_SUPPORTED("EXT_float_blend", EXTFloatBlend::supported(*m_context))
@@ -2665,7 +2665,7 @@ std::optional<Vector<String>> WebGL2RenderingContext::getSupportedExtensions()
     APPEND_IF_SUPPORTED("EXT_texture_mirror_clamp_to_edge", EXTTextureMirrorClampToEdge::supported(*m_context) && enableDraftExtensions)
     APPEND_IF_SUPPORTED("EXT_texture_norm16", EXTTextureNorm16::supported(*m_context))
     APPEND_IF_SUPPORTED("KHR_parallel_shader_compile", KHRParallelShaderCompile::supported(*m_context))
-    APPEND_IF_SUPPORTED("NV_shader_noperspective_interpolation", NVShaderNoperspectiveInterpolation::supported(*m_context) && enableDraftExtensions)
+    APPEND_IF_SUPPORTED("NV_shader_noperspective_interpolation", NVShaderNoperspectiveInterpolation::supported(*m_context))
     APPEND_IF_SUPPORTED("OES_draw_buffers_indexed", OESDrawBuffersIndexed::supported(*m_context))
     APPEND_IF_SUPPORTED("OES_sample_variables", OESSampleVariables::supported(*m_context) && enableDraftExtensions)
     APPEND_IF_SUPPORTED("OES_shader_multisample_interpolation", OESShaderMultisampleInterpolation::supported(*m_context) && enableDraftExtensions)


### PR DESCRIPTION
#### eb38b24329a233f91222a309ea39f67b8c4b7307
<pre>
Move approved WebGL extensions out of draft
<a href="https://bugs.webkit.org/show_bug.cgi?id=267453">https://bugs.webkit.org/show_bug.cgi?id=267453</a>

Reviewed by Kimmo Kinnunen.

Enabled support for the following approved extensions:
* EXT_conservative_depth
* NV_shader_noperspective_interpolation

* LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-default-expected.txt:
* LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-on-expected.txt:
* LayoutTests/webgl/resources/webgl-draft-extensions-flag.js:
* LayoutTests/webgl/webgl-draft-extensions-flag-default-expected.txt:
* LayoutTests/webgl/webgl-draft-extensions-flag-off-expected.txt:
* LayoutTests/webgl/webgl-draft-extensions-flag-on-expected.txt:
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::getExtension):
(WebCore::WebGL2RenderingContext::getSupportedExtensions):

Canonical link: <a href="https://commits.webkit.org/272979@main">https://commits.webkit.org/272979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aed0de81bb8cfd1371acb27aa3028b70d7825fd7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36388 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30618 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29696 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30111 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9239 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37708 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30659 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35462 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33354 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11255 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7803 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10263 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->