### PR TITLE
Adopt dynamicDowncast<> in more accessibility code

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityAttachment.cpp
+++ b/Source/WebCore/accessibility/AccessibilityAttachment.cpp
@@ -68,10 +68,7 @@ float AccessibilityAttachment::valueForRange() const
 HTMLAttachmentElement* AccessibilityAttachment::attachmentElement() const
 {
     ASSERT(is<HTMLAttachmentElement>(node()));
-    if (!is<HTMLAttachmentElement>(node()))
-        return nullptr;
-    
-    return downcast<HTMLAttachmentElement>(node());
+    return dynamicDowncast<HTMLAttachmentElement>(node());
 }
     
 String AccessibilityAttachment::roleDescription() const
@@ -86,7 +83,7 @@ bool AccessibilityAttachment::computeAccessibilityIsIgnored() const
     
 void AccessibilityAttachment::accessibilityText(Vector<AccessibilityText>& textOrder) const
 {
-    HTMLAttachmentElement* attachmentElement = this->attachmentElement();
+    RefPtr attachmentElement = this->attachmentElement();
     if (!attachmentElement)
         return;
     

--- a/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
+++ b/Source/WebCore/accessibility/AccessibilityListBoxOption.cpp
@@ -71,10 +71,11 @@ bool AccessibilityListBoxOption::isEnabled() const
     
 bool AccessibilityListBoxOption::isSelected() const
 {
-    if (!is<HTMLOptionElement>(m_optionElement))
+    if (!m_optionElement)
         return false;
 
-    return downcast<HTMLOptionElement>(*m_optionElement).selected();
+    RefPtr option = dynamicDowncast<HTMLOptionElement>(*m_optionElement);
+    return option && option->selected();
 }
 
 bool AccessibilityListBoxOption::isSelectedOptionActive() const
@@ -139,17 +140,17 @@ String AccessibilityListBoxOption::stringValue() const
 {
     if (!m_optionElement)
         return String();
-    
-    const AtomString& ariaLabel = getAttribute(aria_labelAttr);
+
+    const auto& ariaLabel = getAttribute(aria_labelAttr);
     if (!ariaLabel.isNull())
         return ariaLabel;
-    
-    if (is<HTMLOptionElement>(*m_optionElement))
-        return downcast<HTMLOptionElement>(*m_optionElement).label();
-    
-    if (is<HTMLOptGroupElement>(*m_optionElement))
-        return downcast<HTMLOptGroupElement>(*m_optionElement).groupLabelText();
-    
+
+    if (RefPtr option = dynamicDowncast<HTMLOptionElement>(*m_optionElement))
+        return option->label();
+
+    if (RefPtr optgroup = dynamicDowncast<HTMLOptGroupElement>(*m_optionElement))
+        return optgroup->groupLabelText();
+
     return String();
 }
 
@@ -195,11 +196,11 @@ HTMLSelectElement* AccessibilityListBoxOption::listBoxOptionParentNode() const
     if (!m_optionElement)
         return nullptr;
 
-    if (is<HTMLOptionElement>(*m_optionElement))
-        return downcast<HTMLOptionElement>(*m_optionElement).ownerSelectElement();
+    if (RefPtr option = dynamicDowncast<HTMLOptionElement>(*m_optionElement))
+        return option->ownerSelectElement();
 
-    if (is<HTMLOptGroupElement>(*m_optionElement))
-        return downcast<HTMLOptGroupElement>(*m_optionElement).ownerSelectElement();
+    if (RefPtr optgroup = dynamicDowncast<HTMLOptGroupElement>(*m_optionElement))
+        return optgroup->ownerSelectElement();
 
     return nullptr;
 }

--- a/Source/WebCore/accessibility/AccessibilityMediaObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMediaObject.cpp
@@ -60,10 +60,7 @@ bool AccessibilityMediaObject::computeAccessibilityIsIgnored() const
 
 HTMLMediaElement* AccessibilityMediaObject::mediaElement() const
 {
-    Node* node = this->node();
-    if (!is<HTMLMediaElement>(*node))
-        return nullptr;
-    return downcast<HTMLMediaElement>(node);
+    return dynamicDowncast<HTMLMediaElement>(node());
 }
 
 String AccessibilityMediaObject::stringValue() const
@@ -165,14 +162,10 @@ bool AccessibilityMediaObject::isPlayingInline() const
 
 void AccessibilityMediaObject::enterFullscreen() const
 {
-    Node* node = this->node();
-    if (!is<HTMLVideoElement>(node))
-        return;
-    
-    HTMLVideoElement* element = downcast<HTMLVideoElement>(node);
-    element->enterFullscreen();
+    if (RefPtr element = dynamicDowncast<HTMLVideoElement>(node()))
+        element->enterFullscreen();
 }
-    
+
 } // namespace WebCore
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp
@@ -106,14 +106,14 @@ void AccessibilityMenuListPopup::addChildren()
 {
     if (!m_parent)
         return;
-    
-    auto* parentNode = m_parent->node();
-    if (!is<HTMLSelectElement>(parentNode))
+
+    RefPtr select = dynamicDowncast<HTMLSelectElement>(m_parent->node());
+    if (!select)
         return;
 
     m_childrenInitialized = true;
 
-    for (const auto& listItem : downcast<HTMLSelectElement>(*parentNode).listItems()) {
+    for (const auto& listItem : select->listItems()) {
         if (auto* menuListOptionObject = menuListOptionAccessibilityObject(listItem.get())) {
             menuListOptionObject->setParent(this);
             addChild(menuListOptionObject, DescendIfIgnored::No);


### PR DESCRIPTION
#### a9ea311f3e104b1bf841b927a04e448b16dc421f
<pre>
Adopt dynamicDowncast&lt;&gt; in more accessibility code
<a href="https://bugs.webkit.org/show_bug.cgi?id=267684">https://bugs.webkit.org/show_bug.cgi?id=267684</a>

Reviewed by Chris Dumez.

* Source/WebCore/accessibility/AccessibilityAttachment.cpp:
(WebCore::AccessibilityAttachment::attachmentElement const):
(WebCore::AccessibilityAttachment::accessibilityText const):
* Source/WebCore/accessibility/AccessibilityListBoxOption.cpp:
(WebCore::AccessibilityListBoxOption::isSelected const):
(WebCore::AccessibilityListBoxOption::stringValue const):
(WebCore::AccessibilityListBoxOption::listBoxOptionParentNode const):
* Source/WebCore/accessibility/AccessibilityMediaObject.cpp:
(WebCore::AccessibilityMediaObject::mediaElement const):
(WebCore::AccessibilityMediaObject::enterFullscreen const):
* Source/WebCore/accessibility/AccessibilityMenuListPopup.cpp:
(WebCore::AccessibilityMenuListPopup::addChildren):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::nodeActionElement):
(WebCore::nativeActionElement):
(WebCore::AccessibilityNodeObject::actionElement const):
(WebCore::AccessibilityNodeObject::hierarchicalLevel const):
(WebCore::AccessibilityNodeObject::setIsExpanded):
(WebCore::shouldUseAccessibilityObjectInnerText):
(WebCore::AccessibilityNodeObject::textUnderElement const):
(WebCore::isNodeActionElement): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::displayContentsParent const):
(WebCore::AccessibilityObject::insertChild):
(WebCore::AccessibilityObject::visiblePositionForPoint const):
(WebCore::AccessibilityObject::modelElementChildren):
(WebCore::AccessibilityObject::ariaTreeRows):
(WebCore::AccessibilityObject::hasTagName const):
(WebCore::AccessibilityObject::replaceTextInRange):
(WebCore::AccessibilityObject::insertText):
(WebCore::AccessibilityObject::embeddedImageDescription const):
(WebCore::AccessibilityObject::isValueAutofillAvailable const):
(WebCore::AccessibilityObject::isExpanded const):
(WebCore::AccessibilityObject::isFileUploadButton const):
(WebCore::AccessibilityObject::elementsFromAttribute const):
(WebCore::AccessibilityObject::isContainedBySecureField const):

Canonical link: <a href="https://commits.webkit.org/273196@main">https://commits.webkit.org/273196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfc3e4cd889f974180b6c4135b1d38e49eaabac4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37303 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31275 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35757 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30243 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11375 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9938 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10023 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38579 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31434 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31229 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36082 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34036 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11962 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7953 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10690 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11012 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->