### PR TITLE
Fix timeout in fast/images/animated-image-mp4-crash.html

### DIFF
--- a/LayoutTests/fast/images/animated-image-mp4-crash.html
+++ b/LayoutTests/fast/images/animated-image-mp4-crash.html
@@ -2,9 +2,12 @@
 <html>
 <body>
     <img>
-    <script src="../../resources/js-test-pre.js"></script>
+    <script src="../../resources/js-test.js"></script>
     <script>
         window.jsTestIsAsync = true;
+
+        if (window.internals)
+            internals.clearMemoryCache();
 
         function loadImage(src) {
             return new Promise(resolve => {
@@ -14,18 +17,11 @@
             });
         }
 
-        function endTest() {
-            finishJSTest();
-            if (window.testRunner)
-                testRunner.notifyDone();
-        }
-
         description('Test that a malformed mp4 media file loaded as an image should not crash.')
 
         loadImage("resources/two-samples-with-same-pts.mp4").then(image => {
-            setTimeout(endTest, 100);
+            setTimeout(finishJSTest, 100);
         });
     </script>
-    <script src="../../resources/js-test-post.js"></script>
 </body>
 </html>


### PR DESCRIPTION
#### b89b5796147bac47f35c7d50a5ec6c63d2ee184e
<pre>
Fix timeout in fast/images/animated-image-mp4-crash.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=267571">https://bugs.webkit.org/show_bug.cgi?id=267571</a>
<a href="https://rdar.apple.com/121035201">rdar://121035201</a>

Reviewed by Cameron McCormack.

Call &quot;internals.clearMemoryCache()&quot; when initializing the test to reset the
animation state of the image.

* LayoutTests/fast/images/animated-image-mp4-crash.html:

Canonical link: <a href="https://commits.webkit.org/273669@main">https://commits.webkit.org/273669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a921b9a6e067530f9396ec0f56cd53cbe8fb741

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36847 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30957 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/29991 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9578 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30506 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38135 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31036 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35778 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33691 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30122 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8231 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->