### PR TITLE
Adopt more smart pointers in service worker code

### DIFF
--- a/Source/WebCore/workers/service/server/SWServerJobQueue.h
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.h
@@ -29,6 +29,7 @@
 #include "ServiceWorkerJobData.h"
 #include "Timer.h"
 #include "WorkerFetchResult.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Deque.h>
 
 namespace WebCore {
@@ -37,7 +38,7 @@ class SWServerWorker;
 class ServiceWorkerJob;
 struct WorkerFetchResult;
 
-class SWServerJobQueue {
+class SWServerJobQueue : public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit SWServerJobQueue(SWServer&, const ServiceWorkerRegistrationKey&);
@@ -77,10 +78,12 @@ private:
     void removeAllJobsMatching(const Function<bool(ServiceWorkerJobData&)>&);
     void scriptAndImportedScriptsFetchFinished(const ServiceWorkerJobData&, SWServerRegistration&);
 
+    CheckedRef<SWServer> checkedServer() const { return m_server; }
+
     Deque<ServiceWorkerJobData> m_jobQueue;
 
     Timer m_jobTimer;
-    SWServer& m_server;
+    CheckedRef<SWServer> m_server;
     ServiceWorkerRegistrationKey m_registrationKey;
     WorkerFetchResult m_workerFetchResult;
 };

--- a/Source/WebCore/workers/service/server/SWServerRegistration.h
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.h
@@ -31,6 +31,7 @@
 #include "ServiceWorkerRegistrationData.h"
 #include "ServiceWorkerTypes.h"
 #include "Timer.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/WallTime.h>
@@ -47,7 +48,7 @@ struct ServiceWorkerContextData;
 
 enum class IsAppInitiated : bool { No, Yes };
 
-class SWServerRegistration : public CanMakeWeakPtr<SWServerRegistration> {
+class SWServerRegistration : public CanMakeWeakPtr<SWServerRegistration>, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     SWServerRegistration(SWServer&, const ServiceWorkerRegistrationKey&, ServiceWorkerUpdateViaCache, const URL& scopeURL, const URL& scriptURL, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, NavigationPreloadState&&);
@@ -118,6 +119,8 @@ private:
     void handleClientUnload();
     void softUpdate();
 
+    CheckedRef<SWServer> checkedServer() const { return m_server; }
+
     ServiceWorkerRegistrationIdentifier m_identifier;
     ServiceWorkerRegistrationKey m_registrationKey;
     ServiceWorkerUpdateViaCache m_updateViaCache;
@@ -133,7 +136,7 @@ private:
     WallTime m_lastUpdateTime;
     
     HashCountedSet<SWServerConnectionIdentifier> m_connectionsWithClientRegistrations;
-    SWServer& m_server;
+    CheckedRef<SWServer> m_server;
 
     MonotonicTime m_creationTime;
     HashMap<SWServerConnectionIdentifier, HashSet<ScriptExecutionContextIdentifier>> m_clientsUsingRegistration;

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
@@ -57,43 +57,43 @@ SWServer* SWServerToContextConnection::server() const
 
 void SWServerToContextConnection::scriptContextFailedToStart(const std::optional<ServiceWorkerJobDataIdentifier>& jobDataIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, const String& message)
 {
-    if (auto* worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
+    if (RefPtr worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
         worker->scriptContextFailedToStart(jobDataIdentifier, message);
 }
 
 void SWServerToContextConnection::scriptContextStarted(const std::optional<ServiceWorkerJobDataIdentifier>& jobDataIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, bool doesHandleFetch)
 {
-    if (auto* worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
+    if (RefPtr worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
         worker->scriptContextStarted(jobDataIdentifier, doesHandleFetch);
 }
     
 void SWServerToContextConnection::didFinishInstall(const std::optional<ServiceWorkerJobDataIdentifier>& jobDataIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, bool wasSuccessful)
 {
-    if (auto* worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
+    if (RefPtr worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
         worker->didFinishInstall(jobDataIdentifier, wasSuccessful);
 }
 
 void SWServerToContextConnection::didFinishActivation(ServiceWorkerIdentifier serviceWorkerIdentifier)
 {
-    if (auto* worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
+    if (RefPtr worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
         worker->didFinishActivation();
 }
 
 void SWServerToContextConnection::setServiceWorkerHasPendingEvents(ServiceWorkerIdentifier serviceWorkerIdentifier, bool hasPendingEvents)
 {
-    if (auto* worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
+    if (RefPtr worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
         worker->setHasPendingEvents(hasPendingEvents);
 }
 
 void SWServerToContextConnection::workerTerminated(ServiceWorkerIdentifier serviceWorkerIdentifier)
 {
-    if (auto* worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
+    if (RefPtr worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
         worker->contextTerminated();
 }
 
 void SWServerToContextConnection::matchAll(uint64_t requestIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, const ServiceWorkerClientQueryOptions& options)
 {
-    if (auto* worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier)) {
+    if (RefPtr worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier)) {
         worker->matchAll(options, [&] (auto&& data) {
             worker->contextConnection()->matchAllCompleted(requestIdentifier, data);
         });
@@ -102,7 +102,7 @@ void SWServerToContextConnection::matchAll(uint64_t requestIdentifier, ServiceWo
 
 void SWServerToContextConnection::findClientByVisibleIdentifier(ServiceWorkerIdentifier serviceWorkerIdentifier, const String& clientIdentifier, CompletionHandler<void(std::optional<WebCore::ServiceWorkerClientData>&&)>&& callback)
 {
-    if (auto* worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
+    if (RefPtr worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
         worker->findClientByVisibleIdentifier(clientIdentifier, WTFMove(callback));
     else
         callback({ });
@@ -110,26 +110,26 @@ void SWServerToContextConnection::findClientByVisibleIdentifier(ServiceWorkerIde
 
 void SWServerToContextConnection::claim(ServiceWorkerIdentifier serviceWorkerIdentifier, CompletionHandler<void(std::optional<ExceptionData>&&)>&& callback)
 {
-    auto* worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier);
-    auto* server = worker ? worker->server() : nullptr;
+    RefPtr worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier);
+    CheckedPtr server = worker ? worker->server() : nullptr;
     callback(server ? server->claim(*worker) : std::nullopt);
 }
 
 void SWServerToContextConnection::setScriptResource(ServiceWorkerIdentifier serviceWorkerIdentifier, URL&& scriptURL, ServiceWorkerContextData::ImportedScript&& script)
 {
-    if (auto* worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
+    if (RefPtr worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
         worker->setScriptResource(WTFMove(scriptURL), WTFMove(script));
 }
 
 void SWServerToContextConnection::didFailHeartBeatCheck(ServiceWorkerIdentifier identifier)
 {
-    if (auto* worker = SWServerWorker::existingWorkerForIdentifier(identifier))
+    if (RefPtr worker = SWServerWorker::existingWorkerForIdentifier(identifier))
         worker->didFailHeartBeatCheck();
 }
 
 void SWServerToContextConnection::setAsInspected(ServiceWorkerIdentifier identifier, bool isInspected)
 {
-    if (auto* worker = SWServerWorker::existingWorkerForIdentifier(identifier))
+    if (RefPtr worker = SWServerWorker::existingWorkerForIdentifier(identifier))
         worker->setAsInspected(isInspected);
 }
 
@@ -138,7 +138,7 @@ void SWServerToContextConnection::terminateWhenPossible()
     m_shouldTerminateWhenPossible = true;
 
     bool hasServiceWorkerWithPendingEvents = false;
-    server()->forEachServiceWorker([&](auto& worker) {
+    CheckedRef { *server() }->forEachServiceWorker([&](auto& worker) {
         if (worker.isRunning() && worker.registrableDomain() == m_registrableDomain && worker.hasPendingEvents()) {
             hasServiceWorkerWithPendingEvents = true;
             return false;

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -35,6 +35,7 @@
 #include "ServiceWorkerContextData.h"
 #include "ServiceWorkerIdentifier.h"
 #include "ServiceWorkerTypes.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/URLHash.h>
 #include <wtf/WeakPtr.h>
 
@@ -49,7 +50,7 @@ struct ServiceWorkerContextData;
 struct ServiceWorkerJobDataIdentifier;
 enum class WorkerThreadMode : bool;
 
-class SWServerToContextConnection: public CanMakeWeakPtr<SWServerToContextConnection> {
+class SWServerToContextConnection: public CanMakeWeakPtr<SWServerToContextConnection>, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT virtual ~SWServerToContextConnection();

--- a/Source/WebCore/workers/service/server/SWServerWorker.cpp
+++ b/Source/WebCore/workers/service/server/SWServerWorker.cpp
@@ -69,7 +69,7 @@ SWServerWorker::SWServerWorker(SWServer& server, SWServerRegistration& registrat
     auto result = allWorkers().add(identifier, *this);
     ASSERT_UNUSED(result, result.isNewEntry);
 
-    ASSERT(m_server->getRegistration(m_registrationKey) == &registration);
+    ASSERT(checkedServer()->getRegistration(m_registrationKey) == &registration);
 }
 
 SWServerWorker::~SWServerWorker()
@@ -81,6 +81,11 @@ SWServerWorker::~SWServerWorker()
     ASSERT_UNUSED(taken, taken == this);
 
     callTerminationCallbacks();
+}
+
+CheckedPtr<SWServer> SWServerWorker::checkedServer() const
+{
+    return m_server.get();
 }
 
 ServiceWorkerContextData SWServerWorker::contextData() const
@@ -97,7 +102,7 @@ void SWServerWorker::updateAppInitiatedValue(LastNavigationWasAppInitiated lastN
     if (!isRunning())
         return;
 
-    if (auto* connection = contextConnection())
+    if (CheckedPtr connection = contextConnection())
         connection->updateAppInitiatedValue(identifier(), lastNavigationWasAppInitiated);
 }
 
@@ -126,13 +131,13 @@ void SWServerWorker::whenTerminated(CompletionHandler<void()>&& callback)
 
 void SWServerWorker::startTermination(CompletionHandler<void()>&& callback)
 {
-    auto* contextConnection = this->contextConnection();
+    CheckedPtr contextConnection = this->contextConnection();
     ASSERT(contextConnection);
     if (!contextConnection) {
         RELEASE_LOG_ERROR(ServiceWorker, "Request to terminate a worker %" PRIu64 " whose context connection does not exist", identifier().toUInt64());
         setState(State::NotRunning);
         callback();
-        m_server->workerContextTerminated(*this);
+        checkedServer()->workerContextTerminated(*this);
         return;
     }
 
@@ -174,22 +179,22 @@ const ClientOrigin& SWServerWorker::origin() const
 
 SWServerToContextConnection* SWServerWorker::contextConnection()
 {
-    return m_server ? m_server->contextConnectionForRegistrableDomain(registrableDomain()) : nullptr;
+    return m_server ? checkedServer()->contextConnectionForRegistrableDomain(registrableDomain()) : nullptr;
 }
 
 void SWServerWorker::scriptContextFailedToStart(const std::optional<ServiceWorkerJobDataIdentifier>& jobDataIdentifier, const String& message)
 {
     ASSERT(m_server);
-    if (m_server)
-        m_server->scriptContextFailedToStart(jobDataIdentifier, *this, message);
+    if (CheckedPtr server = m_server.get())
+        server->scriptContextFailedToStart(jobDataIdentifier, *this, message);
 }
 
 void SWServerWorker::scriptContextStarted(const std::optional<ServiceWorkerJobDataIdentifier>& jobDataIdentifier, bool doesHandleFetch)
 {
     m_shouldSkipHandleFetch = !doesHandleFetch;
     ASSERT(m_server);
-    if (m_server)
-        m_server->scriptContextStarted(jobDataIdentifier, *this);
+    if (CheckedPtr server = m_server.get())
+        server->scriptContextStarted(jobDataIdentifier, *this);
 }
 
 void SWServerWorker::didFinishInstall(const std::optional<ServiceWorkerJobDataIdentifier>& jobDataIdentifier, bool wasSuccessful)
@@ -200,8 +205,8 @@ void SWServerWorker::didFinishInstall(const std::optional<ServiceWorkerJobDataId
 
     ASSERT(m_server);
     RELEASE_ASSERT_WITH_MESSAGE(state == ServiceWorkerState::Installing, "State is %hhu", static_cast<uint8_t>(state));
-    if (m_server)
-        m_server->didFinishInstall(jobDataIdentifier, *this, wasSuccessful);
+    if (CheckedPtr server = m_server.get())
+        server->didFinishInstall(jobDataIdentifier, *this, wasSuccessful);
 }
 
 void SWServerWorker::didFinishActivation()
@@ -212,15 +217,15 @@ void SWServerWorker::didFinishActivation()
 
     ASSERT(m_server);
     RELEASE_ASSERT_WITH_MESSAGE(state == ServiceWorkerState::Activating, "State is %hhu", static_cast<uint8_t>(state));
-    if (m_server)
-        m_server->didFinishActivation(*this);
+    if (CheckedPtr server = m_server.get())
+        server->didFinishActivation(*this);
 }
 
 void SWServerWorker::contextTerminated()
 {
     ASSERT(m_server);
-    if (m_server)
-        m_server->workerContextTerminated(*this);
+    if (CheckedPtr server = m_server.get())
+        server->workerContextTerminated(*this);
 }
 
 std::optional<ServiceWorkerClientData> SWServerWorker::findClientByIdentifier(const ScriptExecutionContextIdentifier& clientId) const
@@ -228,7 +233,7 @@ std::optional<ServiceWorkerClientData> SWServerWorker::findClientByIdentifier(co
     ASSERT(m_server);
     if (!m_server)
         return { };
-    return m_server->serviceWorkerClientWithOriginByID(origin(), clientId);
+    return checkedServer()->serviceWorkerClientWithOriginByID(origin(), clientId);
 }
 
 void SWServerWorker::findClientByVisibleIdentifier(const String& clientIdentifier, CompletionHandler<void(std::optional<WebCore::ServiceWorkerClientData>&&)>&& callback)
@@ -238,7 +243,7 @@ void SWServerWorker::findClientByVisibleIdentifier(const String& clientIdentifie
         return;
     }
 
-    auto internalIdentifier = m_server->clientIdFromVisibleClientId(clientIdentifier);
+    auto internalIdentifier = checkedServer()->clientIdFromVisibleClientId(clientIdentifier);
     if (!internalIdentifier) {
         callback({ });
         return;
@@ -252,7 +257,7 @@ void SWServerWorker::matchAll(const ServiceWorkerClientQueryOptions& options, Se
     ASSERT(m_server);
     if (!m_server)
         return callback({ });
-    return m_server->matchAll(*this, options, WTFMove(callback));
+    return checkedServer()->matchAll(*this, options, WTFMove(callback));
 }
 
 String SWServerWorker::userAgent() const
@@ -260,7 +265,7 @@ String SWServerWorker::userAgent() const
     ASSERT(m_server);
     if (!m_server)
         return { };
-    return m_server->serviceWorkerClientUserAgent(origin());
+    return checkedServer()->serviceWorkerClientUserAgent(origin());
 }
 
 void SWServerWorker::setScriptResource(URL&& url, ServiceWorkerContextData::ImportedScript&& script)
@@ -271,7 +276,7 @@ void SWServerWorker::setScriptResource(URL&& url, ServiceWorkerContextData::Impo
 void SWServerWorker::didSaveScriptsToDisk(ScriptBuffer&& mainScript, MemoryCompactRobinHoodHashMap<URL, ScriptBuffer>&& importedScripts)
 {
     // Send mmap'd version of the scripts to the ServiceWorker process so we can save dirty memory.
-    if (auto* contextConnection = this->contextConnection())
+    if (CheckedPtr contextConnection = this->contextConnection())
         contextConnection->didSaveScriptsToDisk(identifier(), mainScript, importedScripts);
 
     // The scripts were saved to disk, replace our scripts with the mmap'd version to save dirty memory.
@@ -306,12 +311,14 @@ void SWServerWorker::setHasPendingEvents(bool hasPendingEvents)
         return;
 
     // Do tryClear/tryActivate, as per https://w3c.github.io/ServiceWorker/#wait-until-method.
-    if (!m_registration)
+    WeakPtr registration = m_registration.get();
+    if (!registration)
         return;
 
-    if (m_registration->isUnregistered() && m_registration->tryClear())
+    if (registration->isUnregistered() && registration->tryClear())
         return;
-    m_registration->tryActivate();
+
+    registration->tryActivate();
 }
 
 void SWServerWorker::whenActivated(CompletionHandler<void(bool)>&& handler)
@@ -332,8 +339,8 @@ void SWServerWorker::setState(ServiceWorkerState state)
     m_data.state = state;
 
     ASSERT(m_registration || state == ServiceWorkerState::Redundant);
-    if (m_registration) {
-        m_registration->forEachConnection([&](auto& connection) {
+    if (CheckedPtr registration = m_registration.get()) {
+        registration->forEachConnection([&](auto& connection) {
             connection.updateWorkerStateInClient(this->identifier(), state);
         });
     }
@@ -387,7 +394,7 @@ void SWServerWorker::didFailHeartBeatCheck()
 
 WorkerThreadMode SWServerWorker::workerThreadMode() const
 {
-    if ((m_server && m_server->shouldRunServiceWorkersOnMainThreadForTesting()) || serviceWorkerPageIdentifier())
+    if ((m_server && checkedServer()->shouldRunServiceWorkersOnMainThreadForTesting()) || serviceWorkerPageIdentifier())
         return WorkerThreadMode::UseMainThread;
     return WorkerThreadMode::CreateNewThread;
 }
@@ -414,7 +421,7 @@ void SWServerWorker::setAsInspected(bool isInspected)
 
 bool SWServerWorker::shouldBeTerminated() const
 {
-    return !m_functionalEventCounter && !m_isInspected && m_server && !m_server->hasClientsWithOrigin(origin());
+    return !m_functionalEventCounter && !m_isInspected && m_server && !checkedServer()->hasClientsWithOrigin(origin());
 }
 
 void SWServerWorker::terminateIfPossible()
@@ -433,14 +440,14 @@ void SWServerWorker::terminationIfPossibleTimerFired()
         return;
 
     terminate();
-    m_server->removeContextConnectionIfPossible(registrableDomain());
+    checkedServer()->removeContextConnectionIfPossible(registrableDomain());
 }
 
 bool SWServerWorker::isClientActiveServiceWorker(ScriptExecutionContextIdentifier clientIdentifier) const
 {
     if (!m_server)
         return false;
-    auto registrationIdentifier = m_server->clientIdentifierToControllingRegistration(clientIdentifier);
+    auto registrationIdentifier = checkedServer()->clientIdentifierToControllingRegistration(clientIdentifier);
     return registrationIdentifier == m_data.registrationIdentifier;
 }
 

--- a/Source/WebCore/workers/service/server/SWServerWorker.h
+++ b/Source/WebCore/workers/service/server/SWServerWorker.h
@@ -162,6 +162,8 @@ private:
     void terminateIfPossible();
     bool shouldBeTerminated() const;
 
+    CheckedPtr<SWServer> checkedServer() const;
+
     WeakPtr<SWServer> m_server;
     ServiceWorkerRegistrationKey m_registrationKey;
     WeakPtr<SWServerRegistration> m_registration;

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -227,7 +227,7 @@ public:
     NetworkMDNSRegister& mdnsRegister() { return m_mdnsRegister; }
 #endif
 
-    WeakPtr<WebSWServerToContextConnection> swContextConnection() { return m_swContextConnection.get(); }
+    WebSWServerToContextConnection* swContextConnection() { return m_swContextConnection.get(); }
 
 private:
     NetworkConnectionToWebProcess(NetworkProcess&, WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&, IPC::Connection::Identifier);

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -46,6 +46,7 @@
 #include <WebCore/SWServerDelegate.h>
 #include <WebCore/StoredCredentialsPolicy.h>
 #include <pal/SessionID.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashSet.h>
 #include <wtf/Ref.h>
 #include <wtf/Seconds.h>
@@ -101,8 +102,7 @@ namespace NetworkCache {
 class Cache;
 }
 
-class NetworkSession
-    : public WebCore::SWServerDelegate {
+class NetworkSession : public WebCore::SWServerDelegate, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static std::unique_ptr<NetworkSession> create(NetworkProcess&, const NetworkSessionCreationParameters&);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -106,8 +106,8 @@ ServiceWorkerFetchTask::ServiceWorkerFetchTask(WebSWServerConnection& swServerCo
         session->addNavigationPreloaderTask(*this);
 
         m_preloader->waitForResponse([weakThis = WeakPtr { *this }] {
-            if (weakThis)
-                weakThis->preloadResponseIsReady();
+            if (CheckedPtr checkedThis = weakThis.get())
+                checkedThis->preloadResponseIsReady();
         });
     }
 
@@ -117,8 +117,8 @@ ServiceWorkerFetchTask::ServiceWorkerFetchTask(WebSWServerConnection& swServerCo
 ServiceWorkerFetchTask::~ServiceWorkerFetchTask()
 {
     SWFETCH_RELEASE_LOG("~ServiceWorkerFetchTask:");
-    if (m_serviceWorkerConnection)
-        m_serviceWorkerConnection->unregisterFetch(*this);
+    if (CheckedPtr serviceWorkerConnection = m_serviceWorkerConnection.get())
+        serviceWorkerConnection->unregisterFetch(*this);
 
     cancelPreloadIfNecessary();
 }
@@ -128,13 +128,13 @@ template<typename Message> bool ServiceWorkerFetchTask::sendToServiceWorker(Mess
     if (!m_serviceWorkerConnection)
         return false;
 
-    return m_serviceWorkerConnection->ipcConnection().send(std::forward<Message>(message), 0) == IPC::Error::NoError;
+    return m_serviceWorkerConnection->protectedIPCConnection()->send(std::forward<Message>(message), 0) == IPC::Error::NoError;
 }
 
 template<typename Message> bool ServiceWorkerFetchTask::sendToClient(Message&& message)
 {
-    Ref protectedLoader = *m_loader;
-    return protectedLoader->connectionToWebProcess().connection().send(std::forward<Message>(message), protectedLoader->coreIdentifier()) == IPC::Error::NoError;
+    Ref loader = *m_loader;
+    return loader->connectionToWebProcess().connection().send(std::forward<Message>(message), loader->coreIdentifier()) == IPC::Error::NoError;
 }
 
 void ServiceWorkerFetchTask::start(WebSWServerToContextConnection& serviceWorkerConnection)
@@ -163,22 +163,22 @@ void ServiceWorkerFetchTask::contextClosed()
 void ServiceWorkerFetchTask::startFetch()
 {
     SWFETCH_RELEASE_LOG("startFetch");
-    Ref protectedLoader = *m_loader;
-    protectedLoader->consumeSandboxExtensionsIfNeeded();
-    auto& options = protectedLoader->parameters().options;
+    Ref loader = *m_loader;
+    loader->consumeSandboxExtensionsIfNeeded();
+    auto& options = loader->parameters().options;
     auto referrer = m_currentRequest.httpReferrer();
 
     // We are intercepting fetch calls after going through the HTTP layer, which may add some specific headers.
     auto request = m_currentRequest;
-    cleanHTTPRequestHeadersForAccessControl(request, protectedLoader->parameters().httpHeadersToKeep);
+    cleanHTTPRequestHeadersForAccessControl(request, loader->parameters().httpHeadersToKeep);
 
     String clientIdentifier;
-    if (protectedLoader->parameters().options.mode != FetchOptions::Mode::Navigate) {
-        if (auto identifier = protectedLoader->parameters().options.clientIdentifier)
+    if (loader->parameters().options.mode != FetchOptions::Mode::Navigate) {
+        if (auto identifier = loader->parameters().options.clientIdentifier)
             clientIdentifier = identifier->toString();
     }
     String resultingClientIdentifier;
-    if (auto& identifier = protectedLoader->parameters().options.resultingClientIdentifier)
+    if (auto& identifier = loader->parameters().options.resultingClientIdentifier)
         resultingClientIdentifier = identifier->toString();
 
     bool isSent = sendToServiceWorker(Messages::WebSWContextManagerConnection::StartFetch { m_serverConnectionIdentifier, m_serviceWorkerIdentifier, m_fetchIdentifier, request, options, IPC::FormDataReference { m_currentRequest.httpBody() }, referrer, m_preloader && m_preloader->isServiceWorkerNavigationPreloadEnabled(), clientIdentifier, resultingClientIdentifier });
@@ -205,9 +205,9 @@ void ServiceWorkerFetchTask::processRedirectResponse(ResourceResponse&& response
 
     if (shouldSetSource == ShouldSetSource::Yes)
         response.setSource(ResourceResponse::Source::ServiceWorker);
-    Ref protectedLoader = *m_loader;
-    auto newRequest = m_currentRequest.redirectedRequest(response, protectedLoader->parameters().shouldClearReferrerOnHTTPSToHTTPRedirect, ResourceRequest::ShouldSetHash::Yes);
-    protectedLoader->willSendServiceWorkerRedirectedRequest(ResourceRequest(m_currentRequest), WTFMove(newRequest), WTFMove(response));
+    Ref loader = *m_loader;
+    auto newRequest = m_currentRequest.redirectedRequest(response, loader->parameters().shouldClearReferrerOnHTTPSToHTTPRedirect, ResourceRequest::ShouldSetHash::Yes);
+    loader->willSendServiceWorkerRedirectedRequest(ResourceRequest(m_currentRequest), WTFMove(newRequest), WTFMove(response));
 }
 
 void ServiceWorkerFetchTask::didReceiveResponse(WebCore::ResourceResponse&& response, bool needsContinueDidReceiveResponseMessage)
@@ -223,9 +223,9 @@ void ServiceWorkerFetchTask::processResponse(ResourceResponse&& response, bool n
     if (m_isDone)
         return;
 
-    Ref protectedLoader = *m_loader;
+    Ref loader = *m_loader;
 #if ENABLE(CONTENT_FILTERING)
-    if (!protectedLoader->continueAfterServiceWorkerReceivedResponse(response))
+    if (!loader->continueAfterServiceWorkerReceivedResponse(response))
         return;
 #endif
 
@@ -235,31 +235,31 @@ void ServiceWorkerFetchTask::processResponse(ResourceResponse&& response, bool n
         m_timeoutTimer->stop();
     softUpdateIfNeeded();
 
-    if (protectedLoader->parameters().options.mode == FetchOptions::Mode::Navigate) {
-        if (auto parentOrigin = protectedLoader->parameters().parentOrigin()) {
-            if (auto error = validateCrossOriginResourcePolicy(protectedLoader->parameters().parentCrossOriginEmbedderPolicy.value, *parentOrigin, m_currentRequest.url(), response, ForNavigation::Yes, protectedLoader->connectionToWebProcess().originAccessPatterns())) {
+    if (loader->parameters().options.mode == FetchOptions::Mode::Navigate) {
+        if (auto parentOrigin = loader->parameters().parentOrigin()) {
+            if (auto error = validateCrossOriginResourcePolicy(loader->parameters().parentCrossOriginEmbedderPolicy.value, *parentOrigin, m_currentRequest.url(), response, ForNavigation::Yes, loader->connectionToWebProcess().originAccessPatterns())) {
                 didFail(*error);
                 return;
             }
         }
     }
-    if (protectedLoader->parameters().options.mode == FetchOptions::Mode::NoCors) {
-        if (auto error = validateCrossOriginResourcePolicy(protectedLoader->parameters().crossOriginEmbedderPolicy.value, *protectedLoader->parameters().sourceOrigin.copyRef(), m_currentRequest.url(), response, ForNavigation::No, protectedLoader->connectionToWebProcess().originAccessPatterns())) {
+    if (loader->parameters().options.mode == FetchOptions::Mode::NoCors) {
+        if (auto error = validateCrossOriginResourcePolicy(loader->parameters().crossOriginEmbedderPolicy.value, *loader->parameters().sourceOrigin.copyRef(), m_currentRequest.url(), response, ForNavigation::No, loader->connectionToWebProcess().originAccessPatterns())) {
             didFail(*error);
             return;
         }
     }
 
-    if (auto error = protectedLoader->doCrossOriginOpenerHandlingOfResponse(response)) {
+    if (auto error = loader->doCrossOriginOpenerHandlingOfResponse(response)) {
         didFail(*error);
         return;
     }
 
     if (shouldSetSource == ShouldSetSource::Yes)
         response.setSource(ResourceResponse::Source::ServiceWorker);
-    protectedLoader->sendDidReceiveResponsePotentiallyInNewBrowsingContextGroup(response, PrivateRelayed::No, needsContinueDidReceiveResponseMessage);
+    loader->sendDidReceiveResponsePotentiallyInNewBrowsingContextGroup(response, PrivateRelayed::No, needsContinueDidReceiveResponseMessage);
     if (needsContinueDidReceiveResponseMessage)
-        protectedLoader->setResponse(WTFMove(response));
+        loader->setResponse(WTFMove(response));
 }
 
 void ServiceWorkerFetchTask::didReceiveData(const IPC::SharedBufferReference& data, uint64_t encodedDataLength)
@@ -270,10 +270,10 @@ void ServiceWorkerFetchTask::didReceiveData(const IPC::SharedBufferReference& da
     ASSERT(!m_timeoutTimer || !m_timeoutTimer->isActive());
 
 #if ENABLE(CONTENT_FILTERING)
-    RefPtr<WebCore::SharedBuffer> buffer = data.unsafeBuffer();
+    RefPtr buffer = data.unsafeBuffer();
     if (!buffer)
         return;
-    if (!Ref { *m_loader }->continueAfterServiceWorkerReceivedData(*buffer, encodedDataLength))
+    if (!protectedLoader()->continueAfterServiceWorkerReceivedData(*buffer, encodedDataLength))
         return;
 #endif
     sendToClient(Messages::WebResourceLoader::DidReceiveData { IPC::SharedBufferReference(data), encodedDataLength });
@@ -287,10 +287,10 @@ void ServiceWorkerFetchTask::didReceiveDataFromPreloader(const WebCore::Fragment
     ASSERT(!m_timeoutTimer || !m_timeoutTimer->isActive());
 
 #if ENABLE(CONTENT_FILTERING)
-    RefPtr<WebCore::SharedBuffer> buffer = data.makeContiguous();
+    RefPtr buffer = data.makeContiguous();
     if (!buffer)
         return;
-    if (!Ref { *m_loader }->continueAfterServiceWorkerReceivedData(*buffer, encodedDataLength))
+    if (!protectedLoader()->continueAfterServiceWorkerReceivedData(*buffer, encodedDataLength))
         return;
 #endif
     sendToClient(Messages::WebResourceLoader::DidReceiveData { IPC::SharedBufferReference(data), encodedDataLength });
@@ -315,7 +315,7 @@ void ServiceWorkerFetchTask::didFinish(const NetworkLoadMetrics& networkLoadMetr
         m_timeoutTimer->stop();
 
 #if ENABLE(CONTENT_FILTERING)
-    Ref { *m_loader }->serviceWorkerDidFinish();
+    protectedLoader()->serviceWorkerDidFinish();
 #endif
 
     sendToClient(Messages::WebResourceLoader::DidFinishResourceLoad { networkLoadMetrics });
@@ -333,7 +333,7 @@ void ServiceWorkerFetchTask::didFail(const ResourceError& error)
     cancelPreloadIfNecessary();
 
     SWFETCH_RELEASE_LOG_ERROR("didFail: (error.domain=%" PUBLIC_LOG_STRING ", error.code=%d)", error.domain().utf8().data(), error.errorCode());
-    Ref { *m_loader }->didFailLoading(error);
+    protectedLoader()->didFailLoading(error);
 }
 
 void ServiceWorkerFetchTask::didNotHandle()
@@ -352,7 +352,7 @@ void ServiceWorkerFetchTask::didNotHandle()
     }
 
     m_isDone = true;
-    Ref { *m_loader }->serviceWorkerDidNotHandle(this);
+    protectedLoader()->serviceWorkerDidNotHandle(this);
 }
 
 void ServiceWorkerFetchTask::usePreload()
@@ -367,7 +367,7 @@ void ServiceWorkerFetchTask::usePreload()
     }
 
     m_isDone = true;
-    Ref { *m_loader }->serviceWorkerDidNotHandle(this);
+    protectedLoader()->serviceWorkerDidNotHandle(this);
 }
 
 void ServiceWorkerFetchTask::cannotHandle()
@@ -402,13 +402,13 @@ void ServiceWorkerFetchTask::continueDidReceiveFetchResponse()
 void ServiceWorkerFetchTask::continueFetchTaskWith(ResourceRequest&& request)
 {
     SWFETCH_RELEASE_LOG("continueFetchTaskWith: (hasServiceWorkerConnection=%d)", !!m_serviceWorkerConnection);
-    Ref protectedLoader = *m_loader;
+    Ref loader = *m_loader;
     if (!m_serviceWorkerConnection) {
-        protectedLoader->serviceWorkerDidNotHandle(this);
+        loader->serviceWorkerDidNotHandle(this);
         return;
     }
     if (m_timeoutTimer)
-        m_timeoutTimer->startOneShot(protectedLoader->connectionToWebProcess().networkProcess().serviceWorkerFetchTimeout());
+        m_timeoutTimer->startOneShot(loader->connectionToWebProcess().networkProcess().serviceWorkerFetchTimeout());
     m_currentRequest = WTFMove(request);
     startFetch();
 }
@@ -423,8 +423,8 @@ void ServiceWorkerFetchTask::timeoutTimerFired()
 
     cannotHandle();
 
-    if (m_swServerConnection)
-        m_swServerConnection->fetchTaskTimedOut(serviceWorkerIdentifier());
+    if (CheckedPtr swServerConnection = m_swServerConnection.get())
+        swServerConnection->fetchTaskTimedOut(serviceWorkerIdentifier());
 }
 
 void ServiceWorkerFetchTask::softUpdateIfNeeded()
@@ -432,12 +432,12 @@ void ServiceWorkerFetchTask::softUpdateIfNeeded()
     SWFETCH_RELEASE_LOG("softUpdateIfNeeded: (m_shouldSoftUpdate=%d)", m_shouldSoftUpdate);
     if (!m_shouldSoftUpdate)
         return;
-    Ref protectedLoader = *m_loader;
-    auto* swConnection = protectedLoader->connectionToWebProcess().swConnection();
+    Ref loader = *m_loader;
+    CheckedPtr swConnection = loader->connectionToWebProcess().swConnection();
     if (!swConnection)
         return;
-    if (auto* registration = swConnection->server().getRegistration(m_serviceWorkerRegistrationIdentifier))
-        registration->scheduleSoftUpdate(protectedLoader->isAppInitiated() ? WebCore::IsAppInitiated::Yes : WebCore::IsAppInitiated::No);
+    if (CheckedPtr registration = swConnection->server().getRegistration(m_serviceWorkerRegistrationIdentifier))
+        registration->scheduleSoftUpdate(loader->isAppInitiated() ? WebCore::IsAppInitiated::Yes : WebCore::IsAppInitiated::No);
 }
 
 void ServiceWorkerFetchTask::loadResponseFromPreloader()
@@ -493,19 +493,20 @@ void ServiceWorkerFetchTask::loadBodyFromPreloader()
         return;
     }
 
-    m_preloader->waitForBody([weakThis = WeakPtr { *this }, this](auto&& chunk, uint64_t length) {
-        if (!weakThis)
+    m_preloader->waitForBody([weakThis = WeakPtr { *this }](auto&& chunk, uint64_t length) {
+        CheckedPtr checkedThis = weakThis.get();
+        if (!checkedThis)
             return;
-        if (!m_preloader->error().isNull()) {
+        if (!checkedThis->m_preloader->error().isNull()) {
             // Let's copy the error as calling didFail might destroy m_preloader.
-            didFail(ResourceError { m_preloader->error() });
+            checkedThis->didFail(ResourceError { checkedThis->m_preloader->error() });
             return;
         }
         if (!chunk) {
-            didFinish(m_preloader->networkLoadMetrics());
+            checkedThis->didFinish(checkedThis->m_preloader->networkLoadMetrics());
             return;
         }
-        didReceiveDataFromPreloader(const_cast<WebCore::FragmentedSharedBuffer&>(*chunk), length);
+        checkedThis->didReceiveDataFromPreloader(const_cast<WebCore::FragmentedSharedBuffer&>(*chunk), length);
     });
 }
 
@@ -531,7 +532,7 @@ bool ServiceWorkerFetchTask::convertToDownload(DownloadManager& manager, Downloa
     if (m_preloader)
         return m_preloader->convertToDownload(manager, downloadID, request, response);
 
-    auto* session = this->session();
+    CheckedPtr session = this->session();
     if (!session || !m_serviceWorkerConnection)
         return false;
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -33,6 +33,7 @@
 #include <WebCore/ServiceWorkerTypes.h>
 #include <WebCore/Timer.h>
 #include <pal/SessionID.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -61,7 +62,7 @@ class ServiceWorkerNavigationPreloader;
 class WebSWServerConnection;
 class WebSWServerToContextConnection;
 
-class ServiceWorkerFetchTask : public CanMakeWeakPtr<ServiceWorkerFetchTask> {
+class ServiceWorkerFetchTask : public CanMakeWeakPtr<ServiceWorkerFetchTask>, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static std::unique_ptr<ServiceWorkerFetchTask> fromNavigationPreloader(WebSWServerConnection&, NetworkResourceLoader&, const WebCore::ResourceRequest&, NetworkSession*);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
@@ -63,7 +63,8 @@ void ServiceWorkerNavigationPreloader::start()
     if (m_session->cache()) {
         NetworkCache::GlobalFrameID globalID { m_parameters.webPageProxyID, m_parameters.webPageID, m_parameters.webFrameID };
         m_session->cache()->retrieve(m_parameters.request, globalID, m_parameters.isNavigatingToAppBoundDomain, m_parameters.allowPrivacyProxy, m_parameters.advancedPrivacyProtections, [this, weakThis = WeakPtr { *this }](auto&& entry, auto&&) mutable {
-            if (!weakThis || m_isCancelled)
+            CheckedPtr checkedThis = weakThis.get();
+            if (!checkedThis || m_isCancelled)
                 return;
 
             if (entry && !entry->needsValidation()) {

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h
@@ -30,6 +30,7 @@
 #include "NetworkLoadClient.h"
 #include "NetworkLoadParameters.h"
 #include <WebCore/NavigationPreloadState.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -43,7 +44,7 @@ class DownloadManager;
 class NetworkLoad;
 class NetworkSession;
 
-class ServiceWorkerNavigationPreloader final : public NetworkLoadClient, public CanMakeWeakPtr<ServiceWorkerNavigationPreloader> {
+class ServiceWorkerNavigationPreloader final : public NetworkLoadClient, public CanMakeWeakPtr<ServiceWorkerNavigationPreloader>, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     ServiceWorkerNavigationPreloader(NetworkSession&, NetworkLoadParameters&&, const WebCore::NavigationPreloadState&, bool shouldCaptureExtraNetworkLoadMetrics);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
@@ -203,8 +203,8 @@ void ServiceWorkerSoftUpdateLoader::didFailLoading(const ResourceError& error)
 void ServiceWorkerSoftUpdateLoader::didComplete()
 {
     m_networkLoad = nullptr;
-    if (m_session)
-        m_session->removeSoftUpdateLoader(this);
+    if (CheckedPtr session = m_session.get())
+        session->removeSoftUpdateLoader(this);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.h
@@ -31,6 +31,7 @@
 #include <WebCore/CrossOriginEmbedderPolicy.h>
 #include <WebCore/FetchOptions.h>
 #include <WebCore/ServiceWorkerJobData.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/WeakPtr.h>
 
@@ -45,7 +46,7 @@ namespace WebKit {
 class NetworkLoad;
 class NetworkSession;
 
-class ServiceWorkerSoftUpdateLoader final : public NetworkLoadClient, public CanMakeWeakPtr<ServiceWorkerSoftUpdateLoader> {
+class ServiceWorkerSoftUpdateLoader final : public NetworkLoadClient, public CanMakeWeakPtr<ServiceWorkerSoftUpdateLoader>, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     using Handler = CompletionHandler<void(WebCore::WorkerFetchResult&&)>;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
@@ -91,7 +91,7 @@ void WebSWOriginStore::sendStoreHandle(WebSWServerConnection& connection)
 void WebSWOriginStore::didInvalidateSharedMemory()
 {
     for (auto& connection : m_webSWServerConnections)
-        sendStoreHandle(connection);
+        sendStoreHandle(CheckedRef { connection }.get());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
@@ -39,6 +39,16 @@ WebSWRegistrationStore::WebSWRegistrationStore(WebCore::SWServer& server, Networ
     ASSERT(RunLoop::isMain());
 }
 
+CheckedPtr<NetworkStorageManager> WebSWRegistrationStore::checkedManager() const
+{
+    return m_manager.get();
+}
+
+CheckedPtr<WebCore::SWServer> WebSWRegistrationStore::checkedServer() const
+{
+    return m_server.get();
+}
+
 void WebSWRegistrationStore::clearAll(CompletionHandler<void()>&& callback)
 {
     m_updates.clear();
@@ -46,7 +56,7 @@ void WebSWRegistrationStore::clearAll(CompletionHandler<void()>&& callback)
     if (!m_manager)
         return callback();
 
-    m_manager->clearServiceWorkerRegistrations(WTFMove(callback));
+    checkedManager()->clearServiceWorkerRegistrations(WTFMove(callback));
 }
 
 void WebSWRegistrationStore::flushChanges(CompletionHandler<void()>&& callback)
@@ -62,7 +72,7 @@ void WebSWRegistrationStore::closeFiles(CompletionHandler<void()>&& callback)
     if (!m_manager)
         return callback();
 
-    m_manager->closeServiceWorkerRegistrationFiles(WTFMove(callback));
+    checkedManager()->closeServiceWorkerRegistrationFiles(WTFMove(callback));
 }
 
 void WebSWRegistrationStore::importRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>)>&& callback)
@@ -70,7 +80,7 @@ void WebSWRegistrationStore::importRegistrations(CompletionHandler<void(std::opt
     if (!m_manager)
         return callback(std::nullopt);
 
-    m_manager->importServiceWorkerRegistrations(WTFMove(callback));
+    checkedManager()->importServiceWorkerRegistrations(WTFMove(callback));
 }
 
 void WebSWRegistrationStore::updateRegistration(const WebCore::ServiceWorkerContextData& registration)
@@ -112,7 +122,7 @@ void WebSWRegistrationStore::updateToStorage(CompletionHandler<void()>&& callbac
     if (!m_manager)
         return callback();
 
-    m_manager->updateServiceWorkerRegistrations(WTFMove(registrationsToUpdate), WTFMove(registrationsToDelete), [this, weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& result) mutable {
+    checkedManager()->updateServiceWorkerRegistrations(WTFMove(registrationsToUpdate), WTFMove(registrationsToDelete), [this, weakThis = WeakPtr { *this }, callback = WTFMove(callback)](auto&& result) mutable {
         ASSERT(RunLoop::isMain());
 
         if (!weakThis || !m_server || !result)
@@ -120,7 +130,7 @@ void WebSWRegistrationStore::updateToStorage(CompletionHandler<void()>&& callbac
 
         auto allScripts = WTFMove(result.value());
         for (auto&& scripts : allScripts)
-            m_server->didSaveWorkerScriptsToDisk(scripts.identifier, WTFMove(scripts.mainScript), WTFMove(scripts.importedScripts));
+            checkedServer()->didSaveWorkerScriptsToDisk(scripts.identifier, WTFMove(scripts.mainScript), WTFMove(scripts.importedScripts));
 
         callback();
     });

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
@@ -55,6 +55,9 @@ private:
     void updateToStorage(CompletionHandler<void()>&&);
     void updateTimerFired() { updateToStorage([] { }); }
 
+    CheckedPtr<NetworkStorageManager> checkedManager() const;
+    CheckedPtr<WebCore::SWServer> checkedServer() const;
+
     WeakPtr<WebCore::SWServer> m_server;
     WeakPtr<NetworkStorageManager> m_manager;
     WebCore::Timer m_updateTimer;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -83,16 +83,16 @@ WebSWServerConnection::WebSWServerConnection(NetworkConnectionToWebProcess& netw
     , m_networkConnectionToWebProcess(networkConnectionToWebProcess)
     , m_contentConnection(connection)
 {
-    if (auto* session = this->session())
+    if (CheckedPtr session = this->session())
         session->registerSWServerConnection(*this);
 }
 
 WebSWServerConnection::~WebSWServerConnection()
 {
-    if (auto* session = this->session())
+    if (CheckedPtr session = this->session())
         session->unregisterSWServerConnection(*this);
     for (const auto& keyValue : m_clientOrigins)
-        server().unregisterServiceWorkerClient(keyValue.value, keyValue.key);
+        checkedServer()->unregisterServiceWorkerClient(keyValue.value, keyValue.key);
     for (auto& completionHandler : m_unregisterJobs.values())
         completionHandler(false);
 }
@@ -143,28 +143,28 @@ void WebSWServerConnection::startScriptFetchInClient(ServiceWorkerJobIdentifier 
 void WebSWServerConnection::updateRegistrationStateInClient(ServiceWorkerRegistrationIdentifier identifier, ServiceWorkerRegistrationState state, const std::optional<ServiceWorkerData>& serviceWorkerData)
 {
     send(Messages::WebSWClientConnection::UpdateRegistrationState(identifier, state, serviceWorkerData));
-    if (auto contextConnection = m_networkConnectionToWebProcess->swContextConnection())
+    if (CheckedPtr contextConnection = m_networkConnectionToWebProcess->swContextConnection())
         sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::UpdateRegistrationState(identifier, state, serviceWorkerData));
 }
 
 void WebSWServerConnection::fireUpdateFoundEvent(ServiceWorkerRegistrationIdentifier identifier)
 {
     send(Messages::WebSWClientConnection::FireUpdateFoundEvent(identifier));
-    if (auto contextConnection = m_networkConnectionToWebProcess->swContextConnection())
+    if (CheckedPtr contextConnection = m_networkConnectionToWebProcess->swContextConnection())
         sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::FireUpdateFoundEvent(identifier));
 }
 
 void WebSWServerConnection::setRegistrationLastUpdateTime(ServiceWorkerRegistrationIdentifier identifier, WallTime lastUpdateTime)
 {
     send(Messages::WebSWClientConnection::SetRegistrationLastUpdateTime(identifier, lastUpdateTime));
-    if (auto contextConnection = m_networkConnectionToWebProcess->swContextConnection())
+    if (CheckedPtr contextConnection = m_networkConnectionToWebProcess->swContextConnection())
         sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::SetRegistrationLastUpdateTime(identifier, lastUpdateTime));
 }
 
 void WebSWServerConnection::setRegistrationUpdateViaCache(ServiceWorkerRegistrationIdentifier identifier, ServiceWorkerUpdateViaCache updateViaCache)
 {
     send(Messages::WebSWClientConnection::SetRegistrationUpdateViaCache(identifier, updateViaCache));
-    if (auto contextConnection = m_networkConnectionToWebProcess->swContextConnection())
+    if (CheckedPtr contextConnection = m_networkConnectionToWebProcess->swContextConnection())
         sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::SetRegistrationUpdateViaCache(identifier, updateViaCache));
 }
 
@@ -176,7 +176,7 @@ void WebSWServerConnection::notifyClientsOfControllerChange(const HashSet<Script
 void WebSWServerConnection::updateWorkerStateInClient(ServiceWorkerIdentifier worker, ServiceWorkerState state)
 {
     send(Messages::WebSWClientConnection::UpdateWorkerState(worker, state));
-    if (auto contextConnection = m_networkConnectionToWebProcess->swContextConnection())
+    if (CheckedPtr contextConnection = m_networkConnectionToWebProcess->swContextConnection())
         sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::UpdateWorkerState(worker, state));
 }
 
@@ -218,13 +218,13 @@ std::unique_ptr<ServiceWorkerFetchTask> WebSWServerConnection::createFetchTask(N
         return nullptr;
     }
 
-    if (!server().canHandleScheme(loader.originalRequest().url().protocol()))
+    if (!checkedServer()->canHandleScheme(loader.originalRequest().url().protocol()))
         return nullptr;
 
     std::optional<ServiceWorkerRegistrationIdentifier> serviceWorkerRegistrationIdentifier;
     if (auto resultingClientIdentifier = loader.parameters().options.resultingClientIdentifier) {
         auto topOrigin = loader.parameters().isMainFrameNavigation ? SecurityOriginData::fromURLWithoutStrictOpaqueness(request.url()) : loader.parameters().topOrigin->data();
-        auto* registration = doRegistrationMatching(topOrigin, request.url());
+        CheckedPtr registration = doRegistrationMatching(topOrigin, request.url());
         if (!registration)
             return nullptr;
 
@@ -241,7 +241,7 @@ std::unique_ptr<ServiceWorkerFetchTask> WebSWServerConnection::createFetchTask(N
         serviceWorkerRegistrationIdentifier = *loader.parameters().serviceWorkerRegistrationIdentifier;
     }
 
-    auto* registration = server().getRegistration(*serviceWorkerRegistrationIdentifier);
+    CheckedPtr registration = checkedServer()->getRegistration(*serviceWorkerRegistrationIdentifier);
     RefPtr worker = registration ? registration->activeWorker() : nullptr;
     if (!worker) {
         SWSERVERCONNECTION_RELEASE_LOG_ERROR("startFetch: DidNotHandle because no active worker for registration %" PRIu64, serviceWorkerRegistrationIdentifier->toUInt64());
@@ -272,7 +272,8 @@ void WebSWServerConnection::startFetch(ServiceWorkerFetchTask& task, SWServerWor
         if (!task)
             return;
 
-        if (!weakThis) {
+        CheckedPtr checkedThis = weakThis.get();
+        if (!checkedThis) {
             task->cannotHandle();
             return;
         }
@@ -283,24 +284,26 @@ void WebSWServerConnection::startFetch(ServiceWorkerFetchTask& task, SWServerWor
             return;
         }
 
-        RefPtr worker = server().workerByID(task->serviceWorkerIdentifier());
+        CheckedPtr server = checkedServer();
+        RefPtr worker = server->workerByID(task->serviceWorkerIdentifier());
         if (!worker || worker->hasTimedOutAnyFetchTasks()) {
             task->cannotHandle();
             return;
         }
 
         if (!worker->contextConnection())
-            server().createContextConnection(worker->registrableDomain(), worker->serviceWorkerPageIdentifier());
+            server->createContextConnection(worker->registrableDomain(), worker->serviceWorkerPageIdentifier());
 
         auto identifier = task->serviceWorkerIdentifier();
-        server().runServiceWorkerIfNecessary(identifier, [weakThis = WTFMove(weakThis), this, task = WTFMove(task)](auto* contextConnection) mutable {
+        server->runServiceWorkerIfNecessary(identifier, [weakThis = WTFMove(weakThis), this, task = WTFMove(task)](auto* contextConnection) mutable {
 #if RELEASE_LOG_DISABLED
             UNUSED_PARAM(this);
 #endif
             if (!task)
                 return;
 
-            if (!weakThis) {
+            CheckedPtr checkedThis = weakThis.get();
+            if (!checkedThis) {
                 task->cannotHandle();
                 return;
             }
@@ -320,13 +323,14 @@ void WebSWServerConnection::startFetch(ServiceWorkerFetchTask& task, SWServerWor
 
 void WebSWServerConnection::postMessageToServiceWorker(ServiceWorkerIdentifier destinationIdentifier, MessageWithMessagePorts&& message, const ServiceWorkerOrClientIdentifier& sourceIdentifier)
 {
-    RefPtr destinationWorker = server().workerByID(destinationIdentifier);
+    CheckedPtr server = checkedServer();
+    RefPtr destinationWorker = server->workerByID(destinationIdentifier);
     if (!destinationWorker)
         return;
 
     std::optional<ServiceWorkerOrClientData> sourceData;
     WTF::switchOn(sourceIdentifier, [&](ServiceWorkerIdentifier identifier) {
-        if (auto* sourceWorker = server().workerByID(identifier))
+        if (RefPtr sourceWorker = server->workerByID(identifier))
             sourceData = ServiceWorkerOrClientData { sourceWorker->data() };
     }, [&](ScriptExecutionContextIdentifier identifier) {
         if (auto clientData = destinationWorker->findClientByIdentifier(identifier))
@@ -337,7 +341,7 @@ void WebSWServerConnection::postMessageToServiceWorker(ServiceWorkerIdentifier d
         return;
 
     // It's possible this specific worker cannot be re-run (e.g. its registration has been removed)
-    server().runServiceWorkerIfNecessary(destinationIdentifier, [destinationIdentifier, message = WTFMove(message), sourceData = WTFMove(*sourceData)](auto* contextConnection) mutable {
+    server->runServiceWorkerIfNecessary(destinationIdentifier, [destinationIdentifier, message = WTFMove(message), sourceData = WTFMove(*sourceData)](auto* contextConnection) mutable {
         if (contextConnection)
             sendToContextProcess(*contextConnection, Messages::WebSWContextManagerConnection::PostMessageToServiceWorker { destinationIdentifier, WTFMove(message), WTFMove(sourceData) });
     });
@@ -356,7 +360,7 @@ void WebSWServerConnection::scheduleJobInServer(ServiceWorkerJobData&& jobData)
     SWSERVERCONNECTION_RELEASE_LOG("Scheduling ServiceWorker job %s in server", jobData.identifier().loggingString().utf8().data());
     ASSERT(identifier() == jobData.connectionIdentifier());
 
-    server().scheduleJob(WTFMove(jobData));
+    checkedServer()->scheduleJob(WTFMove(jobData));
 }
 
 URL WebSWServerConnection::clientURLFromIdentifier(ServiceWorkerOrClientIdentifier contextIdentifier)
@@ -366,13 +370,13 @@ URL WebSWServerConnection::clientURLFromIdentifier(ServiceWorkerOrClientIdentifi
         if (iterator == m_clientOrigins.end())
             return { };
 
-        auto clientData = server().serviceWorkerClientWithOriginByID(iterator->value, clientIdentifier);
+        auto clientData = checkedServer()->serviceWorkerClientWithOriginByID(iterator->value, clientIdentifier);
         if (!clientData)
             return { };
 
         return clientData->url;
     }, [&](ServiceWorkerIdentifier serviceWorkerIdentifier) -> URL {
-        RefPtr worker = server().workerByID(serviceWorkerIdentifier);
+        RefPtr worker = checkedServer()->workerByID(serviceWorkerIdentifier);
         if (!worker)
             return { };
         return worker->data().scriptURL;
@@ -383,7 +387,7 @@ void WebSWServerConnection::scheduleUnregisterJobInServer(ServiceWorkerJobIdenti
 {
     SWSERVERCONNECTION_RELEASE_LOG("Scheduling unregister ServiceWorker job in server");
 
-    auto* registration = server().getRegistration(registrationIdentifier);
+    CheckedPtr registration = checkedServer()->getRegistration(registrationIdentifier);
     if (!registration)
         return completionHandler(false);
 
@@ -394,19 +398,19 @@ void WebSWServerConnection::scheduleUnregisterJobInServer(ServiceWorkerJobIdenti
     ASSERT(!m_unregisterJobs.contains(jobIdentifier));
     m_unregisterJobs.add(jobIdentifier, WTFMove(completionHandler));
 
-    server().scheduleUnregisterJob(ServiceWorkerJobDataIdentifier { identifier(), jobIdentifier }, *registration, contextIdentifier, WTFMove(clientURL));
+    checkedServer()->scheduleUnregisterJob(ServiceWorkerJobDataIdentifier { identifier(), jobIdentifier }, *registration, contextIdentifier, WTFMove(clientURL));
 }
 
 void WebSWServerConnection::postMessageToServiceWorkerClient(ScriptExecutionContextIdentifier destinationContextIdentifier, const MessageWithMessagePorts& message, ServiceWorkerIdentifier sourceIdentifier, const String& sourceOrigin)
 {
-    server().postMessageToServiceWorkerClient(destinationContextIdentifier, message, sourceIdentifier, sourceOrigin, [this] (auto destinationContextIdentifier, auto& message, auto sourceServiceWorkerData, auto& sourceOrigin) {
+    checkedServer()->postMessageToServiceWorkerClient(destinationContextIdentifier, message, sourceIdentifier, sourceOrigin, [this] (auto destinationContextIdentifier, auto& message, auto sourceServiceWorkerData, auto& sourceOrigin) {
         send(Messages::WebSWClientConnection::PostMessageToServiceWorkerClient { destinationContextIdentifier, message, sourceServiceWorkerData, sourceOrigin }, 0);
     });
 }
 
 void WebSWServerConnection::matchRegistration(const SecurityOriginData& topOrigin, const URL& clientURL, CompletionHandler<void(std::optional<ServiceWorkerRegistrationData>&&)>&& callback)
 {
-    if (auto* registration = doRegistrationMatching(topOrigin, clientURL)) {
+    if (CheckedPtr registration = doRegistrationMatching(topOrigin, clientURL)) {
         callback(registration->data());
         return;
     }
@@ -415,7 +419,7 @@ void WebSWServerConnection::matchRegistration(const SecurityOriginData& topOrigi
 
 void WebSWServerConnection::getRegistrations(const SecurityOriginData& topOrigin, const URL& clientURL, CompletionHandler<void(const Vector<ServiceWorkerRegistrationData>&)>&& callback)
 {
-    callback(server().getRegistrations(topOrigin, clientURL));
+    callback(checkedServer()->getRegistrations(topOrigin, clientURL));
 }
 
 void WebSWServerConnection::registerServiceWorkerClient(WebCore::ClientOrigin&& clientOrigin, ServiceWorkerClientData&& data, const std::optional<ServiceWorkerRegistrationIdentifier>& controllingServiceWorkerRegistrationIdentifier, String&& userAgent)
@@ -440,16 +444,17 @@ void WebSWServerConnection::registerServiceWorkerClientInternal(WebCore::ClientO
     bool isNewOrigin = WTF::allOf(m_clientOrigins.values(), [&contextOrigin](auto& origin) {
         return contextOrigin != origin.clientOrigin;
     });
-    auto* contextConnection = isNewOrigin ? server().contextConnectionForRegistrableDomain(RegistrableDomain { contextOrigin }) : nullptr;
+    CheckedPtr server = checkedServer();
+    CheckedPtr contextConnection = isNewOrigin ? server->contextConnectionForRegistrableDomain(RegistrableDomain { contextOrigin }) : nullptr;
 
     m_clientOrigins.add(data.identifier, clientOrigin);
 
     if (isBeingCreatedClient == SWServer::IsBeingCreatedClient::No) {
-        for (auto&& pendingMessage : server().releaseServiceWorkerClientPendingMessage(data.identifier))
+        for (auto&& pendingMessage : server->releaseServiceWorkerClientPendingMessage(data.identifier))
             send(Messages::WebSWClientConnection::PostMessageToServiceWorkerClient { data.identifier, pendingMessage.message, pendingMessage.sourceData, pendingMessage.sourceOrigin }, 0);
     }
 
-    server().registerServiceWorkerClient(WTFMove(clientOrigin), WTFMove(data), controllingServiceWorkerRegistrationIdentifier, WTFMove(userAgent), isBeingCreatedClient);
+    server->registerServiceWorkerClient(WTFMove(clientOrigin), WTFMove(data), controllingServiceWorkerRegistrationIdentifier, WTFMove(userAgent), isBeingCreatedClient);
 
     if (!m_isThrottleable)
         updateThrottleState();
@@ -469,7 +474,7 @@ void WebSWServerConnection::unregisterServiceWorkerClient(const ScriptExecutionC
 
     auto clientOrigin = iterator->value;
 
-    server().unregisterServiceWorkerClient(clientOrigin, clientIdentifier);
+    checkedServer()->unregisterServiceWorkerClient(clientOrigin, clientIdentifier);
     m_clientOrigins.remove(iterator);
 
     if (!m_isThrottleable)
@@ -482,7 +487,7 @@ void WebSWServerConnection::unregisterServiceWorkerClient(const ScriptExecutionC
     if (isDeletedOrigin) {
         RegistrableDomain potentiallyRemovedDomain { clientOrigin.clientOrigin };
         if (!hasMatchingClient(potentiallyRemovedDomain)) {
-            if (auto* contextConnection = server().contextConnectionForRegistrableDomain(potentiallyRemovedDomain)) {
+            if (CheckedPtr contextConnection = checkedServer()->contextConnectionForRegistrableDomain(potentiallyRemovedDomain)) {
                 auto& connection = static_cast<WebSWServerToContextConnection&>(*contextConnection);
                 networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::UnregisterRemoteWorkerClientProcess { RemoteWorkerType::ServiceWorker, identifier(), connection.webProcessIdentifier() }, 0);
             }
@@ -499,7 +504,7 @@ bool WebSWServerConnection::hasMatchingClient(const RegistrableDomain& domain) c
 
 bool WebSWServerConnection::computeThrottleState(const RegistrableDomain& domain) const
 {
-    return WTF::allOf(server().connections().values(), [&domain](auto& serverConnection) {
+    return WTF::allOf(checkedServer()->connections().values(), [&domain](auto& serverConnection) {
         auto& connection = static_cast<WebSWServerConnection&>(*serverConnection);
         return connection.isThrottleable() || !connection.hasMatchingClient(domain);
     });
@@ -518,7 +523,7 @@ void WebSWServerConnection::updateThrottleState()
         origins.add(origin.clientOrigin);
 
     for (auto& origin : origins) {
-        if (auto* contextConnection = server().contextConnectionForRegistrableDomain(RegistrableDomain { origin })) {
+        if (CheckedPtr contextConnection = checkedServer()->contextConnectionForRegistrableDomain(RegistrableDomain { origin })) {
             auto& connection = static_cast<WebSWServerToContextConnection&>(*contextConnection);
 
             if (connection.isThrottleable() == m_isThrottleable)
@@ -538,7 +543,7 @@ void WebSWServerConnection::subscribeToPushService(WebCore::ServiceWorkerRegistr
     UNUSED_PARAM(applicationServerKey);
     completionHandler(makeUnexpected(ExceptionData { ExceptionCode::AbortError, "Push service not implemented"_s }));
 #else
-    auto registration = server().getRegistration(registrationIdentifier);
+    CheckedPtr registration = checkedServer()->getRegistration(registrationIdentifier);
     if (!registration) {
         completionHandler(makeUnexpected(ExceptionData { ExceptionCode::InvalidStateError, "Subscribing for push requires an active service worker"_s }));
         return;
@@ -568,7 +573,7 @@ void WebSWServerConnection::unsubscribeFromPushService(WebCore::ServiceWorkerReg
 
     completionHandler(false);
 #else
-    auto registration = server().getRegistration(registrationIdentifier);
+    CheckedPtr registration = checkedServer()->getRegistration(registrationIdentifier);
     if (!registration) {
         completionHandler(makeUnexpected(ExceptionData { ExceptionCode::InvalidStateError, "Unsubscribing from push requires a service worker"_s }));
         return;
@@ -590,7 +595,7 @@ void WebSWServerConnection::getPushSubscription(WebCore::ServiceWorkerRegistrati
 
     completionHandler(std::optional<PushSubscriptionData>(std::nullopt));
 #else
-    auto registration = server().getRegistration(registrationIdentifier);
+    CheckedPtr registration = checkedServer()->getRegistration(registrationIdentifier);
     if (!registration) {
         completionHandler(makeUnexpected(ExceptionData { ExceptionCode::InvalidStateError, "Getting push subscription requires a service worker"_s }));
         return;
@@ -612,7 +617,7 @@ void WebSWServerConnection::getPushPermissionState(WebCore::ServiceWorkerRegistr
 
     completionHandler(static_cast<uint8_t>(PushPermissionState::Denied));
 #else
-    auto registration = server().getRegistration(registrationIdentifier);
+    CheckedPtr registration = checkedServer()->getRegistration(registrationIdentifier);
     if (!registration) {
         completionHandler(makeUnexpected(ExceptionData { ExceptionCode::InvalidStateError, "Getting push permission state requires a service worker"_s }));
         return;
@@ -669,7 +674,7 @@ template<typename U> void WebSWServerConnection::sendToContextProcess(WebCore::S
 
 void WebSWServerConnection::fetchTaskTimedOut(ServiceWorkerIdentifier serviceWorkerIdentifier)
 {
-    RefPtr worker = server().workerByID(serviceWorkerIdentifier);
+    RefPtr worker = checkedServer()->workerByID(serviceWorkerIdentifier);
     if (!worker)
         return;
 
@@ -679,7 +684,7 @@ void WebSWServerConnection::fetchTaskTimedOut(ServiceWorkerIdentifier serviceWor
 
 void WebSWServerConnection::enableNavigationPreload(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, ExceptionOrVoidCallback&& callback)
 {
-    auto* registration = server().getRegistration(registrationIdentifier);
+    CheckedPtr registration = checkedServer()->getRegistration(registrationIdentifier);
     if (!registration) {
         callback(ExceptionData { ExceptionCode::InvalidStateError, "No registration"_s });
         return;
@@ -689,7 +694,7 @@ void WebSWServerConnection::enableNavigationPreload(WebCore::ServiceWorkerRegist
 
 void WebSWServerConnection::disableNavigationPreload(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, ExceptionOrVoidCallback&& callback)
 {
-    auto* registration = server().getRegistration(registrationIdentifier);
+    CheckedPtr registration = checkedServer()->getRegistration(registrationIdentifier);
     if (!registration) {
         callback(ExceptionData { ExceptionCode::InvalidStateError, "No registration"_s });
         return;
@@ -699,7 +704,7 @@ void WebSWServerConnection::disableNavigationPreload(WebCore::ServiceWorkerRegis
 
 void WebSWServerConnection::setNavigationPreloadHeaderValue(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, String&& headerValue, ExceptionOrVoidCallback&& callback)
 {
-    auto* registration = server().getRegistration(registrationIdentifier);
+    CheckedPtr registration = checkedServer()->getRegistration(registrationIdentifier);
     if (!registration) {
         callback(ExceptionData { ExceptionCode::InvalidStateError, "No registration"_s });
         return;
@@ -709,7 +714,7 @@ void WebSWServerConnection::setNavigationPreloadHeaderValue(WebCore::ServiceWork
 
 void WebSWServerConnection::getNavigationPreloadState(WebCore::ServiceWorkerRegistrationIdentifier registrationIdentifier, ExceptionOrNavigationPreloadStateCallback&& callback)
 {
-    auto* registration = server().getRegistration(registrationIdentifier);
+    CheckedPtr registration = checkedServer()->getRegistration(registrationIdentifier);
     if (!registration) {
         callback(makeUnexpected(ExceptionData { ExceptionCode::InvalidStateError, { } }));
         return;
@@ -734,7 +739,7 @@ std::optional<SWServer::GatheredClientData> WebSWServerConnection::gatherClientD
     if (iterator == m_clientOrigins.end())
         return { };
 
-    return server().gatherClientData(iterator->value, clientIdentifier);
+    return checkedServer()->gatherClientData(iterator->value, clientIdentifier);
 }
 
 void WebSWServerConnection::updateBackgroundFetchRegistration(const WebCore::BackgroundFetchInformation& information)
@@ -745,13 +750,14 @@ void WebSWServerConnection::updateBackgroundFetchRegistration(const WebCore::Bac
 void WebSWServerConnection::retrieveRecordResponseBody(WebCore::BackgroundFetchRecordIdentifier recordIdentifier, RetrieveRecordResponseBodyCallbackIdentifier callbackIdentifier)
 {
     SWServer::Connection::retrieveRecordResponseBody(recordIdentifier, [weakThis = WeakPtr { *this }, callbackIdentifier](auto&& result) {
-        if (!weakThis)
+        CheckedPtr checkedThis = weakThis.get();
+        if (!checkedThis)
             return;
         if (!result.has_value()) {
-            weakThis->send(Messages::WebSWClientConnection::NotifyRecordResponseBodyEnd(callbackIdentifier, result.error()));
+            checkedThis->send(Messages::WebSWClientConnection::NotifyRecordResponseBodyEnd(callbackIdentifier, result.error()));
             return;
         }
-        weakThis->send(Messages::WebSWClientConnection::NotifyRecordResponseBodyChunk(callbackIdentifier, IPC::SharedBufferReference(WTFMove(result.value()))));
+        checkedThis->send(Messages::WebSWClientConnection::NotifyRecordResponseBodyChunk(callbackIdentifier, IPC::SharedBufferReference(WTFMove(result.value()))));
     });
 }
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -66,18 +66,23 @@ WebSWServerToContextConnection::~WebSWServerToContextConnection()
             download->contextClosed();
     }
 
-    if (auto* server = this->server(); server && server->contextConnectionForRegistrableDomain(registrableDomain()) == this)
+    if (CheckedPtr server = this->server(); server && server->contextConnectionForRegistrableDomain(registrableDomain()) == this)
         server->removeContextConnection(*this);
 }
 
 NetworkProcess& WebSWServerToContextConnection::networkProcess()
 {
-    return m_connection.networkProcess();
+    return m_connection->networkProcess();
+}
+
+Ref<IPC::Connection> WebSWServerToContextConnection::protectedIPCConnection() const
+{
+    return ipcConnection();
 }
 
 IPC::Connection& WebSWServerToContextConnection::ipcConnection() const
 {
-    return m_connection.connection();
+    return m_connection->connection();
 }
 
 IPC::Connection* WebSWServerToContextConnection::messageSenderConnection() const
@@ -92,14 +97,14 @@ uint64_t WebSWServerToContextConnection::messageSenderDestinationID() const
 
 void WebSWServerToContextConnection::postMessageToServiceWorkerClient(const ScriptExecutionContextIdentifier& destinationIdentifier, const MessageWithMessagePorts& message, ServiceWorkerIdentifier sourceIdentifier, const String& sourceOrigin)
 {
-    auto* server = this->server();
-    if (auto* connection = server ? server->connection(destinationIdentifier.processIdentifier()) : nullptr)
+    CheckedPtr server = this->server();
+    if (CheckedPtr connection = server ? server->connection(destinationIdentifier.processIdentifier()) : nullptr)
         connection->postMessageToServiceWorkerClient(destinationIdentifier, message, sourceIdentifier, sourceOrigin);
 }
 
 void WebSWServerToContextConnection::skipWaiting(uint64_t requestIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier)
 {
-    if (auto* worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
+    if (RefPtr worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
         worker->skipWaiting();
 
     send(Messages::WebSWContextManagerConnection::SkipWaitingCompleted { requestIdentifier });
@@ -133,14 +138,14 @@ void WebSWServerToContextConnection::fireActivateEvent(ServiceWorkerIdentifier s
 void WebSWServerToContextConnection::firePushEvent(ServiceWorkerIdentifier serviceWorkerIdentifier, const std::optional<Vector<uint8_t>>& data, std::optional<NotificationPayload>&& proposedPayload, CompletionHandler<void(bool, std::optional<NotificationPayload>&&)>&& callback)
 {
     if (!m_processingFunctionalEventCount++)
-        m_connection.networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::StartServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
+        m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::StartServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
 
     std::optional<IPC::DataReference> ipcData;
     if (data)
         ipcData = IPC::DataReference { data->data(), data->size() };
     sendWithAsyncReply(Messages::WebSWContextManagerConnection::FirePushEvent(serviceWorkerIdentifier, ipcData, WTFMove(proposedPayload)), [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](bool wasProcessed, std::optional<NotificationPayload>&& resultPayload) mutable {
-        if (weakThis && !--weakThis->m_processingFunctionalEventCount)
-            weakThis->m_connection.networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::EndServiceWorkerBackgroundProcessing { weakThis->webProcessIdentifier() }, 0);
+        if (CheckedPtr checkedThis = weakThis.get(); checkedThis && !--checkedThis->m_processingFunctionalEventCount)
+            checkedThis->m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::EndServiceWorkerBackgroundProcessing { checkedThis->webProcessIdentifier() }, 0);
 
         callback(wasProcessed, WTFMove(resultPayload));
     });
@@ -149,18 +154,19 @@ void WebSWServerToContextConnection::firePushEvent(ServiceWorkerIdentifier servi
 void WebSWServerToContextConnection::fireNotificationEvent(ServiceWorkerIdentifier serviceWorkerIdentifier, const NotificationData& data, NotificationEventType eventType, CompletionHandler<void(bool)>&& callback)
 {
     if (!m_processingFunctionalEventCount++)
-        m_connection.networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::StartServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
+        m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::StartServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
 
     sendWithAsyncReply(Messages::WebSWContextManagerConnection::FireNotificationEvent { serviceWorkerIdentifier, data, eventType }, [weakThis = WeakPtr { *this }, eventType, callback = WTFMove(callback)](bool wasProcessed) mutable {
-        if (!weakThis)
+        CheckedPtr checkedThis = weakThis.get();
+        if (!checkedThis)
             return callback(wasProcessed);
 
-        if (!--weakThis->m_processingFunctionalEventCount)
-            weakThis->m_connection.networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::EndServiceWorkerBackgroundProcessing { weakThis->webProcessIdentifier() }, 0);
+        if (!--checkedThis->m_processingFunctionalEventCount)
+            checkedThis->m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::EndServiceWorkerBackgroundProcessing { checkedThis->webProcessIdentifier() }, 0);
 
-        auto* session = weakThis->m_connection.networkSession();
+        CheckedPtr session = checkedThis->m_connection->networkSession();
         if (auto* resourceLoadStatistics = session ? session->resourceLoadStatistics() : nullptr; resourceLoadStatistics && wasProcessed && eventType == NotificationEventType::Click) {
-            return resourceLoadStatistics->setMostRecentWebPushInteractionTime(RegistrableDomain(weakThis->registrableDomain()), [callback = WTFMove(callback), wasProcessed] () mutable {
+            return resourceLoadStatistics->setMostRecentWebPushInteractionTime(RegistrableDomain(checkedThis->registrableDomain()), [callback = WTFMove(callback), wasProcessed] () mutable {
                 callback(wasProcessed);
             });
         }
@@ -172,14 +178,15 @@ void WebSWServerToContextConnection::fireNotificationEvent(ServiceWorkerIdentifi
 void WebSWServerToContextConnection::fireBackgroundFetchEvent(ServiceWorkerIdentifier serviceWorkerIdentifier, const BackgroundFetchInformation& info, CompletionHandler<void(bool)>&& callback)
 {
     if (!m_processingFunctionalEventCount++)
-        m_connection.networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::StartServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
+        m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::StartServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
 
     sendWithAsyncReply(Messages::WebSWContextManagerConnection::FireBackgroundFetchEvent { serviceWorkerIdentifier, info }, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](bool wasProcessed) mutable {
-        if (!weakThis)
+        CheckedPtr checkedThis = weakThis.get();
+        if (!checkedThis)
             return callback(wasProcessed);
 
-        if (!--weakThis->m_processingFunctionalEventCount)
-            weakThis->m_connection.networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::EndServiceWorkerBackgroundProcessing { weakThis->webProcessIdentifier() }, 0);
+        if (!--checkedThis->m_processingFunctionalEventCount)
+            checkedThis->m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::EndServiceWorkerBackgroundProcessing { checkedThis->webProcessIdentifier() }, 0);
 
         callback(wasProcessed);
     });
@@ -188,14 +195,15 @@ void WebSWServerToContextConnection::fireBackgroundFetchEvent(ServiceWorkerIdent
 void WebSWServerToContextConnection::fireBackgroundFetchClickEvent(ServiceWorkerIdentifier serviceWorkerIdentifier, const BackgroundFetchInformation& info, CompletionHandler<void(bool)>&& callback)
 {
     if (!m_processingFunctionalEventCount++)
-        m_connection.networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::StartServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
+        m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::StartServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
 
     sendWithAsyncReply(Messages::WebSWContextManagerConnection::FireBackgroundFetchClickEvent { serviceWorkerIdentifier, info }, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)](bool wasProcessed) mutable {
-        if (!weakThis)
+        CheckedPtr checkedThis = weakThis.get();
+        if (!checkedThis)
             return callback(wasProcessed);
 
-        if (!--weakThis->m_processingFunctionalEventCount)
-            weakThis->m_connection.networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::EndServiceWorkerBackgroundProcessing { weakThis->webProcessIdentifier() }, 0);
+        if (!--checkedThis->m_processingFunctionalEventCount)
+            checkedThis->m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::EndServiceWorkerBackgroundProcessing { checkedThis->webProcessIdentifier() }, 0);
 
         callback(wasProcessed);
     });
@@ -226,12 +234,12 @@ void WebSWServerToContextConnection::didSaveScriptsToDisk(ServiceWorkerIdentifie
 
 void WebSWServerToContextConnection::terminateDueToUnresponsiveness()
 {
-    m_connection.networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::TerminateUnresponsiveServiceWorkerProcesses { webProcessIdentifier() }, 0);
+    m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::TerminateUnresponsiveServiceWorkerProcesses { webProcessIdentifier() }, 0);
 }
 
 void WebSWServerToContextConnection::openWindow(WebCore::ServiceWorkerIdentifier identifier, const URL& url, OpenWindowCallback&& callback)
 {
-    auto* server = this->server();
+    CheckedPtr server = this->server();
     if (!server) {
         callback(makeUnexpected(ExceptionData { ExceptionCode::TypeError, "No SWServer"_s }));
         return;
@@ -255,19 +263,19 @@ void WebSWServerToContextConnection::openWindow(WebCore::ServiceWorkerIdentifier
             return;
         }
 
-        callback(server->topLevelServiceWorkerClientFromPageIdentifier(origin, *pageIdentifier));
+        callback(CheckedRef { *server }->topLevelServiceWorkerClientFromPageIdentifier(origin, *pageIdentifier));
     };
 
-    m_connection.networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::OpenWindowFromServiceWorker { m_connection.sessionID(), url.string(), worker->origin().clientOrigin }, WTFMove(innerCallback));
+    m_connection->networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::OpenWindowFromServiceWorker { m_connection->sessionID(), url.string(), worker->origin().clientOrigin }, WTFMove(innerCallback));
 }
 
 void WebSWServerToContextConnection::reportConsoleMessage(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, MessageSource source, MessageLevel level, const String& message, unsigned long requestIdentifier)
 {
-    auto* server = this->server();
+    CheckedPtr server = this->server();
     RefPtr worker = server ? server->workerByID(serviceWorkerIdentifier) : nullptr;
     if (!worker)
         return;
-    m_connection.networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::ReportConsoleMessage { m_connection.sessionID(), worker->scriptURL(), worker->origin().clientOrigin, source, level, message, requestIdentifier }, 0);
+    m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::ReportConsoleMessage { m_connection->sessionID(), worker->scriptURL(), worker->origin().clientOrigin, source, level, message, requestIdentifier }, 0);
 }
 
 void WebSWServerToContextConnection::matchAllCompleted(uint64_t requestIdentifier, const Vector<ServiceWorkerClientData>& clientsData)
@@ -277,7 +285,7 @@ void WebSWServerToContextConnection::matchAllCompleted(uint64_t requestIdentifie
 
 void WebSWServerToContextConnection::connectionIsNoLongerNeeded()
 {
-    m_connection.serviceWorkerServerToContextConnectionNoLongerNeeded();
+    m_connection->serviceWorkerServerToContextConnectionNoLongerNeeded();
 }
 
 void WebSWServerToContextConnection::setThrottleState(bool isThrottleable)
@@ -325,13 +333,13 @@ void WebSWServerToContextConnection::unregisterDownload(ServiceWorkerDownloadTas
 
 WebCore::ProcessIdentifier WebSWServerToContextConnection::webProcessIdentifier() const
 {
-    return m_connection.webProcessIdentifier();
+    return m_connection->webProcessIdentifier();
 }
 
 void WebSWServerToContextConnection::focus(ScriptExecutionContextIdentifier clientIdentifier, CompletionHandler<void(std::optional<WebCore::ServiceWorkerClientData>&&)>&& callback)
 {
-    auto* server = this->server();
-    auto* connection = server ? server->connection(clientIdentifier.processIdentifier()) : nullptr;
+    CheckedPtr server = this->server();
+    CheckedPtr connection = server ? server->connection(clientIdentifier.processIdentifier()) : nullptr;
     if (!connection) {
         callback({ });
         return;
@@ -359,8 +367,9 @@ void WebSWServerToContextConnection::navigate(ScriptExecutionContextIdentifier c
     }
 
     auto frameIdentifier = *data->frameIdentifier;
-    m_connection.networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::NavigateServiceWorkerClient { frameIdentifier, clientIdentifier, url }, [weakThis = WeakPtr { *this }, url, clientOrigin = worker->origin(), callback = WTFMove(callback)](auto pageIdentifier, auto frameIdentifier) mutable {
-        if (!weakThis || !weakThis->server()) {
+    m_connection->networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::NavigateServiceWorkerClient { frameIdentifier, clientIdentifier, url }, [weakThis = WeakPtr { *this }, url, clientOrigin = worker->origin(), callback = WTFMove(callback)](auto pageIdentifier, auto frameIdentifier) mutable {
+        CheckedPtr checkedThis = weakThis.get();
+        if (!checkedThis || !checkedThis->server()) {
             callback(makeUnexpected(ExceptionData { ExceptionCode::TypeError, "service worker is gone"_s }));
             return;
         }
@@ -371,7 +380,7 @@ void WebSWServerToContextConnection::navigate(ScriptExecutionContextIdentifier c
         }
 
         std::optional<ServiceWorkerClientData> clientData;
-        weakThis->server()->forEachClientForOrigin(clientOrigin, [pageIdentifier, frameIdentifier, url, &clientData](auto& data) {
+        checkedThis->server()->forEachClientForOrigin(clientOrigin, [pageIdentifier, frameIdentifier, url, &clientData](auto& data) {
             if (!clientData && data.pageIdentifier && *data.pageIdentifier == *pageIdentifier && data.frameIdentifier && *data.frameIdentifier == *frameIdentifier && equalIgnoringFragmentIdentifier(data.url, url))
                 clientData = data;
         });

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -65,6 +65,7 @@ public:
     WebSWServerToContextConnection(NetworkConnectionToWebProcess&, WebPageProxyIdentifier, WebCore::RegistrableDomain&&, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, WebCore::SWServer&);
     ~WebSWServerToContextConnection();
 
+    Ref<IPC::Connection> protectedIPCConnection() const;
     IPC::Connection& ipcConnection() const;
 
     // IPC::MessageReceiver
@@ -119,7 +120,7 @@ private:
 
     void setInspectable(WebCore::ServiceWorkerIsInspectable) final;
 
-    NetworkConnectionToWebProcess& m_connection;
+    WeakRef<NetworkConnectionToWebProcess> m_connection;
     HashMap<WebCore::FetchIdentifier, WeakPtr<ServiceWorkerFetchTask>> m_ongoingFetches;
     HashMap<WebCore::FetchIdentifier, ThreadSafeWeakPtr<ServiceWorkerDownloadTask>> m_ongoingDownloads;
     bool m_isThrottleable { true };

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -44,6 +44,7 @@
 #include <WebCore/IndexedDB.h>
 #include <WebCore/ServiceWorkerTypes.h>
 #include <pal/SessionID.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 
@@ -82,7 +83,7 @@ class ServiceWorkerStorageManager;
 class StorageAreaBase;
 class StorageAreaRegistry;
 
-class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver {
+class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver, public CanMakeCheckedPtr {
 public:
     static Ref<NetworkStorageManager> create(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
     static bool canHandleTypes(OptionSet<WebsiteDataType>);


### PR DESCRIPTION
#### 1c9013f934cfde85be73ee267d5701957e74d695
<pre>
Adopt more smart pointers in service worker code
<a href="https://bugs.webkit.org/show_bug.cgi?id=267475">https://bugs.webkit.org/show_bug.cgi?id=267475</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::~SWServer):
(WebCore::SWServer::workerByID const):
(WebCore::SWServer::activeWorkerFromRegistrationID):
(WebCore::SWServer::addRegistrationFromStore):
(WebCore::SWServer::didSaveWorkerScriptsToDisk):
(WebCore::SWServer::removeRegistration):
(WebCore::SWServer::getRegistrations):
(WebCore::SWServer::clearAll):
(WebCore::SWServer::clearInternal):
(WebCore::SWServer::Connection::finishFetchingScriptInServer):
(WebCore::SWServer::Connection::didResolveRegistrationPromise):
(WebCore::SWServer::Connection::addServiceWorkerRegistrationInServer):
(WebCore::SWServer::Connection::removeServiceWorkerRegistrationInServer):
(WebCore::SWServer::SWServer):
(WebCore::SWServer::scheduleJob):
(WebCore::SWServer::rejectJob):
(WebCore::SWServer::resolveRegistrationJob):
(WebCore::SWServer::resolveUnregistrationJob):
(WebCore::SWServer::startScriptFetch):
(WebCore::SWServer::scriptFetchFinished):
(WebCore::SWServer::refreshImportedScripts):
(WebCore::SWServer::refreshImportedScriptsFinished):
(WebCore::SWServer::scriptContextFailedToStart):
(WebCore::SWServer::scriptContextStarted):
(WebCore::SWServer::terminatePreinstallationWorker):
(WebCore::SWServer::didFinishInstall):
(WebCore::SWServer::didFinishActivation):
(WebCore::SWServer::claim):
(WebCore::SWServer::didResolveRegistrationPromise):
(WebCore::SWServer::addClientServiceWorkerRegistration):
(WebCore::SWServer::removeClientServiceWorkerRegistration):
(WebCore::SWServer::tryInstallContextData):
(WebCore::SWServer::contextConnectionCreated):
(WebCore::SWServer::forEachServiceWorker const):
(WebCore::SWServer::terminateContextConnectionWhenPossible):
(WebCore::SWServer::installContextData):
(WebCore::SWServer::runServiceWorkerIfNecessary):
(WebCore::SWServer::runServiceWorker):
(WebCore::SWServer::markAllWorkersForRegistrableDomainAsTerminated):
(WebCore::SWServer::workerContextTerminated):
(WebCore::SWServer::fireInstallEvent):
(WebCore::SWServer::removeConnection):
(WebCore::SWServer::doRegistrationMatching):
(WebCore::SWServer::updateAppInitiatedValueForWorkers):
(WebCore::SWServer::registerServiceWorkerClient):
(WebCore::SWServer::unregisterServiceWorkerClient):
(WebCore::SWServer::removeContextConnectionIfPossible):
(WebCore::SWServer::resolveRegistrationReadyRequests):
(WebCore::SWServer::Connection::whenRegistrationReady):
(WebCore::SWServer::Connection::storeRegistrationsOnDisk):
(WebCore::SWServer::getAllOrigins):
(WebCore::SWServer::createContextConnection):
(WebCore::SWServer::softUpdate):
(WebCore::SWServer::processPushMessage):
(WebCore::SWServer::processNotificationEvent):
(WebCore::SWServer::fireFunctionalEvent):
(WebCore::SWServer::postMessageToServiceWorkerClient):
(WebCore::SWServer::setInspectable):
(WebCore::SWServer::Connection::startBackgroundFetch):
(WebCore::SWServer::Connection::backgroundFetchInformation):
(WebCore::SWServer::Connection::backgroundFetchIdentifiers):
(WebCore::SWServer::Connection::abortBackgroundFetch):
(WebCore::SWServer::Connection::matchBackgroundFetch):
(WebCore::SWServer::Connection::retrieveRecordResponse):
(WebCore::SWServer::Connection::retrieveRecordResponseBody):
* Source/WebCore/workers/service/server/SWServer.h:
(WebCore::SWServer::Connection::doRegistrationMatching):
(WebCore::SWServer::Connection::server):
(WebCore::SWServer::Connection::server const):
(WebCore::SWServer::Connection::checkedServer const):
* Source/WebCore/workers/service/server/SWServerJobQueue.cpp:
(WebCore::SWServerJobQueue::scriptFetchFinished):
(WebCore::SWServerJobQueue::importedScriptsFetchFinished):
(WebCore::SWServerJobQueue::scriptAndImportedScriptsFetchFinished):
(WebCore::SWServerJobQueue::scriptContextFailedToStart):
(WebCore::SWServerJobQueue::scriptContextStarted):
(WebCore::SWServerJobQueue::install):
(WebCore::SWServerJobQueue::didResolveRegistrationPromise):
(WebCore::SWServerJobQueue::didFinishInstall):
(WebCore::SWServerJobQueue::runRegisterJob):
(WebCore::SWServerJobQueue::runUnregisterJob):
(WebCore::SWServerJobQueue::runUpdateJob):
(WebCore::SWServerJobQueue::rejectCurrentJob):
* Source/WebCore/workers/service/server/SWServerJobQueue.h:
(WebCore::SWServerJobQueue::checkedServer const):
* Source/WebCore/workers/service/server/SWServerRegistration.cpp:
(WebCore::SWServerRegistration::forEachConnection):
(WebCore::SWServerRegistration::notifyClientsOfControllerChange):
(WebCore::SWServerRegistration::clear):
(WebCore::SWServerRegistration::activate):
(WebCore::SWServerRegistration::didFinishActivation):
(WebCore::SWServerRegistration::isUnregistered const):
(WebCore::SWServerRegistration::controlClient):
(WebCore::SWServerRegistration::softUpdate):
(WebCore::SWServerRegistration::enableNavigationPreload):
(WebCore::SWServerRegistration::disableNavigationPreload):
(WebCore::SWServerRegistration::setNavigationPreloadHeaderValue):
* Source/WebCore/workers/service/server/SWServerRegistration.h:
(WebCore::SWServerRegistration::checkedServer const):
* Source/WebCore/workers/service/server/SWServerToContextConnection.cpp:
(WebCore::SWServerToContextConnection::scriptContextFailedToStart):
(WebCore::SWServerToContextConnection::scriptContextStarted):
(WebCore::SWServerToContextConnection::didFinishInstall):
(WebCore::SWServerToContextConnection::didFinishActivation):
(WebCore::SWServerToContextConnection::setServiceWorkerHasPendingEvents):
(WebCore::SWServerToContextConnection::workerTerminated):
(WebCore::SWServerToContextConnection::matchAll):
(WebCore::SWServerToContextConnection::findClientByVisibleIdentifier):
(WebCore::SWServerToContextConnection::claim):
(WebCore::SWServerToContextConnection::setScriptResource):
(WebCore::SWServerToContextConnection::didFailHeartBeatCheck):
(WebCore::SWServerToContextConnection::setAsInspected):
(WebCore::SWServerToContextConnection::terminateWhenPossible):
* Source/WebCore/workers/service/server/SWServerToContextConnection.h:
* Source/WebCore/workers/service/server/SWServerWorker.cpp:
(WebCore::m_lastNavigationWasAppInitiated):
(WebCore::SWServerWorker::checkedServer const):
(WebCore::SWServerWorker::updateAppInitiatedValue):
(WebCore::SWServerWorker::startTermination):
(WebCore::SWServerWorker::contextConnection):
(WebCore::SWServerWorker::scriptContextFailedToStart):
(WebCore::SWServerWorker::scriptContextStarted):
(WebCore::SWServerWorker::didFinishInstall):
(WebCore::SWServerWorker::didFinishActivation):
(WebCore::SWServerWorker::contextTerminated):
(WebCore::SWServerWorker::findClientByIdentifier const):
(WebCore::SWServerWorker::findClientByVisibleIdentifier):
(WebCore::SWServerWorker::matchAll):
(WebCore::SWServerWorker::userAgent const):
(WebCore::SWServerWorker::didSaveScriptsToDisk):
(WebCore::SWServerWorker::setHasPendingEvents):
(WebCore::SWServerWorker::setState):
(WebCore::SWServerWorker::workerThreadMode const):
(WebCore::SWServerWorker::shouldBeTerminated const):
(WebCore::SWServerWorker::terminationIfPossibleTimerFired):
(WebCore::SWServerWorker::isClientActiveServiceWorker const):
* Source/WebCore/workers/service/server/SWServerWorker.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
(WebKit::NetworkConnectionToWebProcess::swContextConnection):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp:
(WebKit::ServiceWorkerDownloadTask::startListeningForIPC):
(WebKit::ServiceWorkerDownloadTask::close):
(WebKit::ServiceWorkerDownloadTask::sendToServiceWorker):
(WebKit::ServiceWorkerDownloadTask::cancel):
(WebKit::ServiceWorkerDownloadTask::setPendingDownloadLocation):
(WebKit::ServiceWorkerDownloadTask::didFinish):
(WebKit::ServiceWorkerDownloadTask::didFailDownload):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::ServiceWorkerFetchTask):
(WebKit::ServiceWorkerFetchTask::~ServiceWorkerFetchTask):
(WebKit::ServiceWorkerFetchTask::sendToServiceWorker):
(WebKit::ServiceWorkerFetchTask::sendToClient):
(WebKit::ServiceWorkerFetchTask::startFetch):
(WebKit::ServiceWorkerFetchTask::processRedirectResponse):
(WebKit::ServiceWorkerFetchTask::processResponse):
(WebKit::ServiceWorkerFetchTask::didReceiveData):
(WebKit::ServiceWorkerFetchTask::didReceiveDataFromPreloader):
(WebKit::ServiceWorkerFetchTask::didFinish):
(WebKit::ServiceWorkerFetchTask::didFail):
(WebKit::ServiceWorkerFetchTask::didNotHandle):
(WebKit::ServiceWorkerFetchTask::usePreload):
(WebKit::ServiceWorkerFetchTask::cannotHandle):
(WebKit::ServiceWorkerFetchTask::continueFetchTaskWith):
(WebKit::ServiceWorkerFetchTask::timeoutTimerFired):
(WebKit::ServiceWorkerFetchTask::softUpdateIfNeeded):
(WebKit::ServiceWorkerFetchTask::loadBodyFromPreloader):
(WebKit::ServiceWorkerFetchTask::convertToDownload):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp:
(WebKit::ServiceWorkerNavigationPreloader::start):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp:
(WebKit::ServiceWorkerSoftUpdateLoader::didComplete):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp:
(WebKit::WebSWOriginStore::didInvalidateSharedMemory):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp:
(WebKit::WebSWRegistrationStore::checkedManager const):
(WebKit::WebSWRegistrationStore::checkedServer const):
(WebKit::WebSWRegistrationStore::clearAll):
(WebKit::WebSWRegistrationStore::closeFiles):
(WebKit::WebSWRegistrationStore::importRegistrations):
(WebKit::WebSWRegistrationStore::updateToStorage):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::WebSWServerConnection):
(WebKit::WebSWServerConnection::~WebSWServerConnection):
(WebKit::WebSWServerConnection::updateRegistrationStateInClient):
(WebKit::WebSWServerConnection::fireUpdateFoundEvent):
(WebKit::WebSWServerConnection::setRegistrationLastUpdateTime):
(WebKit::WebSWServerConnection::setRegistrationUpdateViaCache):
(WebKit::WebSWServerConnection::updateWorkerStateInClient):
(WebKit::WebSWServerConnection::createFetchTask):
(WebKit::WebSWServerConnection::startFetch):
(WebKit::WebSWServerConnection::postMessageToServiceWorker):
(WebKit::WebSWServerConnection::scheduleJobInServer):
(WebKit::WebSWServerConnection::clientURLFromIdentifier):
(WebKit::WebSWServerConnection::scheduleUnregisterJobInServer):
(WebKit::WebSWServerConnection::postMessageToServiceWorkerClient):
(WebKit::WebSWServerConnection::matchRegistration):
(WebKit::WebSWServerConnection::getRegistrations):
(WebKit::WebSWServerConnection::registerServiceWorkerClientInternal):
(WebKit::WebSWServerConnection::unregisterServiceWorkerClient):
(WebKit::WebSWServerConnection::computeThrottleState const):
(WebKit::WebSWServerConnection::updateThrottleState):
(WebKit::WebSWServerConnection::subscribeToPushService):
(WebKit::WebSWServerConnection::unsubscribeFromPushService):
(WebKit::WebSWServerConnection::getPushSubscription):
(WebKit::WebSWServerConnection::getPushPermissionState):
(WebKit::WebSWServerConnection::fetchTaskTimedOut):
(WebKit::WebSWServerConnection::enableNavigationPreload):
(WebKit::WebSWServerConnection::disableNavigationPreload):
(WebKit::WebSWServerConnection::setNavigationPreloadHeaderValue):
(WebKit::WebSWServerConnection::getNavigationPreloadState):
(WebKit::WebSWServerConnection::gatherClientData):
(WebKit::WebSWServerConnection::retrieveRecordResponseBody):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::~WebSWServerToContextConnection):
(WebKit::WebSWServerToContextConnection::networkProcess):
(WebKit::WebSWServerToContextConnection::protectedIPCConnection const):
(WebKit::WebSWServerToContextConnection::ipcConnection const):
(WebKit::WebSWServerToContextConnection::postMessageToServiceWorkerClient):
(WebKit::WebSWServerToContextConnection::skipWaiting):
(WebKit::WebSWServerToContextConnection::firePushEvent):
(WebKit::WebSWServerToContextConnection::fireNotificationEvent):
(WebKit::WebSWServerToContextConnection::fireBackgroundFetchEvent):
(WebKit::WebSWServerToContextConnection::fireBackgroundFetchClickEvent):
(WebKit::WebSWServerToContextConnection::terminateDueToUnresponsiveness):
(WebKit::WebSWServerToContextConnection::openWindow):
(WebKit::WebSWServerToContextConnection::reportConsoleMessage):
(WebKit::WebSWServerToContextConnection::connectionIsNoLongerNeeded):
(WebKit::WebSWServerToContextConnection::webProcessIdentifier const):
(WebKit::WebSWServerToContextConnection::focus):
(WebKit::WebSWServerToContextConnection::navigate):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:

Canonical link: <a href="https://commits.webkit.org/273025@main">https://commits.webkit.org/273025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8c57bb0c69721b7f38dae8b4647581feabd74ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36523 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30717 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34956 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9829 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29771 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9338 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37831 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30774 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30562 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35549 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33450 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11355 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7830 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10139 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10373 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->