### PR TITLE
Unexpose non-standard `resize: auto` value

### DIFF
--- a/LayoutTests/fast/css/textarea-resizable-preference-disabled-expected.html
+++ b/LayoutTests/fast/css/textarea-resizable-preference-disabled-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<textarea style="resize: none"></textarea>
+<div>textarea has resize: none</div>

--- a/LayoutTests/fast/css/textarea-resizable-preference-disabled.html
+++ b/LayoutTests/fast/css/textarea-resizable-preference-disabled.html
@@ -1,0 +1,7 @@
+<!-- webkit-test-runner [ TextAreasAreResizable=false ] -->
+<!DOCTYPE html>
+<textarea id="textarea"></textarea>
+<div>textarea has resize: <span id="computedStyle"></span></div>
+<script>
+computedStyle.textContent = getComputedStyle(textarea).resize;
+</script>

--- a/LayoutTests/fast/css/textarea-resizable-preference-enabled-expected.html
+++ b/LayoutTests/fast/css/textarea-resizable-preference-enabled-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<textarea style="resize: both"></textarea>
+<div>textarea has resize: both</div>

--- a/LayoutTests/fast/css/textarea-resizable-preference-enabled.html
+++ b/LayoutTests/fast/css/textarea-resizable-preference-enabled.html
@@ -1,0 +1,7 @@
+<!-- webkit-test-runner [ TextAreasAreResizable=true ] -->
+<!DOCTYPE html>
+<textarea id="textarea"></textarea>
+<div>textarea has resize: <span id="computedStyle"></span></div>
+<script>
+computedStyle.textContent = getComputedStyle(textarea).resize;
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/resize-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/resize-invalid-expected.txt
@@ -1,5 +1,6 @@
 
-FAIL e.style['resize'] = "auto" should not set the property value assert_equals: expected "" but got "auto"
+PASS e.style['resize'] = "auto" should not set the property value
 PASS e.style['resize'] = "horizontal vertical" should not set the property value
 PASS e.style['resize'] = "both 0" should not set the property value
+PASS e.style['resize'] = "-internal-textarea-auto" should not set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/resize-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/resize-invalid.html
@@ -15,6 +15,7 @@
 test_invalid_value("resize", "auto");
 test_invalid_value("resize", "horizontal vertical");
 test_invalid_value("resize", "both 0");
+test_invalid_value("resize", "-internal-textarea-auto");
 </script>
 </body>
 </html>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5412,8 +5412,8 @@
                     "url": "https://www.w3.org/TR/css-logical/#resize"
                 },
                 {
-                    "value": "auto",
-                    "status": "non-standard"
+                    "value": "-internal-textarea-auto",
+                    "status": "internal"
                 }
             ],
             "codegen-properties": {

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1751,3 +1751,12 @@ both-edges
 // transition-behavior
 // normal
 allow-discrete
+
+// resize
+// none
+// both
+// horizontal
+// vertical
+// block
+// inline
+-internal-textarea-auto

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -808,7 +808,7 @@ textarea {
     padding-block: 2px;
 #endif
     flex-direction: column;
-    resize: auto;
+    resize: -internal-textarea-auto;
     cursor: auto;
     white-space: pre-wrap;
     word-wrap: break-word;

--- a/Source/WebCore/css/parser/CSSParserIdioms.cpp
+++ b/Source/WebCore/css/parser/CSSParserIdioms.cpp
@@ -46,6 +46,7 @@ bool isValueAllowedInMode(unsigned short id, CSSParserMode mode)
     case CSSValueAppleSystemQuaternaryFill:
 #endif
     case CSSValueInternalDocumentTextColor:
+    case CSSValueInternalTextareaAuto:
     case CSSValueInternalThCenter:
         return isUASheetBehavior(mode);
     default:

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -798,8 +798,8 @@ inline Resize BuilderConverter::convertResize(BuilderState& builderState, const 
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
 
-    Resize resize = Resize::None;
-    if (primitiveValue.valueID() == CSSValueAuto)
+    auto resize = Resize::None;
+    if (primitiveValue.valueID() == CSSValueInternalTextareaAuto)
         resize = builderState.document().settings().textAreasAreResizable() ? Resize::Both : Resize::None;
     else
         resize = fromCSSValue<Resize>(value);


### PR DESCRIPTION
#### b829c58e74144cfe9feb5c76e58f2a37d08d11b1
<pre>
Unexpose non-standard `resize: auto` value
<a href="https://bugs.webkit.org/show_bug.cgi?id=266614">https://bugs.webkit.org/show_bug.cgi?id=266614</a>
<a href="https://rdar.apple.com/120138995">rdar://120138995</a>

Reviewed by Anne van Kesteren.

Rename `resize: auto` to `resize: -internal-textarea-auto` and make it specific to UA stylesheets.

Also add some tests for the &quot;TextAreasAreResizable&quot; preference since it was previously untested.

* LayoutTests/fast/css/textarea-resizable-preference-disabled-expected.html: Added.
* LayoutTests/fast/css/textarea-resizable-preference-disabled.html: Added.
* LayoutTests/fast/css/textarea-resizable-preference-enabled-expected.html: Added.
* LayoutTests/fast/css/textarea-resizable-preference-enabled.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/resize-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/resize-invalid.html:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/html.css:
(#endif):
* Source/WebCore/css/parser/CSSParserIdioms.cpp:
(WebCore::isValueAllowedInMode):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertResize):

Canonical link: <a href="https://commits.webkit.org/273035@main">https://commits.webkit.org/273035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3910851dd7692580a69bd8414bf75ab1225a8823

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36657 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30835 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35092 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29886 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9455 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9560 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37965 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30904 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35668 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33570 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/29991 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7836 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10254 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->