### PR TITLE
Generate serialization for WebCore::PaymentMethod

### DIFF
--- a/Source/WebCore/Modules/applepay/PaymentMethod.h
+++ b/Source/WebCore/Modules/applepay/PaymentMethod.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(APPLE_PAY)
 
+#include <wtf/ArgumentCoder.h>
 #include <wtf/RetainPtr.h>
 
 OBJC_CLASS PKPaymentMethod;
@@ -46,6 +47,7 @@ public:
     PKPaymentMethod *pkPaymentMethod() const;
 
 private:
+    friend struct IPC::ArgumentCoder<PaymentMethod, void>;
     RetainPtr<PKPaymentMethod> m_pkPaymentMethod;
 };
 

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -104,6 +104,12 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                 "dataDetectorResults"_s
             },
         } },
+        { "Namespace::ClassWithMemberPrecondition"_s, {
+            {
+                "RetainPtr<PKPaymentMethod>"_s,
+                "m_pkPaymentMethod"_s
+            },
+        } },
         { "Namespace::ReturnRefClass"_s, {
             {
                 "double"_s,

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -19,6 +19,10 @@ headers: "StructHeader.h" "FirstMemberType.h" "SecondMemberType.h"
     [SecureCodingAllowed=[NSArray.class, PAL::getDDScannerResultClass()]] RetainPtr<NSArray> dataDetectorResults;
 }
 
+[Nested] class Namespace::ClassWithMemberPrecondition {
+    [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKPaymentMethodClass()]] RetainPtr<PKPaymentMethod> m_pkPaymentMethod;
+}
+
 [RefCounted] class Namespace::ReturnRefClass {
     double functionCall().member1
     double functionCall().member2

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
@@ -137,20 +137,6 @@ std::optional<WebCore::PaymentMerchantSession> ArgumentCoder<WebCore::PaymentMer
     return WebCore::PaymentMerchantSession { WTFMove(*paymentMerchantSession) };
 }
 
-void ArgumentCoder<WebCore::PaymentMethod>::encode(Encoder& encoder, const WebCore::PaymentMethod& paymentMethod)
-{
-    encoder << paymentMethod.pkPaymentMethod();
-}
-
-std::optional<WebCore::PaymentMethod> ArgumentCoder<WebCore::PaymentMethod>::decode(Decoder& decoder)
-{
-    auto paymentMethod = decoder.decodeWithAllowedClasses<PKPaymentMethod>();
-    if (!paymentMethod)
-        return std::nullopt;
-
-    return WebCore::PaymentMethod { WTFMove(*paymentMethod) };
-}
-
 void ArgumentCoder<WebCore::ApplePaySessionPaymentRequest>::encode(Encoder& encoder, const WebCore::ApplePaySessionPaymentRequest& request)
 {
     encoder << request.countryCode();

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -108,6 +108,11 @@ enum class WebCore::ApplePaySessionPaymentRequestShippingType : uint8_t {
     StorePickup,
     ServicePickup,
 };
+
+headers: <pal/cocoa/PassKitSoftLink.h>
+class WebCore::PaymentMethod {
+    [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKPaymentMethodClass()], Validator='m_pkPaymentMethod'] RetainPtr<PKPaymentMethod> m_pkPaymentMethod;
+}
 #endif
 
 #if ENABLE(APPLE_PAY_SHIPPING_CONTACT_EDITING_MODE)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -236,11 +236,6 @@ template<> struct ArgumentCoder<WebCore::PaymentMerchantSession> {
     static std::optional<WebCore::PaymentMerchantSession> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<WebCore::PaymentMethod> {
-    static void encode(Encoder&, const WebCore::PaymentMethod&);
-    static std::optional<WebCore::PaymentMethod> decode(Decoder&);
-};
-
 template<> struct ArgumentCoder<WebCore::ApplePaySessionPaymentRequest> {
     static void encode(Encoder&, const WebCore::ApplePaySessionPaymentRequest&);
     static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::ApplePaySessionPaymentRequest&);


### PR DESCRIPTION
#### 1d1685a41c3174c0c6e393ec6a96e008f86e02c9
<pre>
Generate serialization for WebCore::PaymentMethod
<a href="https://bugs.webkit.org/show_bug.cgi?id=267518">https://bugs.webkit.org/show_bug.cgi?id=267518</a>
<a href="https://rdar.apple.com/120985221">rdar://120985221</a>

Reviewed by Alex Christensen.

* Source/WebCore/Modules/applepay/PaymentMethod.h:
* Source/WebKit/Scripts/generate-serializers.py:
(decode_type):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::ClassWithMemberPrecondition&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::ClassWithMemberPrecondition&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::ArgumentCoder&lt;WebCore::PaymentMethod&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::PaymentMethod&gt;::decode): Deleted.
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.h:

Canonical link: <a href="https://commits.webkit.org/273135@main">https://commits.webkit.org/273135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82e7a74e9f0d05830f63773751a1f3f586f98e75

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36648 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30826 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29881 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30348 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9450 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/34309 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37956 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30895 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35661 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9680 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33563 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11465 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10245 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4413 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->