### PR TITLE
Implement MediaStreamTrack transfer to dedicated workers in same agent cluster

### DIFF
--- a/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Transfer MediaStreamTrack to dedicated worker and use MediaStreamTrackProcessor
+PASS Transferred audio track get muted/unmuted according page state
+PASS Transferred video track get muted/unmuted according page state
+PASS Page state gets updated when transferred tracks get stopped
+PASS Page state gets updated when clones of transferred tracks get stopped
+

--- a/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker-worker.js
+++ b/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker-worker.js
@@ -1,0 +1,65 @@
+// META: title=MediaStreamTrack processor and generator.
+importScripts("/resources/testharness.js");
+
+function makeOffscreenCanvasVideoFrame(width, height) {
+    let canvas = new OffscreenCanvas(width, height);
+    let ctx = canvas.getContext('2d');
+    ctx.fillStyle = 'rgba(50, 100, 150, 255)';
+    ctx.fillRect(0, 0, width, height);
+    return new VideoFrame(canvas, { timestamp: 1 });
+}
+
+promise_test(async (t) => {
+    const frame1 = makeOffscreenCanvasVideoFrame(100, 100);
+    t.add_cleanup(() => frame1.close());
+
+    const generator = new VideoTrackGenerator();
+    const writer = generator.writable.getWriter();
+    assert_equals(frame1.codedWidth, 100);
+    await writer.write(frame1);
+    assert_equals(frame1.codedWidth, 0);
+}, "Frames get closed when written in a VideoTrackGenerator writable");
+
+
+promise_test(async (t) => {
+    const frame1 = makeOffscreenCanvasVideoFrame(100, 100);
+    t.add_cleanup(() => frame1.close());
+
+    const generator = new VideoTrackGenerator();
+    generator.muted = true;
+    await new Promise(resolve => generator.track.onmute = resolve);
+
+    generator.muted = false;
+    await new Promise(resolve => generator.track.onunmute = resolve);
+}, "Track gets muted based on VideoTrackGenerator.muted");
+
+promise_test(async (t) => {
+    const frame1 = makeOffscreenCanvasVideoFrame(100, 100);
+    t.add_cleanup(() => frame1.close());
+
+    const frame2 = makeOffscreenCanvasVideoFrame(200, 200);
+    t.add_cleanup(() => frame2.close());
+
+    const generator = new VideoTrackGenerator();
+    const processor = new MediaStreamTrackProcessor({ track : generator.track });
+
+    const writer = generator.writable.getWriter();
+    const reader = processor.readable.getReader();
+
+    writer.write(frame1);
+
+    let chunk = await reader.read();
+    assert_equals(chunk.value.codedWidth, 100);
+
+    writer.write(frame2);
+
+    chunk = await reader.read();
+    assert_equals(chunk.value.codedWidth, 200);
+
+    writer.close();
+
+    chunk = await reader.read();
+    assert_true(chunk.done);
+}, "Test frames going from VideoTrackGenerator to MediaStreamTrackProcessor");
+
+done();

--- a/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker.html
+++ b/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Transfer MediaStreamTrack to dedicated worker</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+async function createWorker(script)
+{
+    script += "self.postMessage('ready');";
+    const blob = new Blob([script], { type: 'text/javascript' });
+    const url = URL.createObjectURL(blob);
+    const worker = new Worker(url);
+    await new Promise(resolve => worker.onmessage = () => {
+        resolve();
+    });
+    URL.revokeObjectURL(url);
+    return worker;
+}
+
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480 } });
+
+    const worker = await createWorker(`
+        self.onmessage = async (event) => {
+            const processor = new MediaStreamTrackProcessor({ track: event.data.track });
+            const data = await processor.readable.getReader().read();
+            self.postMessage(data);
+            data.value.close();
+        }
+    `);
+    test.add_cleanup(() => worker.terminate());
+    const track = stream.getVideoTracks()[0];
+    worker.postMessage({ track }, [track]);
+
+    const result = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
+    assert_false(result.done);
+
+    test.add_cleanup(() => result.value.close());
+    assert_equals(result.value.codedWidth, 640);
+    assert_equals(result.value.codedHeight, 480);
+}, "Transfer MediaStreamTrack to dedicated worker and use MediaStreamTrackProcessor");
+
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+
+    const worker = await createWorker(`
+        self.onmessage = async (event) => {
+            const track = event.data.track;
+            track.onmute = () => self.postMessage("muted");
+            track.onunmute = () => self.postMessage("unmuted");
+        }
+    `);
+    test.add_cleanup(() => worker.terminate());
+    const track = stream.getAudioTracks()[0];
+    worker.postMessage({ track }, [track]);
+
+    if (!window.internals)
+        return;
+
+    internals.setPageMuted("capturedevices");
+    let result = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
+    assert_equals(result, "muted");
+
+    internals.setPageMuted("");
+    result = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
+    assert_equals(result, "unmuted");
+}, "Transferred audio track get muted/unmuted according page state");
+
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+
+    const worker = await createWorker(`
+        self.onmessage = async (event) => {
+            const track = event.data.track;
+            track.onmute = () => self.postMessage("muted");
+            track.onunmute = () => self.postMessage("unmuted");
+        }
+   `);
+    test.add_cleanup(() => worker.terminate());
+    const track = stream.getVideoTracks()[0];
+    worker.postMessage({ track }, [track]);
+
+    if (!window.internals)
+        return;
+
+    internals.setPageMuted("capturedevices");
+    let result = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
+    assert_equals(result, "muted");
+
+    internals.setPageMuted("");
+    result = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
+    assert_equals(result, "unmuted");
+}, "Transferred video track get muted/unmuted according page state");
+
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+
+    const worker = await createWorker(`
+        var audioTrack, videoTrack;
+        self.onmessage = async (event) => {
+            if (event.data.type === "tracks") {
+                audioTrack = event.data.audioTrack
+                videoTrack = event.data.videoTrack;
+            } else if (event.data.type === "stopAudioTrack")
+                audioTrack.stop();
+            else if (event.data.type === "stopVideoTrack")
+                videoTrack.stop();
+        }
+    `);
+    test.add_cleanup(() => worker.terminate());
+    const audioTrack = stream.getAudioTracks()[0];
+    const videoTrack = stream.getVideoTracks()[0];
+    worker.postMessage({ type : "tracks", audioTrack, videoTrack }, [audioTrack, videoTrack]);
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    if (!window.internals)
+        return;
+
+    assert_equals(internals.pageMediaState(), "HasActiveAudioCaptureDevice,HasActiveVideoCaptureDevice");
+
+    let audioCounter = 0;
+    worker.postMessage({ type : "stopAudioTrack" });
+    do {
+        await new Promise(resolve => setTimeout(resolve, 50));
+    } while (++audioCounter < 40 && internals.pageMediaState() !== "HasActiveVideoCaptureDevice")
+    assert_equals(internals.pageMediaState(), "HasActiveVideoCaptureDevice");
+
+    let videoCounter = 0;
+    worker.postMessage({ type : "stopVideoTrack" });
+    do {
+        await new Promise(resolve => setTimeout(resolve, 50));
+    } while (++videoCounter < 40 && internals.pageMediaState() !== "IsNotPlaying")
+    assert_equals(internals.pageMediaState(), "IsNotPlaying");
+}, "Page state gets updated when transferred tracks get stopped");
+
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+
+    const worker = await createWorker(`
+        var audioTrack, videoTrack;
+        self.onmessage = async (event) => {
+            if (event.data.type === "tracks") {
+                audioTrack = event.data.audioTrack.clone()
+                event.data.audioTrack.stop();
+                videoTrack = event.data.videoTrack.clone();
+                event.data.videoTrack.stop();
+            } else if (event.data.type === "stopAudioTrack")
+                audioTrack.stop();
+            else if (event.data.type === "stopVideoTrack")
+                videoTrack.stop();
+        }
+    `);
+    test.add_cleanup(() => worker.terminate());
+    const audioTrack = stream.getAudioTracks()[0];
+    const videoTrack = stream.getVideoTracks()[0];
+    worker.postMessage({ type : "tracks", audioTrack, videoTrack }, [audioTrack, videoTrack]);
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    if (!window.internals)
+        return;
+
+    assert_equals(internals.pageMediaState(), "HasActiveAudioCaptureDevice,HasActiveVideoCaptureDevice");
+
+    let audioCounter = 0;
+    worker.postMessage({ type : "stopAudioTrack" });
+    do {
+        await new Promise(resolve => setTimeout(resolve, 50));
+    } while (++audioCounter < 40 && internals.pageMediaState() !== "HasActiveVideoCaptureDevice")
+    assert_equals(internals.pageMediaState(), "HasActiveVideoCaptureDevice");
+
+    let videoCounter = 0;
+    worker.postMessage({ type : "stopVideoTrack" });
+    do {
+        await new Promise(resolve => setTimeout(resolve, 50));
+    } while (++videoCounter < 40 && internals.pageMediaState() !== "IsNotPlaying")
+    assert_equals(internals.pageMediaState(), "IsNotPlaying");
+}, "Page state gets updated when clones of transferred tracks get stopped");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/mediastream/transfer-videotrackgenerator-track-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/transfer-videotrackgenerator-track-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Transfer VideoTrackGenerator from dedicated worker and play it
+

--- a/LayoutTests/http/wpt/mediastream/transfer-videotrackgenerator-track.html
+++ b/LayoutTests/http/wpt/mediastream/transfer-videotrackgenerator-track.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Transfer MediaStreamTrack to dedicated worker</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<video id=video autoplay controls playsInline></video>
+<script>
+
+async function createWorker(script)
+{
+    script += "self.postMessage('ready');";
+    const blob = new Blob([script], { type: 'text/javascript' });
+    const url = URL.createObjectURL(blob);
+    const worker = new Worker(url);
+    await new Promise(resolve => worker.onmessage = () => {
+        resolve();
+    });
+    URL.revokeObjectURL(url);
+    return worker;
+}
+
+promise_test(async test => {
+    const worker = await createWorker(`
+        function makeOffscreenCanvasVideoFrame(width, height) {
+            let canvas = new OffscreenCanvas(width, height);
+            let ctx = canvas.getContext('2d');
+            ctx.fillStyle = 'rgba(50, 100, 150, 255)';
+            ctx.fillRect(0, 0, width, height);
+            return new VideoFrame(canvas, { timestamp: 1 });
+        }
+        var generator = new VideoTrackGenerator();
+
+        const writer = generator.writable.getWriter();
+        var width = 100;
+        var height = 100;
+        setInterval(() => {
+            writer.write(makeOffscreenCanvasVideoFrame(width, height));
+        }, 100);
+        self.onmessage = async (event) => {
+            if (event.data === "mute")
+               generator.muted = true;
+            else if (event.data === "unmute")
+               generator.muted = false;
+            else if (event.data === "track")
+                self.postMessage({ track : generator.track }, [generator.track]);
+            else if (event.data === "increaseSize") {
+                width = 200;
+                height = 200;
+            } else if (event.data === "decreaseSize") {
+                width = 100;
+                height = 100;
+            }
+        }
+    `);
+    test.add_cleanup(() => worker.terminate());
+
+    worker.postMessage("track");
+    const track = await new Promise(resolve => worker.onmessage = e => resolve(e.data.track));
+    video.srcObject = new MediaStream([track]);
+    await new Promise(resolve => video.requestVideoFrameCallback(resolve));
+
+    assert_equals(video.videoWidth, 100, "video width 1");
+    assert_equals(video.videoHeight, 100, "video height1");
+    assert_equals(track.getSettings().width, 100, "track width 1");
+    assert_equals(track.getSettings().height, 100, "track height 1");
+    assert_equals(track.getCapabilities().width.max, 100, "track capabilities width 1");
+    assert_equals(track.getCapabilities().height.max, 100, "track capabilities height 1");
+
+    worker.postMessage("mute");
+    await new Promise(resolve => track.onmute = resolve);
+
+    worker.postMessage("unmute");
+    await new Promise(resolve => track.onunmute = resolve);
+
+    worker.postMessage("increaseSize");
+
+    let counter = 0;
+    do {
+        await new Promise(resolve => setTimeout(resolve, 50));
+    } while (++counter < 100 && video.videoWidth !== 200);
+
+    assert_equals(video.videoWidth, 200, "video width 2");
+    assert_equals(video.videoHeight, 200, "video height 2");
+
+    counter = 0;
+    do {
+        await new Promise(resolve => setTimeout(resolve, 50));
+    } while (++counter < 100 && track.getSettings().width !== 200);
+
+    assert_equals(track.getSettings().width, 200, "track width 2");
+    assert_equals(track.getSettings().height, 200, "track height 2");
+    assert_equals(track.getCapabilities().width.max, 200, "track capabilities width 2");
+    assert_equals(track.getCapabilities().height.max, 200, "track capabilities height 2");
+
+    worker.postMessage("decreaseSize");
+
+    counter = 0;
+    do {
+        await new Promise(resolve => setTimeout(resolve, 50));
+    } while (++counter < 100 && video.videoWidth !== 100);
+
+    assert_equals(video.videoWidth, 100, "video width 3");
+    assert_equals(video.videoHeight, 100, "video height 3");
+
+    counter = 0;
+    do {
+        await new Promise(resolve => setTimeout(resolve, 50));
+    } while (++counter < 100 && track.getSettings().width !== 200);
+
+    assert_equals(track.getSettings().width, 100, "track width 3");
+    assert_equals(track.getSettings().height, 100, "track height 3");
+    assert_equals(track.getCapabilities().width.max, 200, "track capabilities width 3");
+    assert_equals(track.getCapabilities().height.max, 200, "track capabilities height 3");
+}, "Transfer VideoTrackGenerator from dedicated worker and play it");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.worker-expected.txt
@@ -24,5 +24,5 @@ PASS VideoTrackGenerator must be primary interface of new VideoTrackGenerator()
 PASS Stringification of new VideoTrackGenerator()
 PASS VideoTrackGenerator interface: new VideoTrackGenerator() must inherit property "writable" with the proper type
 PASS VideoTrackGenerator interface: new VideoTrackGenerator() must inherit property "muted" with the proper type
-FAIL VideoTrackGenerator interface: new VideoTrackGenerator() must inherit property "track" with the proper type Right hand side of instanceof is not an object
+PASS VideoTrackGenerator interface: new VideoTrackGenerator() must inherit property "track" with the proper type
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-transfer-video.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-transfer-video.https-expected.txt
@@ -1,11 +1,4 @@
-CONSOLE MESSAGE: DataCloneError: The object can not be cloned.
 
 
-Harness Error (FAIL), message = DataCloneError: The object can not be cloned.
-
-TIMEOUT MediaStreamTrack transfer to iframe Test timed out
-
-Harness Error (FAIL), message = DataCloneError: The object can not be cloned.
-
-TIMEOUT MediaStreamTrack transfer to iframe Test timed out
+PASS MediaStreamTrack transfer to iframe
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1871,6 +1871,8 @@ webkit.org/b/187603 fast/mediastream/media-stream-track-source-failure.html [ Ti
 
 webkit.org/b/264803 fast/mediastream/mediastreamtrack-video-resize-event.html [ Failure ]
 
+http/wpt/mediastream/transfer-mediastreamtrack-to-worker.html [ Failure Crash ]
+
 # Adding transceivers without tracks is broken.
 webkit.org/b/265865 imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation.html [ Skip ]
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -62,6 +62,7 @@ media/audioSession [ Skip ]
 
 # Media Stream API testing is not supported for WK1 yet.
 fast/mediastream
+http/wpt/mediastream
 imported/w3c/web-platform-tests/feature-policy/reporting/camera-reporting.https.html [ Skip ]
 imported/w3c/web-platform-tests/feature-policy/reporting/microphone-reporting.https.html [ Skip ]
 imported/w3c/web-platform-tests/mediacapture-streams

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2166,6 +2166,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/mediastream/MediaSettingsRange.h
     platform/mediastream/MediaStreamPrivate.h
     platform/mediastream/MediaStreamRequest.h
+    platform/mediastream/MediaStreamTrackDataHolder.h
     platform/mediastream/MediaStreamTrackPrivate.h
     platform/mediastream/MeteringMode.h
     platform/mediastream/PhotoCapabilities.h

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -621,6 +621,28 @@ bool MediaStreamTrack::wantsToCaptureAudio() const
     return !ended() && (!muted() || m_private->interrupted());
 }
 
+UniqueRef<MediaStreamTrackDataHolder> MediaStreamTrack::detach()
+{
+    m_isDetached = true;
+    return m_private->toDataHolder();
+}
+
+Ref<MediaStreamTrack> MediaStreamTrack::create(ScriptExecutionContext& context, UniqueRef<MediaStreamTrackDataHolder>&& dataHolder)
+{
+    RefPtr<MediaStreamTrackPrivate> privateTrack;
+    if (RefPtr document = dynamicDowncast<Document>(context))
+        privateTrack = MediaStreamTrackPrivate::create(document->logger(), WTFMove(dataHolder->source), WTFMove(dataHolder->trackId));
+    else {
+        privateTrack = MediaStreamTrackPrivate::create(Logger::create(&context), WTFMove(dataHolder), [identifier = context.identifier()](Function<void()>&& task) {
+            ScriptExecutionContext::postTaskTo(identifier, [task = WTFMove(task)] (auto&) mutable {
+                task();
+            });
+        });
+    }
+
+    return MediaStreamTrack::create(context, privateTrack.releaseNonNull(), RegisterCaptureTrackToOwner::No);
+}
+
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& MediaStreamTrack::logChannel() const
 {

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -35,6 +35,7 @@
 #include "IDLTypes.h"
 #include "JSDOMPromiseDeferred.h"
 #include "MediaProducer.h"
+#include "MediaStreamTrackDataHolder.h"
 #include "MediaStreamTrackPrivate.h"
 #include "MediaTrackCapabilities.h"
 #include "MediaTrackConstraints.h"
@@ -70,6 +71,7 @@ public:
 
     enum class RegisterCaptureTrackToOwner : bool { No, Yes };
     static Ref<MediaStreamTrack> create(ScriptExecutionContext&, Ref<MediaStreamTrackPrivate>&&, RegisterCaptureTrackToOwner = RegisterCaptureTrackToOwner::Yes);
+    static Ref<MediaStreamTrack> create(ScriptExecutionContext&, UniqueRef<MediaStreamTrackDataHolder>&&);
     virtual ~MediaStreamTrack();
 
     static MediaProducerMediaStateFlags captureState(const RealtimeMediaSource&);
@@ -164,6 +166,18 @@ public:
 
     void setShouldFireMuteEventImmediately(bool value) { m_shouldFireMuteEventImmediately = value; }
 
+    struct Storage {
+        bool enabled { false };
+        bool ended { false };
+        bool muted { false };
+        RealtimeMediaSourceSettings settings;
+        RealtimeMediaSourceCapabilities capabilities;
+        RefPtr<RealtimeMediaSource> source;
+    };
+
+    bool isDetached() const { return m_isDetached; }
+    UniqueRef<MediaStreamTrackDataHolder> detach();
+
 protected:
     MediaStreamTrack(ScriptExecutionContext&, Ref<MediaStreamTrackPrivate>&&);
 
@@ -215,6 +229,7 @@ private:
     const bool m_isCaptureTrack { false };
     bool m_isInterrupted { false };
     bool m_shouldFireMuteEventImmediately { false };
+    bool m_isDetached { false };
 };
 
 typedef Vector<Ref<MediaStreamTrack>> MediaStreamTrackVector;

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
@@ -32,7 +32,7 @@ enum MediaStreamTrackState { "live", "ended" };
     ExportToWrappedFunction,
     PrivateIdentifier,
     PublicIdentifier,
-    Exposed=Window
+    Exposed=(Window,DedicatedWorker)
 ] interface MediaStreamTrack : EventTarget {
     readonly attribute DOMString kind;
     readonly attribute DOMString id;

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2442,6 +2442,7 @@ platform/mediastream/CaptureDeviceManager.cpp
 platform/mediastream/MediaConstraints.cpp
 platform/mediastream/MediaEndpointConfiguration.cpp
 platform/mediastream/MediaStreamPrivate.cpp
+platform/mediastream/MediaStreamTrackDataHolder.cpp
 platform/mediastream/MediaStreamTrackPrivate.cpp
 platform/mediastream/RTCIceCandidateDescriptor.cpp
 platform/mediastream/RTCSessionDescriptionDescriptor.cpp

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -37,6 +37,10 @@
 #include <wtf/Gigacage.h>
 #include <wtf/text/WTFString.h>
 
+#if ENABLE(MEDIA_STREAM)
+#include "MediaStreamTrackDataHolder.h"
+#endif
+
 #if ENABLE(WEB_CODECS)
 #include "WebCodecsAudioData.h"
 #include "WebCodecsAudioInternalData.h"
@@ -131,6 +135,9 @@ private:
         , Vector<RefPtr<WebCodecsEncodedAudioChunkStorage>>&& = { }
         , Vector<WebCodecsAudioInternalData>&& = { }
 #endif
+#if ENABLE(MEDIA_STREAM)
+        , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& = { }
+#endif
         );
 
     SerializedScriptValue(Vector<unsigned char>&&, Vector<URLKeepingBlobAlive>&& blobHandles, std::unique_ptr<ArrayBufferContentsArray>, std::unique_ptr<ArrayBufferContentsArray> sharedBuffers, Vector<std::optional<DetachedImageBitmap>>&&
@@ -152,6 +159,9 @@ private:
         , Vector<RefPtr<WebCodecsEncodedAudioChunkStorage>>&& = { }
         , Vector<WebCodecsAudioInternalData>&& = { }
 #endif
+#if ENABLE(MEDIA_STREAM)
+        , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& = { }
+#endif
         );
 
     size_t computeMemoryCost() const;
@@ -167,6 +177,9 @@ private:
         Vector<RefPtr<WebCodecsEncodedAudioChunkStorage>> serializedAudioChunks;
         Vector<WebCodecsVideoFrameData> serializedVideoFrames { };
         Vector<WebCodecsAudioInternalData> serializedAudioData { };
+#endif
+#if ENABLE(MEDIA_STREAM)
+        Vector<std::unique_ptr<MediaStreamTrackDataHolder>> serializedMediaStreamTracks { };
 #endif
         std::unique_ptr<ArrayBufferContentsArray> sharedBufferContentsArray { };
         Vector<std::optional<DetachedImageBitmap>> detachedImageBitmaps { };

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MediaStreamTrackDataHolder.h"
+
+#if ENABLE(MEDIA_STREAM)
+
+namespace WebCore {
+
+class PreventSourceFromEndingObserverWrapper : public ThreadSafeRefCounted<PreventSourceFromEndingObserverWrapper, WTF::DestructionThread::Main> {
+public:
+    static Ref<PreventSourceFromEndingObserverWrapper> create(Ref<RealtimeMediaSource>&& source)
+    {
+        auto wrapper = adoptRef(*new PreventSourceFromEndingObserverWrapper);
+        wrapper->initialize(WTFMove(source));
+        return wrapper;
+    }
+
+private:
+    PreventSourceFromEndingObserverWrapper() = default;
+
+    void initialize(Ref<RealtimeMediaSource>&& source)
+    {
+        ensureOnMainThread([protectedThis = Ref { *this }, source = WTFMove(source)] () mutable {
+            protectedThis->m_observer = makeUnique<PreventSourceFromEndingObserver>(WTFMove(source));
+        });
+    }
+
+    class PreventSourceFromEndingObserver final : public RealtimeMediaSource::Observer {
+        WTF_MAKE_FAST_ALLOCATED;
+    public:
+        explicit PreventSourceFromEndingObserver(Ref<RealtimeMediaSource>&& source)
+            : m_source(WTFMove(source))
+        {
+            m_source->addObserver(*this);
+        }
+
+        ~PreventSourceFromEndingObserver()
+        {
+            m_source->removeObserver(*this);
+        }
+
+    private:
+        bool preventSourceFromEnding() final { return true; }
+
+        Ref<RealtimeMediaSource> m_source;
+    };
+
+    std::unique_ptr<PreventSourceFromEndingObserver> m_observer;
+};
+
+MediaStreamTrackDataHolder::MediaStreamTrackDataHolder(bool isProducingData, bool enabled, bool ended, bool muted, bool interrupted, String&& trackId, String&& label, RealtimeMediaSource::Type type, CaptureDevice::DeviceType deviceType, RealtimeMediaSourceSettings&& settings, RealtimeMediaSourceCapabilities&& capabilities, Ref<RealtimeMediaSource>&& source)
+    : isProducingData(isProducingData)
+    , enabled(enabled)
+    , ended(ended)
+    , muted(muted)
+    , interrupted(interrupted)
+    , trackId(WTFMove(trackId))
+    , label(WTFMove(label))
+    , type(type)
+    , deviceType(deviceType)
+    , settings(WTFMove(settings))
+    , capabilities(WTFMove(capabilities))
+    , source(source.get())
+    , preventSourceFromEndingObserverWrapper(PreventSourceFromEndingObserverWrapper::create(WTFMove(source)))
+{
+}
+
+MediaStreamTrackDataHolder::~MediaStreamTrackDataHolder()
+{
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(MEDIA_STREAM)
+
+#include "CaptureDevice.h"
+#include "RealtimeMediaSource.h"
+#include <wtf/FastMalloc.h>
+
+namespace WebCore {
+
+class PreventSourceFromEndingObserverWrapper;
+
+struct MediaStreamTrackDataHolder {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+    WEBCORE_EXPORT MediaStreamTrackDataHolder(bool isProducingData, bool enabled, bool ended, bool muted, bool interrupted, String&& trackId, String&& label, RealtimeMediaSource::Type, CaptureDevice::DeviceType, RealtimeMediaSourceSettings&&, RealtimeMediaSourceCapabilities&&, Ref<RealtimeMediaSource>&&);
+    WEBCORE_EXPORT ~MediaStreamTrackDataHolder();
+
+    MediaStreamTrackDataHolder(const MediaStreamTrackDataHolder &) = delete;
+    MediaStreamTrackDataHolder &operator=(const MediaStreamTrackDataHolder &) = delete;
+
+    bool isProducingData { false };
+    bool enabled { false };
+    bool ended { false };
+    bool muted { false };
+    bool interrupted { false };
+    String trackId;
+    String label;
+    RealtimeMediaSource::Type type;
+    CaptureDevice::DeviceType deviceType;
+    RealtimeMediaSourceSettings settings;
+    RealtimeMediaSourceCapabilities capabilities;
+    Ref<RealtimeMediaSource> source;
+
+    Ref<PreventSourceFromEndingObserverWrapper> preventSourceFromEndingObserverWrapper;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -33,6 +33,7 @@
 #include "GraphicsContext.h"
 #include "IntRect.h"
 #include "Logging.h"
+#include "MediaStreamTrackDataHolder.h"
 #include "PlatformMediaSessionManager.h"
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/NativePromise.h>
@@ -60,6 +61,12 @@ Ref<MediaStreamTrackPrivate> MediaStreamTrackPrivate::create(Ref<const Logger>&&
     return privateTrack;
 }
 
+Ref<MediaStreamTrackPrivate> MediaStreamTrackPrivate::create(Ref<const Logger>&& logger, UniqueRef<MediaStreamTrackDataHolder>&& dataHolder, std::function<void(Function<void()>&&)>&& postTask)
+{
+    auto privateTrack = adoptRef(*new MediaStreamTrackPrivate(WTFMove(logger), WTFMove(dataHolder), WTFMove(postTask)));
+    privateTrack->initialize();
+    return privateTrack;
+}
 class MediaStreamTrackPrivateSourceObserver : public ThreadSafeRefCounted<MediaStreamTrackPrivateSourceObserver, WTF::DestructionThread::Main> {
 public:
     static Ref<MediaStreamTrackPrivateSourceObserver> create(Ref<RealtimeMediaSource>&& source, std::function<void(Function<void()>&&)>&& postTask) { return adoptRef(*new MediaStreamTrackPrivateSourceObserver(WTFMove(source), WTFMove(postTask))); }
@@ -315,11 +322,35 @@ MediaStreamTrackPrivate::MediaStreamTrackPrivate(Ref<const Logger>&& trackLogger
 {
     UNUSED_PARAM(trackLogger);
     ALWAYS_LOG(LOGIDENTIFIER);
+    if (!isMainThread())
+        return;
 
 #if !RELEASE_LOG_DISABLED
-    if (isMainThread())
-        m_sourceObserver->source().setLogger(m_logger.copyRef(), m_logIdentifier);
+    m_sourceObserver->source().setLogger(m_logger.copyRef(), m_logIdentifier);
 #endif
+}
+
+MediaStreamTrackPrivate::MediaStreamTrackPrivate(Ref<const Logger>&& logger, UniqueRef<MediaStreamTrackDataHolder>&& dataHolder, std::function<void(Function<void()>&&)>&& postTask)
+    : m_sourceObserver(MediaStreamTrackPrivateSourceObserver::create(WTFMove(dataHolder->source), WTFMove(postTask)))
+    , m_id(WTFMove(dataHolder->trackId))
+    , m_label(WTFMove(dataHolder->label))
+    , m_type(dataHolder->type)
+    , m_deviceType(dataHolder->deviceType)
+    , m_isCaptureTrack(false)
+    , m_captureDidFail(false)
+    , m_logger(WTFMove(logger))
+#if !RELEASE_LOG_DISABLED
+    , m_logIdentifier(uniqueLogIdentifier())
+#endif
+    , m_isProducingData(dataHolder->isProducingData)
+    , m_isMuted(dataHolder->muted)
+    , m_isInterrupted(dataHolder->interrupted)
+    , m_settings(WTFMove(dataHolder->settings))
+    , m_capabilities(WTFMove(dataHolder->capabilities))
+#if ASSERT_ENABLED
+    , m_creationThreadId(isMainThread() ? 0 : Thread::current().uid())
+#endif
+{
 }
 
 void MediaStreamTrackPrivate::initialize()
@@ -612,6 +643,23 @@ void MediaStreamTrackPrivate::updateReadyState()
     forEachObserver([this](auto& observer) {
         observer.readyStateChanged(*this);
     });
+}
+
+UniqueRef<MediaStreamTrackDataHolder> MediaStreamTrackPrivate::toDataHolder()
+{
+    return makeUniqueRef<MediaStreamTrackDataHolder>(
+        m_isProducingData,
+        m_isEnabled,
+        m_isEnded,
+        m_isMuted,
+        m_isInterrupted,
+        m_id.isolatedCopy(),
+        m_label.isolatedCopy(),
+        m_type,
+        m_deviceType,
+        m_settings.isolatedCopy(),
+        m_capabilities.isolatedCopy(),
+        Ref { m_sourceObserver->source() });
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -42,6 +42,8 @@ class MediaStreamTrackPrivateSourceObserver;
 class RealtimeMediaSourceCapabilities;
 class WebAudioSourceProvider;
 
+struct MediaStreamTrackDataHolder;
+
 class MediaStreamTrackPrivate final
     : public RefCounted<MediaStreamTrackPrivate>
     , public CanMakeWeakPtr<MediaStreamTrackPrivate>
@@ -63,6 +65,7 @@ public:
         virtual void readyStateChanged(MediaStreamTrackPrivate&) { };
     };
 
+    static Ref<MediaStreamTrackPrivate> create(Ref<const Logger>&&, UniqueRef<MediaStreamTrackDataHolder>&&, std::function<void(Function<void()>&&)>&&);
     static Ref<MediaStreamTrackPrivate> create(Ref<const Logger>&&, Ref<RealtimeMediaSource>&&, std::function<void(Function<void()>&&)>&& postTask = { });
     static Ref<MediaStreamTrackPrivate> create(Ref<const Logger>&&, Ref<RealtimeMediaSource>&&, String&& id, std::function<void(Function<void()>&&)>&& postTask = { });
 
@@ -141,8 +144,11 @@ public:
     void initializeSettings(RealtimeMediaSourceSettings&& settings) { m_settings = WTFMove(settings); }
     void initializeCapabilities(RealtimeMediaSourceCapabilities&& capabilities) { m_capabilities = WTFMove(capabilities); }
 
+    UniqueRef<MediaStreamTrackDataHolder> toDataHolder();
+
 private:
     MediaStreamTrackPrivate(Ref<const Logger>&&, Ref<RealtimeMediaSource>&&, String&& id, std::function<void(Function<void()>&&)>&&);
+    MediaStreamTrackPrivate(Ref<const Logger>&&, UniqueRef<MediaStreamTrackDataHolder>&&, std::function<void(Function<void()>&&)>&&);
 
     void initialize();
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6923,6 +6923,9 @@ headers: <JavaScriptCore/WasmModule.h> <WebCore/ImageBitmap.h> <WebCore/MessageP
     [NotSerialized] Vector<WebCore::WebCodecsVideoFrameData> serializedVideoFrames;
     [NotSerialized] Vector<WebCore::WebCodecsAudioInternalData> serializedAudioData;
 #endif
+#if ENABLE(MEDIA_STREAM)
+    [NotSerialized] Vector<std::unique_ptr<WebCore::MediaStreamTrackDataHolder>> serializedMediaStreamTracks;
+#endif
     [NotSerialized] std::unique_ptr<Vector<JSC::ArrayBufferContents>> sharedBufferContentsArray;
     [NotSerialized] Vector<std::optional<WebCore::DetachedImageBitmap>> detachedImageBitmaps;
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)

--- a/Tools/TestWebKitAPI/cocoa/UserMediaCaptureUIDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/UserMediaCaptureUIDelegate.h
@@ -24,10 +24,11 @@
  */
 
 #if ENABLE(MEDIA_STREAM)
+#import <WebKit/WKNavigationDelegate.h>
 #import <WebKit/WKUIDelegate.h>
 #import <WebKit/WKUIDelegatePrivate.h>
 
-@interface UserMediaCaptureUIDelegate : NSObject<WKUIDelegate> {
+@interface UserMediaCaptureUIDelegate : NSObject<WKNavigationDelegate, WKUIDelegate> {
     bool _wasPrompted;
     int _numberOfPrompts;
     WKPermissionDecision _audioDecision;
@@ -38,19 +39,22 @@
 @property (readonly) BOOL wasPrompted;
 @property int numberOfPrompts;
 @property WKPermissionDecision decision;
+@property (readonly) BOOL shouldCreateNewWebView;
 
-- (void)waitUntilPrompted;
+-(void)waitUntilPrompted;
 -(void)resetWasPrompted;
 
 -(void)setAudioDecision:(WKPermissionDecision)decision;
 -(void)setVideoDecision:(WKPermissionDecision)decision;
 -(void)setGetDisplayMediaDecision:(WKDisplayCapturePermissionDecision)decision;
+-(void)setWebViewForPopup:(WKWebView*)webView;
 
 // WKUIDelegate
 - (void)webView:(WKWebView *)webView requestMediaCapturePermissionForOrigin:(WKSecurityOrigin *)origin initiatedByFrame:(WKFrameInfo *)frame type:(WKMediaCaptureType)type decisionHandler:(void (^)(WKPermissionDecision decision))decisionHandler;
 - (void)_webView:(WKWebView *)webView checkUserMediaPermissionForURL:(NSURL *)url mainFrameURL:(NSURL *)mainFrameURL frameIdentifier:(NSUInteger)frameIdentifier decisionHandler:(void (^)(NSString *salt, BOOL authorized))decisionHandler;
 - (void)_webView:(WKWebView *)webView requestDisplayCapturePermissionForOrigin:(WKSecurityOrigin *)origin initiatedByFrame:(WKFrameInfo *)frame withSystemAudio:(BOOL)withSystemAudio decisionHandler:(void (^)(WKDisplayCapturePermissionDecision decision))decisionHandler;
 - (void)_webView:(WKWebView *)webView queryPermission:(NSString*) name forOrigin:(WKSecurityOrigin *)origin completionHandler:(void (^)(WKPermissionDecision state))completionHandler;
+- (WKWebView *)webView:(WKWebView *)webView createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration forNavigationAction:(WKNavigationAction *)navigationAction windowFeatures:(WKWindowFeatures *)windowFeatures;
 
 @end
 


### PR DESCRIPTION
#### 0b9dfbd9559968b03834522225f58dcaeffaa57f
<pre>
Implement MediaStreamTrack transfer to dedicated workers in same agent cluster
<a href="https://rdar.apple.com/121180907">rdar://121180907</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=267682">https://bugs.webkit.org/show_bug.cgi?id=267682</a>

Reviewed by Eric Carlson.

Introduce MediaStreamTrackDataHolder which is used to store the MediaStreamTrack information necessary as part of the transfer.
It keeps the track source alive and allows to create a MediaStreamTrackPrivate from it.
We expose MediaStreamTrack to window and dedicated worker but only support transferring tracks in the same agent cluster.
The goal is typically to transfer the track from a window context to a dedicated worker created by the window context, to do track video frame processing.

Given the source, even if transferred, is kept by the document for which was created the source, there is no impact on the privacy indicators.

The new tests highlighted three issues in MediaStreamTrackProcessor:
- The observer needs to be created right away or we need to add an if check. We are creating it right away
- We were missing protecting the processor in MediaStreamTrackProcessor::VideoFrameObserver::videoFrameAvailable.
- We should call ReadableStreamSource::pullFinished() only if enqueuing went well.

* LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker-expected.txt: Added.
* LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker-worker.js: Added.
(makeOffscreenCanvasVideoFrame):
(promise_test.async t):
* LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker.html: Added.
* LayoutTests/http/wpt/mediastream/transfer-videotrackgenerator-track-expected.txt: Added.
* LayoutTests/http/wpt/mediastream/transfer-videotrackgenerator-track.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/idlharness.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-transfer-video.https-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::detach):
(WebCore::MediaStreamTrack::create):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
(WebCore::MediaStreamTrack::isDetached const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.idl:
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp:
(WebCore::MediaStreamTrackProcessor::VideoFrameObserverWrapper::initialize):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserver::VideoFrameObserver):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserver::videoFrameAvailable):
(WebCore::MediaStreamTrackProcessor::Source::enqueue):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::isTypeExposedToGlobalObject):
(WebCore::CloneSerializer::serialize):
(WebCore::CloneSerializer::CloneSerializer):
(WebCore::CloneSerializer::dumpMediaStreamTrack):
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::CloneDeserializer::deserialize):
(WebCore::CloneDeserializer::readMediaStreamTrack):
(WebCore::CloneDeserializer::readTerminal):
(WebCore::SerializedScriptValue::SerializedScriptValue):
(WebCore::canDetachMediaStreamTracks):
(WebCore::SerializedScriptValue::create):
(WebCore::SerializedScriptValue::deserialize):
* Source/WebCore/bindings/js/SerializedScriptValue.h:
* Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp: Added.
(WebCore::PreventSourceFromEndingObserverWrapper::create):
(WebCore::PreventSourceFromEndingObserverWrapper::initialize):
(WebCore::MediaStreamTrackDataHolder::MediaStreamTrackDataHolder):
(WebCore::MediaStreamTrackDataHolder::~MediaStreamTrackDataHolder):
* Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.h: Added.
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivate::create):
(WebCore::MediaStreamTrackPrivate::MediaStreamTrackPrivate):
(WebCore::MediaStreamTrackPrivate::toDataHolder):
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:
(TestWebKitAPI::captureAndTransferAudioTrack):
(TestWebKitAPI::captureAndTransferVideoTrack):
(TestWebKitAPI::start):
* Tools/TestWebKitAPI/cocoa/UserMediaCaptureUIDelegate.h:
* Tools/TestWebKitAPI/cocoa/UserMediaCaptureUIDelegate.mm:
(-[UserMediaCaptureUIDelegate setWebViewForPopup:]):
(-[UserMediaCaptureUIDelegate webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:]):
(-[UserMediaCaptureUIDelegate webView:decidePolicyForNavigationAction:preferences:decisionHandler:]):

Canonical link: <a href="https://commits.webkit.org/273300@main">https://commits.webkit.org/273300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4797c61973666e332100ffcec316b79c4a4b20b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35011 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37760 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31623 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10980 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30561 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10326 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31312 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39011 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31842 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31641 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36408 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34395 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12290 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30956 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8024 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11022 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11354 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->