### PR TITLE
[ImageCapture] Commit configuration changes after changing/restoring settings for image capture

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -558,11 +558,10 @@ void AVVideoCaptureSource::rejectPendingPhotoRequest(const String& error)
 {
     Locker lock { m_photoLock };
 
-    if (!m_photoProducer) {
-        ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "no photo producer");
+    if (!m_photoProducer)
         return;
-    }
 
+    ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, error);
     m_photoProducer->reject(error);
     m_photoProducer = nullptr;
 }
@@ -654,7 +653,7 @@ auto AVVideoCaptureSource::takePhotoInternal(PhotoSettings&& photoSettings) -> R
     }
 
     auto avPhotoSettings = photoConfiguration(photoSettings);
-    if (avPhotoSettings) {
+    if (!avPhotoSettings) {
         ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "photoConfiguration() failed");
         return TakePhotoNativePromise::createAndReject("Internal error"_s);
     }

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -362,6 +362,7 @@ const RealtimeMediaSourceSettings& MockRealtimeVideoSource::settings()
 void MockRealtimeVideoSource::setFrameRateAndZoomWithPreset(double frameRate, double zoom, std::optional<VideoPreset>&& preset)
 {
     UNUSED_PARAM(zoom);
+    ASSERT(m_beingConfigured);
     m_preset = WTFMove(preset);
     if (m_preset)
         setIntrinsicSize(m_preset->size());
@@ -416,6 +417,7 @@ void MockRealtimeVideoSource::startCaptureTimer()
 
 void MockRealtimeVideoSource::startProducingData()
 {
+    ASSERT(!m_beingConfigured);
     startCaptureTimer();
     m_startTime = MonotonicTime::now();
 }
@@ -725,6 +727,16 @@ void MockRealtimeVideoSource::setIsInterrupted(bool isInterrupted)
             source.startCaptureTimer();
         source.notifyMutedChange(isInterrupted);
     }
+}
+
+void MockRealtimeVideoSource::startApplyingConstraints()
+{
+    m_beingConfigured = true;
+}
+
+void MockRealtimeVideoSource::endApplyingConstraints()
+{
+    m_beingConfigured = false;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
@@ -112,6 +112,9 @@ private:
     bool mockWindow() const { return mockDisplayType(CaptureDevice::DeviceType::Window); }
     bool mockDisplayType(CaptureDevice::DeviceType) const;
 
+    void startApplyingConstraints() final;
+    void endApplyingConstraints() final;
+
     class DrawingState {
     public:
         explicit DrawingState(float baseFontSize)
@@ -167,6 +170,7 @@ private:
     Lock m_imageBufferLock;
     std::optional<PhotoCapabilities> m_photoCapabilities;
     std::optional<PhotoSettings> m_photoSettings;
+    bool m_beingConfigured { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 519c8375e5ac2dd3fc404e4a5b00a8056478e0db
<pre>
[ImageCapture] Commit configuration changes after changing/restoring settings for image capture
<a href="https://bugs.webkit.org/show_bug.cgi?id=267580">https://bugs.webkit.org/show_bug.cgi?id=267580</a>
<a href="https://rdar.apple.com/121045984">rdar://121045984</a>

Reviewed by Youenn Fablet.

AVCapture sometimes throws an exception if an AVCaptureSession is started while it is being
configured, so ensure that session configuration is ended explicitly after setting up or
restoring session configuration for image capture.

* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp:
(WebCore::RealtimeVideoCaptureSource::takePhoto): Call startApplyingConstraints and
endApplyingConstraints around setting and restoring configuration.

* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::rejectPendingPhotoRequest): Drive-by: don&apos;t log if the
photo producer doesn&apos;t exist.
(WebCore::AVVideoCaptureSource::takePhotoInternal): Reject the promise if there are no
settings.

* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::setFrameRateAndZoomWithPreset): Assert if
`m_beingConfigured` is  not set.
(WebCore::MockRealtimeVideoSource::startProducingData): Ditto.
(WebCore::MockRealtimeVideoSource::startApplyingConstraints): Set `m_beingConfigured`.
(WebCore::MockRealtimeVideoSource::endApplyingConstraints): Clear `m_beingConfigured`.
* Source/WebCore/platform/mock/MockRealtimeVideoSource.h:

Canonical link: <a href="https://commits.webkit.org/273091@main">https://commits.webkit.org/273091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f226625a852ea8a4d574846c1d87a61eb49e2a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31003 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30035 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34730 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9629 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9740 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38198 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31094 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30887 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35820 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33735 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11645 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7882 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10677 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->