### PR TITLE
Avoid JIT compilation for simple attribute-only exact matching

### DIFF
--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -32,7 +32,9 @@
 #include "CommonAtomStrings.h"
 #include "ElementAncestorIteratorInlines.h"
 #include "HTMLBaseElement.h"
+#include "HTMLDocument.h"
 #include "HTMLNames.h"
+#include "SVGElement.h"
 #include "SelectorChecker.h"
 #include "StaticNodeList.h"
 #include "StyledElement.h"
@@ -51,6 +53,12 @@ static bool isSingleClassNameSelector(const CSSSelector& selector)
 {
     return selector.isLastInTagHistory() && selector.match() == CSSSelector::Match::Class;
 }
+
+static bool isSingleAttributeExactSelector(const CSSSelector& selector)
+{
+    return selector.isLastInTagHistory() && selector.match() == CSSSelector::Match::Exact;
+}
+
 #endif // ASSERT_ENABLED
 
 enum class IdMatchingType : uint8_t {
@@ -89,6 +97,27 @@ static IdMatchingType findIdMatchingType(const CSSSelector& firstSelector)
     return IdMatchingType::None;
 }
 
+static bool canOptimizeSingleAttributeExactMatch(const CSSSelector& selector)
+{
+    // Bailout if attribute name needs to be definitely case-insensitive.
+    if (selector.attributeValueMatchingIsCaseInsensitive())
+        return false;
+
+    const auto& attribute = selector.attribute();
+
+    if (!HTMLDocument::isCaseSensitiveAttribute(attribute))
+        return false;
+
+    // Bailout if we need to synchronize attributes.
+    if (Attribute::nameMatchesFilter(HTMLNames::styleAttr, attribute.prefix(), attribute.localNameLowercase(), attribute.namespaceURI()))
+        return false;
+
+    if (Attribute::nameMatchesFilter(SVGElement::animatableAttributeForName(attribute.localName()), attribute.prefix(), attribute.localName(), attribute.namespaceURI()))
+        return false;
+
+    return true;
+}
+
 SelectorDataList::SelectorDataList(const CSSSelectorList& selectorList)
 {
     unsigned selectorCount = 0;
@@ -108,6 +137,14 @@ SelectorDataList::SelectorDataList(const CSSSelectorList& selectorList)
                 break;
             case CSSSelector::Match::Class:
                 m_matchType = ClassNameMatch;
+                break;
+            case CSSSelector::Match::Exact:
+                if (canBeUsedForIdFastPath(selector))
+                    m_matchType = RightMostWithIdMatch; // [id="name"] pattern goes here.
+                else if (canOptimizeSingleAttributeExactMatch(selector))
+                    m_matchType = AttributeExactMatch;
+                else
+                    m_matchType = CompilableSingle;
                 break;
             default:
                 if (canBeUsedForIdFastPath(selector))
@@ -366,6 +403,41 @@ ALWAYS_INLINE void SelectorDataList::executeSingleClassNameSelectorData(const Co
 }
 
 template<typename OutputType>
+ALWAYS_INLINE void SelectorDataList::executeSingleAttributeExactSelectorData(const ContainerNode& rootNode, const SelectorData& selectorData, OutputType& output) const
+{
+    ASSERT(m_selectors.size() == 1);
+    ASSERT(isSingleAttributeExactSelector(*selectorData.selector));
+    ASSERT(canOptimizeSingleAttributeExactMatch(*selectorData.selector));
+
+    const auto& selectorAttribute = selectorData.selector->attribute();
+    const auto& selectorValue = selectorData.selector->value();
+    const auto& localNameLowercase = selectorAttribute.localNameLowercase();
+    const auto& localName = selectorAttribute.localName();
+    const auto& prefix = selectorAttribute.prefix();
+    const auto& namespaceURI = selectorAttribute.namespaceURI();
+
+    bool documentIsHTML = rootNode.document().isHTMLDocument();
+    for (auto& element : descendantsOfType<Element>(const_cast<ContainerNode&>(rootNode))) {
+        if (!element.hasAttributesWithoutUpdate())
+            continue;
+
+        bool isHTML = documentIsHTML && element.isHTMLElement();
+        const auto& localNameToMatch = isHTML ? localNameLowercase : localName;
+        for (const Attribute& attribute : element.attributesIterator()) {
+            if (!attribute.matches(prefix, localNameToMatch, namespaceURI))
+                continue;
+
+            if (selectorValue == attribute.value()) {
+                appendOutputForElement(output, element);
+                if constexpr (std::is_same_v<OutputType, Element*>)
+                    return;
+                break;
+            }
+        }
+    }
+}
+
+template<typename OutputType>
 ALWAYS_INLINE void SelectorDataList::executeSingleSelectorData(const ContainerNode& rootNode, const ContainerNode& searchRootNode, const SelectorData& selectorData, OutputType& output) const
 {
     ASSERT(m_selectors.size() == 1);
@@ -555,6 +627,9 @@ ALWAYS_INLINE void SelectorDataList::execute(ContainerNode& rootNode, OutputType
         break;
     case ClassNameMatch:
         executeSingleClassNameSelectorData(*searchRootNode, m_selectors.first(), output);
+        break;
+    case AttributeExactMatch:
+        executeSingleAttributeExactSelectorData(*searchRootNode, m_selectors.first(), output);
         break;
     case CompilableMultipleSelectorMatch:
 #if ENABLE(CSS_SELECTOR_JIT)

--- a/Source/WebCore/dom/SelectorQuery.h
+++ b/Source/WebCore/dom/SelectorQuery.h
@@ -67,6 +67,7 @@ private:
     template <typename OutputType> void executeFastPathForIdSelector(const ContainerNode& rootNode, const SelectorData&, const CSSSelector* idSelector, OutputType&) const;
     template <typename OutputType> void executeSingleTagNameSelectorData(const ContainerNode& rootNode, const SelectorData&, OutputType&) const;
     template <typename OutputType> void executeSingleClassNameSelectorData(const ContainerNode& rootNode, const SelectorData&, OutputType&) const;
+    template <typename OutputType> void executeSingleAttributeExactSelectorData(const ContainerNode& rootNode, const SelectorData&, OutputType&) const;
     template <typename OutputType> void executeSingleSelectorData(const ContainerNode& rootNode, const ContainerNode& searchRootNode, const SelectorData&, OutputType&) const;
     template <typename OutputType> void executeSingleMultiSelectorData(const ContainerNode& rootNode, OutputType&) const;
 #if ENABLE(CSS_SELECTOR_JIT)
@@ -89,6 +90,7 @@ private:
         RightMostWithIdMatch,
         TagNameMatch,
         ClassNameMatch,
+        AttributeExactMatch,
         MultipleSelectorMatch,
     } m_matchType;
 };


### PR DESCRIPTION
#### a2cc9142cedd737a7344564b89a5ce0cd14e8c0f
<pre>
Avoid JIT compilation for simple attribute-only exact matching
<a href="https://bugs.webkit.org/show_bug.cgi?id=267616">https://bugs.webkit.org/show_bug.cgi?id=267616</a>
<a href="https://rdar.apple.com/121082724">rdar://121082724</a>

Reviewed by Ryosuke Niwa.

To reduce machine code size, we add a path which handles very simple attribute-only exact matching,
which can avoid code generation for that patterns.

* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::isSingleAttributeExactSelector):
(WebCore::canOptimizeSingleAttributeExactMatch):
(WebCore::SelectorDataList::SelectorDataList):
(WebCore::SelectorDataList::executeSingleAttributeExactSelectorData const):
(WebCore::SelectorDataList::execute const):
* Source/WebCore/dom/SelectorQuery.h:

Canonical link: <a href="https://commits.webkit.org/273157@main">https://commits.webkit.org/273157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/398f624ae24b5ea18d29a00f56de6ac724ba4b9f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37172 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31180 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10413 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30166 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30740 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9836 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9917 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/30803 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38450 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31316 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31117 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35983 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10039 "Failed to checkout and rebase branch from PR 22847") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33932 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11857 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/10595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4424 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10900 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->