### PR TITLE
[WGSL] shader,execution,expression,call,builtin,atomics,atomicCompareExchangeWeak:* is failing

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -322,12 +322,12 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
     }
 
     if (m_callGraph.ast().usesAtomicCompareExchange()) {
-        m_stringBuilder.append(m_indent, "template<typename T>\n");
+        m_stringBuilder.append(m_indent, "template<typename T, typename U = bool>\n");
         m_stringBuilder.append(m_indent, "struct __atomic_compare_exchange_result {\n");
         {
             IndentationScope scope(m_indent);
             m_stringBuilder.append(m_indent, "T old_value;\n");
-            m_stringBuilder.append(m_indent, "bool exchanged;\n");
+            m_stringBuilder.append(m_indent, "U exchanged;\n");
         }
         m_stringBuilder.append(m_indent, "};\n\n");
 
@@ -335,7 +335,8 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
         {
             IndentationScope scope(m_indent);
             m_stringBuilder.append(m_indent, "({ auto innerCompare = compare; \\\n");
-            m_stringBuilder.append(m_indent, "__atomic_compare_exchange_result<decltype(compare)> { innerCompare, atomic_compare_exchange_weak_explicit((atomic), &innerCompare, value, memory_order_relaxed, memory_order_relaxed) }; \\\n");
+            m_stringBuilder.append(m_indent, "bool exchanged = atomic_compare_exchange_weak_explicit((atomic), &innerCompare, value, memory_order_relaxed, memory_order_relaxed); \\\n");
+            m_stringBuilder.append(m_indent, "__atomic_compare_exchange_result<decltype(compare)> { innerCompare, exchanged }; \\\n");
             m_stringBuilder.append(m_indent, "})\n");
         }
     }

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -273,7 +273,7 @@ const Type* TypeStore::atomicCompareExchangeResultType(const Type* type)
         FixedVector<const Type*> values(2);
         values[PrimitiveStruct::AtomicCompareExchangeResult::oldValue] = type;
         values[PrimitiveStruct::AtomicCompareExchangeResult::exchanged] = boolType();
-        member = allocateType<PrimitiveStruct>("__atomic_compare_exchange_result"_s, PrimitiveStruct::ModfResult::kind, values);
+        member = allocateType<PrimitiveStruct>("__atomic_compare_exchange_result"_s, PrimitiveStruct::AtomicCompareExchangeResult::kind, values);
         return member;
     };
 

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -136,8 +136,8 @@ private:
     const Type* m_textureDepthMultisampled2d;
     const Type* m_atomicI32;
     const Type* m_atomicU32;
-    const Type* m_atomicCompareExchangeResultI32;
-    const Type* m_atomicCompareExchangeResultU32;
+    const Type* m_atomicCompareExchangeResultI32 { nullptr };
+    const Type* m_atomicCompareExchangeResultU32 { nullptr };
 };
 
 } // namespace WGSL


### PR DESCRIPTION
#### 3bbb2b0bb5c6fdd080d522db1805c5d8d6f015af
<pre>
[WGSL] shader,execution,expression,call,builtin,atomics,atomicCompareExchangeWeak:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=267551">https://bugs.webkit.org/show_bug.cgi?id=267551</a>
<a href="https://rdar.apple.com/121011135">rdar://121011135</a>

Reviewed by Mike Wyrzykowski.

Fix a few problems in the atomicCompareExchange implementation to pass the CTS tests:
- The generated metal struct needs to take 2 template arguments. The second type is always
  bool, but that is necessary due to the codegen of PrimitiveStructs.
- The __wgslAtomicCompareExchange macro was copying the original value before executing
  the underlying atomic_compare_exchange metal function, which meant the wrong old_value
  was returned when the comparison failed.
- There was a typo in TypeStore::atomicCompareExchangeResultType that set the kind of
  the primitive struct to ModfResult, causing type errors.
- The TypeStore members used for caching the result structs (m_atomicCompareExchangeResultI32
  and m_atomicCompareExchangeResultU32) were not initialized to nullptr, so the lazy
  initialization could return the uninitialized value instead.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::TypeStore::atomicCompareExchangeResultType):
* Source/WebGPU/WGSL/TypeStore.h:

Canonical link: <a href="https://commits.webkit.org/273066@main">https://commits.webkit.org/273066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55853eb028e1bd794075c68be01a15f6504bd76f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36756 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30909 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29945 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30425 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9532 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9631 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38054 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30983 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35734 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9759 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33641 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11545 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7864 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->