### PR TITLE
Adopt dynamicDowncast<> in a number of page classes

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1184,9 +1184,9 @@ Vector<Ref<Element>> Page::editableElementsInRect(const FloatRect& searchRectInR
         return { };
 
     auto rootEditableElement = [](Node& node) -> Element* {
-        if (is<HTMLTextFormControlElement>(node)) {
-            if (downcast<HTMLTextFormControlElement>(node).isInnerTextElementEditable())
-                return &downcast<Element>(node);
+        if (RefPtr element = dynamicDowncast<HTMLTextFormControlElement>(node)) {
+            if (element->isInnerTextElementEditable())
+                return &uncheckedDowncast<Element>(node);
         } else if (is<Element>(node) && node.hasEditableStyle())
             return node.rootEditableElement();
         return nullptr;

--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -78,11 +78,11 @@ static bool isValidSampleLocation(Document& document, const IntPoint& location)
         if (is<RenderImage>(renderer) || renderer->style().hasBackgroundImage())
             return false;
 
-        if (!is<Element>(node))
+        RefPtr element = dynamicDowncast<Element>(node);
+        if (!element)
             continue;
 
-        auto& element = downcast<Element>(node);
-        auto styleable = Styleable::fromElement(element);
+        auto styleable = Styleable::fromElement(*element);
 
         // Skip nodes with animations as the sample may get an odd color if the animation is in-progress.
         if (styleable.hasRunningTransitions())
@@ -96,11 +96,11 @@ static bool isValidSampleLocation(Document& document, const IntPoint& location)
 
         // Skip `<canvas>` but only if they've been drawn into. Guess this by seeing if there's already
         // a `CanvasRenderingContext`, which is only created by JavaScript.
-        if (is<HTMLCanvasElement>(element) && downcast<HTMLCanvasElement>(element).renderingContext())
+        if (RefPtr canvas = dynamicDowncast<HTMLCanvasElement>(*element); canvas && canvas->renderingContext())
             return false;
 
         // Skip 3rd-party `<iframe>` as the content likely won't match the rest of the page.
-        if (is<HTMLIFrameElement>(element))
+        if (is<HTMLIFrameElement>(*element))
             return false;
     }
 

--- a/Source/WebCore/page/PageConsoleClient.cpp
+++ b/Source/WebCore/page/PageConsoleClient.cpp
@@ -340,24 +340,22 @@ void PageConsoleClient::screenshot(JSC::JSGlobalObject* lexicalGlobalObject, Ref
                         }
                     };
 
-                    if (is<HTMLImageElement>(node))
-                        snapshotImageElement(downcast<HTMLImageElement>(*node));
-                    else if (is<HTMLPictureElement>(node)) {
-                        if (auto* firstImage = childrenOfType<HTMLImageElement>(downcast<HTMLPictureElement>(*node)).first())
+                    if (RefPtr imgElement = dynamicDowncast<HTMLImageElement>(node))
+                        snapshotImageElement(*imgElement);
+                    else if (RefPtr pictureElement = dynamicDowncast<HTMLPictureElement>(node)) {
+                        if (RefPtr firstImage = childrenOfType<HTMLImageElement>(*pictureElement).first())
                             snapshotImageElement(*firstImage);
                     }
 #if ENABLE(VIDEO)
-                    else if (is<HTMLVideoElement>(node)) {
-                        auto& videoElement = downcast<HTMLVideoElement>(*node);
-                        unsigned videoWidth = videoElement.videoWidth();
-                        unsigned videoHeight = videoElement.videoHeight();
+                    else if (RefPtr videoElement = dynamicDowncast<HTMLVideoElement>(node)) {
+                        unsigned videoWidth = videoElement->videoWidth();
+                        unsigned videoHeight = videoElement->videoHeight();
                         snapshot = ImageBuffer::create(FloatSize(videoWidth, videoHeight), RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
-                        videoElement.paintCurrentFrameInContext(snapshot->context(), FloatRect(0, 0, videoWidth, videoHeight));
+                        videoElement->paintCurrentFrameInContext(snapshot->context(), FloatRect(0, 0, videoWidth, videoHeight));
                     }
 #endif
-                    else if (is<HTMLCanvasElement>(node)) {
-                        auto& canvasElement = downcast<HTMLCanvasElement>(*node);
-                        if (auto* canvasRenderingContext = canvasElement.renderingContext()) {
+                    else if (RefPtr canvasElement = dynamicDowncast<HTMLCanvasElement>(node)) {
+                        if (auto* canvasRenderingContext = canvasElement->renderingContext()) {
                             if (auto result = InspectorCanvas::getContentAsDataURL(*canvasRenderingContext))
                                 dataURL = result.value();
                         }

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -142,21 +142,21 @@ void PageSerializer::SerializerMarkupAccumulator::appendStartTag(StringBuilder& 
 
 void PageSerializer::SerializerMarkupAccumulator::appendCustomAttributes(StringBuilder& out, const Element& element, Namespaces* namespaces)
 {
-    if (!is<HTMLFrameOwnerElement>(element))
+    RefPtr frameOwner = dynamicDowncast<HTMLFrameOwnerElement>(element);
+    if (!frameOwner)
         return;
 
-    const HTMLFrameOwnerElement& frameOwner = downcast<HTMLFrameOwnerElement>(element);
-    auto* frame = dynamicDowncast<LocalFrame>(frameOwner.contentFrame());
+    auto* frame = dynamicDowncast<LocalFrame>(frameOwner->contentFrame());
     if (!frame)
         return;
 
-    URL url = frame->document()->url();
+    auto url = frame->document()->url();
     if (url.isValid() && !url.protocolIsAbout())
         return;
 
     // We need to give a fake location to blank frames so they can be referenced by the serialized frame.
     url = m_serializer.urlForBlankFrame(frame);
-    appendAttribute(out, element, Attribute(frameOwnerURLAttributeName(frameOwner), AtomString { url.string() }), namespaces);
+    appendAttribute(out, element, Attribute(frameOwnerURLAttributeName(*frameOwner), AtomString { url.string() }), namespaces);
 }
 
 void PageSerializer::SerializerMarkupAccumulator::appendEndTag(StringBuilder& out, const Element& element)
@@ -209,23 +209,21 @@ void PageSerializer::serializeFrame(LocalFrame* frame)
         if (!element)
             continue;
         // We have to process in-line style as it might contain some resources (typically background images).
-        if (is<StyledElement>(*element))
-            retrieveResourcesForProperties(downcast<StyledElement>(*element).inlineStyle(), document);
+        if (RefPtr styledElement = dynamicDowncast<StyledElement>(*element))
+            retrieveResourcesForProperties(styledElement->inlineStyle(), document);
 
-        if (is<HTMLImageElement>(*element)) {
-            Ref imageElement = downcast<HTMLImageElement>(element.releaseNonNull());
-            URL url = document->completeURL(imageElement->attributeWithoutSynchronization(HTMLNames::srcAttr));
-            CachedImage* cachedImage = imageElement->cachedImage();
+        if (RefPtr imageElement = dynamicDowncast<HTMLImageElement>(*element)) {
+            auto url = document->completeURL(imageElement->attributeWithoutSynchronization(HTMLNames::srcAttr));
+            auto* cachedImage = imageElement->cachedImage();
             addImageToResources(cachedImage, imageElement->renderer(), url);
-        } else if (is<HTMLLinkElement>(element)) {
-            Ref linkElement = downcast<HTMLLinkElement>(element.releaseNonNull());
+        } else if (RefPtr linkElement = dynamicDowncast<HTMLLinkElement>(*element)) {
             if (RefPtr sheet = linkElement->sheet()) {
-                URL url = document->completeURL(linkElement->attributeWithoutSynchronization(HTMLNames::hrefAttr));
+                auto url = document->completeURL(linkElement->attributeWithoutSynchronization(HTMLNames::hrefAttr));
                 serializeCSSStyleSheet(sheet.get(), url);
                 ASSERT(m_resourceURLs.contains(url));
             }
-        } else if (is<HTMLStyleElement>(element)) {
-            if (RefPtr sheet = downcast<HTMLStyleElement>(*element).sheet())
+        } else if (RefPtr styleElement = dynamicDowncast<HTMLStyleElement>(*element)) {
+            if (RefPtr sheet = styleElement->sheet())
                 serializeCSSStyleSheet(sheet.get(), URL());
         }
     }
@@ -251,17 +249,16 @@ void PageSerializer::serializeCSSStyleSheet(CSSStyleSheet* styleSheet, const URL
         }
         Document* document = styleSheet->ownerDocument();
         // Some rules have resources associated with them that we need to retrieve.
-        if (is<CSSImportRule>(*rule)) {
-            CSSImportRule& importRule = downcast<CSSImportRule>(*rule);
-            URL importURL = document->completeURL(importRule.href());
+        if (RefPtr importRule = dynamicDowncast<CSSImportRule>(*rule)) {
+            auto importURL = document->completeURL(importRule->href());
             if (m_resourceURLs.contains(importURL))
                 continue;
-            serializeCSSStyleSheet(importRule.styleSheet(), importURL);
+            serializeCSSStyleSheet(importRule->styleSheet(), importURL);
         } else if (is<CSSFontFaceRule>(*rule)) {
             // FIXME: Add support for font face rule. It is not clear to me at this point if the actual otf/eot file can
             // be retrieved from the CSSFontFaceRule object.
-        } else if (is<CSSStyleRule>(*rule))
-            retrieveResourcesForRule(downcast<CSSStyleRule>(*rule).styleRule(), document);
+        } else if (RefPtr styleRule = dynamicDowncast<CSSStyleRule>(*rule))
+            retrieveResourcesForRule(styleRule->styleRule(), document);
     }
 
     if (url.isValid() && !m_resourceURLs.contains(url)) {
@@ -308,11 +305,11 @@ void PageSerializer::retrieveResourcesForProperties(const StyleProperties* style
     // that make use of images. We iterate to make sure we include any other
     // image properties there might be.
     for (auto property : *styleDeclaration) {
-        auto cssValue = property.value();
-        if (!is<CSSImageValue>(*cssValue))
+        RefPtr cssValue = dynamicDowncast<CSSImageValue>(property.value());
+        if (!cssValue)
             continue;
 
-        auto* image = downcast<CSSImageValue>(*cssValue).cachedImage();
+        auto* image = cssValue->cachedImage();
         if (!image)
             continue;
 


### PR DESCRIPTION
#### b0ccbb24dcd4e4d30ac3c5b617daafc578d9cac8
<pre>
Adopt dynamicDowncast&lt;&gt; in a number of page classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=267512">https://bugs.webkit.org/show_bug.cgi?id=267512</a>

Reviewed by Darin Adler.

* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::searchForLabelsBeforeElement):
(WebCore::LocalFrame::setPageAndTextZoomFactors):
(WebCore::LocalFrame::contentFrameFromWindowOrFrameElement):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::init):
(WebCore::LocalFrameView::applyOverflowToViewport):
(WebCore::LocalFrameView::applyPaginationToViewport):
(WebCore::LocalFrameView::addEmbeddedObjectToUpdate):
(WebCore::LocalFrameView::canShowNonOverlayScrollbars const):
(WebCore::LocalFrameView::maintainScrollPositionAtAnchor):
(WebCore::countRenderedCharactersInRenderObjectWithThreshold):
(WebCore::LocalFrameView::updateEmbeddedObject):
(WebCore::LocalFrameView::hasCustomScrollbars const):
(WebCore::LocalFrameView::addChild):
(WebCore::LocalFrameView::removeChild):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::editableElementsInRect const):
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::isValidSampleLocation):
* Source/WebCore/page/PageConsoleClient.cpp:
(WebCore::PageConsoleClient::screenshot):
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::PageSerializer::SerializerMarkupAccumulator::appendCustomAttributes):
(WebCore::PageSerializer::serializeFrame):
(WebCore::PageSerializer::serializeCSSStyleSheet):
(WebCore::PageSerializer::retrieveResourcesForProperties):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDispatchSimulatedMouseEvents const):
(WebCore::Quirks::shouldDispatchedSimulatedMouseEventsAssumeDefaultPrevented const):
(WebCore::Quirks::simulatedMouseEventTypeForTarget const):
(WebCore::Quirks::shouldMakeTouchEventNonCancelableForTarget const):
(WebCore::Quirks::shouldPreventDispatchOfTouchEvent const):
(WebCore::Quirks::shouldBypassBackForwardCache const):
(WebCore::Quirks::shouldMakeEventListenerPassive):
(WebCore::Quirks::triggerOptionalStorageAccessQuirk const):

Canonical link: <a href="https://commits.webkit.org/273154@main">https://commits.webkit.org/273154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a685f7884518f1f5733735637984a707e690ab1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37135 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31154 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30148 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30716 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9809 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38414 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31287 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35964 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33908 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11829 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7925 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10570 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10872 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->