### PR TITLE
`role=textbox` elements should get InteractionRegions

### DIFF
--- a/LayoutTests/interaction-region/aria-roles-expected.txt
+++ b/LayoutTests/interaction-region/aria-roles-expected.txt
@@ -4,6 +4,7 @@ Menu option 1
 Menu option 2
 Menu option 3
 This works like a switch.
+This behaves like a textbox
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -28,6 +29,8 @@ This works like a switch.
         (interaction (40,96) width=760 height=20)
         (cornerRadius 8.00),
         (interaction (0,132) width=800 height=20)
+        (cornerRadius 8.00),
+        (interaction (0,152) width=800 height=20)
         (cornerRadius 8.00)])
       )
     )

--- a/LayoutTests/interaction-region/aria-roles.html
+++ b/LayoutTests/interaction-region/aria-roles.html
@@ -12,6 +12,7 @@
     <li role="option">Menu option 3</li>
 </ul>
 <div role="switch">This works like a switch.</div>
+<div role="textbox">This behaves like a textbox</div>
 <pre id="results"></pre>
 <script>
 document.body.addEventListener("click", function(e) {

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -107,6 +107,7 @@ static bool shouldAllowAccessibilityRoleAsPointerCursorReplacement(const Element
     case AccessibilityRole::PopUpButton:
     case AccessibilityRole::RadioButton:
     case AccessibilityRole::Switch:
+    case AccessibilityRole::TextField:
     case AccessibilityRole::ToggleButton:
         return true;
     default:


### PR DESCRIPTION
#### 0b90437aa9009af380e57f0b5f5eedaa526e76fc
<pre>
`role=textbox` elements should get InteractionRegions
<a href="https://bugs.webkit.org/show_bug.cgi?id=267544">https://bugs.webkit.org/show_bug.cgi?id=267544</a>
&lt;<a href="https://rdar.apple.com/117607868">rdar://117607868</a>&gt;

Reviewed by Anne van Kesteren.

Add `TextField` to the list of roles that can be used instead of
`cursor: pointer;`, this is what `role=textbox` maps to.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::shouldAllowAccessibilityRoleAsPointerCursorReplacement):
Add a `TextField` case.

* LayoutTests/interaction-region/aria-roles-expected.txt:
* LayoutTests/interaction-region/aria-roles.html:
Add a test covering this change.

Canonical link: <a href="https://commits.webkit.org/273055@main">https://commits.webkit.org/273055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91c807f66020413971cb5e68208f1ba23e53ff12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36740 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30894 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35173 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10034 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29939 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30415 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9524 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38038 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30762 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35723 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33628 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11533 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30060 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7855 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10313 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10560 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->