### PR TITLE
Add a MediaStreamTrackProcessor skeleton and implementation

### DIFF
--- a/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker-expected.txt
@@ -4,4 +4,5 @@ PASS Writable gets closed when writing a closed VideoFrame
 PASS Writable gets closed when writing something else than a VideoFrame
 PASS Track settings are updated according enqueued video frames
 PASS Track gets muted based on VideoTrackGenerator.muted
+PASS VideoTrackGenerator to MediaStreamTrackProcessor
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.js
@@ -7,6 +7,7 @@ idl_test(
   ['dom', 'html'],
   idl_array => {
     idl_array.add_objects({
+      MediaStreamTrackProcessor: ['new MediaStreamTrackProcessor({ track: new VideoTrackGenerator() })'],
       VideoTrackGenerator: ['new VideoTrackGenerator()'],
     });
   }

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.worker-expected.txt
@@ -1,13 +1,16 @@
 
 PASS idl_test setup
 PASS idl_test validation
-FAIL MediaStreamTrackProcessor interface: existence and properties of interface object assert_own_property: self does not have own property "MediaStreamTrackProcessor" expected property "MediaStreamTrackProcessor" missing
-FAIL MediaStreamTrackProcessor interface object length assert_own_property: self does not have own property "MediaStreamTrackProcessor" expected property "MediaStreamTrackProcessor" missing
-FAIL MediaStreamTrackProcessor interface object name assert_own_property: self does not have own property "MediaStreamTrackProcessor" expected property "MediaStreamTrackProcessor" missing
-FAIL MediaStreamTrackProcessor interface: existence and properties of interface prototype object assert_own_property: self does not have own property "MediaStreamTrackProcessor" expected property "MediaStreamTrackProcessor" missing
-FAIL MediaStreamTrackProcessor interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "MediaStreamTrackProcessor" expected property "MediaStreamTrackProcessor" missing
-FAIL MediaStreamTrackProcessor interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "MediaStreamTrackProcessor" expected property "MediaStreamTrackProcessor" missing
-FAIL MediaStreamTrackProcessor interface: attribute readable assert_own_property: self does not have own property "MediaStreamTrackProcessor" expected property "MediaStreamTrackProcessor" missing
+PASS MediaStreamTrackProcessor interface: existence and properties of interface object
+PASS MediaStreamTrackProcessor interface object length
+PASS MediaStreamTrackProcessor interface object name
+PASS MediaStreamTrackProcessor interface: existence and properties of interface prototype object
+PASS MediaStreamTrackProcessor interface: existence and properties of interface prototype object's "constructor" property
+PASS MediaStreamTrackProcessor interface: existence and properties of interface prototype object's @@unscopables property
+FAIL MediaStreamTrackProcessor interface: attribute readable assert_equals: setter must be function for PutForwards, Replaceable, or non-readonly attributes expected "function" but got "undefined"
+FAIL MediaStreamTrackProcessor must be primary interface of new MediaStreamTrackProcessor({ track: new VideoTrackGenerator() }) assert_equals: Unexpected exception when evaluating object expected null but got object "TypeError: Type error"
+FAIL Stringification of new MediaStreamTrackProcessor({ track: new VideoTrackGenerator() }) assert_equals: Unexpected exception when evaluating object expected null but got object "TypeError: Type error"
+FAIL MediaStreamTrackProcessor interface: new MediaStreamTrackProcessor({ track: new VideoTrackGenerator() }) must inherit property "readable" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "TypeError: Type error"
 PASS VideoTrackGenerator interface: existence and properties of interface object
 PASS VideoTrackGenerator interface object length
 PASS VideoTrackGenerator interface object name

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -449,6 +449,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/mediastream/MediaStream.idl
     Modules/mediastream/MediaStreamTrack.idl
     Modules/mediastream/MediaStreamTrackEvent.idl
+    Modules/mediastream/MediaStreamTrackProcessor.idl
     Modules/mediastream/MediaTrackCapabilities.idl
     Modules/mediastream/MediaTrackConstraints.idl
     Modules/mediastream/MediaTrackSupportedConstraints.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -574,6 +574,7 @@ $(PROJECT_DIR)/Modules/mediastream/MediaSettingsRange.idl
 $(PROJECT_DIR)/Modules/mediastream/MediaStream.idl
 $(PROJECT_DIR)/Modules/mediastream/MediaStreamTrack.idl
 $(PROJECT_DIR)/Modules/mediastream/MediaStreamTrackEvent.idl
+$(PROJECT_DIR)/Modules/mediastream/MediaStreamTrackProcessor.idl
 $(PROJECT_DIR)/Modules/mediastream/MediaTrackCapabilities.idl
 $(PROJECT_DIR)/Modules/mediastream/MediaTrackConstraints.idl
 $(PROJECT_DIR)/Modules/mediastream/MediaTrackSupportedConstraints.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1869,6 +1869,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStreamTrack.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStreamTrack.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStreamTrackEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStreamTrackEvent.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStreamTrackProcessor.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaStreamTrackProcessor.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaTrackCapabilities.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaTrackCapabilities.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMediaTrackConstraints.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -445,6 +445,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/mediastream/MediaStream.idl \
     $(WebCore)/Modules/mediastream/MediaStreamTrack.idl \
     $(WebCore)/Modules/mediastream/MediaStreamTrackEvent.idl \
+    $(WebCore)/Modules/mediastream/MediaStreamTrackProcessor.idl \
     $(WebCore)/Modules/mediastream/MediaTrackCapabilities.idl \
     $(WebCore)/Modules/mediastream/MediaTrackConstraints.idl \
     $(WebCore)/Modules/mediastream/MediaTrackSupportedConstraints.idl \

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -143,6 +143,7 @@ public:
     void applyConstraints(const std::optional<MediaTrackConstraints>&, DOMPromiseDeferred<void>&&);
 
     RealtimeMediaSource& source() const { return m_private->source(); }
+    RealtimeMediaSource& sourceForProcessor() const { return m_private->sourceForProcessor(); }
     MediaStreamTrackPrivate& privateTrack() { return m_private.get(); }
     const MediaStreamTrackPrivate& privateTrack() const { return m_private.get(); }
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MediaStreamTrackProcessor.h"
+
+#if ENABLE(MEDIA_STREAM) && ENABLE(WEB_CODECS)
+
+#include "JSWebCodecsVideoFrame.h"
+#include "ReadableStream.h"
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(MediaStreamTrackProcessor);
+
+ExceptionOr<Ref<MediaStreamTrackProcessor>> MediaStreamTrackProcessor::create(ScriptExecutionContext& context, Init&& init)
+{
+    if (!init.track->isVideo())
+        return Exception { ExceptionCode::TypeError, "Track is not video"_s };
+
+    if (init.track->ended())
+        return Exception { ExceptionCode::TypeError, "Track is ended"_s };
+
+    return adoptRef(*new MediaStreamTrackProcessor(context, *init.track));
+}
+
+MediaStreamTrackProcessor::MediaStreamTrackProcessor(ScriptExecutionContext& context, Ref<MediaStreamTrack>&& track)
+    : ContextDestructionObserver(&context)
+    , m_videoFrameObserverWrapper(VideoFrameObserverWrapper::create(context.identifier(), *this, Ref { track->sourceForProcessor() }))
+    , m_track(WTFMove(track))
+{
+}
+
+MediaStreamTrackProcessor::~MediaStreamTrackProcessor()
+{
+    stopVideoFrameObserver();
+}
+
+ExceptionOr<Ref<ReadableStream>> MediaStreamTrackProcessor::readable(JSC::JSGlobalObject& globalObject)
+{
+    if (!m_readable) {
+        auto readableStreamSource = Source::create(m_track.get(), *this);
+        auto readableOrException = ReadableStream::create(*JSC::jsCast<JSDOMGlobalObject*>(&globalObject), readableStreamSource.get());
+        if (readableOrException.hasException())
+            return readableOrException.releaseException();
+        m_readableStreamSource = WTFMove(readableStreamSource);
+        m_readable = readableOrException.releaseReturnValue();
+        m_videoFrameObserverWrapper->start();
+    }
+
+    return Ref { *m_readable };
+}
+
+void MediaStreamTrackProcessor::contextDestroyed()
+{
+    m_readableStreamSource = nullptr;
+    stopVideoFrameObserver();
+}
+
+void MediaStreamTrackProcessor::stopVideoFrameObserver()
+{
+    m_videoFrameObserverWrapper = nullptr;
+}
+
+void MediaStreamTrackProcessor::tryEnqueueingVideoFrame()
+{
+    RefPtr context = scriptExecutionContext();
+    if (!context || !m_videoFrameObserverWrapper || !m_readableStreamSource)
+        return;
+
+    // FIXME: If the stream is waiting, we might want to buffer based on
+    // https://w3c.github.io/mediacapture-transform/#dom-mediastreamtrackprocessorinit-maxbuffersize.
+    if (!m_readableStreamSource->isWaiting())
+        return;
+
+    if (auto videoFrame = m_videoFrameObserverWrapper->takeVideoFrame(*context))
+        m_readableStreamSource->enqueue(*videoFrame, *context);
+}
+
+Ref<MediaStreamTrackProcessor::VideoFrameObserverWrapper> MediaStreamTrackProcessor::VideoFrameObserverWrapper::create(ScriptExecutionContextIdentifier identifier, MediaStreamTrackProcessor& processor, Ref<RealtimeMediaSource>&& source)
+{
+    auto wrapper = adoptRef(*new VideoFrameObserverWrapper);
+    wrapper->initialize(identifier, processor, WTFMove(source));
+    return wrapper;
+}
+
+MediaStreamTrackProcessor::VideoFrameObserverWrapper::VideoFrameObserverWrapper()
+{
+}
+
+void MediaStreamTrackProcessor::VideoFrameObserverWrapper::initialize(ScriptExecutionContextIdentifier identifier, MediaStreamTrackProcessor& processor, Ref<RealtimeMediaSource>&& source)
+{
+    callOnMainThread([protectedThis = Ref { *this }, identifier, processor = WeakPtr { processor }, source = WTFMove(source)] () mutable {
+        protectedThis->m_observer = makeUnique<VideoFrameObserver>(identifier, WTFMove(processor), WTFMove(source));
+    });
+}
+
+void MediaStreamTrackProcessor::VideoFrameObserverWrapper::start()
+{
+    callOnMainThread([protectedThis = Ref { *this }] {
+        protectedThis->m_observer->start();
+    });
+}
+
+MediaStreamTrackProcessor::VideoFrameObserver::VideoFrameObserver(ScriptExecutionContextIdentifier identifier, WeakPtr<MediaStreamTrackProcessor>&& processor, Ref<RealtimeMediaSource>&& source)
+    : m_contextIdentifier(identifier)
+    , m_processor(WTFMove(processor))
+    , m_realtimeVideoSource(WTFMove(source))
+{
+    ASSERT(isMainThread());
+}
+
+void MediaStreamTrackProcessor::VideoFrameObserver::start()
+{
+    ASSERT(isMainThread());
+    m_isStarted = true;
+    m_realtimeVideoSource->addVideoFrameObserver(*this);
+}
+
+MediaStreamTrackProcessor::VideoFrameObserver::~VideoFrameObserver()
+{
+    ASSERT(isMainThread());
+    if (m_isStarted)
+        m_realtimeVideoSource->removeVideoFrameObserver(*this);
+}
+
+RefPtr<WebCodecsVideoFrame> MediaStreamTrackProcessor::VideoFrameObserver::takeVideoFrame(ScriptExecutionContext& context)
+{
+    Locker lock(m_videoFrameLock);
+    if (!m_videoFrame)
+        return nullptr;
+
+    WebCodecsVideoFrame::BufferInit init;
+    init.codedWidth = m_videoFrame->presentationSize().width();
+    init.codedHeight = m_videoFrame->presentationSize().height();
+    init.colorSpace = m_videoFrame->colorSpace();
+
+    return WebCodecsVideoFrame::create(context, m_videoFrame.releaseNonNull(), WTFMove(init));
+}
+
+void MediaStreamTrackProcessor::VideoFrameObserver::videoFrameAvailable(VideoFrame& frame, VideoFrameTimeMetadata metadata)
+{
+    {
+        Locker lock(m_videoFrameLock);
+        m_videoFrame = &frame;
+        m_metadata = metadata;
+    }
+    ScriptExecutionContext::postTaskTo(m_contextIdentifier, [processor = m_processor] (auto&) mutable {
+        if (auto protectedProcessor = processor.get())
+            protectedProcessor->tryEnqueueingVideoFrame();
+    });
+}
+
+MediaStreamTrackProcessor::Source::Source(Ref<MediaStreamTrack>&& track, MediaStreamTrackProcessor& processor)
+    : m_track(WTFMove(track))
+    , m_processor(processor)
+{
+    m_track->privateTrack().addObserver(*this);
+}
+
+MediaStreamTrackProcessor::Source::~Source()
+{
+    m_track->privateTrack().removeObserver(*this);
+}
+
+void MediaStreamTrackProcessor::Source::trackEnded(MediaStreamTrackPrivate&)
+{
+    close();
+}
+
+bool MediaStreamTrackProcessor::Source::isWaiting() const
+{
+    return m_isWaiting;
+}
+
+void MediaStreamTrackProcessor::Source::close()
+{
+    if (!m_isCancelled)
+        controller().close();
+}
+
+void MediaStreamTrackProcessor::Source::enqueue(WebCodecsVideoFrame& frame, ScriptExecutionContext& context)
+{
+    auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(context.globalObject());
+    if (!globalObject)
+        return;
+
+    auto& vm = globalObject->vm();
+    JSC::JSLockHolder lock(vm);
+
+    m_isWaiting = false;
+
+    Ref protectedThis { *this };
+
+    if (!m_isCancelled)
+        controller().enqueue(toJS(globalObject, globalObject, frame));
+
+    pullFinished();
+}
+
+void MediaStreamTrackProcessor::Source::doStart()
+{
+    startFinished();
+}
+
+void MediaStreamTrackProcessor::Source::doPull()
+{
+    m_isWaiting = true;
+    if (RefPtr protectedProcessor = m_processor.get())
+        protectedProcessor->tryEnqueueingVideoFrame();
+}
+
+void MediaStreamTrackProcessor::Source::doCancel()
+{
+    m_isCancelled = true;
+    if (RefPtr protectedProcessor = m_processor.get())
+        protectedProcessor->stopVideoFrameObserver();
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_STREAM) && ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(MEDIA_STREAM) && ENABLE(WEB_CODECS)
+
+#include "ExceptionOr.h"
+#include "MediaStreamTrack.h"
+#include "ReadableStreamSource.h"
+#include "RealtimeMediaSource.h"
+#include "WebCodecsVideoFrame.h"
+
+namespace JSC {
+class JSGlobaObject;
+}
+
+namespace WebCore {
+
+class ReadableStream;
+class ScriptExecutionContext;
+class WebCodecsVideoFrame;
+
+class MediaStreamTrackProcessor
+    : public RefCounted<MediaStreamTrackProcessor>
+    , public CanMakeWeakPtr<MediaStreamTrackProcessor>
+    , private ContextDestructionObserver {
+    WTF_MAKE_ISO_ALLOCATED(MediaStreamTrackProcessor);
+public:
+    struct Init {
+        RefPtr<MediaStreamTrack> track;
+    };
+
+    static ExceptionOr<Ref<MediaStreamTrackProcessor>> create(ScriptExecutionContext&, Init&&);
+    ~MediaStreamTrackProcessor();
+
+    ExceptionOr<Ref<ReadableStream>> readable(JSC::JSGlobalObject&);
+
+private:
+    MediaStreamTrackProcessor(ScriptExecutionContext&, Ref<MediaStreamTrack>&&);
+
+    // ContextDestructionObserver
+    void contextDestroyed() final;
+
+    void stopVideoFrameObserver();
+    void tryEnqueueingVideoFrame();
+
+    class VideoFrameObserver final : private RealtimeMediaSource::VideoFrameObserver {
+        WTF_MAKE_FAST_ALLOCATED;
+    public:
+        explicit VideoFrameObserver(ScriptExecutionContextIdentifier, WeakPtr<MediaStreamTrackProcessor>&&, Ref<RealtimeMediaSource>&&);
+        ~VideoFrameObserver();
+
+        void start();
+        RefPtr<WebCodecsVideoFrame> takeVideoFrame(ScriptExecutionContext&);
+
+    private:
+        // RealtimeMediaSource::VideoFrameObserver
+        void videoFrameAvailable(VideoFrame&, VideoFrameTimeMetadata) final;
+
+        bool m_isStarted { false };
+        ScriptExecutionContextIdentifier m_contextIdentifier;
+        WeakPtr<MediaStreamTrackProcessor> m_processor;
+        RefPtr<RealtimeMediaSource> m_realtimeVideoSource;
+
+        Lock m_videoFrameLock;
+        RefPtr<VideoFrame> m_videoFrame WTF_GUARDED_BY_LOCK(m_videoFrameLock);
+        VideoFrameTimeMetadata m_metadata WTF_GUARDED_BY_LOCK(m_videoFrameLock);
+    };
+
+    class VideoFrameObserverWrapper : public ThreadSafeRefCounted<VideoFrameObserverWrapper, WTF::DestructionThread::Main> {
+    public:
+        static Ref<VideoFrameObserverWrapper> create(ScriptExecutionContextIdentifier, MediaStreamTrackProcessor&, Ref<RealtimeMediaSource>&&);
+
+        void start();
+        RefPtr<WebCodecsVideoFrame> takeVideoFrame(ScriptExecutionContext& context) { return m_observer->takeVideoFrame(context); }
+
+    private:
+        VideoFrameObserverWrapper();
+
+        void initialize(ScriptExecutionContextIdentifier, MediaStreamTrackProcessor&, Ref<RealtimeMediaSource>&&);
+
+        std::unique_ptr<VideoFrameObserver> m_observer;
+    };
+
+    class Source final
+        : public ReadableStreamSource
+        , public MediaStreamTrackPrivate::Observer {
+    public:
+        static Ref<Source> create(Ref<MediaStreamTrack>&& track, MediaStreamTrackProcessor& processor) { return adoptRef(*new Source(WTFMove(track), processor)); }
+        ~Source();
+
+        bool isWaiting() const;
+        void close();
+        void enqueue(WebCodecsVideoFrame&, ScriptExecutionContext&);
+
+    private:
+        Source(Ref<MediaStreamTrack>&&, MediaStreamTrackProcessor&);
+
+        // MediaStreamTrackPrivate::Observer
+        void trackEnded(MediaStreamTrackPrivate&) final;
+        void trackMutedChanged(MediaStreamTrackPrivate&) final { }
+        void trackSettingsChanged(MediaStreamTrackPrivate&) final { }
+        void trackEnabledChanged(MediaStreamTrackPrivate&) final { }
+
+        // ReadableStreamSource
+        void setActive() { };
+        void setInactive() { };
+        void doStart() final;
+        void doPull() final;
+        void doCancel() final;
+
+        bool m_isWaiting { false };
+        bool m_isCancelled { false };
+        Ref<MediaStreamTrack> m_track;
+        WeakPtr<MediaStreamTrackProcessor> m_processor;
+    };
+
+    RefPtr<ReadableStream> m_readable;
+    RefPtr<Source> m_readableStreamSource;
+    RefPtr<VideoFrameObserverWrapper> m_videoFrameObserverWrapper;
+    Ref<MediaStreamTrack> m_track;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_STREAM) && ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.idl
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=MEDIA_STREAM&WEB_CODECS,
+    PrivateIdentifier,
+    PublicIdentifier,
+    EnabledBySetting=MediaStreamTrackProcessingEnabled,
+    Exposed=DedicatedWorker
+] interface MediaStreamTrackProcessor {
+    [CallWith=CurrentScriptExecutionContext] constructor(MediaStreamTrackProcessorInit init);
+    [CallWith=CurrentGlobalObject] readonly attribute ReadableStream readable;
+};
+
+[
+    Conditional=MEDIA_STREAM&WEB_CODECS
+] dictionary MediaStreamTrackProcessorInit {
+    required MediaStreamTrack track;
+};

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
@@ -199,4 +199,4 @@ void VideoTrackGenerator::Sink::error(String&&)
 
 } // namespace WebCore
 
-#endif // ENABLE(MEDIA_STREAM)
+#endif // ENABLE(MEDIA_STREAM) && ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#if ENABLE(MEDIA_STREAM)
+#if ENABLE(MEDIA_STREAM) && ENABLE(WEB_CODECS)
 
 #include "ExceptionOr.h"
 #include "RealtimeMediaSource.h"
@@ -101,4 +101,4 @@ private:
 
 } // namespace WebCore
 
-#endif // ENABLE(MEDIA_STREAM)
+#endif // ENABLE(MEDIA_STREAM) && ENABLE(WEB_CODECS)

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.idl
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.idl
@@ -23,7 +23,7 @@
  */
 
 [
-    Conditional=MEDIA_STREAM,
+    Conditional=MEDIA_STREAM&WEB_CODECS,
     PrivateIdentifier,
     PublicIdentifier,
     EnabledBySetting=MediaStreamTrackProcessingEnabled,

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -233,6 +233,7 @@ Modules/mediastream/MediaDevices.cpp
 Modules/mediastream/MediaStream.cpp
 Modules/mediastream/MediaStreamTrack.cpp
 Modules/mediastream/MediaStreamTrackEvent.cpp
+Modules/mediastream/MediaStreamTrackProcessor.cpp
 Modules/mediastream/MediaTrackCapabilities.cpp
 Modules/mediastream/MediaTrackConstraints.cpp
 Modules/mediastream/NavigatorMediaDevices.cpp
@@ -3879,6 +3880,7 @@ JSMediaStreamAudioSourceNode.cpp
 JSMediaStreamAudioSourceOptions.cpp
 JSMediaStreamTrack.cpp
 JSMediaStreamTrackEvent.cpp
+JSMediaStreamTrackProcessor.cpp
 JSMediaTrackCapabilities.cpp
 JSMediaTrackConstraints.cpp
 JSMediaTrackSupportedConstraints.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -300,6 +300,7 @@ namespace WebCore {
     macro(MediaStreamAudioDestinationNode) \
     macro(MediaStreamAudioSourceNode) \
     macro(MediaStreamTrack) \
+    macro(MediaStreamTrackProcessor) \
     macro(MerchantValidationEvent) \
     macro(MockRTCRtpTransform) \
     macro(NavigateEvent) \

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -455,6 +455,12 @@ RealtimeMediaSource& MediaStreamTrackPrivate::source()
     return m_sourceObserver->source();
 }
 
+RealtimeMediaSource& MediaStreamTrackPrivate::sourceForProcessor()
+{
+    ASSERT(isOnCreationThread());
+    return m_sourceObserver->source();
+}
+
 bool MediaStreamTrackPrivate::hasSource(const RealtimeMediaSource* source) const
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -98,6 +98,7 @@ public:
     Ref<MediaStreamTrackPrivate> clone();
 
     WEBCORE_EXPORT RealtimeMediaSource& source();
+    RealtimeMediaSource& sourceForProcessor();
     bool hasSource(const RealtimeMediaSource*) const;
 
     RealtimeMediaSource::Type type() const { return m_type; }


### PR DESCRIPTION
#### b65f4ed6d7773e43c59f050351d01b7396f8e0d8
<pre>
Add a MediaStreamTrackProcessor skeleton and implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=267317">https://bugs.webkit.org/show_bug.cgi?id=267317</a>
<a href="https://rdar.apple.com/120771789">rdar://120771789</a>

Reviewed by Eric Carlson.

Introduce MediaStreamTrackProcessor by getting video frames from the track source and piping them to a ReadableStream source.
We get the video frame from the video pipeline, we store a video frame there and hop to the worker thread where we try to enqueue the video frame.

We use a buffer of one video frame for now.
While each new frame will trigger a task to the worker thread, video frames may currently be dropped if thr worker thread is not fast enough.
Similarly, video frames might be dropped if the web page is not consuming them.

Fix VideoTrackGenerator compile flag to include WEB_CODECS.

Covered by added tests.

* LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker-expected.txt:
* LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.js:
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.js:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.worker-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
(WebCore::MediaStreamTrack::sourceForProcessor const):
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp: Added.
(WebCore::MediaStreamTrackProcessor::create):
(WebCore::MediaStreamTrackProcessor::MediaStreamTrackProcessor):
(WebCore::m_track):
(WebCore::MediaStreamTrackProcessor::~MediaStreamTrackProcessor):
(WebCore::MediaStreamTrackProcessor::readable):
(WebCore::MediaStreamTrackProcessor::contextDestroyed):
(WebCore::MediaStreamTrackProcessor::stopVideoFrameObserver):
(WebCore::MediaStreamTrackProcessor::tryEnqueueingVideoFrame):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserverWrapper::create):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserverWrapper::VideoFrameObserverWrapper):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserverWrapper::initialize):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserverWrapper::start):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserver::VideoFrameObserver):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserver::start):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserver::~VideoFrameObserver):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserver::takeVideoFrame):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserver::videoFrameAvailable):
(WebCore::MediaStreamTrackProcessor::Source::Source):
(WebCore::MediaStreamTrackProcessor::Source::~Source):
(WebCore::MediaStreamTrackProcessor::Source::trackEnded):
(WebCore::MediaStreamTrackProcessor::Source::isWaiting const):
(WebCore::MediaStreamTrackProcessor::Source::close):
(WebCore::MediaStreamTrackProcessor::Source::enqueue):
(WebCore::MediaStreamTrackProcessor::Source::doStart):
(WebCore::MediaStreamTrackProcessor::Source::doPull):
(WebCore::MediaStreamTrackProcessor::Source::doCancel):
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h: Added.
(WebCore::MediaStreamTrackProcessor::VideoFrameObserverWrapper::takeVideoFrame):
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.idl: Copied from Source/WebCore/Modules/mediastream/VideoTrackGenerator.idl.
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp:
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.h:
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivate::sourceForProcessor):
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h:

Canonical link: <a href="https://commits.webkit.org/273117@main">https://commits.webkit.org/273117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3ef4f16c1a07293760e7919bd5428501e02dc2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36656 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30834 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35091 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29885 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9454 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9559 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30376 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37964 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30903 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30699 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35667 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7618 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33569 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11473 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7895 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10253 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->