### PR TITLE
[FreeType] Centralize FcPattern creation

### DIFF
--- a/Source/WebCore/platform/FreeType.cmake
+++ b/Source/WebCore/platform/FreeType.cmake
@@ -9,6 +9,7 @@ list(APPEND WebCore_SOURCES
     platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
     platform/graphics/freetype/FontPlatformDataFreeType.cpp
     platform/graphics/freetype/FontSetCache.cpp
+    platform/graphics/freetype/FontconfigUtilities.cpp
     platform/graphics/freetype/GlyphPageTreeNodeFreeType.cpp
     platform/graphics/freetype/RefPtrFontconfig.cpp
     platform/graphics/freetype/SimpleFontDataFreeType.cpp

--- a/Source/WebCore/platform/graphics/freetype/FontSetCache.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontSetCache.cpp
@@ -24,6 +24,7 @@
 #include "CairoUtilities.h"
 #include "CharacterProperties.h"
 #include "FontCache.h"
+#include "FontconfigUtilities.h"
 
 namespace WebCore {
 
@@ -44,7 +45,7 @@ FontSetCache::FontSet::FontSet(RefPtr<FcPattern>&& fontPattern)
 RefPtr<FcPattern> FontSetCache::bestForCharacters(const FontDescription& fontDescription, bool preferColoredFont, StringView stringView)
 {
     auto addResult = m_cache.ensure(FontSetCacheKey(fontDescription, preferColoredFont), [&fontDescription, preferColoredFont]() -> std::unique_ptr<FontSetCache::FontSet> {
-        RefPtr<FcPattern> pattern = adoptRef(FcPatternCreate());
+        RefPtr<FcPattern> pattern = fontPatternMatchStrategy();
         FcPatternAddBool(pattern.get(), FC_SCALABLE, FcTrue);
 #ifdef FC_COLOR
         if (preferColoredFont)
@@ -55,9 +56,6 @@ RefPtr<FcPattern> FontSetCache::bestForCharacters(const FontDescription& fontDes
         if (!FontCache::configurePatternForFontDescription(pattern.get(), fontDescription))
             return nullptr;
 
-        FcConfigSubstitute(nullptr, pattern.get(), FcMatchPattern);
-        cairo_ft_font_options_substitute(getDefaultCairoFontOptions(), pattern.get());
-        FcDefaultSubstitute(pattern.get());
         return makeUnique<FontSetCache::FontSet>(WTFMove(pattern));
     });
 

--- a/Source/WebCore/platform/graphics/freetype/FontconfigUtilities.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontconfigUtilities.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2024 Sony Interactive Entertainment Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FontconfigUtilities.h"
+
+#if USE(FREETYPE)
+#include <fontconfig/fontconfig.h>
+
+#if USE(CAIRO)
+#include "CairoUtilities.h"
+#endif
+
+namespace WebCore {
+
+RefPtr<FcPattern> fontPatternMatchStrategy()
+{
+    static FcPattern* pattern = nullptr;
+    static std::once_flag flag;
+    std::call_once(flag, [](FcPattern*) {
+        pattern = FcPatternCreate();
+        FcConfigSubstitute(nullptr, pattern, FcMatchPattern);
+#if USE(CAIRO)
+        cairo_ft_font_options_substitute(getDefaultCairoFontOptions(), pattern);
+#endif
+        FcDefaultSubstitute(pattern);
+        FcPatternDel(pattern, FC_FAMILY);
+        FcConfigSubstitute(nullptr, pattern, FcMatchFont);
+    }, pattern);
+    return adoptRef(FcPatternDuplicate(pattern));
+}
+
+} // namespace WebCore
+
+#endif // USE(FREETYPE)

--- a/Source/WebCore/platform/graphics/freetype/FontconfigUtilities.h
+++ b/Source/WebCore/platform/graphics/freetype/FontconfigUtilities.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Sony Interactive Entertainment Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(FREETYPE)
+
+#include "RefPtrFontconfig.h"
+
+namespace WebCore {
+
+// Get some generic default settings from fontconfig for web fonts. Strategy
+// from Behdad Esfahbod in https://code.google.com/p/chromium/issues/detail?id=173207#c35
+RefPtr<FcPattern> fontPatternMatchStrategy();
+
+} // namespace WebCore
+
+#endif // USE(FREETYPE)


### PR DESCRIPTION
#### 76d359b2b1931a8e41493b236af40729ba254fbe
<pre>
[FreeType] Centralize FcPattern creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=267610">https://bugs.webkit.org/show_bug.cgi?id=267610</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp:
* Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp:
* Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp:
* Source/WebCore/platform/graphics/freetype/FontSetCache.cpp:
* Source/WebCore/platform/graphics/freetype/FontconfigUtilities.cpp: Added.
* Source/WebCore/platform/graphics/freetype/FontconfigUtilities.h: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76d359b2b1931a8e41493b236af40729ba254fbe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34322 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37000 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31061 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35402 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10242 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30072 "Failure limit exceed. At least found 496 new test failures: accessibility/checkbox-radio-element-rect.html, accessibility/content-editable-as-textarea.html, accessibility/dynamic-changes-update-position.html, accessibility/image-link.html, accessibility/image-map2.html, accessibility/lists.html, accessibility/node-only-object-element-rect.html, accessibility/press-targets-center-point.html, accessibility/table-attributes.html, accessibility/table-cell-spans.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30607 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9695 "Found 2 new API test failures: /TestWebCore:ComplexTextControllerTest.TotalWidthWithJustification, /TestWebCore:ComplexTextControllerTest.InitialAdvanceInRTLNoOrigins (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38284 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31168 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30974 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35867 "Failure limit exceed. At least found 498 new test failures: accessibility/checkbox-radio-element-rect.html, accessibility/content-editable-as-textarea.html, accessibility/dynamic-changes-update-position.html, accessibility/gtk/object-attributes.html, accessibility/gtk/text-at-offset-wrapped-lines.html, accessibility/gtk/xml-roles-exposed.html, accessibility/image-link.html, accessibility/image-map2.html, accessibility/lists.html, accessibility/press-targets-center-point.html ... (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9916 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7790 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33812 "Found 2 new API test failures: /TestWebCore:ComplexTextControllerTest.TotalWidthWithJustification, /TestWebCore:ComplexTextControllerTest.InitialAdvanceInRTLNoOrigins (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11712 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10473 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10753 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->