### PR TITLE
 invalidateNodeListAndCollectionCachesInAncestorsForAttribute shouldn't call invalidateQuerySelectorAllResults in most cases

### DIFF
--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -1005,9 +1005,10 @@ ExceptionOr<Ref<NodeList>> ContainerNode::querySelectorAll(const String& selecto
     if (query.hasException())
         return query.releaseException();
     auto isCacheable = query.returnValue().shouldStoreInDocument();
+    auto classNameToMatch = query.returnValue().classNameToMatch();
     auto nodeList = query.releaseReturnValue().queryAll(*this);
     if (isCacheable)
-        document->addResultForSelectorAll(*this, selectors, nodeList);
+        document->addResultForSelectorAll(*this, selectors, nodeList, classNameToMatch);
     return nodeList;
 }
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -216,6 +216,7 @@ class SelectorQueryCache;
 class SerializedScriptValue;
 class Settings;
 class SleepDisabler;
+class SpaceSplitString;
 class SpeechRecognition;
 class StorageConnection;
 class StringCallback;
@@ -468,8 +469,9 @@ public:
     void invalidateAccessKeyCache();
 
     RefPtr<NodeList> resultForSelectorAll(ContainerNode&, const String&);
-    void addResultForSelectorAll(ContainerNode&, const String&, NodeList&);
+    void addResultForSelectorAll(ContainerNode&, const String&, NodeList&, const AtomString& classNameToMatch);
     void invalidateQuerySelectorAllResults(Node&);
+    void invalidateQuerySelectorAllResultsForClassAttributeChange(Node&, const SpaceSplitString& oldClasses, const SpaceSplitString& newClasses);
     void clearQuerySelectorAllResults();
 
     ExceptionOr<SelectorQuery&> selectorQueryForString(const String&);

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2292,6 +2292,7 @@ void Element::classAttributeChanged(const AtomString& newClassString)
         auto shouldFoldCase = document().inQuirksMode() ? SpaceSplitString::ShouldFoldCase::Yes : SpaceSplitString::ShouldFoldCase::No;
         SpaceSplitString newClassNames(newClassString, shouldFoldCase);
         Style::ClassChangeInvalidation styleInvalidation(*this, elementData()->classNames(), newClassNames);
+        document().invalidateQuerySelectorAllResultsForClassAttributeChange(*this, elementData()->classNames(), newClassNames);
         elementData()->setClassNames(WTFMove(newClassNames));
     }
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1051,8 +1051,6 @@ void Node::invalidateNodeListAndCollectionCachesInAncestorsForAttribute(const Qu
 {
     ASSERT(is<Element>(*this));
 
-    document().invalidateQuerySelectorAllResults(*this);
-
     if (!document().shouldInvalidateNodeListAndCollectionCachesForAttribute(attrName))
         return;
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -490,7 +490,7 @@ public:
 #endif // ENABLE(TREE_DEBUGGING)
 
     void invalidateNodeListAndCollectionCachesInAncestors();
-    void invalidateNodeListAndCollectionCachesInAncestorsForAttribute(const QualifiedName& attrName);
+    void invalidateNodeListAndCollectionCachesInAncestorsForAttribute(const QualifiedName&);
     NodeListsNodeData* nodeLists();
     void clearNodeLists();
 

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -402,6 +402,15 @@ ALWAYS_INLINE void SelectorDataList::executeSingleClassNameSelectorData(const Co
     }
 }
 
+AtomString SelectorDataList::classNameToMatch() const
+{
+    if (m_matchType != MatchType::ClassNameMatch)
+        return nullAtom();
+    ASSERT(m_selectors.size() == 1);
+    ASSERT(isSingleClassNameSelector(*m_selectors.first().selector));
+    return m_selectors.first().selector->value();
+}
+
 template<typename OutputType>
 ALWAYS_INLINE void SelectorDataList::executeSingleAttributeExactSelectorData(const ContainerNode& rootNode, const SelectorData& selectorData, OutputType& output) const
 {

--- a/Source/WebCore/dom/SelectorQuery.h
+++ b/Source/WebCore/dom/SelectorQuery.h
@@ -51,6 +51,7 @@ public:
     Element* queryFirst(ContainerNode& rootNode) const;
 
     bool shouldStoreInDocument() const { return m_matchType == MatchType::TagNameMatch || m_matchType == MatchType::ClassNameMatch; }
+    AtomString classNameToMatch() const;
 
 private:
     struct SelectorData {
@@ -107,6 +108,7 @@ public:
     Element* queryFirst(ContainerNode& rootNode) const;
 
     bool shouldStoreInDocument() const { return m_selectors.shouldStoreInDocument(); }
+    AtomString classNameToMatch() const { return m_selectors.classNameToMatch(); }
 
 private:
     CSSSelectorList m_selectorList;


### PR DESCRIPTION
#### ffffbfafc4cd8c6819a7598243d3bc4f29af5d61
<pre>
 invalidateNodeListAndCollectionCachesInAncestorsForAttribute shouldn&apos;t call invalidateQuerySelectorAllResults in most cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=267626">https://bugs.webkit.org/show_bug.cgi?id=267626</a>

Reviewed by Yusuke Suzuki.

Invalidation was happening too frequently. Only invalidate when class attribute&apos;s value change. Also, instead of invalidating
the all results entries at once, remove specific selector results which were affected by the class attribute change.

To do this, this PR moves the invalidation logic from Node::invalidateNodeListAndCollectionCachesInAncestorsForAttribute to
Element::classAttributeChanged, which has access to space separated class name list.

* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::querySelectorAll):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::addResultForSelectorAll):
(WebCore::Document::invalidateQuerySelectorAllResultsForClassAttributeChange): Added.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::classAttributeChanged):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::invalidateNodeListAndCollectionCachesInAncestorsForAttribute):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorDataList::classNameToMatch const): Added.
* Source/WebCore/dom/SelectorQuery.h:
(WebCore::SelectorQuery::classNameToMatch const): Added.

Canonical link: <a href="https://commits.webkit.org/273183@main">https://commits.webkit.org/273183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38688bdbd9eb1247a756de8c3471f14b0d2793b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37213 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31208 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35666 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30183 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9860 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9941 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38491 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36010 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33962 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11886 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10619 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4432 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10931 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->