### PR TITLE
Introducing LineColumn.

### DIFF
--- a/Source/JavaScriptCore/API/JSContextRef.cpp
+++ b/Source/JavaScriptCore/API/JSContextRef.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -333,10 +333,8 @@ public:
                 builder.append('\n');
             builder.append('#', visitor->index(), ' ', visitor->functionName(), "() at ", visitor->sourceURL());
             if (visitor->hasLineAndColumnInfo()) {
-                unsigned lineNumber;
-                unsigned unusedColumn;
-                visitor->computeLineAndColumn(lineNumber, unusedColumn);
-                builder.append(':', lineNumber);
+                auto lineColumn = visitor->computeLineAndColumn();
+                builder.append(':', lineColumn.line);
             }
 
             if (!visitor->callee().rawPtr())

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -688,6 +688,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.h
     bytecode/LazyOperandValueProfile.h
     bytecode/LazyValueProfile.h
+    bytecode/LineColumn.h
     bytecode/LinkTimeConstant.h
     bytecode/MetadataTable.h
     bytecode/ObjectAllocationProfile.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2167,6 +2167,7 @@
 		FEB58C15187B8B160098EF0B /* ErrorHandlingScope.h in Headers */ = {isa = PBXBuildFile; fileRef = FEB58C13187B8B160098EF0B /* ErrorHandlingScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEC160322339E9F900A04CB8 /* CellSize.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC160312339E9F900A04CB8 /* CellSize.h */; };
 		FEC3A3A1248735CA00395B54 /* DFGDoesGCCheck.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC3A3A0248735BC00395B54 /* DFGDoesGCCheck.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FEC503FE2B51E09700176A93 /* LineColumn.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC503FD2B51E09700176A93 /* LineColumn.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEC5797323105B5100BCA83F /* VMInspectorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC5797223105B4800BCA83F /* VMInspectorInlines.h */; };
 		FEC5797623105F4E00BCA83F /* Integrity.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC5797523105F4300BCA83F /* Integrity.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FEC579782310954C00BCA83F /* IntegrityInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FEC579772310954B00BCA83F /* IntegrityInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5995,6 +5996,7 @@
 		FEC160312339E9F900A04CB8 /* CellSize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CellSize.h; sourceTree = "<group>"; };
 		FEC3A39F248735BC00395B54 /* DFGDoesGCCheck.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DFGDoesGCCheck.cpp; path = dfg/DFGDoesGCCheck.cpp; sourceTree = "<group>"; };
 		FEC3A3A0248735BC00395B54 /* DFGDoesGCCheck.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DFGDoesGCCheck.h; path = dfg/DFGDoesGCCheck.h; sourceTree = "<group>"; };
+		FEC503FD2B51E09700176A93 /* LineColumn.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LineColumn.h; sourceTree = "<group>"; };
 		FEC5797223105B4800BCA83F /* VMInspectorInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMInspectorInlines.h; sourceTree = "<group>"; };
 		FEC5797423105F4200BCA83F /* Integrity.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Integrity.cpp; sourceTree = "<group>"; };
 		FEC5797523105F4300BCA83F /* Integrity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Integrity.h; sourceTree = "<group>"; };
@@ -9501,6 +9503,7 @@
 				0FB5467614F59AD1002C2989 /* LazyOperandValueProfile.h */,
 				530F0A972AE0606900A0EEC0 /* LazyValueProfile.cpp */,
 				530F0A962AE0606900A0EEC0 /* LazyValueProfile.h */,
+				FEC503FD2B51E09700176A93 /* LineColumn.h */,
 				E3637EE8236E56B00096BD0A /* LinkTimeConstant.cpp */,
 				E3637EE7236E56B00096BD0A /* LinkTimeConstant.h */,
 				53FA2AE21CF380390022711D /* LLIntPrototypeLoadAdaptiveStructureWatchpoint.cpp */,
@@ -11350,6 +11353,7 @@
 				99DA00B01BD5994E00F4575C /* lazywriter.py in Headers */,
 				1409ECBF225E177400BEDD54 /* LeafExecutable.h in Headers */,
 				BC18C4310E16F5CD00B34460 /* Lexer.h in Headers */,
+				FEC503FE2B51E09700176A93 /* LineColumn.h in Headers */,
 				86D3B3C310159D7F002865E7 /* LinkBuffer.h in Headers */,
 				E3637EE9236E56B00096BD0A /* LinkTimeConstant.h in Headers */,
 				A7E2EA6B0FB460CF00601F06 /* LiteralParser.h in Headers */,

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Cameron Zwarich <cwzwarich@uwaterloo.ca>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -244,7 +244,8 @@ public:
     unsigned lineNumberForBytecodeIndex(BytecodeIndex);
     unsigned columnNumberForBytecodeIndex(BytecodeIndex);
     void expressionRangeForBytecodeIndex(BytecodeIndex, unsigned& divot,
-        unsigned& startOffset, unsigned& endOffset, unsigned& line, unsigned& column) const;
+        unsigned& startOffset, unsigned& endOffset, LineColumn&) const;
+    LineColumn lineColumnForBytecodeIndex(BytecodeIndex) const;
 
     std::optional<BytecodeIndex> bytecodeIndexFromCallSiteIndex(CallSiteIndex);
 

--- a/Source/JavaScriptCore/bytecode/ExpressionRangeInfo.h
+++ b/Source/JavaScriptCore/bytecode/ExpressionRangeInfo.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "LineColumn.h"
 #include <wtf/StdLibExtras.h>
 
 namespace JSC {
@@ -49,8 +50,7 @@ struct ExpressionRangeInfo {
     };
 
     struct FatPosition {
-        unsigned line;
-        unsigned column;
+        LineColumn lineColumn;
     };
 
     enum {
@@ -71,30 +71,34 @@ struct ExpressionRangeInfo {
         MaxFatColumnModeColumn = (1 << 22) - 1
     };
 
-    void encodeFatLineMode(unsigned line, unsigned column)
+    void encodeFatLineMode(LineColumn lineColumn)
     {
-        ASSERT(line <= MaxFatLineModeLine);
-        ASSERT(column <= MaxFatLineModeColumn);
-        position = ((line & FatLineModeLineMask) << FatLineModeLineShift | (column & FatLineModeColumnMask));
+        ASSERT(lineColumn.line <= MaxFatLineModeLine);
+        ASSERT(lineColumn.column <= MaxFatLineModeColumn);
+        position = ((lineColumn.line & FatLineModeLineMask) << FatLineModeLineShift | (lineColumn.column & FatLineModeColumnMask));
     }
 
-    void encodeFatColumnMode(unsigned line, unsigned column)
+    void encodeFatColumnMode(LineColumn lineColumn)
     {
-        ASSERT(line <= MaxFatColumnModeLine);
-        ASSERT(column <= MaxFatColumnModeColumn);
-        position = ((line & FatColumnModeLineMask) << FatColumnModeLineShift | (column & FatColumnModeColumnMask));
+        ASSERT(lineColumn.line <= MaxFatColumnModeLine);
+        ASSERT(lineColumn.column <= MaxFatColumnModeColumn);
+        position = ((lineColumn.line & FatColumnModeLineMask) << FatColumnModeLineShift | (lineColumn.column & FatColumnModeColumnMask));
     }
 
-    void decodeFatLineMode(unsigned& line, unsigned& column) const
+    LineColumn decodeFatLineMode() const
     {
-        line = (position >> FatLineModeLineShift) & FatLineModeLineMask;
-        column = position & FatLineModeColumnMask;
+        LineColumn lineColumn;
+        lineColumn.line = (position >> FatLineModeLineShift) & FatLineModeLineMask;
+        lineColumn.column = position & FatLineModeColumnMask;
+        return lineColumn;
     }
 
-    void decodeFatColumnMode(unsigned& line, unsigned& column) const
+    LineColumn decodeFatColumnMode() const
     {
-        line = (position >> FatColumnModeLineShift) & FatColumnModeLineMask;
-        column = position & FatColumnModeColumnMask;
+        LineColumn lineColumn;
+        lineColumn.line = (position >> FatColumnModeLineShift) & FatColumnModeLineMask;
+        lineColumn.column = position & FatColumnModeColumnMask;
+        return lineColumn;
     }
 
     unsigned instructionOffset : 25;

--- a/Source/JavaScriptCore/bytecode/LineColumn.h
+++ b/Source/JavaScriptCore/bytecode/LineColumn.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,43 +25,17 @@
 
 #pragma once
 
-#include "FuzzerAgent.h"
-#include "LineColumn.h"
-#include "Opcode.h"
-#include <wtf/Lock.h>
-#include <wtf/TZoneMalloc.h>
-
 namespace JSC {
 
-class VM;
+struct LineColumn {
+    bool operator==(const LineColumn& other) const
+    {
+        return line == other.line && column == other.column;
+    }
 
-struct PredictionTarget {
-    BytecodeIndex bytecodeIndex;
-    unsigned divot;
-    unsigned startOffset;
-    unsigned endOffset;
-    LineColumn lineColumn;
-    OpcodeID opcodeId;
-    String sourceFilename;
-    String lookupKey;
-};
-
-class FileBasedFuzzerAgentBase : public FuzzerAgent {
-    WTF_MAKE_TZONE_ALLOCATED(FileBasedFuzzerAgentBase);
-
-public:
-    FileBasedFuzzerAgentBase(VM&);
-
-protected:
-    Lock m_lock;
-    virtual SpeculatedType getPredictionInternal(CodeBlock*, PredictionTarget&, SpeculatedType original) = 0;
-
-public:
-    SpeculatedType getPrediction(CodeBlock*, const CodeOrigin&, SpeculatedType original) final;
-
-protected:
-    static String createLookupKey(const String& sourceFilename, OpcodeID, int startLocation, int endLocation);
-    static OpcodeID opcodeAliasForLookupKey(const OpcodeID&);
+    unsigned line { 0 };
+    unsigned column { 0 };
 };
 
 } // namespace JSC
+

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2023 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2012-2024 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -150,40 +150,36 @@ size_t UnlinkedCodeBlock::RareData::sizeInBytes(const AbstractLocker&) const
     return size;
 }
 
-int UnlinkedCodeBlock::lineNumberForBytecodeIndex(BytecodeIndex bytecodeIndex)
+LineColumn UnlinkedCodeBlock::lineColumnForBytecodeIndex(BytecodeIndex bytecodeIndex)
 {
     ASSERT(bytecodeIndex.offset() < instructions().size());
     unsigned divot { 0 };
     unsigned startOffset { 0 };
     unsigned endOffset { 0 };
-    unsigned line { 0 };
-    unsigned column { 0 };
-    expressionRangeForBytecodeIndex(bytecodeIndex, divot, startOffset, endOffset, line, column);
-    return line;
+    LineColumn lineColumn;
+    expressionRangeForBytecodeIndex(bytecodeIndex, divot, startOffset, endOffset, lineColumn);
+    return lineColumn;
 }
 
-inline void UnlinkedCodeBlock::getLineAndColumn(const ExpressionRangeInfo& info,
-    unsigned& line, unsigned& column) const
+inline LineColumn UnlinkedCodeBlock::getLineAndColumn(const ExpressionRangeInfo& info) const
 {
     switch (info.mode) {
     case ExpressionRangeInfo::FatLineMode:
-        info.decodeFatLineMode(line, column);
-        break;
+        return info.decodeFatLineMode();
     case ExpressionRangeInfo::FatColumnMode:
-        info.decodeFatColumnMode(line, column);
-        break;
+        return info.decodeFatColumnMode();
     case ExpressionRangeInfo::FatLineAndColumnMode: {
         unsigned fatIndex = info.position;
         ExpressionRangeInfo::FatPosition& fatPos = m_rareData->m_expressionInfoFatPositions[fatIndex];
-        line = fatPos.line;
-        column = fatPos.column;
-        break;
+        return fatPos.lineColumn;
     }
     } // switch
+    ASSERT_NOT_REACHED();
+    return { };
 }
 
 #ifndef NDEBUG
-static void dumpLineColumnEntry(size_t index, const JSInstructionStream& instructionStream, unsigned instructionOffset, unsigned line, unsigned column)
+static void dumpLineColumnEntry(size_t index, const JSInstructionStream& instructionStream, unsigned instructionOffset, LineColumn lineColumn)
 {
     const auto instruction = instructionStream.at(instructionOffset);
     const char* event = "";
@@ -198,7 +194,7 @@ static void dumpLineColumnEntry(size_t index, const JSInstructionStream& instruc
         case WillExecuteExpression: event = " WillExecuteExpression"; break;
         }
     }
-    dataLogF("  [%zu] pc %u @ line %u col %u : %s%s\n", index, instructionOffset, line, column, instruction->name(), event);
+    dataLogF("  [%zu] pc %u @ line %u col %u : %s%s\n", index, instructionOffset, lineColumn.line, lineColumn.column, instruction->name(), event);
 }
 
 void UnlinkedCodeBlock::dumpExpressionRangeInfo()
@@ -209,16 +205,13 @@ void UnlinkedCodeBlock::dumpExpressionRangeInfo()
     dataLogF("UnlinkedCodeBlock %p expressionRangeInfo[%zu] {\n", this, size);
     for (size_t i = 0; i < size; i++) {
         ExpressionRangeInfo& info = expressionInfo[i];
-        unsigned line;
-        unsigned column;
-        getLineAndColumn(info, line, column);
-        dumpLineColumnEntry(i, instructions(), info.instructionOffset, line, column);
+        dumpLineColumnEntry(i, instructions(), info.instructionOffset, getLineAndColumn(info));
     }
     dataLog("}\n");
 }
 #endif
 
-void UnlinkedCodeBlock::expressionRangeForBytecodeIndex(BytecodeIndex bytecodeIndex, unsigned& divot, unsigned& startOffset, unsigned& endOffset, unsigned& line, unsigned& column) const
+void UnlinkedCodeBlock::expressionRangeForBytecodeIndex(BytecodeIndex bytecodeIndex, unsigned& divot, unsigned& startOffset, unsigned& endOffset, LineColumn& lineColumn) const
 {
     ASSERT(bytecodeIndex.offset() < instructions().size());
 
@@ -226,8 +219,7 @@ void UnlinkedCodeBlock::expressionRangeForBytecodeIndex(BytecodeIndex bytecodeIn
         startOffset = 0;
         endOffset = 0;
         divot = 0;
-        line = 0;
-        column = 0;
+        lineColumn = { };
         return;
     }
 
@@ -250,7 +242,7 @@ void UnlinkedCodeBlock::expressionRangeForBytecodeIndex(BytecodeIndex bytecodeIn
     startOffset = info.startOffset;
     endOffset = info.endOffset;
     divot = info.divotPoint;
-    getLineAndColumn(info, line, column);
+    lineColumn = getLineAndColumn(info);
 }
 
 bool UnlinkedCodeBlock::typeProfilerExpressionInfoForBytecodeOffset(unsigned bytecodeOffset, unsigned& startDivot, unsigned& endDivot)

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2023 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2012-2024 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -250,9 +250,9 @@ public:
 
     bool hasRareData() const { return m_rareData.get(); }
 
-    int lineNumberForBytecodeIndex(BytecodeIndex);
+    LineColumn lineColumnForBytecodeIndex(BytecodeIndex);
 
-    void expressionRangeForBytecodeIndex(BytecodeIndex, unsigned& divot, unsigned& startOffset, unsigned& endOffset, unsigned& line, unsigned& column) const;
+    void expressionRangeForBytecodeIndex(BytecodeIndex, unsigned& divot, unsigned& startOffset, unsigned& endOffset, LineColumn&) const;
 
     bool typeProfilerExpressionInfoForBytecodeOffset(unsigned bytecodeOffset, unsigned& startDivot, unsigned& endDivot);
 
@@ -390,7 +390,7 @@ private:
             m_rareData = makeUnique<RareData>();
     }
 
-    void getLineAndColumn(const ExpressionRangeInfo&, unsigned& line, unsigned& column) const;
+    LineColumn getLineAndColumn(const ExpressionRangeInfo&) const;
     BytecodeLivenessAnalysis& livenessAnalysisSlow(CodeBlock*);
 
 

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,7 +37,7 @@ namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(UnlinkedCodeBlockGenerator);
 
-void UnlinkedCodeBlockGenerator::addExpressionInfo(unsigned instructionOffset, unsigned divot, unsigned startOffset, unsigned endOffset, unsigned line, unsigned column)
+void UnlinkedCodeBlockGenerator::addExpressionInfo(unsigned instructionOffset, unsigned divot, unsigned startOffset, unsigned endOffset, LineColumn lineColumn)
 {
     if (divot > ExpressionRangeInfo::MaxDivot) {
         // Overflow has occurred, we can only give line number info for errors for this region
@@ -58,9 +58,9 @@ void UnlinkedCodeBlockGenerator::addExpressionInfo(unsigned instructionOffset, u
     }
 
     unsigned positionMode =
-        (line <= ExpressionRangeInfo::MaxFatLineModeLine && column <= ExpressionRangeInfo::MaxFatLineModeColumn)
+        (lineColumn.line <= ExpressionRangeInfo::MaxFatLineModeLine && lineColumn.column <= ExpressionRangeInfo::MaxFatLineModeColumn)
         ? ExpressionRangeInfo::FatLineMode
-        : (line <= ExpressionRangeInfo::MaxFatColumnModeLine && column <= ExpressionRangeInfo::MaxFatColumnModeColumn)
+        : (lineColumn.line <= ExpressionRangeInfo::MaxFatColumnModeLine && lineColumn.column <= ExpressionRangeInfo::MaxFatColumnModeColumn)
         ? ExpressionRangeInfo::FatColumnMode
         : ExpressionRangeInfo::FatLineAndColumnMode;
 
@@ -73,14 +73,14 @@ void UnlinkedCodeBlockGenerator::addExpressionInfo(unsigned instructionOffset, u
     info.mode = positionMode;
     switch (positionMode) {
     case ExpressionRangeInfo::FatLineMode:
-        info.encodeFatLineMode(line, column);
+        info.encodeFatLineMode(lineColumn);
         break;
     case ExpressionRangeInfo::FatColumnMode:
-        info.encodeFatColumnMode(line, column);
+        info.encodeFatColumnMode(lineColumn);
         break;
     case ExpressionRangeInfo::FatLineAndColumnMode: {
         unsigned fatIndex = m_expressionInfoFatPositions.size();
-        ExpressionRangeInfo::FatPosition fatPos = { line, column };
+        ExpressionRangeInfo::FatPosition fatPos = { lineColumn };
         m_expressionInfoFatPositions.append(fatPos);
         info.position = fatIndex;
     }

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,7 +77,7 @@ public:
     void setNumParameters(unsigned newValue) { m_codeBlock->setNumParameters(newValue); }
 
     UnlinkedMetadataTable& metadata() { return m_codeBlock->metadata(); }
-    void addExpressionInfo(unsigned instructionOffset, unsigned divot, unsigned startOffset, unsigned endOffset, unsigned line, unsigned column);
+    void addExpressionInfo(unsigned instructionOffset, unsigned divot, unsigned startOffset, unsigned endOffset, LineColumn);
     void addTypeProfilerExpressionInfo(unsigned instructionOffset, unsigned startDivot, unsigned endDivot);
     void addOpProfileControlFlowBytecodeOffset(JSInstructionStream::Offset offset)
     {

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Cameron Zwarich <cwzwarich@uwaterloo.ca>
  * Copyright (C) 2012 Igalia, S.L.
  *
@@ -612,7 +612,7 @@ namespace JSC {
             unsigned column = divotOffset - lineStart;
 
             unsigned instructionOffset = instructions().size();
-            m_codeBlock->addExpressionInfo(instructionOffset, divotOffset, startOffset, endOffset, line, column);
+            m_codeBlock->addExpressionInfo(instructionOffset, divotOffset, startOffset, endOffset, { line, column });
         }
 
 

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Matt Lilek <webkit@mattlilek.com>
  * Copyright (C) 2012 Google Inc. All rights reserved.
  *
@@ -187,12 +187,11 @@ InjectedScript InjectedScriptManager::injectedScriptFor(JSGlobalObject* globalOb
         if (globalObject->vm().isTerminationException(error))
             return InjectedScript();
 
-        unsigned line = 0;
-        unsigned column = 0;
+        LineColumn lineColumn;
         auto& stack = error->stack();
         if (stack.size() > 0)
-            stack[0].computeLineAndColumn(line, column);
-        WTFLogAlways("Error when creating injected script: %s (%d:%d)\n", error->value().toWTFString(globalObject).utf8().data(), line, column);
+            lineColumn = stack[0].computeLineAndColumn();
+        WTFLogAlways("Error when creating injected script: %s (%d:%d)\n", error->value().toWTFString(globalObject).utf8().data(), lineColumn.line, lineColumn.column);
         RELEASE_ASSERT_NOT_REACHED();
     }
     if (!createResult.value()) {

--- a/Source/JavaScriptCore/inspector/InjectedScriptModule.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptModule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2012 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -68,12 +68,11 @@ void InjectedScriptModule::ensureInjected(InjectedScriptManager* injectedScriptM
     if (!hasInjectedModuleResult) {
         auto& error = hasInjectedModuleResult.error();
         ASSERT(error);
-        unsigned line = 0;
-        unsigned column = 0;
+        JSC::LineColumn lineColumn;
         auto& stack = error->stack();
         if (stack.size() > 0)
-            stack[0].computeLineAndColumn(line, column);
-        WTFLogAlways("Error when calling 'hasInjectedModule' for '%s': %s (%d:%d)\n", name().utf8().data(), error->value().toWTFString(injectedScript.globalObject()).utf8().data(), line, column);
+            lineColumn = stack[0].computeLineAndColumn();
+        WTFLogAlways("Error when calling 'hasInjectedModule' for '%s': %s (%d:%d)\n", name().utf8().data(), error->value().toWTFString(injectedScript.globalObject()).utf8().data(), lineColumn.line, lineColumn.column);
         RELEASE_ASSERT_NOT_REACHED();
     }
     if (!hasInjectedModuleResult.value()) {
@@ -89,12 +88,11 @@ void InjectedScriptModule::ensureInjected(InjectedScriptManager* injectedScriptM
         if (!injectModuleResult) {
             auto& error = injectModuleResult.error();
             ASSERT(error);
-            unsigned line = 0;
-            unsigned column = 0;
+            JSC::LineColumn lineColumn;
             auto& stack = error->stack();
             if (stack.size() > 0)
-                stack[0].computeLineAndColumn(line, column);
-            WTFLogAlways("Error when calling 'injectModule' for '%s': %s (%d:%d)\n", name().utf8().data(), error->value().toWTFString(injectedScript.globalObject()).utf8().data(), line, column);
+                lineColumn = stack[0].computeLineAndColumn();
+            WTFLogAlways("Error when calling 'injectModule' for '%s': %s (%d:%d)\n", name().utf8().data(), error->value().toWTFString(injectedScript.globalObject()).utf8().data(), lineColumn.line, lineColumn.column);
             RELEASE_ASSERT_NOT_REACHED();
         }
     }

--- a/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
+++ b/Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp
@@ -168,9 +168,9 @@ void JSGlobalObjectInspectorController::appendAPIBacktrace(ScriptCallStack& call
     for (int i = 0; i < size; ++i) {
         auto demangled = StackTraceSymbolResolver::demangle(stack[i]);
         if (demangled)
-            callStack.append(ScriptCallFrame(String::fromLatin1(demangled->demangledName() ? demangled->demangledName() : demangled->mangledName()), "[native code]"_s, noSourceID, 0, 0));
+            callStack.append(ScriptCallFrame(String::fromLatin1(demangled->demangledName() ? demangled->demangledName() : demangled->mangledName()), "[native code]"_s, noSourceID, { }));
         else
-            callStack.append(ScriptCallFrame("?"_s, "[native code]"_s, noSourceID, 0, 0));
+            callStack.append(ScriptCallFrame("?"_s, "[native code]"_s, noSourceID, { }));
     }
 }
 

--- a/Source/JavaScriptCore/inspector/ScriptCallFrame.cpp
+++ b/Source/JavaScriptCore/inspector/ScriptCallFrame.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2024 Apple Inc. All rights reserved.
  * Copyright (c) 2010 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -34,22 +34,20 @@
 
 namespace Inspector {
 
-ScriptCallFrame::ScriptCallFrame(const String& functionName, const String& scriptName, JSC::SourceID sourceID, unsigned lineNumber, unsigned column)
+ScriptCallFrame::ScriptCallFrame(const String& functionName, const String& scriptName, JSC::SourceID sourceID, JSC::LineColumn lineColumn)
     : m_functionName(functionName)
     , m_scriptName(scriptName)
     , m_sourceID(sourceID)
-    , m_lineNumber(lineNumber)
-    , m_column(column)
+    , m_lineColumn(lineColumn)
 {
 }
 
-ScriptCallFrame::ScriptCallFrame(const String& functionName, const String& scriptName, const String& preRedirectURL, JSC::SourceID sourceID, unsigned lineNumber, unsigned column)
+ScriptCallFrame::ScriptCallFrame(const String& functionName, const String& scriptName, const String& preRedirectURL, JSC::SourceID sourceID, JSC::LineColumn lineColumn)
     : m_functionName(functionName)
     , m_scriptName(scriptName)
     , m_preRedirectURL(preRedirectURL)
     , m_sourceID(sourceID)
-    , m_lineNumber(lineNumber)
-    , m_column(column)
+    , m_lineColumn(lineColumn)
 {
 }
 
@@ -64,8 +62,7 @@ bool ScriptCallFrame::isEqual(const ScriptCallFrame& o) const
     return m_functionName == o.m_functionName
         && m_scriptName == o.m_scriptName
         && m_preRedirectURL == o.m_preRedirectURL
-        && m_lineNumber == o.m_lineNumber
-        && m_column == o.m_column;
+        && m_lineColumn == o.m_lineColumn;
 }
 
 bool ScriptCallFrame::isNative() const
@@ -79,8 +76,8 @@ Ref<Protocol::Console::CallFrame> ScriptCallFrame::buildInspectorObject() const
         .setFunctionName(m_functionName)
         .setUrl(m_scriptName)
         .setScriptId(String::number(m_sourceID))
-        .setLineNumber(m_lineNumber)
-        .setColumnNumber(m_column)
+        .setLineNumber(m_lineColumn.line)
+        .setColumnNumber(m_lineColumn.column)
         .release();
 }
 

--- a/Source/JavaScriptCore/inspector/ScriptCallFrame.h
+++ b/Source/JavaScriptCore/inspector/ScriptCallFrame.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2024 Apple Inc. All rights reserved.
  * Copyright (c) 2010 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,6 +33,7 @@
 
 #include "DebuggerPrimitives.h"
 #include "InspectorProtocolObjects.h"
+#include "LineColumn.h"
 #include <wtf/Forward.h>
 #include <wtf/text/WTFString.h>
 
@@ -40,15 +41,17 @@ namespace Inspector {
 
 class JS_EXPORT_PRIVATE ScriptCallFrame  {
 public:
-    ScriptCallFrame(const String& functionName, const String& scriptName, JSC::SourceID, unsigned lineNumber, unsigned column);
-    ScriptCallFrame(const String& functionName, const String& scriptName, const String& preRedirectURL, JSC::SourceID, unsigned lineNumber, unsigned column);
+    using LineColumn = JSC::LineColumn;
+
+    ScriptCallFrame(const String& functionName, const String& scriptName, JSC::SourceID, LineColumn);
+    ScriptCallFrame(const String& functionName, const String& scriptName, const String& preRedirectURL, JSC::SourceID, LineColumn);
     ~ScriptCallFrame();
 
     const String& functionName() const { return m_functionName; }
     const String& sourceURL() const { return m_scriptName; }
     const String& preRedirectURL() const { return m_preRedirectURL; }
-    unsigned lineNumber() const { return m_lineNumber; }
-    unsigned columnNumber() const { return m_column; }
+    unsigned lineNumber() const { return m_lineColumn.line; }
+    unsigned columnNumber() const { return m_lineColumn.column; }
     JSC::SourceID sourceID() const { return m_sourceID; }
 
     bool isEqual(const ScriptCallFrame&) const;
@@ -63,8 +66,7 @@ private:
     String m_scriptName;
     String m_preRedirectURL;
     JSC::SourceID m_sourceID;
-    unsigned m_lineNumber;
-    unsigned m_column;
+    LineColumn m_lineColumn;
 };
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/interpreter/StackVisitor.h
+++ b/Source/JavaScriptCore/interpreter/StackVisitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #include "BytecodeIndex.h"
 #include "CalleeBits.h"
+#include "LineColumn.h"
 #include "SourceID.h"
 #include "WasmIndexOrName.h"
 #include <wtf/Function.h>
@@ -95,7 +96,7 @@ public:
 
         CodeType codeType() const;
         bool hasLineAndColumnInfo() const;
-        JS_EXPORT_PRIVATE void computeLineAndColumn(unsigned& line, unsigned& column) const;
+        JS_EXPORT_PRIVATE LineColumn computeLineAndColumn() const;
 
 #if ENABLE(ASSEMBLER)
         std::optional<RegisterAtOffsetList> calleeSaveRegistersForUnwinding();
@@ -113,7 +114,6 @@ public:
         Frame() { }
         ~Frame() { }
 
-        void retrieveExpressionInfo(unsigned& divot, unsigned& startOffset, unsigned& endOffset, unsigned& line, unsigned& column) const;
         void setToEnd();
 
 #if ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/runtime/Error.h
+++ b/Source/JavaScriptCore/runtime/Error.h
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 1999-2001 Harri Porten (porten@kde.org)
  *  Copyright (C) 2001 Peter Kelly (pmk@post.com)
- *  Copyright (C) 2003-2019 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2024 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -27,6 +27,7 @@
 #include "Exception.h"
 #include "InternalFunction.h"
 #include "JSObject.h"
+#include "LineColumn.h"
 #include "ThrowScope.h"
 #include <stdint.h>
 
@@ -67,7 +68,7 @@ JS_EXPORT_PRIVATE JSObject* createError(JSGlobalObject*, ErrorTypeWithExtension,
 
 std::unique_ptr<Vector<StackFrame>> getStackTrace(JSGlobalObject*, VM&, JSObject*, bool useCurrentFrame);
 std::tuple<CodeBlock*, BytecodeIndex> getBytecodeIndex(VM&, CallFrame*);
-bool getLineColumnAndSource(VM&, Vector<StackFrame>* stackTrace, unsigned& line, unsigned& column, String& sourceURL);
+bool getLineColumnAndSource(VM&, Vector<StackFrame>* stackTrace, LineColumn&, String& sourceURL);
 bool addErrorInfo(VM&, Vector<StackFrame>*, JSObject*);
 JS_EXPORT_PRIVATE void addErrorInfo(JSGlobalObject*, JSObject*, bool);
 JSObject* addErrorInfo(VM&, JSObject* error, int line, const SourceCode&);

--- a/Source/JavaScriptCore/runtime/ErrorInstance.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 1999-2000 Harri Porten (porten@kde.org)
- *  Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2024 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -46,12 +46,12 @@ ErrorInstance::ErrorInstance(VM& vm, Structure* structure, ErrorType errorType)
 {
 }
 
-ErrorInstance* ErrorInstance::create(JSGlobalObject* globalObject, String&& message, ErrorType errorType, unsigned line, unsigned column, String&& sourceURL, String&& stackString)
+ErrorInstance* ErrorInstance::create(JSGlobalObject* globalObject, String&& message, ErrorType errorType, LineColumn lineColumn, String&& sourceURL, String&& stackString)
 {
     VM& vm = globalObject->vm();
     Structure* structure = globalObject->errorStructure(errorType);
     ErrorInstance* instance = new (NotNull, allocateCell<ErrorInstance>(vm)) ErrorInstance(vm, structure, errorType);
-    instance->finishCreation(vm, WTFMove(message), line, column, WTFMove(sourceURL), WTFMove(stackString));
+    instance->finishCreation(vm, WTFMove(message), lineColumn, WTFMove(sourceURL), WTFMove(stackString));
     return instance;
 }
 
@@ -86,10 +86,9 @@ static String appendSourceToErrorMessage(CodeBlock* codeBlock, ErrorInstance* ex
     unsigned startOffset = 0;
     unsigned endOffset = 0;
     unsigned divotPoint = 0;
-    unsigned line = 0;
-    unsigned column = 0;
+    LineColumn lineColumn;
 
-    codeBlock->expressionRangeForBytecodeIndex(bytecodeIndex, divotPoint, startOffset, endOffset, line, column);
+    codeBlock->expressionRangeForBytecodeIndex(bytecodeIndex, divotPoint, startOffset, endOffset, lineColumn);
     
     int expressionStart = divotPoint - startOffset;
     int expressionStop = divotPoint + endOffset;
@@ -147,13 +146,12 @@ void ErrorInstance::finishCreation(VM& vm, JSGlobalObject* globalObject, const S
         putDirect(vm, vm.propertyNames->cause, cause, static_cast<unsigned>(PropertyAttribute::DontEnum));
 }
 
-void ErrorInstance::finishCreation(VM& vm, String&& message, unsigned line, unsigned column, String&& sourceURL, String&& stackString)
+void ErrorInstance::finishCreation(VM& vm, String&& message, LineColumn lineColumn, String&& sourceURL, String&& stackString)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
 
-    m_line = line;
-    m_column = column;
+    m_lineColumn = lineColumn;
     m_sourceURL = WTFMove(sourceURL);
     m_stackString = WTFMove(stackString);
     if (!message.isNull())
@@ -249,7 +247,7 @@ void ErrorInstance::computeErrorInfo(VM& vm)
     ASSERT(!m_errorInfoMaterialized);
 
     if (m_stackTrace && !m_stackTrace->isEmpty()) {
-        getLineColumnAndSource(vm, m_stackTrace.get(), m_line, m_column, m_sourceURL);
+        getLineColumnAndSource(vm, m_stackTrace.get(), m_lineColumn, m_sourceURL);
         m_stackString = Interpreter::stackTraceAsString(vm, *m_stackTrace.get());
         m_stackTrace = nullptr;
     }
@@ -265,8 +263,8 @@ bool ErrorInstance::materializeErrorInfoIfNeeded(VM& vm)
     if (!m_stackString.isNull()) {
         auto attributes = static_cast<unsigned>(PropertyAttribute::DontEnum);
 
-        putDirect(vm, vm.propertyNames->line, jsNumber(m_line), attributes);
-        putDirect(vm, vm.propertyNames->column, jsNumber(m_column), attributes);
+        putDirect(vm, vm.propertyNames->line, jsNumber(m_lineColumn.line), attributes);
+        putDirect(vm, vm.propertyNames->column, jsNumber(m_lineColumn.column), attributes);
         if (!m_sourceURL.isEmpty())
             putDirect(vm, vm.propertyNames->sourceURL, jsString(vm, WTFMove(m_sourceURL)), attributes);
 

--- a/Source/JavaScriptCore/runtime/ErrorInstance.h
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.h
@@ -1,6 +1,6 @@
 /*
  *  Copyright (C) 1999-2000 Harri Porten (porten@kde.org)
- *  Copyright (C) 2008-2022 Apple Inc. All rights reserved.
+ *  Copyright (C) 2008-2024 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -59,7 +59,7 @@ public:
         return instance;
     }
 
-    JS_EXPORT_PRIVATE static ErrorInstance* create(JSGlobalObject*, String&& message, ErrorType, unsigned line, unsigned column, String&& sourceURL, String&& stackString);
+    JS_EXPORT_PRIVATE static ErrorInstance* create(JSGlobalObject*, String&& message, ErrorType, LineColumn, String&& sourceURL, String&& stackString);
     static ErrorInstance* create(JSGlobalObject*, Structure*, JSValue message, JSValue options, SourceAppender = nullptr, RuntimeType = TypeNothing, ErrorType = ErrorType::Error, bool useCurrentFrame = true);
 
     bool hasSourceAppender() const { return !!m_sourceAppender; }
@@ -99,7 +99,7 @@ protected:
     explicit ErrorInstance(VM&, Structure*, ErrorType);
 
     void finishCreation(VM&, JSGlobalObject*, const String& message, JSValue cause, SourceAppender = nullptr, RuntimeType = TypeNothing, bool useCurrentFrame = true);
-    void finishCreation(VM&, String&& message, unsigned line, unsigned column, String&& sourceURL, String&& stackString);
+    void finishCreation(VM&, String&& message, LineColumn, String&& sourceURL, String&& stackString);
 
     static bool getOwnPropertySlot(JSObject*, JSGlobalObject*, PropertyName, PropertySlot&);
     static void getOwnSpecialPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArray&, DontEnumPropertiesMode);
@@ -111,8 +111,7 @@ protected:
 
     SourceAppender m_sourceAppender { nullptr };
     std::unique_ptr<Vector<StackFrame>> m_stackTrace;
-    unsigned m_line;
-    unsigned m_column;
+    LineColumn m_lineColumn;
     String m_sourceURL;
     String m_stackString;
     RuntimeType m_runtimeTypeForCause { TypeNothing };

--- a/Source/JavaScriptCore/runtime/FileBasedFuzzerAgent.cpp
+++ b/Source/JavaScriptCore/runtime/FileBasedFuzzerAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -101,7 +101,7 @@ SpeculatedType FileBasedFuzzerAgent::getPredictionInternal(CodeBlock* codeBlock,
     }
     if (!generated) {
         if (Options::dumpFuzzerAgentPredictions())
-            dataLogLn(MAGENTA(BOLD(target.bytecodeIndex)), " ", BOLD(YELLOW(target.opcodeId)), " missing prediction for: ", RED(BOLD(target.lookupKey)), " ", GREEN(target.sourceFilename), ":", CYAN(target.line), ":", CYAN(target.column), " divot: ", target.divot, " -", target.startOffset, " +", target.endOffset, " name: '", YELLOW(codeBlock->inferredName()), "' source: '", BLUE(sourceUpToDivot), BLUE(BOLD(sourceAfterDivot)), "'");
+            dataLogLn(MAGENTA(BOLD(target.bytecodeIndex)), " ", BOLD(YELLOW(target.opcodeId)), " missing prediction for: ", RED(BOLD(target.lookupKey)), " ", GREEN(target.sourceFilename), ":", CYAN(target.lineColumn.line), ":", CYAN(target.lineColumn.column), " divot: ", target.divot, " -", target.startOffset, " +", target.endOffset, " name: '", YELLOW(codeBlock->inferredName()), "' source: '", BLUE(sourceUpToDivot), BLUE(BOLD(sourceAfterDivot)), "'");
 
         RELEASE_ASSERT_WITH_MESSAGE(!Options::requirePredictionForFileBasedFuzzerAgent(), "Missing expected prediction in FuzzerAgent");
         return original;

--- a/Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.cpp
+++ b/Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -71,7 +71,7 @@ SpeculatedType FileBasedFuzzerAgentBase::getPrediction(CodeBlock* codeBlock, con
 
     PredictionTarget predictionTarget;
     BytecodeIndex bytecodeIndex = codeOrigin.bytecodeIndex();
-    codeBlock->expressionRangeForBytecodeIndex(bytecodeIndex, predictionTarget.divot, predictionTarget.startOffset, predictionTarget.endOffset, predictionTarget.line, predictionTarget.column);
+    codeBlock->expressionRangeForBytecodeIndex(bytecodeIndex, predictionTarget.divot, predictionTarget.startOffset, predictionTarget.endOffset, predictionTarget.lineColumn);
 
     Vector<String> urlParts = sourceURL.split('/');
     predictionTarget.sourceFilename = urlParts.isEmpty() ? sourceURL : urlParts.last();

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Cameron Zwarich (cwzwarich@uwaterloo.ca)
  *
  * Redistribution and use in source and binary forms, with or without
@@ -391,7 +391,7 @@ JSC_DEFINE_HOST_FUNCTION(assertCall, (JSGlobalObject* globalObject, CallFrame* c
 
     bool iteratedOnce = false;
     CodeBlock* codeBlock = nullptr;
-    unsigned line;
+    LineColumn lineColumn;
     StackVisitor::visit(callFrame, globalObject->vm(), [&] (StackVisitor& visitor) {
         if (!iteratedOnce) {
             iteratedOnce = true;
@@ -399,13 +399,12 @@ JSC_DEFINE_HOST_FUNCTION(assertCall, (JSGlobalObject* globalObject, CallFrame* c
         }
 
         RELEASE_ASSERT(visitor->hasLineAndColumnInfo());
-        unsigned column;
-        visitor->computeLineAndColumn(line, column);
+        lineColumn = visitor->computeLineAndColumn();
         codeBlock = visitor->codeBlock();
         return IterationStatus::Done;
     });
     RELEASE_ASSERT(!!codeBlock);
-    RELEASE_ASSERT_WITH_MESSAGE(false, "JS assertion failed at line %u in:\n%s\n", line, codeBlock->sourceCodeForTools().data());
+    RELEASE_ASSERT_WITH_MESSAGE(false, "JS assertion failed at line %u in:\n%s\n", lineColumn.line, codeBlock->sourceCodeForTools().data());
     return JSValue::encode(jsUndefined());
 }
 #endif // ASSERT_ENABLED

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -496,7 +496,7 @@ void SamplingProfiler::processUnverifiedStackTraces()
                 unsigned startOffset;
                 unsigned endOffset;
                 codeBlock->expressionRangeForBytecodeIndex(bytecodeIndex, divot, startOffset, endOffset,
-                    location.lineNumber, location.columnNumber);
+                    location.lineColumn);
                 location.bytecodeIndex = bytecodeIndex;
             }
             if (codeBlock->hasHash())

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.h
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -121,13 +121,12 @@ public:
 
             bool hasExpressionInfo() const
             {
-                return lineNumber != std::numeric_limits<unsigned>::max()
-                    && columnNumber != std::numeric_limits<unsigned>::max();
+                return lineColumn.line != std::numeric_limits<unsigned>::max()
+                    && lineColumn.column != std::numeric_limits<unsigned>::max();
             }
 
             // These attempt to be expression-level line and column number.
-            unsigned lineNumber { std::numeric_limits<unsigned>::max() };
-            unsigned columnNumber { std::numeric_limits<unsigned>::max() };
+            LineColumn lineColumn { std::numeric_limits<unsigned>::max(), std::numeric_limits<unsigned>::max() };
             BytecodeIndex bytecodeIndex;
             CodeBlockHash codeBlockHash;
             JITType jitType { JITType::None };
@@ -141,12 +140,12 @@ public:
         unsigned lineNumber() const
         {
             ASSERT(hasExpressionInfo());
-            return semanticLocation.lineNumber;
+            return semanticLocation.lineColumn.line;
         }
         unsigned columnNumber() const
         {
             ASSERT(hasExpressionInfo());
-            return semanticLocation.columnNumber;
+            return semanticLocation.lineColumn.column;
         }
 
         // These are function-level data.

--- a/Source/JavaScriptCore/runtime/StackFrame.h
+++ b/Source/JavaScriptCore/runtime/StackFrame.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #include "BytecodeIndex.h"
 #include "Heap.h"
+#include "LineColumn.h"
 #include "SlotVisitorMacros.h"
 #include "VM.h"
 #include "WasmIndexOrName.h"
@@ -48,7 +49,7 @@ public:
     bool hasLineAndColumnInfo() const { return !!m_codeBlock; }
     CodeBlock* codeBlock() const { return m_codeBlock.get(); }
 
-    void computeLineAndColumn(unsigned& line, unsigned& column) const;
+    LineColumn computeLineAndColumn() const;
     String functionName(VM&) const;
     SourceID sourceID() const;
     String sourceURL(VM&) const;

--- a/Source/JavaScriptCore/tools/VMInspector.cpp
+++ b/Source/JavaScriptCore/tools/VMInspector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -511,10 +511,8 @@ SUPPRESS_ASAN void VMInspector::dumpRegisters(CallFrame* callFrame)
     
     StackVisitor::visit(callFrame, vm, [&] (StackVisitor& visitor) {
         if (visitor->callFrame() == callFrame) {
-            unsigned line = 0;
-            unsigned unusedColumn = 0;
-            visitor->computeLineAndColumn(line, unusedColumn);
-            dataLogF("% 2d.1  ReturnVPC        : %10p  %d (line %d)\n", registerNumber, it, visitor->bytecodeIndex().offset(), line);
+            auto lineColumn = visitor->computeLineAndColumn();
+            dataLogF("% 2d.1  ReturnVPC        : %10p  %d (line %d)\n", registerNumber, it, visitor->bytecodeIndex().offset(), lineColumn.line);
             return IterationStatus::Done;
         }
         return IterationStatus::Continue;

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -4476,7 +4476,7 @@ private:
                 fail();
                 return JSValue();
             }
-            return ErrorInstance::create(m_lexicalGlobalObject, WTFMove(message), toErrorType(serializedErrorType), line, column, WTFMove(sourceURL), WTFMove(stackString));
+            return ErrorInstance::create(m_lexicalGlobalObject, WTFMove(message), toErrorType(serializedErrorType), { line, column }, WTFMove(sourceURL), WTFMove(stackString));
         }
         case ObjectReferenceTag: {
             auto index = readConstantPoolIndex(m_gcBuffer);


### PR DESCRIPTION
#### a9319f524ab7a73affd9e90d36048e46924b0a21
<pre>
Introducing LineColumn.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267499">https://bugs.webkit.org/show_bug.cgi?id=267499</a>
<a href="https://rdar.apple.com/120949750">rdar://120949750</a>

Reviewed by Justin Michaud.

In ExpressionRangeInfo code (and a lot of other places in JSC), we pass line and column values
around as a pair.  Sometimes, we have to pass these as references.  Introducing a LineColumn data
structure to pair the 2 values together.  As a result, the code reads more compact and concise.
We also get some minimal efficiency because we can now pass a single LineColumn reference
instead of 2 unsigned references for the 2 values.  We can also now return a LineColumn value
Instead of have to pass in 2 unsigned references to getters that compute these values.

Also applied the usage of LineColumn throughout JSC, with the exception of the Parser and
Debugger where they use slightly &quot;coordinate&quot; systems for the encoding line and column.
Changing them to use LineColumn may incur significant logic change.  Since this patch is
intended as a minimal refactoring patch, we&apos;ll leave those sub-systems alone for now.

This change is a stepping stone towards an upcoming patch to compress the encoding of
ExpressionRangeInfo for memory savings.

* Source/JavaScriptCore/API/JSContextRef.cpp:
(BacktraceFunctor::operator() const):
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::lineColumnForBytecodeIndex const):
(JSC::CodeBlock::expressionRangeForBytecodeIndex const):
(JSC::CodeBlock::hasOpDebugForLineAndColumn):
(JSC::CodeBlock::lineNumberForBytecodeIndex): Deleted.
(JSC::CodeBlock::columnNumberForBytecodeIndex): Deleted.
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/bytecode/ExpressionRangeInfo.h:
(JSC::ExpressionRangeInfo::encodeFatLineMode):
(JSC::ExpressionRangeInfo::encodeFatColumnMode):
(JSC::ExpressionRangeInfo::decodeFatLineMode const):
(JSC::ExpressionRangeInfo::decodeFatColumnMode const):
* Source/JavaScriptCore/bytecode/LineColumn.h: Copied from Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.h.
(JSC::LineColumn::operator== const):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp:
(JSC::UnlinkedCodeBlock::lineColumnForBytecodeIndex):
(JSC::UnlinkedCodeBlock::getLineAndColumn const):
(JSC::dumpLineColumnEntry):
(JSC::UnlinkedCodeBlock::dumpExpressionRangeInfo):
(JSC::UnlinkedCodeBlock::expressionRangeForBytecodeIndex const):
(JSC::UnlinkedCodeBlock::lineNumberForBytecodeIndex): Deleted.
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp:
(JSC::UnlinkedCodeBlockGenerator::addExpressionInfo):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::BytecodeGenerator::emitExpressionInfo):
* Source/JavaScriptCore/debugger/DebuggerCallFrame.cpp:
(JSC::LineAndColumnFunctor::operator() const):
(JSC::LineAndColumnFunctor::line const):
(JSC::LineAndColumnFunctor::column const):
(JSC::DebuggerCallFrame::currentPosition):
(): Deleted.
* Source/JavaScriptCore/inspector/InjectedScriptManager.cpp:
(Inspector::InjectedScriptManager::injectedScriptFor):
* Source/JavaScriptCore/inspector/InjectedScriptModule.cpp:
(Inspector::InjectedScriptModule::ensureInjected):
* Source/JavaScriptCore/inspector/JSGlobalObjectInspectorController.cpp:
(Inspector::JSGlobalObjectInspectorController::appendAPIBacktrace):
* Source/JavaScriptCore/inspector/ScriptCallFrame.cpp:
(Inspector::ScriptCallFrame::ScriptCallFrame):
(Inspector::ScriptCallFrame::isEqual const):
(Inspector::ScriptCallFrame::buildInspectorObject const):
* Source/JavaScriptCore/inspector/ScriptCallFrame.h:
* Source/JavaScriptCore/inspector/ScriptCallStackFactory.cpp:
(Inspector::CreateScriptCallStackFunctor::operator() const):
(Inspector::extractSourceInformationFromException):
(Inspector::createScriptCallStackFromException):
* Source/JavaScriptCore/interpreter/StackVisitor.cpp:
(JSC::StackVisitor::Frame::toString const):
(JSC::StackVisitor::Frame::computeLineAndColumn const):
(JSC::StackVisitor::Frame::dump const):
(JSC::StackVisitor::Frame::retrieveExpressionInfo const): Deleted.
* Source/JavaScriptCore/interpreter/StackVisitor.h:
* Source/JavaScriptCore/runtime/Error.cpp:
(JSC::getLineColumnAndSource):
(JSC::addErrorInfo):
* Source/JavaScriptCore/runtime/Error.h:
* Source/JavaScriptCore/runtime/ErrorInstance.cpp:
(JSC::ErrorInstance::create):
(JSC::appendSourceToErrorMessage):
(JSC::ErrorInstance::finishCreation):
(JSC::ErrorInstance::computeErrorInfo):
(JSC::ErrorInstance::materializeErrorInfoIfNeeded):
* Source/JavaScriptCore/runtime/ErrorInstance.h:
* Source/JavaScriptCore/runtime/FileBasedFuzzerAgent.cpp:
(JSC::FileBasedFuzzerAgent::getPredictionInternal):
* Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.cpp:
(JSC::FileBasedFuzzerAgentBase::getPrediction):
* Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::processUnverifiedStackTraces):
* Source/JavaScriptCore/runtime/SamplingProfiler.h:
(JSC::SamplingProfiler::StackFrame::CodeLocation::hasExpressionInfo const):
(JSC::SamplingProfiler::StackFrame::lineNumber const):
(JSC::SamplingProfiler::StackFrame::columnNumber const):
* Source/JavaScriptCore/runtime/StackFrame.cpp:
(JSC::StackFrame::computeLineAndColumn const):
(JSC::StackFrame::toString const):
* Source/JavaScriptCore/runtime/StackFrame.h:
* Source/JavaScriptCore/tools/VMInspector.cpp:
(JSC::VMInspector::dumpRegisters):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readTerminal):

Canonical link: <a href="https://commits.webkit.org/273012@main">https://commits.webkit.org/273012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9721c4388419bbb83eb2bf0377e478dc68477b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36558 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30750 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/34991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29800 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9369 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9470 "Found 1 new test failure: imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-all.https.sub.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37866 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/28874 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30817 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30600 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35584 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/33849 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7538 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33480 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11390 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/40401 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10170 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8438 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4375 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10407 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->