### PR TITLE
Generate serialization for WebCore::Payment, WebCore::PaymentContact, and WebCore::PaymentMerchantSession

### DIFF
--- a/Source/WebCore/Modules/applepay/Payment.h
+++ b/Source/WebCore/Modules/applepay/Payment.h
@@ -43,7 +43,7 @@ public:
 
     virtual ApplePayPayment toApplePayPayment(unsigned version) const;
 
-    PKPayment *pkPayment() const;
+    RetainPtr<PKPayment> pkPayment() const;
 
 private:
     RetainPtr<PKPayment> m_pkPayment;

--- a/Source/WebCore/Modules/applepay/PaymentContact.h
+++ b/Source/WebCore/Modules/applepay/PaymentContact.h
@@ -45,7 +45,7 @@ public:
     static PaymentContact fromApplePayPaymentContact(unsigned version, const ApplePayPaymentContact&);
     virtual ApplePayPaymentContact toApplePayPaymentContact(unsigned version) const;
 
-    PKContact *pkContact() const;
+    RetainPtr<PKContact> pkContact() const;
 
 private:
     RetainPtr<PKContact> m_pkContact;

--- a/Source/WebCore/Modules/applepay/PaymentMerchantSession.h
+++ b/Source/WebCore/Modules/applepay/PaymentMerchantSession.h
@@ -50,7 +50,7 @@ public:
 
     static std::optional<PaymentMerchantSession> fromJS(JSC::JSGlobalObject&, JSC::JSValue, String& errorMessage);
 
-    PKPaymentMerchantSession *pkPaymentMerchantSession() const { return m_pkPaymentMerchantSession.get(); }
+    RetainPtr<PKPaymentMerchantSession> pkPaymentMerchantSession() const { return m_pkPaymentMerchantSession; }
 
 private:
     RetainPtr<PKPaymentMerchantSession> m_pkPaymentMerchantSession;

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentCocoa.mm
@@ -94,9 +94,9 @@ ApplePayPayment Payment::toApplePayPayment(unsigned version) const
     return convert(version, m_pkPayment.get());
 }
 
-PKPayment *Payment::pkPayment() const
+RetainPtr<PKPayment> Payment::pkPayment() const
 {
-    return m_pkPayment.get();
+    return m_pkPayment;
 }
 
 }

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentContactCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentContactCocoa.mm
@@ -169,9 +169,9 @@ ApplePayPaymentContact PaymentContact::toApplePayPaymentContact(unsigned version
     return convert(version, m_pkContact.get());
 }
 
-PKContact *PaymentContact::pkContact() const
+RetainPtr<PKContact> PaymentContact::pkContact() const
 {
-    return m_pkContact.get();
+    return m_pkContact;
 }
 
 }

--- a/Source/WebCore/testing/MockPaymentCoordinator.cpp
+++ b/Source/WebCore/testing/MockPaymentCoordinator.cpp
@@ -112,7 +112,7 @@ void MockPaymentCoordinator::dispatchIfShowing(Function<void()>&& function)
 
 bool MockPaymentCoordinator::showPaymentUI(const URL&, const Vector<URL>&, const ApplePaySessionPaymentRequest& request)
 {
-    if (request.shippingContact().pkContact())
+    if (request.shippingContact().pkContact().get())
         m_shippingAddress = request.shippingContact().toApplePayPaymentContact(request.version());
     m_supportedCountries = request.supportedCountries();
     m_shippingMethods = request.shippingMethods();

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
@@ -205,7 +205,7 @@ static RetainPtr<NSArray> toNSErrors(const Vector<RefPtr<WebCore::ApplePayError>
 void PaymentAuthorizationPresenter::completeMerchantValidation(const WebCore::PaymentMerchantSession& merchantSession)
 {
     ASSERT(platformDelegate());
-    [platformDelegate() completeMerchantValidation:merchantSession.pkPaymentMerchantSession() error:nil];
+    [platformDelegate() completeMerchantValidation:merchantSession.pkPaymentMerchantSession().get() error:nil];
 }
 
 void PaymentAuthorizationPresenter::completePaymentMethodSelection(std::optional<WebCore::ApplePayPaymentMethodUpdate>&& update)

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -287,8 +287,8 @@ RetainPtr<PKPaymentRequest> WebPaymentCoordinatorProxy::platformPaymentRequest(W
 
     [result setCountryCode:paymentRequest.countryCode()];
     [result setCurrencyCode:paymentRequest.currencyCode()];
-    [result setBillingContact:paymentRequest.billingContact().pkContact()];
-    [result setShippingContact:paymentRequest.shippingContact().pkContact()];
+    [result setBillingContact:paymentRequest.billingContact().pkContact().get()];
+    [result setShippingContact:paymentRequest.shippingContact().pkContact().get()];
     [result setRequiredBillingContactFields:toPKContactFields(paymentRequest.requiredBillingContactFields()).get()];
     [result setRequiredShippingContactFields:toPKContactFields(paymentRequest.requiredShippingContactFields()).get()];
 

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
@@ -80,63 +80,6 @@ namespace IPC {
 
 #if ENABLE(APPLE_PAY)
 
-template<> Class getClass<PKPayment>()
-{
-    return PAL::getPKPaymentClass();
-}
-
-template<> Class getClass<PKPaymentMerchantSession>()
-{
-    return PAL::getPKPaymentMerchantSessionClass();
-}
-
-template<> Class getClass<PKPaymentMethod>()
-{
-    return PAL::getPKPaymentMethodClass();
-}
-
-void ArgumentCoder<WebCore::Payment>::encode(Encoder& encoder, const WebCore::Payment& payment)
-{
-    encoder << payment.pkPayment();
-}
-
-std::optional<WebCore::Payment> ArgumentCoder<WebCore::Payment>::decode(Decoder& decoder)
-{
-    auto payment = decoder.decodeWithAllowedClasses<PKPayment>();
-    if (!payment)
-        return std::nullopt;
-
-    return WebCore::Payment { WTFMove(*payment) };
-}
-
-void ArgumentCoder<WebCore::PaymentContact>::encode(Encoder& encoder, const WebCore::PaymentContact& paymentContact)
-{
-    encoder << paymentContact.pkContact();
-}
-
-std::optional<WebCore::PaymentContact> ArgumentCoder<WebCore::PaymentContact>::decode(Decoder& decoder)
-{
-    auto contact = decoder.decodeWithAllowedClasses<PKContact>();
-    if (!contact)
-        return std::nullopt;
-
-    return WebCore::PaymentContact { WTFMove(*contact) };
-}
-
-void ArgumentCoder<WebCore::PaymentMerchantSession>::encode(Encoder& encoder, const WebCore::PaymentMerchantSession& paymentMerchantSession)
-{
-    encoder << paymentMerchantSession.pkPaymentMerchantSession();
-}
-
-std::optional<WebCore::PaymentMerchantSession> ArgumentCoder<WebCore::PaymentMerchantSession>::decode(Decoder& decoder)
-{
-    auto paymentMerchantSession = decoder.decodeWithAllowedClasses<PKPaymentMerchantSession>();
-    if (!paymentMerchantSession)
-        return std::nullopt;
-
-    return WebCore::PaymentMerchantSession { WTFMove(*paymentMerchantSession) };
-}
-
 void ArgumentCoder<WebCore::ApplePaySessionPaymentRequest>::encode(Encoder& encoder, const WebCore::ApplePaySessionPaymentRequest& request)
 {
     encoder << request.countryCode();

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -117,7 +117,19 @@ class WebCore::PaymentSessionError {
 headers: <pal/cocoa/PassKitSoftLink.h>
 class WebCore::PaymentMethod {
     [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKPaymentMethodClass()], Validator='m_pkPaymentMethod'] RetainPtr<PKPaymentMethod> m_pkPaymentMethod;
-}
+};
+
+class WebCore::Payment {
+    [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKPaymentClass()]] RetainPtr<PKPayment> pkPayment();
+};
+
+class WebCore::PaymentContact {
+    [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKContactClass()]] RetainPtr<PKContact> pkContact();
+};
+
+class WebCore::PaymentMerchantSession {
+    [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKPaymentMerchantSessionClass()]] RetainPtr<PKPaymentMerchantSession> pkPaymentMerchantSession();
+};
 #endif
 
 #if ENABLE(APPLE_PAY_SHIPPING_CONTACT_EDITING_MODE)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -220,21 +220,6 @@ template<> struct ArgumentCoder<WebCore::MediaPlaybackTargetContext> {
 
 #if ENABLE(APPLE_PAY)
 
-template<> struct ArgumentCoder<WebCore::Payment> {
-    static void encode(Encoder&, const WebCore::Payment&);
-    static std::optional<WebCore::Payment> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<WebCore::PaymentContact> {
-    static void encode(Encoder&, const WebCore::PaymentContact&);
-    static std::optional<WebCore::PaymentContact> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<WebCore::PaymentMerchantSession> {
-    static void encode(Encoder&, const WebCore::PaymentMerchantSession&);
-    static std::optional<WebCore::PaymentMerchantSession> decode(Decoder&);
-};
-
 template<> struct ArgumentCoder<WebCore::ApplePaySessionPaymentRequest> {
     static void encode(Encoder&, const WebCore::ApplePaySessionPaymentRequest&);
     static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::ApplePaySessionPaymentRequest&);


### PR DESCRIPTION
#### 2a16c10dc012b0a6e2f7c69ada165274fec5bed8
<pre>
Generate serialization for WebCore::Payment, WebCore::PaymentContact, and WebCore::PaymentMerchantSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=267703">https://bugs.webkit.org/show_bug.cgi?id=267703</a>
<a href="https://rdar.apple.com/121195605">rdar://121195605</a>

Reviewed by Alex Christensen.

* Source/WebCore/Modules/applepay/Payment.h:
* Source/WebCore/Modules/applepay/PaymentContact.h:
* Source/WebCore/Modules/applepay/PaymentMerchantSession.h:
(WebCore::PaymentMerchantSession::pkPaymentMerchantSession const):
* Source/WebCore/Modules/applepay/cocoa/PaymentCocoa.mm:
(WebCore::Payment::pkPayment const):
* Source/WebCore/Modules/applepay/cocoa/PaymentContactCocoa.mm:
(WebCore::PaymentContact::pkContact const):
* Source/WebCore/testing/MockPaymentCoordinator.cpp:
(WebCore::MockPaymentCoordinator::showPaymentUI):
* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm:
(WebKit::PaymentAuthorizationPresenter::completeMerchantValidation):
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformPaymentRequest):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::getClass&lt;PKPayment&gt;): Deleted.
(IPC::getClass&lt;PKPaymentMerchantSession&gt;): Deleted.
(IPC::getClass&lt;PKPaymentMethod&gt;): Deleted.
(IPC::ArgumentCoder&lt;WebCore::Payment&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::Payment&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::PaymentContact&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::PaymentContact&gt;::decode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::PaymentMerchantSession&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::PaymentMerchantSession&gt;::decode): Deleted.
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.h:

Canonical link: <a href="https://commits.webkit.org/273512@main">https://commits.webkit.org/273512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dc79c545b89d280aaa9d07e7a2788b340bbdee4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37702 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38306 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32050 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11534 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30862 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31657 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10764 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39551 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36741 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10963 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34800 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12678 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11477 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4617 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11743 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->