### PR TITLE
[iOS] Fullscreen warning banner can be cut off with long domain name

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -600,6 +600,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self videoControlsManagerDidChange];
 
 #if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
+    [_bannerLabel setPreferredMaxLayoutWidth:self.view.bounds.size.width];
     [_banner setAlpha:0];
     [_banner setHidden:YES];
 #endif
@@ -638,6 +639,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self _updateWebViewFullscreenInsets];
     _secheuristic.setSize(self.view.bounds.size);
     [self._webView setFrame:[_animatingView bounds]];
+#if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
+    [_bannerLabel setPreferredMaxLayoutWidth:self.view.bounds.size.width];
+#endif
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator


### PR DESCRIPTION
#### 61d7c5072309026883e08661e30eedd9d6c446d3
<pre>
[iOS] Fullscreen warning banner can be cut off with long domain name
<a href="https://bugs.webkit.org/show_bug.cgi?id=267621">https://bugs.webkit.org/show_bug.cgi?id=267621</a>
<a href="https://rdar.apple.com/118078137">rdar://118078137</a>

Reviewed by Eric Carlson.

Give the warning banner a maximum width, forcing it to break lines when
domain names are long enough to justify it.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController loadView]):
(-[WKFullScreenViewController viewDidLayoutSubviews]):

Canonical link: <a href="https://commits.webkit.org/273129@main">https://commits.webkit.org/273129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4b3396f37153dd4a3ee4a31cd162c2e87769857

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37035 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31084 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10276 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30090 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9725 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9834 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38319 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31224 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35893 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33829 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11743 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7902 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10497 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->