### PR TITLE
Add more support for testing site-isolation in our infrastructure

### DIFF
--- a/Tools/Scripts/webkitperl/FeatureList.pm
+++ b/Tools/Scripts/webkitperl/FeatureList.pm
@@ -134,6 +134,7 @@ my (
     $serverPreconnectSupport,
     $serviceControlsSupport,
     $shareableResourceSupport,
+    $siteIsolationSupport,
     $smoothScrollingSupport,
     $speechSynthesisSupport,
     $spellcheckSupport,
@@ -397,6 +398,9 @@ my @features = (
 
     { option => "shareable-resource", desc => "Toggle network shareable resources support",
       define => "ENABLE_SHAREABLE_RESOURCE", value => \$shareableResourceSupport },
+
+    { option => "site-isolation", desc => "Toggle site isolation tree support",
+      define => "ENABLE_SITE_ISOLATION_TREE", value => \$siteIsolationSupport },
 
     { option => "smooth-scrolling", desc => "Toggle smooth scrolling",
       define => "ENABLE_SMOOTH_SCROLLING", value => \$smoothScrollingSupport },

--- a/Tools/Scripts/webkitpy/port/driver.py
+++ b/Tools/Scripts/webkitpy/port/driver.py
@@ -581,6 +581,8 @@ class Driver(object):
             cmd.append('--show-window')
         if self._port.get_option('accessibility_isolated_tree'):
             cmd.append('--accessibility-isolated-tree')
+        if self._port.get_option('site-istolation'):
+            cmd.append('--site-isolation')
 
         for allowed_host in self._port.allowed_hosts():
             cmd.append('--allowed-host')

--- a/Tools/WebKitTestRunner/Options.cpp
+++ b/Tools/WebKitTestRunner/Options.cpp
@@ -114,6 +114,14 @@ static bool handleOptionAccessibilityIsolatedTreeMode(Options& options, const ch
 }
 #endif
 
+#if ENABLE(SITE_ISOLATION)
+static bool handleOptionSiteIsolation(Options& options, const char*, const char*)
+{
+    options.features.boolWebPreferenceFeatures.insert_or_assign("IsSiteIsolationEnabled", true);
+    return true;
+}
+#endif
+
 static bool handleOptionAllowedHost(Options& options, const char*, const char* host)
 {
     options.allowedHosts.insert(host);
@@ -214,6 +222,9 @@ OptionsHandler::OptionsHandler(Options& o)
     optionList.append(Option("--internal-feature", "Enable internal feature", handleOptionInternalFeature, true));
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     optionList.append(Option("--accessibility-isolated-tree", "Enable accessibility isolated tree mode for tests", handleOptionAccessibilityIsolatedTreeMode));
+#endif
+#if ENABLE(SITE_ISOLATION)
+    optionList.append(Option("--SITE-ISOLATION", "Enable site isolation for tests", handleOptionSiteIsolation));
 #endif
     optionList.append(Option("--webcore-logging", "Enable WebCore log channels", handleOptionWebCoreLogging, true));
     optionList.append(Option("--webkit-logging", "Enable WebKit log channels", handleOptionWebKitLogging, true));


### PR DESCRIPTION
#### 96fab26904533d45e166d2ff3192a691b2baeba1
<pre>
Add more support for testing site-isolation in our infrastructure
<a href="https://bugs.webkit.org/show_bug.cgi?id=267659">https://bugs.webkit.org/show_bug.cgi?id=267659</a>
<a href="https://rdar.apple.com/121152795">rdar://121152795</a>

Reviewed by NOBODY (OOPS!).

Adding additional tools to support testing site-isolation in our infrastructure.

* Tools/Scripts/webkitperl/FeatureList.pm:
* Tools/Scripts/webkitpy/port/driver.py:
(Driver.cmd_line):
* Tools/WebKitTestRunner/Options.cpp:
(WTR::handleOptionSiteIsolation):
(WTR::OptionsHandler::OptionsHandler):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96fab26904533d45e166d2ff3192a691b2baeba1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37201 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31198 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30174 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30756 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9848 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/34817 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9947 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38479 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35992 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10056 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33943 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11875 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10612 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10920 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->