### PR TITLE
Fix the build after "[webkitdirs] Compute Xcode destination specifier"

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -41,11 +41,11 @@ endif
 ifneq (,$(ARCHS))
 	ifneq (,$(OVERRIDE_ARCHS))
 		ifneq (default,$(OVERRIDE_ARCHS))
-			BUILD_WEBKIT_BASE := $(BUILD_WEBKIT_BASE) --architectures="$(OVERRIDE_ARCHS)"
+			BUILD_WEBKIT_BASE := $(BUILD_WEBKIT_BASE) --architecture="$(OVERRIDE_ARCHS)"
 		endif
 		OVERRIDE_ARCHS =
 	else
-		BUILD_WEBKIT_BASE := $(BUILD_WEBKIT_BASE) --architectures="$(ARCHS)"
+		BUILD_WEBKIT_BASE := $(BUILD_WEBKIT_BASE) --architecture="$(ARCHS)"
 	endif
 endif
 

--- a/Tools/Scripts/build-webkit
+++ b/Tools/Scripts/build-webkit
@@ -115,7 +115,7 @@ Usage: $programName [options] [options to pass to build system]
   --debug                           Compile with Debug configuration
   --release                         Compile with Release configuration
   --sdk=<sdk>                       Use a specific Xcode SDK (Apple platforms only)
-  --arch=<architecture>             Compile for a specific architecture (or architectures)
+  --architecture=<architecture>     Compile for a specific architecture (or architectures)
   --ios-device                      Use "iphoneos.internal" SDK if installed, else "iphoneos" SDK (iOS only)
   --device                          DEPRECATED alias of --ios-device
   --ios-simulator                   Use "iphonesimulator.internal" SDK if installed, else "iphonesimulator" SDK (iOS only)

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -614,7 +614,7 @@ sub determineXcodeDestination
         $destination .= 'platform=visionOS Simulator';
     } else {
         $destination .= 'platform=macOS';
-        $destination .= ',arch=' . $architectures[0];
+        $destination .= ',arch=' . $architectures[0] if !$generic;
         $destination .= ',variant=Mac Catalyst' if willUseMacCatalystSDK();
     }
         


### PR DESCRIPTION
#### 841d1c12d8361c1bfe5866d06eafe28da112f80d
<pre>
Fix the build after &quot;[webkitdirs] Compute Xcode destination specifier&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=266493">https://bugs.webkit.org/show_bug.cgi?id=266493</a>
<a href="https://rdar.apple.com/86340301">rdar://86340301</a>

Unreviewed.

&quot;--architecture&quot; was misspelled &quot;--architectures&quot;. Also, generic
destinations do not have an architecture parameter, and some Xcode
versions fail on this.

* Makefile.shared:
* Tools/Scripts/build-webkit:
* Tools/Scripts/webkitdirs.pm:
(determineXcodeDestination):

Canonical link: <a href="https://commits.webkit.org/273162@main">https://commits.webkit.org/273162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84db232b73f660a51b654b2bdec3148014d552f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37217 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10458 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9864 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38495 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/29335 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31144 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/34409 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/10067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/33961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/11890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41000 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/10623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8553 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4427 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/10935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->