### PR TITLE
[WGSL] shader,execution,expression,call,builtin,arrayLength:* is failing

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTStructure.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructure.h
@@ -33,6 +33,8 @@
 namespace WGSL {
 
 class AttributeValidator;
+class RewriteGlobalVariables;
+class TypeChecker;
 
 namespace AST {
 
@@ -52,6 +54,8 @@ enum class StructureRole : uint8_t {
 class Structure final : public Declaration {
     WGSL_AST_BUILDER_NODE(Structure);
     friend AttributeValidator;
+    friend RewriteGlobalVariables;
+    friend TypeChecker;
 
 public:
     using Ref = std::reference_wrapper<Structure>;
@@ -65,6 +69,7 @@ public:
     StructureMember::List& members() { return m_members; }
     Structure* original() const { return m_original; }
     Structure* packed() const { return m_packed; }
+    const Type* inferredType() const { return m_inferredType; }
 
     void setRole(StructureRole role) { m_role = role; }
 
@@ -95,6 +100,7 @@ private:
     StructureRole m_role;
     Structure* m_original;
     Structure* m_packed { nullptr };
+    const Type* m_inferredType { nullptr };
 
     // Computed properties
     bool m_hasSizeOrAlignmentAttributes { false };

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -347,6 +347,7 @@ void TypeChecker::visit(AST::Structure& structure)
         ASSERT_UNUSED(result, result.isNewEntry);
     }
     const Type* structType = m_types.structType(structure, WTFMove(fields));
+    structure.m_inferredType = structType;
     introduceType(structure.name(), structType);
 }
 

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -40,6 +40,19 @@ class TypeChecker;
 class TypeStore;
 struct Type;
 
+enum Packing : uint8_t {
+    Packed       = 1 << 0,
+    Unpacked     = 1 << 1,
+    Either       = Packed | Unpacked,
+
+    PStruct = 1 << 2,
+    Vec3   = 1 << 3,
+
+    PackedStruct = Packed | PStruct,
+    PackedVec3   = Packed | Vec3,
+};
+
+
 namespace Types {
 
 #define FOR_EACH_PRIMITIVE_TYPE(f) \
@@ -257,6 +270,8 @@ struct Type : public std::variant<
     String toString() const;
     unsigned size() const;
     unsigned alignment() const;
+    Packing packing() const;
+    bool isConstructible() const;
 };
 
 using ConversionRank = Markable<unsigned, IntegralMarkableTraits<unsigned, std::numeric_limits<unsigned>::max()>>;

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -68,10 +68,6 @@ public:
     void setUsesPackArray() { m_usesPackArray = true; }
     void clearUsesPackArray() { m_usesPackArray = false; }
 
-    bool usesPackedStructs() const { return m_usesPackedStructs; }
-    void setUsesPackedStructs() { m_usesPackedStructs = true; }
-    void clearUsesPackedStructs() { m_usesPackedStructs = false; }
-
     bool usesUnpackArray() const { return m_usesUnpackArray; }
     void setUsesUnpackArray() { m_usesUnpackArray = true; }
     void clearUsesUnpackArray() { m_usesUnpackArray = false; }
@@ -273,7 +269,6 @@ private:
     String m_source;
     bool m_usesExternalTextures { false };
     bool m_usesPackArray { false };
-    bool m_usesPackedStructs { false };
     bool m_usesUnpackArray { false };
     bool m_usesWorkgroupUniformLoad { false };
     bool m_usesDivision { false };


### PR DESCRIPTION
#### aa1bdf7dca239287827c1c5f41d64b4cd1b3d0a4
<pre>
[WGSL] shader,execution,expression,call,builtin,arrayLength:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=267549">https://bugs.webkit.org/show_bug.cgi?id=267549</a>
<a href="https://rdar.apple.com/121010619">rdar://121010619</a>

Reviewed by Mike Wyrzykowski.

There were a couple issues with arrayLength:
- The offset of the array in the buffer has to be subtracted from the buffer size
  before dividing by the array stride.
- Packing and unpacking functions should not be generated if the struct is not
  constructible.
- In the process we also avoid emitting pack/unpack calls when implicitly conversion
  would work instead, e.g. assignment from vec3 to packed_vec3, and also for types
  that were not packed, where previously we&apos;d emit pack/unpack for all struct fields
  unconditionally.

* Source/WebGPU/WGSL/AST/ASTStructure.h:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visit):
(WGSL::RewriteGlobalVariables::pack):
(WGSL::RewriteGlobalVariables::getPacking):
(WGSL::RewriteGlobalVariables::packingForType):
(WGSL::RewriteGlobalVariables::packStructType):
(WGSL::RewriteGlobalVariables::finalizeArgumentBufferStruct):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
(WGSL::Metal::FunctionDefinitionWriter::generatePackingHelpers):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::packing const):
(WGSL::Type::isConstructible const):
* Source/WebGPU/WGSL/Types.h:
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::usesPackedStructs const): Deleted.
(WGSL::ShaderModule::setUsesPackedStructs): Deleted.
(WGSL::ShaderModule::clearUsesPackedStructs): Deleted.
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:

Canonical link: <a href="https://commits.webkit.org/273064@main">https://commits.webkit.org/273064@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c22cb57eb6e322e5632a1705dfc41b00a48460fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36753 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30906 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29942 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9528 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9628 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38051 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30980 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30770 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35731 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33636 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11543 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7862 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10323 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10570 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->