### PR TITLE
Implement enforcement of `trusted-types` CSP directive

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5497,6 +5497,9 @@ webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/block-string-a
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval.html [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-importScripts.html [ Skip ]
 
+# require-trusted-types-for CSP directive isn't implemented yet
+webkit.org/b/267685 imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting.html [ Skip ]
+
 # These tests are image failures
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/vertical-rl-viewport-size-change-000.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/vertical-rl-viewport-size-change-001.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicy-CSP-no-name-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicy-CSP-no-name-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: Refused to create a TrustedTypePolicy named 'SomeName' because it violates the following Content Security Policy directive: "trusted-types "
 
-FAIL No name list given - policy creation fails. assert_throws_js: createPolicy with an empty trusted-types CSP directive function "() => window.trustedTypes.createPolicy('SomeName', { createHTML: s => s } )" did not throw
+PASS No name list given - policy creation fails.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-expected.txt
@@ -1,7 +1,6 @@
+CONSOLE MESSAGE: Refused to create a TrustedTypePolicy named 'SomeOtherName' because it violates the following Content Security Policy directive: "trusted-types SomeName JustOneMoreName"
 
 PASS Allowed-name policy creation works.
 PASS Another allowed-name policy creation works.
-FAIL Non-allowed name policy creation throws. assert_throws_js: function "_ => {
-     window.trustedTypes.createPolicy('SomeOtherName', { createURL: s => s } );
-    }" did not throw
+PASS Non-allowed name policy creation throws.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-noNamesGiven-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-noNamesGiven-expected.txt
@@ -1,5 +1,4 @@
+CONSOLE MESSAGE: Refused to create a TrustedTypePolicy named 'SomeName' because it violates the following Content Security Policy directive: "trusted-types "
 
-FAIL No name list given - policy creation throws assert_throws_js: function "_ => {
-      window.trustedTypes.createPolicy('SomeName', { createHTML: s => s } );
-    }" did not throw
+PASS No name list given - policy creation throws
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none-expected.txt
@@ -1,8 +1,6 @@
+CONSOLE MESSAGE: Refused to create a TrustedTypePolicy named 'SomeName' because it violates the following Content Security Policy directive: "trusted-types 'none'"
+CONSOLE MESSAGE: Refused to create a TrustedTypePolicy named 'default' because it violates the following Content Security Policy directive: "trusted-types 'none'"
 
-FAIL Cannot create policy with name 'SomeName' - policy creation throws assert_throws_js: function "_ => {
-      window.trustedTypes.createPolicy('SomeName', { createHTML: s => s } );
-    }" did not throw
-FAIL Cannot create policy with name 'default' - policy creation throws assert_throws_js: function "_ => {
-      window.trustedTypes.createPolicy('default', { createHTML: s => s } );
-    }" did not throw
+PASS Cannot create policy with name 'SomeName' - policy creation throws
+PASS Cannot create policy with name 'default' - policy creation throws
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-createPolicy-nameTests-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-createPolicy-nameTests-expected.txt
@@ -1,7 +1,8 @@
+CONSOLE MESSAGE: Refused to create a TrustedTypePolicy named 'SomeName' because it violates the following Content Security Policy directive: "trusted-types SomeName SomeOtherName"
+CONSOLE MESSAGE: Refused to create a TrustedTypePolicy named 'unknown name' because it violates the following Content Security Policy directive: "trusted-types SomeName SomeOtherName"
+CONSOLE MESSAGE: Refused to create a TrustedTypePolicy named 'SomeName' because it violates the following Content Security Policy directive: "trusted-types SomeName SomeOtherName"
 
 PASS policy.name = name
-FAIL duplicate policy name attempt throws assert_throws_js: function "_ => {
-     trustedTypes.createPolicy('SomeName', {} );
-    }" did not throw
+PASS duplicate policy name attempt throws
 PASS Error messages for duplicates and unlisted policies should be different
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-duplicate-names-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-duplicate-names-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: Refused to create a TrustedTypePolicy named 'default' because it violates the following Content Security Policy directive: "trusted-types 'allow-duplicates' duplicatename default"
 
-FAIL policy - duplicate names assert_throws_js: function "_ => trustedTypes.createPolicy("default", {})" did not throw
+PASS policy - duplicate names
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-duplicate-names-list-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-duplicate-names-list-expected.txt
@@ -1,3 +1,5 @@
+CONSOLE MESSAGE: Refused to create a TrustedTypePolicy named 'a' because it violates the following Content Security Policy directive: "trusted-types a b c*"
+CONSOLE MESSAGE: Refused to create a TrustedTypePolicy named 'd' because it violates the following Content Security Policy directive: "trusted-types a b c*"
 
-FAIL TrustedTypePolicyFactory and policy list in CSP. assert_throws_js: Duplicate name function "_ => trustedTypes.createPolicy("a", {})" did not throw
+PASS TrustedTypePolicyFactory and policy list in CSP.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-duplicate-names-list-report-only-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-duplicate-names-list-report-only-expected.txt
@@ -1,4 +1,6 @@
 CONSOLE MESSAGE: The Content Security Policy 'trusted-types a b c' was delivered in report-only mode, but does not specify a 'report-to'; the policy will have no effect. Please either add a 'report-to' directive, or deliver the policy via the 'Content-Security-Policy' header.
+CONSOLE MESSAGE: [Report Only] Refused to create a TrustedTypePolicy named 'a' because it violates the following Content Security Policy directive: "trusted-types a b c"
+CONSOLE MESSAGE: [Report Only] Refused to create a TrustedTypePolicy named 'd' because it violates the following Content Security Policy directive: "trusted-types a b c"
 
 PASS TrustedTypePolicyFactory and policy list in CSP.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-check-report-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-check-report-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: [Report Only] Refused to create a TrustedTypePolicy named 'three' because it violates the following Content Security Policy directive: "trusted-types one two"
 
-FAIL Violation report status OK. undefined is not an object (evaluating 'data[0]["body"]')
+PASS Violation report status OK.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-expected.txt
@@ -1,12 +1,20 @@
+CONSOLE MESSAGE: Refused to create a TrustedTypePolicy named 'three' because it violates the following Content Security Policy directive: "trusted-types one"
+CONSOLE MESSAGE: [Report Only] Refused to create a TrustedTypePolicy named 'three' because it violates the following Content Security Policy directive: "trusted-types two"
 CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to create a TrustedTypePolicy named 'two' because it violates the following Content Security Policy directive: "trusted-types one"
+CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
+CONSOLE MESSAGE: [Report Only] Refused to create a TrustedTypePolicy named 'one' because it violates the following Content Security Policy directive: "trusted-types two"
+CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
+CONSOLE MESSAGE: SyntaxError: Unexpected token '<'
 
 
-Harness Error (TIMEOUT), message = null
 
-TIMEOUT Trusted Type violation report: creating a forbidden policy. Test timed out
-NOTRUN Trusted Type violation report: creating a report-only-forbidden policy.
-NOTRUN Trusted Type violation report: creating a forbidden-but-not-reported policy.
-NOTRUN Trusted Type violation report: assign string to script url
+Harness Error (FAIL), message = SyntaxError: Unexpected token '<'
+
+PASS Trusted Type violation report: creating a forbidden policy.
+PASS Trusted Type violation report: creating a report-only-forbidden policy.
+PASS Trusted Type violation report: creating a forbidden-but-not-reported policy.
+TIMEOUT Trusted Type violation report: assign string to script url Test timed out
 NOTRUN Trusted Type violation report: assign string to html
 NOTRUN Trusted Type violation report: assign trusted script to script; no report
 NOTRUN Trusted Type violation report: assign trusted HTML to html; no report

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -80,7 +80,7 @@ enum class ContentSecurityPolicyModeForExtension : uint8_t {
     ManifestV3
 };
 
-enum class AllowTrustedTypePolicyDetails : uint8_t {
+enum class AllowTrustedTypePolicy : uint8_t {
     Allowed,
     DisallowedName,
     DisallowedDuplicateName,
@@ -149,6 +149,8 @@ public:
 
     bool allowObjectFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No, const URL& preRedirectURL = URL()) const;
     bool allowBaseURI(const URL&, bool overrideContentSecurityPolicy = false) const;
+
+    AllowTrustedTypePolicy allowTrustedTypesPolicy(const String&, bool isDuplicate) const;
 
     void setOverrideAllowInlineStyle(bool);
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -443,6 +443,14 @@ const ContentSecurityPolicyDirective* ContentSecurityPolicyDirectiveList::violat
     return operativeDirective;
 }
 
+const ContentSecurityPolicyDirective* ContentSecurityPolicyDirectiveList::violatedDirectiveForTrustedTypesPolicy(const String& value, bool isDuplicate, AllowTrustedTypePolicy& details) const
+{
+    auto* directive = m_trustedTypes.get();
+    if (!directive || directive->allows(value, isDuplicate, details))
+        return nullptr;
+    return directive;
+}
+
 // policy            = directive-list
 // directive-list    = [ directive *( ";" [ directive ] ) ]
 //
@@ -754,6 +762,8 @@ bool ContentSecurityPolicyDirectiveList::shouldReportSample(const String& violat
         directive = m_styleSrc.get();
     else if (violatedDirective.startsWith(StringView { ContentSecurityPolicyDirectiveNames::scriptSrc }))
         directive = m_scriptSrc.get();
+    else if (violatedDirective.startsWith(StringView { ContentSecurityPolicyDirectiveNames::trustedTypes }))
+        return true;
 
     return directive && directive->shouldReportSample();
 }

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
@@ -76,6 +76,7 @@ public:
     const ContentSecurityPolicyDirective* violatedDirectiveForScript(const URL&, bool didReceiveRedirectResponse, const Vector<ResourceCryptographicDigest>&, const String&) const;
     const ContentSecurityPolicyDirective* violatedDirectiveForStyle(const URL&, bool didReceiveRedirectResponse, const String&) const;
     const ContentSecurityPolicyDirective* violatedDirectiveForWorker(const URL&, bool didReceiveRedirectResponse);
+    const ContentSecurityPolicyDirective* violatedDirectiveForTrustedTypesPolicy(const String&, bool isDuplicate, AllowTrustedTypePolicy&) const;
 
     const ContentSecurityPolicyDirective* defaultSrc() const { return m_defaultSrc.get(); }
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
@@ -62,24 +62,24 @@ ContentSecurityPolicyTrustedTypesDirective::ContentSecurityPolicyTrustedTypesDir
     parse(value);
 }
 
-bool ContentSecurityPolicyTrustedTypesDirective::allows(const String& value, bool isDuplicate, AllowTrustedTypePolicyDetails& details) const
+bool ContentSecurityPolicyTrustedTypesDirective::allows(const String& value, bool isDuplicate, AllowTrustedTypePolicy& details) const
 {
     auto invalidPolicy = value.find([](UChar ch) {
         return !isPolicyNameCharacter(ch);
     });
 
     if (isDuplicate && !m_allowDuplicates)
-        details = AllowTrustedTypePolicyDetails::DisallowedDuplicateName;
+        details = AllowTrustedTypePolicy::DisallowedDuplicateName;
     else if (isDuplicate && value == "default"_s)
-        details = AllowTrustedTypePolicyDetails::DisallowedDuplicateName;
+        details = AllowTrustedTypePolicy::DisallowedDuplicateName;
     else if (invalidPolicy != notFound)
-        details = AllowTrustedTypePolicyDetails::DisallowedName;
+        details = AllowTrustedTypePolicy::DisallowedName;
     else if (!(m_allowAny || m_list.contains(value)))
-        details = AllowTrustedTypePolicyDetails::DisallowedName;
+        details = AllowTrustedTypePolicy::DisallowedName;
     else
-        details = AllowTrustedTypePolicyDetails::Allowed;
+        details = AllowTrustedTypePolicy::Allowed;
 
-    return details == AllowTrustedTypePolicyDetails::Allowed;
+    return details == AllowTrustedTypePolicy::Allowed;
 }
 
 void ContentSecurityPolicyTrustedTypesDirective::parse(const String& value)

--- a/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.h
@@ -32,13 +32,13 @@
 namespace WebCore {
 
 class ContentSecurityPolicyDirectiveList;
-enum class AllowTrustedTypePolicyDetails : uint8_t;
+enum class AllowTrustedTypePolicy : uint8_t;
 
 class ContentSecurityPolicyTrustedTypesDirective : public ContentSecurityPolicyDirective {
 public:
     ContentSecurityPolicyTrustedTypesDirective(const ContentSecurityPolicyDirectiveList&, const String& name, const String& value);
 
-    bool allows(const String& value, bool isDuplicate, AllowTrustedTypePolicyDetails&) const;
+    bool allows(const String& value, bool isDuplicate, AllowTrustedTypePolicy&) const;
 
 private:
     void parse(const String&);


### PR DESCRIPTION
#### 142d2a80207e10069b36196a19a83cda6b96223d
<pre>
Implement enforcement of `trusted-types` CSP directive
<a href="https://bugs.webkit.org/show_bug.cgi?id=267632">https://bugs.webkit.org/show_bug.cgi?id=267632</a>

Reviewed by Youenn Fablet.

This updates the trusted types policy creation code to validate that it&apos;s allowed by CSP.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicy-CSP-no-name-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-noNamesGiven-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-createPolicy-cspTests-none-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-createPolicy-nameTests-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-duplicate-names-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-duplicate-names-list-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-duplicate-names-list-report-only-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-check-report-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-expected.txt:
* Source/WebCore/dom/TrustedTypePolicyFactory.cpp:
(WebCore::TrustedTypePolicyFactory::createPolicy):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::allowTrustedTypesPolicy const):
(WebCore::ContentSecurityPolicy::reportViolation const):
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::ContentSecurityPolicyDirectiveList::violatedDirectiveForTrustedTypesPolicy const):
(WebCore::ContentSecurityPolicyDirectiveList::shouldReportSample const):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h:
* Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp:
(WebCore::ContentSecurityPolicyTrustedTypesDirective::allows const):
* Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.h:

Canonical link: <a href="https://commits.webkit.org/274263@main">https://commits.webkit.org/274263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90f30755aae96762685cde5c7fd0c03357c9516d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40896 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34095 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40586 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32325 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14589 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12693 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12671 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42175 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34887 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34678 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38517 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36718 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14820 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8643 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13666 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14284 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->