### PR TITLE
Safari pages randomly crashing under DynamicContentScalingBifurcatedImageBuffer::dynamicContentScalingDisplayList() when switching tabs

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm
@@ -56,7 +56,7 @@ std::optional<WebCore::DynamicContentScalingDisplayList> DynamicContentScalingBi
     if (!is<ImageBufferBackendHandleSharing>(sharing))
         return std::nullopt;
     auto handle = downcast<ImageBufferBackendHandleSharing>(*sharing).takeBackendHandle();
-    if (!std::holds_alternative<WebCore::DynamicContentScalingDisplayList>(*handle))
+    if (!handle || !std::holds_alternative<WebCore::DynamicContentScalingDisplayList>(*handle))
         return std::nullopt;
     auto& displayList = std::get<WebCore::DynamicContentScalingDisplayList>(*handle);
 


### PR DESCRIPTION
#### 0d514898fa0100ac4fdcd9635d82811a620fc332
<pre>
Safari pages randomly crashing under DynamicContentScalingBifurcatedImageBuffer::dynamicContentScalingDisplayList() when switching tabs
<a href="https://bugs.webkit.org/show_bug.cgi?id=267459">https://bugs.webkit.org/show_bug.cgi?id=267459</a>
<a href="https://rdar.apple.com/120856029">rdar://120856029</a>

Reviewed by Aditya Keerthi.

* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm:
(WebKit::DynamicContentScalingBifurcatedImageBuffer::dynamicContentScalingDisplayList):
One more optional check in this new code.

Canonical link: <a href="https://commits.webkit.org/272987@main">https://commits.webkit.org/272987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8930a83c78693c7d88108e5210e660ea71740189

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36420 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30646 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9730 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29714 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10612 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9257 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9365 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37738 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30682 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30480 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35482 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33373 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11281 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7804 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/10079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10291 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->