### PR TITLE
Fix svg-write-resources-null-maskImage-crash-expected.html.

### DIFF
--- a/LayoutTests/svg/css/svg-write-resources-null-maskImage-crash-expected.html
+++ b/LayoutTests/svg/css/svg-write-resources-null-maskImage-crash-expected.html
@@ -1,5 +1,4 @@
-<svg>
-    <g style="mask-image: none, url()">
-    </g>
-</svg>
-This test passes if it doesn't crash.
+<div>
+    <svg></svg>
+    This test passes if it doesn't crash.
+</div>

--- a/LayoutTests/svg/css/svg-write-resources-null-maskImage-crash.html
+++ b/LayoutTests/svg/css/svg-write-resources-null-maskImage-crash.html
@@ -1,5 +1,7 @@
-<svg>
-    <g style="mask-image: none, url()">
-    </g>
-</svg>
-This test passes if it doesn't crash.
+<div>
+    <svg>
+        <g style="mask-image: none, url()">
+        </g>
+    </svg>
+    This test passes if it doesn't crash.
+</div>


### PR DESCRIPTION
#### c8a4c028a9e7cdade35b4a20cf7db8721c3b5b9b
<pre>
Fix svg-write-resources-null-maskImage-crash-expected.html.
<a href="https://rdar.apple.com/121162928">rdar://121162928</a>

Reviewed by Tim Nguyen.

Removing &lt;g&gt; and style attribute from expected file.

* LayoutTests/svg/css/svg-write-resources-null-maskImage-crash-expected.html:
* LayoutTests/svg/css/svg-write-resources-null-maskImage-crash.html:

Canonical link: <a href="https://commits.webkit.org/273345@main">https://commits.webkit.org/273345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3bf7f8747768db692ff3b80c87107b97ebda2a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37275 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31252 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30225 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9913 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38553 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31197 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36059 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34012 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11937 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30506 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8047 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10667 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10987 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->