### PR TITLE
Overflow should establish an independent formatting context on only block boxes.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/overflow-hidden-does-not-prohibit-subgrid-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/overflow-hidden-does-not-prohibit-subgrid-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/overflow-hidden-does-not-prohibit-subgrid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/overflow-hidden-does-not-prohibit-subgrid.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#overflow-control">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#track-sizing">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="overflow on a grid item does not cause it to establish an independent formatting context, and as a result does not prohibit subgrid">
+<style>
+.grid {
+  display: inline-grid;
+  grid-template: auto auto / auto auto;
+  background-color: green;
+}
+.subgrid {
+    grid-row: span 2;
+    grid-column: 2;
+    display: grid;
+    grid-template-rows: subgrid;
+    overflow: hidden;
+}
+.item {
+    width: 50px;
+    height: 50px;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<div class="grid">
+  <div class="item" style="grid-row: 1;"></div>
+  <div class="subgrid">
+    <div class="item" style="grid-row: 2;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -643,7 +643,6 @@ public:
 
     bool isGridItem() const { return parent() && parent()->isRenderGrid() && !isExcludedFromNormalLayout(); }
     bool isFlexItem() const { return parent() && parent()->isRenderFlexibleBox() && !isExcludedFromNormalLayout(); }
-    inline bool isBlockLevelBox() const;
 
     virtual void adjustBorderBoxRectForPainting(LayoutRect&) { };
 

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -49,7 +49,6 @@ inline bool RenderBox::hasScrollableOverflowX() const { return scrollsOverflowX(
 inline bool RenderBox::hasScrollableOverflowY() const { return scrollsOverflowY() && hasVerticalOverflow(); }
 inline bool RenderBox::hasVerticalOverflow() const { return scrollHeight() != roundToInt(paddingBoxHeight()); }
 inline LayoutUnit RenderBox::intrinsicLogicalHeight() const { return style().isHorizontalWritingMode() ? intrinsicSize().height() : intrinsicSize().width(); }
-inline bool RenderBox::isBlockLevelBox() const { return style().isDisplayBlockLevel(); }
 inline bool RenderBox::isLeftLayoutOverflowAllowed() const { return !style().isLeftToRightDirection() && isHorizontalWritingMode(); }
 inline bool RenderBox::isTopLayoutOverflowAllowed() const { return !style().isLeftToRightDirection() && !isHorizontalWritingMode(); }
 inline LayoutUnit RenderBox::logicalBottom() const { return logicalTop() + logicalHeight(); }

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2322,7 +2322,7 @@ bool RenderElement::createsNewFormattingContext() const
 
 bool RenderElement::establishesIndependentFormattingContext() const
 {
-    return isFloatingOrOutOfFlowPositioned() || hasPotentiallyScrollableOverflow() || style().containsLayout() || paintContainmentApplies() || (style().isDisplayBlockLevel() && style().blockStepSize());
+    return isFloatingOrOutOfFlowPositioned() || (isBlockBox() && hasPotentiallyScrollableOverflow()) || style().containsLayout() || paintContainmentApplies() || (style().isDisplayBlockLevel() && style().blockStepSize());
 }
 
 FloatRect RenderElement::referenceBoxRect(CSSBoxType boxType) const

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -220,6 +220,12 @@ bool RenderObject::isHTMLMarquee() const
     return node() && node()->renderer() == this && node()->hasTagName(marqueeTag);
 }
 
+bool RenderObject::isBlockBox() const
+{
+    // A block-level box that is also a block container.
+    return isBlockLevelBox() && isBlockContainer();
+}
+
 bool RenderObject::isBlockContainer() const
 {
     auto display = style().display();

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -639,6 +639,8 @@ public:
     virtual bool hasIntrinsicAspectRatio() const { return isReplacedOrInlineBlock() && (isImage() || isRenderVideo() || isRenderHTMLCanvas()); }
     bool isAnonymous() const { return m_typeFlags.contains(TypeFlag::IsAnonymous); }
     bool isAnonymousBlock() const;
+    bool isBlockBox() const;
+    inline bool isBlockLevelBox() const;
     bool isBlockContainer() const;
 
     bool isFloating() const { return m_stateBitfields.hasFlag(StateFlag::Floating); }

--- a/Source/WebCore/rendering/RenderObjectInlines.h
+++ b/Source/WebCore/rendering/RenderObjectInlines.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 inline bool RenderObject::hasTransformOrPerspective() const { return hasTransformRelatedProperty() && (isTransformed() || style().hasPerspective()); }
 inline bool RenderObject::isAtomicInlineLevelBox() const { return style().isDisplayInlineType() && !(style().display() == DisplayType::Inline && !isReplacedOrInlineBlock()); }
+inline bool RenderObject::isBlockLevelBox() const { return style().isDisplayBlockLevel(); }
 inline bool RenderObject::isTransformed() const { return hasTransformRelatedProperty() && (style().affectsTransform() || hasSVGTransform()); }
 inline bool RenderObject::preservesNewline() const { return !isRenderSVGInlineText() && style().preserveNewline(); }
 inline Ref<Document> RenderObject::protectedDocument() const { return document(); }


### PR DESCRIPTION
#### 78a954e5a2bd3f1acacb08e8fd5c370809ea4fe7
<pre>
Overflow should establish an independent formatting context on only block boxes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267085">https://bugs.webkit.org/show_bug.cgi?id=267085</a>
<a href="https://rdar.apple.com/problem/120848131">rdar://problem/120848131</a>

Reviewed by Tim Nguyen.

css-overflow-3 states: If the computed value of overflow on a block box
is neither visible nor clip nor a combination thereof, it establishes
an independent formatting context for its contents.
<a href="https://drafts.csswg.org/css-overflow-3/#overflow-control">https://drafts.csswg.org/css-overflow-3/#overflow-control</a>

This means other types of boxes (e.g. grid items or flex items)
should not be establshing independent formatting contexts. This is
important in cases such as when a grid item is also a subgrid. If a grid
item which is supposed to be a subgrid establishes an independent
formatting context (e.g. due to layout containment), then the grid item
would not actually be a subgrid. A grid item with certain values of
overflow do not appear to be a case in which this would occur.

Currently establishesIndependentFormattingContext returns true
unconditionally if hasPotentiallyScrollableOverflow() returns true.
Instead, we should make sure this only occurs if the box is a block box
to match the spec.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/overflow-hidden-does-not-prohibit-subgrid-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/overflow-hidden-does-not-prohibit-subgrid.html: Added.
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::isFlexItem const):
* Source/WebCore/rendering/RenderBoxInlines.h:
(WebCore::RenderBox::intrinsicLogicalHeight const):
(WebCore::RenderBox::isBlockLevelBox const): Deleted.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::establishesIndependentFormattingContext const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::isBlockBox const):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderObjectInlines.h:
(WebCore::RenderObject::isBlockLevelBox const):

Canonical link: <a href="https://commits.webkit.org/273134@main">https://commits.webkit.org/273134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8df1e194bc9e721e82db3278aa8596b24240e4a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13145 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36330 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37017 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31071 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35419 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30079 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11118 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30619 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9708 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9798 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38301 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31183 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35880 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33811 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30291 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7905 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10483 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->