### PR TITLE
[wpe][wayland] Opaque region support

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -48,6 +48,7 @@ struct _WPEViewPrivate {
     GRefPtr<WPEDisplay> display;
     int width;
     int height;
+    bool fullscreen;
     bool inResize;
     gdouble scale { 1 };
     WPEViewState state;
@@ -586,7 +587,11 @@ gboolean wpe_view_fullscreen(WPEView* view)
     g_return_val_if_fail(WPE_IS_VIEW(view), FALSE);
 
     auto* viewClass = WPE_VIEW_GET_CLASS(view);
-    return viewClass->set_fullscreen ? viewClass->set_fullscreen(view, TRUE) : FALSE;
+    gboolean result = viewClass->set_fullscreen ? viewClass->set_fullscreen(view, TRUE) : FALSE;
+    if (result)
+        view->priv->fullscreen = TRUE;
+
+    return result;
 }
 
 /**
@@ -604,7 +609,26 @@ gboolean wpe_view_unfullscreen(WPEView* view)
     g_return_val_if_fail(WPE_IS_VIEW(view), FALSE);
 
     auto* viewClass = WPE_VIEW_GET_CLASS(view);
-    return viewClass->set_fullscreen ? viewClass->set_fullscreen(view, FALSE) : FALSE;
+    gboolean result = viewClass->set_fullscreen ? viewClass->set_fullscreen(view, FALSE) : FALSE;
+    if (result)
+        view->priv->fullscreen = FALSE;
+
+    return result;
+}
+
+/**
+ * wpe_view_is_fullscreen:
+ * @view: a #WPEView
+ *
+ * Get if @view is fullscreen
+ *
+ * Returns: the view fullscreen state
+ */
+gboolean wpe_view_is_fullscreen(WPEView *view)
+{
+    g_return_val_if_fail(WPE_IS_VIEW(view), FALSE);
+
+    return view->priv->fullscreen;
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -117,6 +117,7 @@ WPE_API void         wpe_view_set_state                     (WPEView     *view,
                                                              WPEViewState state);
 WPE_API gboolean     wpe_view_fullscreen                    (WPEView     *view);
 WPE_API gboolean     wpe_view_unfullscreen                  (WPEView     *view);
+WPE_API gboolean     wpe_view_is_fullscreen                 (WPEView     *view);
 WPE_API gboolean     wpe_view_render_buffer                 (WPEView     *view,
                                                              WPEBuffer   *buffer,
                                                              GError     **error);


### PR DESCRIPTION
#### 8fdb5d78628e4090403280b035f2e964d320a6a1
<pre>
[wpe][wayland] Opaque region support

<a href="https://bugs.webkit.org/show_bug.cgi?id=267705">https://bugs.webkit.org/show_bug.cgi?id=267705</a>

Reviewed by NOBODY (OOPS!).

Setting the Wayland surface opaque region in fullscreen allows the
compositor to optimize the redrawing of content.

Set only the opaque region for the wl_surface used as output the first
time a wl_buffer is attached, and only once after the surface has been
set fullscreen.

This improves graphics intensive benchmarks.

* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_fullscreen):
(wpe_view_unfullscreen):
(wpe_view_is_fullscreen):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(wpeViewWaylandSetFullscreen):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fdb5d78628e4090403280b035f2e964d320a6a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37285 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31260 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10525 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30233 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11354 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9921 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10007 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38563 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31211 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36067 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10123 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8015 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34020 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11947 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10677 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/10997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->