### PR TITLE
[WebGPU] Release assert running shader,validation,shader_io,* tests

### DIFF
--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -1118,21 +1118,25 @@ static bool textureFormatAllowedForRetunType(WGPUTextureFormat format, MTLDataTy
 static uint32_t componentsForDataType(MTLDataType dataType)
 {
     switch (dataType) {
+    case MTLDataTypeBool:
     case MTLDataTypeInt:
     case MTLDataTypeUInt:
     case MTLDataTypeHalf:
     case MTLDataTypeFloat:
         return 1;
+    case MTLDataTypeBool2:
     case MTLDataTypeInt2:
     case MTLDataTypeUInt2:
     case MTLDataTypeHalf2:
     case MTLDataTypeFloat2:
         return 2;
+    case MTLDataTypeBool3:
     case MTLDataTypeInt3:
     case MTLDataTypeUInt3:
     case MTLDataTypeHalf3:
     case MTLDataTypeFloat3:
         return 3;
+    case MTLDataTypeBool4:
     case MTLDataTypeInt4:
     case MTLDataTypeUInt4:
     case MTLDataTypeHalf4:

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -277,6 +277,8 @@ static MTLDataType metalDataTypeFromPrimitive(const WGSL::Types::Primitive *prim
             return MTLDataTypeHalf;
         case WGSL::Types::Primitive::F32:
             return MTLDataTypeFloat;
+        case WGSL::Types::Primitive::Bool:
+            return MTLDataTypeBool;
         default:
             RELEASE_ASSERT_NOT_REACHED();
         }
@@ -290,6 +292,8 @@ static MTLDataType metalDataTypeFromPrimitive(const WGSL::Types::Primitive *prim
             return MTLDataTypeHalf2;
         case WGSL::Types::Primitive::F32:
             return MTLDataTypeFloat2;
+        case WGSL::Types::Primitive::Bool:
+            return MTLDataTypeBool2;
         default:
             RELEASE_ASSERT_NOT_REACHED();
         }
@@ -303,6 +307,8 @@ static MTLDataType metalDataTypeFromPrimitive(const WGSL::Types::Primitive *prim
             return MTLDataTypeHalf3;
         case WGSL::Types::Primitive::F32:
             return MTLDataTypeFloat3;
+        case WGSL::Types::Primitive::Bool:
+            return MTLDataTypeBool3;
         default:
             RELEASE_ASSERT_NOT_REACHED();
         }
@@ -316,6 +322,8 @@ static MTLDataType metalDataTypeFromPrimitive(const WGSL::Types::Primitive *prim
             return MTLDataTypeHalf4;
         case WGSL::Types::Primitive::F32:
             return MTLDataTypeFloat4;
+        case WGSL::Types::Primitive::Bool:
+            return MTLDataTypeBool4;
         default:
             RELEASE_ASSERT_NOT_REACHED();
         }


### PR DESCRIPTION
#### c46dee2bb6ab6d0a35dd55a04e3902703dccb294
<pre>
[WebGPU] Release assert running shader,validation,shader_io,* tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=267708">https://bugs.webkit.org/show_bug.cgi?id=267708</a>
&lt;radar://121199735&gt;

Reviewed by Tadeu Zagallo.

Bool types were not supported, add support for them.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::componentsForDataType):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::metalDataTypeFromPrimitive):

Canonical link: <a href="https://commits.webkit.org/273231@main">https://commits.webkit.org/273231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3be6580895fea0a7750690cea3d77d46b2817f8e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37291 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31265 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30238 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30831 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9928 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10036 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38569 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31453 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31212 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36075 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34027 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11952 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7984 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10682 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11002 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->