### PR TITLE
[web-animations] rename DeclarativeAnimation to StyleOriginatedAnimation

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -571,8 +571,6 @@ animation/CSSTransition.cpp
 animation/CSSTransitionEvent.cpp
 animation/CompositeOperation.cpp
 animation/CustomEffect.cpp
-animation/DeclarativeAnimation.cpp
-animation/DeclarativeAnimationEvent.cpp
 animation/DocumentTimeline.cpp
 animation/DocumentTimelinesController.cpp
 animation/ElementAnimationRareData.cpp
@@ -581,6 +579,8 @@ animation/KeyframeEffect.cpp
 animation/KeyframeEffectStack.cpp
 animation/KeyframeInterpolation.cpp
 animation/ScrollTimeline.cpp
+animation/StyleOriginatedAnimation.cpp
+animation/StyleOriginatedAnimationEvent.cpp
 animation/ViewTimeline.cpp
 animation/WebAnimation.cpp
 animation/WebAnimationUtilities.cpp

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -59,8 +59,8 @@ void AnimationEffect::setAnimation(WebAnimation* animation)
 
 EffectTiming AnimationEffect::getBindingsTiming() const
 {
-    if (auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(animation()))
-        declarativeAnimation->flushPendingStyleChanges();
+    if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation()))
+        styleOriginatedAnimation->flushPendingStyleChanges();
 
     EffectTiming timing;
     timing.delay = secondsToWebAnimationsAPITime(m_timing.delay);
@@ -102,8 +102,8 @@ BasicEffectTiming AnimationEffect::getBasicTiming(std::optional<Seconds> startTi
 
 ComputedEffectTiming AnimationEffect::getBindingsComputedTiming() const
 {
-    if (auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(animation()))
-        declarativeAnimation->flushPendingStyleChanges();
+    if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation()))
+        styleOriginatedAnimation->flushPendingStyleChanges();
     return getComputedTiming();
 }
 

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -48,14 +48,14 @@ Ref<CSSAnimation> CSSAnimation::create(const Styleable& owningElement, const Ani
 }
 
 CSSAnimation::CSSAnimation(const Styleable& element, const Animation& backingAnimation)
-    : DeclarativeAnimation(element, backingAnimation)
+    : StyleOriginatedAnimation(element, backingAnimation)
     , m_animationName(backingAnimation.name().name)
 {
 }
 
 void CSSAnimation::syncPropertiesWithBackingAnimation()
 {
-    DeclarativeAnimation::syncPropertiesWithBackingAnimation();
+    StyleOriginatedAnimation::syncPropertiesWithBackingAnimation();
 
     if (!effect())
         return;
@@ -136,7 +136,7 @@ ExceptionOr<void> CSSAnimation::bindingsPlay()
     // After a successful call to play() or pause() on a CSSAnimation, any subsequent change to the animation-play-state will
     // no longer cause the CSSAnimation to be played or paused.
 
-    auto retVal = DeclarativeAnimation::bindingsPlay();
+    auto retVal = StyleOriginatedAnimation::bindingsPlay();
     if (!retVal.hasException())
         m_overriddenProperties.add(Property::PlayState);
     return retVal;
@@ -149,7 +149,7 @@ ExceptionOr<void> CSSAnimation::bindingsPause()
     // After a successful call to play() or pause() on a CSSAnimation, any subsequent change to the animation-play-state will
     // no longer cause the CSSAnimation to be played or paused.
 
-    auto retVal = DeclarativeAnimation::bindingsPause();
+    auto retVal = StyleOriginatedAnimation::bindingsPause();
     if (!retVal.hasException())
         m_overriddenProperties.add(Property::PlayState);
     return retVal;
@@ -165,7 +165,7 @@ void CSSAnimation::setBindingsEffect(RefPtr<AnimationEffect>&& newEffect)
     // matching @keyframes rule is removed the animation must still be canceled.
 
     auto* previousEffect = effect();
-    DeclarativeAnimation::setBindingsEffect(WTFMove(newEffect));
+    StyleOriginatedAnimation::setBindingsEffect(WTFMove(newEffect));
     if (effect() != previousEffect) {
         m_overriddenProperties.add(Property::Duration);
         m_overriddenProperties.add(Property::TimingFunction);
@@ -187,7 +187,7 @@ ExceptionOr<void> CSSAnimation::setBindingsStartTime(const std::optional<CSSNumb
     // change to the animation-play-state will no longer cause the CSSAnimation to be played or paused.
 
     auto previousPlayState = playState();
-    auto result = DeclarativeAnimation::setBindingsStartTime(startTime);
+    auto result = StyleOriginatedAnimation::setBindingsStartTime(startTime);
     if (result.hasException())
         return result.releaseException();
     auto currentPlayState = playState();
@@ -206,7 +206,7 @@ ExceptionOr<void> CSSAnimation::bindingsReverse()
     // change to the animation-play-state will no longer cause the CSSAnimation to be played or paused.
 
     auto previousPlayState = playState();
-    auto retVal = DeclarativeAnimation::bindingsReverse();
+    auto retVal = StyleOriginatedAnimation::bindingsReverse();
     if (!retVal.hasException()) {
         auto currentPlayState = playState();
         if (currentPlayState != previousPlayState && (currentPlayState == PlayState::Paused || previousPlayState == PlayState::Paused))
@@ -285,10 +285,10 @@ void CSSAnimation::updateKeyframesIfNeeded(const RenderStyle* oldStyle, const Re
         return;
 
     if (keyframeEffect->blendingKeyframes().isEmpty())
-        keyframeEffect->computeDeclarativeAnimationBlendingKeyframes(oldStyle, newStyle, resolutionContext);
+        keyframeEffect->computeStyleOriginatedAnimationBlendingKeyframes(oldStyle, newStyle, resolutionContext);
 }
 
-Ref<DeclarativeAnimationEvent> CSSAnimation::createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId)
+Ref<StyleOriginatedAnimationEvent> CSSAnimation::createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId)
 {
     return CSSAnimationEvent::create(eventType, this, scheduledTime, elapsedTime, pseudoId, m_animationName);
 }

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "DeclarativeAnimation.h"
+#include "StyleOriginatedAnimation.h"
 #include "Styleable.h"
 #include <wtf/OptionSet.h>
 #include <wtf/Ref.h>
@@ -35,7 +35,7 @@ namespace WebCore {
 class Animation;
 class RenderStyle;
 
-class CSSAnimation final : public DeclarativeAnimation {
+class CSSAnimation final : public StyleOriginatedAnimation {
     WTF_MAKE_ISO_ALLOCATED(CSSAnimation);
 public:
     static Ref<CSSAnimation> create(const Styleable&, const Animation&, const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
@@ -54,7 +54,7 @@ private:
     CSSAnimation(const Styleable&, const Animation&);
 
     void syncPropertiesWithBackingAnimation() final;
-    Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId) final;
+    Ref<StyleOriginatedAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId) final;
 
     ExceptionOr<void> bindingsPlay() final;
     ExceptionOr<void> bindingsPause() final;

--- a/Source/WebCore/animation/CSSAnimationEvent.cpp
+++ b/Source/WebCore/animation/CSSAnimationEvent.cpp
@@ -33,13 +33,13 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSSAnimationEvent);
 
 CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : DeclarativeAnimationEvent(type, initializer, isTrusted, initializer.elapsedTime, initializer.pseudoElement)
+    : StyleOriginatedAnimationEvent(type, initializer, isTrusted, initializer.elapsedTime, initializer.pseudoElement)
     , m_animationName(initializer.animationName)
 {
 }
 
 CSSAnimationEvent::CSSAnimationEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId, const String& animationName)
-    : DeclarativeAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoId)
+    : StyleOriginatedAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoId)
     , m_animationName(animationName)
 {
 }

--- a/Source/WebCore/animation/CSSAnimationEvent.h
+++ b/Source/WebCore/animation/CSSAnimationEvent.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include "DeclarativeAnimationEvent.h"
+#include "StyleOriginatedAnimationEvent.h"
 
 namespace WebCore {
 
-class CSSAnimationEvent final : public DeclarativeAnimationEvent {
+class CSSAnimationEvent final : public StyleOriginatedAnimationEvent {
     WTF_MAKE_ISO_ALLOCATED(CSSAnimationEvent);
 public:
     static Ref<CSSAnimationEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId, const String& animationName)

--- a/Source/WebCore/animation/CSSTransition.cpp
+++ b/Source/WebCore/animation/CSSTransition.cpp
@@ -50,7 +50,7 @@ Ref<CSSTransition> CSSTransition::create(const Styleable& owningElement, const A
 }
 
 CSSTransition::CSSTransition(const Styleable& styleable, const AnimatableCSSProperty& property, MonotonicTime generationTime, const Animation& backingAnimation, const RenderStyle& oldStyle, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double reversingShorteningFactor)
-    : DeclarativeAnimation(styleable, backingAnimation)
+    : StyleOriginatedAnimation(styleable, backingAnimation)
     , m_property(property)
     , m_generationTime(generationTime)
     , m_timelineTimeAtCreation(styleable.element.document().timeline().currentTime())
@@ -63,16 +63,16 @@ CSSTransition::CSSTransition(const Styleable& styleable, const AnimatableCSSProp
 
 void CSSTransition::resolve(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext, std::optional<Seconds> startTime)
 {
-    DeclarativeAnimation::resolve(targetStyle, resolutionContext, startTime);
+    StyleOriginatedAnimation::resolve(targetStyle, resolutionContext, startTime);
     m_currentStyle = RenderStyle::clonePtr(targetStyle);
 }
 
 void CSSTransition::animationDidFinish()
 {
-    DeclarativeAnimation::animationDidFinish();
+    StyleOriginatedAnimation::animationDidFinish();
 
     if (auto owningElement = this->owningElement())
-        owningElement->removeDeclarativeAnimationFromListsForOwningElement(*this);
+        owningElement->removeStyleOriginatedAnimationFromListsForOwningElement(*this);
 }
 
 void CSSTransition::setTimingProperties(Seconds delay, Seconds duration)
@@ -95,7 +95,7 @@ void CSSTransition::setTimingProperties(Seconds delay, Seconds duration)
     unsuspendEffectInvalidation();
 }
 
-Ref<DeclarativeAnimationEvent> CSSTransition::createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId)
+Ref<StyleOriginatedAnimationEvent> CSSTransition::createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId)
 {
     return CSSTransitionEvent::create(eventType, this, scheduledTime, elapsedTime, pseudoId, transitionProperty());
 }

--- a/Source/WebCore/animation/CSSTransition.h
+++ b/Source/WebCore/animation/CSSTransition.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "CSSPropertyNames.h"
-#include "DeclarativeAnimation.h"
+#include "StyleOriginatedAnimation.h"
 #include "Styleable.h"
 #include "WebAnimationTypes.h"
 #include <wtf/Markable.h>
@@ -39,7 +39,7 @@ namespace WebCore {
 class Animation;
 class RenderStyle;
 
-class CSSTransition final : public DeclarativeAnimation {
+class CSSTransition final : public StyleOriginatedAnimation {
     WTF_MAKE_ISO_ALLOCATED(CSSTransition);
 public:
     static Ref<CSSTransition> create(const Styleable&, const AnimatableCSSProperty&, MonotonicTime generationTime, const Animation&, const RenderStyle& oldStyle, const RenderStyle& newStyle, Seconds delay, Seconds duration, const RenderStyle& reversingAdjustedStartStyle, double);
@@ -57,7 +57,7 @@ public:
 private:
     CSSTransition(const Styleable&, const AnimatableCSSProperty&, MonotonicTime generationTime, const Animation&, const RenderStyle& oldStyle, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double);
     void setTimingProperties(Seconds delay, Seconds duration);
-    Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId) final;
+    Ref<StyleOriginatedAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId) final;
     void resolve(RenderStyle& targetStyle, const Style::ResolutionContext&, std::optional<Seconds>) final;
     void animationDidFinish() final;
     bool isCSSTransition() const final { return true; }

--- a/Source/WebCore/animation/CSSTransitionEvent.cpp
+++ b/Source/WebCore/animation/CSSTransitionEvent.cpp
@@ -34,13 +34,13 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSSTransitionEvent);
 
 CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId, const String propertyName)
-    : DeclarativeAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoId)
+    : StyleOriginatedAnimationEvent(type, animation, scheduledTime, elapsedTime, pseudoId)
     , m_propertyName(propertyName)
 {
 }
 
 CSSTransitionEvent::CSSTransitionEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : DeclarativeAnimationEvent(type, initializer, isTrusted, initializer.elapsedTime, initializer.pseudoElement)
+    : StyleOriginatedAnimationEvent(type, initializer, isTrusted, initializer.elapsedTime, initializer.pseudoElement)
     , m_propertyName(initializer.propertyName)
 {
 }

--- a/Source/WebCore/animation/CSSTransitionEvent.h
+++ b/Source/WebCore/animation/CSSTransitionEvent.h
@@ -26,11 +26,11 @@
 
 #pragma once
 
-#include "DeclarativeAnimationEvent.h"
+#include "StyleOriginatedAnimationEvent.h"
 
 namespace WebCore {
 
-class CSSTransitionEvent final : public DeclarativeAnimationEvent {
+class CSSTransitionEvent final : public StyleOriginatedAnimationEvent {
     WTF_MAKE_ISO_ALLOCATED(CSSTransitionEvent);
 public:
     static Ref<CSSTransitionEvent> create(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime,  double elapsedTime, PseudoId pseudoId, const String propertyName)

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -32,7 +32,6 @@
 #include "CustomAnimationOptions.h"
 #include "CustomEffect.h"
 #include "CustomEffectCallback.h"
-#include "DeclarativeAnimation.h"
 #include "Document.h"
 #include "DocumentTimelinesController.h"
 #include "EventNames.h"
@@ -46,6 +45,7 @@
 #include "RenderElement.h"
 #include "RenderLayer.h"
 #include "RenderLayerBacking.h"
+#include "StyleOriginatedAnimation.h"
 #include "WebAnimationTypes.h"
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -633,8 +633,8 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
 {
     // https://drafts.csswg.org/web-animations-1/#dom-keyframeeffectreadonly-getkeyframes
 
-    if (auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(animation()))
-        declarativeAnimation->flushPendingStyleChanges();
+    if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation()))
+        styleOriginatedAnimation->flushPendingStyleChanges();
 
     Vector<ComputedKeyframe> computedKeyframes;
 
@@ -1054,9 +1054,9 @@ std::optional<unsigned> KeyframeEffect::transformFunctionListPrefix() const
     return isTransformFunctionListsMatchPrefixRelevant() ? std::optional<unsigned>(m_transformFunctionListsMatchPrefix) : std::nullopt;
 }
 
-void KeyframeEffect::computeDeclarativeAnimationBlendingKeyframes(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext& resolutionContext)
+void KeyframeEffect::computeStyleOriginatedAnimationBlendingKeyframes(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext& resolutionContext)
 {
-    ASSERT(is<DeclarativeAnimation>(animation()));
+    ASSERT(is<StyleOriginatedAnimation>(animation()));
     if (is<CSSAnimation>(animation()))
         computeCSSAnimationBlendingKeyframes(newStyle, resolutionContext);
     else if (is<CSSTransition>(animation())) {
@@ -1544,15 +1544,15 @@ void KeyframeEffect::setAnimatedPropertiesInStyle(RenderStyle& targetStyle, doub
 
 const TimingFunction* KeyframeEffect::timingFunctionForBlendingKeyframe(const BlendingKeyframe& keyframe) const
 {
-    if (auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(animation())) {
+    if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation())) {
         // If we're dealing with a CSS Animation, the timing function is specified either on the keyframe itself.
-        if (is<CSSAnimation>(declarativeAnimation)) {
+        if (is<CSSAnimation>(styleOriginatedAnimation)) {
             if (auto* timingFunction = keyframe.timingFunction())
                 return timingFunction;
         }
 
         // Failing that, or for a CSS Transition, the timing function is inherited from the backing Animation object.
-        return declarativeAnimation->backingAnimation().timingFunction();
+        return styleOriginatedAnimation->backingAnimation().timingFunction();
     }
 
     return keyframe.timingFunction();
@@ -2132,7 +2132,7 @@ bool KeyframeEffect::computeExtentOfTransformAnimation(LayoutRect& bounds) const
     for (const auto& keyframe : m_blendingKeyframes) {
         const auto* keyframeStyle = keyframe.style();
 
-        // FIXME: maybe for declarative animations we always say it's true for the first and last keyframe.
+        // FIXME: maybe for style-originated animations we always say it's true for the first and last keyframe.
         if (!keyframe.animatesProperty(CSSPropertyTransform)) {
             // If the first keyframe is missing transform style, use the current style.
             if (!keyframe.offset())
@@ -2338,8 +2338,8 @@ void KeyframeEffect::setComposite(CompositeOperation compositeOperation)
 
 CompositeOperation KeyframeEffect::bindingsComposite() const
 {
-    if (auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(animation()))
-        declarativeAnimation->flushPendingStyleChanges();
+    if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation()))
+        styleOriginatedAnimation->flushPendingStyleChanges();
     return composite();
 }
 

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -149,7 +149,7 @@ public:
 
     std::optional<unsigned> transformFunctionListPrefix() const override;
 
-    void computeDeclarativeAnimationBlendingKeyframes(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
+    void computeStyleOriginatedAnimationBlendingKeyframes(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
     const BlendingKeyframes& blendingKeyframes() const { return m_blendingKeyframes; }
     const HashSet<AnimatableCSSProperty>& animatedProperties();
     bool animatesProperty(const AnimatableCSSProperty&) const;

--- a/Source/WebCore/animation/StyleOriginatedAnimation.h
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.h
@@ -36,16 +36,16 @@
 namespace WebCore {
 
 class Animation;
-class DeclarativeAnimationEvent;
+class StyleOriginatedAnimationEvent;
 class Element;
 class RenderStyle;
 
-class DeclarativeAnimation : public WebAnimation {
-    WTF_MAKE_ISO_ALLOCATED(DeclarativeAnimation);
+class StyleOriginatedAnimation : public WebAnimation {
+    WTF_MAKE_ISO_ALLOCATED(StyleOriginatedAnimation);
 public:
-    ~DeclarativeAnimation();
+    ~StyleOriginatedAnimation();
 
-    bool isDeclarativeAnimation() const final { return true; }
+    bool isStyleOriginatedAnimation() const final { return true; }
 
     const std::optional<const Styleable> owningElement() const;
     const Animation& backingAnimation() const { return m_backingAnimation; }
@@ -72,11 +72,11 @@ public:
     void flushPendingStyleChanges() const;
 
 protected:
-    DeclarativeAnimation(const Styleable&, const Animation&);
+    StyleOriginatedAnimation(const Styleable&, const Animation&);
 
     void initialize(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
     virtual void syncPropertiesWithBackingAnimation();
-    virtual Ref<DeclarativeAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId) = 0;
+    virtual Ref<StyleOriginatedAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId) = 0;
 
     enum class ShouldFireEvents : uint8_t { No, YesForCSSAnimation, YesForCSSTransition };
     ShouldFireEvents shouldFireDOMEvents() const;
@@ -102,4 +102,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_WEB_ANIMATION(DeclarativeAnimation, isDeclarativeAnimation())
+SPECIALIZE_TYPE_TRAITS_WEB_ANIMATION(StyleOriginatedAnimation, isStyleOriginatedAnimation())

--- a/Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp
@@ -24,23 +24,24 @@
  */
 
 #include "config.h"
-#include "DeclarativeAnimationEvent.h"
+#include "StyleOriginatedAnimationEvent.h"
+
 #include "WebAnimationUtilities.h"
 
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 
-WTF_MAKE_ISO_ALLOCATED_IMPL(DeclarativeAnimationEvent);
+WTF_MAKE_ISO_ALLOCATED_IMPL(StyleOriginatedAnimationEvent);
 
-DeclarativeAnimationEvent::DeclarativeAnimationEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId)
+StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent(const AtomString& type, WebAnimation* animation, std::optional<Seconds> scheduledTime, double elapsedTime, PseudoId pseudoId)
     : AnimationEventBase(type, animation, scheduledTime)
     , m_elapsedTime(elapsedTime)
     , m_pseudoId(pseudoId)
 {
 }
 
-DeclarativeAnimationEvent::DeclarativeAnimationEvent(const AtomString& type, const EventInit& init, IsTrusted isTrusted, double elapsedTime, const String& pseudoElement)
+StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent(const AtomString& type, const EventInit& init, IsTrusted isTrusted, double elapsedTime, const String& pseudoElement)
     : AnimationEventBase(type, init, isTrusted)
     , m_elapsedTime(elapsedTime)
     , m_pseudoElement(pseudoElement)
@@ -50,9 +51,9 @@ DeclarativeAnimationEvent::DeclarativeAnimationEvent(const AtomString& type, con
         m_pseudoId = *pseudoId;
 }
 
-DeclarativeAnimationEvent::~DeclarativeAnimationEvent() = default;
+StyleOriginatedAnimationEvent::~StyleOriginatedAnimationEvent() = default;
 
-const String& DeclarativeAnimationEvent::pseudoElement()
+const String& StyleOriginatedAnimationEvent::pseudoElement()
 {
     if (m_pseudoElement.isNull())
         m_pseudoElement = pseudoIdAsString(m_pseudoId);

--- a/Source/WebCore/animation/StyleOriginatedAnimationEvent.h
+++ b/Source/WebCore/animation/StyleOriginatedAnimationEvent.h
@@ -30,18 +30,18 @@
 
 namespace WebCore {
 
-class DeclarativeAnimationEvent : public AnimationEventBase {
-    WTF_MAKE_ISO_ALLOCATED(DeclarativeAnimationEvent);
+class StyleOriginatedAnimationEvent : public AnimationEventBase {
+    WTF_MAKE_ISO_ALLOCATED(StyleOriginatedAnimationEvent);
 public:
-    virtual ~DeclarativeAnimationEvent();
+    virtual ~StyleOriginatedAnimationEvent();
 
     double elapsedTime() const { return m_elapsedTime; }
     const String& pseudoElement();
     PseudoId pseudoId() const { return m_pseudoId; }
 
 protected:
-    DeclarativeAnimationEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double, PseudoId);
-    DeclarativeAnimationEvent(const AtomString&, const EventInit&, IsTrusted, double, const String&);
+    StyleOriginatedAnimationEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double, PseudoId);
+    StyleOriginatedAnimationEvent(const AtomString&, const EventInit&, IsTrusted, double, const String&);
 
 private:
     double m_elapsedTime;

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -37,7 +37,6 @@
 #include "ChromeClient.h"
 #include "ComputedStyleExtractor.h"
 #include "DOMPromiseProxy.h"
-#include "DeclarativeAnimation.h"
 #include "Document.h"
 #include "DocumentTimeline.h"
 #include "Element.h"
@@ -50,6 +49,7 @@
 #include "KeyframeEffectStack.h"
 #include "Logging.h"
 #include "RenderElement.h"
+#include "StyleOriginatedAnimation.h"
 #include "StylePropertyShorthand.h"
 #include "StyleResolver.h"
 #include "StyledElement.h"
@@ -191,7 +191,7 @@ void WebAnimation::setEffect(RefPtr<AnimationEffect>&& newEffect)
         newEffect->animation()->setEffect(nullptr);
 
     // 6. Let the target effect of animation be new effect.
-    // In the case of a declarative animation, we don't want to remove the animation from the relevant maps because
+    // In the case of a style-originated animation, we don't want to remove the animation from the relevant maps because
     // while the effect was set via the API, the element still has a transition or animation set up and we must
     // not break the timeline-to-animation relationship.
 
@@ -199,7 +199,7 @@ void WebAnimation::setEffect(RefPtr<AnimationEffect>&& newEffect)
 
     // This object could be deleted after clearing the effect relationship.
     Ref protectedThis { *this };
-    setEffectInternal(WTFMove(newEffect), isDeclarativeAnimation());
+    setEffectInternal(WTFMove(newEffect), isStyleOriginatedAnimation());
 
     // 7. Run the procedure to update an animation's finished state for animation with the did seek flag set to false,
     // and the synchronously notify flag set to false.
@@ -252,10 +252,10 @@ void WebAnimation::setTimeline(RefPtr<AnimationTimeline>&& timeline)
 
     if (auto keyframeEffect = dynamicDowncast<KeyframeEffect>(m_effect.get())) {
         if (auto target = keyframeEffect->targetStyleable()) {
-            // In the case of a declarative animation, we don't want to remove the animation from the relevant maps because
+            // In the case of a dstyle-originated animation, we don't want to remove the animation from the relevant maps because
             // while the timeline was set via the API, the element still has a transition or animation set up and we must
             // not break the relationship.
-            if (!isDeclarativeAnimation())
+            if (!isStyleOriginatedAnimation())
                 target->animationWasRemoved(*this);
             target->animationWasAdded(*this);
         }
@@ -1495,8 +1495,8 @@ bool WebAnimation::isReplaceable() const
 
     // The existence of the animation is not prescribed by markup. That is, it is not a CSS animation with an owning element,
     // nor a CSS transition with an owning element.
-    auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(*this);
-    if (declarativeAnimation && declarativeAnimation->owningElement())
+    auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(*this);
+    if (styleOriginatedAnimation && styleOriginatedAnimation->owningElement())
         return false;
 
     // The animation's play state is finished.
@@ -1676,7 +1676,7 @@ std::optional<Seconds> WebAnimation::convertAnimationTimeToTimelineTime(Seconds 
 
 bool WebAnimation::isSkippedContentAnimation() const
 {
-    if (auto animation = dynamicDowncast<DeclarativeAnimation>(this)) {
+    if (auto animation = dynamicDowncast<StyleOriginatedAnimation>(this)) {
         if (auto element = animation->owningElement())
             return element->element.renderer() && element->element.renderer()->isSkippedContent();
     }

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -65,7 +65,7 @@ public:
 
     WEBCORE_EXPORT static HashSet<WebAnimation*>& instances();
 
-    virtual bool isDeclarativeAnimation() const { return false; }
+    virtual bool isStyleOriginatedAnimation() const { return false; }
     virtual bool isCSSAnimation() const { return false; }
     virtual bool isCSSTransition() const { return false; }
 

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -27,7 +27,6 @@
 #include "ContentVisibilityDocumentState.h"
 
 #include "ContentVisibilityAutoStateChangeEvent.h"
-#include "DeclarativeAnimation.h"
 #include "DocumentInlines.h"
 #include "DocumentTimeline.h"
 #include "EventNames.h"
@@ -38,6 +37,7 @@
 #include "RenderElement.h"
 #include "RenderStyleInlines.h"
 #include "SimpleRange.h"
+#include "StyleOriginatedAnimation.h"
 #include "VisibleSelection.h"
 
 namespace WebCore {
@@ -243,15 +243,15 @@ void ContentVisibilityDocumentState::updateAnimations(const Element& element, Is
     if (wasSkipped == IsSkippedContent::No || becomesSkipped == IsSkippedContent::Yes)
         return;
     for (RefPtr animation : WebAnimation::instances()) {
-        RefPtr declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(animation.releaseNonNull());
-        if (!declarativeAnimation)
+        RefPtr styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation.releaseNonNull());
+        if (!styleOriginatedAnimation)
             continue;
-        auto owningElement = declarativeAnimation->owningElement();
+        auto owningElement = styleOriginatedAnimation->owningElement();
         if (!owningElement || !owningElement->element.isDescendantOrShadowDescendantOf(&element))
             continue;
 
-        if (RefPtr timeline = declarativeAnimation->timeline())
-            timeline->animationTimingDidChange(*declarativeAnimation);
+        if (RefPtr timeline = styleOriginatedAnimation->timeline())
+            timeline->animationTimingDidChange(*styleOriginatedAnimation);
     }
 }
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3940,7 +3940,7 @@ void Element::removeFromTopLayer()
     if (CheckedPtr renderer = this->renderer()) {
         if (CheckedPtr backdrop = renderer->backdropRenderer().get()) {
             if (auto styleable = Styleable::fromRenderer(*backdrop))
-                styleable->cancelDeclarativeAnimations();
+                styleable->cancelStyleOriginatedAnimations();
         }
     }
 

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -35,7 +35,6 @@
 #include "CanvasBase.h"
 #include "CanvasRenderingContext.h"
 #include "Database.h"
-#include "DeclarativeAnimation.h"
 #include "DocumentThreadableLoader.h"
 #include "Element.h"
 #include "Event.h"
@@ -49,6 +48,7 @@
 #include "ResourceLoader.h"
 #include "ResourceLoaderIdentifier.h"
 #include "StorageArea.h"
+#include "StyleOriginatedAnimation.h"
 #include "WebAnimation.h"
 #include "WorkerInspectorProxy.h"
 #include <JavaScriptCore/ConsoleMessage.h>

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -34,7 +34,6 @@
 #include "CSSTransition.h"
 #include "CSSValue.h"
 #include "ComputedStyleExtractor.h"
-#include "DeclarativeAnimation.h"
 #include "Element.h"
 #include "Event.h"
 #include "FillMode.h"
@@ -49,6 +48,7 @@
 #include "Page.h"
 #include "PlaybackDirection.h"
 #include "RenderElement.h"
+#include "StyleOriginatedAnimation.h"
 #include "Styleable.h"
 #include "TimingFunction.h"
 #include "WebAnimation.h"
@@ -118,7 +118,7 @@ static Ref<JSON::ArrayOf<Protocol::Animation::Keyframe>> buildObjectForKeyframes
     const auto& blendingKeyframes = keyframeEffect.blendingKeyframes();
     const auto& parsedKeyframes = keyframeEffect.parsedKeyframes();
 
-    if (auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(keyframeEffect.animation())) {
+    if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(keyframeEffect.animation())) {
         auto* target = keyframeEffect.target();
         auto* renderer = keyframeEffect.renderer();
 
@@ -141,7 +141,7 @@ static Ref<JSON::ArrayOf<Protocol::Animation::Keyframe>> buildObjectForKeyframes
             if (!timingFunction)
                 timingFunction = blendingKeyframe.timingFunction();
             if (!timingFunction)
-                timingFunction = declarativeAnimation->backingAnimation().timingFunction();
+                timingFunction = styleOriginatedAnimation->backingAnimation().timingFunction();
             if (timingFunction)
                 keyframePayload->setEasing(timingFunction->cssText());
 
@@ -351,7 +351,7 @@ Protocol::ErrorStringOr<void> InspectorAnimationAgent::startTracking()
 
     m_instrumentingAgents.setTrackingAnimationAgent(this);
 
-    ASSERT(m_trackedDeclarativeAnimationData.isEmpty());
+    ASSERT(m_trackedStyleOriginatedAnimationData.isEmpty());
 
     m_frontendDispatcher->trackingStart(m_environment.executionStopwatch().elapsedTime().seconds());
 
@@ -365,7 +365,7 @@ Protocol::ErrorStringOr<void> InspectorAnimationAgent::stopTracking()
 
     m_instrumentingAgents.setTrackingAnimationAgent(nullptr);
 
-    m_trackedDeclarativeAnimationData.clear();
+    m_trackedStyleOriginatedAnimationData.clear();
 
     m_frontendDispatcher->trackingComplete(m_environment.executionStopwatch().elapsedTime().seconds());
 
@@ -382,11 +382,11 @@ static bool isDelayed(const ComputedEffectTiming& computedTiming)
 void InspectorAnimationAgent::willApplyKeyframeEffect(const Styleable& target, KeyframeEffect& keyframeEffect, const ComputedEffectTiming& computedTiming)
 {
     auto* animation = keyframeEffect.animation();
-    if (!is<DeclarativeAnimation>(animation))
+    if (!is<StyleOriginatedAnimation>(animation))
         return;
 
-    auto ensureResult = m_trackedDeclarativeAnimationData.ensure(downcast<DeclarativeAnimation>(animation), [&] () -> UniqueRef<TrackedDeclarativeAnimationData> {
-        return makeUniqueRef<TrackedDeclarativeAnimationData>(TrackedDeclarativeAnimationData { makeString("animation:"_s, IdentifiersFactory::createIdentifier()), computedTiming });
+    auto ensureResult = m_trackedStyleOriginatedAnimationData.ensure(downcast<StyleOriginatedAnimation>(animation), [&] () -> UniqueRef<TrackedStyleOriginatedAnimationData> {
+        return makeUniqueRef<TrackedStyleOriginatedAnimationData>(TrackedStyleOriginatedAnimationData { makeString("animation:"_s, IdentifiersFactory::createIdentifier()), computedTiming });
     });
     auto& trackingData = ensureResult.iterator->value.get();
 
@@ -456,8 +456,8 @@ void InspectorAnimationAgent::didChangeWebAnimationName(WebAnimation& animation)
 
 void InspectorAnimationAgent::didSetWebAnimationEffect(WebAnimation& animation)
 {
-    if (auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(animation))
-        stopTrackingDeclarativeAnimation(*declarativeAnimation);
+    if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation))
+        stopTrackingStyleOriginatedAnimation(*styleOriginatedAnimation);
 
     didChangeWebAnimationEffectTiming(animation);
     didChangeWebAnimationEffectTarget(animation);
@@ -508,8 +508,8 @@ void InspectorAnimationAgent::animationBindingTimerFired()
 
 void InspectorAnimationAgent::willDestroyWebAnimation(WebAnimation& animation)
 {
-    if (auto* declarativeAnimation = dynamicDowncast<DeclarativeAnimation>(animation))
-        stopTrackingDeclarativeAnimation(*declarativeAnimation);
+    if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation))
+        stopTrackingStyleOriginatedAnimation(*styleOriginatedAnimation);
 
     // The `animationId` may be empty if Animation is tracking but not enabled.
     auto animationId = findAnimationId(animation);
@@ -616,9 +616,9 @@ void InspectorAnimationAgent::reset()
         m_animationDestroyedTimer.stop();
 }
 
-void InspectorAnimationAgent::stopTrackingDeclarativeAnimation(DeclarativeAnimation& animation)
+void InspectorAnimationAgent::stopTrackingStyleOriginatedAnimation(StyleOriginatedAnimation& animation)
 {
-    auto data = m_trackedDeclarativeAnimationData.take(&animation);
+    auto data = m_trackedStyleOriginatedAnimationData.take(&animation);
     if (!data)
         return;
 

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.h
@@ -38,12 +38,12 @@
 namespace WebCore {
 
 class AnimationEffect;
-class DeclarativeAnimation;
 class Element;
 class Event;
 class KeyframeEffect;
 class LocalFrame;
 class Page;
+class StyleOriginatedAnimation;
 class WebAnimation;
 class WeakPtrImplWithEventTargetData;
 
@@ -87,7 +87,7 @@ private:
     void animationDestroyedTimerFired();
     void reset();
 
-    void stopTrackingDeclarativeAnimation(DeclarativeAnimation&);
+    void stopTrackingStyleOriginatedAnimation(StyleOriginatedAnimation&);
 
     std::unique_ptr<Inspector::AnimationFrontendDispatcher> m_frontendDispatcher;
     RefPtr<Inspector::AnimationBackendDispatcher> m_backendDispatcher;
@@ -103,12 +103,12 @@ private:
     Vector<String> m_removedAnimationIds;
     Timer m_animationDestroyedTimer;
 
-    struct TrackedDeclarativeAnimationData {
+    struct TrackedStyleOriginatedAnimationData {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
         String trackingAnimationId;
         ComputedEffectTiming lastComputedTiming;
     };
-    HashMap<DeclarativeAnimation*, UniqueRef<TrackedDeclarativeAnimationData>> m_trackedDeclarativeAnimationData;
+    HashMap<StyleOriginatedAnimation*, UniqueRef<TrackedStyleOriginatedAnimationData>> m_trackedStyleOriginatedAnimationData;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -32,10 +32,10 @@
 #include "BlendingKeyframes.h"
 #include "CSSPropertyAnimation.h"
 #include "CSSPropertyNames.h"
-#include "DeclarativeAnimation.h"
 #include "Document.h"
 #include "KeyframeEffect.h"
 #include "LayoutSize.h"
+#include "StyleOriginatedAnimation.h"
 #include "WebAnimation.h"
 #include "WebAnimationTypes.h"
 #include <wtf/IsoMallocInlines.h>
@@ -203,8 +203,8 @@ AcceleratedEffect::AcceleratedEffect(const KeyframeEffect& effect, const IntRect
         ASSERT(animation->holdTime() || animation->startTime());
         m_holdTime = animation->holdTime();
         m_startTime = animation->startTime();
-        if (is<DeclarativeAnimation>(animation)) {
-            if (auto* defaultKeyframeTimingFunction = downcast<DeclarativeAnimation>(*animation).backingAnimation().timingFunction())
+        if (is<StyleOriginatedAnimation>(animation)) {
+            if (auto* defaultKeyframeTimingFunction = downcast<StyleOriginatedAnimation>(*animation).backingAnimation().timingFunction())
                 m_defaultKeyframeTimingFunction = defaultKeyframeTimingFunction;
         }
     }

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -710,11 +710,11 @@ void RenderTreeUpdater::tearDownRenderers(Element& root, TeardownType teardownTy
                 element.clearHoverAndActiveStatusBeforeDetachingRenderer();
                 break;
             case TeardownType::Full:
-                styleable.cancelDeclarativeAnimations();
+                styleable.cancelStyleOriginatedAnimations();
                 element.clearHoverAndActiveStatusBeforeDetachingRenderer();
                 break;
             case TeardownType::RendererUpdateCancelingAnimations:
-                styleable.cancelDeclarativeAnimations();
+                styleable.cancelStyleOriginatedAnimations();
                 break;
             case TeardownType::RendererUpdate:
                 styleable.willChangeRenderer();
@@ -730,7 +730,7 @@ void RenderTreeUpdater::tearDownRenderers(Element& root, TeardownType teardownTy
                 // we cannot create a Styleable with a PseudoElement.
                 if (auto* renderListItem = dynamicDowncast<RenderListItem>(element.renderer())) {
                     if (renderListItem->markerRenderer())
-                        Styleable(element, PseudoId::Marker).cancelDeclarativeAnimations();
+                        Styleable(element, PseudoId::Marker).cancelStyleOriginatedAnimations();
                 }
             }
 

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -175,12 +175,12 @@ struct Styleable {
     void elementWasRemoved() const;
 
     void willChangeRenderer() const;
-    void cancelDeclarativeAnimations() const;
+    void cancelStyleOriginatedAnimations() const;
 
     void animationWasAdded(WebAnimation&) const;
     void animationWasRemoved(WebAnimation&) const;
 
-    void removeDeclarativeAnimationFromListsForOwningElement(WebAnimation&) const;
+    void removeStyleOriginatedAnimationFromListsForOwningElement(WebAnimation&) const;
 
     void updateCSSAnimations(const RenderStyle* currentStyle, const RenderStyle& afterChangeStyle, const Style::ResolutionContext&) const;
     void updateCSSTransitions(const RenderStyle& currentStyle, const RenderStyle& newStyle) const;


### PR DESCRIPTION
#### 1701618d04c4680a58da33544f9a349daacd1186
<pre>
[web-animations] rename DeclarativeAnimation to StyleOriginatedAnimation
<a href="https://bugs.webkit.org/show_bug.cgi?id=267640">https://bugs.webkit.org/show_bug.cgi?id=267640</a>
<a href="https://rdar.apple.com/121121419">rdar://121121419</a>

Reviewed by Ryosuke Niwa.

Animations originated from CSS, CSS Animations and CSS Transitions, share a superclass named `DeclarativeAnimation`.
However, the terminology is &quot;style-originated animation&quot; as opposed to &quot;script-originated animation&quot;. We rename
that shared superclass to reflect this.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/AnimationEffect.cpp:
(WebCore::AnimationEffect::getBindingsTiming const):
(WebCore::AnimationEffect::getBindingsComputedTiming const):
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::CSSAnimation):
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):
(WebCore::CSSAnimation::bindingsPlay):
(WebCore::CSSAnimation::bindingsPause):
(WebCore::CSSAnimation::setBindingsEffect):
(WebCore::CSSAnimation::setBindingsStartTime):
(WebCore::CSSAnimation::bindingsReverse):
(WebCore::CSSAnimation::updateKeyframesIfNeeded):
(WebCore::CSSAnimation::createEvent):
* Source/WebCore/animation/CSSAnimation.h:
* Source/WebCore/animation/CSSAnimationEvent.cpp:
(WebCore::CSSAnimationEvent::CSSAnimationEvent):
* Source/WebCore/animation/CSSAnimationEvent.h:
* Source/WebCore/animation/CSSTransition.cpp:
(WebCore::CSSTransition::CSSTransition):
(WebCore::CSSTransition::resolve):
(WebCore::CSSTransition::animationDidFinish):
(WebCore::CSSTransition::createEvent):
* Source/WebCore/animation/CSSTransition.h:
* Source/WebCore/animation/CSSTransitionEvent.cpp:
(WebCore::CSSTransitionEvent::CSSTransitionEvent):
* Source/WebCore/animation/CSSTransitionEvent.h:
* Source/WebCore/animation/DocumentTimeline.cpp:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::getKeyframes):
(WebCore::KeyframeEffect::computeStyleOriginatedAnimationBlendingKeyframes):
(WebCore::KeyframeEffect::timingFunctionForBlendingKeyframe const):
(WebCore::KeyframeEffect::computeExtentOfTransformAnimation const):
(WebCore::KeyframeEffect::bindingsComposite const):
(WebCore::KeyframeEffect::computeDeclarativeAnimationBlendingKeyframes): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/StyleOriginatedAnimation.cpp: Renamed from Source/WebCore/animation/DeclarativeAnimation.cpp.
(WebCore::StyleOriginatedAnimation::StyleOriginatedAnimation):
(WebCore::StyleOriginatedAnimation::~StyleOriginatedAnimation):
(WebCore::StyleOriginatedAnimation::owningElement const):
(WebCore::StyleOriginatedAnimation::tick):
(WebCore::StyleOriginatedAnimation::canHaveGlobalPosition):
(WebCore::StyleOriginatedAnimation::disassociateFromOwningElement):
(WebCore::StyleOriginatedAnimation::setBackingAnimation):
(WebCore::StyleOriginatedAnimation::initialize):
(WebCore::StyleOriginatedAnimation::syncPropertiesWithBackingAnimation):
(WebCore::StyleOriginatedAnimation::bindingsStartTime const):
(WebCore::StyleOriginatedAnimation::bindingsCurrentTime const):
(WebCore::StyleOriginatedAnimation::bindingsPlayState const):
(WebCore::StyleOriginatedAnimation::bindingsReplaceState const):
(WebCore::StyleOriginatedAnimation::bindingsPending const):
(WebCore::StyleOriginatedAnimation::bindingsReady):
(WebCore::StyleOriginatedAnimation::bindingsFinished):
(WebCore::StyleOriginatedAnimation::bindingsPlay):
(WebCore::StyleOriginatedAnimation::bindingsPause):
(WebCore::StyleOriginatedAnimation::flushPendingStyleChanges const):
(WebCore::StyleOriginatedAnimation::setTimeline):
(WebCore::StyleOriginatedAnimation::cancel):
(WebCore::StyleOriginatedAnimation::cancelFromStyle):
(WebCore::StyleOriginatedAnimation::phaseWithoutEffect const):
(WebCore::StyleOriginatedAnimation::effectTimeAtStart const):
(WebCore::StyleOriginatedAnimation::effectTimeAtIteration const):
(WebCore::StyleOriginatedAnimation::effectTimeAtEnd const):
(WebCore::StyleOriginatedAnimation::shouldFireDOMEvents const):
(WebCore::StyleOriginatedAnimation::invalidateDOMEvents):
(WebCore::StyleOriginatedAnimation::enqueueDOMEvent):
* Source/WebCore/animation/StyleOriginatedAnimation.h: Renamed from Source/WebCore/animation/DeclarativeAnimation.h.
(WebCore::StyleOriginatedAnimation::backingAnimation const):
* Source/WebCore/animation/StyleOriginatedAnimationEvent.cpp: Renamed from Source/WebCore/animation/DeclarativeAnimationEvent.cpp.
(WebCore::StyleOriginatedAnimationEvent::StyleOriginatedAnimationEvent):
(WebCore::StyleOriginatedAnimationEvent::pseudoElement):
* Source/WebCore/animation/StyleOriginatedAnimationEvent.h: Renamed from Source/WebCore/animation/DeclarativeAnimationEvent.h.
(WebCore::StyleOriginatedAnimationEvent::elapsedTime const):
(WebCore::StyleOriginatedAnimationEvent::pseudoId const):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setEffect):
(WebCore::WebAnimation::setTimeline):
(WebCore::WebAnimation::isReplaceable const):
(WebCore::WebAnimation::isSkippedContentAnimation const):
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::isStyleOriginatedAnimation const):
(WebCore::WebAnimation::isDeclarativeAnimation const): Deleted.
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::compareStyleOriginatedAnimationOwningElementPositionsInDocumentTreeOrder):
(WebCore::compareCSSTransitions):
(WebCore::compareCSSAnimations):
(WebCore::compareAnimationsByCompositeOrder):
(WebCore::compareStyleOriginatedAnimationEvents):
(WebCore::compareAnimationEventsByCompositeOrder):
(WebCore::compareDeclarativeAnimationOwningElementPositionsInDocumentTreeOrder): Deleted.
(WebCore::compareDeclarativeAnimationEvents): Deleted.
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::updateAnimations):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::removeFromTopLayer):
* Source/WebCore/inspector/InspectorInstrumentation.h:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::buildObjectForKeyframes):
(WebCore::InspectorAnimationAgent::startTracking):
(WebCore::InspectorAnimationAgent::stopTracking):
(WebCore::InspectorAnimationAgent::willApplyKeyframeEffect):
(WebCore::InspectorAnimationAgent::didSetWebAnimationEffect):
(WebCore::InspectorAnimationAgent::willDestroyWebAnimation):
(WebCore::InspectorAnimationAgent::stopTrackingStyleOriginatedAnimation):
(WebCore::InspectorAnimationAgent::stopTrackingDeclarativeAnimation): Deleted.
* Source/WebCore/inspector/agents/InspectorAnimationAgent.h:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::AcceleratedEffect):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::tearDownRenderers):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::removeStyleOriginatedAnimationFromListsForOwningElement const):
(WebCore::Styleable::animationWasRemoved const):
(WebCore::Styleable::elementWasRemoved const):
(WebCore::Styleable::cancelStyleOriginatedAnimations const):
(WebCore::updateCSSTransitionsForStyleableAndProperty):
(WebCore::Styleable::removeDeclarativeAnimationFromListsForOwningElement const): Deleted.
(WebCore::Styleable::cancelDeclarativeAnimations const): Deleted.
* Source/WebCore/style/Styleable.h:

Canonical link: <a href="https://commits.webkit.org/273170@main">https://commits.webkit.org/273170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d306c82525cb674a54c7ceb240a4582e53aa7def

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37101 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31130 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30127 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11198 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9784 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9870 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38384 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31261 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35944 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/9996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33888 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11802 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10548 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4429 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->