### PR TITLE
querySelectorAll should consult document

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -59,6 +59,7 @@
 #include <wtf/Observer.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/WeakHashMap.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakListHashSet.h>
 #include <wtf/WeakPtr.h>
@@ -182,6 +183,7 @@ class MessagePortChannelProvider;
 class MouseEventWithHitTestResults;
 class NodeFilter;
 class NodeIterator;
+class NodeList;
 class Page;
 class PaintWorklet;
 class PaintWorkletGlobalScope;
@@ -257,6 +259,7 @@ struct BoundaryPoint;
 struct ClientOrigin;
 struct FocusOptions;
 struct IntersectionObserverData;
+struct QuerySelectorAllResults;
 struct SecurityPolicyViolationEventInit;
 
 #if ENABLE(TOUCH_EVENTS)
@@ -463,6 +466,11 @@ public:
 
     Element* elementForAccessKey(const String& key);
     void invalidateAccessKeyCache();
+
+    RefPtr<NodeList> resultForSelectorAll(ContainerNode&, const String&);
+    void addResultForSelectorAll(ContainerNode&, const String&, NodeList&);
+    void invalidateQuerySelectorAllResults(Node&);
+    void clearQuerySelectorAllResults();
 
     ExceptionOr<SelectorQuery&> selectorQueryForString(const String&);
 
@@ -2178,6 +2186,8 @@ private:
     bool m_hasViewTransitionPseudoElementTree;
 
     Timer m_loadEventDelayTimer;
+
+    WeakHashMap<Node, std::unique_ptr<QuerySelectorAllResults>, WeakPtrImplWithEventTargetData> m_querySelectorAllResults;
 
     ViewportArguments m_viewportArguments;
 

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -171,6 +171,9 @@ public:
     bool isInGCReacheableRefMap() const { return hasEventTargetFlag(EventTargetFlag::IsInGCReachableRefMap); }
     void setIsInGCReacheableRefMap(bool flag) { setEventTargetFlag(EventTargetFlag::IsInGCReachableRefMap, flag); }
 
+    bool hasValidQuerySelectorAllResults() const { return hasEventTargetFlag(EventTargetFlag::HasValidQuerySelectorAllResults); }
+    void setHasValidQuerySelectorAllResults(bool flag) { setEventTargetFlag(EventTargetFlag::HasValidQuerySelectorAllResults, flag); }
+
 protected:
     enum ConstructNodeTag { ConstructNode };
     EventTarget() = default;
@@ -190,17 +193,18 @@ protected:
         IsConnected = 1 << 3,
         IsInShadowTree = 1 << 4,
         HasBeenInUserAgentShadowTree = 1 << 5,
+        HasValidQuerySelectorAllResults = 1 << 6,
         // Element bits
-        HasSyntheticAttrChildNodes = 1 << 6,
-        HasDuplicateAttribute = 1 << 7,
-        HasLangAttr = 1 << 8,
-        HasXMLLangAttr = 1 << 9,
-        HasFormAssociatedCustomElementInterface = 1 << 10,
-        HasShadowRootContainingSlots = 1 << 11,
-        IsInTopLayer = 1 << 12,
+        HasSyntheticAttrChildNodes = 1 << 7,
+        HasDuplicateAttribute = 1 << 8,
+        HasLangAttr = 1 << 9,
+        HasXMLLangAttr = 1 << 10,
+        HasFormAssociatedCustomElementInterface = 1 << 11,
+        HasShadowRootContainingSlots = 1 << 12,
+        IsInTopLayer = 1 << 13,
         // SVGElement bits
-        HasPendingResources = 1 << 13,
-        // 2 Free bits
+        HasPendingResources = 1 << 14,
+        // 1 Free bits
     };
 
     EventTargetData& ensureEventTargetData()

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1029,6 +1029,8 @@ void Node::invalidateNodeListAndCollectionCachesInAncestors()
             lists->clearChildNodeListCache();
     }
 
+    document().invalidateQuerySelectorAllResults(*this);
+
     if (!document().shouldInvalidateNodeListAndCollectionCaches())
         return;
 
@@ -1048,6 +1050,8 @@ void Node::invalidateNodeListAndCollectionCachesInAncestors()
 void Node::invalidateNodeListAndCollectionCachesInAncestorsForAttribute(const QualifiedName& attrName)
 {
     ASSERT(is<Element>(*this));
+
+    document().invalidateQuerySelectorAllResults(*this);
 
     if (!document().shouldInvalidateNodeListAndCollectionCachesForAttribute(attrName))
         return;

--- a/Source/WebCore/dom/SelectorQuery.h
+++ b/Source/WebCore/dom/SelectorQuery.h
@@ -50,6 +50,8 @@ public:
     Ref<NodeList> queryAll(ContainerNode& rootNode) const;
     Element* queryFirst(ContainerNode& rootNode) const;
 
+    bool shouldStoreInDocument() const { return m_matchType == MatchType::TagNameMatch || m_matchType == MatchType::ClassNameMatch; }
+
 private:
     struct SelectorData {
         const CSSSelector* selector;
@@ -101,6 +103,8 @@ public:
     Element* closest(Element&) const;
     Ref<NodeList> queryAll(ContainerNode& rootNode) const;
     Element* queryFirst(ContainerNode& rootNode) const;
+
+    bool shouldStoreInDocument() const { return m_selectors.shouldStoreInDocument(); }
 
 private:
     CSSSelectorList m_selectorList;

--- a/Source/WebCore/dom/StaticNodeList.cpp
+++ b/Source/WebCore/dom/StaticNodeList.cpp
@@ -34,6 +34,7 @@
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(StaticNodeList);
+WTF_MAKE_ISO_ALLOCATED_IMPL(StaticWrapperNodeList);
 WTF_MAKE_ISO_ALLOCATED_IMPL(StaticElementList);
 
 unsigned StaticNodeList::length() const
@@ -46,6 +47,16 @@ Node* StaticNodeList::item(unsigned index) const
     if (index < m_nodes.size())
         return const_cast<Node*>(m_nodes[index].ptr());
     return nullptr;
+}
+
+unsigned StaticWrapperNodeList::length() const
+{
+    return m_nodeList->length();
+}
+
+Node* StaticWrapperNodeList::item(unsigned index) const
+{
+    return m_nodeList->item(index);
 }
 
 unsigned StaticElementList::length() const

--- a/Source/WebCore/dom/StaticNodeList.h
+++ b/Source/WebCore/dom/StaticNodeList.h
@@ -53,6 +53,25 @@ private:
     Vector<Ref<Node>> m_nodes;
 };
 
+class StaticWrapperNodeList final : public NodeList {
+    WTF_MAKE_ISO_ALLOCATED(StaticWrapperNodeList);
+public:
+    static Ref<StaticWrapperNodeList> create(NodeList& nodeList)
+    {
+        return adoptRef(*new StaticWrapperNodeList(nodeList));
+    }
+
+    unsigned length() const override;
+    Node* item(unsigned index) const override;
+
+private:
+    StaticWrapperNodeList(NodeList& nodeList)
+        : m_nodeList(nodeList)
+    { }
+
+    Ref<NodeList>  m_nodeList;
+};
+
 class StaticElementList final : public NodeList {
     WTF_MAKE_ISO_ALLOCATED(StaticElementList);
 public:

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -121,6 +121,7 @@ static void releaseCriticalMemory(Synchronous synchronous, MaintainBackForwardCa
         return document.get();
     });
     for (auto& document : protectedDocuments) {
+        document->clearQuerySelectorAllResults();
         document->styleScope().releaseMemory();
         document->fontSelector().emptyCaches();
         document->cachedResourceLoader().garbageCollectDocumentResources();


### PR DESCRIPTION
#### 8948469628f6e2c8cd44d680b2f194371e9b3f97
<pre>
querySelectorAll should consult document
<a href="https://bugs.webkit.org/show_bug.cgi?id=267591">https://bugs.webkit.org/show_bug.cgi?id=267591</a>

Reviewed by Yusuke Suzuki.

This PR makes querySelectorAll consult with Document.

* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::querySelectorAll):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resultForSelectorAll): Added.
(WebCore::Document::addResultForSelectorAll): Added.
(WebCore::Document::invalidateQuerySelectorAllResults): Added.
(WebCore::Document::clearQuerySelectorAllResults): Added.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/EventTarget.h:
(WebCore::EventTarget::hasValidQuerySelectorAllResults const): Added.
(WebCore::EventTarget::setHasValidQuerySelectorAllResults): Added.
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::invalidateNodeListAndCollectionCachesInAncestors):
(WebCore::Node::invalidateNodeListAndCollectionCachesInAncestorsForAttribute):
* Source/WebCore/dom/SelectorQuery.h:
(WebCore::SelectorDataList::shouldStoreInDocument const): Added.
(WebCore::SelectorQuery::shouldStoreInDocument const): Added.
* Source/WebCore/dom/StaticNodeList.cpp:
(WebCore::StaticWrapperNodeList::length const):
(WebCore::StaticWrapperNodeList::item const):
* Source/WebCore/dom/StaticNodeList.h:
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::releaseCriticalMemory):

Canonical link: <a href="https://commits.webkit.org/273107@main">https://commits.webkit.org/273107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e543c7a9476011c4cceb4466405887baa118a3d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36953 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31038 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10203 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30058 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9667 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38243 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31136 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30931 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9894 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33771 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10451 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4404 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10720 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->