### PR TITLE
Incorrect wheel event behavior with Shadow DOM

### DIFF
--- a/LayoutTests/fast/scrolling/mac/wheel-event-in-overflow-with-shadow-dom-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/wheel-event-in-overflow-with-shadow-dom-expected.txt
@@ -1,0 +1,10 @@
+
+Test scroll over shadow content
+PASS overflowScrollEventCount > 0 is true
+PASS windowScrollEventCount == 0 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Scrolling over this element should scroll the overflow scroller
+
+

--- a/LayoutTests/fast/scrolling/mac/wheel-event-in-overflow-with-shadow-dom.html
+++ b/LayoutTests/fast/scrolling/mac/wheel-event-in-overflow-with-shadow-dom.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 5000px;
+        }
+        
+        .filler {
+            width: 20px;
+            height: 250px;
+            background-color: silver;
+        }
+
+        #container {
+            height: 400px;
+            width: 400px;
+            padding: 10px;
+            border: 1px solid black;
+        }
+        
+        #target {
+            border: 1px solid gray;
+            padding: 10px;
+            height: 150px;
+            background-color: orange;
+        }
+    </style>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        var jsTestIsAsync = true;
+
+        var overflowScrollEventCount = 0;
+        var windowScrollEventCount = 0;
+
+        async function testScrollOverContent()
+        {
+            debug('');
+            debug('Test scroll over shadow content');
+            await UIHelper.mouseWheelScrollAt(200, 400);
+
+            shouldBe('overflowScrollEventCount > 0', 'true');
+            shouldBe('windowScrollEventCount == 0', 'true');
+        }
+
+        async function scrollTest()
+        {
+            await testScrollOverContent();
+            finishJSTest();
+        }
+        
+        function setupCustomElement(target)
+        {
+            target.addEventListener('wheel', () => {});
+
+            class TestContainer extends HTMLElement {
+                connectedCallback() {
+                    const shadow = this.attachShadow({ mode: 'open' });
+                    shadow.innerHTML = `
+                            <div style="height: calc(100% - 20px); overflow: auto; border: 1px solid green; padding: 10px" onscroll="++overflowScrollEventCount">
+                                <slot></slot>
+                            </div>`;
+                }
+            }
+
+            customElements.define('test-container', TestContainer);
+        }
+
+        window.addEventListener('load', () => {
+            setupCustomElement(document.getElementById('target'));
+
+            window.addEventListener('scroll', () => {
+                ++windowScrollEventCount;
+            }, false);
+
+            setTimeout(scrollTest, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <div id="container">
+        <test-container>
+            <div class="filler"></div>
+            <div id="target">
+                <p>Scrolling over this element should scroll the overflow scroller<p>
+            </div>
+            <div class="filler"></div>
+        </test-container>
+    </div>
+    <script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -800,7 +800,7 @@ static ContainerNode* findEnclosingScrollableContainer(ContainerNode* node, cons
 {
     // Find the first node with a valid scrollable area starting with the current
     // node and traversing its parents (or shadow hosts).
-    for (ContainerNode* candidate = node; candidate; candidate = candidate->parentOrShadowHostNode()) {
+    for (auto* candidate = node; candidate; candidate = candidate->parentInComposedTree()) {
         if (is<HTMLIFrameElement>(*candidate))
             continue;
 


### PR DESCRIPTION
#### bd33a8e97f273f32b0034c9fed1f7ce52b460393
<pre>
Incorrect wheel event behavior with Shadow DOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=264469">https://bugs.webkit.org/show_bug.cgi?id=264469</a>
<a href="https://rdar.apple.com/118496293">rdar://118496293</a>

Reviewed by Ryosuke Niwa and Chris Dumez.

`findEnclosingScrollableContainer()` needs to use `parentInComposedTree()` to find the enclosing
ScrollableArea for the overflow scroll.

* LayoutTests/fast/scrolling/mac/wheel-event-in-overflow-with-shadow-dom-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/wheel-event-in-overflow-with-shadow-dom.html: Added.
* Source/WebCore/page/mac/EventHandlerMac.mm:
(WebCore::findEnclosingScrollableContainer):

Canonical link: <a href="https://commits.webkit.org/273181@main">https://commits.webkit.org/273181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d36a6dd61866371a2bf9a04cff08d3c3ae2dae01

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37216 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31211 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30185 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11286 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9863 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9942 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38494 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31348 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36008 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7951 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33960 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30452 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7946 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10622 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10934 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->