### PR TITLE
Adopt dynamicDowncast<> in InjectedBundle

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -134,10 +134,11 @@ RefPtr<InjectedBundleNodeHandle> InjectedBundleNodeHandle::document()
 
 IntRect InjectedBundleNodeHandle::elementBounds()
 {
-    if (!is<Element>(m_node))
+    RefPtr element = dynamicDowncast<Element>(m_node);
+    if (!element)
         return IntRect();
 
-    return downcast<Element>(*m_node).boundsInRootViewSpace();
+    return element->boundsInRootViewSpace();
 }
     
 IntRect InjectedBundleNodeHandle::absoluteBoundingRect(bool* isReplaced)
@@ -243,120 +244,137 @@ RefPtr<InjectedBundleRangeHandle> InjectedBundleNodeHandle::visibleRange()
 
 void InjectedBundleNodeHandle::setHTMLInputElementValueForUser(const String& value)
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return;
 
-    downcast<HTMLInputElement>(*m_node).setValueForUser(value);
+    input->setValueForUser(value);
 }
 
 void InjectedBundleNodeHandle::setHTMLInputElementSpellcheckEnabled(bool enabled)
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return;
 
-    downcast<HTMLInputElement>(*m_node).setSpellcheckDisabledExceptTextReplacement(!enabled);
+    input->setSpellcheckDisabledExceptTextReplacement(!enabled);
 }
 
 bool InjectedBundleNodeHandle::isHTMLInputElementAutoFilled() const
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return false;
     
-    return downcast<HTMLInputElement>(*m_node).isAutoFilled();
+    return input->isAutoFilled();
 }
 
 bool InjectedBundleNodeHandle::isHTMLInputElementAutoFilledAndViewable() const
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return false;
 
-    return downcast<HTMLInputElement>(*m_node).isAutoFilledAndViewable();
+    return input->isAutoFilledAndViewable();
 }
 
 bool InjectedBundleNodeHandle::isHTMLInputElementAutoFilledAndObscured() const
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return false;
 
-    return downcast<HTMLInputElement>(*m_node).isAutoFilledAndObscured();
+    return input->isAutoFilledAndObscured();
 }
 
 void InjectedBundleNodeHandle::setHTMLInputElementAutoFilled(bool filled)
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return;
 
-    downcast<HTMLInputElement>(*m_node).setAutoFilled(filled);
+    input->setAutoFilled(filled);
 }
 
 void InjectedBundleNodeHandle::setHTMLInputElementAutoFilledAndViewable(bool autoFilledAndViewable)
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return;
 
-    downcast<HTMLInputElement>(*m_node).setAutoFilledAndViewable(autoFilledAndViewable);
+    input->setAutoFilledAndViewable(autoFilledAndViewable);
 }
 
 void InjectedBundleNodeHandle::setHTMLInputElementAutoFilledAndObscured(bool autoFilledAndObscured)
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return;
 
-    downcast<HTMLInputElement>(*m_node).setAutoFilledAndObscured(autoFilledAndObscured);
+    input->setAutoFilledAndObscured(autoFilledAndObscured);
 }
 
 bool InjectedBundleNodeHandle::isHTMLInputElementAutoFillButtonEnabled() const
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return false;
     
-    return downcast<HTMLInputElement>(*m_node).autoFillButtonType() != AutoFillButtonType::None;
+    return input->autoFillButtonType() != AutoFillButtonType::None;
 }
 
 void InjectedBundleNodeHandle::setHTMLInputElementAutoFillButtonEnabled(AutoFillButtonType autoFillButtonType)
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return;
 
-    downcast<HTMLInputElement>(*m_node).setShowAutoFillButton(autoFillButtonType);
+    input->setShowAutoFillButton(autoFillButtonType);
 }
 
 AutoFillButtonType InjectedBundleNodeHandle::htmlInputElementAutoFillButtonType() const
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return AutoFillButtonType::None;
-    return downcast<HTMLInputElement>(*m_node).autoFillButtonType();
+
+    return input->autoFillButtonType();
 }
 
 AutoFillButtonType InjectedBundleNodeHandle::htmlInputElementLastAutoFillButtonType() const
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return AutoFillButtonType::None;
-    return downcast<HTMLInputElement>(*m_node).lastAutoFillButtonType();
+
+    return input->lastAutoFillButtonType();
 }
 
 bool InjectedBundleNodeHandle::isAutoFillAvailable() const
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return false;
 
-    return downcast<HTMLInputElement>(*m_node).isAutoFillAvailable();
+    return input->isAutoFillAvailable();
 }
 
 void InjectedBundleNodeHandle::setAutoFillAvailable(bool autoFillAvailable)
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return;
 
-    downcast<HTMLInputElement>(*m_node).setAutoFillAvailable(autoFillAvailable);
+    input->setAutoFillAvailable(autoFillAvailable);
 }
 
 IntRect InjectedBundleNodeHandle::htmlInputElementAutoFillButtonBounds()
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return IntRect();
 
-    auto autoFillButton = downcast<HTMLInputElement>(*m_node).autoFillButtonElement();
+    auto autoFillButton = input->autoFillButtonElement();
     if (!autoFillButton)
         return IntRect();
 
@@ -365,26 +383,29 @@ IntRect InjectedBundleNodeHandle::htmlInputElementAutoFillButtonBounds()
 
 bool InjectedBundleNodeHandle::htmlInputElementLastChangeWasUserEdit()
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return false;
 
-    return downcast<HTMLInputElement>(*m_node).lastChangeWasUserEdit();
+    return input->lastChangeWasUserEdit();
 }
 
 bool InjectedBundleNodeHandle::htmlTextAreaElementLastChangeWasUserEdit()
 {
-    if (!is<HTMLTextAreaElement>(m_node))
+    RefPtr textarea = dynamicDowncast<HTMLTextAreaElement>(m_node);
+    if (!textarea)
         return false;
 
-    return downcast<HTMLTextAreaElement>(*m_node).lastChangeWasUserEdit();
+    return textarea->lastChangeWasUserEdit();
 }
 
 bool InjectedBundleNodeHandle::isTextField() const
 {
-    if (!is<HTMLInputElement>(m_node))
+    RefPtr input = dynamicDowncast<HTMLInputElement>(m_node);
+    if (!input)
         return false;
 
-    return downcast<HTMLInputElement>(*m_node).isTextField();
+    return input->isTextField();
 }
 
 bool InjectedBundleNodeHandle::isSelectElement() const
@@ -403,18 +424,20 @@ bool InjectedBundleNodeHandle::isSelectableTextNode() const
 
 RefPtr<InjectedBundleNodeHandle> InjectedBundleNodeHandle::htmlTableCellElementCellAbove()
 {
-    if (!is<HTMLTableCellElement>(m_node))
+    RefPtr tableCell = dynamicDowncast<HTMLTableCellElement>(m_node);
+    if (!tableCell)
         return nullptr;
 
-    return getOrCreate(downcast<HTMLTableCellElement>(*m_node).cellAbove());
+    return getOrCreate(tableCell->cellAbove());
 }
 
 RefPtr<WebFrame> InjectedBundleNodeHandle::documentFrame()
 {
-    if (!m_node || !m_node->isDocumentNode())
+    RefPtr document = dynamicDowncast<Document>(m_node);
+    if (!document)
         return nullptr;
 
-    auto* frame = downcast<Document>(*m_node).frame();
+    auto* frame = document->frame();
     if (!frame)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
@@ -167,20 +167,19 @@ IntRect InjectedBundleHitTestResult::imageRect() const
 
 RefPtr<WebImage> InjectedBundleHitTestResult::image() const
 {
-    Image* image = m_hitTestResult.image();
     // For now, we only handle bitmap images.
-    if (!is<BitmapImage>(image))
+    auto* bitmapImage = dynamicDowncast<BitmapImage>(m_hitTestResult.image());
+    if (!bitmapImage)
         return nullptr;
 
-    BitmapImage& bitmapImage = downcast<BitmapImage>(*image);
-    IntSize size(bitmapImage.size());
+    IntSize size(bitmapImage->size());
     auto webImage = WebImage::create(size, static_cast<ImageOptions>(0), DestinationColorSpace::SRGB());
     if (!webImage->context())
         return nullptr;
 
     // FIXME: need to handle EXIF rotation.
     auto& graphicsContext = *webImage->context();
-    graphicsContext.drawImage(bitmapImage, { { }, size });
+    graphicsContext.drawImage(*bitmapImage, { { }, size });
 
     return webImage;
 }


### PR DESCRIPTION
#### eb1578b3bd2fa9d25a84bcd087d51d80b96d1ba6
<pre>
Adopt dynamicDowncast&lt;&gt; in InjectedBundle
<a href="https://bugs.webkit.org/show_bug.cgi?id=267576">https://bugs.webkit.org/show_bug.cgi?id=267576</a>

Reviewed by Chris Dumez.

The only InjectedBundle-related unqualified downcasts that remain for
Apple platforms are in WKDOMDocument, WKDOMElement, and WKDOMText.

* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::InjectedBundleNodeHandle::elementBounds):
(WebKit::InjectedBundleNodeHandle::setHTMLInputElementValueForUser):
(WebKit::InjectedBundleNodeHandle::setHTMLInputElementSpellcheckEnabled):
(WebKit::InjectedBundleNodeHandle::isHTMLInputElementAutoFilled const):
(WebKit::InjectedBundleNodeHandle::isHTMLInputElementAutoFilledAndViewable const):
(WebKit::InjectedBundleNodeHandle::isHTMLInputElementAutoFilledAndObscured const):
(WebKit::InjectedBundleNodeHandle::setHTMLInputElementAutoFilled):
(WebKit::InjectedBundleNodeHandle::setHTMLInputElementAutoFilledAndViewable):
(WebKit::InjectedBundleNodeHandle::setHTMLInputElementAutoFilledAndObscured):
(WebKit::InjectedBundleNodeHandle::isHTMLInputElementAutoFillButtonEnabled const):
(WebKit::InjectedBundleNodeHandle::setHTMLInputElementAutoFillButtonEnabled):
(WebKit::InjectedBundleNodeHandle::htmlInputElementAutoFillButtonType const):
(WebKit::InjectedBundleNodeHandle::htmlInputElementLastAutoFillButtonType const):
(WebKit::InjectedBundleNodeHandle::isAutoFillAvailable const):
(WebKit::InjectedBundleNodeHandle::setAutoFillAvailable):
(WebKit::InjectedBundleNodeHandle::htmlInputElementAutoFillButtonBounds):
(WebKit::InjectedBundleNodeHandle::htmlInputElementLastChangeWasUserEdit):
(WebKit::InjectedBundleNodeHandle::htmlTextAreaElementLastChangeWasUserEdit):
(WebKit::InjectedBundleNodeHandle::isTextField const):
(WebKit::InjectedBundleNodeHandle::htmlTableCellElementCellAbove):
(WebKit::InjectedBundleNodeHandle::documentFrame):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp:
(WebKit::InjectedBundleHitTestResult::image const):

Canonical link: <a href="https://commits.webkit.org/273074@main">https://commits.webkit.org/273074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/884282d836613a6cdb82c0412ceb28b7464a2934

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/12991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36872 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30975 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30012 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/10993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30501 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9598 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9703 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38163 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31057 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35793 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7703 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33706 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11613 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7872 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10643 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->