### PR TITLE
[iPad] Videos shift up and down when fullscreen overlay controls appear/disappear

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -392,6 +392,26 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #endif // PLATFORM(VISION)
 
+- (UIEdgeInsets)additionalSafeAreaInsets
+{
+    // When the status bar hides, the resulting changes to safeAreaInsets cause
+    // fullscreen content to jump up and down in response.
+
+    // Do not add additional insets if the status bar is not hidden.
+    if (!self.view.window.windowScene.statusBarManager.statusBarHidden)
+        return UIEdgeInsetsZero;
+
+    // Additionally, hiding the status bar does not reduce safeAreaInsets when
+    // the status bar resides within a larger safe area inset (e.g., due to the
+    // camera area).
+    if (self.view.window.safeAreaInsets.top > 0)
+        return UIEdgeInsetsZero;
+
+    // Otherwise, provide what is effectively a constant safeAreaInset.top by adding
+    // an additional safeAreaInset at the top equal to the status bar height.
+    return UIEdgeInsetsMake(_nonZeroStatusBarHeight, 0, 0, 0);
+}
+
 - (void)setPrefersStatusBarHidden:(BOOL)value
 {
     ASSERT(_valid);


### PR DESCRIPTION
#### e1d19dec257b5a212dfb30849c9260342e34b74d
<pre>
[iPad] Videos shift up and down when fullscreen overlay controls appear/disappear
<a href="https://bugs.webkit.org/show_bug.cgi?id=267468">https://bugs.webkit.org/show_bug.cgi?id=267468</a>
<a href="https://rdar.apple.com/120848395">rdar://120848395</a>

Reviewed by Tim Nguyen.

When the system status bar hides during media playback, this updates the UIWindow&apos;s safeAreaInsets
property, which propogates into web content by resizing the content area of the WKWebView.

Avoid this resizing by providing a minimum value for the safeAreaInsets.top, via overriding the
WKFullScreenViewController&apos;s -additionalSafeAreaInsets method.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController additionalSafeAreaInsets]):

Canonical link: <a href="https://commits.webkit.org/273140@main">https://commits.webkit.org/273140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f973290e32e2f36d7d4e65f724a6ea0caa6abe85

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37027 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31077 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30084 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30628 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9717 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9805 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38311 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/30996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35888 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33822 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11735 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7913 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10776 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->