### PR TITLE
[Navigation] Implement the initialize the navigation API entries algorithm

### DIFF
--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -454,6 +454,8 @@ private:
     void clearProvisionalLoadForPolicyCheck();
     bool hasOpenedFrames() const;
 
+    void updateNavigationAPIEntries();
+
     WeakRef<LocalFrame> m_frame;
     UniqueRef<LocalFrameLoaderClient> m_client;
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -692,8 +692,13 @@ History& LocalDOMWindow::history()
 Navigation& LocalDOMWindow::navigation()
 {
     if (!m_navigation)
-        m_navigation = Navigation::create(scriptExecutionContext(), *this);
+        m_navigation = Navigation::create(protectedScriptExecutionContext().get(), *this);
     return *m_navigation;
+}
+
+Ref<Navigation> LocalDOMWindow::protectedNavigation()
+{
+    return navigation();
 }
 
 Crypto& LocalDOMWindow::crypto() const

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -386,6 +386,7 @@ public:
 
     // Navigation API
     Navigation& navigation();
+    Ref<Navigation> protectedNavigation();
 
     // FIXME: When this LocalDOMWindow is no longer the active LocalDOMWindow (i.e.,
     // when its document is no longer the document that is displayed in its

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-template<typename IDLType> class DOMPromiseDeferred;
+class HistoryItem;
 
 class Navigation final : public RefCounted<Navigation>, public EventTarget, public ContextDestructionObserver, public LocalDOMWindowProperty {
     WTF_MAKE_ISO_ALLOCATED(Navigation);
@@ -75,12 +75,14 @@ public:
         RefPtr<DOMPromise> finished;
     };
 
-    Vector<Ref<NavigationHistoryEntry>> entries() { return m_entries; };
-    RefPtr<NavigationHistoryEntry> currentEntry() { return m_currentEntry; };
+    const Vector<Ref<NavigationHistoryEntry>>& entries() const;
+    NavigationHistoryEntry* currentEntry() const;
     RefPtr<NavigationTransition> transition() { return m_transition; };
 
     bool canGoBack() const { return m_canGoBack; };
     bool canGoForward() const { return m_canGoForward; };
+
+    void initializeEntries(const Ref<HistoryItem>& currentItem, const Vector<Ref<HistoryItem>> &items);
 
     Result navigate(const String& url, NavigateOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
@@ -100,7 +102,9 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
-    RefPtr<NavigationHistoryEntry> m_currentEntry;
+    bool hasEntriesAndEventsDisabled() const;
+
+    int m_currentEntryIndex { -1 };
     RefPtr<NavigationTransition> m_transition;
     bool m_canGoBack { false };
     bool m_canGoForward { false };

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -34,8 +34,11 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(NavigationHistoryEntry);
 
-NavigationHistoryEntry::NavigationHistoryEntry(ScriptExecutionContext* context)
+NavigationHistoryEntry::NavigationHistoryEntry(ScriptExecutionContext* context, const URL& url)
     : ContextDestructionObserver(context)
+    , m_url(url)
+    , m_key(WTF::UUID::createVersion4())
+    , m_id(WTF::UUID::createVersion4())
 {
 }
 

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -29,6 +29,7 @@
 #include "EventHandler.h"
 #include "EventTarget.h"
 #include <wtf/RefCounted.h>
+#include <wtf/UUID.h>
 
 namespace JSC {
 class JSValue;
@@ -42,26 +43,26 @@ public:
     using RefCounted<NavigationHistoryEntry>::ref;
     using RefCounted<NavigationHistoryEntry>::deref;
 
-    static Ref<NavigationHistoryEntry> create(ScriptExecutionContext* context) { return adoptRef(*new NavigationHistoryEntry(context)); }
+    static Ref<NavigationHistoryEntry> create(ScriptExecutionContext* context, const URL& url) { return adoptRef(*new NavigationHistoryEntry(context, url)); }
 
-    const String& url() const { return m_url; };
-    const String& key() const { return m_key; };
-    const String& id() const { return m_id; };
+    const String& url() const { return m_url.string(); };
+    String key() const { return m_key.toString(); };
+    String id() const { return m_id.toString(); };
     uint64_t index() const { return m_index; };
     bool sameDocument() const { return m_sameDocument; };
     const JSC::JSValue& getState() const { return m_state; };
 
 private:
-    NavigationHistoryEntry(ScriptExecutionContext*);
+    NavigationHistoryEntry(ScriptExecutionContext*, const URL&);
 
     EventTargetInterface eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
-    String m_url;
-    String m_key;
-    String m_id;
+    const URL m_url;
+    const WTF::UUID m_key;
+    const WTF::UUID m_id;
     uint64_t m_index;
     JSC::JSValue m_state;
     bool m_sameDocument;


### PR DESCRIPTION
#### 4d20880a9333b70b8444b5305d52035589e893ba
<pre>
[Navigation] Implement the initialize the navigation API entries algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=267636">https://bugs.webkit.org/show_bug.cgi?id=267636</a>

Reviewed by Alex Christensen and Chris Dumez.

Implement the initialize the navigation API entries algorithm [1] by calling it in FrameLoader
when a new document is starting to be loaded.

Also add a minimal implementation of the has entries and events disabled algorithm [2]
in order to not regress existing navigation API tests.

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#initialize-the-navigation-api-entries-for-a-new-document">https://html.spec.whatwg.org/multipage/nav-history-apis.html#initialize-the-navigation-api-entries-for-a-new-document</a>
[2] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#has-entries-and-events-disabled">https://html.spec.whatwg.org/multipage/nav-history-apis.html#has-entries-and-events-disabled</a>

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didBeginDocument):
(WebCore::FrameLoader::updateNavigationAPIEntries):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::navigation):
(WebCore::LocalDOMWindow::protectedNavigation):
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::Navigation):
(WebCore::Navigation::initializeEntries):
(WebCore::Navigation::entries const):
(WebCore::Navigation::currentEntry const):
(WebCore::Navigation::navigate):
(WebCore::Navigation::reload):
(WebCore::Navigation::traverseTo):
(WebCore::Navigation::back):
(WebCore::Navigation::forward):
(WebCore::Navigation::hasEntriesAndEventsDisabled const):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::NavigationHistoryEntry):
* Source/WebCore/page/NavigationHistoryEntry.h:

Canonical link: <a href="https://commits.webkit.org/273532@main">https://commits.webkit.org/273532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/155c4a1cb8d9bac4bf8b59b1a407d53d2101a5e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38392 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32116 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36852 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/17017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11619 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30902 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31729 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10841 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10843 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31869 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39637 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36801 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34882 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12753 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8146 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11543 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->