### PR TITLE
REGRESSION(272844@main): [GStreamer][Debug] ASSERTION FAILED: isMainThread() in WebCore::MediaStreamTrackPrivate::source()

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1854,7 +1854,8 @@ webkit.org/b/251106 webgl/2.0.y/conformance/offscreencanvas/methods-worker.html 
 webkit.org/b/251106 webgl/2.0.y/conformance/offscreencanvas/offscreencanvas-timer-query.html [ Pass Timeout ]
 
 # Fails when using two textures.
-webkit.org/b/258296 webrtc/canvas-to-peer-connection.html [ Failure Timeout ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/258296 webrtc/canvas-to-peer-connection.html [ Failure Timeout ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of WebGL-related bugs
@@ -2016,9 +2017,10 @@ webkit.org/b/235885 webrtc/audio-video-element-playing.html [ Timeout ]
 # Uncomment when webkit.org/b/267411 is fixed
 #webkit.org/b/235885 webrtc/ephemeral-certificates-and-cnames.html [ Failure ]
 webkit.org/b/235885 webrtc/filtering-ice-candidate-after-reload.html [ Failure ]
-webkit.org/b/235885 webrtc/peer-connection-track-end.html [ Failure ]
-webkit.org/b/235885 webrtc/peerconnection-page-cache-long.html [ Timeout ]
-webkit.org/b/235885 webrtc/peerconnection-page-cache.html [ Timeout ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/235885 webrtc/peer-connection-track-end.html [ Failure ]
+#webkit.org/b/235885 webrtc/peerconnection-page-cache-long.html [ Timeout ]
+#webkit.org/b/235885 webrtc/peerconnection-page-cache.html [ Timeout ]
 webkit.org/b/235885 webrtc/video-stats.html [ Failure ]
 webkit.org/b/235885 webrtc/vp8-then-h264.html [ Failure Timeout Crash ]
 webkit.org/b/252878 fast/mediastream/mediastreamtrack-video-clone.html [ Crash Failure Timeout Pass ]
@@ -3560,7 +3562,7 @@ webkit.org/b/252878 imported/w3c/web-platform-tests/wasm/webapi/instantiateStrea
 webkit.org/b/252878 loader/navigation-policy/should-open-external-urls/subframe-navigated-programatically-by-main-frame.html [ Failure Pass ]
 # Uncomment when webkit.org/b/267411 is fixed
 #webkit.org/b/252878 webrtc/multi-video.html [ Failure Pass Timeout ]
-webkit.org/b/252878 webrtc/peer-connection-remote-audio-mute2.html [ Pass Timeout ]
+#webkit.org/b/252878 webrtc/peer-connection-remote-audio-mute2.html [ Pass Timeout ]
 
 # Missing support for UIScriptController.paste()
 fast/forms/input-text-max-length-emojis.html [ Failure ]
@@ -3756,7 +3758,7 @@ webkit.org/b/267411 imported/w3c/web-platform-tests/mediacapture-record/MediaRec
 webkit.org/b/267411 fast/mediastream/RTCPeerConnection-overloaded-operations.html [ Pass Crash ]
 webkit.org/b/267411 webrtc/addTransceiver-then-addTrack.html [ Failure Crash ]
 webkit.org/b/267411 webrtc/audio-muted-stats.html [ Pass Crash ]
-webkit.org/b/267411 webrtc/audio-peer-connection-g722.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/audio-peer-connection-g722.html [ Failure Pass Timeout Crash ]
 webkit.org/b/267411 webrtc/audio-peer-connection-webaudio.html [ Failure Pass Timeout Crash ]
 webkit.org/b/267411 webrtc/audio-replace-track.html [ Failure Pass Timeout Crash ]
 webkit.org/b/267411 webrtc/audio-samplerate-change.html [ Pass Timeout Crash ]
@@ -3778,6 +3780,18 @@ webkit.org/b/267411 webrtc/multi-audio.html [ Timeout Pass Failure Crash ]
 webkit.org/b/267411 webrtc/multi-video.html [ Failure Pass Timeout Crash ]
 webkit.org/b/267411 webrtc/no-port-zero-in-upd-candidates.html [ Pass Crash ]
 webkit.org/b/267411 webrtc/peer-connection-audio-mute2.html [ Failure Timeout Pass Crash ]
+webkit.org/b/267411 webrtc/canvas-to-peer-connection.html [ Failure Timeout Crash ]
+webkit.org/b/267411 webrtc/peer-connection-audio-mute.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/peer-connection-audio-unmute.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/peer-connection-createMediaStreamDestination.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/peer-connection-remote-audio-mute.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/peer-connection-remote-audio-mute2.html [ Pass Timeout Crash ]
+webkit.org/b/267411 webrtc/peer-connection-track-end.html  [ Failure Crash ]
+webkit.org/b/267411 webrtc/peerconnection-page-cache-long.html  [ Timeout Crash ]
+webkit.org/b/267411 webrtc/peerconnection-page-cache.html [ Timeout Crash ]
+webkit.org/b/267411 webrtc/receiver-track-should-stay-live-even-if-receiver-is-inactive.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/release-after-getting-track.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/remoteAudio-never-played.html [ Pass Crash ]
 
 # End: Common failures between GTK and WPE.
 

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -888,8 +888,8 @@ webkit.org/b/252878 perf/append-text-nodes-without-renderers.html [ Failure Pass
 webkit.org/b/252878 svg/as-image/svg-as-image-canvas.html [ ImageOnlyFailure Pass ]
 webkit.org/b/252878 webanimations/accelerated-animation-tiled-while-running.html [ Pass Timeout ]
 webkit.org/b/252878 webaudio/audioworklet-addModule-failure.html [ Pass Timeout ]
-webkit.org/b/252878 webrtc/audio-peer-connection-g722.html [ Failure Pass Timeout ]
 # Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/252878 webrtc/audio-peer-connection-g722.html [ Failure Pass Timeout ]
 #webkit.org/b/252878 webrtc/audio-peer-connection-webaudio.html [ Pass Timeout ]
 webkit.org/b/252878 webrtc/datachannel/bufferedAmountLowThreshold-default.html [ Crash Failure Pass Timeout ]
 


### PR DESCRIPTION
#### af9d3ff330efc496fb2ca267ec345a973ba83894
<pre>
REGRESSION(272844@main): [GStreamer][Debug] ASSERTION FAILED: isMainThread() in WebCore::MediaStreamTrackPrivate::source()
<a href="https://bugs.webkit.org/show_bug.cgi?id=267411">https://bugs.webkit.org/show_bug.cgi?id=267411</a>

Unreviewed test gardening.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/273119@main">https://commits.webkit.org/273119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/faf2d1a71df755aa4c7fda2c9b5f6cae60ed8a05

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37060 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10302 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34893 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/11155 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/30651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9747 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/30704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38344 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31220 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/31020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/9961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/33849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/11766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/10516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4407 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->