### PR TITLE
[Wasm-GC] Support arrays of vectors

### DIFF
--- a/JSTests/wasm/gc/array_new_data.js
+++ b/JSTests/wasm/gc/array_new_data.js
@@ -355,7 +355,8 @@ function testSingletonArray() {
 
 function testTypeErrors() {
     let notArray = "WebAssembly.Module doesn't validate: array.new_data index 0 does not reference an array definition, in function at index 0";
-    let refType = "WebAssembly.Module doesn't validate: array.new_data expected numeric, packed, or vector type; found RefNull";
+    let refFuncType = "WebAssembly.Module doesn't validate: array.new_data expected numeric, packed, or vector type; found (ref null func)";
+    let refExternType = "WebAssembly.Module doesn't validate: array.new_data expected numeric, packed, or vector type; found (ref null extern)";
     let erroneousCase = (ty, msg) => {
         assert.throws(() => compile (`
           (module
@@ -374,8 +375,8 @@ function testTypeErrors() {
      */
     for (const [badType, message] of [["(struct (field i64) (field i32))", notArray],
                            ["(func (result i32))", notArray],
-                           ["(array (mut funcref))", refType],
-                           ["(array (mut externref))", refType]]) {
+                           ["(array (mut funcref))", refFuncType],
+                           ["(array (mut externref))", refExternType]]) {
         erroneousCase(badType, message);
     }
 }

--- a/JSTests/wasm/gc/simd.js
+++ b/JSTests/wasm/gc/simd.js
@@ -1,0 +1,409 @@
+//@ skip unless $isSIMDPlatform
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import * as assert from "../assert.js";
+import { compile, instantiate } from "./wast-wrapper.js";
+
+function testSIMDStruct() {
+  instantiate(`
+    (module
+      (type (struct (field v128))))
+  `);
+
+  instantiate(`
+    (module
+      (type (struct (field (mut v128)))))
+  `);
+
+  {
+    const m = instantiate(`
+      (module
+        (type (struct (field (mut v128))))
+        (global (ref 0) (struct.new 0 (v128.const i64x2 0xFFFFFFFFFFFFFFFF 0xFFFFFFFFFFFFFFFF)))
+        (func (result v128)
+          (struct.get 0 0 (global.get 0)))
+        (func (export "f") (result i32)
+          (i64x2.all_true
+            (i64x2.eq (call 0) (v128.const i64x2 0xFFFFFFFFFFFFFFFF 0xFFFFFFFFFFFFFFFF))))
+      )
+    `);
+    assert.eq(m.exports.f(), 1);
+  }
+
+  {
+    const m = instantiate(`
+      (module
+        (type (struct (field (mut v128))))
+        (global (mut (ref null 0)) (ref.null 0))
+        (start 0)
+        (func
+          (global.set 0 (struct.new 0 (v128.const i64x2 0x42 0x84))))
+        (func (export "lane0") (result i64)
+          (i64x2.extract_lane 0 (struct.get 0 0 (global.get 0))))
+        (func (export "lane1") (result i64)
+          (i64x2.extract_lane 1 (struct.get 0 0 (global.get 0))))
+      )
+    `);
+    assert.eq(m.exports.lane0(), 0x42n);
+    assert.eq(m.exports.lane1(), 0x84n);
+  }
+
+  {
+    const m = instantiate(`
+      (module
+        (type (struct (field (mut v128))))
+        (global (mut (ref null 0)) (ref.null 0))
+        (start 0)
+        (func
+          (global.set 0 (struct.new_default 0)))
+        (func (export "lane0") (result i64)
+          (i64x2.extract_lane 0 (struct.get 0 0 (global.get 0))))
+        (func (export "lane1") (result i64)
+          (i64x2.extract_lane 1 (struct.get 0 0 (global.get 0))))
+      )
+    `);
+    assert.eq(m.exports.lane0(), 0n);
+    assert.eq(m.exports.lane1(), 0n);
+  }
+
+  {
+    const m = instantiate(`
+      (module
+        (type (struct (field i32 i32 i8 v128 i16)))
+        (global (mut (ref null 0)) (ref.null 0))
+        (start 0)
+        (func
+          (global.set 0 (struct.new 0 (i32.const 31) (i32.const 63) (i32.const 127) (v128.const i64x2 0x42 0x84) (i32.const 255))))
+        (func (export "get0") (result i32) (struct.get 0 0 (global.get 0)))
+        (func (export "get1") (result i32) (struct.get 0 1 (global.get 0)))
+        (func (export "get2") (result i32) (struct.get_u 0 2 (global.get 0)))
+        (func (export "get4") (result i32) (struct.get_u 0 4 (global.get 0)))
+        (func (export "lane0") (result i64)
+          (i64x2.extract_lane 0 (struct.get 0 3 (global.get 0))))
+        (func (export "lane1") (result i64)
+          (i64x2.extract_lane 1 (struct.get 0 3 (global.get 0))))
+      )
+    `);
+    assert.eq(m.exports.lane0(), 0x42n);
+    assert.eq(m.exports.lane1(), 0x84n);
+    assert.eq(m.exports.get0(), 31);
+    assert.eq(m.exports.get1(), 63);
+    assert.eq(m.exports.get2(), 127);
+    assert.eq(m.exports.get4(), 255);
+  }
+
+  {
+    const m = instantiate(`
+      (module
+        (type (struct (field (mut v128))))
+        (global (ref 0) (struct.new 0 (v128.const i64x2 0xFFFFFFFFFFFFFFFF 0xFFFFFFFFFFFFFFFF)))
+        (func (result v128)
+          (struct.set 0 0 (global.get 0) (v128.const i64x2 0x01 0x2))
+          (struct.get 0 0 (global.get 0)))
+        (func (export "f") (result i32)
+          (i64x2.all_true
+            (i64x2.eq (call 0) (v128.const i64x2 0x1 0x2))))
+      )
+    `);
+    assert.eq(m.exports.f(), 1);
+  }
+}
+
+function testSIMDArray() {
+  instantiate(`
+    (module
+      (type (array v128)))
+  `);
+
+  instantiate(`
+    (module
+      (type (array (mut v128))))
+  `);
+
+  {
+    const m = instantiate(`
+      (module
+        (type (array v128))
+        (global (mut (ref null 0)) (ref.null 0))
+        (start 0)
+        (func
+          (global.set 0 (array.new 0 (v128.const i64x2 0x01 0x02) (i32.const 5))))
+        (func (export "lane0") (param i32) (result i64)
+          (i64x2.extract_lane 0 (array.get 0 (global.get 0) (local.get 0))))
+        (func (export "lane1") (param i32) (result i64)
+          (i64x2.extract_lane 1 (array.get 0 (global.get 0) (local.get 0))))
+      )
+    `);
+    for (var i = 0; i < 5; i++) {
+      assert.eq(m.exports.lane0(i), 1n);
+      assert.eq(m.exports.lane1(i), 2n);
+    }
+  }
+
+  {
+    const m = instantiate(`
+      (module
+        (type (array v128))
+        (global (mut (ref null 0)) (ref.null 0))
+        (start 0)
+        (func
+          (global.set 0 (array.new_default 0 (i32.const 5))))
+        (func (export "lane0") (param i32) (result i64)
+          (i64x2.extract_lane 0 (array.get 0 (global.get 0) (local.get 0))))
+        (func (export "lane1") (param i32) (result i64)
+          (i64x2.extract_lane 1 (array.get 0 (global.get 0) (local.get 0))))
+      )
+    `);
+    for (var i = 0; i < 5; i++) {
+      assert.eq(m.exports.lane0(i), 0n);
+      assert.eq(m.exports.lane1(i), 0n);
+    }
+  }
+
+  {
+    const m = instantiate(`
+      (module
+        (type (array v128))
+        (global (mut (ref null 0)) (ref.null 0))
+        (start 0)
+        (func
+          (global.set 0 (array.new_fixed 0 3 (v128.const i64x2 0x01 0x02) (v128.const i64x2 0x3 0x4) (v128.const i64x2 0x5 0x6))))
+        (func (export "lane0") (param i32) (result i64)
+          (i64x2.extract_lane 0 (array.get 0 (global.get 0) (local.get 0))))
+        (func (export "lane1") (param i32) (result i64)
+          (i64x2.extract_lane 1 (array.get 0 (global.get 0) (local.get 0))))
+      )
+    `);
+    assert.eq(m.exports.lane0(0), 1n);
+    assert.eq(m.exports.lane1(0), 2n);
+    assert.eq(m.exports.lane0(1), 3n);
+    assert.eq(m.exports.lane1(1), 4n);
+    assert.eq(m.exports.lane0(2), 5n);
+    assert.eq(m.exports.lane1(2), 6n);
+  }
+
+  {
+    const m = instantiate(`
+      (module
+        (type (array v128))
+        (global (ref 0) (array.new 0 (v128.const i64x2 0xFFFFFFFFFFFFFFFF 0xFFFFFFFFFFFFFFFF) (i32.const 5)))
+        (func (param i32) (result v128)
+          (array.get 0 (global.get 0) (local.get 0)))
+        (func (export "f") (param i32) (result i32)
+          (i64x2.all_true
+            (i64x2.eq (call 0 (local.get 0)) (v128.const i64x2 0xFFFFFFFFFFFFFFFF 0xFFFFFFFFFFFFFFFF))))
+      )
+    `);
+    for (var i = 0; i < 5; i++)
+      assert.eq(m.exports.f(i), 1);
+  }
+
+  {
+    const m = instantiate(`
+      (module
+        (type (array v128))
+        (global (ref 0) (array.new_fixed 0 2 (v128.const i64x2 0x1 0x2) (v128.const i64x2 0x3 0x4)))
+        (func (export "lane0") (param i32) (result i64)
+          (i64x2.extract_lane 0
+            (array.get 0 (global.get 0) (local.get 0))))
+        (func (export "lane1") (param i32) (result i64)
+          (i64x2.extract_lane 1
+            (array.get 0 (global.get 0) (local.get 0))))
+      )
+    `);
+    assert.eq(m.exports.lane0(0), 0x1n);
+    assert.eq(m.exports.lane1(0), 0x2n);
+    assert.eq(m.exports.lane0(1), 0x3n);
+    assert.eq(m.exports.lane1(1), 0x4n);
+  }
+
+  {
+    const m = instantiate(`
+      (module
+        (type (array (mut v128)))
+        (global (ref 0) (array.new 0 (v128.const i64x2 0xFFFFFFFFFFFFFFFF 0xFFFFFFFFFFFFFFFF) (i32.const 5)))
+        (start 0)
+        (func
+          (array.set 0 (global.get 0) (i32.const 2) (v128.const i64x2 0x1 0x2)))
+        (func (param i32) (result v128)
+          (array.get 0 (global.get 0) (local.get 0)))
+        (func (export "f") (param i32) (result i32)
+          (i64x2.all_true
+            (i64x2.eq (call 1 (local.get 0)) (v128.const i64x2 0xFFFFFFFFFFFFFFFF 0xFFFFFFFFFFFFFFFF))))
+        (func (export "g") (param i32) (result i32)
+          (i64x2.all_true
+            (i64x2.eq (call 1 (local.get 0)) (v128.const i64x2 0x1 0x2))))
+      )
+    `);
+    for (var i = 0; i < 2; i++)
+      assert.eq(m.exports.f(i), 1);
+    assert.eq(m.exports.g(2), 1);
+    for (var i = 3; i < 5; i++)
+      assert.eq(m.exports.f(i), 1);
+  }
+
+  {
+    const m = instantiate(`
+      (module
+        (type (array (mut v128)))
+        (global (ref 0) (array.new 0 (v128.const i64x2 0xFFFFFFFFFFFFFFFF 0xFFFFFFFFFFFFFFFF) (i32.const 5)))
+        (global i32 (i32.const 2))
+        (start 0)
+        (func
+          (array.set 0 (global.get 0) (global.get 1) (v128.const i64x2 0x1 0x2)))
+        (func (param i32) (result v128)
+          (array.get 0 (global.get 0) (local.get 0)))
+        (func (export "f") (param i32) (result i32)
+          (i64x2.all_true
+            (i64x2.eq (call 1 (local.get 0)) (v128.const i64x2 0xFFFFFFFFFFFFFFFF 0xFFFFFFFFFFFFFFFF))))
+        (func (export "g") (param i32) (result i32)
+          (i64x2.all_true
+            (i64x2.eq (call 1 (local.get 0)) (v128.const i64x2 0x1 0x2))))
+      )
+    `);
+    for (var i = 0; i < 2; i++)
+      assert.eq(m.exports.f(i), 1);
+    assert.eq(m.exports.g(2), 1);
+    for (var i = 3; i < 5; i++)
+      assert.eq(m.exports.f(i), 1);
+  }
+
+  {
+    const m = instantiate(`
+      (module
+        (type (array v128))
+        (data "\\00\\01\\02\\03\\04\\05\\06\\07\\08\\09\\0A\\0B\\0C\\0D\\0E\\0F\\10\\11\\12\\13\\14\\15\\16\\17\\18\\19\\1A\\1B\\1C\\1D\\1E\\1F")
+        (global (mut (ref null 0)) (ref.null 0))
+        (start 0)
+        (func
+          (global.set 0 (array.new_data 0 0 (i32.const 0) (i32.const 2))))
+        (func (param i32) (result v128)
+          (array.get 0 (global.get 0) (local.get 0)))
+        (func (export "lane0") (param i32) (result i64)
+          (i64x2.extract_lane 0 (call 1 (local.get 0))))
+        (func (export "lane1") (param i32) (result i64)
+          (i64x2.extract_lane 1 (call 1 (local.get 0))))
+      )
+    `);
+    assert.eq(m.exports.lane0(0), 0x0706050403020100n);
+    assert.eq(m.exports.lane1(0), 0x0F0E0D0C0B0A0908n);
+    assert.eq(m.exports.lane0(1), 0x1716151413121110n);
+    assert.eq(m.exports.lane1(1), 0x1F1E1D1C1B1A1918n);
+  }
+
+  {
+    const m = instantiate(`
+      (module
+        (type (array (mut v128)))
+        (data "\\00\\01\\02\\03\\04\\05\\06\\07\\08\\09\\0A\\0B\\0C\\0D\\0E\\0F\\10\\11\\12\\13\\14\\15\\16\\17\\18\\19\\1A\\1B\\1C\\1D\\1E\\1F")
+        (global (ref null 0) (array.new_default 0 (i32.const 5)))
+        (start 0)
+        (func
+          (array.init_data 0 0 (global.get 0) (i32.const 0) (i32.const 0) (i32.const 2)))
+        (func (param i32) (result v128)
+          (array.get 0 (global.get 0) (local.get 0)))
+        (func (export "lane0") (param i32) (result i64)
+          (i64x2.extract_lane 0 (call 1 (local.get 0))))
+        (func (export "lane1") (param i32) (result i64)
+          (i64x2.extract_lane 1 (call 1 (local.get 0))))
+      )
+    `);
+
+    assert.eq(m.exports.lane0(0), 0x0706050403020100n);
+    assert.eq(m.exports.lane1(0), 0x0F0E0D0C0B0A0908n);
+    assert.eq(m.exports.lane0(1), 0x1716151413121110n);
+    assert.eq(m.exports.lane1(1), 0x1F1E1D1C1B1A1918n);
+    for (var i = 2; i < 5; i++) {
+      assert.eq(m.exports.lane0(i), 0n);
+      assert.eq(m.exports.lane1(i), 0n);
+    }
+  }
+
+  {
+     const m = instantiate(`
+       (module
+         (type (array (mut v128)))
+         (global $fill v128 (v128.const i64x2 0x42 0x84))
+         (global $arr (ref 0) (array.new_default 0 (i32.const 10)))
+         (func
+           (array.fill 0 (global.get $arr) (i32.const 1) (global.get $fill) (i32.const 5)))
+         (func (export "lane0") (param i32) (result i64)
+           (i64x2.extract_lane 0
+             (array.get 0 (global.get $arr) (local.get 0))))
+         (func (export "lane1") (param i32) (result i64)
+           (i64x2.extract_lane 1
+             (array.get 0 (global.get $arr) (local.get 0))))
+         (start 0))
+    `);
+
+    assert.eq(m.exports.lane0(0), 0n);
+    assert.eq(m.exports.lane1(0), 0n);
+    for (let i = 1; i < 6; i++) {
+      assert.eq(m.exports.lane0(i), 0x42n);
+      assert.eq(m.exports.lane1(i), 0x84n);
+    }
+    for (let i = 6; i < 10; i++) {
+      assert.eq(m.exports.lane0(i), 0n);
+      assert.eq(m.exports.lane1(i), 0n);
+    }
+  }
+
+  {
+    const m = instantiate(`
+      (module
+        (type (array (mut v128)))
+        (global $fill v128 (v128.const i64x2 0x42 0x84))
+        (global $dst (ref 0) (array.new_default 0 (i32.const 10)))
+        (global $src (ref 0) (array.new_default 0 (i32.const 10)))
+        (func
+          (array.fill 0 (global.get $src) (i32.const 3) (global.get $fill) (i32.const 4))
+          (array.copy 0 0 (global.get $dst) (i32.const 1) (global.get $src) (i32.const 2) (i32.const 6)))
+        (func (export "lane0") (param i32) (result i64)
+          (i64x2.extract_lane 0
+            (array.get 0 (global.get $dst) (local.get 0))))
+        (func (export "lane1") (param i32) (result i64)
+          (i64x2.extract_lane 1
+            (array.get 0 (global.get $dst) (local.get 0))))
+        (start 0))
+    `);
+
+    for (let i = 0; i < 2; i++) {
+      assert.eq(m.exports.lane0(i), 0n);
+      assert.eq(m.exports.lane1(i), 0n);
+    }
+    for (let i = 2; i < 6; i++) {
+      assert.eq(m.exports.lane0(i), 0x42n);
+      assert.eq(m.exports.lane1(i), 0x84n);
+    }
+    for (let i = 6; i < 10; i++) {
+      assert.eq(m.exports.lane0(i), 0n);
+      assert.eq(m.exports.lane1(i), 0n);
+    }
+  }
+}
+
+function testJSAPI() {
+  {
+    const m = instantiate(`
+      (module
+        (type (array v128))
+        (global (export "arr") (mut (ref null 0)) (ref.null 0))
+        (start 0)
+        (func
+          (global.set 0 (array.new_default 0 (i32.const 5))))
+        (func (export "lane0") (param (ref 0) i32) (result i64)
+          (i64x2.extract_lane 0 (array.get 0 (local.get 0) (local.get 1))))
+        (func (export "lane1") (param (ref 0) i32) (result i64)
+          (i64x2.extract_lane 1 (array.get 0 (local.get 0) (local.get 1))))
+      )
+    `);
+    for (var i = 0; i < 5; i++) {
+      assert.eq(m.exports.lane0(m.exports.arr.value, i), 0n);
+      assert.eq(m.exports.lane1(m.exports.arr.value, i), 0n);
+    }
+  }
+}
+
+testSIMDStruct();
+testSIMDArray();
+testJSAPI();

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -53,18 +53,24 @@ public:
     // If a constant expression allocates an object, it should be put in a Strong handle.
     struct ConstExprValue {
         enum ConstExprValueType : uint8_t {
-            NonObject,
+            Numeric,
+            Vector,
             Object,
         };
 
         ConstExprValue()
-            : m_type(ConstExprValueType::NonObject)
+            : m_type(ConstExprValueType::Numeric)
             , m_bits(0)
         { }
 
         ConstExprValue(uint64_t value)
-            : m_type(ConstExprValueType::NonObject)
+            : m_type(ConstExprValueType::Numeric)
             , m_bits(value)
+        { }
+
+        ConstExprValue(v128_t value)
+            : m_type(ConstExprValueType::Vector)
+            , m_vector(value)
         { }
 
         ConstExprValue(Strong<JSObject> object)
@@ -72,11 +78,18 @@ public:
             , m_object(object)
         { }
 
-        EncodedJSValue getValue()
+        uint64_t getValue()
         {
-            if (m_type == ConstExprValueType::NonObject)
+            if (m_type == ConstExprValueType::Numeric)
                 return m_bits;
+            ASSERT(m_type == ConstExprValueType::Object);
             return JSValue::encode(JSValue(m_object.get()));
+        }
+
+        v128_t getVector()
+        {
+            ASSERT(m_type == ConstExprValueType::Vector);
+            return m_vector;
         }
 
         ConstExprValueType type()
@@ -86,25 +99,28 @@ public:
 
         ConstExprValue operator+(ConstExprValue value)
         {
-            ASSERT(m_type == ConstExprValueType::NonObject);
+            ASSERT(m_type == ConstExprValueType::Numeric);
             return ConstExprValue(m_bits + value.getValue());
         }
 
         ConstExprValue operator-(ConstExprValue value)
         {
-            ASSERT(m_type == ConstExprValueType::NonObject);
+            ASSERT(m_type == ConstExprValueType::Numeric);
             return ConstExprValue(m_bits - value.getValue());
         }
 
         ConstExprValue operator*(ConstExprValue value)
         {
-            ASSERT(m_type == ConstExprValueType::NonObject);
+            ASSERT(m_type == ConstExprValueType::Numeric);
             return ConstExprValue(m_bits * value.getValue());
         }
 
     private:
         ConstExprValueType m_type;
-        uint64_t m_bits;
+        union {
+            uint64_t m_bits;
+            v128_t m_vector;
+        };
         Strong<JSObject> m_object;
     };
 
@@ -273,7 +289,11 @@ public:
     ExpressionType createNewArray(uint32_t typeIndex, uint32_t size, ExpressionType value)
     {
         VM& vm = m_instance->vm();
-        EncodedJSValue obj = arrayNew(m_instance.get(), typeIndex, size, value.getValue());
+        EncodedJSValue obj;
+        if (value.type() == ConstExprValue::Vector)
+            obj = arrayNew(m_instance.get(), typeIndex, size, value.getVector());
+        else
+            obj = arrayNew(m_instance.get(), typeIndex, size, value.getValue());
         return ConstExprValue(Strong<JSObject>(vm, JSValue::decode(obj).getObject()));
     }
 
@@ -294,8 +314,13 @@ public:
         if (m_mode == Mode::Evaluate) {
             Ref<TypeDefinition> typeDef = m_info.typeSignatures[typeIndex];
             const TypeDefinition& arraySignature = typeDef->expand();
-            uint64_t elementValue = isRefType(arraySignature.as<ArrayType>()->elementType().type) ? JSValue::encode(jsNull()) : 0;
-            result = createNewArray(typeIndex, static_cast<uint32_t>(size.getValue()), elementValue);
+            auto elementType = arraySignature.as<ArrayType>()->elementType().type.unpacked();
+            ExpressionType initValue = { 0 };
+            if (isRefType(elementType))
+                initValue = { static_cast<uint64_t>(JSValue::encode(jsNull())) };
+            if (elementType == Wasm::Types::V128)
+                initValue = { vectorAllZeros() };
+            result = createNewArray(typeIndex, static_cast<uint32_t>(size.getValue()), initValue);
         }
 
         return { };
@@ -306,10 +331,18 @@ public:
         WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled");
 
         if (m_mode == Mode::Evaluate) {
-            result = createNewArray(typeIndex, args.size(), { });
-            JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(JSValue::decode(result.getValue()));
-            for (size_t i = 0; i < args.size(); i++)
-                arrayObject->set(i, args[i].getValue());
+            auto* arrayType = m_info.typeSignatures[typeIndex]->expand().as<ArrayType>();
+            if (arrayType->elementType().type.unpacked().isV128()) {
+                result = createNewArray(typeIndex, args.size(), { vectorAllZeros() });
+                JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(JSValue::decode(result.getValue()));
+                for (size_t i = 0; i < args.size(); i++)
+                    arrayObject->set(i, args[i].getVector());
+            } else {
+                result = createNewArray(typeIndex, args.size(), { });
+                JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(JSValue::decode(result.getValue()));
+                for (size_t i = 0; i < args.size(); i++)
+                    arrayObject->set(i, args[i].getValue());
+            }
         }
 
         return { };
@@ -350,8 +383,12 @@ public:
         if (m_mode == Mode::Evaluate) {
             result = createNewStruct(typeIndex);
             JSWebAssemblyStruct* structObject = jsCast<JSWebAssemblyStruct*>(JSValue::decode(result.getValue()));
-            for (size_t i = 0; i < args.size(); i++)
-                structObject->set(i, args[i].getValue());
+            for (size_t i = 0; i < args.size(); i++) {
+                if (args[i].type() == ConstExprValue::Vector)
+                    structObject->set(i, args[i].getVector());
+                else
+                    structObject->set(i, args[i].getValue());
+            }
         }
 
         return { };
@@ -366,7 +403,7 @@ public:
     {
         WASM_PARSER_FAIL_IF(!Options::useWebAssemblyGC(), "Wasm GC is not enabled");
         if (m_mode == Mode::Evaluate) {
-            if (reference.type() == ConstExprValue::ConstExprValueType::NonObject)
+            if (reference.type() == ConstExprValue::Numeric)
                 result = ConstExprValue(externInternalize(reference.getValue()));
             else
                 // To avoid creating a new Strong handle, we pass the original reference.
@@ -629,14 +666,12 @@ public:
     PartialResult WARN_UNUSED_RETURN addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t) CONST_EXPR_STUB
     PartialResult WARN_UNUSED_RETURN addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
     PartialResult WARN_UNUSED_RETURN addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
-    ExpressionType WARN_UNUSED_RETURN addConstant(v128_t)
+    ExpressionType WARN_UNUSED_RETURN addConstant(v128_t vector)
     {
-        // While v128 constants may appear in extended constant expressions, currently
-        // there is no valid expression other than (v128.const x), which is handled
-        // in a separate codepath.
+        RELEASE_ASSERT(Options::useWebAssemblySIMD());
         if (m_mode == Mode::Evaluate)
-            RELEASE_ASSERT_NOT_REACHED();
-        return 0;
+            return ConstExprValue(vector);
+        return { };
     }
     PartialResult WARN_UNUSED_RETURN addExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&) CONST_EXPR_STUB
     PartialResult WARN_UNUSED_RETURN addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
@@ -683,14 +718,17 @@ Expected<void, String> parseExtendedConstExpr(const uint8_t* source, size_t leng
     return { };
 }
 
-Expected<EncodedJSValue, String> evaluateExtendedConstExpr(const Vector<uint8_t>& constantExpression, RefPtr<Instance> instance, const ModuleInformation& info, Type expectedType)
+Expected<uint64_t, String> evaluateExtendedConstExpr(const Vector<uint8_t>& constantExpression, RefPtr<Instance> instance, const ModuleInformation& info, Type expectedType)
 {
     RELEASE_ASSERT_WITH_MESSAGE(Options::useWebAssemblyExtendedConstantExpressions(), "Wasm extended const expressions not enabled");
     ConstExprGenerator generator(ConstExprGenerator::Mode::Evaluate, info, instance);
     FunctionParser<ConstExprGenerator> parser(generator, constantExpression.data(), constantExpression.size(), *TypeInformation::typeDefinitionForFunction({ expectedType }, { }), info);
     WASM_FAIL_IF_HELPER_FAILS(parser.parseConstantExpression());
 
-    return { generator.result().getValue() };
+    ConstExprGenerator::ExpressionType result = generator.result();
+    ASSERT(result.type() != ConstExprGenerator::ExpressionType::Vector);
+
+    return { result.getValue() };
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.h
@@ -33,7 +33,7 @@
 namespace JSC { namespace Wasm {
 
 Expected<void, String> parseExtendedConstExpr(const uint8_t*, size_t, size_t, size_t&, ModuleInformation&, Type);
-Expected<EncodedJSValue, String> evaluateExtendedConstExpr(const Vector<uint8_t>&, RefPtr<Instance>, const ModuleInformation&, Type);
+Expected<uint64_t, String> evaluateExtendedConstExpr(const Vector<uint8_t>&, RefPtr<Instance>, const ModuleInformation&, Type);
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -108,13 +108,15 @@ struct ThrownExceptionInfo {
     void* payload;
 };
 
-JSC_DECLARE_JIT_OPERATION(operationWasmArrayNew, EncodedJSValue, (Instance* instance, uint32_t typeIndex, uint32_t size, EncodedJSValue encValue));
+JSC_DECLARE_JIT_OPERATION(operationWasmArrayNew, EncodedJSValue, (Instance* instance, uint32_t typeIndex, uint32_t size, uint64_t value));
+JSC_DECLARE_JIT_OPERATION(operationWasmArrayNewVector, EncodedJSValue, (Instance* instance, uint32_t typeIndex, uint32_t size, uint64_t lane0, uint64_t lane1));
 JSC_DECLARE_JIT_OPERATION(operationWasmArrayNewData, EncodedJSValue, (Instance* instance, uint32_t typeIndex, uint32_t dataSegmentIndex, uint32_t arraySize, uint32_t offset));
 JSC_DECLARE_JIT_OPERATION(operationWasmArrayNewElem, EncodedJSValue, (Instance* instance, uint32_t typeIndex, uint32_t elemSegmentIndex, uint32_t arraySize, uint32_t offset));
 JSC_DECLARE_JIT_OPERATION(operationWasmArrayNewEmpty, EncodedJSValue, (Instance* instance, uint32_t typeIndex, uint32_t size));
 JSC_DECLARE_JIT_OPERATION(operationWasmArrayGet, EncodedJSValue, (Instance* instance, uint32_t typeIndex, EncodedJSValue encValue, uint32_t index));
 JSC_DECLARE_JIT_OPERATION(operationWasmArraySet, void, (Instance* instance, uint32_t typeIndex, EncodedJSValue encValue, uint32_t index, EncodedJSValue value));
-JSC_DECLARE_JIT_OPERATION(operationWasmArrayFill, UCPUStrictInt32, (Instance*, uint32_t, EncodedJSValue, uint32_t, EncodedJSValue, uint32_t));
+JSC_DECLARE_JIT_OPERATION(operationWasmArrayFill, UCPUStrictInt32, (Instance*, EncodedJSValue, uint32_t, uint64_t, uint32_t));
+JSC_DECLARE_JIT_OPERATION(operationWasmArrayFillVector, UCPUStrictInt32, (Instance*, EncodedJSValue, uint32_t, uint64_t, uint64_t, uint32_t));
 JSC_DECLARE_JIT_OPERATION(operationWasmArrayCopy, UCPUStrictInt32, (Instance*, EncodedJSValue, uint32_t, EncodedJSValue, uint32_t, uint32_t));
 JSC_DECLARE_JIT_OPERATION(operationWasmArrayInitElem, UCPUStrictInt32, (Instance*, EncodedJSValue, uint32_t, uint32_t, uint32_t, uint32_t));
 JSC_DECLARE_JIT_OPERATION(operationWasmArrayInitData, UCPUStrictInt32, (Instance*, EncodedJSValue, uint32_t, uint32_t, uint32_t, uint32_t));

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -284,6 +284,8 @@ constexpr size_t typeKindSizeInBytes(TypeKind kind)
     case TypeKind::F64: {
         return 8;
     }
+    case TypeKind::V128:
+        return 16;
 
     case TypeKind::Arrayref:
     case TypeKind::Structref:
@@ -293,7 +295,6 @@ constexpr size_t typeKindSizeInBytes(TypeKind kind)
     case TypeKind::RefNull: {
         return sizeof(WriteBarrierBase<Unknown>);
     }
-    case TypeKind::V128:
     case TypeKind::Array:
     case TypeKind::Func:
     case TypeKind::Struct:
@@ -422,8 +423,15 @@ public:
             case Wasm::TypeKind::I32:
             case Wasm::TypeKind::F32:
                 return sizeof(uint32_t);
-            default:
+            case Wasm::TypeKind::I64:
+            case Wasm::TypeKind::F64:
+            case Wasm::TypeKind::Ref:
+            case Wasm::TypeKind::RefNull:
                 return sizeof(uint64_t);
+            case Wasm::TypeKind::V128:
+                return sizeof(v128_t);
+            default:
+                RELEASE_ASSERT_NOT_REACHED();
             }
         }
         switch (as<PackedType>()) {

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -99,6 +99,8 @@ uint64_t JSWebAssemblyStruct::get(uint32_t fieldIndex) const
     case TypeKind::Ref:
     case TypeKind::RefNull:
         return JSValue::encode(bitwise_cast<WriteBarrierBase<Unknown>*>(targetPointer)->get());
+    case TypeKind::V128:
+        // V128 is not supported in LLInt.
     default:
         ASSERT_NOT_REACHED();
         return 0;
@@ -162,6 +164,14 @@ void JSWebAssemblyStruct::set(uint32_t fieldIndex, uint64_t argument)
     }
 
     ASSERT_NOT_REACHED();
+}
+
+void JSWebAssemblyStruct::set(uint32_t fieldIndex, v128_t argument)
+{
+    uint8_t* targetPointer = fieldPointer(fieldIndex);
+    ASSERT(fieldType(fieldIndex).type.is<Wasm::Type>());
+    ASSERT(fieldType(fieldIndex).type.as<Wasm::Type>().kind == Wasm::TypeKind::V128);
+    *bitwise_cast<v128_t*>(targetPointer) = argument;
 }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
@@ -59,6 +59,7 @@ public:
 
     uint64_t get(uint32_t) const;
     void set(uint32_t, uint64_t);
+    void set(uint32_t, v128_t);
     const Wasm::StructType* structType() const { return m_type->as<Wasm::StructType>(); }
     Wasm::FieldType fieldType(uint32_t fieldIndex) const { return structType()->field(fieldIndex); }
 


### PR DESCRIPTION
#### 4750403b1e468379440c41dc48db2a82648ca23e
<pre>
[Wasm-GC] Support arrays of vectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=251330">https://bugs.webkit.org/show_bug.cgi?id=251330</a>

Reviewed by Justin Michaud.

Adds support for V128 types in structs/arrays.

Adds new C++ runtime operations for the v128_t value case as they cannot be
passed as uint64_t. Most GC operations now also need to check if SIMD
is supported by the compile context during validation.

* JSTests/wasm/gc/array_new_data.js:
(testTypeErrors):
* JSTests/wasm/gc/simd.js: Added.
(testSIMDStruct):
(testSIMDArray):
(testJSAPI):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::pushArrayNew):
(JSC::Wasm::B3IRGenerator::addArrayNewDefault):
(JSC::Wasm::B3IRGenerator::addArrayFill):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewDefault):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNewElem):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNew): Deleted.
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayFill): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNew):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayFill):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayNew):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitArraySetUnchecked):
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayFill):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitStructPayloadSet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNewDefault):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructGet):
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
(JSC::Wasm::ConstExprGenerator::ConstExprValue::ConstExprValue):
(JSC::Wasm::ConstExprGenerator::ConstExprValue::getValue):
(JSC::Wasm::ConstExprGenerator::ConstExprValue::getVector):
(JSC::Wasm::ConstExprGenerator::ConstExprValue::operator+):
(JSC::Wasm::ConstExprGenerator::ConstExprValue::operator-):
(JSC::Wasm::ConstExprGenerator::ConstExprValue::operator*):
(JSC::Wasm::ConstExprGenerator::createNewArray):
(JSC::Wasm::ConstExprGenerator::addArrayNewDefault):
(JSC::Wasm::ConstExprGenerator::addArrayNewFixed):
(JSC::Wasm::ConstExprGenerator::addStructNew):
(JSC::Wasm::ConstExprGenerator::addAnyConvertExtern):
(JSC::Wasm::ConstExprGenerator::addConstant):
(JSC::Wasm::evaluateExtendedConstExpr):
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.h:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::arrayNew):
(JSC::Wasm::arrayNewData):
(JSC::Wasm::doArrayFill):
(JSC::Wasm::arrayFill):
(JSC::Wasm::structNew):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::typeKindSizeInBytes):
(JSC::Wasm::StorageType::elementSize const):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp:
(JSC::JSWebAssemblyArray::JSWebAssemblyArray):
(JSC::JSWebAssemblyArray::~JSWebAssemblyArray):
(JSC::JSWebAssemblyArray::fill):
(JSC::JSWebAssemblyArray::copy):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::get const):
(JSC::JSWebAssemblyStruct::set):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h:

Canonical link: <a href="https://commits.webkit.org/273663@main">https://commits.webkit.org/273663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/977d60e161a7592955518442ce7cedfe3ad48bb2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38637 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32314 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11887 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31065 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11035 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11087 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39886 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/30386 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32700 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37006 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/35761 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35087 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12967 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/42467 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8229 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11732 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8824 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12049 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->