### PR TITLE
GraphicscContextCG uses memory redundantly for SourceBrush

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -176,13 +176,11 @@ private:
         m_changeFlags.add(change);
     }
 
-    ChangeFlags m_changeFlags;
-
     SourceBrush m_fillBrush { Color::black };
-    WindRule m_fillRule { WindRule::NonZero };
-
     SourceBrush m_strokeBrush { Color::black };
+    ChangeFlags m_changeFlags;
     float m_strokeThickness { 0 };
+    WindRule m_fillRule { WindRule::NonZero };
     StrokeStyle m_strokeStyle { StrokeStyle::SolidStroke };
 
     CompositeMode m_compositeMode { CompositeOperator::SourceOver, BlendMode::Normal };

--- a/Source/WebCore/platform/graphics/SourceBrush.cpp
+++ b/Source/WebCore/platform/graphics/SourceBrush.cpp
@@ -28,26 +28,22 @@
 
 namespace WebCore {
 
-SourceBrush::SourceBrush(const Color& color, std::optional<Brush>&& brush)
+SourceBrush::SourceBrush(const Color& color, OptionalPatternGradient&& patternGradient)
     : m_color(color)
-    , m_brush(WTFMove(brush))
+    , m_patternGradient(WTFMove(patternGradient))
 {
 }
 
 const AffineTransform& SourceBrush::gradientSpaceTransform() const
 {
-    if (!m_brush)
-        return identity;
-    if (auto* logicalGradient = std::get_if<Brush::LogicalGradient>(&m_brush->brush))
+    if (auto* logicalGradient = std::get_if<SourceBrushLogicalGradient>(&m_patternGradient))
         return logicalGradient->spaceTransform;
     return identity;
 }
 
 Gradient* SourceBrush::gradient() const
 {
-    if (!m_brush)
-        return nullptr;
-    if (auto* logicalGradient = std::get_if<Brush::LogicalGradient>(&m_brush->brush)) {
+    if (auto* logicalGradient = std::get_if<SourceBrushLogicalGradient>(&m_patternGradient)) {
         if (auto* gradient = std::get_if<Ref<Gradient>>(&logicalGradient->gradient))
             return gradient->ptr();
     }
@@ -56,10 +52,7 @@ Gradient* SourceBrush::gradient() const
 
 std::optional<RenderingResourceIdentifier> SourceBrush::gradientIdentifier() const
 {
-    if (!m_brush)
-        return std::nullopt;
-
-    auto* gradient = std::get_if<Brush::LogicalGradient>(&m_brush->brush);
+    auto* gradient = std::get_if<SourceBrushLogicalGradient>(&m_patternGradient);
     if (!gradient)
         return std::nullopt;
 
@@ -77,21 +70,19 @@ std::optional<RenderingResourceIdentifier> SourceBrush::gradientIdentifier() con
 
 Pattern* SourceBrush::pattern() const
 {
-    if (!m_brush)
-        return nullptr;
-    if (auto* pattern = std::get_if<Ref<Pattern>>(&m_brush->brush))
+    if (auto* pattern = std::get_if<Ref<Pattern>>(&m_patternGradient))
         return pattern->ptr();
     return nullptr;
 }
 
 void SourceBrush::setGradient(Ref<Gradient>&& gradient, const AffineTransform& spaceTransform)
 {
-    m_brush = Brush { Brush::LogicalGradient { { WTFMove(gradient) }, spaceTransform } };
+    m_patternGradient = SourceBrushLogicalGradient { { WTFMove(gradient) }, spaceTransform };
 }
 
 void SourceBrush::setPattern(Ref<Pattern>&& pattern)
 {
-    m_brush = Brush { Brush::Variant { std::in_place_type<Ref<Pattern>>, WTFMove(pattern) } };
+    m_patternGradient = WTFMove(pattern);
 }
 
 WTF::TextStream& operator<<(TextStream& ts, const SourceBrush& brush)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2681,13 +2681,9 @@ class WebCore::TransformOperations {
     WebCore::Pattern::Parameters parameters();
 }
 
-[Nested, AdditionalEncoder=StreamConnectionEncoder] class WebCore::SourceBrush::Brush {
-    std::variant<WebCore::SourceBrush::Brush::LogicalGradient, Ref<WebCore::Pattern>> brush;
-}
-
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::SourceBrush {
     WebCore::Color color();
-    std::optional<WebCore::SourceBrush::Brush> brush();
+    WebCore::SourceBrush::OptionalPatternGradient patternGradient();
 }
 
 header: <WebCore/ThreadSafeDataBuffer.h>
@@ -6561,11 +6557,11 @@ header: <WebCore/GraphicsContextState.h>
 };
 
 [LegacyPopulateFromEmptyConstructor, AdditionalEncoder=StreamConnectionEncoder] class WebCore::GraphicsContextState {
-    OptionSet<WebCore::GraphicsContextState::Change> m_changeFlags;
     WebCore::SourceBrush m_fillBrush;
-    WebCore::WindRule m_fillRule;
     WebCore::SourceBrush m_strokeBrush;
+    OptionSet<WebCore::GraphicsContextState::Change> m_changeFlags;
     float m_strokeThickness;
+    WebCore::WindRule m_fillRule;
     WebCore::StrokeStyle m_strokeStyle;
     WebCore::CompositeMode m_compositeMode;
     std::optional<WebCore::GraphicsDropShadow> m_dropShadow;


### PR DESCRIPTION
#### d08bfd77fc2346828b9fc49a9dd6e8a8bbc8e320
<pre>
GraphicscContextCG uses memory redundantly for SourceBrush
<a href="https://bugs.webkit.org/show_bug.cgi?id=267405">https://bugs.webkit.org/show_bug.cgi?id=267405</a>
<a href="https://rdar.apple.com/120841202">rdar://120841202</a>

Reviewed by Said Abou-Hallawa.

SourceBrush would contain std::optional&lt;std::variant&lt;...&gt;&gt;.
This wastes quite a bit of memory to padding and redundant tag field.
Instead, store it just as variant&lt;monostate, ...&gt;
Also store the SourceBrush instances as the first instances,
as SourceBrush has alignof == 8 and ChangeFlags has sizeof == 4.

Before:
Total byte size: 800
Total pad bytes: 60
Padding percentage: 7.50 %

After:
Total byte size: 752
Total pad bytes: 62
Padding percentage: 8.24 %

Some, likely leaky, pages might create thousands of layers or 2d
contexts. GraphicscContextCG for these ImageBuffers end up taking
significant amount of memory, risking GPUP jetsams.

* Source/WebCore/platform/graphics/GraphicsContextState.h:
* Source/WebCore/platform/graphics/SourceBrush.cpp:
(WebCore::SourceBrush::SourceBrush):
(WebCore::SourceBrush::gradientSpaceTransform const):
(WebCore::SourceBrush::gradient const):
(WebCore::SourceBrush::gradientIdentifier const):
(WebCore::SourceBrush::pattern const):
(WebCore::SourceBrush::setGradient):
(WebCore::SourceBrush::setPattern):
* Source/WebCore/platform/graphics/SourceBrush.h:
(WebCore::SourceBrush::SourceBrush):
(WebCore::SourceBrush::patternGradient const):
(WebCore::SourceBrush::isInlineColor const):
(WebCore::SourceBrush::isVisible const):
(WebCore::SourceBrush::hasPatternOrGradient const):
(WebCore::operator==):
(WebCore::SourceBrush::brush const): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/273073@main">https://commits.webkit.org/273073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76272109da996e938fc92915afeb467525c03f6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36682 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30856 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29906 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30382 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9475 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9587 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37990 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30931 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30725 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35689 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33592 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11496 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7868 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10275 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10522 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->