### PR TITLE
[WGSL] shader,execution,shader_io,compute_builtins:* is failing

### DIFF
--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -61,7 +61,7 @@ private:
     void collectParameters();
     void checkReturnType();
     void constructInputStruct();
-    void materialize(Vector<String>& path, MemberOrParameter&, IsBuiltin);
+    void materialize(Vector<String>& path, MemberOrParameter&, IsBuiltin, const String* builtinName = nullptr);
     void visit(Vector<String>& path, MemberOrParameter&&);
     void appendBuiltins();
 
@@ -76,6 +76,7 @@ private:
     String m_structTypeName;
     String m_structParameterName;
     Reflection::EntryPointInformation& m_information;
+    unsigned m_builtinID { 0 };
 };
 
 EntryPointRewriter::EntryPointRewriter(ShaderModule& shaderModule, const AST::Function& function, ShaderStage stage, Reflection::EntryPointInformation& information)
@@ -250,11 +251,11 @@ void EntryPointRewriter::constructInputStruct()
     m_structType = m_shaderModule.types().structType(structure);
 }
 
-void EntryPointRewriter::materialize(Vector<String>& path, MemberOrParameter& data, IsBuiltin isBuiltin)
+void EntryPointRewriter::materialize(Vector<String>& path, MemberOrParameter& data, IsBuiltin isBuiltin, const String* builtinName)
 {
     AST::Expression::Ptr rhs;
     if (isBuiltin == IsBuiltin::Yes)
-        rhs = &m_shaderModule.astBuilder().construct<AST::IdentifierExpression>(SourceSpan::empty(), AST::Identifier::make(data.name));
+        rhs = &m_shaderModule.astBuilder().construct<AST::IdentifierExpression>(SourceSpan::empty(), AST::Identifier::make(*builtinName));
     else {
         rhs = &m_shaderModule.astBuilder().construct<AST::FieldAccessExpression>(
             SourceSpan::empty(),
@@ -328,16 +329,26 @@ void EntryPointRewriter::visit(Vector<String>& path, MemberOrParameter&& data)
     }
 
     if (builtin.has_value()) {
-        // if path is empty, then it was already a parameter and there's nothing to do
-        if (!path.isEmpty())
-            materialize(path, data, IsBuiltin::Yes);
+        if (!path.isEmpty()) {
+            // builtin was hoisted from a struct into a parameter, we need to reconstruct the struct
+            // ${path}.${data.name} = __builtin${builtinID}
+            // Note that we don't use ${data.name} on the right-hand side because it's the name of a
+            // struct field, and it might not be unique.
+            auto builtinName = makeString("__builtin", String::number(m_builtinID++));
+            materialize(path, data, IsBuiltin::Yes, &builtinName);
+            m_builtins.append({
+                {
+                    AST::Identifier::make(builtinName),
+                    data.type,
+                    data.attributes
+                },
+                *builtin
+            });
+            return;
+        }
 
-        // builtin was hoisted from a struct into a parameter, we need to reconstruct the struct
-        // ${path}.${data.name} = ${data.name}
-        m_builtins.append({
-            data,
-            *builtin
-        });
+        // if path is empty, then it was already a parameter and there's nothing to do
+        m_builtins.append({ data, *builtin });
         return;
     }
 


### PR DESCRIPTION
#### e00eb7be3a35d71e9afbeae7512f10b3b8d5a941
<pre>
[WGSL] shader,execution,shader_io,compute_builtins:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=267717">https://bugs.webkit.org/show_bug.cgi?id=267717</a>
<a href="https://rdar.apple.com/121207920">rdar://121207920</a>

Reviewed by Mike Wyrzykowski.

When rewriting entry points to move builtin arguments from structs into top level
parameters we were using the name of the struct field. However, field names are
only unique within the struct, so when extracting fields from multiple structs they
could clash. In order to fix that we generate a new unique name for the parameter,
instead of using the name of the struct field. This doesn&apos;t affect the rest of the
program, since we reconstruct the struct anyway.

* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::materialize):
(WGSL::EntryPointRewriter::visit):

Canonical link: <a href="https://commits.webkit.org/273219@main">https://commits.webkit.org/273219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/588ae7b571686aab0ceeac0d69801581946a10c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37310 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31282 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30248 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11383 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9943 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10030 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38586 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31442 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36087 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10145 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34041 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11969 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7967 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10698 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11019 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->