### PR TITLE
Remove BitmapImage::updateFromSettings()

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1649,11 +1649,17 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(Document& document, Ca
                 return { };
             image = bitmapImage.copyRef();
         }
-        bitmapImage->updateFromSettings(document.settings());
+
         shouldPostProcess = false;
     }
 
-    ImagePaintingOptions options = { op, blendMode, orientation };
+    ImagePaintingOptions options = {
+        op,
+        blendMode,
+        orientation,
+        document.settings().imageSubsamplingEnabled() ? AllowImageSubsampling::Yes : AllowImageSubsampling::No,
+        document.settings().showDebugBorders() ? ShowDebugBackground::Yes : ShowDebugBackground::No
+    };
 
     bool repaintEntireCanvas = false;
     if (rectContainsCanvas(normalizedDstRect)) {

--- a/Source/WebCore/platform/graphics/ImagePaintingOptions.h
+++ b/Source/WebCore/platform/graphics/ImagePaintingOptions.h
@@ -28,6 +28,7 @@
 #include "DecodingOptions.h"
 #include "GraphicsTypes.h"
 #include "ImageOrientation.h"
+#include "ImageTypes.h"
 #include <initializer_list>
 #include <wtf/Forward.h>
 
@@ -40,7 +41,9 @@ struct ImagePaintingOptions {
         || std::is_same_v<Type, DecodingMode>
         || std::is_same_v<Type, ImageOrientation>
         || std::is_same_v<Type, ImageOrientation::Orientation>
-        || std::is_same_v<Type, InterpolationQuality>;
+        || std::is_same_v<Type, InterpolationQuality>
+        || std::is_same_v<Type, AllowImageSubsampling>
+        || std::is_same_v<Type, ShowDebugBackground>;
 
     // This is a single-argument initializer to support pattern of
     // ImageDrawResult drawImage(..., ImagePaintingOptions = { ImageOrientation::Orientation::FromImage });
@@ -83,6 +86,8 @@ struct ImagePaintingOptions {
     DecodingMode decodingMode() const { return m_decodingMode; }
     ImageOrientation orientation() const { return m_orientation; }
     InterpolationQuality interpolationQuality() const { return m_interpolationQuality; }
+    AllowImageSubsampling allowImageSubsampling() const { return m_allowImageSubsampling; }
+    ShowDebugBackground showDebugBackground() const { return m_showDebugBackground; }
 
 private:
     void setOption(CompositeOperator compositeOperator) { m_compositeOperator = compositeOperator; }
@@ -91,12 +96,16 @@ private:
     void setOption(ImageOrientation orientation) { m_orientation = orientation.orientation(); }
     void setOption(ImageOrientation::Orientation orientation) { m_orientation = orientation; }
     void setOption(InterpolationQuality interpolationQuality) { m_interpolationQuality = interpolationQuality; }
+    void setOption(AllowImageSubsampling allowImageSubsampling) { m_allowImageSubsampling = allowImageSubsampling; }
+    void setOption(ShowDebugBackground showDebugBackground) { m_showDebugBackground = showDebugBackground; }
 
     BlendMode m_blendMode : 5 { BlendMode::Normal };
     DecodingMode m_decodingMode : 3 { DecodingMode::Synchronous };
     CompositeOperator m_compositeOperator : 4 { CompositeOperator::SourceOver };
     ImageOrientation::Orientation m_orientation : 4 { ImageOrientation::Orientation::None };
     InterpolationQuality m_interpolationQuality : 4 { InterpolationQuality::Default };
+    AllowImageSubsampling m_allowImageSubsampling : 1 { AllowImageSubsampling::No };
+    ShowDebugBackground m_showDebugBackground : 1 { ShowDebugBackground::No };
 };
 static_assert(sizeof(ImagePaintingOptions) <= sizeof(uint64_t), "Pass by value");
 

--- a/Source/WebCore/platform/graphics/ImageTypes.h
+++ b/Source/WebCore/platform/graphics/ImageTypes.h
@@ -92,4 +92,14 @@ enum class ImageDrawResult {
     DidDraw
 };
 
+enum class ShowDebugBackground : bool {
+    No,
+    Yes
+};
+
+enum class AllowImageSubsampling : bool {
+    No,
+    Yes
+};
+
 }

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "BackgroundPainter.h"
 
-#include "BitmapImage.h"
 #include "BorderPainter.h"
 #include "CachedImage.h"
 #include "ColorBlending.h"
@@ -405,15 +404,14 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
         if (!geometry.destinationRect.isEmpty() && (image = bgImage->image(backgroundObject ? backgroundObject : &m_renderer, geometry.tileSize, isFirstLine))) {
             context.setDrawLuminanceMask(bgLayer.maskMode() == MaskMode::Luminance);
 
-            if (RefPtr bitmapImage = dynamicDowncast<BitmapImage>(image))
-                bitmapImage->updateFromSettings(document().settings());
-
             ImagePaintingOptions options = {
                 op == CompositeOperator::SourceOver ? bgLayer.compositeForPainting() : op,
                 bgLayer.blendMode(),
                 m_renderer.decodingModeForImageDraw(*image, m_paintInfo),
                 ImageOrientation::Orientation::FromImage,
-                m_renderer.chooseInterpolationQuality(context, *image, &bgLayer, geometry.tileSize)
+                m_renderer.chooseInterpolationQuality(context, *image, &bgLayer, geometry.tileSize),
+                document().settings().imageSubsamplingEnabled() ? AllowImageSubsampling::Yes : AllowImageSubsampling::No,
+                document().settings().showDebugBorders() ? ShowDebugBackground::Yes : ShowDebugBackground::No
             };
 
             auto drawResult = context.drawTiledImage(*image, geometry.destinationRect, toLayoutPoint(geometry.relativePhase()), geometry.tileSize, geometry.spaceSize, options);

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -700,14 +700,14 @@ ImageDrawResult RenderImage::paintIntoRect(PaintInfo& paintInfo, const FloatRect
 
     // FIXME: Document when image != img.get().
     auto* image = imageResource().image().get();
-    if (RefPtr bitmapImage = dynamicDowncast<BitmapImage>(image))
-        bitmapImage->updateFromSettings(settings());
 
     ImagePaintingOptions options = {
         imageElement ? imageElement->compositeOperator() : CompositeOperator::SourceOver,
         decodingModeForImageDraw(*image, paintInfo),
         imageOrientation(),
-        image ? chooseInterpolationQuality(paintInfo.context(), *image, image, LayoutSize(rect.size())) : InterpolationQuality::Default
+        image ? chooseInterpolationQuality(paintInfo.context(), *image, image, LayoutSize(rect.size())) : InterpolationQuality::Default,
+        settings().imageSubsamplingEnabled() ? AllowImageSubsampling::Yes : AllowImageSubsampling::No,
+        settings().showDebugBorders() ? ShowDebugBackground::Yes : ShowDebugBackground::No
     };
 
     auto drawResult = paintInfo.context().drawImage(*img, rect, options);

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -173,14 +173,13 @@ ImageDrawResult RenderSVGImage::paintIntoRect(PaintInfo& paintInfo, const FloatR
     if (!image || image->isNull())
         return ImageDrawResult::DidNothing;
 
-    if (auto* bitmapImage = dynamicDowncast<BitmapImage>(*image))
-        bitmapImage->updateFromSettings(settings());
-
     ImagePaintingOptions options {
         CompositeOperator::SourceOver,
         DecodingMode::Synchronous,
         imageOrientation(),
-        InterpolationQuality::Default
+        InterpolationQuality::Default,
+        settings().imageSubsamplingEnabled() ? AllowImageSubsampling::Yes : AllowImageSubsampling::No,
+        settings().showDebugBorders() ? ShowDebugBackground::Yes : ShowDebugBackground::No
     };
 
     auto drawResult = paintInfo.context().drawImage(*image, rect, sourceRect, options);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1078,7 +1078,7 @@ static PDFDocumentImage* pdfDocumentImageFromImageElement(HTMLImageElement& elem
 unsigned Internals::imageFrameIndex(HTMLImageElement& element)
 {
     auto* bitmapImage = bitmapImageFromImageElement(element);
-    return bitmapImage ? bitmapImage->currentFrame() : 0;
+    return bitmapImage ? bitmapImage->currentFrameIndex() : 0;
 }
 
 unsigned Internals::imageFrameCount(HTMLImageElement& element)


### PR DESCRIPTION
#### 0c6288be7ffe1f75fcd39a6bd2aa10ee6afa993f
<pre>
Remove BitmapImage::updateFromSettings()
<a href="https://bugs.webkit.org/show_bug.cgi?id=267607">https://bugs.webkit.org/show_bug.cgi?id=267607</a>
<a href="https://rdar.apple.com/121077174">rdar://121077174</a>

Reviewed by Cameron McCormack.

Calculate all the image painting options before calling BitmapImage::draw().
Remove all the calls to BitmapImage::updateFromSettings() and pass the calculated
AllowImageSubsampling and ShowDebugBackground through ImagePaintingOptions.

The first frame of an animated image had to be decoded synchronously. In fact
this restriction is not needed. The rules to decode the static image and the
first frame of an animated image should be the same.

Late decoded frames of an animated images was showing a yellow rectangle if
showDebugBackground is enabled. This is not really needed since the animation
does not advance until the next frame is fully decoded.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawImage):
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::draw):
(WebCore::BitmapImage::shouldUseAsyncDecodingForAnimatedImages const):
(WebCore::BitmapImage::subsamplingLevelForScaleFactor):
(WebCore::BitmapImage::internalStartAnimation):
(WebCore::BitmapImage::advanceAnimation):
(WebCore::BitmapImage::decode):
(WebCore::BitmapImage::updateFromSettings): Deleted.
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/ImagePaintingOptions.h:
(WebCore::ImagePaintingOptions::allowImageSubsampling const):
(WebCore::ImagePaintingOptions::showDebugBackground const):
(WebCore::ImagePaintingOptions::setOption):
* Source/WebCore/platform/graphics/ImageTypes.h:
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::decodingModeForImageDraw const):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::paintIntoRect):
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::paintIntoRect):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::imageFrameIndex):

Canonical link: <a href="https://commits.webkit.org/273528@main">https://commits.webkit.org/273528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f3509fe8133d7933dae4ad6f8096f7fc9041339

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38396 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11626 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31732 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10845 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39641 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32403 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32209 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36804 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34885 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12757 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8144 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11825 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->