### PR TITLE
svg/compositing/transform-change-repainting-viewBox.html should not enable layer borders

### DIFF
--- a/LayoutTests/compositing/updates/animation-non-composited.html
+++ b/LayoutTests/compositing/updates/animation-non-composited.html
@@ -30,7 +30,7 @@ requestAnimationFrame(() => {
         internals.updateLayoutIgnorePendingStylesheetsAndRunPostLayoutTasks();
         initialCompositingUpdateCount = internals.compositingUpdateCount();
     }
-}, 0);
+});
 
 test.onanimationend = () => {
     if (!window.internals)

--- a/LayoutTests/svg/compositing/transform-change-repainting-viewBox-expected.html
+++ b/LayoutTests/svg/compositing/transform-change-repainting-viewBox-expected.html
@@ -9,18 +9,18 @@
             transform-origin: 50% 50%;
             transform-box: border-box;
             transform: translateZ(0);
-	}
+        }
 
         .animating2 {
             transform-origin: 50% 50%;
             transform-box: border-box;
             transform: rotate(25deg) translateZ(0);
-	}
+        }
 
         .animating3 {
             transform-origin: 50% 50%;
             transform-box: border-box;
-	    transform: rotate(45deg) translateZ(0);
+            transform: rotate(45deg) translateZ(0);
             fill: green;
         }
     </style>
@@ -28,21 +28,16 @@
         if (window.testRunner)
             testRunner.waitUntilDone();
 
-        if (window.internals) {
-            internals.settings.setShowRepaintCounter(true);
-            internals.settings.setShowDebugBorders(true);
-        }
-
         window.addEventListener('load', () => {
             requestAnimationFrame(() => {
                 document.getElementById('rect').setAttribute("class", "animating2");
-		requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
                     document.getElementById('rect').setAttribute("class", "animating3");
                     if (window.testRunner)
-			testRunner.notifyDone();
-		    });
-		});
-	    }, false);
+                        testRunner.notifyDone();
+                });
+            });
+        }, false);
     </script>
 </head>
 <body>

--- a/LayoutTests/svg/compositing/transform-change-repainting-viewBox.html
+++ b/LayoutTests/svg/compositing/transform-change-repainting-viewBox.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=35; totalPixels=12" />
     <title>Tests that SVG documents with viewBox don't trigger unnecessary repaints during animations.</title>
     <style>
         svg { border: 1px solid black; }
@@ -9,10 +8,10 @@
         #animating {
             transform-origin: 50% 50%;
             transform-box: border-box;
-	    transform: translateZ(0);
+            transform: translateZ(0);
 
             animation: rotation 1s 1s;
-	    animation-fill-mode: forwards;
+            animation-fill-mode: forwards;
         }
 
         @keyframes rotation {
@@ -31,11 +30,6 @@
             ["rotation", 1.5, "animating", "webkitTransform", "matrix(0.707107, 0.707107, -0.707107, 0.707107, 0, 0)", 0],
         ];
 
-        if (window.internals) {
-            internals.settings.setShowRepaintCounter(true);
-            internals.settings.setShowDebugBorders(true);
-        }
-
         var doPixelTest = true;
         var disablePauseAPI = true;
         runAnimationTest(expectedValues, null, undefined, disablePauseAPI, doPixelTest);
@@ -45,6 +39,6 @@
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="500" height="300">    
         <rect id="animating" x="10" y="10" width="180" height="180" fill="green"/>
     </svg>
-    <div id="result"/>
+    <div id="result"></div>
 </body>
 </html>


### PR DESCRIPTION
#### 15ebca4a77aaa3598046f640bbb4db3636af1b16
<pre>
svg/compositing/transform-change-repainting-viewBox.html should not enable layer borders
<a href="https://bugs.webkit.org/show_bug.cgi?id=267588">https://bugs.webkit.org/show_bug.cgi?id=267588</a>
<a href="https://rdar.apple.com/121052864">rdar://121052864</a>

Reviewed by Tim Nguyen.

Turn off layer borders, remove pixel tolerance, and de-tab.

* LayoutTests/compositing/updates/animation-non-composited.html: Drive-by nit fix.
* LayoutTests/svg/compositing/transform-change-repainting-viewBox-expected.html:
* LayoutTests/svg/compositing/transform-change-repainting-viewBox.html:

Canonical link: <a href="https://commits.webkit.org/273090@main">https://commits.webkit.org/273090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a725c1fa85083276cb820388dc0cb9afc98b1eb9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36896 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30993 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10145 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30028 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30525 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9618 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9731 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38187 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31083 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35812 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33725 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11634 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30176 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7880 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10407 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->