### PR TITLE
Advanced tracking and fingerprinting protection performance issues with drawImage

### DIFF
--- a/LayoutTests/fast/canvas/canvas-noise-injection-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-noise-injection-expected.txt
@@ -14,9 +14,17 @@ PASS fillRect should not require noise injection when noise injection is not ena
 PASS drawImage that covers entire canvas should not require noise injection
 PASS fillText should not require noise injection when noise injection is not enabled
 PASS drawImage after fillText should not require noise injection when noise injection is not enabled
+PASS drawImage with detached Canvas source should not require noise injection when noise injection is not enabled
+PASS drawImage with attached Canvas destination should not require noise injection when noise injection is not enabled
+PASS drawImage with attached Canvas source should not require noise injection when noise injection is not enabled
+PASS drawImage with attached Canvas destination should not require noise injection when noise injection is not enabled
 PASS getImageData should not apply noise when noise injection is not enabled
 PASS putImageData should not require noise injection
 PASS fillRect should not require noise injection when noise injection is not enabled
+PASS drawImage with detached Canvas source should not require noise injection when noise injection is not enabled
+PASS drawImage with attached Canvas destination should not require noise injection when noise injection is not enabled
+PASS drawImage with attached Canvas source should not require noise injection when noise injection is not enabled
+PASS drawImage with attached Canvas destination should not require noise injection when noise injection is not enabled
 Enabling canvas noise injection
 PASS Initial canvas should not have pending dirty rects
 PASS drawImage should not require noise injection
@@ -28,13 +36,25 @@ PASS getImageData should apply all required noise
 PASS putImageData should not require noise injection
 PASS fillRect should require noise injection
 PASS data: url after fillRect should not be equal
+PASS Canvas2D dataURL with noise value 0 should be identical
 PASS drawImage that covers entire canvas should not require noise injection
 PASS fillText should require noise injection
 PASS drawImage after fillText require noise injection
+PASS drawImage with detached Canvas source should not apply noise
+PASS drawImage with attached Canvas destination should add dirty rect and not apply noise
+PASS drawImage with attached Canvas source should not apply noise
+PASS drawImage with attached Canvas destination should add dirty rect and not apply noise
 PASS getImageData should apply all required noise
 PASS putImageData should not require noise injection
 PASS fillRect should require noise injection
 PASS data: url after fillRect should not be equal
+PASS drawImage with detached Canvas source should not have pending noise
+PASS drawImage with attached Canvas destination should not add dirty rect
+PASS drawImage with attached Canvas source should not have pending noise
+PASS drawImage with attached Canvas destination should not add dirty rect
+PASS dataURL with noise value 0 should be identical
+PASS WebGL dataURL with noise should not be identical
+PASS WebGL dataURL with noise value 0 should be identical
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/canvas/canvas-noise-injection.html
+++ b/LayoutTests/fast/canvas/canvas-noise-injection.html
@@ -1,6 +1,7 @@
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>
+<script src="webgl/resources/webgl-fingerprinting-support.js"></script>
 </head>
 <body>
 <img src="resources/background.png" id="img">
@@ -91,6 +92,16 @@
         document.body.removeChild(canvas);
 
         canvas = document.createElement("canvas");
+        if (noiseInjectionEnabled)
+            internals.setCanvasNoiseInjectionSalt(canvas, 0);
+        document.body.appendChild(canvas);
+        ctx = canvas.getContext("2d");
+        ctx.setFillColor("blue", .9);
+        ctx.fillText("This is text", 10, 10);
+        setOrCompareDataUrl(dataURLComparisonIndex++, canvas.toDataURL(), true, "Canvas2D dataURL with noise value 0 should be identical");
+        document.body.removeChild(canvas);
+
+        canvas = document.createElement("canvas");
         canvas.width = img.width;
         canvas.height = img.height;
         if (noiseInjectionEnabled)
@@ -123,6 +134,34 @@
         else
             expectFalse(hasPendingCanvasNoiseInjection(canvas), "drawImage after fillText should not require noise injection when noise injection is not enabled");
 
+        let canvas2 = document.createElement("canvas");
+        canvas2.width = canvas.width + 2;
+        canvas2.height = canvas.height + 2;
+        if (noiseInjectionEnabled)
+            setCanvasNoiseInjection(canvas2);
+
+        let ctx2 = canvas2.getContext("2d");
+        ctx2.drawImage(canvas, 0, 0);
+        if (noiseInjectionEnabled) {
+            expectTrue(hasPendingCanvasNoiseInjection(canvas), "drawImage with detached Canvas source should not apply noise");
+            expectTrue(hasPendingCanvasNoiseInjection(canvas2), "drawImage with attached Canvas destination should add dirty rect and not apply noise");
+        } else {
+            expectFalse(hasPendingCanvasNoiseInjection(canvas), "drawImage with detached Canvas source should not require noise injection when noise injection is not enabled");
+            expectFalse(hasPendingCanvasNoiseInjection(canvas2), "drawImage with attached Canvas destination should not require noise injection when noise injection is not enabled");
+        }
+
+        document.body.appendChild(canvas2);
+
+        ctx2.drawImage(canvas, 0, 0);
+        if (noiseInjectionEnabled) {
+            expectTrue(hasPendingCanvasNoiseInjection(canvas), "drawImage with attached Canvas source should not apply noise");
+            expectTrue(hasPendingCanvasNoiseInjection(canvas2), "drawImage with attached Canvas destination should add dirty rect and not apply noise");
+        } else {
+            expectFalse(hasPendingCanvasNoiseInjection(canvas), "drawImage with attached Canvas source should not require noise injection when noise injection is not enabled");
+            expectFalse(hasPendingCanvasNoiseInjection(canvas2), "drawImage with attached Canvas destination should not require noise injection when noise injection is not enabled");
+        }
+        document.body.removeChild(canvas2);
+
         imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
         if (noiseInjectionEnabled)
             expectFalse(hasPendingCanvasNoiseInjection(canvas), "getImageData should apply all required noise");
@@ -140,6 +179,57 @@
             dataURLMsg = "data: url after fillRect should be equal";
         }
         setOrCompareDataUrl(dataURLComparisonIndex++, canvas.toDataURL(), !noiseInjectionEnabled, dataURLMsg);
+
+        ctx2.drawImage(canvas, 0, 0);
+        if (noiseInjectionEnabled) {
+            expectFalse(hasPendingCanvasNoiseInjection(canvas), "drawImage with detached Canvas source should not have pending noise");
+            expectFalse(hasPendingCanvasNoiseInjection(canvas2), "drawImage with attached Canvas destination should not add dirty rect");
+        } else {
+            expectFalse(hasPendingCanvasNoiseInjection(canvas), "drawImage with detached Canvas source should not require noise injection when noise injection is not enabled");
+            expectFalse(hasPendingCanvasNoiseInjection(canvas2), "drawImage with attached Canvas destination should not require noise injection when noise injection is not enabled");
+        }
+
+        document.body.appendChild(canvas2);
+
+        ctx2.drawImage(canvas, 0, 0);
+        if (noiseInjectionEnabled) {
+            expectFalse(hasPendingCanvasNoiseInjection(canvas), "drawImage with attached Canvas source should not have pending noise");
+            expectFalse(hasPendingCanvasNoiseInjection(canvas2), "drawImage with attached Canvas destination should not add dirty rect");
+        } else {
+            expectFalse(hasPendingCanvasNoiseInjection(canvas), "drawImage with attached Canvas source should not require noise injection when noise injection is not enabled");
+            expectFalse(hasPendingCanvasNoiseInjection(canvas2), "drawImage with attached Canvas destination should not require noise injection when noise injection is not enabled");
+        }
+
+        document.body.removeChild(canvas2);
+
+        canvas = document.createElement("canvas");
+        document.body.appendChild(canvas);
+        if (noiseInjectionEnabled)
+            internals.setCanvasNoiseInjectionSalt(canvas, 0);
+        ctx = canvas.getContext("2d");
+        ctx.setFillColor("blue", .9);
+        ctx.fillText("This is text", 10, 10);
+        setOrCompareDataUrl(dataURLComparisonIndex++, canvas.toDataURL(), true, "dataURL with noise value 0 should be identical");
+
+        document.body.removeChild(canvas);
+
+        canvas = document.createElement("canvas");
+        document.body.appendChild(canvas);
+        if (noiseInjectionEnabled)
+            setCanvasNoiseInjection(canvas);
+
+        main(canvas);
+        setOrCompareDataUrl(dataURLComparisonIndex++, canvas.toDataURL(), false, "WebGL dataURL with noise should not be identical");
+
+        document.body.removeChild(canvas);
+
+        canvas = document.createElement("canvas");
+        document.body.appendChild(canvas);
+        if (noiseInjectionEnabled)
+            internals.setCanvasNoiseInjectionSalt(canvas, 0);
+
+        main(canvas);
+        setOrCompareDataUrl(dataURLComparisonIndex++, canvas.toDataURL(), true, "WebGL dataURL with noise value 0 should be identical");
 
         document.body.removeChild(canvas);
     }

--- a/LayoutTests/fast/canvas/webgl/resources/webgl-fingerprinting-support.js
+++ b/LayoutTests/fast/canvas/webgl/resources/webgl-fingerprinting-support.js
@@ -1,0 +1,316 @@
+// Inspired by https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Tutorial/Using_shaders_to_apply_color_in_WebGL
+
+function createMatrix() {
+    let out = new Float32Array(16);
+    out[0] = 1;
+    out[5] = 1;
+    out[10] = 1;
+    out[15] = 1;
+    return out;
+}
+
+function drawScene(gl, programInfo, buffers) {
+    gl.clearColor(0.0, 0.0, 0.0, 1.0); // Clear to black, fully opaque
+    gl.clearDepth(1.0); // Clear everything
+    gl.enable(gl.DEPTH_TEST); // Enable depth testing
+    gl.depthFunc(gl.LEQUAL); // Near things obscure far things
+
+    // Clear the canvas before we start drawing on it.
+
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    // Create a perspective matrix, a special matrix that is
+    // used to simulate the distortion of perspective in a camera.
+    // Our field of view is 45 degrees, with a width/height
+    // ratio that matches the display size of the canvas
+    // and we only want to see objects between 0.1 units
+    // and 100 units away from the camera.
+
+    const fieldOfView = (45 * Math.PI) / 180; // in radians
+    const aspect = gl.canvas.clientWidth / gl.canvas.clientHeight;
+    const zNear = 0.1;
+    const zFar = 100.0;
+    const projectionMatrix = (() => {
+        let out = createMatrix();
+        const f = 1.0 / Math.tan(fieldOfView / 2);
+        out[0] = f / aspect;
+        out[1] = 0;
+        out[2] = 0;
+        out[3] = 0;
+        out[4] = 0;
+        out[5] = f;
+        out[6] = 0;
+        out[7] = 0;
+        out[8] = 0;
+        out[9] = 0;
+        out[11] = -1;
+        out[12] = 0;
+        out[13] = 0;
+        out[15] = 0;
+        if (zFar != null && zFar !== Infinity) {
+          const nf = 1 / (zNear - zFar);
+          out[10] = (zFar + zNear) * nf;
+          out[14] = 2 * zFar * zNear * nf;
+        } else {
+          out[10] = -1;
+          out[14] = -2 * zNear;
+        }
+        return out;
+    })();
+
+    // Set the drawing position to the "identity" point, which is
+    // the center of the scene.
+    // Now move the drawing position a bit to where we want to
+    // start drawing the square.
+    // Inspired by https://github.com/toji/gl-matrix/blob/master/src/mat4.js
+    const modelViewMatrix = (() => {
+       let x = -0.0;
+       let y = 0.0;
+       let z = -6.0;
+       let out = createMatrix();
+
+       out[12] = out[0] * x + out[4] * y + out[8] * z + out[12];
+       out[13] = out[1] * x + out[5] * y + out[9] * z + out[13];
+       out[14] = out[2] * x + out[6] * y + out[10] * z + out[14];
+       out[15] = out[3] * x + out[7] * y + out[11] * z + out[15];
+       return out;
+    })();
+
+    // Tell WebGL how to pull out the positions from the position
+    // buffer into the vertexPosition attribute.
+    setPositionAttribute(gl, buffers, programInfo);
+    setColorAttribute(gl, buffers, programInfo);
+
+    // Tell WebGL to use our program when drawing
+    gl.useProgram(programInfo.program);
+
+    // Set the shader uniforms
+    gl.uniformMatrix4fv(
+      programInfo.uniformLocations.projectionMatrix,
+      false,
+      projectionMatrix
+    );
+    gl.uniformMatrix4fv(
+      programInfo.uniformLocations.modelViewMatrix,
+      false,
+      modelViewMatrix
+    );
+
+    {
+      const offset = 0;
+      const vertexCount = 4;
+      gl.drawArrays(gl.TRIANGLE_STRIP, offset, vertexCount);
+    }
+}
+
+// Tell WebGL how to pull out the positions from the position
+// buffer into the vertexPosition attribute.
+function setPositionAttribute(gl, buffers, programInfo) {
+    const numComponents = 2; // pull out 2 values per iteration
+    const type = gl.FLOAT; // the data in the buffer is 32bit floats
+    const normalize = false; // don't normalize
+    const stride = 0; // how many bytes to get from one set of values to the next
+    // 0 = use type and numComponents above
+    const offset = 0; // how many bytes inside the buffer to start from gl.bindBuffer(gl.ARRAY_BUFFER, buffers.position);
+    gl.vertexAttribPointer(
+        programInfo.attribLocations.vertexPosition,
+        numComponents,
+        type,
+        normalize,
+        stride,
+        offset
+    );
+    gl.enableVertexAttribArray(programInfo.attribLocations.vertexPosition);
+}
+
+// Tell WebGL how to pull out the colors from the color buffer
+// into the vertexColor attribute.
+function setColorAttribute(gl, buffers, programInfo) {
+    const numComponents = 4;
+    const type = gl.FLOAT;
+    const normalize = false;
+    const stride = 0;
+    const offset = 0;
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffers.color);
+    gl.vertexAttribPointer(
+        programInfo.attribLocations.vertexColor,
+        numComponents,
+        type,
+        normalize,
+        stride,
+        offset
+    );
+    gl.enableVertexAttribArray(programInfo.attribLocations.vertexColor);
+}
+
+function initBuffers(gl) {
+    const positionBuffer = initPositionBuffer(gl);
+    const colorBuffer = initColorBuffer(gl);
+
+    return {
+        position: positionBuffer,
+        color: colorBuffer,
+    };
+}
+
+function initPositionBuffer(gl) {
+    // Create a buffer for the square's positions.
+    const positionBuffer = gl.createBuffer();
+
+    // Select the positionBuffer as the one to apply buffer
+    // operations to from here out.
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+
+    // Now create an array of positions for the square.
+    const positions = [1.0, 1.0, -1.0, 1.0, 1.0, -1.0, -1.0, -1.0];
+
+    // Now pass the list of positions into WebGL to build the
+    // shape. We do this by creating a Float32Array from the
+    // JavaScript array, then use it to fill the current buffer.
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(positions), gl.STATIC_DRAW);
+
+    return positionBuffer;
+}
+
+function initColorBuffer(gl) {
+    const colors = [
+        1.0,
+        1.0,
+        1.0,
+        1.0, // white
+        1.0,
+        0.0,
+        0.0,
+        1.0, // red
+        0.0,
+        1.0,
+        0.0,
+        1.0, // green
+        0.0,
+        0.0,
+        1.0,
+        1.0, // blue
+    ];
+
+    const colorBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, colorBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(colors), gl.STATIC_DRAW);
+
+    return colorBuffer;
+}
+
+//
+// Initialize a shader program, so WebGL knows how to draw our data
+//
+function initShaderProgram(gl, vsSource, fsSource) {
+    const vertexShader = loadShader(gl, gl.VERTEX_SHADER, vsSource);
+    const fragmentShader = loadShader(gl, gl.FRAGMENT_SHADER, fsSource);
+
+    // Create the shader program
+
+    const shaderProgram = gl.createProgram();
+    gl.attachShader(shaderProgram, vertexShader);
+    gl.attachShader(shaderProgram, fragmentShader);
+    gl.linkProgram(shaderProgram);
+
+    // If creating the shader program failed, alert
+
+    if (!gl.getProgramParameter(shaderProgram, gl.LINK_STATUS)) {
+        alert(
+            `Unable to initialize the shader program: ${gl.getProgramInfoLog(shaderProgram)}`
+        );
+        return null;
+    }
+
+    return shaderProgram;
+}
+
+//
+// creates a shader of the given type, uploads the source and
+// compiles it.
+//
+function loadShader(gl, type, source) {
+    const shader = gl.createShader(type);
+
+    // Send the source to the shader object
+
+    gl.shaderSource(shader, source);
+
+    // Compile the shader program
+
+    gl.compileShader(shader);
+
+    // See if it compiled successfully
+
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        alert(`An error occurred compiling the shaders: ${gl.getShaderInfoLog(shader)}`);
+        gl.deleteShader(shader);
+        return null;
+    }
+
+    return shader;
+}
+
+function main(canvas) {
+    // Initialize the GL context
+    const gl = canvas.getContext("webgl");
+
+    // Only continue if WebGL is available and working
+    if (gl === null) {
+      alert(
+        "Unable to initialize WebGL. Your browser or machine may not support it."
+      );
+      return;
+    }
+
+    // Set clear color to black, fully opaque
+    gl.clearColor(0.0, 0.0, 0.0, 1.0);
+    // Clear the color buffer with specified clear color
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    // Vertex shader program
+    const vsSource = `
+        attribute vec4 aVertexPosition;
+        attribute vec4 aVertexColor;
+        uniform mat4 uModelViewMatrix;
+        uniform mat4 uProjectionMatrix;
+        varying lowp vec4 vColor;
+        void main() {
+            gl_Position = uProjectionMatrix * uModelViewMatrix * aVertexPosition;
+            vColor = aVertexColor;
+        }
+    `;
+
+    const fsSource = `
+        varying lowp vec4 vColor;
+        void main() {
+            gl_FragColor = vColor;
+        }
+    `;
+
+    // Initialize a shader program; this is where all the lighting
+    // for the vertices and so forth is established.
+    const shaderProgram = initShaderProgram(gl, vsSource, fsSource);
+
+    // Collect all the info needed to use the shader program.
+    // Look up which attribute our shader program is using
+    // for aVertexPosition and look up uniform locations.
+    const programInfo = {
+        program: shaderProgram,
+        attribLocations: {
+            vertexPosition: gl.getAttribLocation(shaderProgram, "aVertexPosition"),
+            vertexColor: gl.getAttribLocation(shaderProgram, "aVertexColor"),
+        },
+        uniformLocations: {
+            projectionMatrix: gl.getUniformLocation(shaderProgram, "uProjectionMatrix"),
+            modelViewMatrix: gl.getUniformLocation(shaderProgram, "uModelViewMatrix"),
+        },
+    };
+
+    // Here's where we call the routine that builds all the
+    // objects we'll be drawing.
+    const buffers = initBuffers(gl);
+
+    // Draw the scene
+    drawScene(gl, programInfo, buffers);
+}

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -99,12 +99,12 @@ AffineTransform CanvasBase::baseTransform() const
     return m_imageBuffer->baseTransform();
 }
 
-void CanvasBase::makeRenderingResultsAvailable()
+void CanvasBase::makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)
 {
     if (auto* context = renderingContext()) {
         context->drawBufferToCanvas(CanvasRenderingContext::SurfaceBuffer::DrawingBuffer);
-        if (m_canvasNoiseHashSalt)
-            m_canvasNoiseInjection.postProcessDirtyCanvasBuffer(buffer(), *m_canvasNoiseHashSalt);
+        if (m_canvasNoiseHashSalt && shouldApplyPostProcessingToDirtyRect == ShouldApplyPostProcessingToDirtyRect::Yes)
+            m_canvasNoiseInjection.postProcessDirtyCanvasBuffer(buffer(), *m_canvasNoiseHashSalt, context->is2d() ? CanvasNoiseInjectionPostProcessArea::DirtyRect : CanvasNoiseInjectionPostProcessArea::FullBuffer);
     }
 }
 

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -83,7 +83,7 @@ public:
 
     virtual AffineTransform baseTransform() const;
 
-    void makeRenderingResultsAvailable();
+    void makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect = ShouldApplyPostProcessingToDirtyRect::Yes);
 
     size_t memoryCost() const;
     size_t externalMemoryCost() const;
@@ -164,7 +164,7 @@ private:
     String m_lastFillText;
 
     CanvasNoiseInjection m_canvasNoiseInjection;
-    Markable<NoiseInjectionHashSalt, IntegralMarkableTraits<NoiseInjectionHashSalt>> m_canvasNoiseHashSalt;
+    Markable<NoiseInjectionHashSalt, IntegralMarkableTraits<NoiseInjectionHashSalt, std::numeric_limits<int64_t>::max()>> m_canvasNoiseHashSalt;
     bool m_originClean { true };
 #if ASSERT_ENABLED
     bool m_didNotifyObserversCanvasDestroyed { false };

--- a/Source/WebCore/html/CanvasNoiseInjection.cpp
+++ b/Source/WebCore/html/CanvasNoiseInjection.cpp
@@ -185,23 +185,24 @@ static std::pair<std::array<int, 4>, std::array<int, 4>> boundingNeighbors(int i
     return tightestBoundingColors;
 }
 
-void CanvasNoiseInjection::postProcessDirtyCanvasBuffer(ImageBuffer* imageBuffer, NoiseInjectionHashSalt salt)
+void CanvasNoiseInjection::postProcessDirtyCanvasBuffer(ImageBuffer* imageBuffer, NoiseInjectionHashSalt salt, CanvasNoiseInjectionPostProcessArea postProcessArea)
 {
-    ASSERT(salt);
 
-    if (m_postProcessDirtyRect.isEmpty())
+    if (m_postProcessDirtyRect.isEmpty() && postProcessArea == CanvasNoiseInjectionPostProcessArea::DirtyRect)
         return;
 
     if (!imageBuffer)
         return;
 
+    auto dirtyRect = postProcessArea == CanvasNoiseInjectionPostProcessArea::DirtyRect ? m_postProcessDirtyRect : IntRect(IntPoint::zero(), imageBuffer->truncatedLogicalSize());
+
     PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, imageBuffer->colorSpace() };
-    auto pixelBuffer = imageBuffer->getPixelBuffer(format, m_postProcessDirtyRect);
+    auto pixelBuffer = imageBuffer->getPixelBuffer(format, dirtyRect);
     if (!is<ByteArrayPixelBuffer>(pixelBuffer))
         return;
 
     if (postProcessPixelBufferResults(*pixelBuffer, salt)) {
-        imageBuffer->putPixelBuffer(*pixelBuffer, { IntPoint::zero(), m_postProcessDirtyRect.size() }, m_postProcessDirtyRect.location());
+        imageBuffer->putPixelBuffer(*pixelBuffer, { IntPoint::zero(), dirtyRect.size() }, dirtyRect.location());
         m_postProcessDirtyRect = { };
     }
 }
@@ -247,12 +248,15 @@ static void adjustNeighborColorBounds(std::array<int, 4>& neighborColor1, const 
 
 bool CanvasNoiseInjection::postProcessPixelBufferResults(PixelBuffer& pixelBuffer, NoiseInjectionHashSalt salt) const
 {
-    ASSERT(salt);
     ASSERT(pixelBuffer.format().pixelFormat == PixelFormat::RGBA8);
 
     constexpr int bytesPerPixel = 4;
     std::span<uint8_t> bytes = std::span(pixelBuffer.bytes(), pixelBuffer.sizeInBytes());
     bool wasPixelBufferModified { false };
+
+    // Salt value 0 is used for testing.
+    if (!salt)
+        return true;
 
     for (size_t i = 0; i < bytes.size_bytes(); i += bytesPerPixel) {
         auto& redChannel = bytes[i];

--- a/Source/WebCore/html/CanvasNoiseInjection.h
+++ b/Source/WebCore/html/CanvasNoiseInjection.h
@@ -33,11 +33,12 @@ class CanvasBase;
 class ImageBuffer;
 class PixelBuffer;
 
+enum class CanvasNoiseInjectionPostProcessArea : bool { DirtyRect, FullBuffer };
 using NoiseInjectionHashSalt = uint64_t;
 
 class CanvasNoiseInjection {
 public:
-    void postProcessDirtyCanvasBuffer(ImageBuffer*, NoiseInjectionHashSalt);
+    void postProcessDirtyCanvasBuffer(ImageBuffer*, NoiseInjectionHashSalt, CanvasNoiseInjectionPostProcessArea = CanvasNoiseInjectionPostProcessArea::DirtyRect);
     bool postProcessPixelBufferResults(PixelBuffer&, NoiseInjectionHashSalt) const;
     void updateDirtyRect(const IntRect&);
     void clearDirtyRect();

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1711,7 +1711,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
 
     checkOrigin(&sourceCanvas);
 
-    sourceCanvas.makeRenderingResultsAvailable();
+    sourceCanvas.makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect::No);
 
     bool repaintEntireCanvas = false;
     if (rectContainsCanvas(normalizedDstRect)) {
@@ -1735,7 +1735,8 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
     } else
         c->drawImageBuffer(*buffer, normalizedDstRect, normalizedSrcRect, { state().globalComposite, state().globalBlend });
 
-    didDraw(repaintEntireCanvas, normalizedDstRect, defaultDidDrawOptionsWithoutPostProcessing());
+    auto shouldUseDrawOptionsWithoutPostProcessing = sourceCanvas.renderingContext() && sourceCanvas.renderingContext()->is2d() && !sourceCanvas.havePendingCanvasNoiseInjection();
+    didDraw(repaintEntireCanvas, normalizedDstRect, shouldUseDrawOptionsWithoutPostProcessing ? defaultDidDrawOptionsWithoutPostProcessing() : defaultDidDrawOptions());
 
     return { };
 }

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -711,7 +711,7 @@ void WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver(WebGLR
 
     if (m_canvasBufferContents.has_value()) {
         m_canvasBufferContents = std::nullopt;
-        canvasBase().didDraw(FloatRect(FloatPoint(0, 0), clampedCanvasSize()));
+        canvasBase().didDraw(FloatRect(FloatPoint(0, 0), clampedCanvasSize()), ShouldApplyPostProcessingToDirtyRect::No);
     }
 }
 


### PR DESCRIPTION
#### 4c31678fef6899bc5aa8db9efe5883e9b24db160
<pre>
Advanced tracking and fingerprinting protection performance issues with drawImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=266181">https://bugs.webkit.org/show_bug.cgi?id=266181</a>
<a href="https://rdar.apple.com/problem/119783395">rdar://problem/119783395</a>

Reviewed by Kimmo Kinnunen.

In 270207@main, in the case when canvas noise injection is enabled, I added
exceptions where noise would not be applied to the canvas following
putImageData and drawImage commands. However, I excluded some cases which
weren&apos;t safe. One of those is applying noise to the source buffer of a canvas
when it is drawn onto another canvas.

This patch changes the above behavior by not applying any pending noise to the
source buffer, and instead the destination rect of the destination canvas is
marked as needing noise application. In order to accomplish this for both
canvas2d and webgl, this patch also stops tracking WebGL dirty rects that need
noise applied. The current mechanism for tracking was not sufficient and it
wasn&apos;t necessary. Instead, this patch now applies noise the the entire image
buffer if the rendering context is not 2D.

This patch adds tests that verify drawing one canvas from another accumulates
pending noise in the destination without applying noise to the source. It also
verifies that the noise application process does not change the image by
incorrectly placing the extracted pixelbuffer at the wrong offset of the image
buffer.

* LayoutTests/fast/canvas/canvas-noise-injection-expected.txt:
* LayoutTests/fast/canvas/canvas-noise-injection.html:
* LayoutTests/fast/canvas/webgl/resources/webgl-fingerprinting-support.js: Added.
(createMatrix):
(drawScene):
(setPositionAttribute):
(setColorAttribute):
(initBuffers):
(initPositionBuffer):
(initColorBuffer):
(initShaderProgram):
(loadShader):
(main):
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::makeRenderingResultsAvailable):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/CanvasNoiseInjection.cpp:
(WebCore::CanvasNoiseInjection::postProcessDirtyCanvasBuffer):
(WebCore::CanvasNoiseInjection::postProcessPixelBufferResults const):
* Source/WebCore/html/CanvasNoiseInjection.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawImage):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver):

Canonical link: <a href="https://commits.webkit.org/273301@main">https://commits.webkit.org/273301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/855aeb48076d21275f87dd4018c94f8304e0c89a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33910 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36531 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30725 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34964 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29775 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9345 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37839 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30786 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35558 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33452 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11363 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29887 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8025 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10145 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10381 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->