### PR TITLE
ImageBitmap data is drawn to GPUP surface needlessly

### DIFF
--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -4121,7 +4121,7 @@ private:
         auto imageDataSize = logicalSize;
         imageDataSize.scale(resolutionScale);
 
-        auto buffer = ImageBitmap::createImageBuffer(*executionContext(m_lexicalGlobalObject), logicalSize, RenderingMode::Unaccelerated, colorSpace, resolutionScale);
+        auto buffer = ImageBitmap::createImageBuffer(*executionContext(m_lexicalGlobalObject), logicalSize, colorSpace, resolutionScale);
         if (!buffer) {
             fail();
             return JSValue();

--- a/Source/WebCore/html/ImageBitmap.h
+++ b/Source/WebCore/html/ImageBitmap.h
@@ -96,7 +96,6 @@ public:
     static void createPromise(ScriptExecutionContext&, Source&&, ImageBitmapOptions&&, Promise&&);
     static void createPromise(ScriptExecutionContext&, Source&&, ImageBitmapOptions&&, int sx, int sy, int sw, int sh, Promise&&);
 
-    static RefPtr<ImageBuffer> createImageBuffer(ScriptExecutionContext&, const FloatSize&, RenderingMode, DestinationColorSpace, float resolutionScale = 1);
     static RefPtr<ImageBuffer> createImageBuffer(ScriptExecutionContext&, const FloatSize&, DestinationColorSpace, float resolutionScale = 1);
 
     static Ref<ImageBitmap> create(ScriptExecutionContext&, const IntSize&, DestinationColorSpace);

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -71,6 +71,9 @@ RefPtr<ImageBuffer> ImageBuffer::create(const FloatSize& size, RenderingPurpose 
     }
 
 #if HAVE(IOSURFACE)
+    if (purpose == RenderingPurpose::ImageBitmap)
+        options.add(ImageBufferOptions::Accelerated);
+
     if (options.contains(ImageBufferOptions::Accelerated) && ProcessCapabilities::canUseAcceleratedBuffers()) {
         ImageBufferCreationContext creationContext;
         if (graphicsClient)

--- a/Source/WebCore/platform/graphics/RenderingMode.cpp
+++ b/Source/WebCore/platform/graphics/RenderingMode.cpp
@@ -42,6 +42,7 @@ TextStream& operator<<(TextStream& ts, RenderingPurpose purpose)
     case RenderingPurpose::ShareableSnapshot: ts << "ShareableSnapshot"; break;
     case RenderingPurpose::ShareableLocalSnapshot: ts << "ShareableLocalSnapshot"; break;
     case RenderingPurpose::MediaPainting: ts << "MediaPainting"; break;
+    case RenderingPurpose::ImageBitmap: ts << "ImageBitmap"; break;
     }
     return ts;
 }

--- a/Source/WebCore/platform/graphics/RenderingMode.h
+++ b/Source/WebCore/platform/graphics/RenderingMode.h
@@ -41,6 +41,7 @@ enum class RenderingPurpose : uint8_t {
     ShareableSnapshot,
     ShareableLocalSnapshot,
     MediaPainting,
+    ImageBitmap,
 };
 
 enum class RenderingMode : bool { Unaccelerated, Accelerated };

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -70,6 +70,7 @@ public:
         Snapshot,
         ShareableSnapshot,
         ShareableLocalSnapshot,
+        ImageBitmap,
     };
 
     enum class Format {

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -75,6 +75,8 @@ static auto surfaceNameToNSString(IOSurface::Name name)
         return @"WKWebView Snapshot (shareable)";
     case IOSurface::Name::ShareableLocalSnapshot:
         return @"WKWebView Snapshot (shareable local)";
+    case IOSurface::Name::ImageBitmap:
+        return @"WebKit ImageBitmap";
     }
 }
 
@@ -695,6 +697,8 @@ IOSurface::Name IOSurface::nameForRenderingPurpose(RenderingPurpose purpose)
 
     case RenderingPurpose::MediaPainting:
         return Name::MediaPainting;
+    case RenderingPurpose::ImageBitmap:
+        return Name::ImageBitmap;
     }
 
     return Name::Default;

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2238,6 +2238,7 @@ bool WebProcess::shouldUseRemoteRenderingFor(RenderingPurpose purpose)
         return m_useGPUProcessForDOMRendering;
     case RenderingPurpose::MediaPainting:
         return m_useGPUProcessForMedia;
+    case RenderingPurpose::ImageBitmap:
     case RenderingPurpose::ShareableLocalSnapshot:
     case RenderingPurpose::Unspecified:
         return false;


### PR DESCRIPTION
#### 100a05fade16fba123fd635995de6eb5aa80e238
<pre>
ImageBitmap data is drawn to GPUP surface needlessly
<a href="https://bugs.webkit.org/show_bug.cgi?id=267702">https://bugs.webkit.org/show_bug.cgi?id=267702</a>
<a href="https://rdar.apple.com/121194515">rdar://121194515</a>

Reviewed by NOBODY (OOPS!).

MISSING: reoredSetState does not send non-RIBP ImageBuffers to GPUP
so the GPUP will fail finding one.
--&gt; blocks on make ImageBitmap store NativeImage
MISSING: cannot make a fast NativeImage.

Holding the ImageBitmap backing store (ImageBuffer) in GPUP is redundant.
There is two copy draws: once as software draw to IPC buffer and
once as accelerated draw to ImageBuffer.

Instead, hold it as unaccelerated, shareable ImageBuffer in WP side.
The NativeImage reference is used upon each draw, and the data is
available in GPUP.

* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readImageBitmap):
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::ImageBitmap::create):
(WebCore::ImageBitmap::createImageBuffer):
(WebCore::ImageBitmap::createBlankImageBuffer):
(WebCore::ImageBitmap::createCompletionHandler):
(WebCore::ImageBitmap::createFromBuffer):
* Source/WebCore/html/ImageBitmap.h:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::create):
* Source/WebCore/platform/graphics/RenderingMode.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/RenderingMode.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::surfaceNameToNSString):
(WebCore::IOSurface::nameForRenderingPurpose):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createImageBuffer const):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::shouldUseRemoteRenderingFor):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/100a05fade16fba123fd635995de6eb5aa80e238

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37434 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31357 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30307 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10037 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10096 "Too many flaky failures: imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-all.https.sub.html, imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop.html, imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in.html, imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-in.html, imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-in.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-out.html, imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-out.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.image.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.image.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.crosscanvas.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.crosscanvas.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.basic.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.basic.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord1.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord1.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord2.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord2.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.orientation.image.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.orientation.image.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.basic.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.basic.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord1.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord1.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord2.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord2.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord3.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord3.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.outside.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.outside.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.basic.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.basic.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.basic.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.basic.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.repeat.empty.html, imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.repeat.empty.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.alpha.html, imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.alpha.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.basic.html, imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.basic.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.2.html, imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.2.worker.html, imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-senderCaptureTimeOffset.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38698 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31541 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31339 "Found 60 new test failures: compositing/clipping/border-radius-async-overflow-non-stacking.html, fast/dom/intersection-observer-document-leak.html, fast/speechrecognition/start-recognition-after-denied-gum.html, http/tests/cache/disk-cache/disk-cache-vary.html, http/tests/resourceLoadStatistics/non-prevalent-resource-with-user-interaction.html, http/tests/security/script-crossorigin-error-event-information.html, imported/w3c/web-platform-tests/content-security-policy/generic/no-default-src.sub.html, imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window.html, imported/w3c/web-platform-tests/css/css-box/box-chrome-crash-001.html, imported/w3c/web-platform-tests/css/css-multicol/going-out-of-flow-after-spanner.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36149 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10216 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8118 "Found 60 new test failures: fast/css/aspect-ratio-min-height-replaced.html, http/tests/images/gif-progressive-load.html, imported/w3c/web-platform-tests/html/canvas/element/compositing/2d.composite.globalAlpha.imagepattern.html, imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.globalAlpha.imagepattern.html, imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.globalAlpha.imagepattern.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.copy.html, imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.copy.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop.html, imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop.worker.html, imported/w3c/web-platform-tests/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34130 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12045 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10764 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11107 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->