### PR TITLE
No Review - Test only - Potential fix for not horizontally scrolling on Mac when margins are wider than the view and end up with very wide rectables.

### DIFF
--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2441,11 +2441,13 @@ FloatRect FrameSelection::selectionBounds(ClipToVisibleContent clipToVisibleCont
     if (clipToVisibleContent == ClipToVisibleContent::No)
         return visibleSelectionRect;
 #else
-    auto& selection = renderView->selection();
-    auto visibleSelectionRect = selection.boundsClippedToVisibleContent();
+    auto textSelectionRect = RenderObject::absoluteTextRects(m_selection.range().value());
+    IntRect visibleSelectionRect;
+    for (auto rect : textSelectionRect)
+        visibleSelectionRect.unite(rect);
     
     if (clipToVisibleContent == ClipToVisibleContent::No)
-        return selection.bounds();
+        return visibleSelectionRect;
 #endif
     
     return intersection(visibleSelectionRect, renderView->frameView().visibleContentRect(ScrollableArea::LegacyIOSDocumentVisibleRect));


### PR DESCRIPTION
#### 204f82ae1368af28030ecea44e3efef320796330
<pre>
No Review - Test only - Potential fix for not horizontally scrolling on Mac when margins are wider than the view and end up with very wide rectables.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267658">https://bugs.webkit.org/show_bug.cgi?id=267658</a>
<a href="https://rdar.apple.com/121078919">rdar://121078919</a>

Reviewed by NOBODY (OOPS!).

This uses code more similar to what we do on iOS for determining
the bounds of a selection. Seeing if this breaks any tests, but
passing will still be inconclusive bececause we don&apos;t have enough
coverage.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::selectionBounds):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/204f82ae1368af28030ecea44e3efef320796330

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37167 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31178 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35600 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10408 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30164 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11282 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30766 "5 api tests failed or timed out") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9833 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9939 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30796 "Found 2 new test failures: editing/selection/block-cursor-overtype-mode.html, imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38445 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31344 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31112 "Found 3 new test failures: editing/selection/block-cursor-overtype-mode.html, fast/images/text-recognition/mac/image-overlay-maintain-selection-during-size-change.html, imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35980 "Found 2 new test failures: editing/selection/block-cursor-overtype-mode.html, imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10037 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7921 "Found 3 new test failures: editing/selection/block-cursor-overtype-mode.html, fast/images/text-recognition/mac/image-overlay-maintain-selection-during-size-change.html, imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33928 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11855 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10593 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10898 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->