### PR TITLE
Deleted unused SendMouseOverUpDownEvents

### DIFF
--- a/Source/WebCore/dom/SimulatedClick.cpp
+++ b/Source/WebCore/dom/SimulatedClick.cpp
@@ -91,9 +91,6 @@ bool simulateClick(Element& element, Event* underlyingEvent, SimulatedClickMouse
         return false;
 
     auto& eventNames = WebCore::eventNames();
-    if (mouseEventOptions == SendMouseOverUpDownEvents)
-        simulateMouseEvent(eventNames.mouseoverEvent, element, underlyingEvent, creationOptions);
-
     if (mouseEventOptions != SendNoEvents)
         simulateMouseEvent(eventNames.mousedownEvent, element, underlyingEvent, creationOptions);
     if (mouseEventOptions != SendNoEvents || visualOptions == ShowPressedLook)

--- a/Source/WebCore/dom/SimulatedClickOptions.h
+++ b/Source/WebCore/dom/SimulatedClickOptions.h
@@ -25,7 +25,6 @@ namespace WebCore {
 enum SimulatedClickMouseEventOptions {
     SendNoEvents,
     SendMouseUpDownEvents,
-    SendMouseOverUpDownEvents
 };
 
 enum SimulatedClickVisualOptions {


### PR DESCRIPTION
#### bb6b4064682196191f012b802f57ff0d52ebb349
<pre>
Deleted unused SendMouseOverUpDownEvents
<a href="https://bugs.webkit.org/show_bug.cgi?id=267486">https://bugs.webkit.org/show_bug.cgi?id=267486</a>

Reviewed by Wenson Hsieh.

Delete the unused code.

* Source/WebCore/dom/SimulatedClick.cpp:
(WebCore::simulateClick):
* Source/WebCore/dom/SimulatedClickOptions.h:

Canonical link: <a href="https://commits.webkit.org/273013@main">https://commits.webkit.org/273013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69b3ac4167300b5527f8ccf402237e2726f1eb71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12680 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30714 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29770 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34383 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10735 "Found 1 new test failure: fast/forms/ios/dismiss-date-picker-on-rotation.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30227 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9336 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37828 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30805 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35547 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33440 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11352 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10137 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4376 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->