### PR TITLE
[WGSL] shader,execution,zero_init:* is failing

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTCallExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTCallExpression.h
@@ -28,6 +28,7 @@
 #include "ASTExpression.h"
 
 namespace WGSL {
+class RewriteGlobalVariables;
 class TypeChecker;
 
 namespace AST {
@@ -39,6 +40,7 @@ namespace AST {
 class CallExpression final : public Expression {
     WGSL_AST_BUILDER_NODE(CallExpression);
 
+    friend RewriteGlobalVariables;
     friend TypeChecker;
 
 public:


### PR DESCRIPTION
#### d86fef64a7c356724248608496d68f3f8f27044a
<pre>
[WGSL] shader,execution,zero_init:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=267646">https://bugs.webkit.org/show_bug.cgi?id=267646</a>
<a href="https://rdar.apple.com/121134298">rdar://121134298</a>

Reviewed by Mike Wyrzykowski.

Arrays and structs in the workgroup/threadgroup address space also need to be
explicitly initialized.

* Source/WebGPU/WGSL/AST/ASTCallExpression.h:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::insertLocalDefinitions):
(WGSL::RewriteGlobalVariables::initializeVariables):
(WGSL::RewriteGlobalVariables::storeInitialValue):
(WGSL::RewriteGlobalVariables::initializeAtomics): Deleted.
(WGSL::RewriteGlobalVariables::atomicStoreInitialValue): Deleted.
(WGSL::RewriteGlobalVariables::containsAtomic): Deleted.

Canonical link: <a href="https://commits.webkit.org/273176@main">https://commits.webkit.org/273176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a40ac393430fc6462b058d5757f5da856e4ff6f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37122 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31144 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10364 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30141 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34955 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11211 "Found 2 new test failures: fast/forms/ios/dismiss-date-picker-on-rotation.html, fast/forms/ios/file-upload-panel-capture.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30706 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9798 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9885 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38404 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31274 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35960 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33904 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11819 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7940 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10561 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10862 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->