### PR TITLE
Unreviewed, fix wrong conditions

### DIFF
--- a/Source/JavaScriptCore/bytecode/RepatchInlines.h
+++ b/Source/JavaScriptCore/bytecode/RepatchInlines.h
@@ -149,7 +149,7 @@ ALWAYS_INLINE void* linkFor(JSGlobalObject* globalObject, JSCell* owner, CallFra
             }
             case CallLinkInfo::Mode::Monomorphic:
             case CallLinkInfo::Mode::Polymorphic: {
-#if USE(JIT)
+#if ENABLE(JIT)
                 if (kind == CodeForCall && callLinkInfo->allowStubs()) {
                     linkPolymorphicCall(globalObject, owner, calleeFrame, *callLinkInfo, CallVariant(internalFunction));
                     break;
@@ -212,7 +212,7 @@ ALWAYS_INLINE void* linkFor(JSGlobalObject* globalObject, JSCell* owner, CallFra
     }
     case CallLinkInfo::Mode::Monomorphic:
     case CallLinkInfo::Mode::Polymorphic: {
-#if USE(JIT)
+#if ENABLE(JIT)
         if (kind == CodeForCall && callLinkInfo->allowStubs()) {
             linkPolymorphicCall(globalObject, owner, calleeFrame, *callLinkInfo, CallVariant(callee));
             break;


### PR DESCRIPTION
#### 16e02df0f087c38ff1fb099a02c4e19a938179ba
<pre>
Unreviewed, fix wrong conditions
<a href="https://bugs.webkit.org/show_bug.cgi?id=267353">https://bugs.webkit.org/show_bug.cgi?id=267353</a>
<a href="https://rdar.apple.com/120794646">rdar://120794646</a>

* Source/JavaScriptCore/bytecode/RepatchInlines.h:
(JSC::linkFor):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16e02df0f087c38ff1fb099a02c4e19a938179ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36547 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/37230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10471 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/37230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35066 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/11305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/30779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/37230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/9960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/30843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38508 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/29344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/31367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/31159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/34419 "Found 55 new JSC stress test failures: wasm.yaml/wasm/gc-spec-tests/array.wast.js.default-wasm, wasm.yaml/wasm/gc-spec-tests/array.wast.js.wasm-bbq, wasm.yaml/wasm/gc-spec-tests/array.wast.js.wasm-collect-continuously, wasm.yaml/wasm/gc-spec-tests/array.wast.js.wasm-eager-jettison, wasm.yaml/wasm/gc-spec-tests/array.wast.js.wasm-no-cjit, wasm.yaml/wasm/gc-spec-tests/array.wast.js.wasm-omg, wasm.yaml/wasm/gc-spec-tests/array.wast.js.wasm-simd, wasm.yaml/wasm/gc-spec-tests/struct.wast.js.default-wasm, wasm.yaml/wasm/gc-spec-tests/struct.wast.js.wasm-bbq, wasm.yaml/wasm/gc-spec-tests/struct.wast.js.wasm-eager-jettison ... (failure)") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/10076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/7967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/33975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/11900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41014 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/10632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/10947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->