### PR TITLE
Font caches need to be invalidated when the font content size category changes

### DIFF
--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1072,13 +1072,15 @@ void KeyframeEffect::computeCSSAnimationBlendingKeyframes(const RenderStyle& una
     auto& backingAnimation = downcast<CSSAnimation>(*animation()).backingAnimation();
 
     BlendingKeyframes blendingKeyframes(AtomString { backingAnimation.name().name });
-    if (auto* styleScope = Style::Scope::forOrdinal(*m_target, backingAnimation.name().scopeOrdinal))
-        styleScope->resolver().keyframeStylesForAnimation(*m_target, unanimatedStyle, resolutionContext, blendingKeyframes);
+    if (m_target) {
+        if (auto* styleScope = Style::Scope::forOrdinal(*m_target, backingAnimation.name().scopeOrdinal))
+            styleScope->resolver().keyframeStylesForAnimation(*m_target, unanimatedStyle, resolutionContext, blendingKeyframes);
 
-    // Ensure resource loads for all the frames.
-    for (auto& keyframe : blendingKeyframes) {
-        if (auto* style = const_cast<RenderStyle*>(keyframe.style()))
-            Style::loadPendingResources(*style, *document(), m_target.get());
+        // Ensure resource loads for all the frames.
+        for (auto& keyframe : blendingKeyframes) {
+            if (auto* style = const_cast<RenderStyle*>(keyframe.style()))
+                Style::loadPendingResources(*style, *document(), m_target.get());
+        }
     }
 
     m_animationType = WebAnimationType::CSSAnimation;

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCocoa.mm
@@ -62,7 +62,11 @@ CFStringRef contentSizeCategory()
 
 void setContentSizeCategory(const String& contentSizeCategory)
 {
+    if (contentSizeCategory == contentSizeCategoryStorage())
+        return;
+
     contentSizeCategoryStorage() = contentSizeCategory;
+    FontCache::invalidateAllFontCaches();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -182,7 +182,7 @@ void FontCache::platformInit()
     CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenter(), this, &fontCacheRegisteredFontsChangedNotificationCallback, kCTFontManagerRegisteredFontsChangedNotification, nullptr, CFNotificationSuspensionBehaviorDeliverImmediately);
 
 #if PLATFORM(IOS_FAMILY)
-    CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenter(), this, &fontCacheRegisteredFontsChangedNotificationCallback, getUIContentSizeCategoryDidChangeNotificationName(), 0, CFNotificationSuspensionBehaviorDeliverImmediately);
+    CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenter(), this, &fontCacheRegisteredFontsChangedNotificationCallback, getUIContentSizeCategoryDidChangeNotificationName(), nullptr, CFNotificationSuspensionBehaviorDeliverImmediately);
 #endif
 
     CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenter(), this, &fontCacheRegisteredFontsChangedNotificationCallback, kAXSEnhanceTextLegibilityChangedNotification, nullptr, CFNotificationSuspensionBehaviorDeliverImmediately);


### PR DESCRIPTION
#### e213ae74ae87ab8274aec65366b7981129b6f882
<pre>
Font caches need to be invalidated when the font content size category changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=267564">https://bugs.webkit.org/show_bug.cgi?id=267564</a>
<a href="https://rdar.apple.com/121024996">rdar://121024996</a>

Reviewed by Antoine Quint.

On iOS with <a href="https://github.com/WebKit/WebKit/pull/22531">https://github.com/WebKit/WebKit/pull/22531</a>, fast/attachment/attachment-dynamic-type.html fails,
showing that fonts failed to update after we change `contentSizeCategory()` via Internals.

When the content size category changes via the user setting it in the UI, we get notified
via a `UIContentSizeCategoryDidChangeNotification` notification, and in response to this
we call `FontCache::invalidateAllFontCaches()` (see `fontCacheRegisteredFontsChangedNotificationCallback()`).
So we need to do the same when the content size category is changed through Internals.

This caused webanimations/css-animation-effect-target-change-and-get-keyframes-crash.html to crash
with a null m_target, so add a null check in `computeCSSAnimationBlendingKeyframes()`.

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::computeCSSAnimationBlendingKeyframes):
* Source/WebCore/platform/graphics/cocoa/FontCacheCocoa.mm:
(WebCore::setContentSizeCategory):
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::FontCache::platformInit):

Canonical link: <a href="https://commits.webkit.org/273070@main">https://commits.webkit.org/273070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aefcc26541aa7ecc6c89800660ce80b993e3e48a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36831 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30945 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35227 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29978 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10962 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30462 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9565 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9675 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30496 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/autoplay-allowed-by-feature-policy-attribute.https.sub.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38121 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31026 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35766 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33678 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11581 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7867 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10358 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10611 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->