### PR TITLE
[WGSL] webgpu:shader,execution,robust_access:* is crashing

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -423,14 +423,15 @@ void TypeChecker::visitVariable(AST::Variable& variable, VariableKind variableKi
         variable.m_addressSpace = addressSpace;
         variable.m_accessMode = accessMode;
         result = m_types.referenceType(addressSpace, result, accessMode);
-        if (auto* maybeTypeName = variable.maybeTypeName()) {
-            auto& referenceType = m_shaderModule.astBuilder().construct<AST::ReferenceTypeExpression>(
-                maybeTypeName->span(),
-                *maybeTypeName
-            );
-            referenceType.m_inferredType = result;
-            variable.m_referenceType = &referenceType;
-        }
+        auto* typeName = variable.maybeTypeName();
+        if (!typeName)
+            typeName = &m_shaderModule.astBuilder().construct<AST::IdentifierExpression>(SourceSpan::empty(), AST::Identifier::make(result->toString()));
+        auto& referenceType = m_shaderModule.astBuilder().construct<AST::ReferenceTypeExpression>(
+            typeName->span(),
+            *typeName
+        );
+        referenceType.m_inferredType = result;
+        variable.m_referenceType = &referenceType;
     }
 
     introduceValue(variable.name(), result, value ? std::optional<ConstantValue>(*value) : std::nullopt);


### PR DESCRIPTION
#### 8c2f912a0edfdb7d2833a620529a49a589711a34
<pre>
[WGSL] webgpu:shader,execution,robust_access:* is crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=267721">https://bugs.webkit.org/show_bug.cgi?id=267721</a>
<a href="https://rdar.apple.com/121209161">rdar://121209161</a>

Reviewed by Mike Wyrzykowski.

The global variable rewriter assumes that all global variables will have a reference
type, but the type checker was not creating reference types for variable that did not
have a type annotation, which is valid for global variables in the private address
space. This isn&apos;t enough to make the test pass, but it no longer crashes.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitVariable):

Canonical link: <a href="https://commits.webkit.org/273220@main">https://commits.webkit.org/273220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c717d2acb1495da0c7a01222bdde4914617722a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37316 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31286 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10559 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30251 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11386 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9947 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10032 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38592 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31446 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36090 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10149 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34045 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11973 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7968 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10702 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11024 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->