### PR TITLE
"Turn off the lights" extension service worker fails to load.

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -229,13 +229,8 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
         parameters.parentIdentifier = parentIdentifier.stringValue;
 
     if (NSString *title = properties[titleKey]) {
-        if (!title.length) {
+        if (!title.length && parameters.type != WebExtensionMenuItemType::Separator) {
             *outExceptionString = toErrorString(nil, titleKey, @"it must not be empty");
-            return false;
-        }
-
-        if (parameters.type == WebExtensionMenuItemType::Separator) {
-            *outExceptionString = toErrorString(nil, titleKey, @"it cannot be provided when type is 'separator'");
             return false;
         }
 
@@ -248,11 +243,6 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
             return false;
         }
 
-        if (parameters.type == WebExtensionMenuItemType::Separator) {
-            *outExceptionString = toErrorString(nil, onclickKey, @"it cannot be provided when type is 'separator'");
-            return false;
-        }
-
         outClickCallback = WebExtensionCallbackHandler::create(clickCallback);
     }
 
@@ -262,11 +252,6 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
         iconDictionary = @{ @"16": iconPath };
 
     if (NSDictionary *iconPaths = objectForKey<NSDictionary>(properties, iconsKey)) {
-        if (parameters.type == WebExtensionMenuItemType::Separator) {
-            *outExceptionString = toErrorString(nil, iconsKey, @"it cannot be provided when type is 'separator'");
-            return false;
-        }
-
         for (NSString *key in iconPaths) {
             if (!WebExtensionAPIAction::isValidDimensionKey(key)) {
                 *outExceptionString = toErrorString(nil, iconsKey, @"'%@' in not a valid dimension", key);
@@ -284,11 +269,6 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
         parameters.iconDictionaryJSON = encodeJSONString(iconDictionary);
 
     if (NSString *command = properties[commandKey]) {
-        if (parameters.type == WebExtensionMenuItemType::Separator) {
-            *outExceptionString = toErrorString(nil, commandKey, @"it cannot be provided when type is 'separator'");
-            return false;
-        }
-
         if (!command.length) {
             *outExceptionString = toErrorString(nil, commandKey, @"it must not be empty");
             return false;
@@ -297,23 +277,11 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
         parameters.command = command;
     }
 
-    if (NSNumber *checked = properties[checkedKey]) {
-        if (parameters.type == WebExtensionMenuItemType::Separator) {
-            *outExceptionString = toErrorString(nil, checkedKey, @"it cannot be provided when type is 'separator'");
-            return false;
-        }
-
+    if (NSNumber *checked = properties[checkedKey])
         parameters.checked = checked.boolValue;
-    }
 
-    if (NSNumber *enabled = properties[enabledKey]) {
-        if (parameters.type == WebExtensionMenuItemType::Separator) {
-            *outExceptionString = toErrorString(nil, enabledKey, @"it cannot be provided when type is 'separator'");
-            return false;
-        }
-
+    if (NSNumber *enabled = properties[enabledKey])
         parameters.enabled = enabled.boolValue;
-    }
 
     if (NSNumber *visible = properties[visibleKey])
         parameters.visible = visible.boolValue;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
@@ -91,7 +91,6 @@ TEST(WKWebExtensionAPIMenus, Errors)
 
         @"browser.test.assertThrows(() => browser.menus.create({ type: 123, title: 'Test' }), /'type' is expected to be a string, but a number was provided/i)",
         @"browser.test.assertThrows(() => browser.menus.create({ type: 'bad', title: 'Test' }), /'type' value is invalid, because it must specify either 'normal', 'checkbox', 'radio', or 'separator'/i)",
-        @"browser.test.assertThrows(() => browser.menus.create({ type: 'separator', title: 'Test' }), /'title' value is invalid, because it cannot be provided when type is 'separator'/i)",
 
         @"browser.test.assertThrows(() => browser.menus.create({ command: 123, title: 'Test' }), /'command' is expected to be a string, but a number was provided/i)",
         @"browser.test.assertThrows(() => browser.menus.create({ command: '', title: 'Test' }), /'command' value is invalid, because it must not be empty/i)",


### PR DESCRIPTION
#### b30ec2ac54474e2b9e82e0cc5bbf1b6abd7821f9
<pre>
&quot;Turn off the lights&quot; extension service worker fails to load.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267590">https://bugs.webkit.org/show_bug.cgi?id=267590</a>
<a href="https://rdar.apple.com/120864698">rdar://120864698</a>

Reviewed by Timothy Hatcher.

Turn off the light&apos;s service worker fails to load because we incorrectly throw an error for empty
titles when context menus of type &quot;separator&quot; are created. We should update the check to allow for
empty titles for type &apos;separator&apos;. We should also remove the checks that prevent &apos;command&apos;, &apos;onclick&apos;,
&apos;icons&apos;, &apos;checked&apos;, and &apos;enabled&apos; from being specified if the type is &apos;separator&apos; since that isn&apos;t
specified in the Chrome or MDN documentation.

Testing:
TOTL extension works as expected.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::WebExtensionAPIMenus::parseCreateAndUpdateProperties):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/273128@main">https://commits.webkit.org/273128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9bb7bdeeb18efd36d4b75a2e87da2cd3a089c4d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36901 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/30997 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35295 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30030 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30532 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9622 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9744 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38192 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31087 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30882 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35816 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9853 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33730 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11639 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10412 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4411 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10671 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->