### PR TITLE
Remove unused function `dateType` across various InputType files

### DIFF
--- a/Source/WebCore/html/DateInputType.cpp
+++ b/Source/WebCore/html/DateInputType.cpp
@@ -60,11 +60,6 @@ const AtomString& DateInputType::formControlType() const
     return InputTypeNames::date();
 }
 
-DateComponentsType DateInputType::dateType() const
-{
-    return DateComponentsType::Date;
-}
-
 StepRange DateInputType::createStepRange(AnyStepHandling anyStepHandling) const
 {
     ASSERT(element());

--- a/Source/WebCore/html/DateInputType.h
+++ b/Source/WebCore/html/DateInputType.h
@@ -47,7 +47,6 @@ private:
     explicit DateInputType(HTMLInputElement&);
 
     const AtomString& formControlType() const final;
-    DateComponentsType dateType() const final;
     StepRange createStepRange(AnyStepHandling) const final;
     std::optional<DateComponents> parseToDateComponents(StringView) const final;
     std::optional<DateComponents> setMillisecondToDateComponents(double) const final;

--- a/Source/WebCore/html/DateTimeLocalInputType.cpp
+++ b/Source/WebCore/html/DateTimeLocalInputType.cpp
@@ -57,11 +57,6 @@ const AtomString& DateTimeLocalInputType::formControlType() const
     return InputTypeNames::datetimelocal();
 }
 
-DateComponentsType DateTimeLocalInputType::dateType() const
-{
-    return DateComponentsType::DateTimeLocal;
-}
-
 WallTime DateTimeLocalInputType::valueAsDate() const
 {
     // valueAsDate doesn't work for the datetime-local type according to the standard.

--- a/Source/WebCore/html/DateTimeLocalInputType.h
+++ b/Source/WebCore/html/DateTimeLocalInputType.h
@@ -50,7 +50,6 @@ private:
     }
 
     const AtomString& formControlType() const final;
-    DateComponentsType dateType() const final;
     WallTime valueAsDate() const final;
     ExceptionOr<void> setValueAsDate(WallTime) const final;
     StepRange createStepRange(AnyStepHandling) const final;

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -680,11 +680,6 @@ String InputType::serialize(const Decimal&) const
     return String();
 }
 
-DateComponentsType InputType::dateType() const
-{
-    return DateComponentsType::Invalid;
-}
-
 void InputType::dispatchSimulatedClickIfActive(KeyboardEvent& event) const
 {
     ASSERT(element());

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -397,8 +397,6 @@ public:
     virtual bool receiveDroppedFiles(const DragData&);
 #endif
 
-    virtual DateComponentsType dateType() const;
-
     virtual String displayString() const;
 
     virtual String resultForDialogSubmit() const;

--- a/Source/WebCore/html/MonthInputType.cpp
+++ b/Source/WebCore/html/MonthInputType.cpp
@@ -59,11 +59,6 @@ const AtomString& MonthInputType::formControlType() const
     return InputTypeNames::month();
 }
 
-DateComponentsType MonthInputType::dateType() const
-{
-    return DateComponentsType::Month;
-}
-
 WallTime MonthInputType::valueAsDate() const
 {
     ASSERT(element());

--- a/Source/WebCore/html/MonthInputType.h
+++ b/Source/WebCore/html/MonthInputType.h
@@ -50,7 +50,6 @@ private:
     }
 
     const AtomString& formControlType() const final;
-    DateComponentsType dateType() const final;
     WallTime valueAsDate() const final;
     String serializeWithMilliseconds(double) const final;
     Decimal parseToNumber(const String&, const Decimal&) const final;

--- a/Source/WebCore/html/TimeInputType.cpp
+++ b/Source/WebCore/html/TimeInputType.cpp
@@ -63,11 +63,6 @@ const AtomString& TimeInputType::formControlType() const
     return InputTypeNames::time();
 }
 
-DateComponentsType TimeInputType::dateType() const
-{
-    return DateComponentsType::Time;
-}
-
 Decimal TimeInputType::defaultValueForStepUp() const
 {
     double current = WallTime::now().secondsSinceEpoch().milliseconds();

--- a/Source/WebCore/html/TimeInputType.h
+++ b/Source/WebCore/html/TimeInputType.h
@@ -47,7 +47,6 @@ private:
     explicit TimeInputType(HTMLInputElement&);
 
     const AtomString& formControlType() const final;
-    DateComponentsType dateType() const final;
     Decimal defaultValueForStepUp() const final;
     StepRange createStepRange(AnyStepHandling) const final;
     std::optional<DateComponents> parseToDateComponents(StringView) const final;

--- a/Source/WebCore/html/WeekInputType.cpp
+++ b/Source/WebCore/html/WeekInputType.cpp
@@ -54,11 +54,6 @@ const AtomString& WeekInputType::formControlType() const
     return InputTypeNames::week();
 }
 
-DateComponentsType WeekInputType::dateType() const
-{
-    return DateComponentsType::Week;
-}
-
 StepRange WeekInputType::createStepRange(AnyStepHandling anyStepHandling) const
 {
     ASSERT(element());

--- a/Source/WebCore/html/WeekInputType.h
+++ b/Source/WebCore/html/WeekInputType.h
@@ -50,7 +50,6 @@ private:
     }
 
     const AtomString& formControlType() const final;
-    DateComponentsType dateType() const final;
     StepRange createStepRange(AnyStepHandling) const final;
     std::optional<DateComponents> parseToDateComponents(StringView) const final;
     std::optional<DateComponents> setMillisecondToDateComponents(double) const final;


### PR DESCRIPTION
<pre>
Remove unused function `dateType` across various InputType files
<a href="https://bugs.webkit.org/show_bug.cgi?id=267592">https://bugs.webkit.org/show_bug.cgi?id=267592</a>

Reviewed by NOBODY (OOPS!).

This patch is to remove unused function `dateType` across various InputType files.

* Source/WebCore/html/DateInputType.cpp:
(DateInputType::dateType): Removed
* Source/WebCore/html/DateInputType.h: Remove 'function' definition
* Source/WebCore/html/DateTimeLocalInputType.cpp:
(DateTimeLocalInputType::dateType): Removed
* Source/WebCore/html/DateTimeLocalInputType.h: Remove 'function' definition
* Source/WebCore/html/InputType.cpp:
(InputType::dateType): Removed
* Source/WebCore/html/InputType.h: Remove 'function' definition
* Source/WebCore/html/MonthInputType.cpp:
(MonthInputType::dateType): Removed
* Source/WebCore/html/MonthInputType.h: Remove 'function' definition
* Source/WebCore/html/TimeInputType.cpp:
(TimeInputType::dateType): Removed
* Source/WebCore/html/TimeInputType.h: Remove 'function' definition
* Source/WebCore/html/WeekInputType.cpp:
(WeekInputType::dateType): Removed
* Source/WebCore/html/WeekInputType.h: Remove 'function' definition
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d53d24087be1e49d09e2386b2fbed07f66d23067

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34229 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13038 "Hash d53d2408 for PR 22827 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36219 "Hash d53d2408 for PR 22827 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/36918 "Hash d53d2408 for PR 22827 does not build (failure)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35313 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15425 "Hash d53d2408 for PR 22827 does not build (failure)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/10168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/36918 "Hash d53d2408 for PR 22827 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34741 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/15425 "Hash d53d2408 for PR 22827 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/36219 "Hash d53d2408 for PR 22827 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/36918 "Hash d53d2408 for PR 22827 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/15425 "Hash d53d2408 for PR 22827 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/36219 "Hash d53d2408 for PR 22827 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38208 "Hash d53d2408 for PR 22827 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/15425 "Hash d53d2408 for PR 22827 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/36219 "Hash d53d2408 for PR 22827 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/38208 "Hash d53d2408 for PR 22827 does not build (failure)") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/10168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/38208 "Hash d53d2408 for PR 22827 does not build (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/11654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/36219 "Hash d53d2408 for PR 22827 does not build (failure)") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/10426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/10687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->