### PR TITLE
Increase totalPixels of fast/forms/switch/no-pixels-outside-the-box.html and friend to encompass more platforms

### DIFF
--- a/LayoutTests/fast/forms/switch/no-pixels-outside-the-box-vertical-lr-rtl.html
+++ b/LayoutTests/fast/forms/switch/no-pixels-outside-the-box-vertical-lr-rtl.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html class="reftest-wait" dir=rtl>
-<meta name="fuzzy" content="maxDifference=0-37; totalPixels=0-1288">
+<meta name="fuzzy" content="maxDifference=0-38; totalPixels=0-1290">
 <style>
 body { zoom: 5; display: grid; writing-mode:vertical-lr }
 span { display: inline-block; background: white }

--- a/LayoutTests/fast/forms/switch/no-pixels-outside-the-box.html
+++ b/LayoutTests/fast/forms/switch/no-pixels-outside-the-box.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html class="reftest-wait">
-<meta name="fuzzy" content="maxDifference=0-37; totalPixels=0-1288">
+<meta name="fuzzy" content="maxDifference=0-38; totalPixels=0-1290">
 <style>
 body { zoom: 5; display: grid }
 span { display: inline-block; background: white }


### PR DESCRIPTION
#### 0f175b5f707cff6bdd321663efacd8261f3f3ac4
<pre>
Increase totalPixels of fast/forms/switch/no-pixels-outside-the-box.html and friend to encompass more platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=267645">https://bugs.webkit.org/show_bug.cgi?id=267645</a>
<a href="https://rdar.apple.com/121133972">rdar://121133972</a>

Reviewed by Aditya Keerthi.

* LayoutTests/fast/forms/switch/no-pixels-outside-the-box-vertical-lr-rtl.html:
* LayoutTests/fast/forms/switch/no-pixels-outside-the-box.html:

Canonical link: <a href="https://commits.webkit.org/273145@main">https://commits.webkit.org/273145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/875440f5ef7713775a54329f4055b41f7f8d9b04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37132 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31152 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10374 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30146 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30717 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9805 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9892 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38412 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31284 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31087 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/35963 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10012 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33907 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30394 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7916 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10568 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->