### PR TITLE
Move local variables in function `genericParseNumber` closer to their use in SVGParserUtilities.cpp

### DIFF
--- a/Source/WebCore/svg/SVGParserUtilities.cpp
+++ b/Source/WebCore/svg/SVGParserUtilities.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2002, 2003 The Karbon Developers
  * Copyright (C) 2006 Alexander Kellett <lypanov@kde.org>
  * Copyright (C) 2006, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2007-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -44,16 +44,8 @@ template <typename FloatType> static inline bool isValidRange(const FloatType& x
 // FIXME: Can this be shared/replaced with number parsing in WTF?
 template <typename CharacterType, typename FloatType = float> static std::optional<FloatType> genericParseNumber(StringParsingBuffer<CharacterType>& buffer, SuffixSkippingPolicy skip = SuffixSkippingPolicy::Skip)
 {
-    FloatType number = 0;
-    FloatType integer = 0;
-    FloatType decimal = 0;
-    FloatType frac = 1;
-    FloatType exponent = 0;
-    int sign = 1;
-    int expsign = 1;
-    auto start = buffer.position();
-
     // read the sign
+    int sign = 1;
     if (buffer.hasCharactersRemaining() && *buffer == '+')
         ++buffer;
     else if (buffer.hasCharactersRemaining() && *buffer == '-') {
@@ -70,6 +62,7 @@ template <typename CharacterType, typename FloatType = float> static std::option
     // Advance to first non-digit.
     skipWhile<isASCIIDigit>(buffer);
 
+    FloatType integer = 0;
     if (buffer.position() != ptrStartIntPart) {
         auto ptrScanIntPart = buffer.position() - 1;
         FloatType multiplier = 1;
@@ -83,6 +76,7 @@ template <typename CharacterType, typename FloatType = float> static std::option
     }
 
     // read the decimals
+    FloatType decimal = 0;
     if (buffer.hasCharactersRemaining() && *buffer == '.') {
         ++buffer;
         
@@ -90,11 +84,15 @@ template <typename CharacterType, typename FloatType = float> static std::option
         if (buffer.atEnd() || !isASCIIDigit(*buffer))
             return std::nullopt;
         
+        FloatType frac = 1;
         while (buffer.hasCharactersRemaining() && isASCIIDigit(*buffer))
             decimal += (*(buffer++) - '0') * (frac *= static_cast<FloatType>(0.1));
     }
 
     // read the exponent part
+    FloatType exponent = 0;
+    int expsign = 1;
+    auto start = buffer.position();
     if (buffer.position() != start && buffer.position() + 1 < buffer.end() && (*buffer == 'e' || *buffer == 'E')
         && (buffer[1] != 'x' && buffer[1] != 'm')) {
         ++buffer;
@@ -120,6 +118,7 @@ template <typename CharacterType, typename FloatType = float> static std::option
             return std::nullopt;
     }
 
+    FloatType number = 0;
     number = integer + decimal;
     number *= sign;
 


### PR DESCRIPTION
<pre>
Move local variables in function `genericParseNumber` closer to their use in SVGParserUtilities.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=267583">https://bugs.webkit.org/show_bug.cgi?id=267583</a>

Reviewed by NOBODY (OOPS!).

This change does not change any functionality but is just to move all local variables
closer to their usage in the inner-most scope.

* Source/WebCore/svg/SVGParserUtilities.cpp:
(genericParseNumber):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74573e36490f405ea64912bb4dd0877b9e0c73e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36897 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30994 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15403 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10146 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30029 "Failure limit exceed. At least found 416 new test failures: accessibility/math-foreign-content.html, accessibility/svg-element-press.html, accessibility/svg-element-with-aria-role.html, accessibility/svg-group-element-with-title.html, accessibility/svg-image.html, accessibility/svg-labelledby.html, accessibility/svg-remote-element.html, accessibility/svg-shape-labelled.html, accessibility/w3c-svg-content-language-attribute.html, accessibility/w3c-svg-description-calculation.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34719 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11085 "Found 60 new test failures: accessibility/element-line-rects-and-text.html, accessibility/ios-simulator/element-paths.html, accessibility/ios-simulator/svg-group-element-with-title.html, accessibility/ios-simulator/svg-path-crash.html, css3/blending/background-blend-mode-data-uri-svg-image.html, css3/blending/background-blend-mode-separate-layer-declaration.html, css3/blending/svg-blend-color-burn.html, css3/blending/svg-blend-color-dodge.html, css3/blending/svg-blend-darken.html, css3/blending/svg-blend-difference.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30550 "Found 4 new API test failures: TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoContainsQRCodePayloadStringSVG, TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoContainsQRCodePayloadStringSVGInsideTransformedElement, TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoContainsQRCodePayloadStringObscuredSVG, TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoContainsQRCodePayloadStringSVGPageZoom (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9621 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9732 "Found 60 new test failures: imported/w3c/web-platform-tests/IndexedDB/idbfactory-open-opaque-origin.html, imported/w3c/web-platform-tests/accname/name/comp_host_language_label.html, imported/w3c/web-platform-tests/content-security-policy/script-src/worker-data-set-timeout.sub.html, imported/w3c/web-platform-tests/content-security-policy/worker-src/shared-child.sub.html, imported/w3c/web-platform-tests/css/css-backgrounds/background-size/background-size-cover-svg.html, imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/background-size-vector-001.html, imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/background-size-vector-002.html, imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/background-size-vector-019.html, imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/background-size-vector-020.html, imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/background-size-vector-022.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30586 "Found 60 new test failures: accessibility/mac/active-descendant-with-aria-controls.html, accessibility/mac/element-paths.html, accessibility/math-foreign-content.html, css3/blending/background-blend-mode-data-uri-svg-image.html, css3/blending/background-blend-mode-separate-layer-declaration.html, css3/blending/svg-blend-color-burn.html, css3/blending/svg-blend-color-dodge.html, css3/blending/svg-blend-darken.html, css3/blending/svg-blend-difference.html, css3/blending/svg-blend-exclusion.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38188 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31084 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30903 "Found 60 new test failures: accessibility/element-line-rects-and-text.html, accessibility/mac/element-paths.html, css3/blending/background-blend-mode-data-uri-svg-image.html, css3/blending/background-blend-mode-separate-layer-declaration.html, css3/blending/svg-blend-color-burn.html, css3/blending/svg-blend-color-dodge.html, css3/blending/svg-blend-darken.html, css3/blending/svg-blend-difference.html, css3/blending/svg-blend-exclusion.html, css3/blending/svg-blend-hard-light.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35814 "Failure limit exceed. At least found 438 new test failures: accessibility/math-foreign-content.html, accessibility/svg-element-press.html, accessibility/svg-element-with-aria-role.html, accessibility/svg-group-element-with-title.html, accessibility/svg-image.html, accessibility/svg-labelledby.html, accessibility/svg-remote-element.html, accessibility/svg-shape-labelled.html, accessibility/w3c-svg-content-language-attribute.html, accessibility/w3c-svg-description-calculation.html ... (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9849 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7718 "Found 60 new test failures: accessibility/mac/element-paths.html, css3/blending/background-blend-mode-data-uri-svg-image.html, css3/blending/background-blend-mode-separate-layer-declaration.html, css3/blending/svg-blend-color-burn.html, css3/blending/svg-blend-color-dodge.html, css3/blending/svg-blend-darken.html, css3/blending/svg-blend-difference.html, css3/blending/svg-blend-exclusion.html, css3/blending/svg-blend-hard-light.html, css3/blending/svg-blend-layer-blend.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33770 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11635 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10667 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->