### PR TITLE
Adopt dynamicDowncast<> in more editing code

### DIFF
--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -782,20 +782,16 @@ Ref<HTMLElement> createHTMLElement(Document& document, const AtomString& tagName
     return createHTMLElement(document, QualifiedName(nullAtom(), tagName, xhtmlNamespaceURI));
 }
 
-bool isTabSpanNode(const Node* node)
+HTMLSpanElement* tabSpanNode(Node* node)
 {
-    RefPtr span = dynamicDowncast<HTMLSpanElement>(node);
-    return span && span->attributeWithoutSynchronization(classAttr) == AppleTabSpanClass;
+    if (auto* span = dynamicDowncast<HTMLSpanElement>(node); span && span->attributeWithoutSynchronization(classAttr) == AppleTabSpanClass)
+        return span;
+    return nullptr;
 }
 
-bool isTabSpanTextNode(const Node* node)
+HTMLSpanElement* parentTabSpanNode(Node* node)
 {
-    return is<Text>(node) && isTabSpanNode(node->parentNode());
-}
-
-HTMLSpanElement* tabSpanNode(const Node* node)
-{
-    return isTabSpanTextNode(node) ? downcast<HTMLSpanElement>(node->parentNode()) : nullptr;
+    return is<Text>(node) ? tabSpanNode(node->parentNode()) : nullptr;
 }
 
 static Ref<Element> createTabSpanElement(Document& document, Text& tabTextNode)

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -61,7 +61,8 @@ RefPtr<Node> enclosingEmptyListItem(const VisiblePosition&);
 RefPtr<Element> enclosingAnchorElement(const Position&);
 Element* enclosingElementWithTag(const Position&, const QualifiedName&);
 RefPtr<Node> enclosingNodeOfType(const Position&, bool (*nodeIsOfType)(const Node&), EditingBoundaryCrossingRule = CannotCrossEditingBoundary);
-HTMLSpanElement* tabSpanNode(const Node*);
+HTMLSpanElement* tabSpanNode(Node*);
+HTMLSpanElement* parentTabSpanNode(Node*);
 RefPtr<Element> isLastPositionBeforeTable(const VisiblePosition&); // FIXME: Strange to name this isXXX, but return an element.
 RefPtr<Element> isFirstPositionAfterTable(const VisiblePosition&); // FIXME: Strange to name this isXXX, but return an element.
 
@@ -88,8 +89,6 @@ bool isAtomicNode(const Node*);
 bool isBlock(const Node&);
 bool isBlockFlowElement(const Node&);
 bool isInline(const Node&);
-bool isTabSpanNode(const Node*);
-bool isTabSpanTextNode(const Node*);
 bool isMailBlockquote(const Node&);
 bool isRenderedTable(const Node*);
 bool isTableCell(const Node&);

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -531,9 +531,9 @@ static int textAlignResolvingStartAndEnd(T& style)
 
 void EditingStyle::init(Node* node, PropertiesToInclude propertiesToInclude)
 {
-    if (isTabSpanTextNode(node))
-        node = tabSpanNode(node)->parentNode();
-    else if (isTabSpanNode(node))
+    if (auto* tabSpan = parentTabSpanNode(node))
+        node = tabSpan->parentNode();
+    else if (tabSpanNode(node))
         node = node->parentNode();
 
     ComputedStyleExtractor computedStyleAtPosition(node);
@@ -955,7 +955,7 @@ bool EditingStyle::conflictsWithInlineStyleOfElement(StyledElement& element, Ref
         auto propertyID = property.id();
 
         // We don't override whitespace property of a tab span because that would collapse the tab into a space.
-        if ((propertyID == CSSPropertyWhiteSpaceCollapse || propertyID == CSSPropertyTextWrapMode) && isTabSpanNode(&element))
+        if ((propertyID == CSSPropertyWhiteSpaceCollapse || propertyID == CSSPropertyTextWrapMode) && tabSpanNode(&element))
             continue;
 
         if (propertyID == CSSPropertyWebkitTextDecorationsInEffect && inlineStyle->getPropertyCSSValue(CSSPropertyTextDecorationLine)) {
@@ -1784,7 +1784,7 @@ StyleChange::StyleChange(EditingStyle* style, const Position& position)
     }
 
     // Changing the whitespace style in a tab span would collapse the tab into a space.
-    if (isTabSpanTextNode(position.deprecatedNode()) || isTabSpanNode((position.deprecatedNode()))) {
+    if (parentTabSpanNode(position.deprecatedNode()) || tabSpanNode(position.deprecatedNode())) {
         mutableStyle->removeProperty(CSSPropertyWhiteSpaceCollapse);
         mutableStyle->removeProperty(CSSPropertyTextWrapMode);
     }


### PR DESCRIPTION
#### 00672842afaa5ec635ddeb5c4c7b0fa2ac12df8a
<pre>
Adopt dynamicDowncast&lt;&gt; in more editing code
<a href="https://bugs.webkit.org/show_bug.cgi?id=267498">https://bugs.webkit.org/show_bug.cgi?id=267498</a>

Reviewed by Darin Adler.

This implements a refactoring suggested during review of 272993@main.
Namely to turn the tabSpanNode methods into dynamicDowncast&lt;&gt; wrappers.

It also adopts dynamicDowncast&lt;&gt; in the surrounding code, including in
replaceChildrenWithFragment() which will need careful review.

* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::isRemovableBlock):
(WebCore::CompositeEditCommand::insertNodeAt):
(WebCore::CompositeEditCommand::replaceSelectedTextInNode):
(WebCore::CompositeEditCommand::positionOutsideTabSpan):
(WebCore::CompositeEditCommand::rebalanceWhitespaceOnTextSubstring):
(WebCore::CompositeEditCommand::deleteInsignificantText):
(WebCore::CompositeEditCommand::moveParagraphs):
* Source/WebCore/editing/Editing.cpp:
(WebCore::tabSpanNode):
(WebCore::parentTabSpanNode):
(WebCore::isTabSpanNode): Deleted.
(WebCore::isTabSpanTextNode): Deleted.
* Source/WebCore/editing/Editing.h:
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::init):
(WebCore::EditingStyle::conflictsWithInlineStyleOfElement const):
(WebCore::StyleChange::StyleChange):
* Source/WebCore/editing/InsertTextCommand.cpp:
(WebCore::InsertTextCommand::positionInsideTextNode):
(WebCore::InsertTextCommand::insertTab):
* Source/WebCore/editing/markup.cpp:
(WebCore::StyledMarkupAccumulator::wrapWithNode):
(WebCore::StyledMarkupAccumulator::appendCustomAttributes):
(WebCore::StyledMarkupAccumulator::appendStartTag):
(WebCore::highestAncestorToWrapMarkup):
(WebCore::isPlainTextMarkup):
(WebCore::replaceChildrenWithFragment):

Canonical link: <a href="https://commits.webkit.org/273037@main">https://commits.webkit.org/273037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15e36557690c46145539087e9c55bd2b2a6ff87f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34028 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36663 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30841 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29889 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10859 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30363 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9458 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9567 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37971 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30911 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35670 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7623 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33572 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11480 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7838 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10260 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10505 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->