### PR TITLE
Add required entitlement for WebKitTestRunner

### DIFF
--- a/Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp-iOS.entitlements
+++ b/Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp-iOS.entitlements
@@ -14,5 +14,7 @@
 	<true/>
 	<key>com.apple.private.web-browser-engine.host</key>
 	<true/>
+	<key>com.apple.developer.web-browser</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
#### 4dc7d9f0e71f92a114505c60b7ed31854ca740ce
<pre>
Add required entitlement for WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=267699">https://bugs.webkit.org/show_bug.cgi?id=267699</a>
<a href="https://rdar.apple.com/121192393">rdar://121192393</a>

Reviewed by NOBODY (OOPS!).

Add required entitlement for WebKitTestRunner in simulator.

* Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp-iOS.entitlements:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dc7d9f0e71f92a114505c60b7ed31854ca740ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37276 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31253 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30226 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35111 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11351 "Found 3 new test failures: http/tests/in-app-browser-privacy/app-bound-domain-gets-app-bound-session.html, http/tests/in-app-browser-privacy/non-app-bound-iframe-under-app-bound-domain-is-app-bound.html, http/wpt/webauthn/public-key-credential-is-user-verifying-platform-authenticator-available.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9914 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/9999 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38554 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36058 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10115 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8007 "Found 1 new test failure: accessibility/mac/search-predicate-container-not-included.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34011 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11938 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10668 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10988 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->