### PR TITLE
Add support for WebExtensionAPIWebRequestEvent and filter code

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -512,6 +512,7 @@ $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigation.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigationEvent.idl
+$(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWindows.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWindowsEvent.idl
 $(PROJECT_DIR)/WebProcess/Extensions/WebExtensionContextProxy.messages.in

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -88,6 +88,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigation.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigation.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigationEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigationEvent.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebRequestEvent.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebRequestEvent.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWindows.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWindows.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWindowsEvent.h

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -825,6 +825,7 @@ EXTENSION_INTERFACES = \
     WebExtensionAPIStorageArea \
     WebExtensionAPITabs \
     WebExtensionAPITest \
+    WebExtensionAPIWebRequestEvent \
     WebExtensionAPIWebNavigation \
     WebExtensionAPIWebNavigationEvent \
     WebExtensionAPIWindows \

--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -2224,6 +2224,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionWebRequestFilter {
+    header "_WKWebExtensionWebRequestFilter.h"
+    export *
+  }
+
   explicit module _WKWebExtensionWindow {
     header "_WKWebExtensionWindow.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -3126,6 +3126,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionWebRequestFilter {
+    header "_WKWebExtensionWebRequestFilter.h"
+    export *
+  }
+
   explicit module _WKWebExtensionWindow {
     header "_WKWebExtensionWindow.h"
     export *

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -917,6 +917,11 @@
 		3343C3262B21140C00AD10A6 /* _WKWebExtensionDeclarativeNetRequestSQLiteStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 3343C3242B21140C00AD10A6 /* _WKWebExtensionDeclarativeNetRequestSQLiteStore.h */; };
 		3343C3272B21140C00AD10A6 /* _WKWebExtensionDeclarativeNetRequestSQLiteStore.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3343C3252B21140C00AD10A6 /* _WKWebExtensionDeclarativeNetRequestSQLiteStore.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		335698F62B19307700C7FEE4 /* WebExtensionConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 335698F52B19307700C7FEE4 /* WebExtensionConstants.h */; };
+		337042022B58A0B70077FF78 /* JSWebExtensionAPIWebRequestEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 337042002B58A0880077FF78 /* JSWebExtensionAPIWebRequestEvent.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		337042042B58A2430077FF78 /* WebExtensionAPIWebRequestEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 337042032B58A2430077FF78 /* WebExtensionAPIWebRequestEvent.h */; };
+		337042062B58A2550077FF78 /* WebExtensionAPIWebRequestEventCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 337042052B58A2550077FF78 /* WebExtensionAPIWebRequestEventCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		337042092B58A8390077FF78 /* _WKWebExtensionWebRequestFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 337042072B58A8390077FF78 /* _WKWebExtensionWebRequestFilter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3370420A2B58A8390077FF78 /* _WKWebExtensionWebRequestFilter.mm in Sources */ = {isa = PBXBuildFile; fileRef = 337042082B58A8390077FF78 /* _WKWebExtensionWebRequestFilter.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		3375A37129429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3375A37029429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		3375A37529429DF50028536D /* WebExtensionAPIWebNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = 3375A37329429DF50028536D /* WebExtensionAPIWebNavigation.h */; };
 		3375A3772942A19D0028536D /* JSWebExtensionAPIWebNavigation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3375A3762942A19C0028536D /* JSWebExtensionAPIWebNavigation.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -4730,6 +4735,13 @@
 		3343C3242B21140C00AD10A6 /* _WKWebExtensionDeclarativeNetRequestSQLiteStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionDeclarativeNetRequestSQLiteStore.h; sourceTree = "<group>"; };
 		3343C3252B21140C00AD10A6 /* _WKWebExtensionDeclarativeNetRequestSQLiteStore.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionDeclarativeNetRequestSQLiteStore.mm; sourceTree = "<group>"; };
 		335698F52B19307700C7FEE4 /* WebExtensionConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionConstants.h; sourceTree = "<group>"; };
+		337041FF2B5895C00077FF78 /* WebExtensionAPIWebRequestEvent.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIWebRequestEvent.idl; sourceTree = "<group>"; };
+		337042002B58A0880077FF78 /* JSWebExtensionAPIWebRequestEvent.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIWebRequestEvent.mm; sourceTree = "<group>"; };
+		337042012B58A0880077FF78 /* JSWebExtensionAPIWebRequestEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIWebRequestEvent.h; sourceTree = "<group>"; };
+		337042032B58A2430077FF78 /* WebExtensionAPIWebRequestEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIWebRequestEvent.h; sourceTree = "<group>"; };
+		337042052B58A2550077FF78 /* WebExtensionAPIWebRequestEventCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIWebRequestEventCocoa.mm; sourceTree = "<group>"; };
+		337042072B58A8390077FF78 /* _WKWebExtensionWebRequestFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionWebRequestFilter.h; sourceTree = "<group>"; };
+		337042082B58A8390077FF78 /* _WKWebExtensionWebRequestFilter.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionWebRequestFilter.mm; sourceTree = "<group>"; };
 		3375A37029429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIWebNavigationCocoa.mm; sourceTree = "<group>"; };
 		3375A37329429DF50028536D /* WebExtensionAPIWebNavigation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIWebNavigation.h; sourceTree = "<group>"; };
 		3375A3762942A19C0028536D /* JSWebExtensionAPIWebNavigation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIWebNavigation.mm; sourceTree = "<group>"; };
@@ -9252,6 +9264,8 @@
 			children = (
 				337822422947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.h */,
 				337822412947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.mm */,
+				337042072B58A8390077FF78 /* _WKWebExtensionWebRequestFilter.h */,
+				337042082B58A8390077FF78 /* _WKWebExtensionWebRequestFilter.mm */,
 				330A30E42951112200F84419 /* WebExtensionContextProxyCocoa.mm */,
 				1C3D0AC0291AE6200093F67E /* WebExtensionControllerProxyCocoa.mm */,
 			);
@@ -9284,6 +9298,7 @@
 				1C15497B2926BF6F001B9E5B /* WebExtensionAPITest.h */,
 				3375A37329429DF50028536D /* WebExtensionAPIWebNavigation.h */,
 				33F6833D293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h */,
+				337042032B58A2430077FF78 /* WebExtensionAPIWebRequestEvent.h */,
 				1C5ACFAF2A96F9F200C041C0 /* WebExtensionAPIWindows.h */,
 				1C5ACFB12A96FA0000C041C0 /* WebExtensionAPIWindowsEvent.h */,
 			);
@@ -9314,6 +9329,7 @@
 				1C1549792926BF02001B9E5B /* WebExtensionAPITestCocoa.mm */,
 				3375A37029429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm */,
 				33F6833F293FFB3F005C63C0 /* WebExtensionAPIWebNavigationEventCocoa.mm */,
+				337042052B58A2550077FF78 /* WebExtensionAPIWebRequestEventCocoa.mm */,
 				1C5ACFB72A96FA3200C041C0 /* WebExtensionAPIWindowsCocoa.mm */,
 				1C5ACFB32A96FA1900C041C0 /* WebExtensionAPIWindowsEventCocoa.mm */,
 			);
@@ -9482,6 +9498,7 @@
 				1CDA62A02925DA3700D90390 /* WebExtensionAPITest.idl */,
 				33066F09293A90DC008C5749 /* WebExtensionAPIWebNavigation.idl */,
 				3302293F2938263E001F00FA /* WebExtensionAPIWebNavigationEvent.idl */,
+				337041FF2B5895C00077FF78 /* WebExtensionAPIWebRequestEvent.idl */,
 				1C5ACF9E2A96E15400C041C0 /* WebExtensionAPIWindows.idl */,
 				1C5ACF9D2A96E15400C041C0 /* WebExtensionAPIWindowsEvent.idl */,
 			);
@@ -14352,6 +14369,8 @@
 				3375A3762942A19C0028536D /* JSWebExtensionAPIWebNavigation.mm */,
 				33F68335293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.h */,
 				33F68336293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.mm */,
+				337042012B58A0880077FF78 /* JSWebExtensionAPIWebRequestEvent.h */,
+				337042002B58A0880077FF78 /* JSWebExtensionAPIWebRequestEvent.mm */,
 				1C5ACFA12A96F8C200C041C0 /* JSWebExtensionAPIWindows.h */,
 				1C5ACFA22A96F8C300C041C0 /* JSWebExtensionAPIWindows.mm */,
 				1C5ACFA42A96F8C300C041C0 /* JSWebExtensionAPIWindowsEvent.h */,
@@ -15237,6 +15256,7 @@
 				1C5ACF912A955CB000C041C0 /* _WKWebExtensionTabCreationOptions.h in Headers */,
 				1C5ACF932A965C4000C041C0 /* _WKWebExtensionTabCreationOptionsInternal.h in Headers */,
 				337822442947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.h in Headers */,
+				337042092B58A8390077FF78 /* _WKWebExtensionWebRequestFilter.h in Headers */,
 				1C049841289AFF9B0010308B /* _WKWebExtensionWindow.h in Headers */,
 				1C5ACF8C2A955CA700C041C0 /* _WKWebExtensionWindowCreationOptions.h in Headers */,
 				1C5ACF952A965C4C00C041C0 /* _WKWebExtensionWindowCreationOptionsInternal.h in Headers */,
@@ -16053,6 +16073,7 @@
 				1C15497C2926BF75001B9E5B /* WebExtensionAPITest.h in Headers */,
 				3375A37529429DF50028536D /* WebExtensionAPIWebNavigation.h in Headers */,
 				33F6833E293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h in Headers */,
+				337042042B58A2430077FF78 /* WebExtensionAPIWebRequestEvent.h in Headers */,
 				1C5ACFB02A96F9F200C041C0 /* WebExtensionAPIWindows.h in Headers */,
 				1C5ACFB22A96FA0000C041C0 /* WebExtensionAPIWindowsEvent.h in Headers */,
 				1C974FE52AFAD137009DE8FC /* WebExtensionCommand.h in Headers */,
@@ -18315,6 +18336,7 @@
 				B6A292352B18FCF30061930E /* _WKWebExtensionSQLiteStore.mm in Sources */,
 				1C5ACF902A955CB000C041C0 /* _WKWebExtensionTabCreationOptions.mm in Sources */,
 				337822432947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.mm in Sources */,
+				3370420A2B58A8390077FF78 /* _WKWebExtensionWebRequestFilter.mm in Sources */,
 				1C5ACF8D2A955CA700C041C0 /* _WKWebExtensionWindowCreationOptions.mm in Sources */,
 				07E4BDC82A3A7089000D5509 /* _WKWebViewTextInputNotifications.mm in Sources */,
 				572EBBDA2538F6B4000552B3 /* AppAttestInternalSoftLink.mm in Sources */,
@@ -18373,6 +18395,7 @@
 				1C15497F2926C073001B9E5B /* JSWebExtensionAPITest.mm in Sources */,
 				3375A3772942A19D0028536D /* JSWebExtensionAPIWebNavigation.mm in Sources */,
 				33F68338293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.mm in Sources */,
+				337042022B58A0B70077FF78 /* JSWebExtensionAPIWebRequestEvent.mm in Sources */,
 				1C5ACFA62A96F8C400C041C0 /* JSWebExtensionAPIWindows.mm in Sources */,
 				1C5ACFA72A96F8C400C041C0 /* JSWebExtensionAPIWindowsEvent.mm in Sources */,
 				1C5DC45F2909B05A0061EC62 /* JSWebExtensionWrapperCocoa.mm in Sources */,
@@ -18713,6 +18736,7 @@
 				1C15497A2926BF03001B9E5B /* WebExtensionAPITestCocoa.mm in Sources */,
 				3375A37129429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm in Sources */,
 				33F68340293FFB3F005C63C0 /* WebExtensionAPIWebNavigationEventCocoa.mm in Sources */,
+				337042062B58A2550077FF78 /* WebExtensionAPIWebRequestEventCocoa.mm in Sources */,
 				1C5ACFB82A96FA3200C041C0 /* WebExtensionAPIWindowsCocoa.mm in Sources */,
 				1C5ACFB42A96FA1900C041C0 /* WebExtensionAPIWindowsEventCocoa.mm in Sources */,
 				1C627478288A1E1D00CED3A2 /* WebExtensionCocoa.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionAPIWebRequestEvent.h"
+
+#import "MessageSenderInlines.h"
+#import "WebExtensionContextMessages.h"
+#import "WebPageProxy.h"
+#import "WebProcess.h"
+#import "_WKWebExtensionWebRequestFilter.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+namespace WebKit {
+
+void WebExtensionAPIWebRequestEvent::addListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener, NSDictionary *filter, id extraInfoSpec, NSString **outExceptionString)
+{
+    ASSERT(page);
+
+    _WKWebExtensionWebRequestFilter *parsedFilter;
+    if (filter) {
+        parsedFilter = [[_WKWebExtensionWebRequestFilter alloc] initWithDictionary:filter outErrorMessage:outExceptionString];
+        if (!parsedFilter)
+            return;
+    }
+
+    m_pageProxyIdentifier = page->webPageProxyIdentifier();
+    m_listeners.append({ listener, parsedFilter });
+
+    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(m_pageProxyIdentifier, m_type, contentWorldType()), extensionContext().identifier());
+}
+
+void WebExtensionAPIWebRequestEvent::removeListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener)
+{
+    ASSERT(page);
+
+    auto removedCount = m_listeners.removeAllMatching([&](auto& entry) {
+        return entry.first->callbackFunction() == listener->callbackFunction();
+    });
+
+    if (!removedCount)
+        return;
+
+    ASSERT(page->webPageProxyIdentifier() == m_pageProxyIdentifier);
+
+    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(m_pageProxyIdentifier, m_type, contentWorldType(), removedCount), extensionContext().identifier());
+}
+
+bool WebExtensionAPIWebRequestEvent::hasListener(RefPtr<WebExtensionCallbackHandler> listener)
+{
+    return m_listeners.containsIf([&](auto& entry) {
+        return entry.first->callbackFunction() == listener->callbackFunction();
+    });
+}
+
+void WebExtensionAPIWebRequestEvent::removeAllListeners()
+{
+    if (m_listeners.isEmpty())
+        return;
+
+    WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(m_pageProxyIdentifier, m_type, contentWorldType(), m_listeners.size()), extensionContext().identifier());
+
+    m_listeners.clear();
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "JSWebExtensionAPIWebRequestEvent.h"
+#include "JSWebExtensionWrappable.h"
+#include "WebExtensionAPIObject.h"
+#include "WebExtensionEventListenerType.h"
+#include "WebPage.h"
+
+OBJC_CLASS JSValue;
+OBJC_CLASS NSDictionary;
+OBJC_CLASS NSString;
+OBJC_CLASS NSURL;
+OBJC_CLASS _WKWebExtensionWebRequestFilter;
+
+namespace WebKit {
+
+class WebExtensionAPIWebRequestEvent : public WebExtensionAPIObject, public JSWebExtensionWrappable {
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebRequestEvent, webRequestEvent);
+
+public:
+    using FilterAndCallbackPair = std::pair<RefPtr<WebExtensionCallbackHandler>, RetainPtr<_WKWebExtensionWebRequestFilter>>;
+    using ListenerVector = Vector<FilterAndCallbackPair>;
+
+    const ListenerVector& listeners() const { return m_listeners; }
+
+    void addListener(WebPage*, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, id extraInfoSpec, NSString **outExceptionString);
+    void removeListener(WebPage*, RefPtr<WebExtensionCallbackHandler>);
+    bool hasListener(RefPtr<WebExtensionCallbackHandler>);
+
+    void removeAllListeners();
+
+    virtual ~WebExtensionAPIWebRequestEvent()
+    {
+        removeAllListeners();
+    }
+
+private:
+    explicit WebExtensionAPIWebRequestEvent(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionEventListenerType type)
+        : WebExtensionAPIObject(forMainWorld, runtime, context)
+        , m_type(type)
+    {
+    }
+
+    WebPageProxyIdentifier m_pageProxyIdentifier;
+    WebExtensionEventListenerType m_type;
+    ListenerVector m_listeners;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.h
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.h
@@ -1,0 +1,41 @@
+// Copyright © 2020 Apple Inc. All rights reserved.
+
+#import <WebKit/WKFoundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class _WKResourceLoadInfo;
+
+// https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType
+typedef NS_ENUM(NSInteger, _WKWebExtensionWebRequestResourceType) {
+    _WKWebExtensionWebRequestResourceTypeMainFrame,
+    _WKWebExtensionWebRequestResourceTypeSubframe,
+    _WKWebExtensionWebRequestResourceTypeStylesheet,
+    _WKWebExtensionWebRequestResourceTypeScript,
+    _WKWebExtensionWebRequestResourceTypeImage,
+    _WKWebExtensionWebRequestResourceTypeFont,
+    _WKWebExtensionWebRequestResourceTypeObject,
+    _WKWebExtensionWebRequestResourceTypeXMLHTTPRequest,
+    _WKWebExtensionWebRequestResourceTypePing,
+    _WKWebExtensionWebRequestResourceTypeCSPReport,
+    _WKWebExtensionWebRequestResourceTypeMedia,
+    _WKWebExtensionWebRequestResourceTypeWebsocket,
+    _WKWebExtensionWebRequestResourceTypeApplicationManifest,
+    _WKWebExtensionWebRequestResourceTypeXSLT,
+    _WKWebExtensionWebRequestResourceTypeBeacon,
+    _WKWebExtensionWebRequestResourceTypeOther,
+};
+
+WK_EXTERN _WKWebExtensionWebRequestResourceType _WKWebExtensionWebRequestResourceTypeFromWKResourceLoadInfo(_WKResourceLoadInfo *);
+
+// https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/RequestFilter
+WK_EXTERN
+@interface _WKWebExtensionWebRequestFilter : NSObject
+
+- (nullable instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dictionary outErrorMessage:(NSString * _Nullable * _Nonnull)outErrorMessage;
+
+- (BOOL)matchesRequestForResourceOfType:(_WKWebExtensionWebRequestResourceType)resourceType URL:(NSURL *)URL tabID:(double)tabID windowID:(double)windowID;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm
@@ -1,0 +1,248 @@
+// Copyright © 2020 Apple Inc. All rights reserved.
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#if ENABLE(WK_WEB_EXTENSIONS)
+#import "_WKWebExtensionWebRequestFilter.h"
+
+#import "CocoaHelpers.h"
+#import "WebExtensionTabIdentifier.h"
+#import "WebExtensionUtilities.h"
+#import "WebExtensionWindowIdentifier.h"
+#import "_WKResourceLoadInfo.h"
+#import "_WKWebExtensionMatchPattern.h"
+
+using namespace WebKit;
+
+static NSString *urlsKey = @"urls";
+static NSString *typesKey = @"types";
+
+static NSString *tabIdKey = @"tabId";
+static NSString *windowIdKey = @"windowId";
+
+_WKWebExtensionWebRequestResourceType _WKWebExtensionWebRequestResourceTypeFromWKResourceLoadInfo(_WKResourceLoadInfo *resourceLoadInfo)
+{
+    switch (resourceLoadInfo.resourceType) {
+    case _WKResourceLoadInfoResourceTypeDocument:
+        return resourceLoadInfo.parentFrame ? _WKWebExtensionWebRequestResourceTypeMainFrame : _WKWebExtensionWebRequestResourceTypeSubframe;
+    case _WKResourceLoadInfoResourceTypeStylesheet:
+        return _WKWebExtensionWebRequestResourceTypeStylesheet;
+    case _WKResourceLoadInfoResourceTypeScript:
+        return _WKWebExtensionWebRequestResourceTypeScript;
+    case _WKResourceLoadInfoResourceTypeImage:
+        return _WKWebExtensionWebRequestResourceTypeImage;
+    case _WKResourceLoadInfoResourceTypeFont:
+        return _WKWebExtensionWebRequestResourceTypeFont;
+    case _WKResourceLoadInfoResourceTypeObject:
+        return _WKWebExtensionWebRequestResourceTypeObject;
+    case _WKResourceLoadInfoResourceTypeFetch:
+    case _WKResourceLoadInfoResourceTypeXMLHTTPRequest:
+        return _WKWebExtensionWebRequestResourceTypeXMLHTTPRequest;
+    case _WKResourceLoadInfoResourceTypeCSPReport:
+        return _WKWebExtensionWebRequestResourceTypeCSPReport;
+    case _WKResourceLoadInfoResourceTypeMedia:
+        return _WKWebExtensionWebRequestResourceTypeMedia;
+    case _WKResourceLoadInfoResourceTypeApplicationManifest:
+        return _WKWebExtensionWebRequestResourceTypeApplicationManifest;
+    case _WKResourceLoadInfoResourceTypeXSLT:
+        return _WKWebExtensionWebRequestResourceTypeXSLT;
+    case _WKResourceLoadInfoResourceTypePing:
+        return _WKWebExtensionWebRequestResourceTypePing;
+    case _WKResourceLoadInfoResourceTypeBeacon:
+        return _WKWebExtensionWebRequestResourceTypeBeacon;
+    case _WKResourceLoadInfoResourceTypeOther:
+        return _WKWebExtensionWebRequestResourceTypeOther;
+    }
+
+    ASSERT_NOT_REACHED();
+    return _WKWebExtensionWebRequestResourceTypeOther;
+}
+
+@implementation _WKWebExtensionWebRequestFilter {
+    std::optional<WebExtensionTabIdentifier> _tabID;
+    std::optional<WebExtensionWindowIdentifier> _windowID;
+    NSArray<_WKWebExtensionMatchPattern *> *_urlPatterns;
+    NSSet<NSNumber *> *_types;
+}
+
+- (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dictionary outErrorMessage:(NSString **)outErrorMessage
+{
+    if (!(self = [super init])) {
+        *outErrorMessage = @"Runtime failure.";
+        return nil;
+    }
+
+    static NSArray<NSString *> *requiredKeys = @[
+        urlsKey,
+    ];
+
+    static NSDictionary<NSString *, id> *expectedTypes = @{
+        urlsKey: @[ NSString.class ],
+        typesKey: NSArray.class,
+        tabIdKey: NSNumber.class,
+        windowIdKey: NSNumber.class,
+    };
+
+    if (!validateDictionary(dictionary, nil, requiredKeys, expectedTypes, outErrorMessage))
+        return nil;
+
+    if ((*outErrorMessage = [self _initializeWithDictionary:dictionary]))
+        return nil;
+
+    return self;
+}
+
+static NSArray<_WKWebExtensionMatchPattern *> *toMatchPatterns(NSArray<NSString *> *value, NSString **outErrorMessage)
+{
+    if (!value.count)
+        return nil;
+
+    NSError *error;
+
+    NSMutableArray<_WKWebExtensionMatchPattern *> *patterns = [[NSMutableArray alloc] init];
+    for (NSString *rawPattern in value) {
+        _WKWebExtensionMatchPattern *pattern = [[_WKWebExtensionMatchPattern alloc] initWithString:rawPattern error:&error];
+        if (!pattern) {
+            if (outErrorMessage)
+                *outErrorMessage = toErrorString(nil, urlsKey, @"'%@' is an invalid match pattern. %@", rawPattern, error.userInfo[NSDebugDescriptionErrorKey]);
+            return nil;
+        }
+        [patterns addObject:pattern];
+    }
+
+    return patterns;
+}
+
+static NSNumber *toResourceType(NSString *typeString, NSString **outErrorMessage)
+{
+    static NSDictionary<NSString *, NSNumber *> *validTypes = @{
+        @"main_frame": @(_WKWebExtensionWebRequestResourceTypeMainFrame),
+        @"sub_frame": @(_WKWebExtensionWebRequestResourceTypeSubframe),
+        @"stylesheet": @(_WKWebExtensionWebRequestResourceTypeStylesheet),
+        @"script": @(_WKWebExtensionWebRequestResourceTypeScript),
+        @"image": @(_WKWebExtensionWebRequestResourceTypeImage),
+        @"font": @(_WKWebExtensionWebRequestResourceTypeFont),
+        @"object": @(_WKWebExtensionWebRequestResourceTypeObject),
+        @"xmlhttprequest": @(_WKWebExtensionWebRequestResourceTypeXMLHTTPRequest),
+        @"ping": @(_WKWebExtensionWebRequestResourceTypePing),
+        @"csp_report": @(_WKWebExtensionWebRequestResourceTypeCSPReport),
+        @"media": @(_WKWebExtensionWebRequestResourceTypeMedia),
+        @"websocket": @(_WKWebExtensionWebRequestResourceTypeWebsocket),
+        @"web_manifest": @(_WKWebExtensionWebRequestResourceTypeApplicationManifest),
+        @"xslt": @(_WKWebExtensionWebRequestResourceTypeXSLT),
+        @"beacon": @(_WKWebExtensionWebRequestResourceTypeBeacon),
+        @"other": @(_WKWebExtensionWebRequestResourceTypeOther),
+    };
+
+    NSNumber *typeAsNumber = validTypes[typeString];
+    if (!typeAsNumber) {
+        *outErrorMessage = toErrorString(nil, typesKey, @"'%@' is an unknown resource type", typeString);
+        return nil;
+    }
+
+    return typeAsNumber;
+}
+
+static NSSet<NSNumber *> *toResourceTypes(NSArray<NSString *> *rawTypes, NSString **outErrorMessage)
+{
+    if (!rawTypes.count)
+        return nil;
+
+    NSMutableSet<NSNumber *> *types = [[NSMutableSet alloc] init];
+    for (NSString *rawType in rawTypes) {
+        NSNumber *type = toResourceType(rawType, outErrorMessage);
+        if (!type)
+            return nil;
+        [types addObject:type];
+    }
+
+    return types;
+}
+
+static std::optional<WebExtensionTabIdentifier> toTabID(NSNumber *rawValue)
+{
+    if (!rawValue)
+        return std::nullopt;
+
+    return toWebExtensionTabIdentifier(rawValue.doubleValue);
+}
+
+static std::optional<WebExtensionWindowIdentifier> toWindowID(NSNumber *rawValue)
+{
+    if (!rawValue)
+        return std::nullopt;
+
+    return toWebExtensionWindowIdentifier(rawValue.doubleValue);
+}
+
+- (NSString *)_initializeWithDictionary:(NSDictionary<NSString *, id> *)dictionary
+{
+    NSString *errorMessage;
+    _urlPatterns = toMatchPatterns(dictionary[urlsKey], &errorMessage);
+    if (errorMessage)
+        return errorMessage;
+
+    _types = toResourceTypes(dictionary[typesKey], &errorMessage);
+    if (errorMessage)
+        return errorMessage;
+
+    _tabID = toTabID(dictionary[tabIdKey]);
+    _windowID = toWindowID(dictionary[windowIdKey]);
+
+    return nil;
+}
+
+- (BOOL)matchesRequestForResourceOfType:(_WKWebExtensionWebRequestResourceType)resourceType URL:(NSURL *)URL tabID:(double)tabID windowID:(double)windowID
+{
+    if (_types && ![_types containsObject:@(resourceType)])
+        return NO;
+
+    if (_urlPatterns) {
+        BOOL hasURLMatch = NO;
+        for (_WKWebExtensionMatchPattern *pattern in _urlPatterns) {
+            if ([pattern matchesURL:URL]) {
+                hasURLMatch = YES;
+                break;
+            }
+        }
+
+        if (!hasURLMatch)
+            return NO;
+    }
+
+    if (isValid(_tabID) && toWebAPI(_tabID.value()) != tabID)
+        return NO;
+
+    if (isValid(_windowID) && toWebAPI(_windowID.value()) != windowID)
+        return NO;
+
+    return YES;
+}
+
+@end
+
+#else
+
+@implementation _WKWebExtensionWebRequestFilter
+
+- (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dictionary outErrorMessage:(NSString **)outErrorMessage
+{
+    return nil;
+}
+
+- (BOOL)matchesRequestForResourceOfType:(_WKWebExtensionWebRequestResourceType)resourceType URL:(NSURL *)URL tabID:(double)tabID windowID:(double)windowID
+{
+    return NO;
+}
+
+_WKWebExtensionWebRequestResourceType _WKWebExtensionWebRequestResourceTypeFromWKResourceLoadInfo(_WKResourceLoadInfo *resourceLoadInfo)
+{
+    return _WKWebExtensionWebRequestResourceTypeOther;
+}
+
+@end
+
+#endif // ENABLE(WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WK_WEB_EXTENSIONS,
+    MainWorldOnly,
+] interface WebExtensionAPIWebRequestEvent {
+
+    [NeedsPage, RaisesException] void addListener([CallbackHandler] function listener, [NSDictionary, Optional] any filter, [Optional] any extraInfoSpec);
+    [NeedsPage] void removeListener([CallbackHandler] function listener);
+    boolean hasListener([CallbackHandler] function listener);
+
+};

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -304,6 +304,7 @@ Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
 Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
 Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
 Tests/WebKitCocoa/WKWebExtensionAPIWebNavigation.mm
+Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm
 Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm
 Tests/WebKitCocoa/WKWebExtensionContext.mm
 Tests/WebKitCocoa/WKWebExtensionController.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -2274,6 +2274,7 @@
 		31F865E526701E73003BFC6D /* CoreCryptoSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreCryptoSPI.h; sourceTree = "<group>"; };
 		3302A64D2A11B4410093FA2A /* DragAndDropSimulator.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; name = DragAndDropSimulator.mm; path = cocoa/DragAndDropSimulator.mm; sourceTree = "<group>"; };
 		330E135E2943C92000367438 /* WKWebExtensionAPINamespace.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPINamespace.mm; sourceTree = "<group>"; };
+		3310E2FB2B599E93003692A8 /* WKWebExtensionAPIWebRequest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIWebRequest.mm; sourceTree = "<group>"; };
 		333B9CE11277F23100FEFCE3 /* PreventEmptyUserAgent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PreventEmptyUserAgent.cpp; sourceTree = "<group>"; };
 		3378222C2947C095002106BB /* WKWebExtensionAPIWebNavigation.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIWebNavigation.mm; sourceTree = "<group>"; };
 		33976D8224DC479B00812304 /* IndexSparseSet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IndexSparseSet.cpp; sourceTree = "<group>"; };
@@ -4274,6 +4275,7 @@
 				B626B7C42B4F4DEE008E8DD1 /* WKWebExtensionAPIStorage.mm */,
 				1CF7FFA72AA7C302003609F0 /* WKWebExtensionAPITabs.mm */,
 				3378222C2947C095002106BB /* WKWebExtensionAPIWebNavigation.mm */,
+				3310E2FB2B599E93003692A8 /* WKWebExtensionAPIWebRequest.mm */,
 				1C9A2E182A9FB6F400D1B4A5 /* WKWebExtensionAPIWindows.mm */,
 				1CBEE26228F47FA9006D1A02 /* WKWebExtensionContext.mm */,
 				1CAB9B7128F5E08900E6C77E /* WKWebExtensionController.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import <WebKit/_WKWebExtensionWebRequestFilter.h>
+
+namespace TestWebKitAPI {
+
+TEST(WKWebExtensionAPIWebRequest, Initialization)
+{
+    NSString *error;
+    _WKWebExtensionWebRequestFilter *filter;
+
+    filter = [[_WKWebExtensionWebRequestFilter alloc] initWithDictionary:@{
+        @"urls": @[ @"http://foo.com/*", @"http://bar.org/*" ]
+    } outErrorMessage:&error];
+    EXPECT_NOT_NULL(filter);
+    EXPECT_NULL(error);
+
+    filter = [[_WKWebExtensionWebRequestFilter alloc] initWithDictionary:@{
+        @"urls": @[ @"http://foo.com/*", @"http://bar.org/*" ],
+        @"types": @[ @"main_frame", @"sub_frame" ],
+        @"tabId": @123
+    } outErrorMessage:&error];
+    EXPECT_NOT_NULL(filter);
+    EXPECT_NULL(error);
+
+    filter = [[_WKWebExtensionWebRequestFilter alloc] initWithDictionary:@{
+        @"urls": @[ @"http://foo.com/*", @"http://bar.org/*" ],
+        @"types": @[ @"main_frame", @"sub_frame" ],
+        @"windowId": @123
+    } outErrorMessage:&error];
+    EXPECT_NOT_NULL(filter);
+    EXPECT_NULL(error);
+
+    filter = [[_WKWebExtensionWebRequestFilter alloc] initWithDictionary:@{
+        @"urls": @[ @"http://has.both.a.tab.id.and.window.id.com/*" ],
+        @"types": @[ @"main_frame", @"sub_frame" ],
+        @"windowId": @123,
+        @"tabId": @9001
+    } outErrorMessage:&error];
+    EXPECT_NOT_NULL(filter);
+    EXPECT_NULL(error);
+
+    filter = [[_WKWebExtensionWebRequestFilter alloc] initWithDictionary:@{
+        @"urls": @[ ],
+    } outErrorMessage:&error];
+    EXPECT_NOT_NULL(filter);
+    EXPECT_NULL(error);
+
+    filter = [[_WKWebExtensionWebRequestFilter alloc] initWithDictionary:@{
+        @"urls": @[ @"http://foo.com/*", @3 ],
+    } outErrorMessage:&error];
+    EXPECT_NULL(filter);
+    EXPECT_NS_EQUAL(error, @"'urls' is expected to be an array of strings, but a number was provided in the array");
+
+    filter = [[_WKWebExtensionWebRequestFilter alloc] initWithDictionary:@{
+        @"urls": @[ @"$" ]
+    } outErrorMessage:&error];
+    EXPECT_NULL(filter);
+
+    // FIXME: We shouldn't be generating an error message with two periods.
+    EXPECT_NS_EQUAL(error, @"The 'urls' value is invalid, because '$' is an invalid match pattern. \"$\" cannot be parsed because it doesn't have a scheme..");
+}
+
+static _WKWebExtensionWebRequestFilter *filterWithDictionary(NSDictionary *dictionary)
+{
+    NSString *error;
+    _WKWebExtensionWebRequestFilter *filter = [[_WKWebExtensionWebRequestFilter alloc] initWithDictionary:dictionary outErrorMessage:&error];
+    EXPECT_NOT_NULL(filter);
+    EXPECT_NULL(error);
+
+    return filter;
+}
+
+TEST(WKWebExtensionAPIWebRequest, TabIDMatch)
+{
+    NSURL *url = [NSURL URLWithString:@"http://example.com/a"];
+    _WKWebExtensionWebRequestResourceType type = _WKWebExtensionWebRequestResourceTypeOther;
+
+    auto filter = filterWithDictionary(@{
+        @"urls": @[ @"http://example.com/*" ],
+    });
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:100 windowID:1]);
+
+    filter = filterWithDictionary(@{
+        @"urls": @[ @"http://example.com/*" ],
+        @"tabId": @(-1),
+    });
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:100 windowID:1]);
+
+    filter = filterWithDictionary(@{
+        @"urls": @[ @"http://example.com/*" ],
+        @"tabId": @(100),
+    });
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:100 windowID:1]);
+    EXPECT_FALSE([filter matchesRequestForResourceOfType:type URL:url tabID:200 windowID:1]);
+}
+
+TEST(WKWebExtensionAPIWebRequest, WindowIDMatch)
+{
+    NSURL *url = [NSURL URLWithString:@"http://example.com/a"];
+    _WKWebExtensionWebRequestResourceType type = _WKWebExtensionWebRequestResourceTypeOther;
+
+    auto filter = filterWithDictionary(@{
+        @"urls": @[ @"http://example.com/*" ],
+    });
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:-1 windowID:-1]);
+
+    filter = filterWithDictionary(@{
+        @"urls": @[ @"http://example.com/*" ],
+        @"windowId": @(-1),
+    });
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
+
+    filter = filterWithDictionary(@{
+        @"urls": @[ @"http://example.com/*" ],
+        @"windowId": @(100),
+    });
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:1 windowID:100]);
+    EXPECT_FALSE([filter matchesRequestForResourceOfType:type URL:url tabID:1 windowID:200]);
+}
+
+TEST(WKWebExtensionAPIWebRequest, URLMatch)
+{
+    NSURL *url = [NSURL URLWithString:@"http://example.com/a/b"];
+    NSURL *otherURL = [NSURL URLWithString:@"http://some-other-website.biz/a/b"];
+    _WKWebExtensionWebRequestResourceType type = _WKWebExtensionWebRequestResourceTypeOther;
+
+    auto filter = filterWithDictionary(@{
+        @"urls": @[ ],
+    });
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:otherURL tabID:1 windowID:1]);
+
+    filter = filterWithDictionary(@{
+        @"urls": @[ @"http://example.com/*" ],
+    });
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
+    EXPECT_FALSE([filter matchesRequestForResourceOfType:type URL:otherURL tabID:1 windowID:1]);
+
+    filter = filterWithDictionary(@{
+        @"urls": @[ @"http://not-example.com/*", @"http://not-some-other-website.biz/*" ],
+    });
+    EXPECT_FALSE([filter matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
+
+    filter = filterWithDictionary(@{
+        @"urls": @[ @"http://example.com/*", @"http://not-some-other-website.biz/*" ],
+    });
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
+    EXPECT_FALSE([filter matchesRequestForResourceOfType:type URL:otherURL tabID:1 windowID:1]);
+
+    filter = filterWithDictionary(@{
+        @"urls": @[ @"http://example.com/*/b", @"http://example.com/a/*" ]
+    });
+
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:type URL:url tabID:1 windowID:1]);
+}
+
+TEST(WKWebExtensionAPIWebRequest, ResourceTypesMatch)
+{
+    NSURL *url = [NSURL URLWithString:@"http://example.com/a/b"];
+
+    auto filter = filterWithDictionary(@{
+        @"urls": @[ ],
+    });
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeImage URL:url tabID:1 windowID:1]);
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeScript URL:url tabID:1 windowID:1]);
+
+    filter = filterWithDictionary(@{
+        @"urls": @[ ],
+        @"types": @[ ],
+    });
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeImage URL:url tabID:1 windowID:1]);
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeScript URL:url tabID:1 windowID:1]);
+
+    filter = filterWithDictionary(@{
+        @"urls": @[ ],
+        @"types": @[ @"image" ],
+    });
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeImage URL:url tabID:1 windowID:1]);
+    EXPECT_FALSE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeScript URL:url tabID:1 windowID:1]);
+
+    filter = filterWithDictionary(@{
+        @"urls": @[ ],
+        @"types": @[ @"image", @"script" ],
+    });
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeImage URL:url tabID:1 windowID:1]);
+    EXPECT_TRUE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeScript URL:url tabID:1 windowID:1]);
+    EXPECT_FALSE([filter matchesRequestForResourceOfType:_WKWebExtensionWebRequestResourceTypeWebsocket URL:url tabID:1 windowID:1]);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### eb8ff94d64827d261308f3c3e98fb19ae87a60a1
<pre>
Add support for WebExtensionAPIWebRequestEvent and filter code
<a href="https://bugs.webkit.org/show_bug.cgi?id=267718">https://bugs.webkit.org/show_bug.cgi?id=267718</a>
<a href="https://rdar.apple.com/114823223">rdar://114823223</a>

Reviewed by Timothy Hatcher.

* Source/WebKit/DerivedSources-input.xcfilelist: Add the new files.
* Source/WebKit/DerivedSources-output.xcfilelist: Ditto.
* Source/WebKit/DerivedSources.make: Ditto.
* Source/WebKit/Modules/OSX_Private.modulemap: Add _WKWebExtensionWebRequestFilter here, it is Private due to being needed in TestWebKitAPI.
* Source/WebKit/Modules/iOS_Private.modulemap: Ditto.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj: Add the new files.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm: Added.
(WebKit::WebExtensionAPIWebRequestEvent::addListener): Add the listener to m_listeners.
(WebKit::WebExtensionAPIWebRequestEvent::removeListener): Remove it from m_listeners.
(WebKit::WebExtensionAPIWebRequestEvent::hasListener): Check for the listener in m_listeners.
(WebKit::WebExtensionAPIWebRequestEvent::removeAllListeners): Clear m_listeners.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h: Added.
(WebKit::WebExtensionAPIWebRequestEvent::listeners const):
(WebKit::WebExtensionAPIWebRequestEvent::~WebExtensionAPIWebRequestEvent):
(WebKit::WebExtensionAPIWebRequestEvent::WebExtensionAPIWebRequestEvent):
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.h: Added.
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm: Added.
(_WKWebExtensionWebRequestResourceTypeFromWKResourceLoadInfo): Get the resource type from the resource load info.
(-[_WKWebExtensionWebRequestFilter initWithDictionary:outErrorMessage:]): Validate the dictionary and create a filter if the dictionary is valid.
(toResourceType): Convert the string to a resource type.
(toTabID): Convert the given double to a std::optional&lt;WebExtensionTabIdentifier&gt;
(toWindowID): Convert the given double to a std::optional&lt;WebExtensionWindowIdentifier&gt;
(-[_WKWebExtensionWebRequestFilter _initializeWithDictionary:]):
(-[_WKWebExtensionWebRequestFilter matchesRequestForResourceOfType:URL:tabID:windowID:]): Perform the matching - making sure URL, tab, window, and resource type match.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl: Added.
* Tools/TestWebKitAPI/SourcesCocoa.txt: Add the new test file.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj: Ditto.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm: Added.
(TestWebKitAPI::TEST):
(TestWebKitAPI::filterWithDictionary):

Canonical link: <a href="https://commits.webkit.org/273194@main">https://commits.webkit.org/273194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb9badc742537183dfe171e9f6ddeaf903c4c934

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34646 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37330 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10568 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9959 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38606 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31458 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31254 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36098 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/10157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34057 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/11981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7951 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/10709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->