### PR TITLE
Avoid traversing all custom properties in Styleable::updateCSSTransitions when not needed

### DIFF
--- a/Source/WebCore/css/CSSCustomPropertyValue.cpp
+++ b/Source/WebCore/css/CSSCustomPropertyValue.cpp
@@ -187,4 +187,9 @@ bool CSSCustomPropertyValue::isCurrentColor() const
     return token.id() == CSSValueCurrentcolor;
 }
 
+bool CSSCustomPropertyValue::isAnimatable() const
+{
+    return std::holds_alternative<SyntaxValue>(m_value) || std::holds_alternative<SyntaxValueList>(m_value);
+}
+
 }

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -97,6 +97,7 @@ public:
     bool isInherit() const { return std::holds_alternative<CSSValueID>(m_value) && std::get<CSSValueID>(m_value) == CSSValueInherit; }
     bool isCurrentColor() const;
     bool containsCSSWideKeyword() const;
+    bool isAnimatable() const;
 
     const VariantValue& value() const { return m_value; }
 

--- a/Source/WebCore/rendering/style/StyleCustomPropertyData.cpp
+++ b/Source/WebCore/rendering/style/StyleCustomPropertyData.cpp
@@ -32,6 +32,7 @@ static constexpr auto maximumAncestorCount = 4;
 
 StyleCustomPropertyData::StyleCustomPropertyData(const StyleCustomPropertyData& other)
     : m_size(other.m_size)
+    , m_mayHaveAnimatableProperties(other.m_mayHaveAnimatableProperties)
 {
     auto shouldReferenceAsParentValues = [&] {
         // Always reference the root style since it likely gets shared a lot.
@@ -80,6 +81,8 @@ void StyleCustomPropertyData::set(const AtomString& name, Ref<const CSSCustomPro
         auto* existing = get(name);
         return !existing || !existing->equals(value);
     }());
+
+    m_mayHaveAnimatableProperties = m_mayHaveAnimatableProperties || value->isAnimatable();
 
     auto addResult = m_ownValues.set(name, WTFMove(value));
 
@@ -166,11 +169,6 @@ AtomString StyleCustomPropertyData::findKeyAtIndex(unsigned index) const
         return IterationStatus::Continue;
     });
     return key;
-}
-
-unsigned StyleCustomPropertyData::size() const
-{
-    return m_size;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleCustomPropertyData.h
+++ b/Source/WebCore/rendering/style/StyleCustomPropertyData.h
@@ -44,7 +44,8 @@ public:
     const CSSCustomPropertyValue* get(const AtomString&) const;
     void set(const AtomString&, Ref<const CSSCustomPropertyValue>&&);
 
-    unsigned size() const;
+    unsigned size() const { return m_size; }
+    bool mayHaveAnimatableProperties() const { return m_mayHaveAnimatableProperties; }
 
     void forEach(const Function<IterationStatus(const KeyValuePair<AtomString, RefPtr<const CSSCustomPropertyValue>>&)>&) const;
     AtomString findKeyAtIndex(unsigned) const;
@@ -59,6 +60,7 @@ private:
     CustomPropertyValueMap m_ownValues;
     unsigned m_size { 0 };
     unsigned m_ancestorCount { 0 };
+    bool m_mayHaveAnimatableProperties { false };
 #if ASSERT_ENABLED
     mutable bool m_hasChildren { false };
 #endif

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -729,11 +729,12 @@ void Styleable::updateCSSTransitions(const RenderStyle& currentStyle, const Rend
 
         transitionCustomProperties.clear();
         auto gatherAnimatableCustomProperties = [&](const StyleCustomPropertyData& customPropertyData) {
+            if (!customPropertyData.mayHaveAnimatableProperties())
+                return;
+
             customPropertyData.forEach([&](auto& customPropertyAndValuePair) {
                 auto [customProperty, customPropertyValue] = customPropertyAndValuePair;
-                auto& variantValue = customPropertyValue->value();
-                if (std::holds_alternative<CSSCustomPropertyValue::SyntaxValue>(variantValue)
-                    || std::holds_alternative<CSSCustomPropertyValue::SyntaxValueList>(variantValue))
+                if (customPropertyValue->isAnimatable())
                     transitionCustomProperties.add(customProperty);
                 return IterationStatus::Continue;
             });


### PR DESCRIPTION
#### 04dd4ecfc6edde45a6517687ab7bf4ff9c66f36f
<pre>
Avoid traversing all custom properties in Styleable::updateCSSTransitions when not needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=267536">https://bugs.webkit.org/show_bug.cgi?id=267536</a>
<a href="https://rdar.apple.com/121002539">rdar://121002539</a>

Reviewed by Antoine Quint.

* Source/WebCore/css/CSSCustomPropertyValue.cpp:
(WebCore::CSSCustomPropertyValue::isAnimatable const):

Factor into a function.

* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/rendering/style/StyleCustomPropertyData.cpp:
(WebCore::StyleCustomPropertyData::StyleCustomPropertyData):
(WebCore::StyleCustomPropertyData::set):

Check if the newly set property is animatable.

(WebCore::StyleCustomPropertyData::size const): Deleted.
* Source/WebCore/rendering/style/StyleCustomPropertyData.h:
(WebCore::StyleCustomPropertyData::size const):
(WebCore::StyleCustomPropertyData::mayHaveAnimatableProperties const):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::updateCSSTransitions const):

Bail out if before traversing if we already know the properties are not animatable.

Canonical link: <a href="https://commits.webkit.org/273045@main">https://commits.webkit.org/273045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1abad89c3a11beafc4852a183401604bd346af1e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36720 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30885 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35157 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10015 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/29927 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10892 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30406 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9505 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9612 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38026 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30959 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30752 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35718 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33623 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11526 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7844 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/10306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10553 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->