### PR TITLE
Remove unused handwritten decoder for WebCore::ApplePayError

### DIFF
--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
@@ -382,31 +382,6 @@ bool ArgumentCoder<WebCore::ApplePaySessionPaymentRequest::MerchantCapabilities>
     return true;
 }
 
-void ArgumentCoder<RefPtr<WebCore::ApplePayError>>::encode(Encoder& encoder, const RefPtr<WebCore::ApplePayError>& error)
-{
-    encoder << !!error;
-    if (error)
-        encoder << *error;
-}
-
-std::optional<RefPtr<WebCore::ApplePayError>> ArgumentCoder<RefPtr<WebCore::ApplePayError>>::decode(Decoder& decoder)
-{
-    std::optional<bool> isValid;
-    decoder >> isValid;
-    if (!isValid)
-        return std::nullopt;
-
-    if (!*isValid)
-        return { nullptr };
-
-    std::optional<Ref<WebCore::ApplePayError>> error;
-    decoder >> error;
-    if (!error)
-        return std::nullopt;
-
-    return error;
-}
-
 void ArgumentCoder<WebCore::PaymentSessionError>::encode(Encoder& encoder, const WebCore::PaymentSessionError& error)
 {
     encoder << error.platformError();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -249,11 +249,6 @@ template<> struct ArgumentCoder<WebCore::ApplePaySessionPaymentRequest::Merchant
     static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::ApplePaySessionPaymentRequest::MerchantCapabilities&);
 };
 
-template<> struct ArgumentCoder<RefPtr<WebCore::ApplePayError>> {
-    static void encode(Encoder&, const RefPtr<WebCore::ApplePayError>&);
-    static std::optional<RefPtr<WebCore::ApplePayError>> decode(Decoder&);
-};
-
 template<> struct ArgumentCoder<WebCore::PaymentSessionError> {
     static void encode(Encoder&, const WebCore::PaymentSessionError&);
     static std::optional<WebCore::PaymentSessionError> decode(Decoder&);


### PR DESCRIPTION
#### 4191facdbfa026c3355647638a8dab5f6a7ca4c6
<pre>
Remove unused handwritten decoder for WebCore::ApplePayError
<a href="https://bugs.webkit.org/show_bug.cgi?id=267737">https://bugs.webkit.org/show_bug.cgi?id=267737</a>
<a href="https://rdar.apple.com/121220118">rdar://121220118</a>

Reviewed by Aditya Keerthi.

WebCore::ApplePayError is declared in WebCoreArgumentCoders.serialization.in.

* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::ApplePayError&gt;&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RefPtr&lt;WebCore::ApplePayError&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:

Canonical link: <a href="https://commits.webkit.org/273362@main">https://commits.webkit.org/273362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5969f089a44564170bef4b4c2cfe56958c52b687

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37817 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31660 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30594 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31272 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10369 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10433 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39064 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31899 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36441 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10537 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34430 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12326 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8059 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11067 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11389 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->