### PR TITLE
Stop using scan-build to run the clang static analyzer

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -136,6 +136,20 @@ else ifeq ($(WK_LTO_MODE),none)
 CONFIG_OPTIONS += --lto-mode=none
 endif
 
+ANALYZER_XCODE_SETTINGS = RUN_CLANG_STATIC_ANALYZER=YES CLANG_STATIC_ANALYZER_MODE=deep CLANG_ANALYZER_OUTPUT=html
+ifneq (,$(ANALYZER_EXEC))
+	ANALYZER_XCODE_SETTINGS += CLANG_ANALYZER_EXEC="$(ANALYZER_EXEC)"
+endif
+ifneq (,$(ANALYZER_FLAGS))
+	ANALYZER_XCODE_SETTINGS += CLANG_ANALYZER_OTHER_FLAGS="$(ANALYZER_FLAGS)"
+endif
+ifneq (,$(ANALYZER_OUTPUT))
+	ANALYZER_XCODE_SETTINGS += CLANG_ANALYZER_OUTPUT_DIR="$(ANALYZER_OUTPUT)"
+endif
+ifeq (,$(PATH_TO_SCAN_BUILD))
+	PATH_TO_SCAN_BUILD = scan-build
+endif
+
 export DSYMUTIL_NUM_THREADS = $(shell sysctl -n hw.activecpu)
 
 define set_webkit_configuration
@@ -148,40 +162,42 @@ define invoke_xcode
 		echo "===== BUILDING $(BUILD_GOAL) ====="; \
 		echo; \
 		eval build_webkit_options=(`perl -I$(SCRIPTS_PATH) -Mwebkitdirs -e 'print XcodeOptionString()' -- $(BUILD_WEBKIT_BASE) $(BUILD_WEBKIT_OPTIONS)`); \
-		$1 xcodebuild $2 $(OTHER_OPTIONS) $(XCODE_TARGET) "$${build_webkit_options[@]}" $(XCODE_OPTIONS) $3 | $(OUTPUT_FILTER) && exit $${PIPESTATUS[0]} \
+		xcodebuild $1 $(OTHER_OPTIONS) $(XCODE_TARGET) "$${build_webkit_options[@]}" $(XCODE_OPTIONS) $2 | $(OUTPUT_FILTER) && exit $${PIPESTATUS[0]} \
 	)
 endef
 
 all:
 	@$(call set_webkit_configuration,)
-	@$(call invoke_xcode,,,)
+	@$(call invoke_xcode,,)
 
 debug d: force
 	@$(call set_webkit_configuration,--debug)
-	@$(call invoke_xcode,,,)
+	@$(call invoke_xcode,,)
 
 release r: force
 	@$(call set_webkit_configuration,--release)
-	@$(call invoke_xcode,,,)
+	@$(call invoke_xcode,,)
 
 release+assert ra: force
 	@$(call set_webkit_configuration,--release)
-	@$(call invoke_xcode,,,)
+	@$(call invoke_xcode,,)
 release+assert ra: override GCC_PREPROCESSOR_ADDITIONS += ASSERT_ENABLED=1
 
 testing t: force
 	@$(call set_webkit_configuration,--debug --force-optimization-level=O3)
-	@$(call invoke_xcode,,,)
+	@$(call invoke_xcode,,)
 
 analyze:
 	@$(call set_webkit_configuration,--debug)
-	@$(call invoke_xcode,$(PATH_TO_SCAN_BUILD),build analyze,CLANG_STATIC_ANALYZER_MODE=deep)
+	@$(call invoke_xcode,analyze,$(ANALYZER_XCODE_SETTINGS)) || true
+	find $(ANALYZER_OUTPUT) -name 'report-*.html' -exec mv {} $(ANALYZER_OUTPUT)/ \;
+	$(PATH_TO_SCAN_BUILD) --generate-index-only $(ANALYZER_OUTPUT)
 
 clean:
 ifndef XCODE_TARGET
-	@$(call invoke_xcode,,,-alltargets clean)
+	@$(call invoke_xcode,,-alltargets clean)
 else
-	@$(call invoke_xcode,,,clean)
+	@$(call invoke_xcode,,clean)
 endif
 
 installsrc:


### PR DESCRIPTION
#### 9af27cfcc6c049b8ea372fd416d51dd14f4d97c9
<pre>
Stop using scan-build to run the clang static analyzer
<a href="https://bugs.webkit.org/show_bug.cgi?id=267706">https://bugs.webkit.org/show_bug.cgi?id=267706</a>
&lt;<a href="https://rdar.apple.com/121199337">rdar://121199337</a>&gt;

Reviewed by Elliott Williams.

Simplify `make analyze` and fix a couple of problems with it.

- No longer use `scan-build xcodebuild` for analysis. Instead, issue commands
to xcodebuild directly. This seems to eliminate duplicate build and analyze
invocations, as well as make the system much easier to reason about.

- Use `xcodebuild analyze` as opposed to `xcodebuild build analyze`.

- Deduplicate HTML reports by filenames. Which, since recently, uses the
stable &quot;issue hash&quot; rather than random numbers as part of the name, so
it&apos;s the intended way to deduplicate HTML reports across Clang invocations.

- `scan-build` is still used for generating index.html.

In order to use the new `make analyze` you need to specify the variables
PATH_TO_SCAN_BUILD (path to `scan-build`) and ANALYZER_OUTPUT
(path to store HTML files). You can also use the optional variable
ANALYZER_FLAGS to pass extra flags straight to `clang -cc1` (but not
to `scan-build`, so they&apos;re different from the flags you&apos;d previously pass
through PATH_TO_SCAN_BUILD - which no longer works!). There&apos;s also
ANALYZER_EXEC that you can use to substitute a different compiler for
analysis.

* Makefile.shared:
(ANALYZER_XCODE_SETTINGS):
- Holds all analyzer-related switches to pass to `xcodebuild`.
(ANALYZER_OUTPUT):
(ANALYZER_FLAGS):
(ANALYZER_EXEC):
(PATH_TO_SCAN_BUILD):
- Add support for passing these variables on the `make` command-line.
(define invoke_xcode):
- Remove now-unused first argument that used to set environment
  variables when invoking `xcodebuild`.
(analyze):
- De-dupe analyzer results by moving all report-*.html files into a
  single folder.
- Invoke `scan-build` directly to generate an index of results.

Canonical link: <a href="https://commits.webkit.org/273508@main">https://commits.webkit.org/273508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73872cc02d902cc8d7ead40751dd522cf9dfe57f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38072 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31870 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30735 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12043 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10566 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10613 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39318 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/29998 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32105 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36593 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/35219 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10767 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8680 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34616 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12527 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41869 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11291 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8717 "Found 231 new JSC stress test failures: microbenchmarks/array-from-derived-object-func.js.bytecode-cache, microbenchmarks/array-from-derived-object-func.js.default, microbenchmarks/array-from-derived-object-func.js.dfg-eager, microbenchmarks/array-from-derived-object-func.js.dfg-eager-no-cjit-validate, microbenchmarks/array-from-derived-object-func.js.eager-jettison-no-cjit, microbenchmarks/array-from-derived-object-func.js.no-cjit-collect-continuously, microbenchmarks/array-from-derived-object-func.js.no-llint, microbenchmarks/array-from-object-func.js.bytecode-cache, microbenchmarks/array-from-object-func.js.default, microbenchmarks/array-from-object-func.js.dfg-eager ... (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4613 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11584 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->