### PR TITLE
[WGSL] shader,execution,expression,call,builtin,atomics,atomicExchange:* is failing

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTParameter.h
+++ b/Source/WebGPU/WGSL/AST/ASTParameter.h
@@ -35,6 +35,7 @@
 namespace WGSL {
 
 class AttributeValidator;
+class EntryPointRewriter;
 
 namespace AST {
 
@@ -47,6 +48,7 @@ enum class ParameterRole : uint8_t {
 class Parameter final : public Node {
     WGSL_AST_BUILDER_NODE(Parameter);
     friend AttributeValidator;
+    friend EntryPointRewriter;
 
 public:
     using List = ReferenceWrapperVector<Parameter>;


### PR DESCRIPTION
#### e1188ea0c298c77b48684d39dc94524f765b5520
<pre>
[WGSL] shader,execution,expression,call,builtin,atomics,atomicExchange:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=267550">https://bugs.webkit.org/show_bug.cgi?id=267550</a>
<a href="https://rdar.apple.com/121011079">rdar://121011079</a>

Reviewed by Mike Wyrzykowski.

Threadgroup atomics need to be explicitly set to zero in the first invocation of
the threadgroup.

* Source/WebGPU/WGSL/AST/ASTParameter.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::visit):
(WGSL::EntryPointRewriter::appendBuiltins):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::insertMaterializations):
(WGSL::RewriteGlobalVariables::insertLocalDefinitions):
(WGSL::RewriteGlobalVariables::initializeAtomics):
(WGSL::RewriteGlobalVariables::insertWorkgroupBarrier):
(WGSL::RewriteGlobalVariables::findOrInsertLocalInvocationIndex):
(WGSL::RewriteGlobalVariables::atomicStoreInitialValue):

Canonical link: <a href="https://commits.webkit.org/273065@main">https://commits.webkit.org/273065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a1548e4098420b173e3bf8886118478958a143b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36754 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30908 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10047 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29943 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9529 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9629 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38053 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30775 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35732 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9758 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33637 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11544 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7863 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10324 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->