### PR TITLE
REGRESSION(273101@main): [Debug] ASSERTION FAILED: ptr in RenderFlexibleBox::maybeCacheChildMainIntrinsicSize()

### DIFF
--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -606,7 +606,7 @@ LayoutUnit RenderFlexibleBox::crossAxisExtentForChild(const RenderBox& child) co
     return isHorizontalFlow() ? child.height() : child.width();
 }
 
-LayoutUnit RenderFlexibleBox::cachedChildIntrinsicContentLogicalHeight(const RenderBox& child) const
+LayoutUnit RenderFlexibleBox::cachedChildIntrinsicContentLogicalHeight(const RenderBox& child)
 {
     if (auto* renderReplaced = dynamicDowncast<RenderReplaced>(child))
         return renderReplaced->intrinsicLogicalHeight();
@@ -631,7 +631,7 @@ void RenderFlexibleBox::clearCachedChildIntrinsicContentLogicalHeight(const Rend
     m_intrinsicContentLogicalHeights.remove(child);
 }
 
-LayoutUnit RenderFlexibleBox::childIntrinsicLogicalHeight(RenderBox& child) const
+LayoutUnit RenderFlexibleBox::childIntrinsicLogicalHeight(RenderBox& child)
 {
     // This should only be called if the logical height is the cross size
     ASSERT(mainAxisIsChildInlineAxis(child));

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -104,7 +104,7 @@ public:
     
     void clearCachedMainSizeForChild(const RenderBox& child);
     
-    LayoutUnit cachedChildIntrinsicContentLogicalHeight(const RenderBox& child) const;
+    LayoutUnit cachedChildIntrinsicContentLogicalHeight(const RenderBox& child);
     void setCachedChildIntrinsicContentLogicalHeight(const RenderBox& child, LayoutUnit);
     void clearCachedChildIntrinsicContentLogicalHeight(const RenderBox& child);
 
@@ -160,7 +160,7 @@ private:
     bool shouldApplyMinSizeAutoForChild(const RenderBox&) const;
     LayoutUnit crossAxisExtentForChild(const RenderBox& child) const;
     LayoutUnit crossAxisIntrinsicExtentForChild(RenderBox& child);
-    LayoutUnit childIntrinsicLogicalHeight(RenderBox& child) const;
+    LayoutUnit childIntrinsicLogicalHeight(RenderBox& child);
     LayoutUnit childIntrinsicLogicalWidth(RenderBox& child);
     LayoutUnit mainAxisExtentForChild(const RenderBox& child) const;
     LayoutUnit mainAxisContentExtentForChildIncludingScrollbar(const RenderBox& child) const;
@@ -265,11 +265,11 @@ private:
 
     // This is used to cache the preferred size for orthogonal flow children so we
     // don't have to relayout to get it
-    HashMap<SingleThreadWeakRef<const RenderBox>, LayoutUnit> m_intrinsicSizeAlongMainAxis;
+    SingleThreadWeakHashMap<const RenderBox, LayoutUnit> m_intrinsicSizeAlongMainAxis;
     
     // This is used to cache the intrinsic size on the cross axis to avoid
     // relayouts when stretching.
-    HashMap<SingleThreadWeakRef<const RenderBox>, LayoutUnit> m_intrinsicContentLogicalHeights;
+    SingleThreadWeakHashMap<const RenderBox, LayoutUnit> m_intrinsicContentLogicalHeights;
 
     // This set is used to keep track of which children we laid out in this
     // current layout iteration. We need it because the ones in this set may


### PR DESCRIPTION
#### 2db392462d9074cbbb07ea8f27b33b1bfd45871a
<pre>
REGRESSION(273101@main): [Debug] ASSERTION FAILED: ptr in RenderFlexibleBox::maybeCacheChildMainIntrinsicSize()
<a href="https://bugs.webkit.org/show_bug.cgi?id=267638">https://bugs.webkit.org/show_bug.cgi?id=267638</a>

Reviewed by NOBODY (OOPS!).

Since `SingleThreadWeakRef` by definition can contain `nullptr`,
we can reach the assertion `ASSERT(ptr)` in `WeakRef::ptr()` while
checking if `m_intrinsicSizeAlongMainAxis` contains cached size for
a child in `RenderFlexibleBox::maybeCacheChildMainIntrinsicSize()`.

We should use `SingleThreadWeakHashMap&lt;const RenderBox, LayoutUnit&gt;`
instead of `HashMap&lt;SingleThreadWeakRef&lt;const RenderBox&gt;, LayoutUnit&gt;`
because it knows how to handle weak pointers.

* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::cachedChildIntrinsicContentLogicalHeight):
(WebCore::RenderFlexibleBox::childIntrinsicLogicalHeight):
(WebCore::RenderFlexibleBox::cachedChildIntrinsicContentLogicalHeight const): Deleted.
(WebCore::RenderFlexibleBox::childIntrinsicLogicalHeight const): Deleted.
* Source/WebCore/rendering/RenderFlexibleBox.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2db392462d9074cbbb07ea8f27b33b1bfd45871a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37269 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31248 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30221 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9907 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9991 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38547 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31398 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31189 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36053 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34005 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11932 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10662 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->