### PR TITLE
Make more service worker classes ref-counted

### DIFF
--- a/Source/WebCore/workers/service/server/SWServerJobQueue.h
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.h
@@ -78,12 +78,12 @@ private:
     void removeAllJobsMatching(const Function<bool(ServiceWorkerJobData&)>&);
     void scriptAndImportedScriptsFetchFinished(const ServiceWorkerJobData&, SWServerRegistration&);
 
-    CheckedRef<SWServer> checkedServer() const { return m_server; }
+    Ref<SWServer> protectedServer() const { return m_server.get(); }
 
     Deque<ServiceWorkerJobData> m_jobQueue;
 
     Timer m_jobTimer;
-    CheckedRef<SWServer> m_server;
+    WeakRef<SWServer> m_server;
     ServiceWorkerRegistrationKey m_registrationKey;
     WorkerFetchResult m_workerFetchResult;
 };

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
@@ -55,6 +55,11 @@ SWServer* SWServerToContextConnection::server() const
     return m_server.get();
 }
 
+RefPtr<SWServer> SWServerToContextConnection::protectedServer() const
+{
+    return m_server.get();
+}
+
 void SWServerToContextConnection::scriptContextFailedToStart(const std::optional<ServiceWorkerJobDataIdentifier>& jobDataIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, const String& message)
 {
     if (RefPtr worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
@@ -111,7 +116,7 @@ void SWServerToContextConnection::findClientByVisibleIdentifier(ServiceWorkerIde
 void SWServerToContextConnection::claim(ServiceWorkerIdentifier serviceWorkerIdentifier, CompletionHandler<void(std::optional<ExceptionData>&&)>&& callback)
 {
     RefPtr worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier);
-    CheckedPtr server = worker ? worker->server() : nullptr;
+    RefPtr server = worker ? worker->server() : nullptr;
     callback(server ? server->claim(*worker) : std::nullopt);
 }
 
@@ -138,7 +143,7 @@ void SWServerToContextConnection::terminateWhenPossible()
     m_shouldTerminateWhenPossible = true;
 
     bool hasServiceWorkerWithPendingEvents = false;
-    CheckedRef { *server() }->forEachServiceWorker([&](auto& worker) {
+    protectedServer()->forEachServiceWorker([&](auto& worker) {
         if (worker.isRunning() && worker.registrableDomain() == m_registrableDomain && worker.hasPendingEvents()) {
             hasServiceWorkerWithPendingEvents = true;
             return false;

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -56,6 +56,8 @@ public:
     WEBCORE_EXPORT virtual ~SWServerToContextConnection();
 
     WEBCORE_EXPORT SWServer* server() const;
+    WEBCORE_EXPORT RefPtr<SWServer> protectedServer() const;
+
     SWServerToContextConnectionIdentifier identifier() const { return m_identifier; }
 
     // This flag gets set when the service worker process is no longer clean (because it has loaded several eTLD+1s).

--- a/Source/WebCore/workers/service/server/SWServerWorker.h
+++ b/Source/WebCore/workers/service/server/SWServerWorker.h
@@ -162,7 +162,7 @@ private:
     void terminateIfPossible();
     bool shouldBeTerminated() const;
 
-    CheckedPtr<SWServer> checkedServer() const;
+    RefPtr<SWServer> protectedServer() const;
 
     WeakPtr<SWServer> m_server;
     ServiceWorkerRegistrationKey m_registrationKey;

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -528,7 +528,7 @@ Vector<RefPtr<WebCore::BlobDataFileReference>> NetworkConnectionToWebProcess::re
     return files;
 }
 
-std::unique_ptr<ServiceWorkerFetchTask> NetworkConnectionToWebProcess::createFetchTask(NetworkResourceLoader& loader, const ResourceRequest& request)
+RefPtr<ServiceWorkerFetchTask> NetworkConnectionToWebProcess::createFetchTask(NetworkResourceLoader& loader, const ResourceRequest& request)
 {
     auto* swConnection = this->swConnection();
     if (!swConnection)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -199,7 +199,7 @@ public:
 
     void serviceWorkerServerToContextConnectionNoLongerNeeded();
     WebSWServerConnection* swConnection();
-    std::unique_ptr<ServiceWorkerFetchTask> createFetchTask(NetworkResourceLoader&, const WebCore::ResourceRequest&);
+    RefPtr<ServiceWorkerFetchTask> createFetchTask(NetworkResourceLoader&, const WebCore::ResourceRequest&);
     void sharedWorkerServerToContextConnectionIsNoLongerNeeded();
 
     WebSharedWorkerServerConnection* sharedWorkerConnection();

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -310,7 +310,7 @@ private:
     std::unique_ptr<EarlyHintsResourceLoader> m_earlyHintsResourceLoader;
 
     std::optional<NetworkActivityTracker> m_networkActivityTracker;
-    std::unique_ptr<ServiceWorkerFetchTask> m_serviceWorkerFetchTask;
+    RefPtr<ServiceWorkerFetchTask> m_serviceWorkerFetchTask;
     WeakPtr<WebCore::SWServerRegistration> m_serviceWorkerRegistration;
     MonotonicTime m_workerStart;
     NetworkResourceLoadIdentifier m_resourceLoadID;

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -623,7 +623,7 @@ void NetworkSession::removeNavigationPreloaderTask(ServiceWorkerFetchTask& task)
 
 ServiceWorkerFetchTask* NetworkSession::navigationPreloaderTaskFromFetchIdentifier(FetchIdentifier identifier)
 {
-    return m_navigationPreloaders.get(identifier).get();
+    return m_navigationPreloaders.get(identifier);
 }
 
 WebSWOriginStore* NetworkSession::swOriginStore() const
@@ -654,7 +654,7 @@ SWServer& NetworkSession::ensureSWServer()
         // If there's not, then where did this PAL::SessionID come from?
         ASSERT(m_sessionID.isEphemeral() || !path.isEmpty());
         auto inspectable = m_inspectionForServiceWorkersAllowed ? ServiceWorkerIsInspectable::Yes : ServiceWorkerIsInspectable::No;
-        m_swServer = makeUnique<SWServer>(*this, makeUniqueRef<WebSWOriginStore>(), info.processTerminationDelayEnabled, WTFMove(path), m_sessionID, shouldRunServiceWorkersOnMainThreadForTesting(), m_networkProcess->parentProcessHasServiceWorkerEntitlement(), overrideServiceWorkerRegistrationCountTestingValue(), inspectable);
+        m_swServer = SWServer::create(*this, makeUniqueRef<WebSWOriginStore>(), info.processTerminationDelayEnabled, WTFMove(path), m_sessionID, shouldRunServiceWorkersOnMainThreadForTesting(), m_networkProcess->parentProcessHasServiceWorkerEntitlement(), overrideServiceWorkerRegistrationCountTestingValue(), inspectable);
     }
     return *m_swServer;
 }

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -336,14 +336,14 @@ protected:
     bool m_shouldRunServiceWorkersOnMainThreadForTesting { false };
     std::optional<unsigned> m_overrideServiceWorkerRegistrationCountTestingValue;
     HashSet<std::unique_ptr<ServiceWorkerSoftUpdateLoader>> m_softUpdateLoaders;
-    HashMap<WebCore::FetchIdentifier, WeakPtr<ServiceWorkerFetchTask>> m_navigationPreloaders;
+    HashMap<WebCore::FetchIdentifier, WeakRef<ServiceWorkerFetchTask>> m_navigationPreloaders;
 
     struct ServiceWorkerInfo {
         String databasePath;
         bool processTerminationDelayEnabled { true };
     };
     std::optional<ServiceWorkerInfo> m_serviceWorkerInfo;
-    std::unique_ptr<WebCore::SWServer> m_swServer;
+    RefPtr<WebCore::SWServer> m_swServer;
     RefPtr<BackgroundFetchStoreImpl> m_backgroundFetchStore;
     bool m_inspectionForServiceWorkersAllowed { true };
     std::unique_ptr<WebSharedWorkerServer> m_sharedWorkerServer;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -33,7 +33,6 @@
 #include <WebCore/ServiceWorkerTypes.h>
 #include <WebCore/Timer.h>
 #include <pal/SessionID.h>
-#include <wtf/CheckedPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -62,13 +61,13 @@ class ServiceWorkerNavigationPreloader;
 class WebSWServerConnection;
 class WebSWServerToContextConnection;
 
-class ServiceWorkerFetchTask : public CanMakeWeakPtr<ServiceWorkerFetchTask>, public CanMakeCheckedPtr {
+class ServiceWorkerFetchTask : public RefCounted<ServiceWorkerFetchTask>, public CanMakeWeakPtr<ServiceWorkerFetchTask> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<ServiceWorkerFetchTask> fromNavigationPreloader(WebSWServerConnection&, NetworkResourceLoader&, const WebCore::ResourceRequest&, NetworkSession*);
+    static RefPtr<ServiceWorkerFetchTask> fromNavigationPreloader(WebSWServerConnection&, NetworkResourceLoader&, const WebCore::ResourceRequest&, NetworkSession*);
 
-    ServiceWorkerFetchTask(WebSWServerConnection&, NetworkResourceLoader&, WebCore::ResourceRequest&&, WebCore::SWServerConnectionIdentifier, WebCore::ServiceWorkerIdentifier, WebCore::SWServerRegistration&, NetworkSession*, bool isWorkerReady);
-    ServiceWorkerFetchTask(WebSWServerConnection&, NetworkResourceLoader&, std::unique_ptr<ServiceWorkerNavigationPreloader>&&);
+    static Ref<ServiceWorkerFetchTask> create(WebSWServerConnection&, NetworkResourceLoader&, WebCore::ResourceRequest&&, WebCore::SWServerConnectionIdentifier, WebCore::ServiceWorkerIdentifier, WebCore::SWServerRegistration&, NetworkSession*, bool isWorkerReady);
+    static Ref<ServiceWorkerFetchTask> create(WebSWServerConnection&, NetworkResourceLoader&, std::unique_ptr<ServiceWorkerNavigationPreloader>&&);
 
     ~ServiceWorkerFetchTask();
 
@@ -92,6 +91,9 @@ public:
     MonotonicTime startTime() const;
 
 private:
+    ServiceWorkerFetchTask(WebSWServerConnection&, NetworkResourceLoader&, WebCore::ResourceRequest&&, WebCore::SWServerConnectionIdentifier, WebCore::ServiceWorkerIdentifier, WebCore::SWServerRegistration&, NetworkSession*, bool isWorkerReady);
+    ServiceWorkerFetchTask(WebSWServerConnection&, NetworkResourceLoader&, std::unique_ptr<ServiceWorkerNavigationPreloader>&&);
+
     enum class ShouldSetSource : bool { No, Yes };
     void didReceiveRedirectResponse(WebCore::ResourceResponse&&);
     void didReceiveResponse(WebCore::ResourceResponse&&, bool needsContinueDidReceiveResponseMessage);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
@@ -44,7 +44,7 @@ CheckedPtr<NetworkStorageManager> WebSWRegistrationStore::checkedManager() const
     return m_manager.get();
 }
 
-CheckedPtr<WebCore::SWServer> WebSWRegistrationStore::checkedServer() const
+RefPtr<WebCore::SWServer> WebSWRegistrationStore::protectedServer() const
 {
     return m_server.get();
 }
@@ -130,7 +130,7 @@ void WebSWRegistrationStore::updateToStorage(CompletionHandler<void()>&& callbac
 
         auto allScripts = WTFMove(result.value());
         for (auto&& scripts : allScripts)
-            checkedServer()->didSaveWorkerScriptsToDisk(scripts.identifier, WTFMove(scripts.mainScript), WTFMove(scripts.importedScripts));
+            protectedServer()->didSaveWorkerScriptsToDisk(scripts.identifier, WTFMove(scripts.mainScript), WTFMove(scripts.importedScripts));
 
         callback();
     });

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
@@ -56,7 +56,7 @@ private:
     void updateTimerFired() { updateToStorage([] { }); }
 
     CheckedPtr<NetworkStorageManager> checkedManager() const;
-    CheckedPtr<WebCore::SWServer> checkedServer() const;
+    RefPtr<WebCore::SWServer> protectedServer() const;
 
     WeakPtr<WebCore::SWServer> m_server;
     WeakPtr<NetworkStorageManager> m_manager;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -83,7 +83,7 @@ public:
     NetworkSession* session();
     PAL::SessionID sessionID() const;
 
-    std::unique_ptr<ServiceWorkerFetchTask> createFetchTask(NetworkResourceLoader&, const WebCore::ResourceRequest&);
+    RefPtr<ServiceWorkerFetchTask> createFetchTask(NetworkResourceLoader&, const WebCore::ResourceRequest&);
     void fetchTaskTimedOut(WebCore::ServiceWorkerIdentifier);
 
     void transferServiceWorkerLoadToNewWebProcess(NetworkResourceLoader&, WebCore::SWServerRegistration&, WebCore::ProcessIdentifier);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -121,7 +121,7 @@ private:
     void setInspectable(WebCore::ServiceWorkerIsInspectable) final;
 
     WeakRef<NetworkConnectionToWebProcess> m_connection;
-    HashMap<WebCore::FetchIdentifier, WeakPtr<ServiceWorkerFetchTask>> m_ongoingFetches;
+    HashMap<WebCore::FetchIdentifier, WeakRef<ServiceWorkerFetchTask>> m_ongoingFetches;
     HashMap<WebCore::FetchIdentifier, ThreadSafeWeakPtr<ServiceWorkerDownloadTask>> m_ongoingDownloads;
     bool m_isThrottleable { true };
     WebPageProxyIdentifier m_webPageProxyID;


### PR DESCRIPTION
#### 24bcf01c94b38587227ec24c11c1afeccbf415cf
<pre>
Make more service worker classes ref-counted
<a href="https://bugs.webkit.org/show_bug.cgi?id=267707">https://bugs.webkit.org/show_bug.cgi?id=267707</a>

Reviewed by Geoffrey Garen.

I recently did smart adoption of smart pointers in service worker code. In
doing so I had to use CheckedPtr a lot because many of the classes were not
ref-counted and I had no way to &quot;protect&quot; an object before calling a member
function on it. It was then pointed out to me that we could make those classes
ref-counted instead. I gave it a try and I think the code looks a lot safer. It
is also a lot less likely to introduce new crashes (since it decreases the use
of CheckedPtr).

* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::create):
(WebCore::SWServer::activeWorkerFromRegistrationID):
(WebCore::SWServer::getRegistration):
(WebCore::SWServer::addRegistrationFromStore):
(WebCore::SWServer::addRegistration):
(WebCore::SWServer::removeRegistration):
(WebCore::SWServer::getRegistrations):
(WebCore::SWServer::clearAll):
(WebCore::SWServer::clearInternal):
(WebCore::SWServer::Connection::finishFetchingScriptInServer):
(WebCore::SWServer::Connection::didResolveRegistrationPromise):
(WebCore::SWServer::Connection::doRegistrationMatching):
(WebCore::SWServer::Connection::addServiceWorkerRegistrationInServer):
(WebCore::SWServer::Connection::removeServiceWorkerRegistrationInServer):
(WebCore::SWServer::SWServer):
(WebCore::SWServer::validateRegistrationDomain):
(WebCore::SWServer::scheduleJob):
(WebCore::SWServer::startScriptFetch):
(WebCore::SWServer::refreshImportedScripts):
(WebCore::SWServer::terminatePreinstallationWorker):
(WebCore::SWServer::didFinishActivation):
(WebCore::SWServer::claim):
(WebCore::SWServer::addClientServiceWorkerRegistration):
(WebCore::SWServer::removeClientServiceWorkerRegistration):
(WebCore::SWServer::installContextData):
(WebCore::SWServer::runServiceWorkerIfNecessary):
(WebCore::SWServer::removeConnection):
(WebCore::SWServer::doRegistrationMatching):
(WebCore::SWServer::registerServiceWorkerClient):
(WebCore::SWServer::unregisterServiceWorkerClient):
(WebCore::SWServer::Connection::whenRegistrationReady):
(WebCore::SWServer::Connection::storeRegistrationsOnDisk):
(WebCore::SWServer::getAllOrigins):
(WebCore::SWServer::createContextConnection):
(WebCore::SWServer::processPushMessage):
(WebCore::SWServer::processNotificationEvent):
(WebCore::SWServer::fireFunctionalEvent):
(WebCore::SWServer::Connection::startBackgroundFetch):
(WebCore::SWServer::Connection::backgroundFetchInformation):
(WebCore::SWServer::Connection::backgroundFetchIdentifiers):
(WebCore::SWServer::Connection::abortBackgroundFetch):
(WebCore::SWServer::Connection::matchBackgroundFetch):
(WebCore::SWServer::Connection::retrieveRecordResponse):
(WebCore::SWServer::Connection::retrieveRecordResponseBody):
* Source/WebCore/workers/service/server/SWServer.h:
(WebCore::SWServer::Connection::protectedServer const):
(WebCore::SWServer::Connection::doRegistrationMatching): Deleted.
(WebCore::SWServer::Connection::checkedServer const): Deleted.
(WebCore::SWServer::getRegistration): Deleted.
* Source/WebCore/workers/service/server/SWServerJobQueue.cpp:
(WebCore::SWServerJobQueue::scriptFetchFinished):
(WebCore::SWServerJobQueue::importedScriptsFetchFinished):
(WebCore::SWServerJobQueue::scriptAndImportedScriptsFetchFinished):
(WebCore::SWServerJobQueue::scriptContextFailedToStart):
(WebCore::SWServerJobQueue::scriptContextStarted):
(WebCore::SWServerJobQueue::install):
(WebCore::SWServerJobQueue::didResolveRegistrationPromise):
(WebCore::SWServerJobQueue::didFinishInstall):
(WebCore::SWServerJobQueue::runRegisterJob):
(WebCore::SWServerJobQueue::runUnregisterJob):
(WebCore::SWServerJobQueue::runUpdateJob):
(WebCore::SWServerJobQueue::rejectCurrentJob):
* Source/WebCore/workers/service/server/SWServerJobQueue.h:
(WebCore::SWServerJobQueue::protectedServer const):
(WebCore::SWServerJobQueue::checkedServer const): Deleted.
* Source/WebCore/workers/service/server/SWServerRegistration.cpp:
(WebCore::SWServerRegistration::create):
(WebCore::SWServerRegistration::forEachConnection):
(WebCore::SWServerRegistration::notifyClientsOfControllerChange):
(WebCore::SWServerRegistration::clear):
(WebCore::SWServerRegistration::activate):
(WebCore::SWServerRegistration::isUnregistered const):
(WebCore::SWServerRegistration::controlClient):
(WebCore::SWServerRegistration::softUpdate):
(WebCore::SWServerRegistration::enableNavigationPreload):
(WebCore::SWServerRegistration::disableNavigationPreload):
(WebCore::SWServerRegistration::setNavigationPreloadHeaderValue):
* Source/WebCore/workers/service/server/SWServerRegistration.h:
(WebCore::SWServerRegistration::protectedServer const):
(WebCore::SWServerRegistration::checkedServer const): Deleted.
* Source/WebCore/workers/service/server/SWServerToContextConnection.cpp:
(WebCore::SWServerToContextConnection::protectedServer const):
(WebCore::SWServerToContextConnection::claim):
(WebCore::SWServerToContextConnection::terminateWhenPossible):
* Source/WebCore/workers/service/server/SWServerToContextConnection.h:
* Source/WebCore/workers/service/server/SWServerWorker.cpp:
(WebCore::m_lastNavigationWasAppInitiated):
(WebCore::SWServerWorker::protectedServer const):
(WebCore::SWServerWorker::startTermination):
(WebCore::SWServerWorker::contextConnection):
(WebCore::SWServerWorker::scriptContextFailedToStart):
(WebCore::SWServerWorker::scriptContextStarted):
(WebCore::SWServerWorker::didFinishInstall):
(WebCore::SWServerWorker::didFinishActivation):
(WebCore::SWServerWorker::contextTerminated):
(WebCore::SWServerWorker::findClientByIdentifier const):
(WebCore::SWServerWorker::findClientByVisibleIdentifier):
(WebCore::SWServerWorker::matchAll):
(WebCore::SWServerWorker::userAgent const):
(WebCore::SWServerWorker::setHasPendingEvents):
(WebCore::SWServerWorker::setState):
(WebCore::SWServerWorker::workerThreadMode const):
(WebCore::SWServerWorker::shouldBeTerminated const):
(WebCore::SWServerWorker::terminationIfPossibleTimerFired):
(WebCore::SWServerWorker::isClientActiveServiceWorker const):
(WebCore::SWServerWorker::checkedServer const): Deleted.
* Source/WebCore/workers/service/server/SWServerWorker.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::createFetchTask):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::navigationPreloaderTaskFromFetchIdentifier):
(WebKit::NetworkSession::ensureSWServer):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::create):
(WebKit::ServiceWorkerFetchTask::fromNavigationPreloader):
(WebKit::ServiceWorkerFetchTask::ServiceWorkerFetchTask):
(WebKit::ServiceWorkerFetchTask::cannotHandle):
(WebKit::ServiceWorkerFetchTask::softUpdateIfNeeded):
(WebKit::ServiceWorkerFetchTask::loadResponseFromPreloader):
(WebKit::ServiceWorkerFetchTask::loadBodyFromPreloader):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp:
(WebKit::WebSWRegistrationStore::protectedServer const):
(WebKit::WebSWRegistrationStore::updateToStorage):
(WebKit::WebSWRegistrationStore::checkedServer const): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::~WebSWServerConnection):
(WebKit::WebSWServerConnection::createFetchTask):
(WebKit::WebSWServerConnection::startFetch):
(WebKit::WebSWServerConnection::postMessageToServiceWorker):
(WebKit::WebSWServerConnection::scheduleJobInServer):
(WebKit::WebSWServerConnection::clientURLFromIdentifier):
(WebKit::WebSWServerConnection::scheduleUnregisterJobInServer):
(WebKit::WebSWServerConnection::postMessageToServiceWorkerClient):
(WebKit::WebSWServerConnection::matchRegistration):
(WebKit::WebSWServerConnection::getRegistrations):
(WebKit::WebSWServerConnection::registerServiceWorkerClientInternal):
(WebKit::WebSWServerConnection::unregisterServiceWorkerClient):
(WebKit::WebSWServerConnection::computeThrottleState const):
(WebKit::WebSWServerConnection::updateThrottleState):
(WebKit::WebSWServerConnection::subscribeToPushService):
(WebKit::WebSWServerConnection::unsubscribeFromPushService):
(WebKit::WebSWServerConnection::getPushSubscription):
(WebKit::WebSWServerConnection::getPushPermissionState):
(WebKit::WebSWServerConnection::fetchTaskTimedOut):
(WebKit::WebSWServerConnection::enableNavigationPreload):
(WebKit::WebSWServerConnection::disableNavigationPreload):
(WebKit::WebSWServerConnection::setNavigationPreloadHeaderValue):
(WebKit::WebSWServerConnection::getNavigationPreloadState):
(WebKit::WebSWServerConnection::gatherClientData):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::~WebSWServerToContextConnection):
(WebKit::WebSWServerToContextConnection::postMessageToServiceWorkerClient):
(WebKit::WebSWServerToContextConnection::openWindow):
(WebKit::WebSWServerToContextConnection::reportConsoleMessage):
(WebKit::WebSWServerToContextConnection::focus):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:

Canonical link: <a href="https://commits.webkit.org/273187@main">https://commits.webkit.org/273187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c995b805db09307e697e93fe10d34c3eee45a84

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37290 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35742 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10530 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30237 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35125 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9927 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38568 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31419 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/31213 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36073 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34030 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11951 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10681 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4435 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->