### PR TITLE
[iOS] Returning to fullscreen to PiP on YouTube breaks subsequent touch input

### DIFF
--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
@@ -1413,7 +1413,7 @@ void VideoFullscreenInterfaceAVKit::preparedToReturnToStandby()
     if (!m_returningToStandby)
         return;
 
-    clearMode(HTMLMediaElementEnums::VideoFullscreenModePictureInPicture, true);
+    returnToStandby();
 }
 
 void VideoFullscreenInterfaceAVKit::finalizeSetup()
@@ -1586,17 +1586,16 @@ void VideoFullscreenInterfaceAVKit::enterFullscreenHandler(BOOL success, NSError
 
 void VideoFullscreenInterfaceAVKit::returnToStandby()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     m_returningToStandby = false;
 
     auto model = videoPresentationModel();
     if (model)
         model->returnVideoView();
 
-    [m_window setHidden:YES];
-    [[m_playerViewController view] setHidden:YES];
-
-    if (model)
-        model->didSetupFullscreen();
+    // Continue processing exit picture-in-picture now that
+    // it is safe to do so:
+    didStopPictureInPicture();
 }
 
 NO_RETURN_DUE_TO_ASSERT void VideoFullscreenInterfaceAVKit::watchdogTimerFired()


### PR DESCRIPTION
#### 5556d4cf108f655932abdbd7004b40578588b5d4
<pre>
[iOS] Returning to fullscreen to PiP on YouTube breaks subsequent touch input
<a href="https://bugs.webkit.org/show_bug.cgi?id=267674">https://bugs.webkit.org/show_bug.cgi?id=267674</a>
<a href="https://rdar.apple.com/119832557">rdar://119832557</a>

Reviewed by Eric Carlson.

When returning to Element Fullscreen from PiP, the normal &quot;exit picture-in-picture&quot; logic
is interrupted in order to restore the previous element fullscreen. Recent changes have
left the video fullscreen state machine broken, waiting to restore the video to its original
location. The WKFullscreenViewController is left in place, but empty, either atop the WKWebView,
or below it but containing the video layer.

When we receive the preparedToReturnToStandby(), instead of just clearing the PiP fullscreen
mode, continue processing the steps of the &quot;exit picture-in-picture&quot; logic at the point at
which it was interrupted.

* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm:
(VideoFullscreenInterfaceAVKit::preparedToReturnToStandby):
(VideoFullscreenInterfaceAVKit::returnToStandby):

Canonical link: <a href="https://commits.webkit.org/273180@main">https://commits.webkit.org/273180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5939affe0706710e5f8d3ecbe945e0c0900d4d70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37227 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31218 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30192 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30775 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9873 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9955 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38505 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31362 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31153 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36017 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7964 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33970 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11897 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7945 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10629 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->