### PR TITLE
Use downcast<>() less in rendering code

### DIFF
--- a/Source/WebCore/rendering/AccessibilityRegionContext.cpp
+++ b/Source/WebCore/rendering/AccessibilityRegionContext.cpp
@@ -53,8 +53,8 @@ void AccessibilityRegionContext::takeBounds(const RenderInline& renderInline, La
 
 void AccessibilityRegionContext::takeBounds(const RenderBox& renderBox, LayoutPoint paintOffset)
 {
-    if (UNLIKELY(is<RenderView>(renderBox))) {
-        takeBounds(downcast<RenderView>(renderBox), WTFMove(paintOffset));
+    if (CheckedPtr renderView = dynamicDowncast<RenderView>(renderBox); UNLIKELY(renderView)) {
+        takeBounds(*renderView, WTFMove(paintOffset));
         return;
     }
     auto mappedPaintRect = enclosingIntRect(mapRect(LayoutRect(paintOffset, renderBox.size())));

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -405,8 +405,8 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
         if (!geometry.destinationRect.isEmpty() && (image = bgImage->image(backgroundObject ? backgroundObject : &m_renderer, geometry.tileSize, isFirstLine))) {
             context.setDrawLuminanceMask(bgLayer.maskMode() == MaskMode::Luminance);
 
-            if (is<BitmapImage>(image))
-                downcast<BitmapImage>(*image).updateFromSettings(document().settings());
+            if (RefPtr bitmapImage = dynamicDowncast<BitmapImage>(image))
+                bitmapImage->updateFromSettings(document().settings());
 
             ImagePaintingOptions options = {
                 op == CompositeOperator::SourceOver ? bgLayer.compositeForPainting() : op,

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -208,8 +208,8 @@ void BorderPainter::paintOutline(const LayoutRect& paintRect)
     if (styleToUse.outlineStyleIsAuto() == OutlineIsAuto::On && !m_renderer.theme().supportsFocusRing(styleToUse)) {
         Vector<LayoutRect> focusRingRects;
         LayoutRect paintRectToUse { paintRect };
-        if (is<RenderBox>(m_renderer))
-            paintRectToUse = m_renderer.theme().adjustedPaintRect(downcast<RenderBox>(m_renderer), paintRectToUse);
+        if (CheckedPtr box = dynamicDowncast<RenderBox>(m_renderer))
+            paintRectToUse = m_renderer.theme().adjustedPaintRect(*box, paintRectToUse);
         m_renderer.addFocusRingRects(focusRingRects, paintRectToUse.location(), m_paintInfo.paintContainer);
         m_renderer.paintFocusRing(m_paintInfo, styleToUse, focusRingRects);
     }
@@ -490,7 +490,8 @@ bool BorderPainter::paintNinePieceImage(const LayoutRect& rect, const RenderStyl
     if (!styleImage->canRender(&m_renderer, style.effectiveZoom()))
         return false;
 
-    if (!is<RenderBoxModelObject>(m_renderer))
+    CheckedPtr modelObject = dynamicDowncast<RenderBoxModelObject>(m_renderer);
+    if (!modelObject)
         return false;
 
     // FIXME: border-image is broken with full page zooming when tiling has to happen, since the tiling function
@@ -501,7 +502,7 @@ bool BorderPainter::paintNinePieceImage(const LayoutRect& rect, const RenderStyl
     rectWithOutsets.expand(style.imageOutsets(ninePieceImage));
     LayoutRect destination = LayoutRect(snapRectToDevicePixels(rectWithOutsets, deviceScaleFactor));
 
-    auto source = downcast<RenderBoxModelObject>(m_renderer).calculateImageIntrinsicDimensions(styleImage, destination.size(), RenderBoxModelObject::DoNotScaleByEffectiveZoom);
+    auto source = modelObject->calculateImageIntrinsicDimensions(styleImage, destination.size(), RenderBoxModelObject::DoNotScaleByEffectiveZoom);
 
     // If both values are ‘auto’ then the intrinsic width and/or height of the image should be used, if any.
     styleImage->setContainerContextForRenderer(m_renderer, source, style.effectiveZoom());

--- a/Source/WebCore/rendering/CSSFilter.cpp
+++ b/Source/WebCore/rendering/CSSFilter.cpp
@@ -246,7 +246,7 @@ bool CSSFilter::buildFilterFunctions(RenderElement& renderer, const FilterOperat
             break;
 
         case FilterOperation::Type::Blur:
-            function = createBlurEffect(downcast<BlurFilterOperation>(*operation));
+            function = createBlurEffect(uncheckedDowncast<BlurFilterOperation>(*operation));
             break;
 
         case FilterOperation::Type::Brightness:
@@ -258,7 +258,7 @@ bool CSSFilter::buildFilterFunctions(RenderElement& renderer, const FilterOperat
             break;
 
         case FilterOperation::Type::DropShadow:
-            function = createDropShadowEffect(downcast<DropShadowFilterOperation>(*operation));
+            function = createDropShadowEffect(uncheckedDowncast<DropShadowFilterOperation>(*operation));
             break;
 
         case FilterOperation::Type::Grayscale:
@@ -286,7 +286,7 @@ bool CSSFilter::buildFilterFunctions(RenderElement& renderer, const FilterOperat
             break;
 
         case FilterOperation::Type::Reference:
-            function = createReferenceFilter(*this, downcast<ReferenceFilterOperation>(*operation), renderer, preferredFilterRenderingModes, targetBoundingBox, destinationContext);
+            function = createReferenceFilter(*this, uncheckedDowncast<ReferenceFilterOperation>(*operation), renderer, preferredFilterRenderingModes, targetBoundingBox, destinationContext);
             break;
 
         default:
@@ -320,10 +320,8 @@ FilterEffectVector CSSFilter::effectsOfType(FilterFunction::Type filterType) con
             continue;
         }
 
-        if (function->isSVGFilter()) {
-            auto& filter = downcast<SVGFilter>(function.get());
-            effects.appendVector(filter.effectsOfType(filterType));
-        }
+        if (RefPtr filter = dynamicDowncast<SVGFilter>(function))
+            effects.appendVector(filter->effectsOfType(filterType));
     }
 
     return effects;
@@ -390,8 +388,8 @@ bool CSSFilter::isIdentity(RenderElement& renderer, const FilterOperations& oper
         return false;
 
     for (auto& operation : operations.operations()) {
-        if (operation->type() == FilterOperation::Type::Reference) {
-            if (!isIdentityReferenceFilter(downcast<ReferenceFilterOperation>(*operation), renderer))
+        if (RefPtr referenceOperation = dynamicDowncast<ReferenceFilterOperation>(*operation)) {
+            if (!isIdentityReferenceFilter(*referenceOperation, renderer))
                 return false;
             continue;
         }
@@ -408,8 +406,8 @@ IntOutsets CSSFilter::calculateOutsets(RenderElement& renderer, const FilterOper
     IntOutsets outsets;
 
     for (auto& operation : operations.operations()) {
-        if (operation->type() == FilterOperation::Type::Reference) {
-            outsets += calculateReferenceFilterOutsets(downcast<ReferenceFilterOperation>(*operation), renderer, targetBoundingBox);
+        if (RefPtr referenceOperation = dynamicDowncast<ReferenceFilterOperation>(*operation)) {
+            outsets += calculateReferenceFilterOutsets(*referenceOperation, renderer, targetBoundingBox);
             continue;
         }
 

--- a/Source/WebCore/rendering/CaretRectComputation.cpp
+++ b/Source/WebCore/rendering/CaretRectComputation.cpp
@@ -228,22 +228,22 @@ static LayoutRect computeCaretRectForSVGInlineText(const InlineBoxAndOffset& box
     auto* box = boxAndOffset.box ? boxAndOffset.box->legacyInlineBox() : nullptr;
     auto caretOffset = boxAndOffset.offset;
 
-    if (!is<LegacyInlineTextBox>(box))
+    auto* textBox = dynamicDowncast<LegacyInlineTextBox>(*box);
+    if (!textBox)
         return { };
 
-    auto& textBox = downcast<LegacyInlineTextBox>(*box);
-    if (caretOffset < textBox.start() || caretOffset > textBox.start() + textBox.len())
+    if (caretOffset < textBox->start() || caretOffset > textBox->start() + textBox->len())
         return { };
 
     // Use the edge of the selection rect to determine the caret rect.
-    if (caretOffset < textBox.start() + textBox.len()) {
-        LayoutRect rect = textBox.localSelectionRect(caretOffset, caretOffset + 1);
-        LayoutUnit x = textBox.isLeftToRightDirection() ? rect.x() : rect.maxX();
+    if (caretOffset < textBox->start() + textBox->len()) {
+        LayoutRect rect = textBox->localSelectionRect(caretOffset, caretOffset + 1);
+        LayoutUnit x = textBox->isLeftToRightDirection() ? rect.x() : rect.maxX();
         return LayoutRect(x, rect.y(), caretWidth(), rect.height());
     }
 
-    LayoutRect rect = textBox.localSelectionRect(caretOffset - 1, caretOffset);
-    LayoutUnit x = textBox.isLeftToRightDirection() ? rect.maxX() : rect.x();
+    LayoutRect rect = textBox->localSelectionRect(caretOffset - 1, caretOffset);
+    LayoutUnit x = textBox->isLeftToRightDirection() ? rect.maxX() : rect.x();
     return { x, rect.y(), caretWidth(), rect.height() };
 }
 
@@ -335,14 +335,14 @@ LayoutRect computeLocalCaretRect(const RenderObject& renderer, const InlineBoxAn
     if (is<RenderLineBreak>(renderer))
         return computeCaretRectForLineBreak(boxAndOffset, caretRectMode);
 
-    if (is<RenderBlock>(renderer))
-        return computeCaretRectForBlock(downcast<RenderBlock>(renderer), boxAndOffset, caretRectMode);
+    if (auto* block = dynamicDowncast<RenderBlock>(renderer))
+        return computeCaretRectForBlock(*block, boxAndOffset, caretRectMode);
 
-    if (is<RenderBox>(renderer))
-        return computeCaretRectForBox(downcast<RenderBox>(renderer), boxAndOffset, caretRectMode);
+    if (auto* box = dynamicDowncast<RenderBox>(renderer))
+        return computeCaretRectForBox(*box, boxAndOffset, caretRectMode);
 
-    if (is<RenderInline>(renderer))
-        return computeCaretRectForInline(downcast<RenderInline>(renderer));
+    if (auto* renderInline = dynamicDowncast<RenderInline>(renderer))
+        return computeCaretRectForInline(*renderInline);
 
     return { };
 }

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -66,8 +66,8 @@ void EventRegionContext::unite(const FloatRoundedRect& roundedRect, RenderObject
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     auto rect = roundedRect.rect();
-    if (is<RenderLayerModelObject>(renderer))
-        rect = snapRectToDevicePixelsIfNeeded(rect, downcast<RenderLayerModelObject>(renderer));
+    if (auto* modelObject = dynamicDowncast<RenderLayerModelObject>(renderer))
+        rect = snapRectToDevicePixelsIfNeeded(rect, *modelObject);
     auto layerBounds = transformAndClipIfNeeded(rect, [](auto affineTransform, auto rect) {
         return affineTransform.mapRect(rect);
     });
@@ -213,9 +213,9 @@ bool EventRegionContext::shouldConsolidateInteractionRegion(RenderObject& render
         }
 
         // We can't consolidate this region but it might be a container we can remove later.
-        if (hasNoVisualBorders && is<RenderElement>(renderer)) {
-            auto& renderElement = downcast<RenderElement>(renderer);
-            m_containerRemovalCandidates.add(renderElement.element()->identifier());
+        if (hasNoVisualBorders) {
+            if (auto* renderElement = dynamicDowncast<RenderElement>(renderer))
+                m_containerRemovalCandidates.add(renderElement->element()->identifier());
         }
 
         // We found a region nested inside a container candidate for removal, flag it for removal.

--- a/Source/WebCore/rendering/Grid.cpp
+++ b/Source/WebCore/rendering/Grid.cpp
@@ -318,17 +318,18 @@ std::optional<GridArea> GridIterator::nextEmptyGridArea(unsigned fixedTrackSpan,
 GridIterator GridIterator::createForSubgrid(const RenderGrid& subgrid, const GridIterator& outer)
 {
     ASSERT(subgrid.isSubgridInParentDirection(outer.direction()));
-    GridSpan fixedSpan = downcast<RenderGrid>(subgrid.parent())->gridSpanForChild(subgrid, outer.direction());
+    CheckedPtr parent = downcast<RenderGrid>(subgrid.parent());
+    auto fixedSpan = parent->gridSpanForChild(subgrid, outer.direction());
 
     // Translate the current row/column indices into the coordinate
     // space of the subgrid.
     unsigned fixedIndex = (outer.direction() == GridTrackSizingDirection::ForColumns) ? outer.m_columnIndex : outer.m_rowIndex;
     fixedIndex -= fixedSpan.startLine();
 
-    GridTrackSizingDirection innerDirection = GridLayoutFunctions::flowAwareDirectionForChild(*downcast<RenderGrid>(subgrid.parent()), subgrid, outer.direction());
+    auto innerDirection = GridLayoutFunctions::flowAwareDirectionForChild(*parent, subgrid, outer.direction());
     ASSERT(subgrid.isSubgrid(innerDirection));
 
-    if (GridLayoutFunctions::isSubgridReversedDirection(*downcast<RenderGrid>(subgrid.parent()), outer.direction(), subgrid)) {
+    if (GridLayoutFunctions::isSubgridReversedDirection(*parent, outer.direction(), subgrid)) {
         unsigned fixedMax = subgrid.currentGrid().numTracks(innerDirection);
         fixedIndex = fixedMax - fixedIndex - 1;
     }

--- a/Source/WebCore/rendering/LegacyInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineBox.cpp
@@ -134,14 +134,14 @@ float LegacyInlineBox::logicalHeight() const
     if (hasVirtualLogicalHeight())
         return virtualLogicalHeight();
 
-    if (is<LegacyRootInlineBox>(*this) && downcast<LegacyRootInlineBox>(*this).isForTrailingFloats())
+    if (auto* inlineBox = dynamicDowncast<LegacyRootInlineBox>(*this); inlineBox && inlineBox->isForTrailingFloats())
         return 0;
 
     const RenderStyle& lineStyle = this->lineStyle();
     if (renderer().isRenderTextOrLineBreak())
         return lineStyle.metricsOfPrimaryFont().height();
-    if (is<RenderBox>(renderer()) && parent())
-        return isHorizontal() ? downcast<RenderBox>(renderer()).height() : downcast<RenderBox>(renderer()).width();
+    if (auto* box = dynamicDowncast<RenderBox>(renderer()); box && parent())
+        return isHorizontal() ? box->height() : box->width();
 
     ASSERT(isInlineFlowBox());
     RenderBoxModelObject* flowObject = boxModelObject();

--- a/Source/WebCore/rendering/LegacyInlineElementBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineElementBox.cpp
@@ -41,10 +41,10 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyInlineElementBox);
 void LegacyInlineElementBox::deleteLine()
 {
     if (!extracted()) {
-        if (is<RenderBox>(renderer()))
-            downcast<RenderBox>(renderer()).setInlineBoxWrapper(nullptr);
-        else if (is<RenderLineBreak>(renderer()))
-            downcast<RenderLineBreak>(renderer()).setInlineBoxWrapper(nullptr);
+        if (CheckedPtr box = dynamicDowncast<RenderBox>(renderer()))
+            box->setInlineBoxWrapper(nullptr);
+        else if (CheckedPtr lineBreak = dynamicDowncast<RenderLineBreak>(renderer()))
+            lineBreak->setInlineBoxWrapper(nullptr);
     }
     delete this;
 }
@@ -52,19 +52,19 @@ void LegacyInlineElementBox::deleteLine()
 void LegacyInlineElementBox::extractLine()
 {
     setExtracted(true);
-    if (is<RenderBox>(renderer()))
-        downcast<RenderBox>(renderer()).setInlineBoxWrapper(nullptr);
-    else if (is<RenderLineBreak>(renderer()))
-        downcast<RenderLineBreak>(renderer()).setInlineBoxWrapper(nullptr);
+    if (CheckedPtr box = dynamicDowncast<RenderBox>(renderer()))
+        box->setInlineBoxWrapper(nullptr);
+    else if (CheckedPtr lineBreak = dynamicDowncast<RenderLineBreak>(renderer()))
+        lineBreak->setInlineBoxWrapper(nullptr);
 }
 
 void LegacyInlineElementBox::attachLine()
 {
     setExtracted(false);
-    if (is<RenderBox>(renderer()))
-        downcast<RenderBox>(renderer()).setInlineBoxWrapper(this);
-    else if (is<RenderLineBreak>(renderer()))
-        downcast<RenderLineBreak>(renderer()).setInlineBoxWrapper(this);
+    if (CheckedPtr box = dynamicDowncast<RenderBox>(renderer()))
+        box->setInlineBoxWrapper(this);
+    else if (CheckedPtr lineBreak = dynamicDowncast<RenderLineBreak>(renderer()))
+        lineBreak->setInlineBoxWrapper(this);
 }
 
 void LegacyInlineElementBox::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset, LayoutUnit /* lineTop */, LayoutUnit /*lineBottom*/)
@@ -76,8 +76,8 @@ void LegacyInlineElementBox::paint(PaintInfo& paintInfo, const LayoutPoint& pain
         return;
 
     LayoutPoint childPoint = paintOffset;
-    if (is<RenderBox>(renderer()) && parent()->renderer().style().isFlippedBlocksWritingMode()) // Faster than calling containingBlock().
-        childPoint = renderer().containingBlock()->flipForWritingModeForChild(downcast<RenderBox>(renderer()), childPoint);
+    if (auto* box = dynamicDowncast<RenderBox>(renderer()); box && parent()->renderer().style().isFlippedBlocksWritingMode()) // Faster than calling containingBlock().
+        childPoint = renderer().containingBlock()->flipForWritingModeForChild(*box, childPoint);
 
     renderer().paintAsInlineBlock(paintInfo, childPoint);
 }
@@ -89,8 +89,8 @@ bool LegacyInlineElementBox::nodeAtPoint(const HitTestRequest& request, HitTestR
     // own stacking context.  (See Appendix E.2, section 6.4 on inline block/table elements in the CSS2.1
     // specification.)
     LayoutPoint childPoint = accumulatedOffset;
-    if (is<RenderBox>(renderer()) && parent()->renderer().style().isFlippedBlocksWritingMode()) // Faster than calling containingBlock().
-        childPoint = renderer().containingBlock()->flipForWritingModeForChild(downcast<RenderBox>(renderer()), childPoint);
+    if (auto* box = dynamicDowncast<RenderBox>(renderer()); box && parent()->renderer().style().isFlippedBlocksWritingMode()) // Faster than calling containingBlock().
+        childPoint = renderer().containingBlock()->flipForWritingModeForChild(*box, childPoint);
 
     return renderer().hitTest(request, result, locationInContainer, childPoint);
 }

--- a/Source/WebCore/rendering/LegacyInlineIteratorInlines.h
+++ b/Source/WebCore/rendering/LegacyInlineIteratorInlines.h
@@ -26,9 +26,10 @@ namespace WebCore {
 
 inline bool LegacyInlineIterator::atTextParagraphSeparator() const
 {
-    return is<RenderText>(m_renderer)
+    auto* textRenderer = dynamicDowncast<RenderText>(m_renderer);
+    return textRenderer
         && m_renderer->preservesNewline()
-        && downcast<RenderText>(*m_renderer).characterAt(m_pos) == '\n';
+        && textRenderer->characterAt(m_pos) == '\n';
 }
 
 inline bool LegacyInlineIterator::atParagraphSeparator() const

--- a/Source/WebCore/rendering/LegacyInlineTextBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineTextBox.cpp
@@ -446,7 +446,11 @@ String LegacyInlineTextBox::text(bool ignoreCombinedText, bool ignoreHyphen) con
 
 const RenderCombineText* LegacyInlineTextBox::combinedText() const
 {
-    return lineStyle().hasTextCombine() && is<RenderCombineText>(renderer()) && downcast<RenderCombineText>(renderer()).isCombined() ? &downcast<RenderCombineText>(renderer()) : nullptr;
+    if (!lineStyle().hasTextCombine())
+        return nullptr;
+
+    auto* renderCombineText = dynamicDowncast<RenderCombineText>(renderer());
+    return renderCombineText && renderCombineText->isCombined() ? renderCombineText : nullptr;
 }
 
 ExpansionBehavior LegacyInlineTextBox::expansionBehavior() const

--- a/Source/WebCore/rendering/LegacyRootInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.cpp
@@ -103,7 +103,8 @@ void LegacyRootInlineBox::clearTruncation()
 bool LegacyRootInlineBox::isHyphenated() const
 {
     for (auto* box = firstLeafDescendant(); box; box = box->nextLeafOnLine()) {
-        if (is<LegacyInlineTextBox>(*box) && downcast<LegacyInlineTextBox>(*box).hasHyphen())
+        auto* textBox = dynamicDowncast<LegacyInlineTextBox>(*box);
+        if (textBox && textBox->hasHyphen())
             return true;
     }
     return false;
@@ -483,9 +484,8 @@ LayoutUnit LegacyRootInlineBox::selectionTop() const
 
 #if !PLATFORM(IOS_FAMILY)
     // See rdar://problem/19692206 ... don't want to do this adjustment for iOS where overlap is ok and handled.
-    if (renderer().isRenderRubyBase()) {
+    if (auto* base = dynamicDowncast<RenderRubyBase>(renderer())) {
         // The ruby base selection should avoid intruding into the ruby text. This is only the case if there is an actual ruby text above us.
-        RenderRubyBase* base = &downcast<RenderRubyBase>(renderer());
         RenderRubyRun* run = base->rubyRun();
         if (run) {
             RenderRubyText* text = run->rubyText();
@@ -494,9 +494,8 @@ LayoutUnit LegacyRootInlineBox::selectionTop() const
                 return selectionTop;
             }
         }
-    } else if (renderer().isRenderRubyText()) {
+    } else if (auto* text = dynamicDowncast<RenderRubyText>(renderer())) {
         // The ruby text selection should go all the way to the selection top of the containing line.
-        RenderRubyText* text = &downcast<RenderRubyText>(renderer());
         RenderRubyRun* run = text->rubyRun();
         if (run && run->inlineBoxWrapper()) {
             RenderRubyBase* base = run->rubyBase();
@@ -550,9 +549,8 @@ LayoutUnit LegacyRootInlineBox::selectionBottom() const
     
 #if !PLATFORM(IOS_FAMILY)
     // See rdar://problem/19692206 ... don't want to do this adjustment for iOS where overlap is ok and handled.
-    if (renderer().isRenderRubyBase()) {
+    if (auto* base = dynamicDowncast<RenderRubyBase>(renderer())) {
         // The ruby base selection should avoid intruding into the ruby text. This is only the case if there is an actual ruby text below us.
-        RenderRubyBase* base = &downcast<RenderRubyBase>(renderer());
         RenderRubyRun* run = base->rubyRun();
         if (run) {
             RenderRubyText* text = run->rubyText();
@@ -561,9 +559,8 @@ LayoutUnit LegacyRootInlineBox::selectionBottom() const
                 return selectionBottom;
             }
         }
-    } else if (renderer().isRenderRubyText()) {
+    } else if (auto* text = dynamicDowncast<RenderRubyText>(renderer())) {
         // The ruby text selection should go all the way to the selection bottom of the containing line.
-        RenderRubyText* text = &downcast<RenderRubyText>(renderer());
         RenderRubyRun* run = text->rubyRun();
         if (run && run->inlineBoxWrapper()) {
             RenderRubyBase* base = run->rubyBase();
@@ -693,8 +690,8 @@ void LegacyRootInlineBox::ascentAndDescentForBox(LegacyInlineBox& box, GlyphOver
 
     Vector<SingleThreadWeakPtr<const Font>>* usedFonts = nullptr;
     GlyphOverflow* glyphOverflow = nullptr;
-    if (is<LegacyInlineTextBox>(box)) {
-        GlyphOverflowAndFallbackFontsMap::iterator it = textBoxDataMap.find(&downcast<LegacyInlineTextBox>(box));
+    if (auto* textBox = dynamicDowncast<LegacyInlineTextBox>(box)) {
+        auto it = textBoxDataMap.find(textBox);
         usedFonts = it == textBoxDataMap.end() ? nullptr : &it->value.first;
         glyphOverflow = it == textBoxDataMap.end() ? nullptr : &it->value.second;
     }
@@ -873,8 +870,11 @@ bool LegacyRootInlineBox::includeFontForBox(LegacyInlineBox& box) const
     if (box.renderer().isReplacedOrInlineBlock() || (box.renderer().isRenderTextOrLineBreak() && !box.behavesLikeText()))
         return false;
     
-    if (!box.behavesLikeText() && is<LegacyInlineFlowBox>(box) && !downcast<LegacyInlineFlowBox>(box).hasTextChildren())
-        return false;
+    if (!box.behavesLikeText()) {
+        auto* flowBox = dynamicDowncast<LegacyInlineFlowBox>(box);
+        if (flowBox && !flowBox->hasTextChildren())
+            return false;
+    }
 
     return renderer().style().lineBoxContain().contains(LineBoxContain::Font);
 }
@@ -884,8 +884,11 @@ bool LegacyRootInlineBox::includeGlyphsForBox(LegacyInlineBox& box) const
     if (box.renderer().isReplacedOrInlineBlock() || (box.renderer().isRenderTextOrLineBreak() && !box.behavesLikeText()))
         return false;
     
-    if (!box.behavesLikeText() && is<LegacyInlineFlowBox>(box) && !downcast<LegacyInlineFlowBox>(box).hasTextChildren())
-        return false;
+    if (!box.behavesLikeText()) {
+        auto* flowBox = dynamicDowncast<LegacyInlineFlowBox>(box);
+        if (flowBox && !flowBox->hasTextChildren())
+            return false;
+    }
 
     return renderer().style().lineBoxContain().contains(LineBoxContain::Glyphs);
 }
@@ -895,8 +898,11 @@ bool LegacyRootInlineBox::includeInitialLetterForBox(LegacyInlineBox& box) const
     if (box.renderer().isReplacedOrInlineBlock() || (box.renderer().isRenderTextOrLineBreak() && !box.behavesLikeText()))
         return false;
     
-    if (!box.behavesLikeText() && is<LegacyInlineFlowBox>(box) && !downcast<LegacyInlineFlowBox>(box).hasTextChildren())
-        return false;
+    if (!box.behavesLikeText()) {
+        auto* flowBox = dynamicDowncast<LegacyInlineFlowBox>(box);
+        if (flowBox && !flowBox->hasTextChildren())
+            return false;
+    }
 
     return renderer().style().lineBoxContain().contains(LineBoxContain::InitialLetter);
 }

--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -88,7 +88,6 @@ bool RayPathOperation::canBlend(const PathOperation& to) const
 
 RefPtr<PathOperation> RayPathOperation::blend(const PathOperation* to, const BlendingContext& context) const
 {
-    ASSERT(is<RayPathOperation>(to));
     auto& toRayPathOperation = downcast<RayPathOperation>(*to);
     return RayPathOperation::create(WebCore::blend(m_angle, toRayPathOperation.angle(), context), m_size, m_isContaining, WebCore::blend(m_position, toRayPathOperation.position(), context), m_referenceBox);
 }

--- a/Source/WebCore/rendering/PathOperation.h
+++ b/Source/WebCore/rendering/PathOperation.h
@@ -97,7 +97,7 @@ private:
     {
         if (!isSameType(other))
             return false;
-        auto& referenceClip = downcast<ReferencePathOperation>(other);
+        auto& referenceClip = uncheckedDowncast<ReferencePathOperation>(other);
         return m_url == referenceClip.m_url;
     }
 
@@ -128,12 +128,12 @@ public:
 
     bool canBlend(const PathOperation& to) const final
     {
-        return is<ShapePathOperation>(to) && m_shape->canBlend(downcast<ShapePathOperation>(to).basicShape());
+        auto* operation = dynamicDowncast<ShapePathOperation>(to);
+        return operation && m_shape->canBlend(operation->basicShape());
     }
 
     RefPtr<PathOperation> blend(const PathOperation* to, const BlendingContext& context) const final
     {
-        ASSERT(is<ShapePathOperation>(to));
         return ShapePathOperation::create(downcast<ShapePathOperation>(*to).basicShape().blend(m_shape, context));
     }
 
@@ -154,7 +154,7 @@ private:
     {
         if (!isSameType(other))
             return false;
-        auto& shapeClip = downcast<ShapePathOperation>(other);
+        auto& shapeClip = uncheckedDowncast<ShapePathOperation>(other);
         return referenceBox() == shapeClip.referenceBox()
             && (m_shape.ptr() == shapeClip.m_shape.ptr() || m_shape.get() == shapeClip.m_shape.get());
     }
@@ -202,7 +202,7 @@ private:
     {
         if (!isSameType(other))
             return false;
-        auto& boxClip = downcast<BoxPathOperation>(other);
+        auto& boxClip = uncheckedDowncast<BoxPathOperation>(other);
         return referenceBox() == boxClip.referenceBox();
     }
 
@@ -250,7 +250,7 @@ private:
         if (!isSameType(other))
             return false;
 
-        auto& otherCasted = downcast<RayPathOperation>(other);
+        auto& otherCasted = uncheckedDowncast<RayPathOperation>(other);
         return m_angle == otherCasted.m_angle
             && m_size == otherCasted.m_size
             && m_isContaining == otherCasted.m_isContaining


### PR DESCRIPTION
#### 3291e10dddc50ca4f66ccb5f0a0de44c03be52b0
<pre>
Use downcast&lt;&gt;() less in rendering code
<a href="https://bugs.webkit.org/show_bug.cgi?id=267488">https://bugs.webkit.org/show_bug.cgi?id=267488</a>

Reviewed by Tim Nguyen.

* Source/WebCore/rendering/AccessibilityRegionContext.cpp:
(WebCore::AccessibilityRegionContext::takeBounds):
* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::recalcColumn):
(WebCore::shouldScaleColumnsForSelf):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer):
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::paintOutline):
(WebCore::BorderPainter::paintNinePieceImage):
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::CSSFilter::buildFilterFunctions):
(WebCore::CSSFilter::effectsOfType const):
(WebCore::CSSFilter::isIdentity):
(WebCore::CSSFilter::calculateOutsets):
* Source/WebCore/rendering/CaretRectComputation.cpp:
(WebCore::computeCaretRectForSVGInlineText):
(WebCore::computeLocalCaretRect):
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::unite):
(WebCore::EventRegionContext::shouldConsolidateInteractionRegion):
* Source/WebCore/rendering/Grid.cpp:
(WebCore::GridIterator::createForSubgrid):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::IndefiniteSizeStrategy::accumulateFlexFraction const):
(WebCore::GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack):
(WebCore::GridTrackSizingAlgorithm::copyUsedTrackSizesForSubgrid):
* Source/WebCore/rendering/LegacyInlineBox.cpp:
(WebCore::LegacyInlineBox::logicalHeight const):
* Source/WebCore/rendering/LegacyInlineElementBox.cpp:
(WebCore::LegacyInlineElementBox::deleteLine):
(WebCore::LegacyInlineElementBox::extractLine):
(WebCore::LegacyInlineElementBox::attachLine):
(WebCore::LegacyInlineElementBox::paint):
(WebCore::LegacyInlineElementBox::nodeAtPoint):
* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
(WebCore::LegacyInlineFlowBox::getFlowSpacingLogicalWidth):
(WebCore::LegacyInlineFlowBox::addToLine):
(WebCore::LegacyInlineFlowBox::determineSpacingForFlowBoxes):
(WebCore::LegacyInlineFlowBox::placeBoxRangeInInlineDirection):
(WebCore::LegacyInlineFlowBox::requiresIdeographicBaseline const):
(WebCore::LegacyInlineFlowBox::adjustMaxAscentAndDescent):
(WebCore::placeChildInlineBoxesInBlockDirection):
(WebCore::LegacyInlineFlowBox::flipLinesInBlockDirection):
(WebCore::LegacyInlineFlowBox::computeOverAnnotationAdjustment const):
(WebCore::LegacyInlineFlowBox::computeUnderAnnotationAdjustment const):
* Source/WebCore/rendering/LegacyInlineIterator.h:
(WebCore::nextInlineRendererSkippingEmpty):
(WebCore::firstInlineRendererSkippingEmpty):
(WebCore::LegacyInlineIterator::increment):
(WebCore::LegacyInlineIterator::characterAt const):
(WebCore::LegacyInlineIterator::direction const):
* Source/WebCore/rendering/LegacyInlineIteratorInlines.h:
(WebCore::LegacyInlineIterator::atTextParagraphSeparator const):
* Source/WebCore/rendering/LegacyInlineTextBox.cpp:
(WebCore::LegacyInlineTextBox::combinedText const):
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::LegacyLineLayout::createRootInlineBox):
(WebCore::LegacyLineLayout::createInlineBoxForRenderer):
(WebCore::dirtyLineBoxesForRenderer):
(WebCore::LegacyLineLayout::createLineBoxes):
(WebCore::reachedEndOfTextRenderer):
(WebCore::LegacyLineLayout::constructLine):
(WebCore::LegacyLineLayout::computeExpansionForJustifiedText):
(WebCore::expansionBehaviorForInlineTextBox):
(WebCore::LegacyLineLayout::computeInlineDirectionPositionsForSegment):
(WebCore::LegacyLineLayout::removeInlineBox const):
(WebCore::LegacyLineLayout::computeBlockDirectionPositionsForLine):
(WebCore::LegacyLineLayout::handleTrailingSpaces):
(WebCore::LegacyLineLayout::positionNewFloatOnLine):
* Source/WebCore/rendering/LegacyRootInlineBox.cpp:
(WebCore::LegacyRootInlineBox::isHyphenated const):
(WebCore::LegacyRootInlineBox::selectionTop const):
(WebCore::LegacyRootInlineBox::selectionBottom const):
(WebCore::LegacyRootInlineBox::ascentAndDescentForBox const):
(WebCore::LegacyRootInlineBox::includeFontForBox const):
(WebCore::LegacyRootInlineBox::includeGlyphsForBox const):
(WebCore::LegacyRootInlineBox::includeInitialLetterForBox const):
* Source/WebCore/rendering/MotionPath.cpp:
(WebCore::MotionPath::motionPathDataForRenderer):
(WebCore::MotionPath::computePathForShape):
* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::RayPathOperation::blend const):
* Source/WebCore/rendering/PathOperation.h:

Canonical link: <a href="https://commits.webkit.org/273095@main">https://commits.webkit.org/273095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f2248158cfe8120ab5c5a084cbf6b7a4da70ce9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36642 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30820 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29872 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30343 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9442 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9545 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37950 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30890 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30686 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35655 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9674 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33557 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11459 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10239 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4397 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->