### PR TITLE
REGRESSION(268621@main): Crash in ContentKeyGroupDataSource::~ContentKeyGroupDataSource() due to CheckedPtr misuse

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/ContentKeyGroupDataSource.h
+++ b/Source/WebCore/platform/graphics/avfoundation/ContentKeyGroupDataSource.h
@@ -32,14 +32,14 @@
 #if HAVE(AVCONTENTKEYSESSION)
 
 #include <wtf/Assertions.h>
-#include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
+#include <wtf/WeakPtr.h>
 
 OBJC_CLASS AVContentKey;
 
 namespace WebCore {
 
-class ContentKeyGroupDataSource : public CanMakeCheckedPtr {
+class ContentKeyGroupDataSource : public CanMakeWeakPtr<ContentKeyGroupDataSource> {
 public:
     virtual ~ContentKeyGroupDataSource() = default;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -172,6 +172,10 @@ class CDMInstanceSessionFairPlayStreamingAVFObjC final
     , public AVContentKeySessionDelegateClient
     , private ContentKeyGroupDataSource {
 public:
+    using AVContentKeySessionDelegateClient::weakPtrFactory;
+    using AVContentKeySessionDelegateClient::WeakValueType;
+    using AVContentKeySessionDelegateClient::WeakPtrImplType;
+
     CDMInstanceSessionFairPlayStreamingAVFObjC(Ref<CDMInstanceFairPlayStreamingAVFObjC>&&);
     virtual ~CDMInstanceSessionFairPlayStreamingAVFObjC() = default;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm
@@ -35,11 +35,11 @@
 #import "ContentKeyGroupDataSource.h"
 #import "Logging.h"
 #import "NotImplemented.h"
-#import <wtf/CheckedPtr.h>
 #import <wtf/LoggerHelper.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/Vector.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/WeakPtr.h>
 #import <wtf/text/WTFString.h>
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation WebAVContentKeyGroup {
     WeakObjCPtr<AVContentKeySession> _contentKeySession;
-    CheckedPtr<WebCore::ContentKeyGroupDataSource> _dataSource;
+    WeakPtr<WebCore::ContentKeyGroupDataSource> _dataSource;
     RetainPtr<NSUUID> _groupIdentifier;
 }
 
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
         return nil;
 
     _contentKeySession = contentKeySession;
-    _dataSource = &dataSource;
+    _dataSource = dataSource;
     _groupIdentifier = adoptNS([[NSUUID alloc] init]);
 
     OBJC_INFO_LOG(OBJC_LOGIDENTIFIER, "groupIdentifier=", _groupIdentifier.get());
@@ -101,6 +101,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)expire
 {
+    if (!_dataSource)
+        return;
+
 #if HAVE(AVCONTENTKEY_REVOKE)
     Vector keys = _dataSource->contentKeyGroupDataSourceKeys();
     OBJC_INFO_LOG(OBJC_LOGIDENTIFIER, "keys=", keys.size());
@@ -128,17 +131,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (const void*)logIdentifier
 {
-    return _dataSource->contentKeyGroupDataSourceLogIdentifier();
+    return _dataSource ? _dataSource->contentKeyGroupDataSourceLogIdentifier() : nullptr;
 }
 
 - (const Logger*)loggerPtr
 {
-    return &_dataSource->contentKeyGroupDataSourceLogger();
+    return _dataSource ? &_dataSource->contentKeyGroupDataSourceLogger() : nullptr;
 }
 
 - (WTFLogChannel*)logChannel
 {
-    return &_dataSource->contentKeyGroupDataSourceLogChannel();
+    return _dataSource ? &_dataSource->contentKeyGroupDataSourceLogChannel() : nullptr;
 }
 
 @end


### PR DESCRIPTION
#### 13c5af2199517d7b83380156216b0bb003d97c61
<pre>
REGRESSION(268621@main): Crash in ContentKeyGroupDataSource::~ContentKeyGroupDataSource() due to CheckedPtr misuse
<a href="https://bugs.webkit.org/show_bug.cgi?id=267489">https://bugs.webkit.org/show_bug.cgi?id=267489</a>
<a href="https://rdar.apple.com/120422670">rdar://120422670</a>

Reviewed by Eric Carlson.

In 268621@main, WebAVContentKeyGroup was changed to store a CheckedPtr to its data source. However,
because CDMInstanceSessionFairPlayStreamingAVFObjC stores m_group in an options dictionary attached
to AVContentKeyRequests whose lifetimes are controlled by AVFoundation, WebKit cannot control the
lifetime of WebAVContentKeyGroup instances.

Fixed this by partially reverting 268621@main so that WebAVContentKeyGroup stores its data source as
a WeakPtr again.

* Source/WebCore/platform/graphics/avfoundation/ContentKeyGroupDataSource.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm:
(-[WebAVContentKeyGroup initWithContentKeySession:dataSource:]):
(-[WebAVContentKeyGroup expire]):
(-[WebAVContentKeyGroup logIdentifier]):
(-[WebAVContentKeyGroup loggerPtr]):
(-[WebAVContentKeyGroup logChannel]):

Canonical link: <a href="https://commits.webkit.org/273014@main">https://commits.webkit.org/273014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0e1f575ed08c559e5b256db125a3f5c72c405f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36539 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30733 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29781 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10726 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30241 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9350 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9449 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37847 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30796 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30578 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35563 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33457 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11371 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7819 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10153 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10389 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->