### PR TITLE
compositing/updates/animation-non-composited.html is flaky

### DIFF
--- a/LayoutTests/compositing/updates/animation-non-composited.html
+++ b/LayoutTests/compositing/updates/animation-non-composited.html
@@ -24,7 +24,7 @@ let initialCompositingUpdateCount = 0;
 if (window.internals)
     internals.updateLayoutIgnorePendingStylesheetsAndRunPostLayoutTasks();
 
-setTimeout(() => {
+requestAnimationFrame(() => {
     test.className = "color-animation";
     if (window.internals) {
         internals.updateLayoutIgnorePendingStylesheetsAndRunPostLayoutTasks();


### PR DESCRIPTION
#### 2cc096e109bacf90ff156b0d186df2f056c349a2
<pre>
compositing/updates/animation-non-composited.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=267553">https://bugs.webkit.org/show_bug.cgi?id=267553</a>
&lt;<a href="https://rdar.apple.com/problem/121011594">rdar://problem/121011594</a>&gt;

Reviewed by Anne van Kesteren.

In this test, the setTimeout(0) races with the m_updateCompositingLayersTimer timer in
RenderLayerCompositor, which is scheduled via `RenderLayerCompositor::rootBackgroundColorOrTransparencyChanged()`
as a result of the background color changing. Because of this, we sometimes get a compositing update
count of 1.

So delay the start of the animation on a requestAnimationFrame().

* LayoutTests/compositing/updates/animation-non-composited.html:

Canonical link: <a href="https://commits.webkit.org/273052@main">https://commits.webkit.org/273052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2847fe815fa81704b1b5498a5441bcede0871f33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36760 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30914 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10051 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29947 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30428 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9534 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9637 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30462 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38058 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/30989 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35736 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9761 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33643 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30078 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7852 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10327 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->