### PR TITLE
Scroll To Text Fragment Text Directives don't find text with additional unrendered white space in their node data.

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/whitespace-collapse-expected.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/whitespace-collapse-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8" />
+<title>Scroll to text fragment - white space between words</title>
+<style>
+  span {
+    background-color: rgb(255, 238, 190);
+  }
+</style>
+
+<p>The test passes if the following word has a yellow background.</p>
+<div><span>Hello          World</span></div>

--- a/LayoutTests/http/tests/scroll-to-text-fragment/whitespace-collapse.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/whitespace-collapse.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Scroll to text fragment - white space between words</title>
+<link rel="help" href="https://wicg.github.io/scroll-to-text-fragment/">
+<meta name="assert" content="This test checks whitespace that is collapsed on rendering is correctly highlighted.">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1500" />
+
+<p>The test passes if the following word has a yellow background.</p>
+<div>Hello          World</div>
+
+<script>
+  location.href = "#:~:text=Hello%20World";
+</script>
+</html>
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-expected.txt
@@ -34,7 +34,7 @@ PASS Test navigation with fragment: Multiple match text directive disambiguated 
 PASS Test navigation with fragment: Multiple match text directive disambiguated by suffix should match the suffixed text.
 PASS Test navigation with fragment: Multiple match text directive disambiguated by prefix and suffix should match the text with the given context.
 PASS Test navigation with fragment: Text directive should match when context terms are separated by node boundaries.
-FAIL Test navigation with fragment: Text directive should match text within shadow DOM. assert_equals: Expected #:~:text=shadow%20text (Text directive should match text within shadow DOM) to scroll to shadow. expected "shadow" but got "top"
+PASS Test navigation with fragment: Text directive should match text within shadow DOM.
 PASS Test navigation with fragment: Text directive should not scroll to hidden text.
 PASS Test navigation with fragment: Text directive should not scroll to display none text.
 FAIL Test navigation with fragment: Text directive should horizontally scroll into view. assert_true: expected true got false

--- a/LayoutTests/platform/glib/http/tests/scroll-to-text-fragment/whitespace-collapse-expected.html
+++ b/LayoutTests/platform/glib/http/tests/scroll-to-text-fragment/whitespace-collapse-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8" />
+<title>Scroll to text fragment - white space between words</title>
+<style>
+  span {
+    background-color: rgba(255, 255, 0, 0.8);
+  }
+</style>
+
+<p>The test passes if the following word has a yellow background.</p>
+<div><span>Hello          World</span></div>

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-expected.txt
@@ -34,7 +34,7 @@ PASS Test navigation with fragment: Multiple match text directive disambiguated 
 PASS Test navigation with fragment: Multiple match text directive disambiguated by suffix should match the suffixed text.
 PASS Test navigation with fragment: Multiple match text directive disambiguated by prefix and suffix should match the text with the given context.
 PASS Test navigation with fragment: Text directive should match when context terms are separated by node boundaries.
-FAIL Test navigation with fragment: Text directive should match text within shadow DOM. assert_equals: Expected #:~:text=shadow%20text (Text directive should match text within shadow DOM) to scroll to shadow. expected "shadow" but got "top"
+PASS Test navigation with fragment: Text directive should match text within shadow DOM.
 PASS Test navigation with fragment: Text directive should not scroll to hidden text.
 PASS Test navigation with fragment: Text directive should not scroll to display none text.
 PASS Test navigation with fragment: Text directive should horizontally scroll into view.

--- a/LayoutTests/platform/wincairo/http/tests/scroll-to-text-fragment/whitespace-collapse-expected.html
+++ b/LayoutTests/platform/wincairo/http/tests/scroll-to-text-fragment/whitespace-collapse-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8" />
+<title>Scroll to text fragment - white space between words</title>
+<style>
+  span {
+    background-color: rgba(255, 255, 0, 0.8);
+  }
+</style>
+
+<p>The test passes if the following word has a yellow background.</p>
+<div><span>Hello          World</span></div>

--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -151,12 +151,24 @@ static std::optional<SimpleRange> findRangeFromNodeList(const String& query, con
     StringBuilder searchBufferBuilder;
     for (auto& node : nodes)
         searchBufferBuilder.append(node->data());
-    // FIXME: try to use SearchBuffer in TextIterator.h instead.
     searchBuffer = searchBufferBuilder.toString();
     
     searchBuffer = foldQuoteMarks(searchBuffer);
     auto foldedQuery = foldQuoteMarks(query);
     
+    // FIXME: add quote folding to TextIterator instead of leaving it here?
+    FindOptions options = { CaseInsensitive, DoNotRevealSelection };
+
+    if (wordStartBounded == WordBounded::Yes)
+        options.add(AtWordStarts);
+    if (wordEndBounded == WordBounded::Yes)
+        options.add(AtWordEnds);
+
+    auto foundText = findPlainText(searchRange, foldedQuery, options);
+
+    if (!foundText.collapsed())
+        return foundText;
+
     unsigned searchStart = 0;
     
     if (nodes[0].ptr() == &searchRange.startContainer())


### PR DESCRIPTION
#### ddae86e7776380e5f787464d595a6d44dac3cf1b
<pre>
Scroll To Text Fragment Text Directives don&apos;t find text with additional unrendered white space in their node data.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267460">https://bugs.webkit.org/show_bug.cgi?id=267460</a>
<a href="https://rdar.apple.com/120913588">rdar://120913588</a>

Reviewed by Ryosuke Niwa.

The spec for Scroll to Text Fragment says to just look a the .data() on the node
to determine it&apos;s text content and search for the fragment directive in the page
text. However, this does not account for extra white space that is removed when rendering.
Therefore, we should use TextItterator which does account for a remove this unrendered white
space. This is technically against the spec, but other engines similarly ignore this
extraneous white space when searching, so the spec should be updated accordingly.
If TextItterator does not find the text, we fall back to the original spec way of finding
the text.

* LayoutTests/http/tests/scroll-to-text-fragment/whitespace-collapse-expected.html: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/whitespace-collapse.html: Added.
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
(WebCore::FragmentDirectiveRangeFinder::findRangeFromNodeList):

Canonical link: <a href="https://commits.webkit.org/273016@main">https://commits.webkit.org/273016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5fd98803c26a587916202c019b250b9a58033c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36561 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30753 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29803 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9372 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9473 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37869 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30603 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35583 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9601 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7541 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33479 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29907 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7820 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10410 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->