### PR TITLE
Test for correct handling of borders/padding on textarea resizers

### DIFF
--- a/LayoutTests/fast/css/resize-textarea-align-content.html
+++ b/LayoutTests/fast/css/resize-textarea-align-content.html
@@ -7,7 +7,8 @@
     #resizable {
         box-sizing: border-box; /* to make the output width/height predictable */
         align-content: center;
-        border: 3px solid;
+        padding: 20px;
+        border: 19px solid;
     }
     </style>
 </head>
@@ -24,9 +25,9 @@
 <script>
 function drag(startX, startY, destX, destY) {
     const actions = new test_driver.Actions()
-        .pointerMove(startX - 6, startY - 7)
+        .pointerMove(startX - 22, startY - 23) // subtract padding + 2-3px
         .pointerDown()
-        .pointerMove(destX - 6, destY - 7)
+        .pointerMove(destX - 22, destY - 23) // subtract padding + 2-3px
         .pointerUp();
     return actions.send();
 }


### PR DESCRIPTION
#### 1e888d214cf43d9c4f0a8652fa632bc6703b38f5
<pre>
Test for correct handling of borders/padding on textarea resizers
<a href="https://bugs.webkit.org/show_bug.cgi?id=238193">https://bugs.webkit.org/show_bug.cgi?id=238193</a>
<a href="https://rdar.apple.com/90639221">rdar://90639221</a>

Reviewed by Aditya Keerthi.

Follow up to <a href="https://commits.webkit.org/272964@main">https://commits.webkit.org/272964@main</a>
which actually fixes the bug.

* LayoutTests/fast/css/resize-textarea-align-content.html:

Canonical link: <a href="https://commits.webkit.org/273029@main">https://commits.webkit.org/273029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4c9953f67d594be9e4d03548d2104c6191044a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36647 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30825 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9945 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34512 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/10827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30346 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/9446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37955 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/30894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30689 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9679 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/33560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29979 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10244 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4380 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10489 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->