### PR TITLE
[iOS] -[WKContentView hasText] is incorrect when initially focusing an editable element

### DIFF
--- a/Source/WebKit/Shared/FocusedElementInformation.h
+++ b/Source/WebKit/Shared/FocusedElementInformation.h
@@ -104,6 +104,7 @@ struct FocusedElementInformation {
     bool allowsUserScaling { false };
     bool allowsUserScalingIgnoringAlwaysScalable { false };
     bool insideFixedPosition { false };
+    bool hasPlainText { false };
     WebCore::AutocapitalizeType autocapitalizeType { WebCore::AutocapitalizeType::Default };
     InputType elementType { InputType::None };
     WebCore::InputMode inputMode { WebCore::InputMode::Unspecified };

--- a/Source/WebKit/Shared/FocusedElementInformation.serialization.in
+++ b/Source/WebKit/Shared/FocusedElementInformation.serialization.in
@@ -74,6 +74,7 @@ enum class WebKit::InputType : uint8_t {
     bool allowsUserScaling;
     bool allowsUserScalingIgnoringAlwaysScalable;
     bool insideFixedPosition;
+    bool hasPlainText;
     WebCore::AutocapitalizeType autocapitalizeType;
     WebKit::InputType elementType;
     WebCore::InputMode inputMode;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -6549,6 +6549,9 @@ static WebKit::WritingDirection coreWritingDirection(NSWritingDirection directio
 
 - (BOOL)hasText
 {
+    if (_isFocusingElementWithKeyboard || _page->waitingForPostLayoutEditorStateUpdateAfterFocusingElement())
+        return _focusedElementInformation.hasPlainText;
+
     auto& editorState = _page->editorState();
     return editorState.hasPostLayoutData() && editorState.postLayoutData->hasPlainText;
 }

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3629,6 +3629,7 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
         information.elementType = InputType::TextArea;
         information.isReadOnly = element->isReadOnly();
         information.value = element->value();
+        information.hasPlainText = !information.value.isEmpty();
         information.autofillFieldName = WebCore::toAutofillFieldName(element->autofillData().fieldName);
         information.nonAutofillCredentialType = element->autofillData().nonAutofillCredentialType;
         information.placeholder = element->attributeWithoutSynchronization(HTMLNames::placeholderAttr);
@@ -3698,6 +3699,7 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
         information.enterKeyHint = element->canonicalEnterKeyHint();
         information.isReadOnly = element->isReadOnly();
         information.value = element->value();
+        information.hasPlainText = !information.value.isEmpty();
         information.valueAsNumber = element->valueAsNumber();
         information.autofillFieldName = WebCore::toAutofillFieldName(element->autofillData().fieldName);
         information.nonAutofillCredentialType = element->autofillData().nonAutofillCredentialType;
@@ -3714,6 +3716,7 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
             information.autocapitalizeType = WebCore::AutocapitalizeType::Default;
         }
         information.isReadOnly = false;
+        information.hasPlainText = hasAnyPlainText(makeRangeSelectingNodeContents(*focusedElement));
     }
 
     if (focusedElement->document().quirks().shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas() && isTransparentOrFullyClipped(*focusedElement)) {

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -1134,6 +1134,56 @@ TEST(KeyboardInputTests, MarkedTextSegmentsWithUnderlines)
     EXPECT_GT(numberOfDifferentPixels, 0U);
 }
 
+TEST(KeyboardInputTests, HasTextAfterFocusingTextField)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 600)]);
+
+    enum class HasText : bool { No, Yes };
+    __block Vector<std::pair<WKInputType, HasText>, 3> results;
+    __block bool doneWaitingForInputSession = false;
+
+    auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    [inputDelegate setDidStartInputSessionHandler:^(WKWebView *webView, id<_WKFormInputSession> session) {
+        results.append({
+            session.focusedElementInfo.type,
+            webView.textInputContentView.hasText ? HasText::Yes : HasText::No
+        });
+        doneWaitingForInputSession = true;
+    }];
+
+    [inputDelegate setFocusStartsInputSessionPolicyHandler:^(WKWebView *, id<_WKFocusedElementInfo>) {
+        return _WKFocusStartsInputSessionPolicyAllow;
+    }];
+    [webView _setInputDelegate:inputDelegate.get()];
+    [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
+        "<html>"
+        "<meta name='viewport' content='width=device-width'>"
+        "<body>"
+        "  <input id='emailField' type='email' value='foo@bar.com'>"
+        "  <input id='passwordField' type='password'>"
+        "  <div id='richTextEditor' contentEditable='true'><span>Hello world</span></div>"
+        "</body>"
+        "</html>"];
+
+    auto waitForInputSessionAfterFocusing = ^(NSString *elementID) {
+        doneWaitingForInputSession = false;
+        [webView objectByEvaluatingJavaScript:[NSString stringWithFormat:@"%@.focus()", elementID]];
+        Util::run(&doneWaitingForInputSession);
+    };
+
+    waitForInputSessionAfterFocusing(@"emailField");
+    waitForInputSessionAfterFocusing(@"passwordField");
+    waitForInputSessionAfterFocusing(@"richTextEditor");
+
+    EXPECT_EQ(results.size(), 3U);
+    EXPECT_EQ(results[0].first, WKInputTypeEmail);
+    EXPECT_EQ(results[0].second, HasText::Yes);
+    EXPECT_EQ(results[1].first, WKInputTypePassword);
+    EXPECT_EQ(results[1].second, HasText::No);
+    EXPECT_EQ(results[2].first, WKInputTypeContentEditable);
+    EXPECT_EQ(results[2].second, HasText::Yes);
+}
+
 #if HAVE(AUTOCORRECTION_ENHANCEMENTS)
 TEST(KeyboardInputTests, AutocorrectionIndicatorColorNotAffectedByAuthorDefinedAncestorColorProperty)
 {


### PR DESCRIPTION
#### 1cb03ba5c4bb1ddc63bbc8a0565383a242fec767
<pre>
[iOS] -[WKContentView hasText] is incorrect when initially focusing an editable element
<a href="https://bugs.webkit.org/show_bug.cgi?id=267729">https://bugs.webkit.org/show_bug.cgi?id=267729</a>
<a href="https://rdar.apple.com/120743391">rdar://120743391</a>

Reviewed by Aditya Keerthi.

Currently, `-hasText` is based entirely on the last cached `EditorState`&apos;s post layout data. In the
case where we&apos;ve just started showing the keyboard for a focused editable element in
`-[WKContentView _elementDidFocus:…:userObject:]`, we&apos;re still waiting for a new `EditorState` to
arrive, so this result ends up being invalid (either `false` if we haven&apos;t received any post-layout
editor state yet, or stale editor state data).

To avoid this, we add a `hasPlainText` flag to `FocusedElementInformation` that represents whether
or not the focused element initially had non-empty text content upon focus; if we&apos;re currently in
the process of focusing (or are waiting for post-layout data) in `-hasText`, then use this initial
value instead of the `EditorState`.

Test: KeyboardInputTests.HasTextAfterFocusingTextField

* Source/WebKit/Shared/FocusedElementInformation.h:
* Source/WebKit/Shared/FocusedElementInformation.serialization.in:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView hasText]):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::focusedElementInformation):

For text fields and text areas, instead of using `hasPlainText` (which relies on `TextIterator`),
simply check whether the `value` is non-empty instead to avoid any extra performance cost.

* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:

Canonical link: <a href="https://commits.webkit.org/273211@main">https://commits.webkit.org/273211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ea43279f06fed03bd2782237fcf267e922f74a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37349 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31307 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30265 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30880 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9973 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10050 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38623 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36106 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10173 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8062 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34074 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/11996 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7960 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11050 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->