### PR TITLE
WebMResourceClientParent::loadFinished parameter is unused

### DIFF
--- a/Source/WebCore/platform/graphics/WebMResourceClient.cpp
+++ b/Source/WebCore/platform/graphics/WebMResourceClient.cpp
@@ -83,7 +83,7 @@ void WebMResourceClient::loadFinished(PlatformMediaResource&, const NetworkLoadM
     if (!m_parent)
         return;
     
-    m_parent->loadFinished(*m_buffer.get());
+    m_parent->loadFinished();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/WebMResourceClient.h
+++ b/Source/WebCore/platform/graphics/WebMResourceClient.h
@@ -35,10 +35,10 @@ namespace WebCore {
 class WebMResourceClientParent : public CanMakeWeakPtr<WebMResourceClientParent> {
 public:
     virtual ~WebMResourceClientParent() = default;
-    
+
     virtual void dataReceived(const SharedBuffer&) = 0;
     virtual void loadFailed(const ResourceError&) = 0;
-    virtual void loadFinished(const FragmentedSharedBuffer&) = 0;
+    virtual void loadFinished() = 0;
 };
 
 class WebMResourceClient final

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -103,7 +103,7 @@ private:
     friend class WebMResourceClient;
     void dataReceived(const SharedBuffer&) final;
     void loadFailed(const ResourceError&) final;
-    void loadFinished(const FragmentedSharedBuffer&) final;
+    void loadFinished() final;
 
     void cancelLoad() final;
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -233,7 +233,7 @@ void MediaPlayerPrivateWebM::loadFailed(const ResourceError& error)
     setNetworkState(MediaPlayer::NetworkState::NetworkError);
 }
 
-void MediaPlayerPrivateWebM::loadFinished(const FragmentedSharedBuffer&)
+void MediaPlayerPrivateWebM::loadFinished()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     m_loadFinished = true;


### PR DESCRIPTION
#### 3ed8adb00eb77e854ded172772b928e2d30ab534
<pre>
WebMResourceClientParent::loadFinished parameter is unused
<a href="https://bugs.webkit.org/show_bug.cgi?id=267669">https://bugs.webkit.org/show_bug.cgi?id=267669</a>
<a href="https://rdar.apple.com/121158587">rdar://121158587</a>

Reviewed by Eric Carlson.

The parameter provided to WebMResourceClientParent::loadFinished is unused.
It could also potentially cause an issue if somehow loadFinished was incorrectly called
before dataReceived.

* Source/WebCore/platform/graphics/WebMResourceClient.cpp:
(WebCore::WebMResourceClient::loadFinished):
* Source/WebCore/platform/graphics/WebMResourceClient.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::loadFinished):

Canonical link: <a href="https://commits.webkit.org/273164@main">https://commits.webkit.org/273164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1107d4688283fe9dffa7f4e2f1deac932fc74b63

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37207 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31203 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35660 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/15756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10448 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30178 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30761 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9852 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9934 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38485 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31339 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31137 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/35999 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10060 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33948 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11880 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7930 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10616 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->