### PR TITLE
REGRESSION(272844@main): [GStreamer][Debug] ASSERTION FAILED: isMainThread() in WebCore::MediaStreamTrackPrivate::source()

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1932,7 +1932,8 @@ webkit.org/b/187064 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-get
 
 webrtc/video-av1.html [ Skip ]
 
-webrtc/h265.html [ Pass Timeout ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webrtc/h265.html [ Pass Timeout ]
 
 # GStreamer's DTLS agent currently generates RSA certificates only. DTLS 1.2 is not supported yet (AFAIK).
 webrtc/datachannel/dtls10.html [ Failure ]
@@ -2011,9 +2012,11 @@ webkit.org/b/235885 fast/mediastream/RTCPeerConnection-setLocalDescription-offer
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpParameters-maxFramerate.html [ Failure ]
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-priority/RTCRtpParameters-encodings.html [ Failure ]
 webkit.org/b/235885 imported/w3c/web-platform-tests/mst-content-hint/RTCRtpSendParameters-degradationPreference.html [ Failure ]
-webkit.org/b/235885 webrtc/addTransceiver-then-addTrack.html [ Failure ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/235885 webrtc/addTransceiver-then-addTrack.html [ Failure ]
 webkit.org/b/235885 webrtc/audio-video-element-playing.html [ Timeout ]
-webkit.org/b/235885 webrtc/ephemeral-certificates-and-cnames.html [ Failure ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/235885 webrtc/ephemeral-certificates-and-cnames.html [ Failure ]
 webkit.org/b/235885 webrtc/filtering-ice-candidate-after-reload.html [ Failure ]
 webkit.org/b/235885 webrtc/peer-connection-track-end.html [ Failure ]
 webkit.org/b/235885 webrtc/peerconnection-page-cache-long.html [ Timeout ]
@@ -2029,8 +2032,9 @@ webkit.org/b/187064 webrtc/video-addTrack.html [ Failure Pass Timeout ]
 webkit.org/b/187064 webrtc/video-rotation.html [ Failure Timeout ]
 webkit.org/b/187064 webrtc/video-with-data-channel.html [ Failure ]
 webkit.org/b/177533 webrtc/video-interruption.html
-webkit.org/b/229346 webkit.org/b/235885 webrtc/multi-audio.html [ Timeout Pass Failure ]
-webkit.org/b/224074 webrtc/concurrentVideoPlayback2.html [ Timeout Pass ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/229346 webkit.org/b/235885 webrtc/multi-audio.html [ Timeout Pass Failure ]
+#webkit.org/b/224074 webrtc/concurrentVideoPlayback2.html [ Timeout Pass ]
 webkit.org/b/206656 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-removetrack.https.html [ Crash Failure Timeout ]
 
 imported/w3c/web-platform-tests/mediacapture-streams/GUM-required-constraint-with-ideal-value.https.html [ Pass Failure ]
@@ -2063,7 +2067,8 @@ webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/protocol/rtp-clockrat
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-senderCaptureTimeOffset.html [ Skip ]
 
 # GStreamerRtpSenderBackend::setParameters() unimplemented.
-webkit.org/b/215005 webkit.org/b/218787 webrtc/h264-baseline.html [ Failure Timeout ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/215005 webkit.org/b/218787 webrtc/h264-baseline.html [ Failure Timeout ]
 webkit.org/b/215007 webrtc/h264-high.html [ Failure Timeout ]
 
 # We don't support spatial encoding yet.
@@ -3557,7 +3562,8 @@ webkit.org/b/252878 imported/w3c/web-platform-tests/service-workers/service-work
 webkit.org/b/252878 imported/w3c/web-platform-tests/wasm/webapi/instantiateStreaming.any.serviceworker.html [ Failure Pass ]
 webkit.org/b/252878 imported/w3c/web-platform-tests/wasm/webapi/instantiateStreaming.any.sharedworker.html [ Failure Pass ]
 webkit.org/b/252878 loader/navigation-policy/should-open-external-urls/subframe-navigated-programatically-by-main-frame.html [ Failure Pass ]
-webkit.org/b/252878 webrtc/multi-video.html [ Failure Pass Timeout ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/252878 webrtc/multi-video.html [ Failure Pass Timeout ]
 webkit.org/b/252878 webrtc/peer-connection-remote-audio-mute2.html [ Pass Timeout ]
 
 # Missing support for UIScriptController.paste()
@@ -3584,7 +3590,8 @@ webkit.org/b/257624 http/tests/workers/service/postmessage-after-terminating-hun
 webkit.org/b/257624 imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-setmediakeys-to-multiple-video-elements.https.html [ Crash Pass ]
 webkit.org/b/257624 imported/w3c/web-platform-tests/navigation-timing/nav2_test_redirect_xserver.html [ Failure Pass ]
 webkit.org/b/257624 webanimations/accelerated-translate-animation-additional-animation-added-in-flight.html [ ImageOnlyFailure Pass ]
-webkit.org/b/257624 webrtc/audio-replace-track.html [ Failure Pass Timeout ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/257624 webrtc/audio-replace-track.html [ Failure Pass Timeout ]
 webkit.org/b/257624 webrtc/negotiatedneeded-event-addStream.html [ Failure Pass ]
 
 webkit.org/b/258162 fast/images/image-alt-text-vertical.html [ ImageOnlyFailure ]
@@ -3772,6 +3779,31 @@ webkit.org/b/267411 media/now-playing-status-for-video-conference-web-page.html 
 webkit.org/b/267411 fast/mediastream/RTCPeerConnection-inspect-offer.html [ Pass Crash ]
 webkit.org/b/267411 fast/mediastream/RTCPeerConnection-setRemoteDescription-offer.html [ Pass Crash ]
 webkit.org/b/267411 imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-disabled-tracks.https.html [ Pass Crash ]
+webkit.org/b/267411 fast/mediastream/RTCPeerConnection-overloaded-operations.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/addTransceiver-then-addTrack.html [ Failure Crash ]
+webkit.org/b/267411 webrtc/audio-muted-stats.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/audio-peer-connection-g722.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/audio-peer-connection-webaudio.html [ Failure Pass Timeout Crash ]
+webkit.org/b/267411 webrtc/audio-replace-track.html [ Failure Pass Timeout Crash ]
+webkit.org/b/267411 webrtc/audio-samplerate-change.html [ Pass Timeout Crash ]
+webkit.org/b/267411 webrtc/canvas-to-peer-connection-2d.html [ Failure Pass Timeout Crash ]
+webkit.org/b/267411 webrtc/captureCanvas-webrtc-software-h264-baseline.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/captureCanvas-webrtc-software-h264-high.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/captureCanvas-webrtc.html [ Pass Timeout Crash ]
+webkit.org/b/267411 webrtc/clone-audio-track.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/concurrentVideoPlayback.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/concurrentVideoPlayback2.html [ Timeout Pass Crash ]
+webkit.org/b/267411 webrtc/connection-state.html [ Pass Timeout Crash ]
+webkit.org/b/267411 webrtc/ephemeral-certificates-and-cnames.html [ Failure Crash ]
+webkit.org/b/267411 webrtc/h264-baseline.html [ Failure Timeout Crash ]
+webkit.org/b/267411 webrtc/h265.html [ Pass Timeout Crash ]
+webkit.org/b/267411 webrtc/legacy-api.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/libwebrtc/descriptionGetters.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/msection-recycling.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/multi-audio.html [ Timeout Pass Failure Crash ]
+webkit.org/b/267411 webrtc/multi-video.html [ Failure Pass Timeout Crash ]
+webkit.org/b/267411 webrtc/no-port-zero-in-upd-candidates.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/peer-connection-audio-mute2.html [ Failure Timeout Pass Crash ]
 
 # End: Common failures between GTK and WPE.
 

--- a/LayoutTests/platform/gtk-wayland/TestExpectations
+++ b/LayoutTests/platform/gtk-wayland/TestExpectations
@@ -30,7 +30,8 @@ webkit.org/b/217159 http/wpt/service-workers/file-upload.html [ Pass ]
 webkit.org/b/132262 [ Release ] http/tests/media/video-redirect.html [ Timeout Pass Crash ]
 
 # WebRTC
-webkit.org/b/212892 webrtc/peer-connection-audio-mute2.html [ Failure Timeout Pass Crash ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/212892 webrtc/peer-connection-audio-mute2.html [ Failure Timeout Pass Crash ]
 
 # Workers
 ## Crashing in X11, but also timing out in Wayland

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1616,8 +1616,9 @@ webkit.org/b/252878 inspector/debugger/breakpoints/resolved-dump-all-pause-locat
 webkit.org/b/252878 inspector/debugger/breakpoints/resolved-dump-each-line.html [ Failure Timeout Pass ]
 webkit.org/b/252878 js/weakref-finalizationregistry.html [ Pass Timeout ]
 webkit.org/b/252878 webaudio/audioworket-out-of-memory.html [ Pass Timeout ]
-webkit.org/b/252878 webrtc/audio-peer-connection-webaudio.html [ Failure Pass Timeout ]
-webkit.org/b/252878 webrtc/audio-samplerate-change.html [ Pass Timeout ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/252878 webrtc/audio-peer-connection-webaudio.html [ Failure Pass Timeout ]
+#webkit.org/b/252878 webrtc/audio-samplerate-change.html [ Pass Timeout ]
 webkit.org/b/252878 webrtc/datachannel/bufferedAmountLowThreshold-default.html [ Failure Pass ]
 webkit.org/b/252878 webrtc/video-h264.html [ Pass Timeout ]
 webkit.org/b/252878 webrtc/video-mute-vp8.html [ Pass Timeout ]
@@ -1661,7 +1662,8 @@ webkit.org/b/257624 imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-w
 webkit.org/b/257624 imported/w3c/web-platform-tests/xhr/xmlhttprequest-timeout-worker-overridesexpires.html [ Failure Pass ]
 webkit.org/b/257624 media/video-audio-session-mode.html [ Pass Timeout ]
 webkit.org/b/257624 webanimations/accelerated-animations-and-motion-path.html [ Failure Pass ]
-webkit.org/b/257624 webrtc/connection-state.html [ Pass Timeout ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/257624 webrtc/connection-state.html [ Pass Timeout ]
 webkit.org/b/257624 webrtc/video-autoplay.html [ Pass Timeout ]
 webkit.org/b/257624 webrtc/video-replace-track-to-null.html [ Pass Timeout ]
 
@@ -2589,7 +2591,8 @@ webkit.org/b/264680 inspector/heap/getPreview.html [ Failure Pass ]
 webkit.org/b/264680 media/video-seek-past-end-playing.html [ Pass Timeout ]
 webkit.org/b/264680 scrollbars/scrollbar-selectors.html [ Missing Pass Timeout ]
 webkit.org/b/264680 webanimations/accelerated-animation-opacity-animation-begin-time-after-scale-animation-ends.html [ ImageOnlyFailure Pass ]
-webkit.org/b/264680 webrtc/peer-connection-audio-mute2.html [ Failure Pass Timeout ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/264680 webrtc/peer-connection-audio-mute2.html [ Failure Pass Timeout ]
 
 webkit.org/b/266204 [ Debug ] imported/w3c/web-platform-tests/scroll-animations/css/animation-inactive-outside-range-test.html [ Crash ]
 [ Debug ] imported/w3c/web-platform-tests/scroll-animations/css/animation-fill-outside-range-test.html [ Crash ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -890,7 +890,8 @@ webkit.org/b/252878 svg/as-image/svg-as-image-canvas.html [ ImageOnlyFailure Pas
 webkit.org/b/252878 webanimations/accelerated-animation-tiled-while-running.html [ Pass Timeout ]
 webkit.org/b/252878 webaudio/audioworklet-addModule-failure.html [ Pass Timeout ]
 webkit.org/b/252878 webrtc/audio-peer-connection-g722.html [ Failure Pass Timeout ]
-webkit.org/b/252878 webrtc/audio-peer-connection-webaudio.html [ Pass Timeout ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/252878 webrtc/audio-peer-connection-webaudio.html [ Pass Timeout ]
 webkit.org/b/252878 webrtc/datachannel/bufferedAmountLowThreshold-default.html [ Crash Failure Pass Timeout ]
 
 webkit.org/b/187064 webkit.org/b/235885 webrtc/video-remote-mute.html [ Failure Pass Timeout ]
@@ -938,7 +939,8 @@ webkit.org/b/257624 webaudio/suspend-context-while-interrupted.html [ Pass Timeo
 webkit.org/b/257624 webgl/1.0.x/conformance/rendering/texture-switch-performance.html [ Failure Pass ]
 webkit.org/b/257624 webgl/2.0.y/conformance2/offscreencanvas/offscreencanvas-timer-query.html [ Pass Timeout ]
 webkit.org/b/257624 webgl/2.0.y/conformance/rendering/texture-switch-performance.html [ Failure Pass ]
-webkit.org/b/257624 webrtc/canvas-to-peer-connection-2d.html [ Failure Pass Timeout ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/257624 webrtc/canvas-to-peer-connection-2d.html [ Failure Pass Timeout ]
 webkit.org/b/257624 webrtc/video-h264.html [ Crash Pass Timeout ]
 webkit.org/b/257624 webrtc/video-mute.html [ Pass Timeout ]
 webkit.org/b/257624 webrtc/video-mute-vp8.html [ Pass Timeout ]
@@ -1476,7 +1478,8 @@ imported/w3c/web-platform-tests/css/css-shapes/shape-outside-invalid-circle-000.
 imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/constants/001.html?wss [ Pass Timeout ]
 webgl/2.0.0/conformance/uniforms/out-of-bounds-uniform-array-access.html [ Pass Timeout ]
 webgl/2.0.y/conformance/reading/read-pixels-test.html [ Pass Timeout ]
-webrtc/captureCanvas-webrtc.html [ Pass Timeout ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webrtc/captureCanvas-webrtc.html [ Pass Timeout ]
 
 imported/blink/fast/text/international/vertical-positioning-with-combining-marks.html [ Pass ImageOnlyFailure ]
 imported/mozilla/svg/dynamic-small-object-scaled-up-02.svg [ Pass ImageOnlyFailure ]


### PR DESCRIPTION
#### 4312e693b8d8181184c4a9108f4c0de5fccd54b4
<pre>
REGRESSION(272844@main): [GStreamer][Debug] ASSERTION FAILED: isMainThread() in WebCore::MediaStreamTrackPrivate::source()
<a href="https://bugs.webkit.org/show_bug.cgi?id=267411">https://bugs.webkit.org/show_bug.cgi?id=267411</a>

Unreviewed test gardening.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk-wayland/TestExpectations:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/273060@main">https://commits.webkit.org/273060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbd95a5f4ec85c1f94d1171a3437a5e2b6580375

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36861 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/30967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10112 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34684 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/10986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30490 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/9590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30524 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38149 "") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/31050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30838 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/38149 "") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/38149 "") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11603 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/10378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4388 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->