### PR TITLE
Sync 'svg-root-lengths.html' from Blink / Chromium to fix flakiness

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2524,7 +2524,6 @@ fast/text/user-installed-fonts/extended-character-with-user-font.html [ Pass Ima
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-channelmergernode-interface/audiochannelmerger-disconnect.html [ DumpJSConsoleLogInStdErr ]
 
 webkit.org/b/148922 svg/as-object/svg-in-object-dynamic-attribute-change.html [ Pass ImageOnlyFailure ]
-webkit.org/b/148925 svg/dom/svg-root-lengths.html [ Pass Failure ]
 
 webkit.org/b/150541 imported/blink/transitions/unprefixed-perspective.html [ Pass Failure Timeout ]
 

--- a/LayoutTests/svg/dom/svg-root-lengths-expected.txt
+++ b/LayoutTests/svg/dom/svg-root-lengths-expected.txt
@@ -3,10 +3,7 @@ This tests the behavior of root SVG length value resolution
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
- PASS successfullyParsed is true
-
-TEST COMPLETE
-Initial/default values:
+ Initial/default values:
 PASS svg.width.baseVal.value is 200
 PASS svg.height.baseVal.value is 200
 
@@ -21,4 +18,7 @@ PASS svg.height.baseVal.value is 50
 viewBox has no effect on top level length resolution.
 PASS svg.width.baseVal.value is 200
 PASS svg.height.baseVal.value is 100
+PASS successfullyParsed is true
+
+TEST COMPLETE
 

--- a/LayoutTests/svg/dom/svg-root-lengths.html
+++ b/LayoutTests/svg/dom/svg-root-lengths.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="../../resources/js-test-pre.js"></script>
+    <script src="../../resources/js-test.js"></script>
   </head>
   <body>
     <p id="description"></p>
@@ -17,42 +17,42 @@
         testRunner.dumpAsText();
       }
 
-      setTimeout(function () {
-        var div = document.getElementById('div');
-        var svg = document.getElementById('svg');
+      // Force layout
+      document.body.offsetTop;
 
-        description('This tests the behavior of root SVG length value resolution');
+      var div = document.getElementById('div');
+      var svg = document.getElementById('svg');
 
-        debug('Initial/default values:');
-        shouldBe('svg.width.baseVal.value', '200');
-        shouldBe('svg.height.baseVal.value', '200');
+      description('This tests the behavior of root SVG length value resolution');
 
-        svg.setAttribute('width', '50%');
-        svg.setAttribute('height', '10%');
-        debug('');
-        debug('Updated relative values:');
-        shouldBe('svg.width.baseVal.value', '100');
-        shouldBe('svg.height.baseVal.value', '20');
+      debug('Initial/default values:');
+      shouldBe('svg.width.baseVal.value', '200');
+      shouldBe('svg.height.baseVal.value', '200');
 
-        svg.setAttribute('width', '150');
-        svg.setAttribute('height', '50');
-        debug('');
-        debug('Updated fixed values:');
-        shouldBe('svg.width.baseVal.value', '150');
-        shouldBe('svg.height.baseVal.value', '50');
+      svg.setAttribute('width', '50%');
+      svg.setAttribute('height', '10%');
+      debug('');
+      debug('Updated relative values:');
+      shouldBe('svg.width.baseVal.value', '100');
+      shouldBe('svg.height.baseVal.value', '20');
 
-        svg.setAttribute('width', '100%');
-        svg.setAttribute('height', '50%');
-        svg.setAttribute('viewBox', '0 0 800 600');
-        debug('');
-        debug('viewBox has no effect on top level length resolution.');
-        shouldBe('svg.width.baseVal.value', '200');
-        shouldBe('svg.height.baseVal.value', '100');
+      svg.setAttribute('width', '150');
+      svg.setAttribute('height', '50');
+      debug('');
+      debug('Updated fixed values:');
+      shouldBe('svg.width.baseVal.value', '150');
+      shouldBe('svg.height.baseVal.value', '50');
 
-        if (window.testRunner)
-          testRunner.notifyDone();
-      }, 0);
+      svg.setAttribute('width', '100%');
+      svg.setAttribute('height', '50%');
+      svg.setAttribute('viewBox', '0 0 800 600');
+      debug('');
+      debug('viewBox has no effect on top level length resolution.');
+      shouldBe('svg.width.baseVal.value', '200');
+      shouldBe('svg.height.baseVal.value', '100');
+
+      if (window.testRunner)
+        testRunner.notifyDone();
     </script>
-    <script src="../../resources/js-test-post.js"></script>
   </body>
 </html>


### PR DESCRIPTION
#### ba9ec2f8082f6c3842b3ad15b16062d033d525ee
<pre>
Sync &apos;svg-root-lengths.html&apos; from Blink / Chromium to fix flakiness

<a href="https://bugs.webkit.org/show_bug.cgi?id=148925">https://bugs.webkit.org/show_bug.cgi?id=148925</a>

Reviewed by Tim Nguyen.

This patch is to sync &apos;svg-root-lengths.html&apos; from Blink / Chromium to fix flakiness since the upstream
uses &apos;js-test.js&apos; and don&apos;t have &apos;setTimeout&apos; especially latter to remove flakiness.

In order to confirm this does not lead to flakiness, I ran following as mentioned in bug:

run-webkit-tests svg/dom/svg-root-lengths.html --repeat 1000 --no-build --no-retry --force -f

and above does not lead to any flakiness or failures.

Blink Source (Merge): <a href="https://source.chromium.org/chromium/chromium/src/+/c639b683032f5f16b6b11c16021bdca69bc7cd6b">https://source.chromium.org/chromium/chromium/src/+/c639b683032f5f16b6b11c16021bdca69bc7cd6b</a>

* LayoutTests/TestExpectations: Remove flakiness expectation
* LayoutTests/svg/dom/svg-root-lengths.html: Updated from Blink Source
* LayoutTests/svg/dom/svg-root-lengths-expected.txt: Updated Expectation

Canonical link: <a href="https://commits.webkit.org/273156@main">https://commits.webkit.org/273156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6c3f0a85245b36b95117689af2b350c82ca4e60

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36463 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37148 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31162 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30155 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/34982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9820 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9902 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38426 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31298 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31098 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35970 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10022 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33918 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11839 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30405 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7927 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10578 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10882 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->