### PR TITLE
jsc_fuz/wktr: null ptr deref in WebCore::writeResources(WTF::TextStream&, WebCore::RenderObject const&, WTF::OptionSet<WebCore::RenderAsTextFlag>) + 116 (SVGRenderTreeAsText.cpp:595)

### DIFF
--- a/LayoutTests/svg/css/svg-write-resources-null-maskImage-crash-expected.html
+++ b/LayoutTests/svg/css/svg-write-resources-null-maskImage-crash-expected.html
@@ -1,0 +1,5 @@
+<svg>
+    <g style="mask-image: none, url()">
+    </g>
+</svg>
+This test passes if it doesn't crash.

--- a/LayoutTests/svg/css/svg-write-resources-null-maskImage-crash.html
+++ b/LayoutTests/svg/css/svg-write-resources-null-maskImage-crash.html
@@ -1,0 +1,5 @@
+<svg>
+    <g style="mask-image: none, url()">
+    </g>
+</svg>
+This test passes if it doesn't crash.

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -592,7 +592,7 @@ void writeResources(TextStream& ts, const RenderObject& renderer, OptionSet<Rend
     if (style.hasPositionedMask()) {
         auto* maskImage = style.maskImage();
         auto& document = renderer.document();
-        auto reresolvedURL = maskImage->reresolvedURL(document);
+        auto reresolvedURL = maskImage ? maskImage->reresolvedURL(document) : URL();
 
         if (!reresolvedURL.isEmpty()) {
             auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(reresolvedURL.string(), document);


### PR DESCRIPTION
#### e87ab3954b6a74b7528e7ec618033367c7f770ea
<pre>
jsc_fuz/wktr: null ptr deref in WebCore::writeResources(WTF::TextStream&amp;, WebCore::RenderObject const&amp;, WTF::OptionSet&lt;WebCore::RenderAsTextFlag&gt;) + 116 (SVGRenderTreeAsText.cpp:595)
<a href="https://bugs.webkit.org/show_bug.cgi?id=267528">https://bugs.webkit.org/show_bug.cgi?id=267528</a>
<a href="https://rdar.apple.com/120991613">rdar://120991613</a>

Reviewed by Nikolas Zimmermann.

Add null check for maskImage in WebCore::writeResources also.

* LayoutTests/svg/css/svg-write-resources-null-maskImage-crash-expected.html: Added.
* LayoutTests/svg/css/svg-write-resources-null-maskImage-crash.html: Added.
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeResources):

Canonical link: <a href="https://commits.webkit.org/273111@main">https://commits.webkit.org/273111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d65c0f99318c50fe719ef7dc68035f805849ad7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36669 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30846 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/9966 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29894 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9463 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9570 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30389 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/37977 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30712 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35675 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33578 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30002 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7892 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10511 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->