### PR TITLE
Import Observable WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any-expected.txt
@@ -1,0 +1,33 @@
+
+FAIL Observable constructor assert_implements: The Observable interface is not implemented undefined
+FAIL Subscriber interface is not constructible assert_implements: The Subscriber interface is not implemented undefined
+FAIL subscribe() can be called with no arguments Can't find variable: Observable
+FAIL Subscribe with just a function as the next handler Can't find variable: Observable
+FAIL Observable constructor calls initializer on subscribe Can't find variable: Observable
+FAIL Observable error path called synchronously Can't find variable: Observable
+FAIL Observable should error if initializer throws Can't find variable: Observable
+FAIL Subscription is inactive after complete() Can't find variable: Observable
+FAIL Subscription is inactive after error() Can't find variable: Observable
+FAIL Subscription is inactive when aborted signal is passed in Can't find variable: Observable
+FAIL Subscriber#signal is not the same AbortSignal as the one passed into `subscribe()` Can't find variable: Observable
+FAIL Subscription does not emit values after completion Can't find variable: Observable
+FAIL Subscription does not emit values after error Can't find variable: Observable
+FAIL Completing or nexting a subscriber after an error does nothing Can't find variable: Observable
+FAIL Errors pushed to the subscriber that are not handled by the subscription are reported to the global Can't find variable: Observable
+FAIL Errors thrown in the initializer that are not handled by the subscription are reported to the global Can't find variable: Observable
+FAIL Subscription reports errors that are pushed after subscriber is closed by completion Can't find variable: Observable
+FAIL Errors thrown by initializer function after subscriber is closed by completion are reported Can't find variable: Observable
+FAIL Errors thrown by initializer function after subscriber is closed by error are reported Can't find variable: Observable
+FAIL Errors pushed by initializer function after subscriber is closed by error are reported Can't find variable: Observable
+FAIL Subscriber#complete() cannot re-entrantly invoke itself Can't find variable: Observable
+FAIL Subscriber#error() cannot re-entrantly invoke itself Can't find variable: Observable
+FAIL Unsubscription lifecycle Can't find variable: Observable
+FAIL Aborting a subscription should stop emitting values Can't find variable: Observable
+FAIL Calling subscribe should never throw an error synchronously, initializer throws error Can't find variable: Observable
+FAIL Calling subscribe should never throw an error synchronously, subscriber pushes error Can't find variable: Observable
+FAIL Teardown should be called when subscription is aborted Can't find variable: Observable
+FAIL Teardowns should be called when subscription is closed by completion Can't find variable: Observable
+FAIL Teardowns should be called when subscription is closed by subscriber pushing an error Can't find variable: Observable
+FAIL Teardowns should be called when subscription is closed by subscriber throwing error Can't find variable: Observable
+FAIL Teardowns should be called synchronously during addTeardown() if the subscription is inactive Can't find variable: Observable
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.js
@@ -1,0 +1,842 @@
+// Because we test that the global error handler is called at various times.
+setup({allow_uncaught_exception: true});
+
+test(() => {
+  assert_implements(self.Observable, "The Observable interface is not implemented");
+
+  assert_true(
+    typeof Observable === "function",
+    "Observable constructor is defined"
+  );
+
+  assert_throws_js(TypeError, () => { new Observable(); });
+}, "Observable constructor");
+
+test(() => {
+  assert_implements(self.Subscriber, "The Subscriber interface is not implemented");
+  assert_true(
+    typeof Subscriber === "function",
+    "Subscriber interface is defined as a function"
+  );
+
+  assert_throws_js(TypeError, () => { new Subscriber(); });
+
+  new Observable(subscriber => {
+    assert_not_equals(subscriber, undefined, "A Subscriber must be passed into the subscribe callback");
+    assert_implements(subscriber.next, "A Subscriber object must have a next() method");
+    assert_implements(subscriber.complete, "A Subscriber object must have a complete() method");
+    assert_implements(subscriber.error, "A Subscriber object must have an error() method");
+  }).subscribe();
+}, "Subscriber interface is not constructible");
+
+test(() => {
+  let initializerCalled = false;
+  const source = new Observable(() => {
+    initializerCalled = true;
+  });
+
+  assert_false(
+    initializerCalled,
+    "initializer should not be called by construction"
+  );
+  source.subscribe();
+  assert_true(initializerCalled, "initializer should be called by subscribe");
+}, "subscribe() can be called with no arguments");
+
+test(() => {
+  let initializerCalled = false;
+  const results = [];
+
+  const source = new Observable((subscriber) => {
+    initializerCalled = true;
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.next(3);
+  });
+
+  assert_false(
+    initializerCalled,
+    "initializer should not be called by construction"
+  );
+
+  source.subscribe(x => results.push(x));
+
+  assert_true(initializerCalled, "initializer should be called by subscribe");
+  assert_array_equals(
+    results,
+    [1, 2, 3],
+    "should emit values synchronously, but not complete"
+  );
+}, "Subscribe with just a function as the next handler");
+
+test(() => {
+  let initializerCalled = false;
+  const results = [];
+
+  const source = new Observable((subscriber) => {
+    initializerCalled = true;
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.next(3);
+    subscriber.complete();
+  });
+
+  assert_false(
+    initializerCalled,
+    "initializer should not be called by construction"
+  );
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: () => assert_unreached("error should not be called"),
+    complete: () => results.push("complete"),
+  });
+
+  assert_true(initializerCalled, "initializer should be called by subscribe");
+  assert_array_equals(
+    results,
+    [1, 2, 3, "complete"],
+    "should emit values synchronously"
+  );
+}, "Observable constructor calls initializer on subscribe");
+
+test(() => {
+  const error = new Error("error");
+  const results = [];
+
+  const source = new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.error(error);
+  });
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: (e) => results.push(e),
+    complete: () => assert_unreached("complete should not be called"),
+  });
+
+  assert_array_equals(
+    results,
+    [1, 2, error],
+    "should emit error synchronously"
+  );
+}, "Observable error path called synchronously");
+
+test(() => {
+  const error = new Error("error");
+  const results = [];
+  let errorReported = null;
+  let innerSubscriber = null;
+  let subscriptionActivityInFinallyAfterThrow;
+  let subscriptionActivityInErrorHandlerAfterThrow;
+
+  self.addEventListener("error", e => errorReported = e, {once: true});
+
+  const source = new Observable((subscriber) => {
+    innerSubscriber = subscriber;
+    subscriber.next(1);
+    try {
+      throw error;
+    } finally {
+      subscriptionActivityInFinallyAfterThrow = subscriber.active;
+    }
+  });
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: (e) => {
+      subscriptionActivityInErrorHandlerAfterThrow = innerSubscriber.active;
+      results.push(e);
+    },
+    complete: () => assert_unreached("complete should not be called"),
+  });
+
+  assert_equals(errorReported, null, "The global error handler should not be " +
+      "invoked when the subscribe callback throws an error and the " +
+      "subscriber has given an error handler");
+  assert_true(subscriptionActivityInFinallyAfterThrow, "Subscriber is " +
+      "considered active in finally block before error handler is invoked");
+  assert_false(subscriptionActivityInErrorHandlerAfterThrow, "Subscriber is " +
+      "considered inactive in error handler block after thrown error");
+  assert_array_equals(
+    results,
+    [1, error],
+    "should emit values and the thrown error synchronously"
+  );
+}, "Observable should error if initializer throws");
+
+test(t => {
+  let innerSubscriber = null;
+  let activeAfterComplete = false;
+  let activeDuringComplete = false;
+
+  const source = new Observable((subscriber) => {
+    innerSubscriber = subscriber;
+
+    subscriber.complete();
+    activeAfterComplete = subscriber.active;
+  });
+
+  source.subscribe({complete: () => activeDuringComplete = innerSubscriber.active});
+  assert_false(activeDuringComplete, "Subscription is not active during complete");
+  assert_false(activeAfterComplete, "Subscription is not active after complete");
+}, "Subscription is inactive after complete()");
+
+test(t => {
+  let innerSubscriber = null;
+  let activeAfterError = false;
+  let activeDuringError = false;
+
+  const error = new Error("error");
+  const source = new Observable((subscriber) => {
+    innerSubscriber = subscriber;
+
+    subscriber.error(error);
+    activeAfterError = subscriber.active;
+  });
+
+  source.subscribe({error: () => activeDuringError = innerSubscriber.active});
+  assert_false(activeDuringError, "Subscription is not active during error");
+  assert_false(activeAfterError, "Subscription is not active after error");
+}, "Subscription is inactive after error()");
+
+test(t => {
+  let innerSubscriber;
+  let initialActivity;
+  let initialSignalAborted;
+
+  const source = new Observable((subscriber) => {
+    innerSubscriber = subscriber;
+    initialActivity = subscriber.active;
+    initialSignalAborted = subscriber.signal.aborted;
+  });
+
+  source.subscribe({}, {signal: AbortSignal.abort('Initially aborted')});
+  assert_false(initialActivity);
+  assert_true(initialSignalAborted);
+  assert_equals(innerSubscriber.signal.reason, 'Initially aborted');
+}, "Subscription is inactive when aborted signal is passed in");
+
+test(() => {
+  let outerSubscriber = null;
+
+  const source = new Observable(subscriber => outerSubscriber = subscriber);
+
+  const controller = new AbortController();
+  source.subscribe({}, {signal: controller.signal});
+
+  assert_not_equals(controller.signal, outerSubscriber.signal);
+}, "Subscriber#signal is not the same AbortSignal as the one passed into `subscribe()`");
+
+test(() => {
+  const results = [];
+
+  const source = new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+    subscriber.next(3);
+  });
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: () => assert_unreached("error should not be called"),
+    complete: () => results.push("complete"),
+  });
+
+  assert_array_equals(
+    results,
+    [1, 2, "complete"],
+    "should emit values synchronously, but not nexted values after complete"
+  );
+}, "Subscription does not emit values after completion");
+
+test(() => {
+  const error = new Error("error");
+  const results = [];
+
+  const source = new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.error(error);
+    subscriber.next(3);
+  });
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: (e) => results.push(e),
+    complete: () => assert_unreached("complete should not be called"),
+  });
+
+  assert_array_equals(
+    results,
+    [1, 2, error],
+    "should emit values synchronously, but not nexted values after error"
+  );
+}, "Subscription does not emit values after error");
+
+test(() => {
+  const error = new Error("error");
+  const results = [];
+
+  const source = new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.error(error);
+    // TODO(https://github.com/WICG/observable/issues/76): Assert
+    // `subscriber.closed` is true, if we add that attribute.
+    // assert_true(subscriber.closed, "subscriber is closed after error");
+    subscriber.next(3);
+    subscriber.complete();
+  });
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: (error) => results.push(error),
+    complete: () => assert_unreached("complete should not be called"),
+  });
+
+  assert_array_equals(results, [1, 2, error], "should emit synchronously");
+}, "Completing or nexting a subscriber after an error does nothing");
+
+test(() => {
+  const error = new Error("custom error");
+  let errorReported = null;
+
+  self.addEventListener("error", e => errorReported = e, { once: true });
+
+  const source = new Observable((subscriber) => {
+    subscriber.error(error);
+  });
+
+  // No error handler provided...
+  source.subscribe({
+    next: () => assert_unreached("next should not be called"),
+    complete: () => assert_unreached("complete should not be called"),
+  });
+
+  // ... still the exception is reported to the global.
+  assert_true(errorReported !== null, "Exception was reported to global");
+  assert_equals(errorReported.message, "Uncaught Error: custom error", "Error message matches");
+  assert_greater_than(errorReported.lineno, 0, "Error lineno is greater than 0");
+  assert_greater_than(errorReported.colno, 0, "Error lineno is greater than 0");
+  assert_equals(errorReported.error, error, "Error object is equivalent");
+}, "Errors pushed to the subscriber that are not handled by the subscription " +
+   "are reported to the global");
+
+test(() => {
+  const error = new Error("custom error");
+  let errorReported = null;
+
+  self.addEventListener("error", e => errorReported = e, { once: true });
+
+  const source = new Observable((subscriber) => {
+    throw error;
+  });
+
+  // No error handler provided...
+  source.subscribe({
+    next: () => assert_unreached("next should not be called"),
+    complete: () => assert_unreached("complete should not be called"),
+  });
+
+  // ... still the exception is reported to the global.
+  assert_true(errorReported !== null, "Exception was reported to global");
+  assert_equals(errorReported.message, "Uncaught Error: custom error", "Error message matches");
+  assert_greater_than(errorReported.lineno, 0, "Error lineno is greater than 0");
+  assert_greater_than(errorReported.colno, 0, "Error lineno is greater than 0");
+  assert_equals(errorReported.error, error, "Error object is equivalent");
+}, "Errors thrown in the initializer that are not handled by the " +
+   "subscription are reported to the global");
+
+test(() => {
+  const error = new Error("custom error");
+  const results = [];
+  let errorReported = null;
+
+  self.addEventListener("error", e => errorReported = e, { once: true });
+
+  const source = new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+    subscriber.error(error);
+  });
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: () => assert_unreached("error should not be called"),
+    complete: () => results.push("complete"),
+  });
+
+  assert_array_equals(
+    results,
+    [1, 2, "complete"],
+    "should emit values synchronously, but not error values after complete"
+  );
+
+  // Error reporting still happens even after  the subscription is closed.
+  assert_true(errorReported !== null, "Exception was reported to global");
+  assert_equals(errorReported.message, "Uncaught Error: custom error", "Error message matches");
+  assert_greater_than(errorReported.lineno, 0, "Error lineno is greater than 0");
+  assert_greater_than(errorReported.colno, 0, "Error lineno is greater than 0");
+  assert_equals(errorReported.error, error, "Error object is equivalent");
+}, "Subscription reports errors that are pushed after subscriber is closed " +
+   "by completion");
+
+test(t => {
+  const error = new Error("custom error");
+  const results = [];
+  let errorReported = null;
+
+  self.addEventListener("error", e => errorReported = e, { once: true });
+
+  const source = new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+    throw error;
+  });
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: () => assert_unreached("error should not be called"),
+    complete: () => results.push("complete"),
+  });
+
+  assert_array_equals(results, [1, 2, "complete"],
+    "should emit values synchronously, but not error after complete"
+  );
+
+  assert_true(errorReported !== null, "Exception was reported to global");
+  assert_true(errorReported.message.includes("custom error"), "Error message matches");
+  assert_greater_than(errorReported.lineno, 0, "Error lineno is greater than 0");
+  assert_greater_than(errorReported.colno, 0, "Error lineno is greater than 0");
+  assert_equals(errorReported.error, error, "Error object is equivalent");
+}, "Errors thrown by initializer function after subscriber is closed by " +
+   "completion are reported");
+
+test(() => {
+  const error1 = new Error("error 1");
+  const error2 = new Error("error 2");
+  const results = [];
+  let errorReported = null;
+
+  self.addEventListener("error", e => errorReported = e, { once: true });
+
+  const source = new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.error(error1);
+    throw error2;
+  });
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: (error) => results.push(error),
+    complete: () => assert_unreached("complete should not be called"),
+  });
+
+  assert_array_equals(
+    results,
+    [1, 2, error1],
+    "should emit values synchronously, but not nexted values after error"
+  );
+
+  assert_true(errorReported !== null, "Exception was reported to global");
+  assert_true(errorReported.message.includes("error 2"), "Error message matches");
+  assert_greater_than(errorReported.lineno, 0, "Error lineno is greater than 0");
+  assert_greater_than(errorReported.colno, 0, "Error lineno is greater than 0");
+  assert_equals(errorReported.error, error2, "Error object is equivalent");
+}, "Errors thrown by initializer function after subscriber is closed by " +
+   "error are reported");
+
+test(() => {
+  const error1 = new Error("error 1");
+  const error2 = new Error("error 2");
+  const results = [];
+  let errorReported = null;
+
+  self.addEventListener("error", e => errorReported = e, { once: true });
+
+  const source = new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.error(error1);
+    subscriber.error(error2);
+  });
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: (error) => results.push(error),
+    complete: () => assert_unreached("complete should not be called"),
+  });
+
+  assert_array_equals(
+    results,
+    [1, 2, error1],
+    "should emit values synchronously, but not nexted values after error"
+  );
+
+  assert_true(errorReported !== null, "Exception was reported to global");
+  assert_true(errorReported.message.includes("error 2"), "Error message matches");
+  assert_greater_than(errorReported.lineno, 0, "Error lineno is greater than 0");
+  assert_greater_than(errorReported.colno, 0, "Error lineno is greater than 0");
+  assert_equals(errorReported.error, error2, "Error object is equivalent");
+}, "Errors pushed by initializer function after subscriber is closed by " +
+   "error are reported");
+
+test(() => {
+  const results = [];
+  const target = new EventTarget();
+
+  const source = new Observable((subscriber) => {
+    target.addEventListener('custom event', e => {
+      subscriber.next(1);
+      subscriber.complete();
+      subscriber.error('not a real error');
+    });
+  });
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: (error) => results.push(error),
+    complete: () => {
+      results.push('complete'),
+      // Re-entrantly tries to invoke `complete()`. However, this function must
+      // only ever run once.
+      target.dispatchEvent(new Event('custom event'));
+    },
+  });
+
+  target.dispatchEvent(new Event('custom event'));
+
+  assert_array_equals(
+    results,
+    [1, 'complete'],
+    "complete() can only be called once, and cannot invoke other Observer methods"
+  );
+}, "Subscriber#complete() cannot re-entrantly invoke itself");
+
+test(() => {
+  const results = [];
+  const target = new EventTarget();
+
+  const source = new Observable((subscriber) => {
+    target.addEventListener('custom event', e => {
+      subscriber.next(1);
+      subscriber.error('not a real error');
+      subscriber.complete();
+    });
+  });
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: (error) => {
+      results.push('error'),
+      // Re-entrantly tries to invoke `error()`. However, this function must
+      // only ever run once.
+      target.dispatchEvent(new Event('custom event'));
+    },
+    complete: () => results.push('complete'),
+  });
+
+  target.dispatchEvent(new Event('custom event'));
+
+  assert_array_equals(
+    results,
+    [1, 'error'],
+    "error() can only be called once, and cannot invoke other Observer methods"
+  );
+}, "Subscriber#error() cannot re-entrantly invoke itself");
+
+// TODO(domfarolino): Once `Subscriber#addTeardown()` and `Subscriber#active`
+// are implemented, add corresponding code for them here so we can assert the following order of everything:
+//   1. The passed-in `Observer#signal` is marked as `aborted`
+//   2. Abort event handlers are invoked for the that outer, passed-in signal.
+//   3. `Subscriber#closed` is true
+//   4. `Subscriber#signal` is marked as aborted
+//   5. Teardown callbacks are executed in the right order
+//   6. Abort event handlers are invoked for `Subscriber#signal`.
+// This ensures we have the "dependent signal" logic wired up correctly:
+// https://dom.spec.whatwg.org/#create-a-dependent-abort-signal.
+test(() => {
+  const results = [];
+  let innerSubscriber = null;
+
+  const source = new Observable((subscriber) => {
+    results.push('subscribe() callback');
+    innerSubscriber = subscriber;
+
+    subscriber.signal.addEventListener('abort', () => {
+      assert_true(subscriber.signal.aborted);
+      results.push('inner abort handler');
+      subscriber.next('next from inner abort handler');
+      subscriber.complete();
+    });
+  });
+
+  const ac = new AbortController();
+  source.subscribe({
+    // This should never get called. If it is, the array assertion below will fail.
+    next: (x) => results.push(x),
+    complete: () => results.push('complete()')
+  }, {signal: ac.signal});
+
+  ac.signal.addEventListener('abort', () => {
+    results.push('outer abort handler');
+    assert_true(ac.signal.aborted);
+    assert_false(innerSubscriber.signal.aborted);
+  });
+
+  assert_array_equals(results, ['subscribe() callback']);
+  ac.abort();
+  results.push('abort() returned');
+  assert_array_equals(results, ['subscribe() callback',
+      'outer abort handler', 'inner abort handler', 'abort() returned']);
+}, "Unsubscription lifecycle");
+
+// TODO(domfarolino): If we add `subscriber.closed`, assert that its value is
+// `true` in this test. See https://github.com/WICG/observable/issues/76.
+test(t => {
+  const source = new Observable((subscriber) => {
+    let n = 0;
+    while (!subscriber.signal.aborted) {
+      subscriber.next(n++);
+      if (n > 3) {
+        assert_unreached("The subscriber should be closed by now");
+      }
+    }
+  });
+
+  const ac = new AbortController();
+  const results = [];
+
+  source.subscribe({
+    next: (x) => {
+      results.push(x);
+      if (x === 2) {
+        ac.abort();
+      }
+    },
+    error: () => results.push('error'),
+    complete: () => results.push('complete')
+  }, {signal: ac.signal});
+
+  assert_array_equals(
+    results,
+    [0, 1, 2],
+    "should emit values synchronously before abort"
+  );
+}, "Aborting a subscription should stop emitting values");
+
+test(() => {
+  const error = new Error("custom error");
+  let errorReported = null;
+
+  self.addEventListener("error", e => errorReported = e, { once: true });
+
+  const source = new Observable(() => {
+    throw error;
+  });
+
+  try {
+    source.subscribe();
+  } catch {
+    assert_unreached("subscriber() never throws an error");
+  }
+
+  assert_true(errorReported !== null, "Exception was reported to global");
+  assert_true(errorReported.message.includes("custom error"), "Error message matches");
+  assert_greater_than(errorReported.lineno, 0, "Error lineno is greater than 0");
+  assert_greater_than(errorReported.colno, 0, "Error lineno is greater than 0");
+  assert_equals(errorReported.error, error, "Error object is equivalent");
+}, "Calling subscribe should never throw an error synchronously, initializer throws error");
+
+test(() => {
+  const error = new Error("custom error");
+  let errorReported = null;
+
+  self.addEventListener("error", e => errorReported = e, { once: true });
+
+  const source = new Observable((subscriber) => {
+    subscriber.error(error);
+  });
+
+  try {
+    source.subscribe();
+  } catch {
+    assert_unreached("subscriber() never throws an error");
+  }
+
+  assert_true(errorReported !== null, "Exception was reported to global");
+  assert_true(errorReported.message.includes("custom error"), "Error message matches");
+  assert_greater_than(errorReported.lineno, 0, "Error lineno is greater than 0");
+  assert_greater_than(errorReported.colno, 0, "Error lineno is greater than 0");
+  assert_equals(errorReported.error, error, "Error object is equivalent");
+}, "Calling subscribe should never throw an error synchronously, subscriber pushes error");
+
+test(() => {
+  let addTeardownCalled = false;
+  let activeDuringTeardown;
+
+  const source = new Observable((subscriber) => {
+    subscriber.addTeardown(() => {
+      addTeardownCalled = true;
+      activeDuringTeardown = subscriber.active;
+    });
+  });
+
+  const ac = new AbortController();
+  source.subscribe({}, {signal: ac.signal});
+
+  assert_false(addTeardownCalled, "Teardown is not be called upon subscription");
+  ac.abort();
+  assert_true(addTeardownCalled, "Teardown is called when subscription is aborted");
+  assert_false(activeDuringTeardown, "Teardown observers inactive subscription");
+}, "Teardown should be called when subscription is aborted");
+
+test(() => {
+  const addTeardownsCalled = [];
+  // This is used to snapshot `addTeardownsCalled` from within the subscribe
+  // callback, for assertion/comparison later.
+  let teardownsSnapshot = [];
+  const results = [];
+
+  const source = new Observable((subscriber) => {
+    subscriber.addTeardown(() => addTeardownsCalled.push("teardown 1"));
+    subscriber.addTeardown(() => addTeardownsCalled.push("teardown 2"));
+
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.next(3);
+    subscriber.complete();
+
+    // We don't run the actual `assert_array_equals` here because if it fails,
+    // it won't be properly caught. This is because assertion failures throw an
+    // error, and in subscriber callback, thrown errors result in
+    // `window.onerror` handlers being called, which this test file doesn't
+    // record as an error (see the first line of this file).
+    teardownsSnapshot = addTeardownsCalled;
+  });
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: () => results.push("unreached"),
+    complete: () => results.push("complete"),
+  });
+
+  assert_array_equals(
+    results,
+    [1, 2, 3, "complete"],
+    "should emit values and complete synchronously"
+  );
+
+  assert_array_equals(teardownsSnapshot, addTeardownsCalled);
+  assert_array_equals(addTeardownsCalled, ["teardown 2", "teardown 1"],
+      "Teardowns called in LIFO order synchronously after complete()");
+}, "Teardowns should be called when subscription is closed by completion");
+
+test(() => {
+  const addTeardownsCalled = [];
+  let teardownsSnapshot = [];
+  const error = new Error("error");
+  const results = [];
+
+  const source = new Observable((subscriber) => {
+    subscriber.addTeardown(() => addTeardownsCalled.push("teardown 1"));
+    subscriber.addTeardown(() => addTeardownsCalled.push("teardown 2"));
+
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.next(3);
+    subscriber.error(error);
+
+    teardownsSnapshot = addTeardownsCalled;
+  });
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: (error) => results.push(error),
+    complete: () => assert_unreached("complete should not be called"),
+  });
+
+  assert_array_equals(
+    results,
+    [1, 2, 3, error],
+    "should emit values and error synchronously"
+  );
+
+  assert_array_equals(teardownsSnapshot, addTeardownsCalled);
+  assert_array_equals(addTeardownsCalled, ["teardown 2", "teardown 1"],
+      "Teardowns called in LIFO order synchronously after error()");
+}, "Teardowns should be called when subscription is closed by subscriber pushing an error");
+
+test(() => {
+  const addTeardownsCalled = [];
+  const error = new Error("error");
+  const results = [];
+
+  const source = new Observable((subscriber) => {
+    subscriber.addTeardown(() => addTeardownsCalled.push("teardown 1"));
+    subscriber.addTeardown(() => addTeardownsCalled.push("teardown 2"));
+
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.next(3);
+    throw error;
+  });
+
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: (error) => results.push(error),
+    complete: () => assert_unreached("complete should not be called"),
+  });
+
+  assert_array_equals(
+    results,
+    [1, 2, 3, error],
+    "should emit values and error synchronously"
+  );
+
+  assert_array_equals(addTeardownsCalled, ["teardown 2", "teardown 1"],
+      "Teardowns called in LIFO order synchronously after thrown error");
+}, "Teardowns should be called when subscription is closed by subscriber throwing error");
+
+test(() => {
+  const addTeardownsCalled = [];
+  const results = [];
+  let firstTeardownInvokedSynchronously = false;
+  let secondTeardownInvokedSynchronously = false;
+
+  const source = new Observable((subscriber) => {
+    subscriber.addTeardown(() => addTeardownsCalled.push("teardown 1"));
+    if (addTeardownsCalled.length === 1) {
+      firstTeardownInvokedSynchronously = true;
+    }
+    subscriber.addTeardown(() => addTeardownsCalled.push("teardown 2"));
+    if (addTeardownsCalled.length === 2) {
+      secondTeardownInvokedSynchronously = true;
+    }
+
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.next(3);
+    subscriber.complete();
+  });
+
+  const ac = new AbortController();
+  ac.abort();
+  source.subscribe({
+    next: (x) => results.push(x),
+    error: (error) => results.push(error),
+    complete: () => results.push('complete')
+  }, {signal: ac.signal});
+
+  assert_array_equals(results, []);
+  assert_true(firstTeardownInvokedSynchronously, "First teardown callback is invoked during addTeardown()");
+  assert_true(secondTeardownInvokedSynchronously, "Second teardown callback is invoked during addTeardown()");
+  assert_array_equals(addTeardownsCalled, ["teardown 1", "teardown 2"],
+      "Teardowns called synchronously upon addition end up in FIFO order");
+}, "Teardowns should be called synchronously during addTeardown() if the subscription is inactive");

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.worker-expected.txt
@@ -1,0 +1,33 @@
+
+FAIL Observable constructor assert_implements: The Observable interface is not implemented undefined
+FAIL Subscriber interface is not constructible assert_implements: The Subscriber interface is not implemented undefined
+FAIL subscribe() can be called with no arguments Can't find variable: Observable
+FAIL Subscribe with just a function as the next handler Can't find variable: Observable
+FAIL Observable constructor calls initializer on subscribe Can't find variable: Observable
+FAIL Observable error path called synchronously Can't find variable: Observable
+FAIL Observable should error if initializer throws Can't find variable: Observable
+FAIL Subscription is inactive after complete() Can't find variable: Observable
+FAIL Subscription is inactive after error() Can't find variable: Observable
+FAIL Subscription is inactive when aborted signal is passed in Can't find variable: Observable
+FAIL Subscriber#signal is not the same AbortSignal as the one passed into `subscribe()` Can't find variable: Observable
+FAIL Subscription does not emit values after completion Can't find variable: Observable
+FAIL Subscription does not emit values after error Can't find variable: Observable
+FAIL Completing or nexting a subscriber after an error does nothing Can't find variable: Observable
+FAIL Errors pushed to the subscriber that are not handled by the subscription are reported to the global Can't find variable: Observable
+FAIL Errors thrown in the initializer that are not handled by the subscription are reported to the global Can't find variable: Observable
+FAIL Subscription reports errors that are pushed after subscriber is closed by completion Can't find variable: Observable
+FAIL Errors thrown by initializer function after subscriber is closed by completion are reported Can't find variable: Observable
+FAIL Errors thrown by initializer function after subscriber is closed by error are reported Can't find variable: Observable
+FAIL Errors pushed by initializer function after subscriber is closed by error are reported Can't find variable: Observable
+FAIL Subscriber#complete() cannot re-entrantly invoke itself Can't find variable: Observable
+FAIL Subscriber#error() cannot re-entrantly invoke itself Can't find variable: Observable
+FAIL Unsubscription lifecycle Can't find variable: Observable
+FAIL Aborting a subscription should stop emitting values Can't find variable: Observable
+FAIL Calling subscribe should never throw an error synchronously, initializer throws error Can't find variable: Observable
+FAIL Calling subscribe should never throw an error synchronously, subscriber pushes error Can't find variable: Observable
+FAIL Teardown should be called when subscription is aborted Can't find variable: Observable
+FAIL Teardowns should be called when subscription is closed by completion Can't find variable: Observable
+FAIL Teardowns should be called when subscription is closed by subscriber pushing an error Can't find variable: Observable
+FAIL Teardowns should be called when subscription is closed by subscriber throwing error Can't find variable: Observable
+FAIL Teardowns should be called synchronously during addTeardown() if the subscription is inactive Can't find variable: Observable
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.window-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL No observer handlers can be invoked in detached document promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Observable"
+FAIL Subscriber.error() does not "report the exception" even when an `error()` handler is not present, when it is invoked in a detached document promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Observable"
+FAIL Cannot subscribe to an Observable in a detached document promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: Observable"
+FAIL Observable from EventTarget does not get notified for events in detached documents promise_test: Unhandled rejection with value: object "TypeError: event_target.on is not a function. (In 'event_target.on('customevent')', 'event_target.on' is undefined)"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.window.js
@@ -1,0 +1,127 @@
+async function loadIframeAndReturnContentWindow() {
+   // Create and attach an iframe.
+  const iframe = document.createElement('iframe');
+  const iframeLoadPromise = new Promise((resolve, reject) => {
+    iframe.onload = resolve;
+    iframe.onerror = reject;
+  });
+  document.body.append(iframe);
+  await iframeLoadPromise;
+  return iframe.contentWindow;
+}
+
+promise_test(async t => {
+  // Hang this off of the main document's global, so the child can easily reach
+  // it.
+  window.results = [];
+  const contentWin = await loadIframeAndReturnContentWindow();
+
+  contentWin.eval(`
+    // Get a reference to the parent result array before we detach and lose
+    // access to the parent.
+    const parentResults = parent.results;
+
+    const source = new Observable((subscriber) => {
+      parentResults.push("subscribe");
+      // Detach the iframe and push a value to the subscriber/Observer.
+      window.frameElement.remove();
+      parentResults.push("detached");
+      subscriber.next("next");
+      subscriber.complete();
+      subscriber.error("error");
+    });
+    source.subscribe({
+      next: v => {
+        // Should never run.
+        parentResults.push(v);
+      },
+      complete: () => {
+        // Should never run.
+        parentResults.push("complete");
+      },
+      erorr: e => {
+        // Should never run.
+        parentResults.push(e);
+      }
+    });
+  `);
+
+  assert_array_equals(results, ["subscribe", "detached"]);
+}, "No observer handlers can be invoked in detached document");
+
+promise_test(async t => {
+  const contentWin = await loadIframeAndReturnContentWindow();
+
+  // Set a global error handler on the iframe document's window, and verify that
+  // it is never called (because the thing triggering the error happens when the
+  // document is detached, and "reporting the exception" relies on an attached
+  // document).
+  contentWin.addEventListener("error",
+      t.unreached_func("Error should not be called"), { once: true });
+
+  contentWin.eval(`
+    const source = new Observable((subscriber) => {
+      // Detach the iframe and push an error, which would normally "report the
+      // exception", since this subscriber did not specify an error handler.
+      window.frameElement.remove();
+      subscriber.error("this is an error that should not be reported");
+    });
+    source.subscribe();
+  `);
+}, "Subscriber.error() does not \"report the exception\" even when an " +
+   "`error()` handler is not present, when it is invoked in a detached document");
+
+promise_test(async t => {
+  // Make this available off the global so the child can reach it.
+  window.results = [];
+  const contentWin = await loadIframeAndReturnContentWindow();
+
+  // Set a global error handler on the iframe document's window, and verify that
+  // it is never called (because the thing triggering the error happens when the
+  // document is detached, and "reporting the exception" relies on an attached
+  // document).
+  contentWin.addEventListener("error",
+      t.unreached_func("Error should not be called"), { once: true });
+
+  contentWin.eval(`
+    const parentResults = parent.results;
+    const source = new Observable((subscriber) => {
+      // This should never run.
+      parentResults.push('subscribe');
+    });
+
+    // Detach the iframe and try to subscribe.
+    window.frameElement.remove();
+    parentResults.push('detached');
+    source.subscribe();
+  `);
+
+  assert_array_equals(results, ["detached"], "Subscribe callback is never invoked");
+}, "Cannot subscribe to an Observable in a detached document");
+
+promise_test(async t => {
+  // Make this available off the global so the child can reach it.
+  window.results = [];
+  const contentWin = await loadIframeAndReturnContentWindow();
+
+  contentWin.eval(`
+    const parentResults = parent.results;
+    const event_target = new EventTarget();
+    // Set up two event listeners, both of which will mutate |parentResults|:
+    //   1. A traditional event listener
+    //   2. An observable
+    event_target.addEventListener('customevent', e => parentResults.push(e));
+    const source = event_target.on('customevent');
+    source.subscribe(e => parentResults.push(e));
+
+    // Detach the iframe and fire an event at the event target. The parent will
+    // confirm that the observable's next handler did not get invoked, because
+    // the window is detached.
+    const event = new Event('customevent');
+    window.frameElement.remove();
+    parentResults.push('detached');
+    event_target.dispatchEvent(event);
+  `);
+
+  assert_array_equals(results, ["detached"], "Subscribe callback is never invoked");
+}, "Observable from EventTarget does not get notified for events in detached documents");

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any-expected.txt
@@ -1,0 +1,5 @@
+
+FAIL EventTarget.on() returns an Observable assert_implements: The EventTarget interface has an `on` method undefined
+FAIL Aborting the subscription should stop the emission of events target.on is not a function. (In 'target.on("test")', 'target.on' is undefined)
+FAIL EventTarget Observables can multicast subscriptions for event handling target.on is not a function. (In 'target.on("test")', 'target.on' is undefined)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.js
@@ -1,0 +1,71 @@
+test(() => {
+  const target = new EventTarget();
+  assert_implements(target.on, "The EventTarget interface has an `on` method");
+  assert_equals(typeof target.on, "function",
+      "EventTarget should have the on method");
+
+  const testEvents = target.on("test");
+  assert_true(testEvents instanceof Observable,
+      "EventTarget.on returns an Observable");
+
+  const results = [];
+  testEvents.subscribe({
+    next: value => results.push(value),
+    error: () => results.push("error"),
+    complete: () => results.push("complete"),
+  });
+
+  assert_array_equals(results, [],
+      "Observable does not emit events until event is fired");
+
+  const event = new Event("test");
+  target.dispatchEvent(event);
+  assert_array_equals(results, [event]);
+
+  target.dispatchEvent(event);
+  assert_array_equals(results, [event, event]);
+}, "EventTarget.on() returns an Observable");
+
+test(() => {
+  const target = new EventTarget();
+  const testEvents = target.on("test");
+  const ac = new AbortController();
+  const results = [];
+  testEvents.subscribe({
+    next: (value) => results.push(value),
+    error: () => results.push('error'),
+    complete: () => results.complete('complete'),
+  }, { signal: ac.signal });
+
+  assert_array_equals(results, [],
+      "Observable does not emit events until event is fired");
+
+  const event1 = new Event("test");
+  const event2 = new Event("test");
+  const event3 = new Event("test");
+  target.dispatchEvent(event1);
+  target.dispatchEvent(event2);
+
+  assert_array_equals(results, [event1, event2]);
+
+  ac.abort();
+  target.dispatchEvent(event3);
+
+  assert_array_equals(results, [event1, event2],
+      "Aborting the subscription removes the event listener and stops the " +
+      "emission of events");
+}, "Aborting the subscription should stop the emission of events");
+
+test(() => {
+  const target = new EventTarget();
+  const testEvents = target.on("test");
+  const results = [];
+  testEvents.subscribe(e => results.push(e));
+  testEvents.subscribe(e => results.push(e));
+
+  const event1 = new Event("test");
+  const event2 = new Event("test");
+  target.dispatchEvent(event1);
+  target.dispatchEvent(event2);
+  assert_array_equals(results, [event1, event1, event2, event2]);
+}, "EventTarget Observables can multicast subscriptions for event handling");

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.worker-expected.txt
@@ -1,0 +1,5 @@
+
+FAIL EventTarget.on() returns an Observable assert_implements: The EventTarget interface has an `on` method undefined
+FAIL Aborting the subscription should stop the emission of events target.on is not a function. (In 'target.on("test")', 'target.on' is undefined)
+FAIL EventTarget Observables can multicast subscriptions for event handling target.on is not a function. (In 'target.on("test")', 'target.on' is undefined)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.window-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL EventTarget Observables can listen for events in the capturing or bubbling phase body.on is not a function. (In 'body.on('click', {capture: true})', 'body.on' is undefined)
+FAIL EventTarget Observables can be 'passive' target.on is not a function. (In 'target.on('event', {passive: true})', 'target.on' is undefined)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.window.js
@@ -1,0 +1,39 @@
+test(() => {
+  // See https://dom.spec.whatwg.org/#dom-event-eventphase.
+  const CAPTURING_PHASE = 1;
+  const BUBBLING_PHASE = 3;
+
+  // First, create a div underneath the `<body>` element. It will be the
+  // dispatch target for synthetic click events.
+  const target =
+      document.querySelector('body').appendChild(document.createElement('div'));
+
+  const body = document.querySelector('body');
+  const captureObservable = body.on('click', {capture: true});
+  const bubbleObservable = body.on('click', {capture: false});
+
+  const results = [];
+  captureObservable.subscribe(e => results.push(e.eventPhase));
+  bubbleObservable.subscribe(e => results.push(e.eventPhase));
+
+  target.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+
+  assert_array_equals(results, [CAPTURING_PHASE, BUBBLING_PHASE]);
+}, "EventTarget Observables can listen for events in the capturing or bubbling phase");
+
+test(() => {
+  const target = new EventTarget();
+
+  const observable = target.on('event', {passive: true});
+  observable.subscribe(event => {
+    assert_false(event.defaultPrevented);
+    // Should do nothing, since `observable` is "passive".
+    event.preventDefault();
+    assert_false(event.defaultPrevented);
+  });
+
+  // Create a cancelable event which ordinarily would be able to have its
+  // "default" prevented.
+  const event = new Event('event', {cancelable: true});
+  target.dispatchEvent(event);
+}, "EventTarget Observables can be 'passive'");

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/w3c-import.log
@@ -1,0 +1,20 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.js
+/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.window.js
+/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.js
+/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.window.js


### PR DESCRIPTION
#### 41b4a3bb8e4b5a4e47a516b969222031a7679adf
<pre>
Import Observable WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=267491">https://bugs.webkit.org/show_bug.cgi?id=267491</a>

Reviewed by Anne van Kesteren.

`./Tools/Scripts/import-w3c-tests -v -t -a web-platform-tests/dom/observable`

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/2fb9eb91e48870dd8f9bbb7adae728d29fbbb58f">https://github.com/web-platform-tests/wpt/commit/2fb9eb91e48870dd8f9bbb7adae728d29fbbb58f</a>

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.js: Added.
(test):
(test.t.const.source.new.Observable):
(test.t.source.subscribe.next):
(test.t.complete.results.push):
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.worker-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.window-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.window.js: Added.
(async loadIframeAndReturnContentWindow):
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.js: Added.
(test):
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.worker-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.window-expected.txt: Rebaselined.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.window.js: Added.
(test):
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/w3c-import.log: Added.

Canonical link: <a href="https://commits.webkit.org/273023@main">https://commits.webkit.org/273023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/983a7ff35a48bfb21f5c8d618298c2a000fdf131

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30743 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29794 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9363 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9464 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37858 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30811 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30593 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35576 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33471 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11382 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29897 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7828 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10163 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10400 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->