### PR TITLE
[WGSL] Global variable rewriter should not use range-based for loop

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -539,7 +539,11 @@ Packing RewriteGlobalVariables::packingForType(const Type* type)
 void RewriteGlobalVariables::collectGlobals()
 {
     Vector<std::tuple<AST::Variable*, unsigned>> bufferLengths;
-    for (auto& declaration : m_callGraph.ast().declarations()) {
+    // we can't use a range-based for loop here since we might create new structs
+    // and insert them into the declarations vector
+    auto size = m_callGraph.ast().declarations().size();
+    for (unsigned i = 0; i < size; ++i) {
+        auto& declaration = m_callGraph.ast().declarations()[i];
         if (!is<AST::Variable>(declaration))
             continue;
         auto& globalVar = downcast<AST::Variable>(declaration);


### PR DESCRIPTION
#### 91061b48751d475257c31fd551d9a2556dbcccf2
<pre>
[WGSL] Global variable rewriter should not use range-based for loop
<a href="https://bugs.webkit.org/show_bug.cgi?id=267720">https://bugs.webkit.org/show_bug.cgi?id=267720</a>
<a href="https://rdar.apple.com/121208769">rdar://121208769</a>

Reviewed by Mike Wyrzykowski.

New structs might be created and inserted into the vector while we&apos;re iterating it,
which invalidates the iterator.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::collectGlobals):

Canonical link: <a href="https://commits.webkit.org/273224@main">https://commits.webkit.org/273224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/890735c03a4b9066e2323ed7c5ce9f6d0f42fa8c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37475 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31393 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10694 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30336 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11523 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10070 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10136 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38740 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31374 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36181 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8154 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34158 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12080 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7972 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10797 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11146 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->