### PR TITLE
Replaced elements avoid floats, including check boxes and radio boxes when turned into block box

### DIFF
--- a/LayoutTests/fast/block/float/checkbox-and-radio-avoid-floats-expected.txt
+++ b/LayoutTests/fast/block/float/checkbox-and-radio-avoid-floats-expected.txt
@@ -1,0 +1,6 @@
+Checkboxes and radio boxes are replaced elements, so they should avoid floats.
+
+
+PASS
+
+PASS

--- a/LayoutTests/fast/block/float/checkbox-and-radio-avoid-floats.html
+++ b/LayoutTests/fast/block/float/checkbox-and-radio-avoid-floats.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+body {
+    margin: 0;
+}
+#float {
+    float: left;
+    width: 100px;
+    height: 200px;
+    background: blue;
+    }
+input {
+    display: block;
+    width: 50px;
+    height: 10px;
+}
+</style>
+<script src="../../../resources/check-layout.js"></script>
+<p> Checkboxes and radio boxes are replaced elements, so they should avoid floats. </p>
+<div id="float"></div>
+<input type="checkbox" data-offset-x=100 />
+<input type="radio" data-offset-x=100 />
+<script>
+onload=function() { checkLayout('input'); }
+</script>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5102,7 +5102,7 @@ bool RenderBox::establishesIndependentFormattingContext() const
 
 bool RenderBox::avoidsFloats() const
 {
-    return isReplacedOrInlineBlock() || isLegend() || isFieldset() || createsNewFormattingContext();
+    return isReplacedOrInlineBlock() || isLegend() || isFieldset() || createsNewFormattingContext() || (element() && element()->isFormControlElement());
 }
 
 void RenderBox::addVisualEffectOverflow()


### PR DESCRIPTION
#### 7adc3dd2a2260a3dd133dbc2245a9be5b8b78772
<pre>
Replaced elements avoid floats, including check boxes and radio boxes when turned into block box

<a href="https://bugs.webkit.org/show_bug.cgi?id=264770">https://bugs.webkit.org/show_bug.cgi?id=264770</a>
<a href="https://rdar.apple.com/problem/118660695">rdar://problem/118660695</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/141235180acceb7bbdd50a315c31171dfcf55a07">https://chromium.googlesource.com/chromium/blink/+/141235180acceb7bbdd50a315c31171dfcf55a07</a>

This bug is reproducible when the input box is turned into a block box
(by default their display type value is inline-block and inline layout handles
such cases just fine i.e. they do avoid floats).

Check boxes and radio boxes are the odd man out among form control
elements: they neither have their own renderer class with which to
override avoidFloats nor are they isReplaced(). If the case for
making form control elements isReplaced() builds further than it may
be worth looking at including them in that effort but for now just
replaced the isReplaced() check in avoidsFloats() with a more inclusive
alternative.

* Source/WebCore/rendering/RenderBox.cpp:
(RenderBox::avoidsFloats):
* LayoutTests/fast/block/float/checkbox-and-radio-avoid-floats.html: Add Test Case
* LayoutTests/fast/block/float/checkbox-and-radio-avoid-floats-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/273047@main">https://commits.webkit.org/273047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f28c27a04a02182662538d1e32f534fc31770e8c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36706 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30876 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29925 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9495 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9617 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38012 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30950 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35707 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9732 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33610 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11517 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30033 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7848 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10294 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10544 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->