### PR TITLE
Update input[type=*]'s step base handling to match spec

### DIFF
--- a/LayoutTests/fast/forms/date/date-stepup-stepdown-expected.txt
+++ b/LayoutTests/fast/forms/date/date-stepup-stepdown-expected.txt
@@ -1,4 +1,4 @@
-Check stepUp() and stepDown() bahevior for type=date.
+Check stepUp() and stepDown() behavior for type=date.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
@@ -14,6 +14,7 @@ PASS stepDown("2010-02-10", null, null, "foo") is "2010-02-10"
 PASS stepUp("2010-02-10", null, null, null) is "2010-02-10"
 PASS stepDown("2010-02-10", null, null, null) is "2010-02-10"
 Normal cases
+PASS stepDown("1970-01-04", "2", null) is "1970-01-03"
 PASS stepUp("2010-02-10", null, null) is "2010-02-11"
 PASS stepDown("2010-02-10", null, null) is "2010-02-09"
 PASS stepUp("2010-02-10", null, null, 10) is "2010-02-20"
@@ -24,7 +25,7 @@ Step=any
 PASS stepUp("2010-02-10", "any", null) threw exception InvalidStateError: The object is in an invalid state..
 PASS stepDown("2010-02-10", "any", null) threw exception InvalidStateError: The object is in an invalid state..
 Overflow/underflow
-PASS stepUp("2010-02-10", "3.40282346e+38", null) is "2010-02-10"
+PASS stepUp("2010-02-10", "3.40282346e+38", null) is "1970-01-01"
 PASS stepDown("2010-02-10", "3.40282346e+38", null) is "1970-01-01"
 PASS stepUp("2010-02-10", "1", "2010-02-10") is "2010-02-10"
 PASS stepDown("2010-02-10", "1", "2010-02-10") is "2010-02-10"

--- a/LayoutTests/fast/forms/date/date-stepup-stepdown.html
+++ b/LayoutTests/fast/forms/date/date-stepup-stepdown.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
 <div id="console"></div>
 <script>
-description('Check stepUp() and stepDown() bahevior for type=date.');
+description('Check stepUp() and stepDown() behavior for type=date.');
 
 var input = document.createElement('input');
 
@@ -38,33 +38,33 @@ function stepDown(value, step, min, optionalStepCount) {
 
 input.type = 'date';
 debug('Invalid value');
-shouldBe('stepUp("", null, null)', '"1970-01-02"');
-shouldBe('stepDown("", null, null)', '"1969-12-31"');
+shouldBeEqualToString('stepUp("", null, null)', '1970-01-02');
+shouldBeEqualToString('stepDown("", null, null)', '1969-12-31');
 debug('Non-number arguments');
-shouldBe('stepUp("2010-02-10", null, null, "0")', '"2010-02-10"');
-shouldBe('stepDown("2010-02-10", null, null, "0")', '"2010-02-10"');
-shouldBe('stepUp("2010-02-10", null, null, "foo")', '"2010-02-10"');
-shouldBe('stepDown("2010-02-10", null, null, "foo")', '"2010-02-10"');
-shouldBe('stepUp("2010-02-10", null, null, null)', '"2010-02-10"');
-shouldBe('stepDown("2010-02-10", null, null, null)', '"2010-02-10"');
+shouldBeEqualToString('stepUp("2010-02-10", null, null, "0")', '2010-02-10');
+shouldBeEqualToString('stepDown("2010-02-10", null, null, "0")', '2010-02-10');
+shouldBeEqualToString('stepUp("2010-02-10", null, null, "foo")', '2010-02-10');
+shouldBeEqualToString('stepDown("2010-02-10", null, null, "foo")', '2010-02-10');
+shouldBeEqualToString('stepUp("2010-02-10", null, null, null)', '2010-02-10');
+shouldBeEqualToString('stepDown("2010-02-10", null, null, null)', '2010-02-10');
 debug('Normal cases');
-shouldBe('stepUp("2010-02-10", null, null)', '"2010-02-11"');
-shouldBe('stepDown("2010-02-10", null, null)', '"2010-02-09"');
-shouldBe('stepUp("2010-02-10", null, null, 10)', '"2010-02-20"');
-shouldBe('stepDown("2010-02-10", null, null, 11)', '"2010-01-30"');
-shouldBe('stepUp("1970-01-01", "4", null, 2)', '"1970-01-09"');
-shouldBe('stepDown("1970-01-01", "4", null, 3)', '"1969-12-20"');
+shouldBeEqualToString('stepDown("1970-01-04", "2", null)', '1970-01-03');
+shouldBeEqualToString('stepUp("2010-02-10", null, null)', '2010-02-11');
+shouldBeEqualToString('stepDown("2010-02-10", null, null)', '2010-02-09');
+shouldBeEqualToString('stepUp("2010-02-10", null, null, 10)', '2010-02-20');
+shouldBeEqualToString('stepDown("2010-02-10", null, null, 11)', '2010-01-30');
+shouldBeEqualToString('stepUp("1970-01-01", "4", null, 2)', '1970-01-09');
+shouldBeEqualToString('stepDown("1970-01-01", "4", null, 3)', '1969-12-20');
 debug('Step=any');
-shouldThrowErrorName('stepUp("2010-02-10", "any", null)', "InvalidStateError");
-shouldThrowErrorName('stepDown("2010-02-10", "any", null)', "InvalidStateError");
+shouldThrow('stepUp("2010-02-10", "any", null)');
+shouldThrow('stepDown("2010-02-10", "any", null)');
 debug('Overflow/underflow');
-shouldBe('stepUp("2010-02-10", "3.40282346e+38", null)', '"2010-02-10"');
-shouldBe('stepDown("2010-02-10", "3.40282346e+38", null)', '"1970-01-01"');
-shouldBe('stepUp("2010-02-10", "1", "2010-02-10")', '"2010-02-10"');
-shouldBe('stepDown("2010-02-10", "1", "2010-02-10")', '"2010-02-10"');
+shouldBeEqualToString('stepUp("2010-02-10", "3.40282346e+38", null)', '1970-01-01');
+shouldBeEqualToString('stepDown("2010-02-10", "3.40282346e+38", null)', '1970-01-01');
+shouldBeEqualToString('stepUp("2010-02-10", "1", "2010-02-10")', '2010-02-10');
+shouldBeEqualToString('stepDown("2010-02-10", "1", "2010-02-10")', '2010-02-10');
 
 debug('');
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/date/input-date-validation-message-expected.txt
+++ b/LayoutTests/fast/forms/date/input-date-validation-message-expected.txt
@@ -14,7 +14,7 @@ PASS testIt("1982-11-02", "", "1970-12-31") is "Value must be less than or equal
 Range underflow
 PASS testIt("1982-11-02", "1990-05-25", "1990-12-24") is "Value must be greater than or equal to 1990-05-25"
 Step mismatch
-PASS testIt("1982-11-02", "", "", "123") is "Enter a valid value"
+PASS testIt("1982-11-02", "", "", "123") is ""
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/date/input-date-validation-message.html
+++ b/LayoutTests/fast/forms/date/input-date-validation-message.html
@@ -38,7 +38,7 @@ debug('Range underflow')
 shouldBeEqualToString('testIt("1982-11-02", "1990-05-25", "1990-12-24")', 'Value must be greater than or equal to 1990-05-25');
 
 debug('Step mismatch')
-shouldBeEqualToString('testIt("1982-11-02", "", "", "123")', 'Enter a valid value');
+shouldBeEqualToString('testIt("1982-11-02", "", "", "123")', '');
 
 </script>
 </body>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-stepup-stepdown-expected.txt
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-stepup-stepdown-expected.txt
@@ -1,4 +1,4 @@
-Check stepUp() and stepDown() bahevior for type=datetime-local.
+Check stepUp() and stepDown() behavior for type=datetime-local.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
@@ -24,7 +24,7 @@ Step=any
 PASS stepUp("2010-02-10T20:13", "any", null) threw exception InvalidStateError: The object is in an invalid state..
 PASS stepDown("2010-02-10T20:13", "any", null) threw exception InvalidStateError: The object is in an invalid state..
 Overflow/underflow
-PASS stepUp("2010-02-10T20:13", "3.40282346e+38", null) is "2010-02-10T20:13"
+PASS stepUp("2010-02-10T20:13", "3.40282346e+38", null) is "1970-01-01T00:00"
 PASS stepDown("2010-02-10T20:13", "3.40282346e+38", null) is "1970-01-01T00:00"
 PASS stepUp("2010-02-10T20:13", "1", "2010-02-10T20:13") is "2010-02-10T20:13"
 PASS stepDown("2010-02-10T20:13", "1", "2010-02-10T20:13") is "2010-02-10T20:13"

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-stepup-stepdown.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-stepup-stepdown.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
 <div id="console"></div>
 <script>
-description('Check stepUp() and stepDown() bahevior for type=datetime-local.');
+description('Check stepUp() and stepDown() behavior for type=datetime-local.');
 
 var input = document.createElement('input');
 
@@ -38,31 +38,30 @@ function stepDown(value, step, min, optionalStepCount) {
 
 input.type = 'datetime-local';
 debug('Invalid value');
-shouldBe('stepUp("", null, null)', '"1970-01-01T00:01"');
-shouldBe('stepDown("", null, null)', '"1969-12-31T23:59"');
+shouldBeEqualToString('stepUp("", null, null)', '1970-01-01T00:01');
+shouldBeEqualToString('stepDown("", null, null)', '1969-12-31T23:59');
 debug('Non-number arguments');
-shouldBe('stepUp("2010-02-10T20:13", null, null, "0")', '"2010-02-10T20:13"');
-shouldBe('stepDown("2010-02-10T20:13", null, null, "0")', '"2010-02-10T20:13"');
-shouldBe('stepUp("2010-02-10T20:13", null, null, "foo")', '"2010-02-10T20:13"');
-shouldBe('stepDown("2010-02-10T20:13", null, null, "foo")', '"2010-02-10T20:13"');
-shouldBe('stepUp("2010-02-10T20:13", null, null, null)', '"2010-02-10T20:13"');
-shouldBe('stepDown("2010-02-10T20:13", null, null, null)', '"2010-02-10T20:13"');
+shouldBeEqualToString('stepUp("2010-02-10T20:13", null, null, "0")', '2010-02-10T20:13');
+shouldBeEqualToString('stepDown("2010-02-10T20:13", null, null, "0")', '2010-02-10T20:13');
+shouldBeEqualToString('stepUp("2010-02-10T20:13", null, null, "foo")', '2010-02-10T20:13');
+shouldBeEqualToString('stepDown("2010-02-10T20:13", null, null, "foo")', '2010-02-10T20:13');
+shouldBeEqualToString('stepUp("2010-02-10T20:13", null, null, null)', '2010-02-10T20:13');
+shouldBeEqualToString('stepDown("2010-02-10T20:13", null, null, null)', '2010-02-10T20:13');
 debug('Normal cases');
-shouldBe('stepUp("2010-02-10T20:13", null, null)', '"2010-02-10T20:14"');
-shouldBe('stepDown("2010-02-10T20:13", null, null)', '"2010-02-10T20:12"');
-shouldBe('stepUp("2010-02-10T20:13", null, null, 10)', '"2010-02-10T20:23"');
-shouldBe('stepDown("2010-02-10T20:13", null, null, 11)', '"2010-02-10T20:02"');
-shouldBe('stepUp("1970-01-01T20:13", "4", null, 2)', '"1970-01-01T20:13:08"');
-shouldBe('stepDown("1970-01-01T20:13", "4", null, 3)', '"1970-01-01T20:12:48"');
+shouldBeEqualToString('stepUp("2010-02-10T20:13", null, null)', '2010-02-10T20:14');
+shouldBeEqualToString('stepDown("2010-02-10T20:13", null, null)', '2010-02-10T20:12');
+shouldBeEqualToString('stepUp("2010-02-10T20:13", null, null, 10)', '2010-02-10T20:23');
+shouldBeEqualToString('stepDown("2010-02-10T20:13", null, null, 11)', '2010-02-10T20:02');
+shouldBeEqualToString('stepUp("1970-01-01T20:13", "4", null, 2)', '1970-01-01T20:13:08');
+shouldBeEqualToString('stepDown("1970-01-01T20:13", "4", null, 3)', '1970-01-01T20:12:48');
 debug('Step=any');
-shouldThrowErrorName('stepUp("2010-02-10T20:13", "any", null)', "InvalidStateError");
-shouldThrowErrorName('stepDown("2010-02-10T20:13", "any", null)', "InvalidStateError");
+shouldThrow('stepUp("2010-02-10T20:13", "any", null)');
+shouldThrow('stepDown("2010-02-10T20:13", "any", null)');
 debug('Overflow/underflow');
-shouldBe('stepUp("2010-02-10T20:13", "3.40282346e+38", null)', '"2010-02-10T20:13"');
-shouldBe('stepDown("2010-02-10T20:13", "3.40282346e+38", null)', '"1970-01-01T00:00"');
-shouldBe('stepUp("2010-02-10T20:13", "1", "2010-02-10T20:13")', '"2010-02-10T20:13"');
-shouldBe('stepDown("2010-02-10T20:13", "1", "2010-02-10T20:13")', '"2010-02-10T20:13"');
+shouldBeEqualToString('stepUp("2010-02-10T20:13", "3.40282346e+38", null)', '1970-01-01T00:00');
+shouldBeEqualToString('stepDown("2010-02-10T20:13", "3.40282346e+38", null)', '1970-01-01T00:00');
+shouldBeEqualToString('stepUp("2010-02-10T20:13", "1", "2010-02-10T20:13")', '2010-02-10T20:13');
+shouldBeEqualToString('stepDown("2010-02-10T20:13", "1", "2010-02-10T20:13")', '2010-02-10T20:13');
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/month/month-stepup-stepdown-expected.txt
+++ b/LayoutTests/fast/forms/month/month-stepup-stepdown-expected.txt
@@ -1,4 +1,4 @@
-Check stepUp() and stepDown() bahevior for type=month.
+Check stepUp() and stepDown() behavior for type=month.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
@@ -24,7 +24,7 @@ Step=any
 PASS stepUp("2010-02", "any", null) threw exception InvalidStateError: The object is in an invalid state..
 PASS stepDown("2010-02", "any", null) threw exception InvalidStateError: The object is in an invalid state..
 Overflow/underflow
-PASS stepUp("2010-02", "3.40282346e+38", null) is "2010-02"
+PASS stepUp("2010-02", "3.40282346e+38", null) is "1970-01"
 PASS stepDown("2010-02", "3.40282346e+38", null) is "1970-01"
 PASS stepUp("2010-02", "1", "2010-02") is "2010-02"
 PASS stepDown("2010-02", "1", "2010-02") is "2010-02"

--- a/LayoutTests/fast/forms/month/month-stepup-stepdown.html
+++ b/LayoutTests/fast/forms/month/month-stepup-stepdown.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
 <div id="console"></div>
 <script>
-description('Check stepUp() and stepDown() bahevior for type=month.');
+description('Check stepUp() and stepDown() behavior for type=month.');
 
 var input = document.createElement('input');
 
@@ -38,33 +38,32 @@ function stepDown(value, step, min, optionalStepCount) {
 
 input.type = 'month';
 debug('Invalid value');
-shouldBe('stepUp("", null, null)', '"1970-02"');
-shouldBe('stepDown("", null, null)', '"1969-12"');
+shouldBeEqualToString('stepUp("", null, null)', '1970-02');
+shouldBeEqualToString('stepDown("", null, null)', '1969-12');
 debug('Non-number arguments');
-shouldBe('stepUp("2010-02", null, null, "0")', '"2010-02"');
-shouldBe('stepDown("2010-02", null, null, "0")', '"2010-02"');
-shouldBe('stepUp("2010-02", null, null, "foo")', '"2010-02"');
-shouldBe('stepDown("2010-02", null, null, "foo")', '"2010-02"');
-shouldBe('stepUp("2010-02", null, null, null)', '"2010-02"');
-shouldBe('stepDown("2010-02", null, null, null)', '"2010-02"');
+shouldBeEqualToString('stepUp("2010-02", null, null, "0")', '2010-02');
+shouldBeEqualToString('stepDown("2010-02", null, null, "0")', '2010-02');
+shouldBeEqualToString('stepUp("2010-02", null, null, "foo")', '2010-02');
+shouldBeEqualToString('stepDown("2010-02", null, null, "foo")', '2010-02');
+shouldBeEqualToString('stepUp("2010-02", null, null, null)', '2010-02');
+shouldBeEqualToString('stepDown("2010-02", null, null, null)', '2010-02');
 debug('Normal cases');
-shouldBe('stepUp("2010-02", null, null)', '"2010-03"');
-shouldBe('stepDown("2010-02", null, null)', '"2010-01"');
-shouldBe('stepUp("2010-02", null, null, 10)', '"2010-12"');
-shouldBe('stepDown("2010-02", null, null, 11)', '"2009-03"');
-shouldBe('stepUp("1970-01", "4", null, 2)', '"1970-09"');
-shouldBe('stepDown("1970-01", "4", null, 3)', '"1969-01"');
+shouldBeEqualToString('stepUp("2010-02", null, null)', '2010-03');
+shouldBeEqualToString('stepDown("2010-02", null, null)', '2010-01');
+shouldBeEqualToString('stepUp("2010-02", null, null, 10)', '2010-12');
+shouldBeEqualToString('stepDown("2010-02", null, null, 11)', '2009-03');
+shouldBeEqualToString('stepUp("1970-01", "4", null, 2)', '1970-09');
+shouldBeEqualToString('stepDown("1970-01", "4", null, 3)', '1969-01');
 debug('Step=any');
-shouldThrowErrorName('stepUp("2010-02", "any", null)', "InvalidStateError");
-shouldThrowErrorName('stepDown("2010-02", "any", null)', "InvalidStateError");
+shouldThrow('stepUp("2010-02", "any", null)');
+shouldThrow('stepDown("2010-02", "any", null)');
 debug('Overflow/underflow');
-shouldBe('stepUp("2010-02", "3.40282346e+38", null)', '"2010-02"');
-shouldBe('stepDown("2010-02", "3.40282346e+38", null)', '"1970-01"');
-shouldBe('stepUp("2010-02", "1", "2010-02")', '"2010-02"');
-shouldBe('stepDown("2010-02", "1", "2010-02")', '"2010-02"');
+shouldBeEqualToString('stepUp("2010-02", "3.40282346e+38", null)', '1970-01');
+shouldBeEqualToString('stepDown("2010-02", "3.40282346e+38", null)', '1970-01');
+shouldBeEqualToString('stepUp("2010-02", "1", "2010-02")', '2010-02');
+shouldBeEqualToString('stepDown("2010-02", "1", "2010-02")', '2010-02');
 
 debug('');
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/number/number-stepup-stepdown-expected.txt
+++ b/LayoutTests/fast/forms/number/number-stepup-stepdown-expected.txt
@@ -4,11 +4,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 Number type
-
 Invalid value
 PASS stepUp("", null, null) is "1"
 PASS stepDown("", null, null) is "-1"
-
 Non-number arguments
 PASS stepUp("0", null, null, "0") is "0"
 PASS stepDown("0", null, null, "0") is "0"
@@ -16,7 +14,6 @@ PASS stepUp("0", null, null, "foo") is "0"
 PASS stepDown("0", null, null, "foo") is "0"
 PASS stepUp("0", null, null, null) is "0"
 PASS stepDown("0", null, null, null) is "0"
-
 Normal cases
 PASS stepUp("0", null, null) is "1"
 PASS stepUp("1", null, null, 2) is "3"
@@ -24,151 +21,44 @@ PASS stepUp("3", null, null, -1) is "2"
 PASS stepDown("2", null, null) is "1"
 PASS stepDown("1", null, null, 2) is "-1"
 PASS stepDown("-1", null, null, -1) is "0"
-
-Fractional cases
-PASS stepUp("0.1", 1, null) is "1.1"
-PASS stepUp("0.2", 1, null) is "1.2"
-PASS stepUp("1.0", 1, null) is "2"
-PASS stepUp("1.1", 1, null) is "2.1"
-PASS stepUp("1.2", 1, null) is "2.2"
-PASS stepUp("2.0", 1, null) is "3"
-
-PASS stepUp("-0.1", 1, null) is "0.9"
-PASS stepUp("-0.2", 1, null) is "0.8"
-PASS stepUp("-1.0", 1, null) is "0"
-PASS stepUp("-1.1", 1, null) is "-0.1"
-PASS stepUp("-1.2", 1, null) is "-0.2"
-PASS stepUp("-2.0", 1, null) is "-1"
-
-PASS stepDown("0.1", 1, null) is "-0.9"
-PASS stepDown("0.2", 1, null) is "-0.8"
-PASS stepDown("1.0", 1, null) is "0"
-PASS stepDown("1.1", 1, null) is "0.1"
-PASS stepDown("1.2", 1, null) is "0.2"
-PASS stepDown("2.0", 1, null) is "1"
-
-PASS stepDown("-0.1", 1, null) is "-1.1"
-PASS stepDown("-0.2", 1, null) is "-1.2"
-PASS stepDown("-1.0", 1, null) is "-2"
-PASS stepDown("-1.1", 1, null) is "-2.1"
-PASS stepDown("-1.2", 1, null) is "-2.2"
-PASS stepDown("-2.0", 1, null) is "-3"
-
-PASS stepUp(".1", 1, null) is "1.1"
-PASS stepUp(".2", 1, null) is "1.2"
-PASS stepUp("1.", 1, null) is "1"
-PASS stepUp("2.", 1, null) is "1"
-
-PASS stepUp("-.1", 1, null) is "0.9"
-PASS stepUp("-.2", 1, null) is "0.8"
-PASS stepUp("-1.", 1, null) is "1"
-PASS stepUp("-2.", 1, null) is "1"
-
-PASS stepDown(".1", 1, null) is "-0.9"
-PASS stepDown(".2", 1, null) is "-0.8"
-PASS stepDown("1.", 1, null) is "-1"
-PASS stepDown("2.", 1, null) is "-1"
-
-PASS stepDown("-.1", 1, null) is "-1.1"
-PASS stepDown("-.2", 1, null) is "-1.2"
-PASS stepDown("-1.", 1, null) is "-1"
-PASS stepDown("-2.", 1, null) is "-1"
-
-PASS stepUp("0.1", .1, null) is "0.2"
-PASS stepUp("0.2", .1, null) is "0.3"
-PASS stepUp("1.0", .1, null) is "1.1"
-PASS stepUp("1.1", .1, null) is "1.2"
-PASS stepUp("1.2", .1, null) is "1.3"
-PASS stepUp("2.0", .1, null) is "2.1"
-
-PASS stepUp("-0.1", .1, null) is "0"
-PASS stepUp("-0.2", .1, null) is "-0.1"
-PASS stepUp("-1.0", .1, null) is "-0.9"
-PASS stepUp("-1.1", .1, null) is "-1"
-PASS stepUp("-1.2", .1, null) is "-1.1"
-PASS stepUp("-2.0", .1, null) is "-1.9"
-
-PASS stepDown("0.1", .1, null) is "0"
-PASS stepDown("0.2", .1, null) is "0.1"
-PASS stepDown("1.0", .1, null) is "0.9"
-PASS stepDown("1.1", .1, null) is "1"
-PASS stepDown("1.2", .1, null) is "1.1"
-PASS stepDown("2.0", .1, null) is "1.9"
-
-PASS stepDown("-0.1", .1, null) is "-0.2"
-PASS stepDown("-0.2", .1, null) is "-0.3"
-PASS stepDown("-1.0", .1, null) is "-1.1"
-PASS stepDown("-1.1", .1, null) is "-1.2"
-PASS stepDown("-1.2", .1, null) is "-1.3"
-PASS stepDown("-2.0", .1, null) is "-2.1"
-
-PASS stepUp(".1", .1, null) is "0.2"
-PASS stepUp(".2", .1, null) is "0.3"
-PASS stepUp("1.", .1, null) is "0.1"
-PASS stepUp("2.", .1, null) is "0.1"
-
-PASS stepUp("-.1", .1, null) is "0"
-PASS stepUp("-.2", .1, null) is "-0.1"
-PASS stepUp("-1.", .1, null) is "0.1"
-PASS stepUp("-2.", .1, null) is "0.1"
-
-PASS stepDown(".1", .1, null) is "0"
-PASS stepDown(".2", .1, null) is "0.1"
-PASS stepDown("1.", .1, null) is "-0.1"
-PASS stepDown("2.", .1, null) is "-0.1"
-
-PASS stepDown("-.1", .1, null) is "-0.2"
-PASS stepDown("-.2", .1, null) is "-0.3"
-PASS stepDown("-1.", .1, null) is "-0.1"
-PASS stepDown("-2.", .1, null) is "-0.1"
-
 Extra arguments
 PASS input.value = "0"; input.min = null; input.step = null; input.stepUp(1, 2); input.value is "1"
 PASS input.value = "1"; input.stepDown(1, 3); input.value is "0"
-
 Invalid step value
 PASS stepUp("0", "foo", null) is "1"
 PASS stepUp("1", "0", null) is "2"
 PASS stepUp("2", "-1", null) is "3"
-
 Step=any
 PASS stepUp("0", "any", null) threw exception InvalidStateError: The object is in an invalid state..
 PASS stepDown("0", "any", null) threw exception InvalidStateError: The object is in an invalid state..
-
 Step=any corner case
 PASS stepUpExplicitBounds("0", "100", "any", "1.5", "1") threw exception InvalidStateError: The object is in an invalid state..
 PASS stepDownExplicitBounds("0", "100", "any", "1.5", "1") threw exception InvalidStateError: The object is in an invalid state..
-
 Overflow/underflow
 PASS stepDown("1", "1", "0") is "0"
 PASS stepDown("0", "1", "0") is "0"
 PASS stepDown("1", "1", "0", 2) is "0"
-PASS input.value is "0"
 PASS stepDown("1", "1.797693134862315e+308", "", 2) is "-1.797693134862315e+308"
 PASS stepUp("-1", "1", "0") is "0"
 PASS stepUp("0", "1", "0") is "0"
 PASS stepUp("-1", "1", "0", 2) is "0"
-PASS input.value is "0"
 PASS stepUp("1", "1.797693134862315e+308", "", 2) is "1.797693134862315e+308"
-
 stepDown()/stepUp() for stepMismatch values
-PASS stepUp("1", "2", "") is "3"
-PASS input.stepDown(); input.value is "1"
-PASS input.min = "0"; stepUp("9", "10", "", 9) is "99"
-PASS stepDown("19", "10", "0") is "9"
-PASS stepUp("89", "10", "99") is "99"
-
+PASS stepUpExplicitBounds("0", "", "2", "1"); input.value is "2"
+PASS stepUp("1", "2", "") is "2"
+PASS input.stepDown(); input.value is "0"
+PASS input.min = "0"; stepUp("9", "10", "", 9) is "90"
+PASS stepDown("19", "10", "0") is "10"
+PASS stepUp("89", "10", "99") is "90"
 Huge value and small step
 PASS input.min = ""; stepUp("1e+308", "1", "", 999999) is "1e+308"
 PASS input.max = ""; stepDown("1e+308", "1", "", 999999) is "1e+308"
-
 Fractional numbers
 PASS input.min = ""; stepUp("0", "0.33333333333333333", "", 3) is "1"
 PASS stepUp("1", "0.1", "", 10) is "2"
 PASS input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.value is "3"
 PASS input.min = "0"; stepUp("0", "0.003921568627450980", "1", 255) is "1"
 PASS for (var i = 0; i < 255; i++) { input.stepDown(); }; input.value is "0"
-
 Rounding
 PASS stepUp("5.005", "0.005", "", 2) is "5.015"
 PASS stepUp("5.005", "0.005", "", 11) is "5.06"

--- a/LayoutTests/fast/forms/number/number-stepup-stepdown.html
+++ b/LayoutTests/fast/forms/number/number-stepup-stepdown.html
@@ -54,13 +54,9 @@ function stepDownExplicitBounds(min, max, step, value, stepCount) {
 
 debug('Number type');
 input.type = 'number';
-
-debug('');
 debug('Invalid value');
-shouldBe('stepUp("", null, null)', '"1"');
-shouldBe('stepDown("", null, null)', '"-1"');
-
-debug('');
+shouldBeEqualToString('stepUp("", null, null)', '1');
+shouldBeEqualToString('stepDown("", null, null)', '-1');
 debug('Non-number arguments');
 shouldBe('stepUp("0", null, null, "0")', '"0"');
 shouldBe('stepDown("0", null, null, "0")', '"0"');
@@ -68,8 +64,6 @@ shouldBe('stepUp("0", null, null, "foo")', '"0"');
 shouldBe('stepDown("0", null, null, "foo")', '"0"');
 shouldBe('stepUp("0", null, null, null)', '"0"');
 shouldBe('stepDown("0", null, null, null)', '"0"');
-
-debug('');
 debug('Normal cases');
 shouldBe('stepUp("0", null, null)', '"1"');
 shouldBe('stepUp("1", null, null, 2)', '"3"');
@@ -77,181 +71,44 @@ shouldBe('stepUp("3", null, null, -1)', '"2"');
 shouldBe('stepDown("2", null, null)', '"1"');
 shouldBe('stepDown("1", null, null, 2)', '"-1"');
 shouldBe('stepDown("-1", null, null, -1)', '"0"');
-
-debug('');
-debug('Fractional cases')
-// Base/model/template tests
-shouldBe('stepUp("0.1", 1, null)', '"1.1"');
-shouldBe('stepUp("0.2", 1, null)', '"1.2"');
-shouldBe('stepUp("1.0", 1, null)', '"2"');
-shouldBe('stepUp("1.1", 1, null)', '"2.1"');
-shouldBe('stepUp("1.2", 1, null)', '"2.2"');
-shouldBe('stepUp("2.0", 1, null)', '"3"');
-
-// Same as above, but with negative numbers.
-debug('');
-shouldBe('stepUp("-0.1", 1, null)', '"0.9"');
-shouldBe('stepUp("-0.2", 1, null)', '"0.8"');
-shouldBe('stepUp("-1.0", 1, null)', '"0"');
-shouldBe('stepUp("-1.1", 1, null)', '"-0.1"');
-shouldBe('stepUp("-1.2", 1, null)', '"-0.2"');
-shouldBe('stepUp("-2.0", 1, null)', '"-1"');
-
-// Same as above, but stepping down rather than up.
-debug('');
-shouldBe('stepDown("0.1", 1, null)', '"-0.9"');
-shouldBe('stepDown("0.2", 1, null)', '"-0.8"');
-shouldBe('stepDown("1.0", 1, null)', '"0"');
-shouldBe('stepDown("1.1", 1, null)', '"0.1"');
-shouldBe('stepDown("1.2", 1, null)', '"0.2"');
-shouldBe('stepDown("2.0", 1, null)', '"1"');
-
-debug('');
-shouldBe('stepDown("-0.1", 1, null)', '"-1.1"');
-shouldBe('stepDown("-0.2", 1, null)', '"-1.2"');
-shouldBe('stepDown("-1.0", 1, null)', '"-2"');
-shouldBe('stepDown("-1.1", 1, null)', '"-2.1"');
-shouldBe('stepDown("-1.2", 1, null)', '"-2.2"');
-shouldBe('stepDown("-2.0", 1, null)', '"-3"');
-
-// Same as above, but with leading/trailing zeros removed.
-debug('');
-shouldBe('stepUp(".1", 1, null)', '"1.1"');
-shouldBe('stepUp(".2", 1, null)', '"1.2"');
-shouldBe('stepUp("1.", 1, null)', '"1"');
-shouldBe('stepUp("2.", 1, null)', '"1"');
-
-debug('');
-shouldBe('stepUp("-.1", 1, null)', '"0.9"');
-shouldBe('stepUp("-.2", 1, null)', '"0.8"');
-shouldBe('stepUp("-1.", 1, null)', '"1"');
-shouldBe('stepUp("-2.", 1, null)', '"1"');
-
-debug('');
-shouldBe('stepDown(".1", 1, null)', '"-0.9"');
-shouldBe('stepDown(".2", 1, null)', '"-0.8"');
-shouldBe('stepDown("1.", 1, null)', '"-1"');
-shouldBe('stepDown("2.", 1, null)', '"-1"');
-
-debug('');
-shouldBe('stepDown("-.1", 1, null)', '"-1.1"');
-shouldBe('stepDown("-.2", 1, null)', '"-1.2"');
-shouldBe('stepDown("-1.", 1, null)', '"-1"');
-shouldBe('stepDown("-2.", 1, null)', '"-1"');
-
-// Same as above, but stepping by .1 rather than 1.
-debug('');
-shouldBe('stepUp("0.1", .1, null)', '"0.2"');
-shouldBe('stepUp("0.2", .1, null)', '"0.3"');
-shouldBe('stepUp("1.0", .1, null)', '"1.1"');
-shouldBe('stepUp("1.1", .1, null)', '"1.2"');
-shouldBe('stepUp("1.2", .1, null)', '"1.3"');
-shouldBe('stepUp("2.0", .1, null)', '"2.1"');
-
-debug('');
-shouldBe('stepUp("-0.1", .1, null)', '"0"');
-shouldBe('stepUp("-0.2", .1, null)', '"-0.1"');
-shouldBe('stepUp("-1.0", .1, null)', '"-0.9"');
-shouldBe('stepUp("-1.1", .1, null)', '"-1"');
-shouldBe('stepUp("-1.2", .1, null)', '"-1.1"');
-shouldBe('stepUp("-2.0", .1, null)', '"-1.9"');
-
-debug('');
-shouldBe('stepDown("0.1", .1, null)', '"0"');
-shouldBe('stepDown("0.2", .1, null)', '"0.1"');
-shouldBe('stepDown("1.0", .1, null)', '"0.9"');
-shouldBe('stepDown("1.1", .1, null)', '"1"');
-shouldBe('stepDown("1.2", .1, null)', '"1.1"');
-shouldBe('stepDown("2.0", .1, null)', '"1.9"');
-
-debug('');
-shouldBe('stepDown("-0.1", .1, null)', '"-0.2"');
-shouldBe('stepDown("-0.2", .1, null)', '"-0.3"');
-shouldBe('stepDown("-1.0", .1, null)', '"-1.1"');
-shouldBe('stepDown("-1.1", .1, null)', '"-1.2"');
-shouldBe('stepDown("-1.2", .1, null)', '"-1.3"');
-shouldBe('stepDown("-2.0", .1, null)', '"-2.1"');
-
-debug('');
-shouldBe('stepUp(".1", .1, null)', '"0.2"');
-shouldBe('stepUp(".2", .1, null)', '"0.3"');
-shouldBe('stepUp("1.", .1, null)', '"0.1"');
-shouldBe('stepUp("2.", .1, null)', '"0.1"');
-
-debug('');
-shouldBe('stepUp("-.1", .1, null)', '"0"');
-shouldBe('stepUp("-.2", .1, null)', '"-0.1"');
-shouldBe('stepUp("-1.", .1, null)', '"0.1"');
-shouldBe('stepUp("-2.", .1, null)', '"0.1"');
-
-debug('');
-shouldBe('stepDown(".1", .1, null)', '"0"');
-shouldBe('stepDown(".2", .1, null)', '"0.1"');
-shouldBe('stepDown("1.", .1, null)', '"-0.1"');
-shouldBe('stepDown("2.", .1, null)', '"-0.1"');
-
-debug('');
-shouldBe('stepDown("-.1", .1, null)', '"-0.2"');
-shouldBe('stepDown("-.2", .1, null)', '"-0.3"');
-shouldBe('stepDown("-1.", .1, null)', '"-0.1"');
-shouldBe('stepDown("-2.", .1, null)', '"-0.1"');
-
-debug('');
 debug('Extra arguments');
 shouldBe('input.value = "0"; input.min = null; input.step = null; input.stepUp(1, 2); input.value', '"1"');
 shouldBe('input.value = "1"; input.stepDown(1, 3); input.value', '"0"');
-
-debug('');
 debug('Invalid step value');
 shouldBe('stepUp("0", "foo", null)', '"1"');
 shouldBe('stepUp("1", "0", null)', '"2"');
 shouldBe('stepUp("2", "-1", null)', '"3"');
-
-debug('');
 debug('Step=any');
-shouldThrowErrorName('stepUp("0", "any", null)', "InvalidStateError");
-shouldThrowErrorName('stepDown("0", "any", null)', "InvalidStateError");
-
-debug('');
+shouldThrow('stepUp("0", "any", null)');
+shouldThrow('stepDown("0", "any", null)');
 debug('Step=any corner case');
-shouldThrowErrorName('stepUpExplicitBounds("0", "100", "any", "1.5", "1")', "InvalidStateError");
-shouldThrowErrorName('stepDownExplicitBounds("0", "100", "any", "1.5", "1")', "InvalidStateError");
-
-debug('');
+shouldThrow('stepUpExplicitBounds("0", "100", "any", "1.5", "1")');
+shouldThrow('stepDownExplicitBounds("0", "100", "any", "1.5", "1")');
 debug('Overflow/underflow');
 shouldBe('stepDown("1", "1", "0")', '"0"');
-shouldBe('stepDown("0", "1", "0")', '"0"');
-shouldBe('stepDown("1", "1", "0", 2)', '"0"');
-shouldBe('input.value', '"0"');
+shouldBeEqualToString('stepDown("0", "1", "0")', '0');
+shouldBeEqualToString('stepDown("1", "1", "0", 2)', '0');
 shouldBeEqualToString('stepDown("1", "1.797693134862315e+308", "", 2)', '-1.797693134862315e+308');
-shouldBe('stepUp("-1", "1", "0")', '"0"');
-shouldBe('stepUp("0", "1", "0")', '"0"');
-shouldBe('stepUp("-1", "1", "0", 2)', '"0"');
-shouldBe('input.value', '"0"');
+shouldBeEqualToString('stepUp("-1", "1", "0")', '0');
+shouldBeEqualToString('stepUp("0", "1", "0")', '0');
+shouldBeEqualToString('stepUp("-1", "1", "0", 2)', '0');
 shouldBeEqualToString('stepUp("1", "1.797693134862315e+308", "", 2)', '1.797693134862315e+308');
-
-debug('');
 debug('stepDown()/stepUp() for stepMismatch values');
-shouldBe('stepUp("1", "2", "")', '"3"');
-shouldBe('input.stepDown(); input.value', '"1"');
-shouldBe('input.min = "0"; stepUp("9", "10", "", 9)', '"99"');
-shouldBe('stepDown("19", "10", "0")', '"9"');
-shouldBe('stepUp("89", "10", "99")', '"99"');
-
-debug('');
+shouldBeEqualToString('stepUpExplicitBounds("0", "", "2", "1"); input.value', '2');
+shouldBeEqualToString('stepUp("1", "2", "")', '2');
+shouldBeEqualToString('input.stepDown(); input.value', '0');
+shouldBeEqualToString('input.min = "0"; stepUp("9", "10", "", 9)', '90');
+shouldBeEqualToString('stepDown("19", "10", "0")', '10');
+shouldBeEqualToString('stepUp("89", "10", "99")', '90');
 debug('Huge value and small step');
 shouldBe('input.min = ""; stepUp("1e+308", "1", "", 999999)', '"1e+308"');
 shouldBe('input.max = ""; stepDown("1e+308", "1", "", 999999)', '"1e+308"');
-
-debug('');
 debug('Fractional numbers');
 shouldBe('input.min = ""; stepUp("0", "0.33333333333333333", "", 3)', '"1"');
 shouldBe('stepUp("1", "0.1", "", 10)', '"2"');
 shouldBe('input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.value', '"3"');
 shouldBe('input.min = "0"; stepUp("0", "0.003921568627450980", "1", 255)', '"1"');
 shouldBe('for (var i = 0; i < 255; i++) { input.stepDown(); }; input.value', '"0"');
-
-debug('');
 debug('Rounding');
 shouldBe('stepUp("5.005", "0.005", "", 2)', '"5.015"');
 shouldBe('stepUp("5.005", "0.005", "", 11)', '"5.06"');

--- a/LayoutTests/fast/forms/range/range-stepup-stepdown-expected.txt
+++ b/LayoutTests/fast/forms/range/range-stepup-stepdown-expected.txt
@@ -1,4 +1,4 @@
-Check stepUp() and stepDown() bahevior for range type.
+Check stepUp() and stepDown() behavior for range type.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
@@ -7,7 +7,6 @@ function arguments are (min, max, step, value, [stepCount])
 Using the default values
 PASS stepUpExplicitBounds(null, null, null, "") is "51"
 PASS stepDownExplicitBounds(null, null, null, "") is "49"
-
 Non-number arguments (stepCount)
 PASS stepUpExplicitBounds(null, null, null, "0", "0") is "0"
 PASS stepDownExplicitBounds(null, null, null, "0", "0") is "0"
@@ -15,7 +14,6 @@ PASS stepUpExplicitBounds(null, null, null, "0", "foo") is "0"
 PASS stepDownExplicitBounds(null, null, null, "0", "foo") is "0"
 PASS stepUpExplicitBounds(null, null, null, "0", null) is "0"
 PASS stepDownExplicitBounds(null, null, null, "0", null) is "0"
-
 Normal cases
 PASS stepUpExplicitBounds(null, null, null, "0") is "1"
 PASS stepUpExplicitBounds(null, null, null, "1", 2) is "3"
@@ -23,108 +21,9 @@ PASS stepUpExplicitBounds(null, null, null, "3", -1) is "2"
 PASS stepDownExplicitBounds("-100", null, null, "2") is "1"
 PASS stepDownExplicitBounds("-100", null, null, "1", 2) is "-1"
 PASS stepDownExplicitBounds("-100", null, null, "-1", -1) is "0"
-
-Fractional cases
-PASS stepUpExplicitBounds(-10, 10, 1, "0.1") is "1"
-PASS stepUpExplicitBounds(-10, 10, 1, "0.2") is "1"
-PASS stepUpExplicitBounds(-10, 10, 1, "1.0") is "2"
-PASS stepUpExplicitBounds(-10, 10, 1, "1.1") is "2"
-PASS stepUpExplicitBounds(-10, 10, 1, "1.2") is "2"
-PASS stepUpExplicitBounds(-10, 10, 1, "2.0") is "3"
-
-PASS stepUpExplicitBounds(-10, 10, 1, "-0.1") is "1"
-PASS stepUpExplicitBounds(-10, 10, 1, "-0.2") is "1"
-PASS stepUpExplicitBounds(-10, 10, 1, "-1.0") is "0"
-PASS stepUpExplicitBounds(-10, 10, 1, "-1.1") is "0"
-PASS stepUpExplicitBounds(-10, 10, 1, "-1.2") is "0"
-PASS stepUpExplicitBounds(-10, 10, 1, "-2.0") is "-1"
-
-PASS stepDownExplicitBounds(-10, 10, 1, "0.1") is "-1"
-PASS stepDownExplicitBounds(-10, 10, 1, "0.2") is "-1"
-PASS stepDownExplicitBounds(-10, 10, 1, "1.0") is "0"
-PASS stepDownExplicitBounds(-10, 10, 1, "1.1") is "0"
-PASS stepDownExplicitBounds(-10, 10, 1, "1.2") is "0"
-PASS stepDownExplicitBounds(-10, 10, 1, "2.0") is "1"
-
-PASS stepDownExplicitBounds(-10, 10, 1, "-0.1") is "-1"
-PASS stepDownExplicitBounds(-10, 10, 1, "-0.2") is "-1"
-PASS stepDownExplicitBounds(-10, 10, 1, "-1.0") is "-2"
-PASS stepDownExplicitBounds(-10, 10, 1, "-1.1") is "-2"
-PASS stepDownExplicitBounds(-10, 10, 1, "-1.2") is "-2"
-PASS stepDownExplicitBounds(-10, 10, 1, "-2.0") is "-3"
-
-PASS stepUpExplicitBounds(-10, 10, 1, ".1") is "1"
-PASS stepUpExplicitBounds(-10, 10, 1, ".2") is "1"
-PASS stepUpExplicitBounds(-10, 10, 1, "1.") is "2"
-PASS stepUpExplicitBounds(-10, 10, 1, "2.") is "3"
-
-PASS stepUpExplicitBounds(-10, 10, 1, "-.1") is "1"
-PASS stepUpExplicitBounds(-10, 10, 1, "-.2") is "1"
-PASS stepUpExplicitBounds(-10, 10, 1, "-1.") is "0"
-PASS stepUpExplicitBounds(-10, 10, 1, "-2.") is "-1"
-
-PASS stepDownExplicitBounds(-10, 10, 1, ".1") is "-1"
-PASS stepDownExplicitBounds(-10, 10, 1, ".2") is "-1"
-PASS stepDownExplicitBounds(-10, 10, 1, "1.") is "0"
-PASS stepDownExplicitBounds(-10, 10, 1, "2.") is "1"
-
-PASS stepDownExplicitBounds(-10, 10, 1, "-.1") is "-1"
-PASS stepDownExplicitBounds(-10, 10, 1, "-.2") is "-1"
-PASS stepDownExplicitBounds(-10, 10, 1, "-1.") is "-2"
-PASS stepDownExplicitBounds(-10, 10, 1, "-2.") is "-3"
-
-PASS stepUpExplicitBounds(-10, 10, .1, "0.1") is "0.2"
-PASS stepUpExplicitBounds(-10, 10, .1, "0.2") is "0.3"
-PASS stepUpExplicitBounds(-10, 10, .1, "1.0") is "1.1"
-PASS stepUpExplicitBounds(-10, 10, .1, "1.1") is "1.2"
-PASS stepUpExplicitBounds(-10, 10, .1, "1.2") is "1.3"
-PASS stepUpExplicitBounds(-10, 10, .1, "2.0") is "2.1"
-
-PASS stepUpExplicitBounds(-10, 10, .1, "-0.1") is "0"
-PASS stepUpExplicitBounds(-10, 10, .1, "-0.2") is "-0.1"
-PASS stepUpExplicitBounds(-10, 10, .1, "-1.0") is "-0.9"
-PASS stepUpExplicitBounds(-10, 10, .1, "-1.1") is "-1"
-PASS stepUpExplicitBounds(-10, 10, .1, "-1.2") is "-1.1"
-PASS stepUpExplicitBounds(-10, 10, .1, "-2.0") is "-1.9"
-
-PASS stepDownExplicitBounds(-10, 10, .1, "0.1") is "0"
-PASS stepDownExplicitBounds(-10, 10, .1, "0.2") is "0.1"
-PASS stepDownExplicitBounds(-10, 10, .1, "1.0") is "0.9"
-PASS stepDownExplicitBounds(-10, 10, .1, "1.1") is "1"
-PASS stepDownExplicitBounds(-10, 10, .1, "1.2") is "1.1"
-PASS stepDownExplicitBounds(-10, 10, .1, "2.0") is "1.9"
-
-PASS stepDownExplicitBounds(-10, 10, .1, "-0.1") is "-0.2"
-PASS stepDownExplicitBounds(-10, 10, .1, "-0.2") is "-0.3"
-PASS stepDownExplicitBounds(-10, 10, .1, "-1.0") is "-1.1"
-PASS stepDownExplicitBounds(-10, 10, .1, "-1.1") is "-1.2"
-PASS stepDownExplicitBounds(-10, 10, .1, "-1.2") is "-1.3"
-PASS stepDownExplicitBounds(-10, 10, .1, "-2.0") is "-2.1"
-
-PASS stepUpExplicitBounds(-10, 10, .1, ".1") is "0.2"
-PASS stepUpExplicitBounds(-10, 10, .1, ".2") is "0.3"
-PASS stepUpExplicitBounds(-10, 10, .1, "1.") is "1.1"
-PASS stepUpExplicitBounds(-10, 10, .1, "2.") is "2.1"
-
-PASS stepUpExplicitBounds(-10, 10, .1, "-.1") is "0"
-PASS stepUpExplicitBounds(-10, 10, .1, "-.2") is "-0.1"
-PASS stepUpExplicitBounds(-10, 10, .1, "-1.") is "-0.9"
-PASS stepUpExplicitBounds(-10, 10, .1, "-2.") is "-1.9"
-
-PASS stepDownExplicitBounds(-10, 10, .1, ".1") is "0"
-PASS stepDownExplicitBounds(-10, 10, .1, ".2") is "0.1"
-PASS stepDownExplicitBounds(-10, 10, .1, "1.") is "0.9"
-PASS stepDownExplicitBounds(-10, 10, .1, "2.") is "1.9"
-
-PASS stepDownExplicitBounds(-10, 10, .1, "-.1") is "-0.2"
-PASS stepDownExplicitBounds(-10, 10, .1, "-.2") is "-0.3"
-PASS stepDownExplicitBounds(-10, 10, .1, "-1.") is "-1.1"
-PASS stepDownExplicitBounds(-10, 10, .1, "-2.") is "-2.1"
-
 Extra arguments
 PASS setInputAttributes(null, null, null, "0"); input.stepUp(1,2); input.value is "1"
 PASS setInputAttributes(null, null, null, "1"); input.stepDown(1,3); input.value is "0"
-
 Invalid step value
 PASS stepUpExplicitBounds(null, null, "foo", "0") is "1"
 PASS stepUpExplicitBounds(null, null, "0", "1") is "2"
@@ -132,42 +31,40 @@ PASS stepUpExplicitBounds(null, null, "-1", "2") is "3"
 PASS stepDownExplicitBounds(null, null, "foo", "1") is "0"
 PASS stepDownExplicitBounds(null, null, "0", "2") is "1"
 PASS stepDownExplicitBounds(null, null, "-1", "3") is "2"
-
+Step bases
+PASS createInputWithContentAttributes(0, 100, "20", "50"); input.value is "60"
+PASS createInputWithContentAttributes(null, null, "50", "25"); input.value is "25"
+PASS createInputWithContentAttributes(null, null, "50", "25"); input.stepUp(1); input.value is "75"
+PASS createInputWithContentAttributes(null, null, "50", "25"); input.stepUp(1); input.stepDown(1); input.value is "25"
+PASS createInputWithContentAttributes(null, null, "50", "25"); input.stepUp(2); input.stepDown(2); input.value is "25"
+PASS createInputWithContentAttributes(null, null, "7", "22"); input.stepUp(40); input.value is "99"
 Step=any
 PASS stepUpExplicitBounds(null, null, "any", "1") threw exception InvalidStateError: The object is in an invalid state..
 PASS stepDownExplicitBounds(null, null, "any", "1") threw exception InvalidStateError: The object is in an invalid state..
-
 Overflow/underflow
 PASS stepUpExplicitBounds(null, "100", "1", "99") is "100"
 PASS stepUpExplicitBounds(null, "100", "1", "100") is "100"
-PASS input.value is "100"
 PASS stepUpExplicitBounds(null, "100", "1", "99", "2") is "100"
-PASS input.value is "100"
 PASS stepDownExplicitBounds("0", null, "1", "1") is "0"
 PASS stepDownExplicitBounds("0", null, "1", "0") is "0"
-PASS input.value is "0"
 PASS stepDownExplicitBounds("0", null, "1", "1", "2") is "0"
-PASS input.value is "0"
 PASS stepDownExplicitBounds(null, null, "3.40282346e+38", "1", "2") is "0"
 PASS stepUpExplicitBounds(-100, 0, 1, -1) is "0"
 PASS stepUpExplicitBounds(null, 0, 1, 0) is "0"
 PASS stepUpExplicitBounds(-100, 0, 1, -1, 2) is "0"
-PASS input.value is "0"
 PASS stepUpExplicitBounds(null, null, "3.40282346e+38", "1", "2") is "0"
-
 stepDown()/stepUp() for stepMismatch values
 PASS stepUpExplicitBounds(null, null, 2, 1) is "4"
 PASS input.stepDown(); input.value is "2"
 PASS stepUpExplicitBounds(0, null, 10, 9, 9) is "100"
 PASS stepDownExplicitBounds(0, null, 10, 19) is "10"
-
 value + step is <= max, but rounded result would be > max.
 PASS stepUpExplicitBounds(null, 99, 10, 89) is "90"
-
+PASS stepUpExplicitBounds(null, 99, 10, 89, 21) is "90"
+PASS stepUpExplicitBounds(null, 99, 10, 77, 2) is "90"
 Huge value and small step
 PASS stepUpExplicitBounds(0, 1e38, 1, 1e38, 999999) is "1e+38"
 PASS stepDownExplicitBounds(0, 1e38, 1, 1e38, 999999) is "1e+38"
-
 Fractional numbers
 PASS stepUpExplicitBounds(null, null, 0.33333333333333333, 0, 3) is "1"
 PASS stepUpExplicitBounds(null, null, 0.1, 1) is "1.1"
@@ -178,7 +75,6 @@ PASS stepUpExplicitBounds(0, 1, 0.003921568627450980, 0, 255) is "1"
 PASS for (var i = 0; i < 255; i++) { input.stepDown(); }; input.value is "0"
 PASS stepDownExplicitBounds(null, null, 0.1, 1, 8) is "0.2"
 PASS stepDownExplicitBounds(null, null, 0.1, 1) is "0.9"
-
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/range/range-stepup-stepdown.html
+++ b/LayoutTests/fast/forms/range/range-stepup-stepdown.html
@@ -1,21 +1,38 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
 <div id="console"></div>
 <script>
-description('Check stepUp() and stepDown() bahevior for range type.');
+description('Check stepUp() and stepDown() behavior for range type.');
 
-var input = document.createElement('input');
+var input;
+
+function createRangeElement() {
+    input = document.createElement('input');
+    input.type = 'range';
+}
 
 function setInputAttributes(min, max, step, value) {
     input.min = min;
     input.max = max;
     input.step = step;
     input.value = value;
+}
+
+function createInputWithContentAttributes(min, max, step, value) {
+    createRangeElement();
+    function setIfNonNull(attribute, value) {
+        if (typeof value !== "null")
+	    input.setAttribute(attribute, value);
+    }
+    setIfNonNull("min", min);
+    setIfNonNull("max", max);
+    setIfNonNull("step", step);
+    setIfNonNull("value", value);
 }
 
 function stepUp(value, step, max, optionalStepCount) {
@@ -57,224 +74,82 @@ function stepDownExplicitBounds(min, max, step, value, stepCount) {
     return input.value;
 }
 
-input.type = 'range';
+createRangeElement();
 debug('function arguments are (min, max, step, value, [stepCount])');
 debug('Using the default values');
-shouldBe('stepUpExplicitBounds(null, null, null, "")', '"51"');
-shouldBe('stepDownExplicitBounds(null, null, null, "")', '"49"');
-
-debug('');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, null, "")', '51');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, null, "")', '49');
 debug('Non-number arguments (stepCount)');
-shouldBe('stepUpExplicitBounds(null, null, null, "0", "0")', '"0"');
-shouldBe('stepDownExplicitBounds(null, null, null, "0", "0")', '"0"');
-shouldBe('stepUpExplicitBounds(null, null, null, "0", "foo")', '"0"');
-shouldBe('stepDownExplicitBounds(null, null, null, "0", "foo")', '"0"');
-shouldBe('stepUpExplicitBounds(null, null, null, "0", null)', '"0"');
-shouldBe('stepDownExplicitBounds(null, null, null, "0", null)', '"0"');
-
-debug('');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, null, "0", "0")', '0');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, null, "0", "0")', '0');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, null, "0", "foo")', '0');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, null, "0", "foo")', '0');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, null, "0", null)', '0');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, null, "0", null)', '0');
 debug('Normal cases');
-shouldBe('stepUpExplicitBounds(null, null, null, "0")', '"1"');
-shouldBe('stepUpExplicitBounds(null, null, null, "1", 2)', '"3"');
-shouldBe('stepUpExplicitBounds(null, null, null, "3", -1)', '"2"');
-shouldBe('stepDownExplicitBounds("-100", null, null, "2")', '"1"');
-shouldBe('stepDownExplicitBounds("-100", null, null, "1", 2)', '"-1"');
-shouldBe('stepDownExplicitBounds("-100", null, null, "-1", -1)', '"0"');
-
-debug('');
-debug('Fractional cases')
-// "When the element is suffering from a step mismatch, the user agent must
-// round the element's value to the nearest number for which the element would
-// not suffer from a step mismatch, and which is greater than or equal to the
-// minimum, and, if the maximum is not less than the minimum, which is less
-// than or equal to the maximum, if there is a number that matches these
-// constraints. If two numbers match these constraints, then user agents must
-// use the one nearest to positive infinity.""
-
-// Base/model/template tests
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "0.1")', '"1"');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "0.2")', '"1"');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "1.0")', '"2"');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "1.1")', '"2"');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "1.2")', '"2"');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "2.0")', '"3"');
-
-// Same as above, but with negative numbers.
-debug('');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "-0.1")', '"1"');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "-0.2")', '"1"');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "-1.0")', '"0"');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "-1.1")', '"0"');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "-1.2")', '"0"');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "-2.0")', '"-1"');
-
-// Same as above, but stepping down rather than up.
-debug('');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "0.1")', '"-1"');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "0.2")', '"-1"');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "1.0")', '"0"');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "1.1")', '"0"');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "1.2")', '"0"');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "2.0")', '"1"');
-
-debug('');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "-0.1")', '"-1"');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "-0.2")', '"-1"');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "-1.0")', '"-2"');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "-1.1")', '"-2"');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "-1.2")', '"-2"');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "-2.0")', '"-3"');
-
-// Same as above, but with leading/trailing zeros removed.
-debug('');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, ".1")', '"1"');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, ".2")', '"1"');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "1.")', '"2"');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "2.")', '"3"');
-
-debug('');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "-.1")', '"1"');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "-.2")', '"1"');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "-1.")', '"0"');
-shouldBe('stepUpExplicitBounds(-10, 10, 1, "-2.")', '"-1"');
-
-debug('');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, ".1")', '"-1"');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, ".2")', '"-1"');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "1.")', '"0"');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "2.")', '"1"');
-
-debug('');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "-.1")', '"-1"');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "-.2")', '"-1"');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "-1.")', '"-2"');
-shouldBe('stepDownExplicitBounds(-10, 10, 1, "-2.")', '"-3"');
-
-// Same as above, but stepping by .1 rather than 1.
-debug('');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "0.1")', '"0.2"');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "0.2")', '"0.3"');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "1.0")', '"1.1"');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "1.1")', '"1.2"');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "1.2")', '"1.3"');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "2.0")', '"2.1"');
-
-debug('');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "-0.1")', '"0"');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "-0.2")', '"-0.1"');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "-1.0")', '"-0.9"');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "-1.1")', '"-1"');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "-1.2")', '"-1.1"');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "-2.0")', '"-1.9"');
-
-debug('');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "0.1")', '"0"');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "0.2")', '"0.1"');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "1.0")', '"0.9"');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "1.1")', '"1"');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "1.2")', '"1.1"');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "2.0")', '"1.9"');
-
-debug('');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "-0.1")', '"-0.2"');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "-0.2")', '"-0.3"');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "-1.0")', '"-1.1"');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "-1.1")', '"-1.2"');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "-1.2")', '"-1.3"');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "-2.0")', '"-2.1"');
-
-debug('');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, ".1")', '"0.2"');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, ".2")', '"0.3"');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "1.")', '"1.1"');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "2.")', '"2.1"');
-
-debug('');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "-.1")', '"0"');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "-.2")', '"-0.1"');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "-1.")', '"-0.9"');
-shouldBe('stepUpExplicitBounds(-10, 10, .1, "-2.")', '"-1.9"');
-
-debug('');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, ".1")', '"0"');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, ".2")', '"0.1"');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "1.")', '"0.9"');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "2.")', '"1.9"');
-
-debug('');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "-.1")', '"-0.2"');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "-.2")', '"-0.3"');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "-1.")', '"-1.1"');
-shouldBe('stepDownExplicitBounds(-10, 10, .1, "-2.")', '"-2.1"');
-
-debug('');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, null, "0")', '1');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, null, "1", 2)', '3');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, null, "3", -1)', '2');
+shouldBeEqualToString('stepDownExplicitBounds("-100", null, null, "2")', '1');
+shouldBeEqualToString('stepDownExplicitBounds("-100", null, null, "1", 2)', '-1');
+shouldBeEqualToString('stepDownExplicitBounds("-100", null, null, "-1", -1)', '0');
 debug('Extra arguments');
-shouldBe('setInputAttributes(null, null, null, "0"); input.stepUp(1,2); input.value', '"1"');
-shouldBe('setInputAttributes(null, null, null, "1"); input.stepDown(1,3); input.value', '"0"');
-
-debug('');
+shouldBeEqualToString('setInputAttributes(null, null, null, "0"); input.stepUp(1,2); input.value', '1');
+shouldBeEqualToString('setInputAttributes(null, null, null, "1"); input.stepDown(1,3); input.value', '0');
 debug('Invalid step value');
-shouldBe('stepUpExplicitBounds(null, null, "foo", "0")', '"1"');
-shouldBe('stepUpExplicitBounds(null, null, "0", "1")', '"2"');
-shouldBe('stepUpExplicitBounds(null, null, "-1", "2")', '"3"');
-shouldBe('stepDownExplicitBounds(null, null, "foo", "1")', '"0"');
-shouldBe('stepDownExplicitBounds(null, null, "0", "2")', '"1"');
-shouldBe('stepDownExplicitBounds(null, null, "-1", "3")', '"2"');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, "foo", "0")', '1');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, "0", "1")', '2');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, "-1", "2")', '3');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, "foo", "1")', '0');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, "0", "2")', '1');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, "-1", "3")', '2');
+debug('Step bases');
+shouldBeEqualToString('createInputWithContentAttributes(0, 100, "20", "50"); input.value', '60');
+shouldBeEqualToString('createInputWithContentAttributes(null, null, "50", "25"); input.value', '25');
+shouldBeEqualToString('createInputWithContentAttributes(null, null, "50", "25"); input.stepUp(1); input.value', '75');
+shouldBeEqualToString('createInputWithContentAttributes(null, null, "50", "25"); input.stepUp(1); input.stepDown(1); input.value', '25');
+shouldBeEqualToString('createInputWithContentAttributes(null, null, "50", "25"); input.stepUp(2); input.stepDown(2); input.value', '25');
+shouldBeEqualToString('createInputWithContentAttributes(null, null, "7", "22"); input.stepUp(40); input.value', '99');
 
-debug('');
+// Reset 'input' for follow-on tests.
+createRangeElement();
 debug('Step=any');
-shouldThrowErrorName('stepUpExplicitBounds(null, null, "any", "1")', "InvalidStateError");
-shouldThrowErrorName('stepDownExplicitBounds(null, null, "any", "1")', "InvalidStateError");
-
-debug('');
+shouldThrow('stepUpExplicitBounds(null, null, "any", "1")');
+shouldThrow('stepDownExplicitBounds(null, null, "any", "1")');
 debug('Overflow/underflow');
-shouldBe('stepUpExplicitBounds(null, "100", "1", "99")', '"100"');
-shouldBe('stepUpExplicitBounds(null, "100", "1", "100")', '"100"');
-shouldBe('input.value', '"100"');
-shouldBe('stepUpExplicitBounds(null, "100", "1", "99", "2")', '"100"');
-shouldBe('input.value', '"100"');
-shouldBe('stepDownExplicitBounds("0", null, "1", "1")', '"0"');
-shouldBe('stepDownExplicitBounds("0", null, "1", "0")', '"0"');
-shouldBe('input.value', '"0"');
-shouldBe('stepDownExplicitBounds("0", null, "1", "1", "2")', '"0"');
-shouldBe('input.value', '"0"');
-shouldBe('stepDownExplicitBounds(null, null, "3.40282346e+38", "1", "2")', '"0"');
-shouldBe('stepUpExplicitBounds(-100, 0, 1, -1)', '"0"');
-shouldBe('stepUpExplicitBounds(null, 0, 1, 0)', '"0"');
-shouldBe('stepUpExplicitBounds(-100, 0, 1, -1, 2)', '"0"');
-shouldBe('input.value', '"0"');
-shouldBe('stepUpExplicitBounds(null, null, "3.40282346e+38", "1", "2")', '"0"');
-
-debug('');
+shouldBeEqualToString('stepUpExplicitBounds(null, "100", "1", "99")', '100');
+shouldBeEqualToString('stepUpExplicitBounds(null, "100", "1", "100")', '100');
+shouldBeEqualToString('stepUpExplicitBounds(null, "100", "1", "99", "2")', '100');
+shouldBeEqualToString('stepDownExplicitBounds("0", null, "1", "1")', '0');
+shouldBeEqualToString('stepDownExplicitBounds("0", null, "1", "0")', '0');
+shouldBeEqualToString('stepDownExplicitBounds("0", null, "1", "1", "2")', '0');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, "3.40282346e+38", "1", "2")', '0');
+shouldBeEqualToString('stepUpExplicitBounds(-100, 0, 1, -1)', '0');
+shouldBeEqualToString('stepUpExplicitBounds(null, 0, 1, 0)', '0');
+shouldBeEqualToString('stepUpExplicitBounds(-100, 0, 1, -1, 2)', '0');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, "3.40282346e+38", "1", "2")', '0');
 debug('stepDown()/stepUp() for stepMismatch values');
-shouldBe('stepUpExplicitBounds(null, null, 2, 1)', '"4"');
-shouldBe('input.stepDown(); input.value', '"2"');
-shouldBe('stepUpExplicitBounds(0, null, 10, 9, 9)', '"100"');
-shouldBe('stepDownExplicitBounds(0, null, 10, 19)', '"10"');
-
-debug('');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, 2, 1)', '4');
+shouldBeEqualToString('input.stepDown(); input.value', '2');
+shouldBeEqualToString('stepUpExplicitBounds(0, null, 10, 9, 9)', '100');
+shouldBeEqualToString('stepDownExplicitBounds(0, null, 10, 19)', '10');
 debug('value + step is <= max, but rounded result would be > max.');
-shouldBe('stepUpExplicitBounds(null, 99, 10, 89)', '"90"');
-
-debug('');
+shouldBeEqualToString('stepUpExplicitBounds(null, 99, 10, 89)', '90');
+shouldBeEqualToString('stepUpExplicitBounds(null, 99, 10, 89, 21)', '90');
+shouldBeEqualToString('stepUpExplicitBounds(null, 99, 10, 77, 2)', '90');
 debug('Huge value and small step');
-shouldBe('stepUpExplicitBounds(0, 1e38, 1, 1e38, 999999)', '"1e+38"');
-shouldBe('stepDownExplicitBounds(0, 1e38, 1, 1e38, 999999)', '"1e+38"');
-
-debug('');
+shouldBeEqualToString('stepUpExplicitBounds(0, 1e38, 1, 1e38, 999999)', '1e+38');
+shouldBeEqualToString('stepDownExplicitBounds(0, 1e38, 1, 1e38, 999999)', '1e+38');
 debug('Fractional numbers');
-shouldBe('stepUpExplicitBounds(null, null, 0.33333333333333333, 0, 3)', '"1"');
-shouldBe('stepUpExplicitBounds(null, null, 0.1, 1)', '"1.1"');
-shouldBe('stepUpExplicitBounds(null, null, 0.1, 1, 8)', '"1.8"');
-shouldBe('stepUpExplicitBounds(null, null, 0.1, 1, 10)', '"2"');
-shouldBe('input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.value', '"3"');
-shouldBe('stepUpExplicitBounds(0, 1, 0.003921568627450980, 0, 255)', '"1"');
-shouldBe('for (var i = 0; i < 255; i++) { input.stepDown(); }; input.value', '"0"');
-shouldBe('stepDownExplicitBounds(null, null, 0.1, 1, 8)', '"0.2"');
-shouldBe('stepDownExplicitBounds(null, null, 0.1, 1)', '"0.9"');
-
-debug('');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, 0.33333333333333333, 0, 3)', '1');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, 0.1, 1)', '1.1');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, 0.1, 1, 8)', '1.8');
+shouldBeEqualToString('stepUpExplicitBounds(null, null, 0.1, 1, 10)', '2');
+shouldBeEqualToString('input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.stepUp(); input.value', '3');
+shouldBeEqualToString('stepUpExplicitBounds(0, 1, 0.003921568627450980, 0, 255)', '1');
+shouldBeEqualToString('for (var i = 0; i < 255; i++) { input.stepDown(); }; input.value', '0');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, 0.1, 1, 8)', '0.2');
+shouldBeEqualToString('stepDownExplicitBounds(null, null, 0.1, 1)', '0.9');
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/time/time-stepup-stepdown-expected.txt
+++ b/LayoutTests/fast/forms/time/time-stepup-stepdown-expected.txt
@@ -1,4 +1,4 @@
-Check stepUp() and stepDown() bahevior for type=time.
+Check stepUp() and stepDown() behavior for type=time.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
@@ -24,7 +24,7 @@ Step=any
 PASS stepUp("20:13", "any", null) threw exception InvalidStateError: The object is in an invalid state..
 PASS stepDown("20:13", "any", null) threw exception InvalidStateError: The object is in an invalid state..
 Overflow/underflow
-PASS stepUp("20:13", "3.40282346e+38", null) is "20:13"
+PASS stepUp("20:13", "3.40282346e+38", null) is "00:00:00"
 PASS stepDown("20:13", "3.40282346e+38", null) is "00:00:00"
 PASS stepUp("20:13", "1", "20:13") is "20:13:00"
 PASS stepDown("20:13", "1", "20:13") is "20:13:00"

--- a/LayoutTests/fast/forms/time/time-stepup-stepdown.html
+++ b/LayoutTests/fast/forms/time/time-stepup-stepdown.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
 <div id="console"></div>
 <script>
-description('Check stepUp() and stepDown() bahevior for type=time.');
+description('Check stepUp() and stepDown() behavior for type=time.');
 
 var input = document.createElement('input');
 
@@ -41,32 +41,31 @@ debug('Invalid value');
 shouldBe('stepUp("", null, null)', '"00:01"');
 shouldBe('stepDown("", null, null)', '"00:00"');
 debug('Non-number arguments');
-shouldBe('stepUp("20:13", null, null, "0")', '"20:13"');
-shouldBe('stepDown("20:13", null, null, "0")', '"20:13"');
-shouldBe('stepUp("20:13", null, null, "foo")', '"20:13"');
-shouldBe('stepDown("20:13", null, null, "foo")', '"20:13"');
-shouldBe('stepUp("20:13", null, null, null)', '"20:13"');
-shouldBe('stepDown("20:13", null, null, null)', '"20:13"');
+shouldBeEqualToString('stepUp("20:13", null, null, "0")', '20:13');
+shouldBeEqualToString('stepDown("20:13", null, null, "0")', '20:13');
+shouldBeEqualToString('stepUp("20:13", null, null, "foo")', '20:13');
+shouldBeEqualToString('stepDown("20:13", null, null, "foo")', '20:13');
+shouldBeEqualToString('stepUp("20:13", null, null, null)', '20:13');
+shouldBeEqualToString('stepDown("20:13", null, null, null)', '20:13');
 debug('Normal cases');
-shouldBe('stepUp("20:13", null, null)', '"20:14"');
-shouldBe('stepDown("20:13", null, null)', '"20:12"');
-shouldBe('stepUp("20:13", null, null, 10)', '"20:23"');
-shouldBe('stepDown("20:13", null, null, 11)', '"20:02"');
-shouldBe('stepUp("20:13", "4", null, 2)', '"20:13:08"');
-shouldBe('stepDown("20:13", "4", null, 3)', '"20:12:48"');
+shouldBeEqualToString('stepUp("20:13", null, null)', '20:14');
+shouldBeEqualToString('stepDown("20:13", null, null)', '20:12');
+shouldBeEqualToString('stepUp("20:13", null, null, 10)', '20:23');
+shouldBeEqualToString('stepDown("20:13", null, null, 11)', '20:02');
+shouldBeEqualToString('stepUp("20:13", "4", null, 2)', '20:13:08');
+shouldBeEqualToString('stepDown("20:13", "4", null, 3)', '20:12:48');
 debug('Step=any');
 shouldThrowErrorName('stepUp("20:13", "any", null)', "InvalidStateError");
 shouldThrowErrorName('stepDown("20:13", "any", null)', "InvalidStateError");
 debug('Overflow/underflow');
-shouldBe('stepUp("20:13", "3.40282346e+38", null)', '"20:13"');
-shouldBe('stepDown("20:13", "3.40282346e+38", null)', '"00:00:00"');
-shouldBe('stepUp("20:13", "1", "20:13")', '"20:13:00"');
-shouldBe('stepDown("20:13", "1", "20:13")', '"20:13:00"');
-shouldBe('stepUp("23:59", null, null)', '"23:59"');
-shouldBe('stepDown("00:00", null, null)', '"00:00"');
+shouldBeEqualToString('stepUp("20:13", "3.40282346e+38", null)', '00:00:00');
+shouldBeEqualToString('stepDown("20:13", "3.40282346e+38", null)', '00:00:00');
+shouldBeEqualToString('stepUp("20:13", "1", "20:13")', '20:13:00');
+shouldBeEqualToString('stepDown("20:13", "1", "20:13")', '20:13:00');
+shouldBeEqualToString('stepUp("23:59", null, null)', '23:59');
+shouldBeEqualToString('stepDown("00:00", null, null)', '00:00');
 
 debug('');
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/week/week-stepup-stepdown-expected.txt
+++ b/LayoutTests/fast/forms/week/week-stepup-stepdown-expected.txt
@@ -1,11 +1,11 @@
-Check stepUp() and stepDown() bahevior for type=week.
+Check stepUp() and stepDown() behavior for type=week.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
 Invalid value
 PASS stepUp("", null, null) is "1970-W02"
-PASS stepDown("", null, null) is "1969-W52"
+PASS stepDown("", null, null) is "1970-W01"
 Non-number arguments
 PASS stepUp("2010-W02", null, null, "0") is "2010-W02"
 PASS stepDown("2010-W02", null, null, "0") is "2010-W02"
@@ -24,7 +24,7 @@ Step=any
 PASS stepUp("2010-W02", "any", null) threw exception InvalidStateError: The object is in an invalid state..
 PASS stepDown("2010-W02", "any", null) threw exception InvalidStateError: The object is in an invalid state..
 Overflow/underflow
-PASS stepUp("2010-W02", "3.40282346e+38", null) is "2010-W02"
+PASS stepUp("2010-W02", "3.40282346e+38", null) is "1970-W01"
 PASS stepDown("2010-W02", "3.40282346e+38", null) is "1970-W01"
 PASS stepUp("2010-W02", "1", "2010-W02") is "2010-W02"
 PASS stepDown("2010-W02", "1", "2010-W02") is "2010-W02"

--- a/LayoutTests/fast/forms/week/week-stepup-stepdown.html
+++ b/LayoutTests/fast/forms/week/week-stepup-stepdown.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
 <div id="console"></div>
 <script>
-description('Check stepUp() and stepDown() bahevior for type=week.');
+description('Check stepUp() and stepDown() behavior for type=week.');
 
 var input = document.createElement('input');
 
@@ -38,33 +38,32 @@ function stepDown(value, step, min, optionalStepCount) {
 
 input.type = 'week';
 debug('Invalid value');
-shouldBe('stepUp("", null, null)', '"1970-W02"');
-shouldBe('stepDown("", null, null)', '"1969-W52"');
+shouldBeEqualToString('stepUp("", null, null)', '1970-W02');
+shouldBeEqualToString('stepDown("", null, null)', '1970-W01');
 debug('Non-number arguments');
-shouldBe('stepUp("2010-W02", null, null, "0")', '"2010-W02"');
-shouldBe('stepDown("2010-W02", null, null, "0")', '"2010-W02"');
-shouldBe('stepUp("2010-W02", null, null, "foo")', '"2010-W02"');
-shouldBe('stepDown("2010-W02", null, null, "foo")', '"2010-W02"');
-shouldBe('stepUp("2010-W02", null, null, null)', '"2010-W02"');
-shouldBe('stepDown("2010-W02", null, null, null)', '"2010-W02"');
+shouldBeEqualToString('stepUp("2010-W02", null, null, "0")', '2010-W02');
+shouldBeEqualToString('stepDown("2010-W02", null, null, "0")', '2010-W02');
+shouldBeEqualToString('stepUp("2010-W02", null, null, "foo")', '2010-W02');
+shouldBeEqualToString('stepDown("2010-W02", null, null, "foo")', '2010-W02');
+shouldBeEqualToString('stepUp("2010-W02", null, null, null)', '2010-W02');
+shouldBeEqualToString('stepDown("2010-W02", null, null, null)', '2010-W02');
 debug('Normal cases');
-shouldBe('stepUp("2010-W02", null, null)', '"2010-W03"');
-shouldBe('stepDown("2010-W02", null, null)', '"2010-W01"');
-shouldBe('stepUp("2010-W02", null, null, 10)', '"2010-W12"');
-shouldBe('stepDown("2010-W02", null, null, 11)', '"2009-W44"');
-shouldBe('stepUp("1970-W01", "4", null, 2)', '"1970-W09"');
-shouldBe('stepDown("1970-W01", "4", null, 3)', '"1969-W41"');
+shouldBeEqualToString('stepUp("2010-W02", null, null)', '2010-W03');
+shouldBeEqualToString('stepDown("2010-W02", null, null)', '2010-W01');
+shouldBeEqualToString('stepUp("2010-W02", null, null, 10)', '2010-W12');
+shouldBeEqualToString('stepDown("2010-W02", null, null, 11)', '2009-W44');
+shouldBeEqualToString('stepUp("1970-W01", "4", null, 2)', '1970-W09');
+shouldBeEqualToString('stepDown("1970-W01", "4", null, 3)', '1969-W41');
 debug('Step=any');
-shouldThrowErrorName('stepUp("2010-W02", "any", null)', "InvalidStateError");
-shouldThrowErrorName('stepDown("2010-W02", "any", null)', "InvalidStateError");
+shouldThrow('stepUp("2010-W02", "any", null)');
+shouldThrow('stepDown("2010-W02", "any", null)');
 debug('Overflow/underflow');
-shouldBe('stepUp("2010-W02", "3.40282346e+38", null)', '"2010-W02"');
-shouldBe('stepDown("2010-W02", "3.40282346e+38", null)', '"1970-W01"');
-shouldBe('stepUp("2010-W02", "1", "2010-W02")', '"2010-W02"');
-shouldBe('stepDown("2010-W02", "1", "2010-W02")', '"2010-W02"');
+shouldBeEqualToString('stepUp("2010-W02", "3.40282346e+38", null)', '1970-W01');
+shouldBeEqualToString('stepDown("2010-W02", "3.40282346e+38", null)', '1970-W01');
+shouldBeEqualToString('stepUp("2010-W02", "1", "2010-W02")', '2010-W02');
+shouldBeEqualToString('stepDown("2010-W02", "1", "2010-W02")', '2010-W02');
 
 debug('');
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/html/DateInputType.cpp
+++ b/Source/WebCore/html/DateInputType.cpp
@@ -68,7 +68,7 @@ DateComponentsType DateInputType::dateType() const
 StepRange DateInputType::createStepRange(AnyStepHandling anyStepHandling) const
 {
     ASSERT(element());
-    const Decimal stepBase = parseToNumber(element()->attributeWithoutSynchronization(minAttr), 0);
+    const Decimal stepBase = findStepBase(dateDefaultStepBase);
     const Decimal minimum = parseToNumber(element()->attributeWithoutSynchronization(minAttr), Decimal::fromDouble(DateComponents::minimumDate()));
     const Decimal maximum = parseToNumber(element()->attributeWithoutSynchronization(maxAttr), Decimal::fromDouble(DateComponents::maximumDate()));
     const Decimal step = StepRange::parseStep(anyStepHandling, dateStepDescription, element()->attributeWithoutSynchronization(stepAttr));

--- a/Source/WebCore/html/DateTimeLocalInputType.cpp
+++ b/Source/WebCore/html/DateTimeLocalInputType.cpp
@@ -77,7 +77,7 @@ ExceptionOr<void> DateTimeLocalInputType::setValueAsDate(WallTime value) const
 StepRange DateTimeLocalInputType::createStepRange(AnyStepHandling anyStepHandling) const
 {
     ASSERT(element());
-    const Decimal stepBase = parseToNumber(element()->attributeWithoutSynchronization(minAttr), 0);
+    const Decimal stepBase = findStepBase(dateTimeLocalDefaultStepBase);
     const Decimal minimum = parseToNumber(element()->attributeWithoutSynchronization(minAttr), Decimal::fromDouble(DateComponents::minimumDateTime()));
     const Decimal maximum = parseToNumber(element()->attributeWithoutSynchronization(maxAttr), Decimal::fromDouble(DateComponents::maximumDateTime()));
     const Decimal step = StepRange::parseStep(anyStepHandling, dateTimeLocalStepDescription, element()->attributeWithoutSynchronization(stepAttr));

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -416,6 +416,9 @@ protected:
     Chrome* chrome() const;
     Decimal parseToNumberOrNaN(const String&) const;
 
+    // Derive the step base, following the HTML algorithm steps.
+    Decimal findStepBase(const Decimal&) const;
+
 private:
     // Helper for stepUp()/stepDown(). Adds step value * count to the current value.
     ExceptionOr<void> applyStep(int count, AnyStepHandling, TextFieldEventBehavior);

--- a/Source/WebCore/html/MonthInputType.cpp
+++ b/Source/WebCore/html/MonthInputType.cpp
@@ -101,7 +101,7 @@ Decimal MonthInputType::defaultValueForStepUp() const
 StepRange MonthInputType::createStepRange(AnyStepHandling anyStepHandling) const
 {
     ASSERT(element());
-    const Decimal stepBase = parseToNumber(element()->attributeWithoutSynchronization(minAttr), Decimal::fromDouble(monthDefaultStepBase));
+    const Decimal stepBase = findStepBase(Decimal::fromDouble(monthDefaultStepBase));
     const Decimal minimum = parseToNumber(element()->attributeWithoutSynchronization(minAttr), Decimal::fromDouble(DateComponents::minimumMonth()));
     const Decimal maximum = parseToNumber(element()->attributeWithoutSynchronization(maxAttr), Decimal::fromDouble(DateComponents::maximumMonth()));
     const Decimal step = StepRange::parseStep(anyStepHandling, monthStepDescription, element()->attributeWithoutSynchronization(stepAttr));

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -141,9 +141,7 @@ StepRange NumberInputType::createStepRange(AnyStepHandling anyStepHandling) cons
     static NeverDestroyed<const StepRange::StepDescription> stepDescription(numberDefaultStep, numberDefaultStepBase, numberStepScaleFactor);
 
     ASSERT(element());
-    Decimal stepBase = parseToDecimalForNumberType(element()->attributeWithoutSynchronization(minAttr), Decimal::nan());
-    if (stepBase.isNaN())
-        stepBase = parseToDecimalForNumberType(element()->attributeWithoutSynchronization(valueAttr), numberDefaultStepBase);
+    const Decimal stepBase = findStepBase(numberDefaultStepBase);
 
     const Decimal doubleMax = Decimal::doubleMax();
     const Element& element = *this->element();

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -119,11 +119,12 @@ bool RangeInputType::supportsRequired() const
 StepRange RangeInputType::createStepRange(AnyStepHandling anyStepHandling) const
 {
     ASSERT(element());
+    const Decimal stepBase = findStepBase(rangeDefaultStepBase);
     const Decimal minimum = parseToNumber(element()->attributeWithoutSynchronization(minAttr), rangeDefaultMinimum);
     const Decimal maximum = ensureMaximum(parseToNumber(element()->attributeWithoutSynchronization(maxAttr), rangeDefaultMaximum), minimum);
 
     const Decimal step = StepRange::parseStep(anyStepHandling, rangeStepDescription, element()->attributeWithoutSynchronization(stepAttr));
-    return StepRange(minimum, RangeLimitations::Valid, minimum, maximum, step, rangeStepDescription);
+    return StepRange(stepBase, RangeLimitations::Valid, minimum, maximum, step, rangeStepDescription);
 }
 
 // FIXME: Should this work for untrusted input?

--- a/Source/WebCore/html/StepRange.cpp
+++ b/Source/WebCore/html/StepRange.cpp
@@ -87,11 +87,12 @@ Decimal StepRange::clampValue(const Decimal& value) const
     const Decimal inRangeValue = std::max(m_minimum, std::min(value, m_maximum));
     if (!m_hasStep)
         return inRangeValue;
-    // Rounds inRangeValue to minimum + N * step.
-    const Decimal roundedValue = roundByStep(inRangeValue, m_minimum);
-    const Decimal clampedValue = roundedValue > m_maximum ? roundedValue - m_step : roundedValue;
-    ASSERT(clampedValue >= m_minimum);
-    ASSERT(clampedValue <= m_maximum);
+    // Rounds inRangeValue to stepBase + N * step.
+    const Decimal roundedValue = roundByStep(inRangeValue, m_stepBase);
+    const Decimal clampedValue = roundedValue > m_maximum ? roundedValue - m_step : (roundedValue < m_minimum ? roundedValue + m_step : roundedValue);
+    // clampedValue can be outside of [m_minimum, m_maximum] if m_step is huge.
+    if (clampedValue < m_minimum || clampedValue > m_maximum)
+        return inRangeValue;
     return clampedValue;
 }
 

--- a/Source/WebCore/html/TimeInputType.cpp
+++ b/Source/WebCore/html/TimeInputType.cpp
@@ -86,7 +86,7 @@ Decimal TimeInputType::defaultValueForStepUp() const
 StepRange TimeInputType::createStepRange(AnyStepHandling anyStepHandling) const
 {
     ASSERT(element());
-    const Decimal stepBase = parseToNumber(element()->attributeWithoutSynchronization(minAttr), 0);
+    const Decimal stepBase = findStepBase(timeDefaultStepBase);
     const Decimal minimum = parseToNumber(element()->attributeWithoutSynchronization(minAttr), Decimal::fromDouble(DateComponents::minimumTime()));
     const Decimal maximum = parseToNumber(element()->attributeWithoutSynchronization(maxAttr), Decimal::fromDouble(DateComponents::maximumTime()));
     const Decimal step = StepRange::parseStep(anyStepHandling, timeStepDescription, element()->attributeWithoutSynchronization(stepAttr));

--- a/Source/WebCore/html/WeekInputType.cpp
+++ b/Source/WebCore/html/WeekInputType.cpp
@@ -62,7 +62,7 @@ DateComponentsType WeekInputType::dateType() const
 StepRange WeekInputType::createStepRange(AnyStepHandling anyStepHandling) const
 {
     ASSERT(element());
-    const Decimal stepBase = parseToNumber(element()->attributeWithoutSynchronization(minAttr), weekDefaultStepBase);
+    const Decimal stepBase = findStepBase(weekDefaultStepBase);
     const Decimal minimum = parseToNumber(element()->attributeWithoutSynchronization(minAttr), Decimal::fromDouble(DateComponents::minimumWeek()));
     const Decimal maximum = parseToNumber(element()->attributeWithoutSynchronization(maxAttr), Decimal::fromDouble(DateComponents::maximumWeek()));
     const Decimal step = StepRange::parseStep(anyStepHandling, weekStepDescription, element()->attributeWithoutSynchronization(stepAttr));


### PR DESCRIPTION
#### 5b73f8e46d3aa14144afe2cd034da272756daf8d
<pre>
Update input[type=*]&apos;s step base handling to match spec

<a href="https://bugs.webkit.org/show_bug.cgi?id=254761">https://bugs.webkit.org/show_bug.cgi?id=254761</a>
<a href="https://rdar.apple.com/problem/107721910">rdar://problem/107721910</a>

Reviewed by Aditya Keerthi.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge [1]: <a href="https://chromium.googlesource.com/chromium/src.git/+/0f836e3f330abbd76df604090db47c6e8fccd5b1">https://chromium.googlesource.com/chromium/src.git/+/0f836e3f330abbd76df604090db47c6e8fccd5b1</a>

Determine the step base for an input element per spec:

Spec: <a href="https://html.spec.whatwg.org/#concept-input-min-zero">https://html.spec.whatwg.org/#concept-input-min-zero</a>

That is, consult the &apos;value&apos; attribute if &apos;min&apos; is not present, and
then fallback to the default step base for the input type if that
isn&apos;t present either. Previously, &apos;value&apos; was not considered.

Merge [2]: <a href="https://chromium.googlesource.com/chromium/src.git/+/f0af3d9cd0b5e0b05f20cd8c4f20103f572f14ef">https://chromium.googlesource.com/chromium/src.git/+/f0af3d9cd0b5e0b05f20cd8c4f20103f572f14ef</a>

The HTML spec recently shifted to using &apos;value&apos; as the first fallback
option for an input element&apos;s &quot;step base&quot; (if no &apos;min&apos; attribute):

Spec: <a href="https://html.spec.whatwg.org/#concept-input-min-zero">https://html.spec.whatwg.org/#concept-input-min-zero</a>

Also bring type=range elements into line with that, including using
that step base when clamping values to the supported range.

Merge [3]: <a href="https://chromium.googlesource.com/chromium/src.git/+/807ab32fd2e5accda8c5cef2678e0e0af23158b0">https://chromium.googlesource.com/chromium/src.git/+/807ab32fd2e5accda8c5cef2678e0e0af23158b0</a>

According to the specification, we should not resolve step-mismatch if there are
no step-matched values in the range. So, StepRange::clampValue() should return
the minimum value or the maximum value.

Spec: <a href="https://html.spec.whatwg.org/multipage/input.html#range-state-(type%3Drange)">https://html.spec.whatwg.org/multipage/input.html#range-state-(type%3Drange)</a>

Merge [4]: <a href="https://github.com/chromium/chromium/commit/fb67b3219964064ba741ffbba0f3f568a23572e0">https://github.com/chromium/chromium/commit/fb67b3219964064ba741ffbba0f3f568a23572e0</a>

The spec for stepUp()/stepDown():

Spec: <a href="https://html.spec.whatwg.org/#dom-input-stepdown">https://html.spec.whatwg.org/#dom-input-stepdown</a>

requires that out-of-step values snap to step, just like the UI
implementation will do. Hence, bring the required clamping/snapping
handling into scope.

NOTE - It matches Blink from top of tree to avoid stack overflow issue:

Stack Overflow: <a href="https://source.chromium.org/chromium/chromium/src/+/ebc1f01b3fdba6c8b1b2b1075e029cd317c685ee">https://source.chromium.org/chromium/chromium/src/+/ebc1f01b3fdba6c8b1b2b1075e029cd317c685ee</a>

* Source/WebCore/html/InputType.cpp:
(InputType::findStepBase): Add Helping function
(InputType::applyStep): Update to spec
* Source/WebCore/html/InputType.h: Helper function definition
* Source/WebCore/html/MonthInputType.cpp:
(MonthInputType::defaultValueForStepUp): Use ’findStepBase’
* Source/WebCore/html/NumberInputType.cpp:
(NumberInputType::createStepRange): Use ’findStepBase’ and remove already covered ‘NaN’ handling
* Source/WebCore/html/TimeInputType.cpp:
(TimeInputType:: createStepRange): Use ’findStepBase’
* Source/WebCore/html/WeekInputType.cpp:
(WeekInputType:: createStepRange): Use ’findStepBase’
* Source/WebCore/html/RangeInputType.cpp:
(RangeInputType::createStepRange): Use &apos;findStepBase&apos;
* Source/WebCore/html/StepRange.cpp:
(StepRange::clampValue): clampValue but respect &apos;stepBase&apos;
* LayoutTests/fast/forms/week/week-stepup-stepdown.html:
* LayoutTests/fast/forms/time/time-stepup-stepdown.html:
* LayoutTests/fast/forms/range/range-stepup-stepdown.html: Removed duplicate tests as well
* LayoutTests/fast/forms/number/number-stepup-stepdown.html: Ditto
* LayoutTests/fast/forms/month/month-stepup-stepdown.html:
* LayoutTests/fast/forms/datetimelocal/datetimelocal-stepup-stepdown.html:
* LayoutTests/fast/forms/date/date-stepup-stepdown.html:
* LayoutTests/fast/forms/date/date-stepup-stepdown-expected.txt: Rebaselined
* LayoutTests/fast/forms/datetimelocal/datetimelocal-stepup-stepdown-expected.txt: Ditto
* LayoutTests/fast/forms/month/month-stepup-stepdown-expected.txt: Ditto
* LayoutTests/fast/forms/range/range-stepup-stepdown-expected.txt: Ditto
* LayoutTests/fast/forms/time/time-stepup-stepdown-expected.txt: Fail Tests also fail in Blink
* LayoutTests/fast/forms/week/week-stepup-stepdown-expected.txt: Rebaselined
* LayoutTests/fast/forms/number/number-stepup-stepdown-expected.txt: Rebaselined
* LayoutTests/fast/forms/date/input-date-validation-message.html: Rebaselined

Canonical link: <a href="https://commits.webkit.org/280127@main">https://commits.webkit.org/280127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0749912c586e2441b49bc9001b31e877246f61e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58596 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6042 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6241 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44779 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4146 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47930 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25911 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29619 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5259 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4186 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60187 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5652 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52211 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31851 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51694 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12369 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32932 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31598 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->