### PR TITLE
RealtimeOutgoingVideoSource needs to trigger resolution scaling in case of WebRTC maintain-framerate degradationPreference

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1880,6 +1880,11 @@ webkit.org/b/264803 fast/mediastream/mediastreamtrack-video-resize-event.html [ 
 # Adding transceivers without tracks is broken.
 webkit.org/b/265865 imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation.html [ Skip ]
 
+# Requires video scaling adaptation.
+webrtc/captureCanvas-webrtc-with-video-scaling-adaptation.html [ Failure ]
+webrtc/video-maxBitrate.html [ Failure ]
+webrtc/video-maxBitrate-vp8.html [ Failure ]
+
 # Times out waiting for DTLS transport setup. Some bug related with data-channel, pending investigation.
 webkit.org/b/265860 imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https.html [ Skip ]
 

--- a/LayoutTests/webrtc/captureCanvas-webrtc-with-video-scaling-adaptation-expected.txt
+++ b/LayoutTests/webrtc/captureCanvas-webrtc-with-video-scaling-adaptation-expected.txt
@@ -1,0 +1,7 @@
+
+
+PASS Setting up the connection
+PASS Checking canvas is green
+PASS Checking canvas is red
+PASS Checking canvas is green again
+

--- a/LayoutTests/webrtc/captureCanvas-webrtc-with-video-scaling-adaptation.html
+++ b/LayoutTests/webrtc/captureCanvas-webrtc-with-video-scaling-adaptation.html
@@ -1,0 +1,97 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+    <head>
+        <canvas id="canvas1" width=640px height=480px></canvas>
+        <video id="video" autoplay></video>
+        <canvas id="canvas2" width=640px height=480px></canvas>
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+        <script src ="routines.js"></script>
+        <script>
+if (window.internals)
+    internals.settings.setPeerConnectionVideoScalingAdaptationDisabled(false);
+
+var color = "green";
+
+function printCanvas()
+{
+    var context = canvas1.getContext("2d");
+    context.fillStyle = color;
+    context.fillRect(0, 0, canvas1.width, canvas1.height);
+}
+
+function printRectangleEvery50ms()
+{
+    printCanvas();
+    setTimeout(printRectangleEvery50ms, 50);
+}
+
+function testCanvas(testName, canvas, isSame, count)
+{
+    var array1 = canvas.getContext("2d").getImageData(20, 20, 60, 60).data;
+    if (count === undefined)
+        count = 0;
+    canvas2.getContext("2d").drawImage(video, 0 ,0);
+    array2 = canvas2.getContext("2d").getImageData(20, 20, 60, 60).data;
+    var isEqual = true;
+    var index = 0;
+    for (index = 0; index < array1.length; ++index) {
+        // Rough comparison since we are compressing data.
+        // This test still catches errors since we are going from green to blue to red.
+        if (Math.abs(array1[index] - array2[index]) > 100) {
+            isEqual = false;
+            continue;
+        }
+    }
+    if (isEqual === isSame)
+        return Promise.resolve();
+
+    if (count === 20)
+        return Promise.reject(testName + " failed, expected " + JSON.stringify(array1) + " but got " + JSON.stringify(array2));
+
+    return waitFor(100).then(() => {
+        return testCanvas(testName, canvas, isSame, ++count);
+    });
+}
+
+promise_test((test) => {
+    printRectangleEvery50ms();
+    return new Promise((resolve, reject) => {
+        createConnections((firstConnection) => {
+            var stream = canvas1.captureStream();
+            firstConnection.addTrack(stream.getVideoTracks()[0], stream);
+        }, (secondConnection) => {
+            secondConnection.ontrack = (trackEvent) => {
+                assert_true(trackEvent.track instanceof MediaStreamTrack);
+                assert_true(trackEvent.receiver instanceof RTCRtpReceiver);
+                assert_true(Array.isArray(trackEvent.streams), "Array.isArray() should return true");
+                assert_true(Object.isFrozen(trackEvent.streams), "Object.isFrozen() should return true");
+                resolve(trackEvent.streams[0]);
+            };
+        });
+        setTimeout(() => reject("Test timed out"), 5000);
+    }).then((stream) => {
+        video.srcObject = stream;
+        return video.play();
+    });
+}, "Setting up the connection");
+
+promise_test((test) => {
+    return testCanvas("test 1", canvas1, true);
+}, "Checking canvas is green");
+
+promise_test((test) => {
+    color = "red";
+    printCanvas()
+    return testCanvas("test 2", canvas1, true);
+}, "Checking canvas is red");
+
+
+promise_test((test) => {
+    color = "green";
+    printCanvas();
+    return testCanvas("test 3", canvas1, true);
+}, "Checking canvas is green again");
+        </script>
+    </head>
+</html>

--- a/LayoutTests/webrtc/video-maxBitrate-expected.txt
+++ b/LayoutTests/webrtc/video-maxBitrate-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Testing that maxBitrate and maintain-framerate have an effect
+

--- a/LayoutTests/webrtc/video-maxBitrate-vp8-expected.txt
+++ b/LayoutTests/webrtc/video-maxBitrate-vp8-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Testing that maxBitrate and maintain-framerate have an effect
+

--- a/LayoutTests/webrtc/video-maxBitrate-vp8.html
+++ b/LayoutTests/webrtc/video-maxBitrate-vp8.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Testing macFramerate</title>
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video id="video" autoplay=""></video>
+        <script src ="routines.js"></script>
+        <script>
+if (window.internals)
+    internals.settings.setPeerConnectionVideoScalingAdaptationDisabled(false);
+
+var pc1, pc2;
+promise_test(async (test) => {
+    const localStream = await navigator.mediaDevices.getUserMedia({video:{width:640}});
+    const stream = await new Promise((resolve, reject) => {
+        createConnections((firstConnection) => {
+            pc1 = firstConnection;
+            const sender = firstConnection.addTrack(localStream.getVideoTracks()[0], localStream);
+            firstConnection.getTransceivers()[0].setCodecPreferences([{mimeType: "video/VP8", clockRate: 90000}]);
+        }, (secondConnection) => {
+            pc2 = secondConnection;
+            secondConnection.ontrack = (trackEvent) => {
+                resolve(trackEvent.streams[0]);
+            };
+        });
+        setTimeout(() => reject("Test timed out"), 5000);
+    });
+
+    video.srcObject = stream;
+    await video.play();
+
+    let settings = stream.getVideoTracks()[0].getSettings();
+
+    let counter = 0;
+    while (++counter < 200 && settings.frameRate < 10) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        settings = stream.getVideoTracks()[0].getSettings();
+    }
+    assert_greater_than(settings.frameRate, 5, "remote track settings frame rate");
+
+    counter = 0;
+    while (++counter < 200 && settings.width < 640) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        settings = stream.getVideoTracks()[0].getSettings();
+    }
+    assert_greater_than_equal(settings.width, 640, "remote track settings width");
+
+    let parameters = pc1.getSenders()[0].getParameters();
+    parameters.encodings[0].maxFramerate = 30;
+    parameters.encodings[0].maxBitrate = 10000;
+    parameters.degradationPreference = "maintain-resolution";
+    await pc1.getSenders()[0].setParameters(parameters);
+
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    assert_greater_than_equal(settings.width, 640, "remote track width with reduced bitrate and maintain-resolution");
+
+    parameters = pc1.getSenders()[0].getParameters();
+    parameters.degradationPreference = "maintain-framerate";
+    await pc1.getSenders()[0].setParameters(parameters);
+
+    counter = 0;
+    while (++counter < 200 && settings.width == 640) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        settings = stream.getVideoTracks()[0].getSettings();
+    }
+    assert_less_than_equal(settings.width, 480, "remote track width with reduced bitrate and maintain-framerate");
+}, "Testing that maxBitrate and maintain-framerate have an effect");
+        </script>
+    </body>
+</html>

--- a/LayoutTests/webrtc/video-maxBitrate.html
+++ b/LayoutTests/webrtc/video-maxBitrate.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Testing macFramerate</title>
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video id="video" autoplay=""></video>
+        <script src ="routines.js"></script>
+        <script>
+if (window.internals)
+    internals.settings.setPeerConnectionVideoScalingAdaptationDisabled(false);
+
+var pc1, pc2;
+promise_test(async (test) => {
+    const localStream = await navigator.mediaDevices.getUserMedia({video:{width:640}});
+    const stream = await new Promise((resolve, reject) => {
+        createConnections((firstConnection) => {
+            pc1 = firstConnection;
+            const sender = firstConnection.addTrack(localStream.getVideoTracks()[0], localStream);
+        }, (secondConnection) => {
+            pc2 = secondConnection;
+            secondConnection.ontrack = (trackEvent) => {
+                resolve(trackEvent.streams[0]);
+            };
+        });
+        setTimeout(() => reject("Test timed out"), 5000);
+    });
+
+    video.srcObject = stream;
+    await video.play();
+
+    let settings = stream.getVideoTracks()[0].getSettings();
+
+    let counter = 0;
+    while (++counter < 200 && settings.frameRate < 10) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        settings = stream.getVideoTracks()[0].getSettings();
+    }
+    assert_greater_than(settings.frameRate, 5, "remote track settings frame rate");
+
+    counter = 0;
+    while (++counter < 200 && settings.width < 640) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        settings = stream.getVideoTracks()[0].getSettings();
+    }
+    assert_greater_than_equal(settings.width, 640, "remote track settings width");
+
+    let parameters = pc1.getSenders()[0].getParameters();
+    parameters.encodings[0].maxFramerate = 30;
+    parameters.encodings[0].maxBitrate = 10000;
+    parameters.degradationPreference = "maintain-resolution";
+    await pc1.getSenders()[0].setParameters(parameters);
+
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    assert_greater_than_equal(settings.width, 640, "remote track width with reduced bitrate and maintain-resolution");
+
+    parameters = pc1.getSenders()[0].getParameters();
+    parameters.degradationPreference = "maintain-framerate";
+    await pc1.getSenders()[0].setParameters(parameters);
+
+    counter = 0;
+    while (++counter < 200 && settings.width == 640) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        settings = stream.getVideoTracks()[0].getSettings();
+    }
+    assert_less_than_equal(settings.width, 480, "remote track width with reduced bitrate and maintain-framerate");
+}, "Testing that maxBitrate and maintain-framerate have an effect");
+        </script>
+    </body>
+</html>

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/native/src/objc_frame_buffer.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/native/src/objc_frame_buffer.h
@@ -34,6 +34,7 @@ class ObjCFrameBuffer : public VideoFrameBuffer {
     ReleaseBufferCallback releaseBuffer { nullptr };
   };
   ObjCFrameBuffer(BufferProvider, int width, int height);
+  ObjCFrameBuffer(id<RTCVideoFrameBuffer>, int width, int height);
 
   Type type() const override;
 
@@ -46,8 +47,13 @@ class ObjCFrameBuffer : public VideoFrameBuffer {
   void* frame_buffer_provider() { return frame_buffer_provider_.pointer; }
 
  private:
+   rtc::scoped_refptr<VideoFrameBuffer> CropAndScale(int offset_x, int offset_y, int crop_width, int crop_height, int scaled_width, int scaled_height) final;
+
+  void set_original_frame(ObjCFrameBuffer& frame) { original_frame_ = &frame; }
+
   id<RTCVideoFrameBuffer> frame_buffer_;
   BufferProvider frame_buffer_provider_;
+  rtc::scoped_refptr<ObjCFrameBuffer> original_frame_;
   int width_;
   int height_;
   mutable webrtc::Mutex mutex_;

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/native/src/objc_frame_buffer.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/native/src/objc_frame_buffer.mm
@@ -60,12 +60,15 @@ ObjCFrameBuffer::ObjCFrameBuffer(id<RTCVideoFrameBuffer> frame_buffer)
 ObjCFrameBuffer::ObjCFrameBuffer(BufferProvider provider, int width, int height)
     : frame_buffer_provider_(provider), width_(width), height_(height) { }
 
+ObjCFrameBuffer::ObjCFrameBuffer(id<RTCVideoFrameBuffer> frame_buffer, int width, int height)
+    : frame_buffer_(frame_buffer), width_(width), height_(height) { }
+
 ObjCFrameBuffer::~ObjCFrameBuffer() {
-#if defined(WEBRTC_WEBKIT_BUILD)
-  [frame_buffer_ close];
-#endif
-  if (frame_buffer_provider_.releaseBuffer)
-    frame_buffer_provider_.releaseBuffer(frame_buffer_provider_.pointer);
+  if (!original_frame_) {
+    [frame_buffer_ close];
+    if (frame_buffer_provider_.releaseBuffer)
+      frame_buffer_provider_.releaseBuffer(frame_buffer_provider_.pointer);
+  }
 }
 
 VideoFrameBuffer::Type ObjCFrameBuffer::type() const {
@@ -87,6 +90,9 @@ rtc::scoped_refptr<I420BufferInterface> ObjCFrameBuffer::ToI420() {
   rtc::scoped_refptr<I420BufferInterface> buffer =
     rtc::make_ref_counted<ObjCI420FrameBuffer>([wrapped_frame_buffer() toI420]);
 
+  if (width_ != buffer->width() || height_ != buffer->height())
+      buffer = buffer->Scale(width_, height_)->ToI420();
+
   return buffer;
 }
 
@@ -99,6 +105,20 @@ id<RTCVideoFrameBuffer> ObjCFrameBuffer::wrapped_frame_buffer() const {
   }
 #endif
   return frame_buffer_;
+}
+
+rtc::scoped_refptr<VideoFrameBuffer> ObjCFrameBuffer::CropAndScale(int offset_x, int offset_y, int crop_width, int crop_height, int scaled_width, int scaled_height)
+{
+  if (offset_x || offset_y || crop_width != width() || crop_height != height())
+    return VideoFrameBuffer::CropAndScale(offset_x, offset_y, crop_width, crop_height, scaled_width, scaled_height);
+
+  webrtc::MutexLock lock(&mutex_);
+  auto newFrame = (!frame_buffer_ && frame_buffer_provider_.getBuffer && frame_buffer_provider_.pointer) ?
+    rtc::make_ref_counted<ObjCFrameBuffer>(frame_buffer_provider_, scaled_width, scaled_height) :
+    rtc::make_ref_counted<ObjCFrameBuffer>(frame_buffer_, scaled_width, scaled_height);
+
+  newFrame->set_original_frame(original_frame_ ? *original_frame_ : *this);
+  return newFrame;
 }
 
 id<RTCVideoFrameBuffer> ToObjCVideoFrameBuffer(const rtc::scoped_refptr<VideoFrameBuffer>& buffer) {

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5061,6 +5061,20 @@ PeerConnectionEnabled:
     WebCore:
       default: true
 
+PeerConnectionVideoScalingAdaptationDisabled:
+  type: bool
+  status: embedder
+  humanReadableName: "WebRTC Peer Connection Video Scaling Adaptation"
+  humanReadableDescription: "Disable RTCPeerConnection Video Scaling Adaptation"
+  condition: ENABLE(WEB_RTC)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 PerElementSpeakerSelectionEnabled:
   type: bool

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -204,6 +204,11 @@ bool LibWebRTCMediaEndpoint::addTrack(LibWebRTCRtpSenderBackend& sender, MediaSt
     }
     case RealtimeMediaSource::Type::Video: {
         auto videoSource = RealtimeOutgoingVideoSource::create(track.privateTrack());
+
+        RefPtr context = m_peerConnectionBackend.connection().scriptExecutionContext();
+        if (context && context->settingsValues().peerConnectionVideoScalingAdaptationDisabled)
+            videoSource->disableVideoScaling();
+
         rtcTrack = m_peerConnectionFactory->CreateVideoTrack(rtc::scoped_refptr<webrtc::VideoTrackSourceInterface> (videoSource.ptr()), track.id().utf8().data());
         source = WTFMove(videoSource);
         break;
@@ -375,6 +380,11 @@ std::pair<LibWebRTCRtpSenderBackend::Source, rtc::scoped_refptr<webrtc::MediaStr
     }
     case RealtimeMediaSource::Type::Video: {
         auto videoSource = RealtimeOutgoingVideoSource::create(track.privateTrack());
+
+        RefPtr context = m_peerConnectionBackend.connection().scriptExecutionContext();
+        if (context && context->settingsValues().peerConnectionVideoScalingAdaptationDisabled)
+            videoSource->disableVideoScaling();
+
         rtcTrack = m_peerConnectionFactory->CreateVideoTrack(rtc::scoped_refptr<webrtc::VideoTrackSourceInterface> (videoSource.ptr()), track.id().utf8().data());
         source = WTFMove(videoSource);
         break;

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
@@ -74,6 +74,7 @@ public:
     }
 
     void applyRotation();
+    void disableVideoScaling() { m_enableVideoFrameScaling = false; }
 
 protected:
     explicit RealtimeOutgoingVideoSource(Ref<MediaStreamTrackPrivate>&&);
@@ -94,11 +95,13 @@ protected:
     WTFLogChannel& logChannel() const final;
 #endif
 
+    double videoFrameScaling() const { return m_enableVideoFrameScaling ? (double)m_videoFrameScaling : 1; }
+
 private:
     void sendBlackFramesIfNeeded();
     void sendOneBlackFrame();
     void initializeFromSource();
-    void updateBlackFramesSending();
+    void updateFramesSending();
 
     void observeSource();
     void unobserveSource();
@@ -154,6 +157,9 @@ private:
     uint32_t m_width { 0 };
     uint32_t m_height { 0 };
     std::optional<double> m_maxFrameRate;
+    std::optional<double> m_maxPixelCount;
+    std::atomic<double> m_videoFrameScaling { 1.0 };
+    bool m_enableVideoFrameScaling { true };
     bool m_isObservingVideoFrames { false };
 
 #if !RELEASE_LOG_DISABLED

--- a/Tools/DumpRenderTree/TestOptions.cpp
+++ b/Tools/DumpRenderTree/TestOptions.cpp
@@ -91,6 +91,7 @@ const TestFeatures& TestOptions::defaults()
             { "MockScrollbarsEnabled", true },
             { "NeedsStorageAccessFromFileURLsQuirk", false },
             { "OfflineWebApplicationCacheEnabled", true },
+            { "PeerConnectionVideoScalingAdaptationDisabled", true },
             { "PushAPIEnabled", true },
             { "ReferrerPolicyAttributeEnabled", true },
             { "RemotePlaybackEnabled", true },

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -118,6 +118,7 @@ const TestFeatures& TestOptions::defaults()
             { "NeedsStorageAccessFromFileURLsQuirk", false },
             { "OfflineWebApplicationCacheEnabled", true },
             { "PageVisibilityBasedProcessSuppressionEnabled", false },
+            { "PeerConnectionVideoScalingAdaptationDisabled", true },
             { "PDFJSViewerEnabled", false },
             { "PluginsEnabled", true },
             { "PushAPIEnabled", true },


### PR DESCRIPTION
#### aedef001a9cb8b3efeb97d9d7afb83c27c12c74c
<pre>
RealtimeOutgoingVideoSource needs to trigger resolution scaling in case of WebRTC maintain-framerate degradationPreference
<a href="https://rdar.apple.com/121041723">rdar://121041723</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=267577">https://bugs.webkit.org/show_bug.cgi?id=267577</a>

Reviewed by Eric Carlson.

Our WebRTC backend is applying degradation preference but it relies on WebKit to react upon resolution decrease signal,
like done for frame rate, via the max_pixel_count value.

WebKit is downsampling sent video frames based on max_pixel_count.
We only do this update based on a runtime flag, which is off by default, since this may introduce flakinesses in tests.
We may as a follow-up enable this adaptation in tests by default and disable it in affecting tests based on bot results.

To do this update, WebKit is computing the updated width and height based on max_pixel_count.
It reuses the 3/4-2/3 approach used by Chromium to select lower resolutions based on the original frame resolution.

To limit the cost of downsampling, we add support for an adaptation layer in ObjCFrameBuffer.
ObjCFrameBuffer takes a pixel buffer (or pixel buffer getter) and a width and height.
The width and height may not match with the underlying pixel buffer.
Downsampling happens when trying to grab the actual pixel buffer, in ToI420.
We implement an optimized Scale routine that is only updating the width and height of the ObjCFrameBuffer without creating the corresponding pixel buffer.

Since we are now sharing the underlying pixel buffer in several different ObjCFrameBuffers, scaled ObjCFrameBuffers keeps a reference to the original ObjCFrameBuffer.
This code path is done for libvpx encoders.
For remote VTB encoders, they directly do the downsampling as part of the encoding process.
We thus do not need to do the downsampling before sending the video frames.

We cover both code paths by doing the same test with H264 and VP8.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/webrtc/video-maxBitrate-expected.txt: Added.
* LayoutTests/webrtc/video-maxBitrate-vp8-expected.txt: Added.
* LayoutTests/webrtc/video-maxBitrate-vp8.html: Added.
* LayoutTests/webrtc/video-maxBitrate.html: Added.
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/native/src/objc_frame_buffer.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/native/src/objc_frame_buffer.mm:
(webrtc::ObjCFrameBuffer::ObjCFrameBuffer):
(webrtc::ObjCFrameBuffer::ToI420):
(webrtc::ObjCFrameBuffer::CropAndScale):
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
(WebCore::LibWebRTCMediaEndpoint::addTrack):
* Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp:
(WebCore::RealtimeOutgoingVideoSource::updateFramesSending):
(WebCore::RealtimeOutgoingVideoSource::sourceMutedChanged):
(WebCore::RealtimeOutgoingVideoSource::sourceEnabledChanged):
(WebCore::RealtimeOutgoingVideoSource::initializeFromSource):
(WebCore::RealtimeOutgoingVideoSource::AddOrUpdateSink):
(WebCore::RealtimeOutgoingVideoSource::updateBlackFramesSending): Deleted.
* Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h:
(WebCore::RealtimeOutgoingVideoSource::disableVideoScaling):
(WebCore::RealtimeOutgoingVideoSource::videoFrameScaling const):
* Source/WebCore/platform/mediastream/mac/RealtimeOutgoingVideoSourceCocoa.cpp:
(WebCore::RealtimeOutgoingVideoSourceCocoa::videoFrameAvailable):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):

Canonical link: <a href="https://commits.webkit.org/273172@main">https://commits.webkit.org/273172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3506454280ffc02ab23af04bbb36088ac277d3b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37229 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31220 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10470 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30196 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9877 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9956 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38507 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/29343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31363 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36021 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/34418 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7966 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33974 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11899 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30467 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41013 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7936 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10631 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8557 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10946 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->