### PR TITLE
REGRESSION (268038@main): :not(:has(:not(foo))) misclassified as scope breaking

### DIFF
--- a/LayoutTests/fast/selectors/has-scope-breaking-classification-expected.txt
+++ b/LayoutTests/fast/selectors/has-scope-breaking-classification-expected.txt
@@ -1,0 +1,54 @@
+:has(foo) is not scope breaking
+:has(foo bar) is not scope breaking
+:has(foo ~ bar) is not scope breaking
+:has(~ foo) is not scope breaking
+:has(~ foo bar) is not scope breaking
+:has(+ foo) is not scope breaking
+:has(+ foo bar) is not scope breaking
+:has(:is(foo)) is not scope breaking
+:has(:is(foo bar)) IS scope breaking
+:has(:is(foo ~ bar)) is not scope breaking
+:is(:has(foo)) is not scope breaking
+:is(:has(foo bar)) is not scope breaking
+:is(:has(:is(foo))) is not scope breaking
+:is(:has(:is(foo bar))) IS scope breaking
+:has(~ foo) is not scope breaking
+:has(~ foo bar) is not scope breaking
+:has(~ :is(foo)) is not scope breaking
+:has(~ :is(foo bar)) IS scope breaking
+:is(~ :has(foo)) is not scope breaking
+:is(:has(~ foo bar)) is not scope breaking
+:is(:has(~ :is(foo))) is not scope breaking
+:is(:has(~ :is(foo bar))) IS scope breaking
+:has(+ foo) is not scope breaking
+:has(+ foo bar) is not scope breaking
+:has(+ :is(foo)) is not scope breaking
+:has(+ :is(foo bar)) IS scope breaking
+:is(+ :has(foo)) is not scope breaking
+:is(:has(+ foo bar)) is not scope breaking
+:is(:has(+ :is(foo))) is not scope breaking
+:is(:has(+ :is(foo bar))) IS scope breaking
+:has(:not(foo)) is not scope breaking
+:has(:not(foo bar)) IS scope breaking
+:has(:not(foo ~ bar)) is not scope breaking
+:not(:has(foo)) is not scope breaking
+:not(:has(foo bar)) is not scope breaking
+:not(:has(:not(foo))) is not scope breaking
+:not(:has(:not(foo bar))) IS scope breaking
+:has(~ foo) is not scope breaking
+:has(~ foo bar) is not scope breaking
+:has(~ :not(foo)) is not scope breaking
+:has(~ :not(foo bar)) IS scope breaking
+:not(~ :has(foo)) is not scope breaking
+:has(+ foo) is not scope breaking
+:has(+ foo bar) is not scope breaking
+:has(+ :not(foo)) is not scope breaking
+:has(+ :not(foo bar)) IS scope breaking
+:not(+ :has(foo)) is not scope breaking
+:not(:has(~ foo bar)) is not scope breaking
+:not(:has(~ :not(foo))) is not scope breaking
+:not(:has(~ :not(foo bar))) IS scope breaking
+:not(:has(+ foo bar)) is not scope breaking
+:not(:has(+ :not(foo))) is not scope breaking
+:not(:has(+ :not(foo bar))) IS scope breaking
+

--- a/LayoutTests/fast/selectors/has-scope-breaking-classification.html
+++ b/LayoutTests/fast/selectors/has-scope-breaking-classification.html
@@ -1,0 +1,70 @@
+<pre id=log></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function testScopeBreaking(selector) {
+    if (!window.internals)
+        return;
+    const style = document.createElement("style");
+    style.textContent = selector + " { color:green }";
+    document.head.appendChild(style);
+    const isScopeBreaking = internals.hasScopeBreakingHasSelectors;
+    log.textContent += selector + (isScopeBreaking ? " IS scope breaking\n" : " is not scope breaking\n");
+    style.remove();
+}
+
+testScopeBreaking(":has(foo)");
+testScopeBreaking(":has(foo bar)");
+testScopeBreaking(":has(foo ~ bar)");
+testScopeBreaking(":has(~ foo)");
+testScopeBreaking(":has(~ foo bar)");
+testScopeBreaking(":has(+ foo)");
+testScopeBreaking(":has(+ foo bar)");
+testScopeBreaking(":has(:is(foo))");
+testScopeBreaking(":has(:is(foo bar))");
+testScopeBreaking(":has(:is(foo ~ bar))");
+testScopeBreaking(":is(:has(foo))");
+testScopeBreaking(":is(:has(foo bar))");
+testScopeBreaking(":is(:has(:is(foo)))");
+testScopeBreaking(":is(:has(:is(foo bar)))");
+testScopeBreaking(":has(~ foo)");
+testScopeBreaking(":has(~ foo bar)");
+testScopeBreaking(":has(~ :is(foo))");
+testScopeBreaking(":has(~ :is(foo bar))");
+testScopeBreaking(":is(~ :has(foo))");
+testScopeBreaking(":is(:has(~ foo bar))");
+testScopeBreaking(":is(:has(~ :is(foo)))");
+testScopeBreaking(":is(:has(~ :is(foo bar)))");
+testScopeBreaking(":has(+ foo)");
+testScopeBreaking(":has(+ foo bar)");
+testScopeBreaking(":has(+ :is(foo))");
+testScopeBreaking(":has(+ :is(foo bar))");
+testScopeBreaking(":is(+ :has(foo))");
+testScopeBreaking(":is(:has(+ foo bar))");
+testScopeBreaking(":is(:has(+ :is(foo)))");
+testScopeBreaking(":is(:has(+ :is(foo bar)))");
+testScopeBreaking(":has(:not(foo))");
+testScopeBreaking(":has(:not(foo bar))");
+testScopeBreaking(":has(:not(foo ~ bar))");
+testScopeBreaking(":not(:has(foo))");
+testScopeBreaking(":not(:has(foo bar))");
+testScopeBreaking(":not(:has(:not(foo)))");
+testScopeBreaking(":not(:has(:not(foo bar)))");
+testScopeBreaking(":has(~ foo)");
+testScopeBreaking(":has(~ foo bar)");
+testScopeBreaking(":has(~ :not(foo))");
+testScopeBreaking(":has(~ :not(foo bar))");
+testScopeBreaking(":not(~ :has(foo))");
+testScopeBreaking(":has(+ foo)");
+testScopeBreaking(":has(+ foo bar)");
+testScopeBreaking(":has(+ :not(foo))");
+testScopeBreaking(":has(+ :not(foo bar))");
+testScopeBreaking(":not(+ :has(foo))");
+testScopeBreaking(":not(:has(~ foo bar))");
+testScopeBreaking(":not(:has(~ :not(foo)))");
+testScopeBreaking(":not(:has(~ :not(foo bar)))");
+testScopeBreaking(":not(:has(+ foo bar))");
+testScopeBreaking(":not(:has(+ :not(foo)))");
+testScopeBreaking(":not(:has(+ :not(foo bar)))");
+</script>

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -111,6 +111,7 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
 
 void ChildChangeInvalidation::invalidateForChangeOutsideHasScope()
 {
+    // FIXME: This is a performance footgun. Any mutation will trigger a full document traversal.
     if (auto* invalidationRuleSet = parentElement().styleResolver().ruleSets().scopeBreakingHasPseudoClassInvalidationRuleSet())
         Invalidator::invalidateWithScopeBreakingHasPseudoClassRuleSet(parentElement(), invalidationRuleSet);
 }

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -306,7 +306,9 @@ DoesBreakScope RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFe
             bool isLogicalCombination = isLogicalCombinationPseudoClass(selector->pseudoClass());
             if (!isLogicalCombination)
                 selectorFeatures.pseudoClasses.append({ selector, matchElement, isNegation });
-            if (isLogicalCombination && selector->pseudoClass() != CSSSelector::PseudoClass::Has)
+
+            // Check for the :has(:is(foo bar)) case. In this case `foo` can match elements outside the :has() scope.
+            if (isLogicalCombination && isHasPseudoClassMatchElement(matchElement))
                 canBreakScope = CanBreakScope::Yes;
         }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7273,4 +7273,10 @@ bool Internals::readyToRetrieveComputedRoleOrLabel(Element& element) const
     return !element.rendererIsNeeded(*computedStyle);
 }
 
+bool Internals::hasScopeBreakingHasSelectors() const
+{
+    contextDocument()->styleScope().flushPendingUpdate();
+    return !!contextDocument()->styleScope().resolver().ruleSets().scopeBreakingHasPseudoClassInvalidationRuleSet();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1425,6 +1425,8 @@ public:
     String getComputedLabel(Element&) const;
     String getComputedRole(Element&) const;
 
+    bool hasScopeBreakingHasSelectors() const;
+
 private:
     explicit Internals(Document&);
     Document* contextDocument() const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1308,4 +1308,6 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     boolean readyToRetrieveComputedRoleOrLabel(Element element);
     DOMString getComputedLabel(Element element);
     DOMString getComputedRole(Element element);
+
+    readonly attribute boolean hasScopeBreakingHasSelectors;
 };


### PR DESCRIPTION
#### 4ff0fdab94ceae40ad1582477eac1b7800a11ba3
<pre>
REGRESSION (268038@main): :not(:has(:not(foo))) misclassified as scope breaking
<a href="https://bugs.webkit.org/show_bug.cgi?id=267628">https://bugs.webkit.org/show_bug.cgi?id=267628</a>
<a href="https://rdar.apple.com/120492012">rdar://120492012</a>

Reviewed by Cameron McCormack.

Seen in <a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">https://tc39.es/ecma262/#sec-completion-record-specification-type</a>

* LayoutTests/fast/selectors/has-scope-breaking-classification-expected.txt: Added.
* LayoutTests/fast/selectors/has-scope-breaking-classification.html: Added.
* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForChangeOutsideHasScope):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):

:not() outside :has() would still put us into CanBreakScope::Yes mode.
Fix by only setting CanBreakScope::Yes if we are actually inside :has().

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::hasScopeBreakingHasSelectors const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Add testing support.

Canonical link: <a href="https://commits.webkit.org/273177@main">https://commits.webkit.org/273177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36e3c58dcebd17dd2d4aa8f579696960eb4d104e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37264 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10505 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9904 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38542 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31400 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/31193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36050 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34006 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30502 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7942 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/10658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->