### PR TITLE
[Win] Implement EventSenderProxy::mouseScrollByWithWheelAndMomentumPhases

### DIFF
--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -356,15 +356,18 @@ fast/url/tab-and-newline-stripping.html [ Failure ]
 webkit.org/b/58845 fast/dom/title-directionality-removeChild.html [ Skip ]
 webkit.org/b/58845 fast/dom/title-directionality.html [ Skip ]
 
-# Need async scrolling
-webkit.org/b/219842 fast/events/wheel/first-wheel-event-cancelable.html [ Skip ]
-webkit.org/b/219842 fast/events/wheel/platform-wheelevent-in-scrolling-div.html [ Skip ]
-webkit.org/b/219842 fast/events/wheel/wheel-event-in-passive-region-non-cancelable.html [ Skip ]
-webkit.org/b/219842 fast/events/wheel/wheel-event-listeners-on-body-made-passive.html [ Skip ]
-webkit.org/b/219842 fast/events/wheel/wheel-event-listeners-on-document-made-passive.html [ Skip ]
-webkit.org/b/219842 fast/events/wheel/wheel-event-listeners-on-window-left-active.html [ Skip ]
-webkit.org/b/219842 fast/events/wheel/wheel-event-listeners-on-window-made-passive.html [ Skip ]
-webkit.org/b/219842 fast/events/wheel/wheel-events-become-non-cancelable.html [ Skip ]
+# Skip because this platform does not support a paging mouse wheel event
+fast/events/wheel/platform-wheelevent-in-scrolling-div.html [ Skip ]
+fast/events/wheel/platform-wheelevent-paging-x-in-non-scrolling-div.html [ Skip ]
+fast/events/wheel/platform-wheelevent-paging-x-in-non-scrolling-page.html [ Skip ]
+fast/events/wheel/platform-wheelevent-paging-x-in-scrolling-div.html [ Skip ]
+fast/events/wheel/platform-wheelevent-paging-x-in-scrolling-page.html [ Skip ]
+fast/events/wheel/platform-wheelevent-paging-xy-in-scrolling-div.html [ Skip ]
+fast/events/wheel/platform-wheelevent-paging-xy-in-scrolling-page.html [ Skip ]
+fast/events/wheel/platform-wheelevent-paging-y-in-non-scrolling-div.html [ Skip ]
+fast/events/wheel/platform-wheelevent-paging-y-in-non-scrolling-page.html [ Skip ]
+fast/events/wheel/platform-wheelevent-paging-y-in-scrolling-div.html [ Skip ]
+fast/events/wheel/platform-wheelevent-paging-y-in-scrolling-page.html [ Skip ]
 
 # Needs WebGL video texture support
 fast/canvas/canvas-createPattern-video-loading.html [ Skip ]
@@ -1977,18 +1980,8 @@ fast/events/shadow-event-path-2.html [ Failure ]
 fast/events/shadow-event-path.html [ Failure ]
 fast/events/special-key-events-in-input-text.html [ Failure ]
 fast/events/wheel/continuous-platform-wheelevent-in-scrolling-div.html [ Failure ]
-fast/events/wheel/platform-wheelevent-paging-x-in-non-scrolling-div.html [ Failure ]
-fast/events/wheel/platform-wheelevent-paging-x-in-non-scrolling-page.html [ Failure ]
-fast/events/wheel/platform-wheelevent-paging-x-in-scrolling-div.html [ Failure ]
-fast/events/wheel/platform-wheelevent-paging-x-in-scrolling-page.html [ Failure ]
-fast/events/wheel/platform-wheelevent-paging-xy-in-scrolling-div.html [ Failure ]
-fast/events/wheel/platform-wheelevent-paging-xy-in-scrolling-page.html [ Failure ]
-fast/events/wheel/platform-wheelevent-paging-y-in-non-scrolling-div.html [ Failure ]
-fast/events/wheel/platform-wheelevent-paging-y-in-non-scrolling-page.html [ Failure ]
-fast/events/wheel/platform-wheelevent-paging-y-in-scrolling-div.html [ Failure ]
-fast/events/wheel/platform-wheelevent-paging-y-in-scrolling-page.html [ Failure ]
-fast/events/wheel/redispatched-wheel-event.html [ Skip ] # Timeout
-fast/events/wheel/wheel-event-destroys-overflow.html [ Skip ] # Timeout
+fast/events/wheel/wheel-event-in-passive-region-non-cancelable.html [ Failure ]
+fast/events/wheel/wheel-events-become-non-cancelable.html [ Failure ]
 fast/events/wheel/wheelevent-basic.html [ Failure ]
 fast/events/wheel/wheelevent-in-horizontal-scrollbar-in-rtl.html [ Failure ]
 fast/events/wheel/wheelevent-in-vertical-scrollbar-in-rtl.html [ Failure ]
@@ -2759,5 +2752,4 @@ http/tests/misc/embed-image-load-outlives-gc-without-crashing.html [ Pass Timeou
 
 fast/dom/no-scroll-when-command-click-fragment-URL.html [ Failure ]
 
-# EventSenderProxy::mouseScrollByWithWheelAndMomentumPhases isn't implemented yet
-fast/events/wheel/wheel-event-after-document-open.html [ Skip ] # Timeout
+webkit.org/b/259464 fast/events/wheel/redispatched-wheel-event.html [ Failure Pass ]

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3123,7 +3123,7 @@ HandleUserInputEventResult EventHandler::handleWheelEventInternal(const Platform
     }
 #endif
 
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) || PLATFORM(WIN)
     LOG_WITH_STREAM(Scrolling, stream << "EventHandler::handleWheelEvent " << event << " processing steps " << processingSteps);
     auto monitor = frame->page()->wheelEventTestMonitor();
     if (monitor)

--- a/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
+++ b/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
@@ -140,9 +140,10 @@ void EventSenderProxy::mouseScrollBy(int x, int y)
     }
 }
 
-void EventSenderProxy::mouseScrollByWithWheelAndMomentumPhases(int, int, int, int)
+void EventSenderProxy::mouseScrollByWithWheelAndMomentumPhases(int x, int y, int /* phase */, int /* momentum */)
 {
-    notImplemented();
+    // Ignore arguments `phase` and `momentum` because they are used only if ENABLE(KINETIC_SCROLLING).
+    mouseScrollBy(x, y);
 }
 
 void EventSenderProxy::continuousMouseScrollBy(int, int, bool)


### PR DESCRIPTION
#### da94d34c7e762608e89adbf378476bb691481c7b
<pre>
[Win] Implement EventSenderProxy::mouseScrollByWithWheelAndMomentumPhases
<a href="https://bugs.webkit.org/show_bug.cgi?id=267522">https://bugs.webkit.org/show_bug.cgi?id=267522</a>

Reviewed by Ross Kirsling.

Some wheel event tests were failing becuase it was not implemented yet
for WebKitTestRunner of Windows port.

The arguments `phase` and `momentum` are used only if
ENABLE(KINETIC_SCROLLING) which is disabled for Windows port at the
moment. We can ignore them.

EventHandler::handleWheelEventInternal has to initiate a
WheelEventTestMonitorCompletionDeferrer to work WheelEventTestMonitor
correctly. Otherwise, `callback` of
WKBundlePageRegisterScrollOperationCompletionCallback never be called
back.

* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebCore/page/EventHandler.cpp:
* Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp:

Canonical link: <a href="https://commits.webkit.org/273031@main">https://commits.webkit.org/273031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffa42768cb22048b936f8d29a7344555654e4668

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/35988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36655 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30833 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35090 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9953 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29884 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9453 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9558 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/30374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37963 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30697 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9687 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33567 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11472 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10252 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4382 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10497 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->