### PR TITLE
REGRESSION (271261@main): [ Monterey Ventura Debug ] ASSERTION FAILED: isValid() in std::unique_ptr<ScrollingStateTree> WebCore::ScrollingStateTree::commit(LayerRepresentation::Type)

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1962,8 +1962,6 @@ webkit.org/b/266490 [ Sonoma+ ] fast/scrolling/overlay-scrollbars-scroll-corner.
 
 webkit.org/b/267384 [ Sonoma+ ] fast/selectors/text-field-selection-window-inactive-stroke-color.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/267655 [ Monterey Ventura Debug ] scrollingcoordinator/scrolling-tree/scroller-with-proxy-nodes-loses-layer.html [ Crash ]
-
 webkit.org/b/267670 [ Sonoma+ ] imported/w3c/web-platform-tests/css/css-position/fixed-z-index-blend.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/267778 [ Sonoma+ Release ] fast/forms/listbox-padding-clip-selected.html [  Pass ImageOnlyFailure ]

--- a/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
@@ -109,6 +109,9 @@ void ThreadedScrollingCoordinator::didScheduleRenderingUpdate()
 
 void ThreadedScrollingCoordinator::willStartRenderingUpdate()
 {
+    ASSERT(isMainThread());
+    if (m_page)
+        m_page->layoutIfNeeded(LayoutOptions::UpdateCompositingLayers);
     RefPtr<ThreadedScrollingTree> threadedScrollingTree = downcast<ThreadedScrollingTree>(scrollingTree());
     threadedScrollingTree->willStartRenderingUpdate();
     commitTreeStateIfNeeded();


### PR DESCRIPTION
#### 2439631889affe94ff5c0abaa592025f2dcf6c68
<pre>
REGRESSION (271261@main): [ Monterey Ventura Debug ] ASSERTION FAILED: isValid() in std::unique_ptr&lt;ScrollingStateTree&gt; WebCore::ScrollingStateTree::commit(LayerRepresentation::Type)
<a href="https://bugs.webkit.org/show_bug.cgi?id=267655">https://bugs.webkit.org/show_bug.cgi?id=267655</a>
&lt;<a href="https://rdar.apple.com/121148828">rdar://121148828</a>&gt;

Reviewed by Simon Fraser.

ThreadedScrollingCoordinator updates the scrolling tree state at the start of
the rendering update (before rAF callbacks), so that async scrolls can be
performed if the rendering update takes too long.

We need to make sure the compositing layer tree is up to date in order for
this to be valid.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp:
(WebCore::ThreadedScrollingCoordinator::willStartRenderingUpdate):

Canonical link: <a href="https://commits.webkit.org/273275@main">https://commits.webkit.org/273275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb8103da6a1ed0d8cf1a7bb3290a43d58446f9b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37695 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31568 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36116 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10914 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30507 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35501 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11729 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10265 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10335 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38947 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31792 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31584 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36352 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34331 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12241 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8010 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10971 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11305 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->