### PR TITLE
Ensure external style sheet resources are saved in subresource directory

### DIFF
--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -623,8 +623,7 @@ static HashMap<RefPtr<CSSStyleSheet>, String> addSubresourcesForCSSStyleSheetsIf
 
             String subresourceFileName = generateValidFileName(url, uniqueFileNames);
             uniqueFileNames.add(subresourceFileName);
-            String subresourceFilePath = FileSystem::pathByAppendingComponent(subresourcesDirectoryName, subresourceFileName);
-            addResult.iterator->value = frame.isMainFrame() ? subresourceFilePath : subresourceFileName;
+            addResult.iterator->value = FileSystem::pathByAppendingComponent(subresourcesDirectoryName, subresourceFileName);
             relativeUniqueCSSStyleSheets.add(currentCSSStyleSheet, subresourceFileName);
         }
     }
@@ -645,7 +644,7 @@ static HashMap<RefPtr<CSSStyleSheet>, String> addSubresourcesForCSSStyleSheetsIf
             subresources.append(newResource.releaseNonNull());
     }
 
-    return uniqueCSSStyleSheets;
+    return frame.isMainFrame() ? uniqueCSSStyleSheets : relativeUniqueCSSStyleSheets;
 }
 
 RefPtr<LegacyWebArchive> LegacyWebArchive::create(const String& markupString, LocalFrame& frame, Vector<Ref<Node>>&& nodes, Function<bool(LocalFrame&)>&& frameFilter, const Vector<MarkupExclusionRule>& markupExclusionRules, const String& mainFrameFilePath)


### PR DESCRIPTION
#### a4c924ac92e1c5e87a83cfd58ce1871d0e49a137
<pre>
Ensure external style sheet resources are saved in subresource directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=267464">https://bugs.webkit.org/show_bug.cgi?id=267464</a>
<a href="https://rdar.apple.com/120911453">rdar://120911453</a>

Reviewed by Ryosuke Niwa.

relativeFilePath of ArchiveResource is target file path (relative to result directory) of the source. In current
implementation of addSubresourcesForCSSStyleSheetsIfNecessary, relativeFilePath of style sheet resource is decided by
values in uniqueCSSStyleSheets. However, uniqueCSSStyleSheets only records file path if frame is main frame. If frame is
subframe, uniqueCSSStyleSheets records file name instead. That means the external style sheet subresource in subframe
will be stored in the result root directory (not the subresource directory).

To fix this problem, this patch makes uniqueCSSStyleSheets always record file path, so the values can be directly used
for creating ArchiveResource. Note with this change, addSubresourcesForCSSStyleSheetsIfNecessary can no longer directly
return uniqueCSSStyleSheets (because the return value should record path relative to frame resource file) -- it should
return relativeUniqueCSSStyleSheets (which records file name) when frame is not main frame.

* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::addSubresourcesForCSSStyleSheetsIfNecessary):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm:

Canonical link: <a href="https://commits.webkit.org/273086@main">https://commits.webkit.org/273086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b88c063a4300697f6cc58fabbd77824c43bb88a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33830 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36450 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30665 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/14982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29728 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9281 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37763 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30503 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35496 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9519 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33385 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11302 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7878 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10094 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->