### PR TITLE
[ApplePay] toDecimalNumber() implementation should be shared

### DIFF
--- a/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
+++ b/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
@@ -32,20 +32,13 @@
 #import "ApplePayInstallmentItemType.h"
 #import "ApplePayInstallmentRetailChannel.h"
 #import "ExceptionOr.h"
+#import "PaymentSummaryItems.h"
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 #import <pal/cocoa/PassKitSoftLink.h>
 
 namespace WebCore {
-
-// FIXME: Merge with toDecimalNumber() in WebPaymentCoordinatorProxyCocoa.
-static NSDecimalNumber *toDecimalNumber(const String& amount)
-{
-    if (!amount)
-        return [NSDecimalNumber zero];
-    return [NSDecimalNumber decimalNumberWithString:amount locale:@{ NSLocaleDecimalSeparator : @"." }];
-}
 
 static String fromDecimalNumber(NSDecimalNumber *number)
 {

--- a/Source/WebCore/Modules/applepay/PaymentSummaryItems.h
+++ b/Source/WebCore/Modules/applepay/PaymentSummaryItems.h
@@ -28,6 +28,7 @@
 #if ENABLE(APPLE_PAY)
 
 OBJC_CLASS NSArray;
+OBJC_CLASS NSDecimalNumber;
 OBJC_CLASS PKAutomaticReloadPaymentSummaryItem;
 OBJC_CLASS PKDeferredPaymentSummaryItem;
 OBJC_CLASS PKPaymentSummaryItem;
@@ -51,6 +52,8 @@ WEBCORE_EXPORT PKAutomaticReloadPaymentSummaryItem *platformAutomaticReloadSumma
 
 WEBCORE_EXPORT PKPaymentSummaryItem *platformSummaryItem(const ApplePayLineItem&);
 WEBCORE_EXPORT NSArray *platformSummaryItems(const ApplePayLineItem& total, const Vector<ApplePayLineItem>&);
+
+WEBCORE_EXPORT NSDecimalNumber *toDecimalNumber(const String& amount);
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-static NSDecimalNumber *toDecimalNumber(const String& amount)
+NSDecimalNumber *toDecimalNumber(const String& amount)
 {
     if (!amount)
         return [NSDecimalNumber zero];

--- a/Source/WebKit/Shared/ApplePay/cocoa/PaymentTokenContextCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/PaymentTokenContextCocoa.mm
@@ -30,6 +30,7 @@
 
 #import "WebPaymentCoordinatorProxyCocoa.h"
 #import <WebCore/ApplePayPaymentTokenContext.h>
+#import <WebCore/PaymentHeaders.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/WTFString.h>
@@ -44,7 +45,7 @@ RetainPtr<PKPaymentTokenContext> platformPaymentTokenContext(const ApplePayPayme
     RetainPtr<NSString> merchantDomain;
     if (!webTokenContext.merchantDomain.isNull())
         merchantDomain = webTokenContext.merchantDomain;
-    return adoptNS([PAL::allocPKPaymentTokenContextInstance() initWithMerchantIdentifier:webTokenContext.merchantIdentifier externalIdentifier:webTokenContext.externalIdentifier merchantName:webTokenContext.merchantName merchantDomain:merchantDomain.get() amount:toDecimalNumber(webTokenContext.amount)]);
+    return adoptNS([PAL::allocPKPaymentTokenContextInstance() initWithMerchantIdentifier:webTokenContext.merchantIdentifier externalIdentifier:webTokenContext.externalIdentifier merchantName:webTokenContext.merchantName merchantDomain:merchantDomain.get() amount:WebCore::toDecimalNumber(webTokenContext.amount)]);
 }
 
 RetainPtr<NSArray<PKPaymentTokenContext *>> platformPaymentTokenContexts(const Vector<ApplePayPaymentTokenContext>& webTokenContexts)

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.h
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.h
@@ -40,7 +40,6 @@ namespace WebKit {
 
 // FIXME: Rather than having these free functions scattered about, Apple Pay data types should know
 // how to convert themselves to and from their platform representations.
-NSDecimalNumber *toDecimalNumber(const String& amount);
 PKShippingMethod *toPKShippingMethod(const WebCore::ApplePayShippingMethod&);
 #if HAVE(PASSKIT_DEFAULT_SHIPPING_METHOD)
 PKShippingMethods *toPKShippingMethods(const Vector<WebCore::ApplePayShippingMethod>&);

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -120,13 +120,6 @@ static RetainPtr<NSSet> toPKContactFields(const WebCore::ApplePaySessionPaymentR
     return adoptNS([[NSSet alloc] initWithObjects:result.data() count:result.size()]);
 }
 
-NSDecimalNumber *toDecimalNumber(const String& amount)
-{
-    if (!amount)
-        return [NSDecimalNumber zero];
-    return [NSDecimalNumber decimalNumberWithString:amount locale:@{ NSLocaleDecimalSeparator : @"." }];
-}
-
 static PKMerchantCapability toPKMerchantCapabilities(const WebCore::ApplePaySessionPaymentRequest::MerchantCapabilities& merchantCapabilities)
 {
     PKMerchantCapability result = 0;
@@ -185,7 +178,7 @@ static RetainPtr<PKDateComponentsRange> toPKDateComponentsRange(const WebCore::A
 
 PKShippingMethod *toPKShippingMethod(const WebCore::ApplePayShippingMethod& shippingMethod)
 {
-    PKShippingMethod *result = [PAL::getPKShippingMethodClass() summaryItemWithLabel:shippingMethod.label amount:toDecimalNumber(shippingMethod.amount)];
+    PKShippingMethod *result = [PAL::getPKShippingMethodClass() summaryItemWithLabel:shippingMethod.label amount:WebCore::toDecimalNumber(shippingMethod.amount)];
     [result setIdentifier:shippingMethod.identifier];
     [result setDetail:shippingMethod.detail];
 #if HAVE(PASSKIT_SHIPPING_METHOD_DATE_COMPONENTS_RANGE)


### PR DESCRIPTION
#### a6b409d73485591bc5f0f89698cd5e3e1dcb71a1
<pre>
[ApplePay] toDecimalNumber() implementation should be shared
<a href="https://bugs.webkit.org/show_bug.cgi?id=267501">https://bugs.webkit.org/show_bug.cgi?id=267501</a>
<a href="https://rdar.apple.com/120952367">rdar://120952367</a>

Reviewed by Wenson Hsieh.

This commit unifies three identical definitions of `toDecimalNumber()`
across the codebase into a single free-function in the WebCore
namespace, declared in PaymentSummaryItems.h, where it is primarily
used (and was introduced).

* Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm:
(WebCore::toDecimalNumber): Deleted.
* Source/WebCore/Modules/applepay/PaymentSummaryItems.h:
* Source/WebCore/Modules/applepay/cocoa/PaymentSummaryItemsCocoa.mm:
(WebCore::toDecimalNumber):
* Source/WebKit/Shared/ApplePay/cocoa/PaymentTokenContextCocoa.mm:
(WebKit::platformPaymentTokenContext):
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.h:
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::toPKShippingMethod):
(WebKit::toDecimalNumber): Deleted.

Canonical link: <a href="https://commits.webkit.org/273079@main">https://commits.webkit.org/273079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f2db56da1c6c2fc4246234573948b3f85b935d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36574 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30761 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29812 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9381 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9483 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37882 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30830 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30614 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35592 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33488 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11402 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7874 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10421 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->