### PR TITLE
browserbench.org's index.html should check "srcset" with hasOwnProperty

### DIFF
--- a/Websites/browserbench.org/index.html
+++ b/Websites/browserbench.org/index.html
@@ -19,7 +19,7 @@
         return null;
     }
 
-    if (!HTMLImageElement.prototype.srcset) {
+    if (!HTMLImageElement.prototype.hasOwnProperty("srcset")) {
         window.addEventListener('DOMContentLoaded', function () {
             var images = document.querySelectorAll('img');
             for (var i = 0; i < images.length; i++) {


### PR DESCRIPTION
#### 6eedffbd7f27fd1cbc5f66915afb2cae45fb1a50
<pre>
browserbench.org&apos;s index.html should check &quot;srcset&quot; with hasOwnProperty
<a href="https://bugs.webkit.org/show_bug.cgi?id=267673">https://bugs.webkit.org/show_bug.cgi?id=267673</a>
<a href="https://rdar.apple.com/121168907">rdar://121168907</a>

Reviewed by Ryosuke Niwa.

HTMLImageElement.prototype.srcset will invoke a setter with wrong object.
We should use hasOwnProperty to detect the existence of &quot;srcset&quot;.

* Websites/browserbench.org/index.html:

Canonical link: <a href="https://commits.webkit.org/273182@main">https://commits.webkit.org/273182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ea3a1bb880b3ea88dc6744d5fbd18671d638600

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37226 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31217 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30190 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35062 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30774 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9871 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9953 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38504 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31360 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31152 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36016 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33969 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11896 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10628 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4431 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->