### PR TITLE
Generate serialization for WebCore::TextRecognitionDataDetector

### DIFF
--- a/Source/WebCore/platform/TextRecognitionResult.h
+++ b/Source/WebCore/platform/TextRecognitionResult.h
@@ -74,8 +74,8 @@ struct TextRecognitionLineData {
 
 struct TextRecognitionDataDetector {
     TextRecognitionDataDetector() = default;
-    TextRecognitionDataDetector(DDScannerResult *scannerResult, Vector<FloatQuad>&& quads)
-        : result(scannerResult)
+    TextRecognitionDataDetector(RetainPtr<DDScannerResult>&& scannerResult, Vector<FloatQuad>&& quads)
+        : result(WTFMove(scannerResult))
         , normalizedQuads(WTFMove(quads))
     {
     }

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
@@ -671,24 +671,6 @@ bool ArgumentCoder<WebCore::MediaPlaybackTargetContext>::decodePlatformData(Deco
 }
 #endif
 
-#if ENABLE(IMAGE_ANALYSIS) && ENABLE(DATA_DETECTION)
-
-void ArgumentCoder<WebCore::TextRecognitionDataDetector>::encodePlatformData(Encoder& encoder, const WebCore::TextRecognitionDataDetector& info)
-{
-    encoder << info.result.get();
-}
-
-bool ArgumentCoder<WebCore::TextRecognitionDataDetector>::decodePlatformData(Decoder& decoder, WebCore::TextRecognitionDataDetector& result)
-{
-    auto scannerResult = decoder.decodeWithAllowedClasses<DDScannerResult>();
-    if (!scannerResult)
-        return false;
-
-    result.result = WTFMove(*scannerResult);
-    return true;
-}
-
-#endif // ENABLE(IMAGE_ANALYSIS) && ENABLE(DATA_DETECTION)
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -907,29 +907,4 @@ std::optional<WebCore::CDMInstanceSession::Message>  ArgumentCoder<WebCore::CDMI
 }
 #endif // ENABLE(ENCRYPTED_MEDIA)
 
-#if ENABLE(IMAGE_ANALYSIS) && ENABLE(DATA_DETECTION)
-
-void ArgumentCoder<TextRecognitionDataDetector>::encode(Encoder& encoder, const TextRecognitionDataDetector& info)
-{
-    encodePlatformData(encoder, info);
-    encoder << info.normalizedQuads;
-}
-
-std::optional<TextRecognitionDataDetector> ArgumentCoder<TextRecognitionDataDetector>::decode(Decoder& decoder)
-{
-    TextRecognitionDataDetector result;
-    if (!decodePlatformData(decoder, result))
-        return std::nullopt;
-
-    std::optional<Vector<FloatQuad>> normalizedQuads;
-    decoder >> normalizedQuads;
-    if (!normalizedQuads)
-        return std::nullopt;
-
-    result.normalizedQuads = WTFMove(*normalizedQuads);
-    return WTFMove(result);
-}
-
-#endif // ENABLE(IMAGE_ANALYSIS) && ENABLE(DATA_DETECTION)
-
 } // namespace IPC

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -127,7 +127,6 @@ class SystemImage;
 struct CompositionUnderline;
 struct DataDetectorElementInfo;
 struct SoupNetworkProxySettings;
-struct TextRecognitionDataDetector;
 struct ViewportArguments;
 
 template <class>
@@ -307,17 +306,6 @@ template<> struct ArgumentCoder<WebCore::CDMInstanceSession::Message> {
     static std::optional<WebCore::CDMInstanceSession::Message> decode(Decoder&);
 };
 #endif
-
-#if ENABLE(IMAGE_ANALYSIS) && ENABLE(DATA_DETECTION)
-
-template<> struct ArgumentCoder<WebCore::TextRecognitionDataDetector> {
-    static void encode(Encoder&, const WebCore::TextRecognitionDataDetector&);
-    static WARN_UNUSED_RETURN std::optional<WebCore::TextRecognitionDataDetector> decode(Decoder&);
-    static void encodePlatformData(Encoder&, const WebCore::TextRecognitionDataDetector&);
-    static WARN_UNUSED_RETURN bool decodePlatformData(Decoder&, WebCore::TextRecognitionDataDetector&);
-};
-
-#endif // ENABLE(IMAGE_ANALYSIS) && ENABLE(DATA_DETECTION)
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7284,6 +7284,14 @@ enum class WebCore::GraphicsContextGLSurfaceBuffer : bool;
     InvalidEnum
 };
 
+#if ENABLE(IMAGE_ANALYSIS) && ENABLE(DATA_DETECTION)
+header: <WebCore/TextRecognitionResult.h>
+[CustomHeader] struct WebCore::TextRecognitionDataDetector {
+    RetainPtr<DDScannerResult> result;
+    Vector<WebCore::FloatQuad> normalizedQuads;
+};
+#endif // ENABLE(IMAGE_ANALYSIS) && ENABLE(DATA_DETECTION)
+
 #if ENABLE(VIDEO)
 
 header: <WebCore/AudioTrackPrivate.h>


### PR DESCRIPTION
#### 74e3ec78b8b5f071640c0e4e5fd10232ed6ea001
<pre>
Generate serialization for WebCore::TextRecognitionDataDetector
<a href="https://bugs.webkit.org/show_bug.cgi?id=267641">https://bugs.webkit.org/show_bug.cgi?id=267641</a>
<a href="https://rdar.apple.com/121125342">rdar://121125342</a>

Reviewed by Alex Christensen.

* Source/WebCore/platform/TextRecognitionResult.h:
(WebCore::TextRecognitionDataDetector::TextRecognitionDataDetector):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::ArgumentCoder&lt;WebCore::TextRecognitionDataDetector&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::TextRecognitionDataDetector&gt;::decodePlatformData): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;TextRecognitionDataDetector&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;TextRecognitionDataDetector&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/273361@main">https://commits.webkit.org/273361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1cd7011c8f3a5e5402c3356b55d94d54c002ff6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37886 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31717 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36290 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30640 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31337 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10425 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10489 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39133 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36486 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34482 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12383 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11129 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4540 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->