### PR TITLE
Remove additional UA stylesheet rule for `audio` element from mediaControls.css

### DIFF
--- a/Source/WebCore/css/mediaControls.css
+++ b/Source/WebCore/css/mediaControls.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2010, 2011, 2013, 2014 Apple Inc.  All rights reserved.
+ * Copyright (C) 2009-2024 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,12 +27,6 @@
 @namespace "http://www.w3.org/1999/xhtml";
 
 /* media controls */
-
-audio {
-    width: 200px;
-    height: 16px;
-}
-
 ::-webkit-media-controls {
     width: inherit;
     height: inherit;


### PR DESCRIPTION
#### f2379cbda4fa28879673e949ae84b5c4a6095fc3
<pre>
Remove additional UA stylesheet rule for `audio` element from mediaControls.css

<a href="https://bugs.webkit.org/show_bug.cgi?id=267615">https://bugs.webkit.org/show_bug.cgi?id=267615</a>

Reviewed by Eric Carlson.

We have an additional UA stylesheet rule for `audio` element in &apos;html.css&apos; added by 223534@main,
when modern media controls were enabled.
The commit tried to consolidate and remove `audio` element UA rules from other files
(i.e., mediaControlsApple.css) but forgot to remove this one.

This patch is to remove it as well and rely on &apos;html.css&apos; as single source of truth.

* Source/WebCore/css/mediaControls.css:
(audio): Removed

Canonical link: <a href="https://commits.webkit.org/273114@main">https://commits.webkit.org/273114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e806a076c09a0511561b37337ad25cb201d97c05

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13136 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37008 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31067 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35410 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10249 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30074 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30611 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9698 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38292 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35868 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7795 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33813 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11719 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7894 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10760 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->