### PR TITLE
Adopt dynamicDowncast<> in more page classes

### DIFF
--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -371,12 +371,11 @@ void Chrome::getToolTip(const HitTestResult& result, String& toolTip, TextDirect
 
     // Next priority is a toolTip from a URL beneath the mouse (if preference is set to show those).
     if (toolTip.isEmpty() && m_page.settings().showsURLsInToolTips()) {
-        if (Element* element = result.innerNonSharedElement()) {
+        if (RefPtr element = result.innerNonSharedElement()) {
             // Get tooltip representing form action, if relevant
-            if (is<HTMLInputElement>(*element)) {
-                HTMLInputElement& input = downcast<HTMLInputElement>(*element);
-                if (input.isSubmitButton()) {
-                    if (HTMLFormElement* form = input.form()) {
+            if (RefPtr input = dynamicDowncast<HTMLInputElement>(*element)) {
+                if (input->isSubmitButton()) {
+                    if (RefPtr form = input->form()) {
                         toolTip = form->action();
                         if (form->renderer())
                             toolTipDirection = form->renderer()->style().direction();
@@ -405,9 +404,9 @@ void Chrome::getToolTip(const HitTestResult& result, String& toolTip, TextDirect
 
     // Lastly, for <input type="file"> that allow multiple files, we'll consider a tooltip for the selected filenames
     if (toolTip.isEmpty()) {
-        if (Element* element = result.innerNonSharedElement()) {
-            if (is<HTMLInputElement>(*element)) {
-                toolTip = downcast<HTMLInputElement>(*element).defaultToolTip();
+        if (RefPtr element = result.innerNonSharedElement()) {
+            if (RefPtr input = dynamicDowncast<HTMLInputElement>(*element)) {
+                toolTip = input->defaultToolTip();
 
                 // FIXME: We should obtain text direction of tooltip from
                 // ChromeClient or platform. As of October 2011, all client

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -179,7 +179,8 @@ static void prepareContextForQRCode(ContextMenuContext& context)
         return;
 
     RefPtr<Element> element;
-    for (auto& lineage : lineageOfType<Element>(is<Element>(*node) ? downcast<Element>(*node) : *node->parentElement())) {
+    RefPtr nodeElement = dynamicDowncast<Element>(*node);
+    for (auto& lineage : lineageOfType<Element>(nodeElement ? *nodeElement : *node->parentElement())) {
         if (is<HTMLTableElement>(lineage) || is<HTMLCanvasElement>(lineage) || is<HTMLImageElement>(lineage) || is<SVGSVGElement>(lineage)) {
             element = &lineage;
             break;
@@ -216,18 +217,18 @@ static void prepareContextForQRCode(ContextMenuContext& context)
 
 std::unique_ptr<ContextMenu> ContextMenuController::maybeCreateContextMenu(Event& event, OptionSet<HitTestRequest::Type> hitType, ContextMenuContext::Type contextType)
 {
-    if (!is<MouseEvent>(event))
+    RefPtr mouseEvent = dynamicDowncast<MouseEvent>(event);
+    if (!mouseEvent)
         return nullptr;
 
-    auto& mouseEvent = downcast<MouseEvent>(event);
-    if (!is<Node>(mouseEvent.target()))
+    RefPtr node = dynamicDowncast<Node>(mouseEvent->target());
+    if (!node)
         return nullptr;
-    auto& node = downcast<Node>(*mouseEvent.target());
-    auto* frame = node.document().frame();
+    auto* frame = node->document().frame();
     if (!frame)
         return nullptr;
 
-    auto result = frame->eventHandler().hitTestResultAtPoint(mouseEvent.absoluteLocation(), WTFMove(hitType));
+    auto result = frame->eventHandler().hitTestResultAtPoint(mouseEvent->absoluteLocation(), WTFMove(hitType));
     if (!result.innerNonSharedNode())
         return nullptr;
 

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -112,12 +112,11 @@ namespace WebCore {
 
 bool isDraggableLink(const Element& element)
 {
-    if (is<HTMLAnchorElement>(element)) {
-        auto& anchorElement = downcast<HTMLAnchorElement>(element);
-        if (!anchorElement.isLiveLink())
+    if (RefPtr anchorElement = dynamicDowncast<HTMLAnchorElement>(element)) {
+        if (!anchorElement->isLiveLink())
             return false;
 #if ENABLE(DATA_DETECTION)
-        return !DataDetection::isDataDetectorURL(anchorElement.href());
+        return !DataDetection::isDataDetectorURL(anchorElement->href());
 #else
         return true;
 #endif
@@ -349,12 +348,11 @@ void DragController::disallowFileAccessIfNeeded(DragData& dragData)
         dragData.disallowFileAccess();
 }
 
-static HTMLInputElement* asFileInput(Node& node)
+static RefPtr<HTMLInputElement> asFileInput(Node& node)
 {
-    if (!is<HTMLInputElement>(node))
+    RefPtr inputElement = dynamicDowncast<HTMLInputElement>(node);
+    if (!inputElement)
         return nullptr;
-
-    auto* inputElement = &downcast<HTMLInputElement>(node);
 
     // If this is a button inside of the a file input, move up to the file input.
     if (inputElement->isTextButton())
@@ -367,10 +365,10 @@ static HTMLInputElement* asFileInput(Node& node)
 
 static bool isEnabledColorInput(Node& node)
 {
-    if (!is<HTMLInputElement>(node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(node);
+    if (!input)
         return false;
-    auto& input = downcast<HTMLInputElement>(node);
-    return input.isColorControl() && !input.isDisabledFormControl();
+    return input->isColorControl() && !input->isDisabledFormControl();
 }
 
 static bool isInShadowTreeOfEnabledColorInput(Node& node)
@@ -451,7 +449,7 @@ DragHandlingMethod DragController::tryDocumentDrag(LocalFrame& frame, const Drag
         if (!element)
             return DragHandlingMethod::None;
         
-        HTMLInputElement* elementAsFileInput = asFileInput(*element);
+        RefPtr elementAsFileInput = asFileInput(*element);
         if (m_fileInputElementUnderMouse != elementAsFileInput) {
             if (m_fileInputElementUnderMouse)
                 m_fileInputElementUnderMouse->setCanReceiveDroppedFiles(false);

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -5013,9 +5013,10 @@ HandleUserInputEventResult EventHandler::handleTouchEvent(const PlatformTouchEve
             pointerTarget = result.targetElement();
         }
 
-        if (!is<Node>(touchTarget))
+        RefPtr touchTargetNode = dynamicDowncast<Node>(touchTarget);
+        if (!touchTargetNode)
             continue;
-        auto& document = downcast<Node>(*touchTarget).document();
+        auto& document = touchTargetNode->document();
         if (!document.hasTouchEventHandlers())
             continue;
         RefPtr targetFrame = document.frame();


### PR DESCRIPTION
#### ce5179747ab8bd2e31e93d9ba666e298d01c82fc
<pre>
Adopt dynamicDowncast&lt;&gt; in more page classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=267539">https://bugs.webkit.org/show_bug.cgi?id=267539</a>

Reviewed by Chris Dumez.

The eagerly awaited sequel.

* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::getToolTip):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::prepareContextForQRCode):
(WebCore::ContextMenuController::maybeCreateContextMenu):
* Source/WebCore/page/DragController.cpp:
(WebCore::isDraggableLink):
(WebCore::asFileInput):
(WebCore::isEnabledColorInput):
(WebCore::DragController::tryDocumentDrag):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleTouchEvent):
* Source/WebCore/page/FocusController.cpp:
(WebCore::hasCustomFocusLogic):
(WebCore::FocusNavigationScope::firstChildInScope const):
(WebCore::FocusNavigationScope::lastChildInScope const):
(WebCore::FocusNavigationScope::owner const):
(WebCore::FocusNavigationScope::scopeOf):
(WebCore::FocusNavigationScope::scopeOwnedByScopeOwner):
(WebCore::FocusController::findFocusableElementDescendingIntoSubframes):
(WebCore::FocusController::advanceFocusInDocumentOrder):
(WebCore::FocusController::findFocusableElementAcrossFocusScope):
(WebCore::FocusController::findElementWithExactTabIndex):
(WebCore::nextElementWithGreaterTabIndex):
(WebCore::previousElementWithLowerTabIndex):
(WebCore::FocusController::nextFocusableElementOrScopeOwner):
(WebCore::FocusController::previousFocusableElementOrScopeOwner):
(WebCore::FocusController::advanceFocusDirectionally):

Canonical link: <a href="https://commits.webkit.org/273080@main">https://commits.webkit.org/273080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/224cfc28dc680f5e9381c8ef9503ce74a80a8c2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36840 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30952 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29985 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30471 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9572 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9684 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38130 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35775 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9801 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33688 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11587 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7871 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10364 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10618 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->