### PR TITLE
Add initial support for Keyboard Lock

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6183,6 +6183,9 @@ webkit.org/b/298948 imported/w3c/web-platform-tests/import-maps/http-url-like-sp
 # WebKit2 Only
 fullscreen/fullscreen-enter-bottom-padding-animation.html [ Skip ]
 
+# Fullscreen based keyboard lock api test, by default it is off, so the test should be timed out
+fullscreen/full-screen-keyboard-lock-option.html [ Timeout ]
+
 # Extra logging needed to be silenced:
 http/tests/loading/oauth.html [ DumpJSConsoleLogInStdErr ]
 http/tests/security/contentSecurityPolicy/video-with-https-url-allowed-by-csp-media-src-star.html [ DumpJSConsoleLogInStdErr ]

--- a/LayoutTests/fullscreen/full-screen-keyboard-lock-option-enabled-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-keyboard-lock-option-enabled-expected.txt
@@ -1,0 +1,8 @@
+Test passes if ESC key received by the test case after enter to fullscreen.
+
+EVENT(fullscreenchange)
+EXPECTED (document.fullscreenElement !== null == 'true') OK
+EVENT(keypress)
+EXPECTED (event.keyCode == '27') OK
+END OF TEST
+

--- a/LayoutTests/fullscreen/full-screen-keyboard-lock-option-enabled.html
+++ b/LayoutTests/fullscreen/full-screen-keyboard-lock-option-enabled.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>This tests that full screen mode with keyboard lock option allows ESC key event.</title>
+</head>
+<body>
+    <div width: 100%; height: 100%;" id="target">
+        <p>Test passes if ESC key received by the test case after enter to fullscreen.</p>
+    </div>
+    <script src="full-screen-test.js"></script>
+    <script>
+    window.internals.settings.setFullScreenKeyboardLock(true);
+
+    runWithKeyDown(async () => {
+        try {
+            const target = document.querySelector("#target");
+            await target.requestFullscreen({ keyboardLock: "browser" });
+
+            // Wait for fullscreen change event
+            await new Promise((resolve) => {
+                waitForEvent(document, "fullscreenchange", resolve, /*endit=*/ false, /*once=*/ true);
+            });
+
+            testExpected("document.fullscreenElement !== null", true);
+
+            // Wait for Escape key press and test inside the callback
+            await new Promise((resolve) => {
+                waitForEvent(document, "keypress", (event) => {
+                    testExpected("event.keyCode", 27); // 'Escape'
+                    resolve();
+                }, /*endit=*/ false, /*once=*/ true);
+                eventSender.keyDown("escape");
+            });
+
+        } catch (err) {
+            logResult(false, `An error occurred while trying to enter full-screen mode: ${err.message}`);
+        } finally {
+            endTest();
+        }
+    });
+    </script>
+
+
+</body>
+</html>

--- a/LayoutTests/fullscreen/full-screen-keyboard-lock-option-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-keyboard-lock-option-expected.txt
@@ -1,0 +1,7 @@
+FAIL: Timed out waiting for notifyDone to be called
+
+Test passes if ESC key received by the test case after enter to fullscreen.
+
+EVENT(fullscreenchange)
+EXPECTED (document.fullscreenElement !== null == 'true') OK
+

--- a/LayoutTests/fullscreen/full-screen-keyboard-lock-option.html
+++ b/LayoutTests/fullscreen/full-screen-keyboard-lock-option.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>This tests that full screen mode with keyboard lock option allows ESC key event.</title>
+</head>
+<body>
+    <div width: 100%; height: 100%;" id="target">
+        <p>Test passes if ESC key received by the test case after enter to fullscreen.</p>
+    </div>
+    <script src="full-screen-test.js"></script>
+    <script>
+    window.internals.settings.setFullScreenKeyboardLock(false);
+
+    runWithKeyDown(async () => {
+        try {
+            const target = document.querySelector("#target");
+            await target.requestFullscreen({ keyboardLock: "browser" });
+
+            // Wait for fullscreen change event
+            await new Promise((resolve) => {
+                waitForEvent(document, "fullscreenchange", resolve, /*endit=*/ false, /*once=*/ true);
+            });
+
+            testExpected("document.fullscreenElement !== null", true);
+
+            // Wait for Escape key press and test inside the callback
+            await new Promise((resolve) => {
+                waitForEvent(document, "keypress", (event) => {
+                    testExpected("event.keyCode", 27); // 'Escape'
+                    resolve();
+                }, /*endit=*/ false, /*once=*/ true);
+                eventSender.keyDown("escape");
+            });
+
+        } catch (err) {
+            logResult(false, `An error occurred while trying to enter full-screen mode: ${err.message}`);
+        } finally {
+            endTest();
+        }
+    });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1361,6 +1361,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/FragmentDirectiveParser.h
     dom/FragmentDirectiveRangeFinder.h
     dom/FragmentDirectiveUtilities.h
+    dom/FullscreenOptions.h
     dom/GCReachableRef.h
     dom/GetHTMLOptions.h
     dom/IdTargetObserver.h

--- a/Source/WebCore/dom/DocumentFullscreen.h
+++ b/Source/WebCore/dom/DocumentFullscreen.h
@@ -28,6 +28,7 @@
 #if ENABLE(FULLSCREEN_API)
 
 #include <WebCore/Document.h>
+#include <WebCore/FullscreenOptions.h>
 #include <WebCore/GCReachableRef.h>
 #include <WebCore/HTMLMediaElement.h>
 #include <WebCore/HTMLMediaElementEnums.h>
@@ -79,6 +80,10 @@ public:
     // Legacy Mozilla API.
     bool isFullscreen() const { return fullscreenElement(); }
     bool isFullscreenKeyboardInputAllowed() const { return fullscreenElement() && m_areKeysEnabledInFullscreen; }
+
+    // Fullscreen Keyboard Lock
+    void setKeyboardLockMode(FullscreenOptions::KeyboardLock mode) { m_keyboardLockMode = mode; }
+    bool isBrowserKeyboardLockEnabled() const { return m_keyboardLockMode == FullscreenOptions::KeyboardLock::Browser; }
 
     enum FullscreenCheckType {
         EnforceIFrameAllowFullscreenRequirement,
@@ -137,6 +142,9 @@ private:
     bool m_areKeysEnabledInFullscreen { false };
     bool m_isAnimatingFullscreen { false };
     bool m_pendingExitFullscreen { false };
+
+    // Fullscreen Keyboard Lock
+    FullscreenOptions::KeyboardLock m_keyboardLockMode { FullscreenOptions::KeyboardLock::None };
 
 #if !RELEASE_LOG_DISABLED
     const uint64_t m_logIdentifier;

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -617,6 +617,7 @@ private:
 
 #if ENABLE(FULLSCREEN_API)
     bool isKeyEventAllowedInFullScreen(const PlatformKeyboardEvent&) const;
+    void holdEscKeyEventTimerFired();
 #endif
 
 #if ENABLE(CURSOR_VISIBILITY)
@@ -702,6 +703,10 @@ private:
 
 #if ENABLE(CURSOR_VISIBILITY)
     Timer m_autoHideCursorTimer;
+#endif
+
+#if ENABLE(FULLSCREEN_API)
+    Timer m_holdEscKeyEventTimer;
 #endif
 
 #if ENABLE(DRAG_SUPPORT)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1376,6 +1376,10 @@ public:
     void updateDisplayEDRSuppression();
 #endif
 
+    // Checking hardware keyboard attached
+    void setHardwareKeyboardAttached(bool attached) { m_hardwareKeyboardAttached = attached; }
+    bool hardwareKeyboardAttached() const { return m_hardwareKeyboardAttached; }
+
 private:
     explicit Page(PageConfiguration&&);
 
@@ -1843,6 +1847,13 @@ private:
 
 #if ENABLE(MODEL_ELEMENT)
     bool m_modelLoadDelaysDisabledForTesting { false };
+#endif
+
+    // Checking hardware keyboard attached
+#if PLATFORM(IOS_FAMILY)
+    bool m_hardwareKeyboardAttached { false };
+#else
+    bool m_hardwareKeyboardAttached { true };
 #endif
 }; // class Page
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1008,6 +1008,8 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     page->setGroupName(m_pageGroup->identifier());
     page->setUserInterfaceLayoutDirection(m_userInterfaceLayoutDirection);
 #if PLATFORM(IOS_FAMILY)
+    // Set hardware keyboard attached status
+    page->setHardwareKeyboardAttached(m_keyboardIsAttached);
     page->setTextAutosizingWidth(parameters.textAutosizingWidth);
     setOverrideViewportArguments(parameters.overrideViewportArguments);
 #endif


### PR DESCRIPTION
#### ceba7343025b0e47c2903877198c8bdd5aeda851
<pre>
Add initial support for Keyboard Lock
<a href="https://bugs.webkit.org/show_bug.cgi?id=264843">https://bugs.webkit.org/show_bug.cgi?id=264843</a>

Reviewed by Brent Fulgham.

Implementation of Browser Keyboard Lock implementation as FullScreen API option.

Tests: fullscreen/full-screen-keyboard-lock-option-enabled.html
       fullscreen/full-screen-keyboard-lock-option.html
* LayoutTests/TestExpectations:
* LayoutTests/fullscreen/full-screen-keyboard-lock-option-enabled-expected.txt: Added.
* LayoutTests/fullscreen/full-screen-keyboard-lock-option-enabled.html: Added.
* LayoutTests/fullscreen/full-screen-keyboard-lock-option-expected.txt: Added.
* LayoutTests/fullscreen/full-screen-keyboard-lock-option.html: Added.
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/DocumentFullscreen.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::requestFullscreen):
* Source/WebCore/dom/FullscreenOptions.idl:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::EventHandler):
(WebCore::EventHandler::clear):
(WebCore::EventHandler::holdEscKeyEventTimerFired):
(WebCore::EventHandler::internalKeyEvent):
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/Page.h:
(WebCore::Page::setHardwareKeyboardAttached):
(WebCore::Page::hardwareKeyboardAttached const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_toolbarsAreVisible):

Canonical link: <a href="https://commits.webkit.org/300356@main">https://commits.webkit.org/300356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3a0cd2c02e434524d2d98a73c593eeb4b3abd03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/122207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/41910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/32579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/128785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/74301 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/124083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/42624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/50503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/92893 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/61748 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/125159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/34004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/109438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/73547 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/33024 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/27600 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/72271 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/103512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/27794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/131531 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/120733 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/49146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/37391 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/101454 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/49521 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/105649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/101324 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25703 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/46695 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/24814 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/45897 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/49003 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/54738 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/48473 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/51823 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/50153 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->