### PR TITLE
Change executable name of WebKit extensions

### DIFF
--- a/Source/WebKit/Configurations/GPUExtension.xcconfig
+++ b/Source/WebKit/Configurations/GPUExtension.xcconfig
@@ -26,5 +26,5 @@
 INFOPLIST_FILE = Shared/AuxiliaryProcessExtensions/GPUExtension-Info.plist;
 INFOPLIST_KEY_CFBundleDisplayName = GPUExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.GPU;
-PRODUCT_BUNDLE_EXECUTABLE = GPUExtension;
+EXECUTABLE_NAME = $(PRODUCT_BUNDLE_IDENTIFIER);
 PRODUCT_BUNDLE_NAME = GPUExtension;

--- a/Source/WebKit/Configurations/NetworkingExtension.xcconfig
+++ b/Source/WebKit/Configurations/NetworkingExtension.xcconfig
@@ -26,5 +26,5 @@
 INFOPLIST_FILE = Shared/AuxiliaryProcessExtensions/NetworkingExtension-Info.plist;
 INFOPLIST_KEY_CFBundleDisplayName = NetworkingExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.Networking;
-PRODUCT_BUNDLE_EXECUTABLE = NetworkingExtension;
+EXECUTABLE_NAME = $(PRODUCT_BUNDLE_IDENTIFIER);
 PRODUCT_BUNDLE_NAME = NetworkingExtension;

--- a/Source/WebKit/Configurations/WebContentCaptivePortalExtension.xcconfig
+++ b/Source/WebKit/Configurations/WebContentCaptivePortalExtension.xcconfig
@@ -26,5 +26,5 @@
 INFOPLIST_FILE = Shared/AuxiliaryProcessExtensions/WebContentExtension-CaptivePortal-Info.plist;
 INFOPLIST_KEY_CFBundleDisplayName = WebContentCaptivePortalExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.WebContent.CaptivePortal;
-PRODUCT_BUNDLE_EXECUTABLE = WebContentCaptivePortalExtension;
+EXECUTABLE_NAME = $(PRODUCT_BUNDLE_IDENTIFIER);
 PRODUCT_BUNDLE_NAME = WebContentCaptivePortalExtension;

--- a/Source/WebKit/Configurations/WebContentExtension.xcconfig
+++ b/Source/WebKit/Configurations/WebContentExtension.xcconfig
@@ -26,5 +26,5 @@
 INFOPLIST_FILE = Shared/AuxiliaryProcessExtensions/WebContentExtension-Info.plist;
 INFOPLIST_KEY_CFBundleDisplayName = WebContentExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.WebContent;
-PRODUCT_BUNDLE_EXECUTABLE = WebContentExtension;
+EXECUTABLE_NAME = $(PRODUCT_BUNDLE_IDENTIFIER);
 PRODUCT_BUNDLE_NAME = WebContentExtension;

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUExtension-Info.plist
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUExtension-Info.plist
@@ -10,7 +10,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleExecutable</key>
-	<string>${PRODUCT_BUNDLE_EXECUTABLE}</string>
+	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleVersion</key>
 	<string>${BUNDLE_VERSION}</string>
 	<key>CFBundleName</key>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingExtension-Info.plist
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingExtension-Info.plist
@@ -10,7 +10,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleExecutable</key>
-	<string>${PRODUCT_BUNDLE_EXECUTABLE}</string>
+	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleVersion</key>
 	<string>${BUNDLE_VERSION}</string>
 	<key>CFBundleName</key>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-CaptivePortal-Info.plist
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-CaptivePortal-Info.plist
@@ -10,7 +10,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleExecutable</key>
-	<string>${PRODUCT_BUNDLE_EXECUTABLE}</string>
+	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleVersion</key>
 	<string>${BUNDLE_VERSION}</string>
 	<key>CFBundleName</key>

--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-Info.plist
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-Info.plist
@@ -10,7 +10,7 @@
 	<key>CFBundleIdentifier</key>
 	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleExecutable</key>
-	<string>${PRODUCT_BUNDLE_EXECUTABLE}</string>
+	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleVersion</key>
 	<string>${BUNDLE_VERSION}</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
#### 34d00b6310fe7bec9399788c3464f73325b1cea5
<pre>
Change executable name of WebKit extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=267637">https://bugs.webkit.org/show_bug.cgi?id=267637</a>
<a href="https://rdar.apple.com/121115146">rdar://121115146</a>

Reviewed by Elliott Williams and Brent Fulgham.

Change executable name of WebKit extensions to match bundle ID.

* Source/WebKit/Configurations/GPUExtension.xcconfig:
* Source/WebKit/Configurations/NetworkingExtension.xcconfig:
* Source/WebKit/Configurations/WebContentCaptivePortalExtension.xcconfig:
* Source/WebKit/Configurations/WebContentExtension.xcconfig:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/GPUExtension-Info.plist:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingExtension-Info.plist:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-CaptivePortal-Info.plist:
* Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentExtension-Info.plist:

Canonical link: <a href="https://commits.webkit.org/273136@main">https://commits.webkit.org/273136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f48e36f76fe4e192f0fe0165495c4bb7f0408b79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37095 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31124 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30123 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9780 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9879 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38378 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31260 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35940 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9990 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33881 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11796 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10542 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4414 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10838 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->