### PR TITLE
[JSC] String and Number multiplication should be optimized

### DIFF
--- a/JSTests/microbenchmarks/string-number-mul-int32.js
+++ b/JSTests/microbenchmarks/string-number-mul-int32.js
@@ -1,0 +1,12 @@
+function test(op1, op2) {
+    return op1 * op2;
+}
+noInline(test);
+
+var array = [
+    "124",
+    "15",
+];
+for (var i = 0; i < 1e6; ++i) {
+    test(array[i & 0x1], i);
+}

--- a/JSTests/microbenchmarks/string-number-mul.js
+++ b/JSTests/microbenchmarks/string-number-mul.js
@@ -1,0 +1,12 @@
+function test(op1, op2) {
+    return op1 * op2;
+}
+noInline(test);
+
+var array = [
+    "0.124",
+    "15.344",
+];
+for (var i = 0; i < 1e6; ++i) {
+    test(array[i & 0x1], i * 0.5);
+}


### PR DESCRIPTION
#### 57a7762336eea989764e026e58f1e3a5e845f652
<pre>
[JSC] String and Number multiplication should be optimized
<a href="https://bugs.webkit.org/show_bug.cgi?id=267507">https://bugs.webkit.org/show_bug.cgi?id=267507</a>
<a href="https://rdar.apple.com/120930167">rdar://120930167</a>

Reviewed by Justin Michaud.

We observed that `string * number` pattern in the wild. This patch optimizes it in DFG / FTL layer
by converting ValueMul(String, Number) to ArithMul(ToNumber(String), Number).

                                        ToT                     Patched

    string-number-mul-int32       15.3303+-0.0371     ^     12.2364+-0.0633        ^ definitely 1.2528x faster
    string-number-mul             16.4883+-0.0731     ^     13.9290+-0.0953        ^ definitely 1.1837x faster

* JSTests/microbenchmarks/string-number-mul.js: Added.
(test):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):

Canonical link: <a href="https://commits.webkit.org/273024@main">https://commits.webkit.org/273024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e01c409971e9ae3f2c745cc1d0191d5e2ed5c13a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/33978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36605 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30789 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29839 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30305 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9408 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9510 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37913 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/28910 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30646 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35621 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/33892 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33521 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11428 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/40441 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10209 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8448 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4378 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->