### PR TITLE
Clean up code for internal CSS values

### DIFF
--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -54,7 +54,7 @@ CSSParserContext::CSSParserContext(CSSParserMode mode, const URL& baseURL)
     , mode(mode)
 {
     // FIXME: We should turn all of the features on from their WebCore Settings defaults.
-    if (mode == UASheetMode) {
+    if (isUASheetBehavior(mode)) {
         colorMixEnabled = true;
         focusVisibleEnabled = true;
         lightDarkEnabled = true;

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -524,7 +524,7 @@ static RefPtr<CSSValue> parseColor(StringView string, const CSSParserContext& co
     ASSERT(!string.isEmpty());
     auto valueID = cssValueKeywordID(string);
     if (StyleColor::isColorKeyword(valueID)) {
-        if (!isValueAllowedInMode(valueID, context.mode))
+        if (!isColorKeywordAllowedInMode(valueID, context.mode))
             return nullptr;
         return CSSPrimitiveValue::create(valueID);
     }

--- a/Source/WebCore/css/parser/CSSParserIdioms.cpp
+++ b/Source/WebCore/css/parser/CSSParserIdioms.cpp
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-bool isValueAllowedInMode(unsigned short id, CSSParserMode mode)
+bool isColorKeywordAllowedInMode(CSSValueID id, CSSParserMode mode)
 {
     switch (id) {
     case CSSValueWebkitFocusRingColor:
@@ -46,8 +46,6 @@ bool isValueAllowedInMode(unsigned short id, CSSParserMode mode)
     case CSSValueAppleSystemQuaternaryFill:
 #endif
     case CSSValueInternalDocumentTextColor:
-    case CSSValueInternalTextareaAuto:
-    case CSSValueInternalThCenter:
         return isUASheetBehavior(mode);
     default:
         return true;

--- a/Source/WebCore/css/parser/CSSParserIdioms.h
+++ b/Source/WebCore/css/parser/CSSParserIdioms.h
@@ -60,7 +60,7 @@ bool isNameCodePoint(CharacterType c)
     return isNameStartCodePoint(c) || isASCIIDigit(c) || c == '-';
 }
 
-bool isValueAllowedInMode(unsigned short, CSSParserMode);
+bool isColorKeywordAllowedInMode(CSSValueID, CSSParserMode);
 
 inline bool isCSSWideKeyword(CSSValueID valueID)
 {

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -547,7 +547,7 @@ struct LengthRawKnownTokenTypeDimensionConsumer {
         auto unitType = token.unitType();
         switch (unitType) {
         case CSSUnitType::CSS_QUIRKY_EM:
-            if (parserMode != UASheetMode)
+            if (!isUASheetBehavior(parserMode))
                 return std::nullopt;
             FALLTHROUGH;
         case CSSUnitType::CSS_EM:
@@ -3310,7 +3310,7 @@ Color consumeColorWorkerSafe(CSSParserTokenRange& range, const CSSParserContext&
         //        For now, we detect the system color, but then intentionally fail parsing.
         if (StyleColor::isSystemColorKeyword(keyword))
             return { };
-        if (!isValueAllowedInMode(keyword, context.mode))
+        if (!isColorKeywordAllowedInMode(keyword, context.mode))
             return { };
         result = StyleColor::colorFromKeyword(keyword, { });
         range.consumeIncludingWhitespace();
@@ -3331,7 +3331,7 @@ RefPtr<CSSPrimitiveValue> consumeColor(CSSParserTokenRange& range, const CSSPars
 {
     auto keyword = range.peek().id();
     if (StyleColor::isColorKeyword(keyword, allowedColorTypes)) {
-        if (!isValueAllowedInMode(keyword, context.mode))
+        if (!isColorKeywordAllowedInMode(keyword, context.mode))
             return nullptr;
         return consumeIdent(range);
     }
@@ -4811,7 +4811,7 @@ AtomString consumeCounterStyleNameInPrelude(CSSParserTokenRange& prelude, CSSPar
     // case-insensitive match for "decimal", "disc", "square", "circle", "disclosure-open" and "disclosure-closed". No <counter-style-name>, prelude or not, may be an ASCII
     // case-insensitive match for "none".
     auto id = nameToken.id();
-    if (identMatches<CSSValueNone>(id) || (mode != CSSParserMode::UASheetMode && identMatches<CSSValueDecimal, CSSValueDisc, CSSValueCircle, CSSValueSquare, CSSValueDisclosureOpen, CSSValueDisclosureClosed>(id)))
+    if (identMatches<CSSValueNone>(id) || (!isUASheetBehavior(mode) && identMatches<CSSValueDecimal, CSSValueDisc, CSSValueCircle, CSSValueSquare, CSSValueDisclosureOpen, CSSValueDisclosureClosed>(id)))
         return AtomString();
     auto name = nameToken.value();
     return isPredefinedCounterStyle(nameToken.id()) ? name.convertToASCIILowercaseAtom() : name.toAtomString();
@@ -5159,7 +5159,7 @@ RefPtr<CSSValue> consumeDisplay(CSSParserTokenRange& range, CSSParserMode mode)
 
     auto allowsValue = [&](CSSValueID value) {
         bool isRuby = value == CSSValueRubyBase || value == CSSValueRubyText || value == CSSValueBlockRuby || value == CSSValueRuby;
-        return !isRuby || mode == CSSParserMode::UASheetMode;
+        return !isRuby || isUASheetBehavior(mode);
     };
 
     if (singleKeyword) {

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -287,7 +287,7 @@ static OptionSet<CompoundSelectorFlag> extractCompoundFlags(const MutableCSSSele
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=161747
     // The UASheetMode check is a work-around to allow this selector in mediaControls(New).css:
     // input[type="range" i]::-webkit-media-slider-container > div {
-    if (parserMode == UASheetMode && simpleSelector.pseudoElement() == CSSSelector::PseudoElement::UserAgentPart)
+    if (isUASheetBehavior(parserMode) && simpleSelector.pseudoElement() == CSSSelector::PseudoElement::UserAgentPart)
         return { };
 
     return CompoundSelectorFlag::HasPseudoElementForRightmostCompound;
@@ -575,7 +575,7 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumeSimpleSelector(CSS
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=161747
         // The UASheetMode check is a work-around to allow this selector in mediaControls(New).css:
         // video::-webkit-media-text-track-region-container.scrolling
-        if (m_context.mode != UASheetMode && !isSimpleSelectorValidAfterPseudoElement(*selector, *m_precedingPseudoElement))
+        if (!isUASheetBehavior(m_context.mode) && !isSimpleSelectorValidAfterPseudoElement(*selector, *m_precedingPseudoElement))
             m_failedParsing = true;
     }
 
@@ -1157,7 +1157,7 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::splitCompoundAtImplicitSh
     bool isSlotted = splitAfter->tagHistory()->match() == CSSSelector::Match::PseudoElement && splitAfter->tagHistory()->pseudoElement() == CSSSelector::PseudoElement::Slotted;
 
     std::unique_ptr<MutableCSSSelector> secondCompound;
-    if (context.mode == UASheetMode || isPart) {
+    if (isUASheetBehavior(context.mode) || isPart) {
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=161747
         // We have to recur, since we have rules in media controls like video::a::b. This should not be allowed, and
         // we should remove this recursion once those rules are gone.

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -333,6 +333,9 @@ class Value:
                 print(f"SKIPPED value {json_value['value']} in {key_path} due to '{json_value['status']}' status designation.")
             return None
 
+        if json_value.get("status", None) != "internal" and json_value["value"].startswith("-internal-"):
+            raise Exception(f'Value "{json_value["value"]}" starts with "-internal-" but does not have "status": "internal" set.')
+
         return Value(**json_value)
 
     @property
@@ -4514,7 +4517,7 @@ class TermGeneratorNonFastPathKeywordTerm(TermGenerator):
                 else:
                     conditions.append(f"!{context_string}.{keyword_term.settings_flag}")
             if keyword_term.status == "internal":
-                conditions.append(f"!isValueAllowedInMode(keyword, {context_string}.mode)")
+                conditions.append(f"!isUASheetBehavior({context_string}.mode)")
 
             if keyword_term.aliased_to:
                 return_value = keyword_term.aliased_to.id
@@ -4623,7 +4626,7 @@ class KeywordFastPathGenerator:
                     else:
                         return_expression.append(f"context.{keyword_term.settings_flag}")
                 if keyword_term.status == "internal":
-                    return_expression.append("isValueAllowedInMode(keyword, context.mode)")
+                    return_expression.append("isUASheetBehavior(context.mode)")
 
                 keyword_term_and_return_expressions.append(KeywordTermReturnExpression(keyword_term, return_expression))
 

--- a/Source/WebCore/css/process-css-pseudo-selectors.py
+++ b/Source/WebCore/css/process-css-pseudo-selectors.py
@@ -637,11 +637,7 @@ class CSSSelectorInlinesGenerator:
                 conditions.append(f'context.{settings_flag}')
 
         if is_internal:
-            # Wrap around parentheses so it's valid when negated with `!boolean`.
-            conditions.append('(context.mode == UASheetMode)')
-
-        if len(conditions) == 1:
-            return conditions[0]
+            conditions.append('isUASheetBehavior(context.mode)')
 
         return ' && '.join(conditions)
 


### PR DESCRIPTION
#### 8c8cfbf1f0f0640439a7a9d5d2972c972b7063a7
<pre>
Clean up code for internal CSS values
<a href="https://bugs.webkit.org/show_bug.cgi?id=267520">https://bugs.webkit.org/show_bug.cgi?id=267520</a>
<a href="https://rdar.apple.com/121019340">rdar://121019340</a>

Reviewed by Darin Adler.

Right now, if you want to make a certain value internal, you have to do 2 changes:
1) Add &quot;status&quot;: &quot;internal&quot; to CSSProperties.json
2) Change isValueAllowedInMode() to include your value

This is error prone, as it&apos;s easy to think that the first step is sufficient.

With this change:
- the first step will be sufficient to make a value UA-sheet only
- isValueAllowedInMode is now named isColorKeywordAllowedInMode as it&apos;s now only used for color parsing.
- we now validate that all values starting with &quot;-internal-&quot; have &quot;status&quot;: &quot;internal&quot; in CSSProperties.json

Also use isUASheetBehavior whenever possible.

* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::CSSParserContext::CSSParserContext):
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::parseColor):
* Source/WebCore/css/parser/CSSParserIdioms.cpp:
(WebCore::isColorKeywordAllowedInMode):
(WebCore::isValueAllowedInMode): Deleted.
* Source/WebCore/css/parser/CSSParserIdioms.h:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::LengthRawKnownTokenTypeDimensionConsumer::consume):
(WebCore::CSSPropertyParserHelpers::consumeColorWorkerSafe):
(WebCore::CSSPropertyParserHelpers::consumeColor):
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleNameInPrelude):
(WebCore::CSSPropertyParserHelpers::consumeDisplay):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::extractCompoundFlags):
(WebCore::CSSSelectorParser::consumeSimpleSelector):
(WebCore::CSSSelectorParser::splitCompoundAtImplicitShadowCrossingCombinator):
* Source/WebCore/css/process-css-properties.py:
Directly check for UASheetMode and add validation for `-internal-` values that they use correct &quot;status&quot; field.

* Source/WebCore/css/process-css-pseudo-selectors.py:
The .join() case also works fine for when there&apos;s only one condition.

Canonical link: <a href="https://commits.webkit.org/273071@main">https://commits.webkit.org/273071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41f5d512ae401b6df2b3b56505aeb640062e7ee7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36833 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30946 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29980 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9567 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9671 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38123 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31022 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30812 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35768 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33680 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11583 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7866 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10359 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10613 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->