### PR TITLE
[scroll-anchoring] Scroll anchoring and Shadow DOM result in weird scrolling behavior

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller-expected.txt
@@ -1,0 +1,5 @@
+Scrolling over this element doesn't scroll the main scroller
+
+
+PASS Ensure there is no scroll anchoring adjustment in the main frame.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-scroll-anchoring/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+    body {
+        height: 5000px;
+    }
+    
+    .filler {
+        width: 20px;
+        height: 500px;
+        background-color: silver;
+    }
+
+    #container {
+        height: 800px;
+        width: 800px;
+        padding: 10px;
+        border: 1px solid black;
+    }
+    
+    #target {
+        border: 1px solid gray;
+        padding: 10px;
+        height: 150px;
+        background-color: orange;
+    }
+</style>
+
+<div id="container">
+    <test-container id="shadowHost" >
+        <div class="filler">
+        </div>
+        <div id="target">
+            <p>Scrolling over this element doesn't scroll the main scroller<p>
+        </div>
+        <div class="filler">
+        </div>
+    </test-container>
+</div>
+
+<script type="module">
+    const content = document.getElementById('target');
+    class TestContainer extends HTMLElement {
+        connectedCallback() {
+            const shadow = this.attachShadow({ mode: 'open' });
+            shadow.innerHTML = `
+                    <div id = "shadowScroller" style="height: calc(100% - 20px); overflow: auto; border: 1px solid green; padding: 10px">
+                        <slot></slot>
+                    </div>`;
+        }
+    }
+
+    customElements.define('test-container', TestContainer);
+
+    promise_test(async function() {
+        var root = document.getElementById('shadowHost');
+        var shadowElement = root.shadowRoot.querySelector("#shadowScroller");
+        document.scrollingElement.scrollBy(0,100);
+        shadowElement.scrollBy(0,150);
+        await new Promise(resolve => {
+            shadowElement.addEventListener("scroll", () => step_timeout(resolve, 0));
+        });
+
+        assert_equals(document.scrollingElement.scrollTop, 100);
+    }, "Ensure there is no scroll anchoring adjustment in the main frame.");
+
+</script>

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -113,7 +113,6 @@ void ScrollAnchoringController::notifyChildHadSuppressingStyleChange()
 bool ScrollAnchoringController::isInScrollAnchoringAncestorChain(const RenderObject& object)
 {
     RefPtr iterElement = m_anchorElement.get();
-
     while (iterElement) {
         if (auto* renderer = iterElement->renderer()) {
             LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::isInScrollAnchoringAncestorChain() checking for : " <<object << " current Element: " << *iterElement);
@@ -122,7 +121,7 @@ bool ScrollAnchoringController::isInScrollAnchoringAncestorChain(const RenderObj
         }
         if (iterElement && elementIsScrollableArea(*iterElement, m_owningScrollableArea))
             break;
-        iterElement = iterElement->parentElement();
+        iterElement = iterElement->parentElementInComposedTree();
     }
     return false;
 }


### PR DESCRIPTION
#### b940c0441af5d96ddd5bb8b5ac87217f7087a5ca
<pre>
[scroll-anchoring] Scroll anchoring and Shadow DOM result in weird scrolling behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=267733">https://bugs.webkit.org/show_bug.cgi?id=267733</a>
<a href="https://rdar.apple.com/121165484">rdar://121165484</a>

Reviewed by Tim Nguyen.

After <a href="https://commits.webkit.org/272277@main">https://commits.webkit.org/272277@main</a> we descend subscrollers that are not maintaining a
scroll anchor. In the logic added to ScrollAnchoringController::invalidateAnchorElement we
look to see if the current scroller is in a scroll anchoring chain, if it is not currently
maintaining an anchor element. When the owning scroller is in the shadow dom, the element walk would
not include it, so it wouldn&apos;t notify the parent scroller to invalidate its anchor element. To fix this,
do the parent walk via parentElementInComposedTree to include the elements in the shadow dom.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html: Added.
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::isInScrollAnchoringAncestorChain):

Canonical link: <a href="https://commits.webkit.org/273254@main">https://commits.webkit.org/273254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb8bd4cf7f02be1e1eb7f738b30a0b1f6a4fd9d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37561 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31455 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10780 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10151 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38816 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31672 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31456 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10316 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34225 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30770 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10860 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4480 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->