### PR TITLE
Remove web-platform.test knowledge from PublicSuffix

### DIFF
--- a/Source/WebCore/platform/PublicSuffix.h
+++ b/Source/WebCore/platform/PublicSuffix.h
@@ -36,12 +36,6 @@ WEBCORE_EXPORT String topPrivatelyControlledDomain(const String& domain);
 WEBCORE_EXPORT void setTopPrivatelyControlledDomain(const String& domain, const String& topPrivatelyControlledDomain);
 String decodeHostName(const String& domain);
 
-inline bool isDomainForTesting(const String& domain)
-{
-    // These domains do not have a real TLD and have to be special cased by implementaitons.
-    return domain.endsWithIgnoringASCIICase("web-platform.test"_s);
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(PUBLIC_SUFFIX_LIST)

--- a/Source/WebCore/platform/soup/PublicSuffixSoup.cpp
+++ b/Source/WebCore/platform/soup/PublicSuffixSoup.cpp
@@ -87,7 +87,7 @@ String topPrivatelyControlledDomain(const String& domain)
         return String::fromUTF8(baseDomain);
 
     if (g_error_matches(error.get(), SOUP_TLD_ERROR, SOUP_TLD_ERROR_NO_BASE_DOMAIN)) {
-        if (isDomainForTesting(domain))
+        if (domain.endsWithIgnoringASCIICase("web-platform.test"_s))
             return permissiveTopPrivateDomain(domain.substring(position));
         return String();
     }


### PR DESCRIPTION
#### c6eeacb52d87a988ac5a26ab6769d6c3a9b08b27
<pre>
Remove web-platform.test knowledge from PublicSuffix
<a href="https://bugs.webkit.org/show_bug.cgi?id=267689">https://bugs.webkit.org/show_bug.cgi?id=267689</a>

Reviewed by Ryosuke Niwa.

It seems this got added in 255810@main, but it has no business here.

* Source/WebCore/platform/PublicSuffix.h:
(WebCore::isDomainForTesting): Deleted.
* Source/WebCore/platform/soup/PublicSuffixSoup.cpp:
(WebCore::topPrivatelyControlledDomain):

Canonical link: <a href="https://commits.webkit.org/273217@main">https://commits.webkit.org/273217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11b0add916026aac3208bed9e8e635a082d5e79d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37253 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31237 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35705 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30215 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9896 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9979 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38531 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31386 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36042 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/7988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/33995 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11920 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7965 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10650 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10968 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->