### PR TITLE
[JSC] Node's JSTokenLocation sometimes doesn't point to the start of an expression

### DIFF
--- a/JSTests/stress/regress-267728.js
+++ b/JSTests/stress/regress-267728.js
@@ -1,0 +1,72 @@
+var obj = {
+    a: {
+        b: {
+            c: {
+                get dGetter() { throw new Error("foo"); },
+                dFunction() { throw new Error("foo"); },
+            },
+        },
+    },
+};
+
+try {
+obj
+.a
+.b
+.c
+    .dGetter // !! error
+;
+} catch (err) {
+    assert(err.stack.endsWith(":17:5"));
+}
+
+try {
+obj
+.a
+.b
+.c
+.dFunction
+    ` // !! error
+    `
+;
+} catch (err) {
+    assert(err.stack.endsWith(":29:5"));
+}
+
+function A() {
+    return function B() {
+        return function C() {
+            return function D() {
+                throw new Error("foo");
+            }
+        }
+    }
+}
+
+try {
+new
+    new // !! error
+new // D
+new // C
+new // B
+A
+;
+} catch (err) {
+    assert(err.stack.endsWith(":48:5"));
+}
+
+try {
+obj
+["a"]
+["b"]
+["c"]
+    ["dGetter"] // !! error
+;
+} catch (err) {
+    assert(err.stack.endsWith(":63:5"));
+}
+
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
@@ -203,7 +203,7 @@ UnlinkedFunctionExecutable* BuiltinExecutables::createExecutable(VM& vm, const S
     JSTokenLocation end;
     end.line = 1;
     end.lineStartOffset = source.startOffset();
-    end.startOffset = source.startOffset() + strlen("(") + asyncOffset;
+    end.startOffset = source.startOffset() + strlen("(");
     end.endOffset = std::numeric_limits<unsigned>::max();
 
     FunctionMetadataNode metadata(

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -362,10 +362,10 @@ public:
         return node;
     }
 
-    ExpressionNode* createNewExpr(const JSTokenLocation& location, ExpressionNode* expr, const JSTextPosition& start, const JSTextPosition& end)
+    ExpressionNode* createNewExpr(const JSTokenLocation& location, ExpressionNode* expr, const JSTextPosition& start, const JSTextPosition& divot, const JSTextPosition& end)
     {
         NewExprNode* node = new (m_parserArena) NewExprNode(location, expr);
-        setExceptionLocation(node, start, end, end);
+        setExceptionLocation(node, start, divot, end);
         return node;
     }
 

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -4233,7 +4233,6 @@ template <typename TreeBuilder> TreeExpression Parser<LexerType>::parseAssignmen
         bool isArrowFunctionToken = match(ARROWFUNCTION);
         if (!lhs || isArrowFunctionToken) {
             SavePointWithError errorRestorationSavePoint = swapSavePointForError(context, savePoint);
-            const unsigned functionStart = start;
             bool isAsync { false };
             if (UNLIKELY(classifier.indicatesPossibleAsyncArrowFunction())) {
                 if (matchContextualKeyword(m_vm.propertyNames->async)) {
@@ -4244,7 +4243,7 @@ template <typename TreeBuilder> TreeExpression Parser<LexerType>::parseAssignmen
             if (isArrowFunctionParameters(context)) {
                 if (wasOpenParen)
                     currentScope()->revertToPreviousUsedVariables(usedVariablesSize);
-                return parseArrowFunctionExpression(context, isAsync, functionStart);
+                return parseArrowFunctionExpression(context, isAsync, location);
             }
             if (isArrowFunctionToken)
                 propagateError();
@@ -4808,11 +4807,10 @@ void Parser<LexerType>::recordFunctionLeaveLocation(const JSTextPosition& positi
 template <typename LexerType>
 template <class TreeBuilder> TreeExpression Parser<LexerType>::parseObjectLiteral(TreeBuilder& context)
 {
+    JSTokenLocation location(tokenLocation());
     consumeOrFail(OPENBRACE, "Expected opening '{' at the start of an object literal");
 
     SetForScope nonLHSCountScope(m_parserState.nonLHSCount);
-
-    JSTokenLocation location(tokenLocation());
     if (match(CLOSEBRACE)) {
         next();
         return context.createObjectLiteral(location);
@@ -4849,6 +4847,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseObjectLitera
 template <typename LexerType>
 template <class TreeBuilder> TreeExpression Parser<LexerType>::parseArrayLiteral(TreeBuilder& context)
 {
+    JSTokenLocation location(tokenLocation());
     consumeOrFailWithFlags(OPENBRACKET, TreeBuilder::DontBuildStrings, "Expected an opening '[' at the beginning of an array literal");
 
     SetForScope nonLHSCountScope(m_parserState.nonLHSCount);
@@ -4859,7 +4858,6 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseArrayLiteral
         elisions++;
     }
     if (match(CLOSEBRACKET)) {
-        JSTokenLocation location(tokenLocation());
         next();
         return context.createArray(location, elisions);
     }
@@ -4889,7 +4887,6 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseArrayLiteral
         }
         
         if (match(CLOSEBRACKET)) {
-            JSTokenLocation location(tokenLocation());
             next();
             return context.createArray(location, elisions, elementList);
         }
@@ -4909,7 +4906,6 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseArrayLiteral
         tail = context.createElementList(tail, elisions, elem);
     }
 
-    JSTokenLocation location(tokenLocation());
     if (!consume(CLOSEBRACKET)) {
         failIfFalse(match(DOTDOTDOT), "Expected either a closing ']' or a ',' following an array element");
         semanticFail("The '...' operator should come before a target expression");
@@ -4947,10 +4943,9 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseFunctionExpr
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeExpression Parser<LexerType>::parseAsyncFunctionExpression(TreeBuilder& context, int functionStart)
+template <class TreeBuilder> TreeExpression Parser<LexerType>::parseAsyncFunctionExpression(TreeBuilder& context, const JSTokenLocation& location)
 {
     ASSERT(match(FUNCTION));
-    JSTokenLocation location(tokenLocation());
     next();
     SourceParseMode parseMode = SourceParseMode::AsyncFunctionMode;
 
@@ -4960,7 +4955,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseAsyncFunctio
 
     ParserFunctionInfo<TreeBuilder> functionInfo;
     functionInfo.name = &m_vm.propertyNames->nullIdentifier;
-    failIfFalse(parseFunctionInfo(context, FunctionNameRequirements::None, false, ConstructorKind::None, SuperBinding::NotNeeded, functionStart, functionInfo, FunctionDefinitionType::Expression), parseMode == SourceParseMode::AsyncFunctionMode ? "Cannot parse async function expression" : "Cannot parse async generator function expression");
+    failIfFalse(parseFunctionInfo(context, FunctionNameRequirements::None, false, ConstructorKind::None, SuperBinding::NotNeeded, location.startOffset, functionInfo, FunctionDefinitionType::Expression), parseMode == SourceParseMode::AsyncFunctionMode ? "Cannot parse async function expression" : "Cannot parse async generator function expression");
     return context.createFunctionExpr(location, functionInfo);
 }
 
@@ -5122,7 +5117,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parsePrimaryExpre
             JSTokenLocation location(tokenLocation());
             next();
             if (match(FUNCTION) && !m_lexer->hasLineTerminatorBeforeToken())
-                return parseAsyncFunctionExpression(context, functionStart);
+                return parseAsyncFunctionExpression(context, location);
 
             // Avoid using variable if it is an arrow function parameter
             if (UNLIKELY(match(ARROWFUNCTION)))
@@ -5316,14 +5311,13 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
 {
     TreeExpression base = 0;
     JSTextPosition expressionStart = tokenStartPosition();
-    int newCount = 0;
     JSTokenLocation startLocation = tokenLocation();
-    JSTokenLocation lastNewTokenLocation;
+    Vector<JSTextPosition> newTokenStartPositions;
     while (match(NEW)) {
-        lastNewTokenLocation = tokenLocation();
+        newTokenStartPositions.append(tokenStartPosition());
         next();
-        newCount++;
     }
+    size_t newCount = newTokenStartPositions.size();
     JSTokenLocation location = tokenLocation();
 
     bool baseIsSuper = match(SUPER);
@@ -5343,8 +5337,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
                 semanticFailIfFalse(!closestOrdinaryFunctionScope->isGlobalCode() || isFunctionEvalContextType || isClassFieldInitializer, "new.target is not valid inside arrow functions in global code");
                 currentScope()->setInnerArrowFunctionUsesNewTarget();
             }
-            ASSERT(lastNewTokenLocation.line);
-            base = context.createNewTargetExpr(lastNewTokenLocation);
+            base = context.createNewTargetExpr(startLocation);
             newCount--;
             next();
         } else {
@@ -5447,17 +5440,16 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
         }
 
         while (true) {
-            location = tokenLocation();
             switch (type) {
             case OPENBRACKET: {
                 m_parserState.nonTrivialExpressionCount++;
-                JSTextPosition expressionEnd = lastTokenEndPosition();
+                JSTextPosition expressionDivot = tokenStartPosition();
                 next();
                 SetForScope nonLHSCountScope(m_parserState.nonLHSCount);
                 int initialAssignments = m_parserState.assignmentCount;
                 TreeExpression property = parseExpression(context);
                 failIfFalse(property, "Cannot parse subscript expression");
-                base = context.createBracketAccess(startLocation, base, property, initialAssignments != m_parserState.assignmentCount, expressionStart, expressionEnd, tokenEndPosition());
+                base = context.createBracketAccess(location, base, property, initialAssignments != m_parserState.assignmentCount, expressionStart, expressionDivot, tokenEndPosition());
 
                 if (UNLIKELY(baseIsSuper && currentScope()->isArrowFunction()))
                     currentFunctionScope()->setInnerArrowFunctionUsesSuperProperty();
@@ -5511,14 +5503,14 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
                     }
 
                     isOptionalCall = optionalChainLocation.endOffset == static_cast<unsigned>(expressionEnd.offset);
-                    base = context.makeFunctionCallNode(startLocation, base, previousBaseWasSuper, arguments, expressionStart,
+                    base = context.makeFunctionCallNode(location, base, previousBaseWasSuper, arguments, expressionStart,
                         expressionEnd, lastTokenEndPosition(), callOrApplyDepthScope ? callOrApplyDepthScope->distanceToInnermostChild() : 0, isOptionalCall);
                 }
                 break;
             }
             case DOT: {
                 m_parserState.nonTrivialExpressionCount++;
-                JSTextPosition expressionEnd = lastTokenEndPosition();
+                JSTextPosition expressionDivot = tokenStartPosition();
                 nextExpectIdentifier(TreeBuilder::DontBuildKeywords | LexerFlags::IgnoreReservedWords);
                 const Identifier* ident = m_token.m_data.ident;
                 auto type = DotType::Name;
@@ -5534,7 +5526,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
                     m_token.m_type = IDENT;
                 }
                 matchOrFail(IDENT, "Expected a property name after ", optionalChainBase ? "'?.'" : "'.'");
-                base = context.createDotAccess(startLocation, base, ident, type, expressionStart, expressionEnd, tokenEndPosition());
+                base = context.createDotAccess(location, base, ident, type, expressionStart, expressionDivot, tokenEndPosition());
                 if (UNLIKELY(baseIsSuper && currentScope()->isArrowFunction()))
                     currentFunctionScope()->setInnerArrowFunctionUsesSuperProperty();
                 next();
@@ -5543,11 +5535,11 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
             case BACKQUOTE: {
                 semanticFailIfTrue(optionalChainBase, "Cannot use tagged templates in an optional chain");
                 semanticFailIfTrue(baseIsSuper, "Cannot use super as tag for tagged templates");
-                JSTextPosition expressionEnd = lastTokenEndPosition();
+                JSTextPosition expressionDivot = tokenStartPosition();
                 SetForScope nonLHSCountScope(m_parserState.nonLHSCount);
                 typename TreeBuilder::TemplateLiteral templateLiteral = parseTemplateLiteral(context, LexerType::RawStringsBuildMode::BuildRawStrings);
                 failIfFalse(templateLiteral, "Cannot parse template literal");
-                base = context.createTaggedTemplate(startLocation, base, templateLiteral, expressionStart, expressionEnd, lastTokenEndPosition());
+                base = context.createTaggedTemplate(location, base, templateLiteral, expressionStart, expressionDivot, lastTokenEndPosition());
                 m_seenTaggedTemplateInNonReparsingFunctionMode = true;
                 break;
             }
@@ -5560,26 +5552,23 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseMemberExpres
         }
 endOfChain:
         if (optionalChainBase)
-            base = context.createOptionalChain(optionalChainLocation, isOptionalCall ? 0 : optionalChainBase, base, !match(QUESTIONDOT));
+            base = context.createOptionalChain(location, isOptionalCall ? 0 : optionalChainBase, base, !match(QUESTIONDOT));
     } while (match(QUESTIONDOT));
 
     semanticFailIfTrue(baseIsSuper, newCount ? "Cannot use new with super call" : "super is not valid in this context");
     while (newCount--)
-        base = context.createNewExpr(location, base, expressionStart, lastTokenEndPosition());
+        base = context.createNewExpr(location, base, expressionStart, newTokenStartPositions[newCount], lastTokenEndPosition());
     return base;
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeExpression Parser<LexerType>::parseArrowFunctionExpression(TreeBuilder& context, bool isAsync, unsigned functionStart)
+template <class TreeBuilder> TreeExpression Parser<LexerType>::parseArrowFunctionExpression(TreeBuilder& context, bool isAsync, const JSTokenLocation& location)
 {
-    JSTokenLocation location;
-
-    location = tokenLocation();
     ParserFunctionInfo<TreeBuilder> info;
     info.name = &m_vm.propertyNames->nullIdentifier;
 
     SetForScope innerParseMode(m_parseMode, isAsync ? SourceParseMode::AsyncArrowFunctionMode : SourceParseMode::ArrowFunctionMode);
-    failIfFalse((parseFunctionInfo(context, FunctionNameRequirements::Unnamed, true, ConstructorKind::None, SuperBinding::NotNeeded, functionStart, info, FunctionDefinitionType::Expression)), "Cannot parse arrow function expression");
+    failIfFalse((parseFunctionInfo(context, FunctionNameRequirements::Unnamed, true, ConstructorKind::None, SuperBinding::NotNeeded, location.startOffset, info, FunctionDefinitionType::Expression)), "Cannot parse arrow function expression");
 
     return context.createArrowFunctionExpr(location, info);
 }

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -1831,7 +1831,7 @@ private:
     template <class TreeBuilder> ALWAYS_INLINE TreeExpression parseObjectLiteral(TreeBuilder&);
     template <class TreeBuilder> ALWAYS_INLINE TreeClassExpression parseClassExpression(TreeBuilder&);
     template <class TreeBuilder> ALWAYS_INLINE TreeExpression parseFunctionExpression(TreeBuilder&);
-    template <class TreeBuilder> ALWAYS_INLINE TreeExpression parseAsyncFunctionExpression(TreeBuilder&, int start);
+    template <class TreeBuilder> ALWAYS_INLINE TreeExpression parseAsyncFunctionExpression(TreeBuilder&, const JSTokenLocation&);
     template <class TreeBuilder> ALWAYS_INLINE TreeArguments parseArguments(TreeBuilder&);
     template <class TreeBuilder> ALWAYS_INLINE TreeExpression parseArgument(TreeBuilder&, ArgumentType&);
     template <class TreeBuilder> TreeProperty parseProperty(TreeBuilder&);
@@ -1842,7 +1842,7 @@ private:
     enum VarDeclarationListContext { ForLoopContext, VarDeclarationContext };
     template <class TreeBuilder> TreeExpression parseVariableDeclarationList(TreeBuilder&, int& declarations, TreeDestructuringPattern& lastPattern, TreeExpression& lastInitializer, JSTextPosition& identStart, JSTextPosition& initStart, JSTextPosition& initEnd, VarDeclarationListContext, DeclarationType, ExportType, bool& forLoopConstDoesNotHaveInitializer);
     template <class TreeBuilder> TreeSourceElements parseArrowFunctionSingleExpressionBodySourceElements(TreeBuilder&);
-    template <class TreeBuilder> TreeExpression parseArrowFunctionExpression(TreeBuilder&, bool isAsync, unsigned functionStart);
+    template <class TreeBuilder> TreeExpression parseArrowFunctionExpression(TreeBuilder&, bool isAsync, const JSTokenLocation&);
     template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern createBindingPattern(TreeBuilder&, DestructuringKind, ExportType, const Identifier&, const JSToken&, AssignmentContext, const Identifier** duplicateIdentifier);
     template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern createAssignmentElement(TreeBuilder&, TreeExpression&, const JSTextPosition&, const JSTextPosition&);
     template <class TreeBuilder> NEVER_INLINE TreeDestructuringPattern parseObjectRestBindingOrAssignmentElement(TreeBuilder& context, DestructuringKind, ExportType, const Identifier** duplicateIdentifier, AssignmentContext bindingContext);

--- a/Source/JavaScriptCore/parser/SyntaxChecker.h
+++ b/Source/JavaScriptCore/parser/SyntaxChecker.h
@@ -188,7 +188,7 @@ public:
     ExpressionType createDotAccess(const JSTokenLocation&, ExpressionType, const Identifier*, DotType type, int, int, int) { return type == DotType::PrivateMember ? PrivateDotExpr : DotExpr; }
     ExpressionType createRegExp(const JSTokenLocation&, const Identifier& pattern, const Identifier& flags, int) { return Yarr::hasError(Yarr::checkSyntax(pattern.string(), flags.string())) ? 0 : RegExpExpr; }
     ExpressionType createNewExpr(const JSTokenLocation&, ExpressionType, int, int, int, int) { return NewExpr; }
-    ExpressionType createNewExpr(const JSTokenLocation&, ExpressionType, int, int) { return NewExpr; }
+    ExpressionType createNewExpr(const JSTokenLocation&, ExpressionType, int, int, int) { return NewExpr; }
     ExpressionType createOptionalChain(const JSTokenLocation&, ExpressionType, ExpressionType, bool) { return OptionalChain; }
     ExpressionType createConditionalExpr(const JSTokenLocation&, ExpressionType, ExpressionType, ExpressionType) { return ConditionalExpr; }
     ExpressionType createAssignResolve(const JSTokenLocation&, const Identifier&, ExpressionType, int, int, int, AssignmentContext) { return AssignmentExpr; }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm
@@ -277,14 +277,14 @@ TEST(WebKit, ConfigurationMaskedURLSchemes)
 
     [[webView configuration].userContentController _addUserScriptImmediately:userScript.get()];
 
-    EXPECT_WK_STREQ([delegate waitForAlert], "global code@webkit-masked-url://hidden/:1:17");
+    EXPECT_WK_STREQ([delegate waitForAlert], "global code@webkit-masked-url://hidden/:1:8");
 
     scriptURL = [NSURL URLWithString:@"https://example.com/foo.js"];
     userScript = adoptNS([[WKUserScript alloc] _initWithSource:@"alert((new Error).stack)" injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES includeMatchPatternStrings:@[] excludeMatchPatternStrings:@[] associatedURL:scriptURL contentWorld:nil deferRunningUntilNotification:NO]);
 
     [[webView configuration].userContentController _addUserScriptImmediately:userScript.get()];
 
-    EXPECT_WK_STREQ([delegate waitForAlert], "global code@https://example.com/foo.js:1:17");
+    EXPECT_WK_STREQ([delegate waitForAlert], "global code@https://example.com/foo.js:1:8");
 }
 
 TEST(WebKit, ConfigurationWebViewToCloneSessionStorageFrom)


### PR DESCRIPTION
#### e0132b80a4223be92a41f2b65a34b6342eab6f76
<pre>
[JSC] Node&apos;s JSTokenLocation sometimes doesn&apos;t point to the start of an expression
<a href="https://bugs.webkit.org/show_bug.cgi?id=267728">https://bugs.webkit.org/show_bug.cgi?id=267728</a>
&lt;<a href="https://rdar.apple.com/problem/121215280">rdar://problem/121215280</a>&gt;

Reviewed by Justin Michaud.

Before this patch, if we tried to reparse at node-&gt;position(), we would fail with SyntaxError for
object / array literals, async (arrow) functions, and member expressions with `new` / optional chaining,
due to Node&apos;s JSTokenLocation not pointing to the start of an expression.

This change fixes JSTokenLocation to be correct for above-mentioned cases, enabling us to redesign
class field initializers reparsing, and also improves accuracy of expression divots by removing
lastTokenEndPosition() usage from OPENBRACKET / DOT / BACKQUOTE cases of parseMemberExpression().

lastTokenEndPosition() makes sense in case of e.g. parseArguments() because after it exits, the
current token is the next one after `)`, yet in the e.g. DOT case, lastTokenEndPosition() most
likely points to previous identifier, which might be even on a different line.

On top of that, this patch improves stack trace accuracy for `new new new C` expressions by
storing position of each NEW token in a vector.

Aligns stack traces (error locations) with V8 and SpiderMonkey, including for modified API test.

* JSTests/stress/regress-267728.js: Added.
* Source/JavaScriptCore/builtins/BuiltinExecutables.cpp:
(JSC::BuiltinExecutables::createExecutable):
* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::createNewExpr):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseAssignmentExpression):
(JSC::Parser&lt;LexerType&gt;::parseObjectLiteral):
(JSC::Parser&lt;LexerType&gt;::parseArrayLiteral):
(JSC::Parser&lt;LexerType&gt;::parseAsyncFunctionExpression):
(JSC::Parser&lt;LexerType&gt;::parsePrimaryExpression):
(JSC::Parser&lt;LexerType&gt;::parseMemberExpression):
(JSC::Parser&lt;LexerType&gt;::parseArrowFunctionExpression):
* Source/JavaScriptCore/parser/Parser.h:
* Source/JavaScriptCore/parser/SyntaxChecker.h:
(JSC::SyntaxChecker::createNewExpr):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm:

Canonical link: <a href="https://commits.webkit.org/273255@main">https://commits.webkit.org/273255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd3065e287e7f5590cc5818213b954dd1ffd438f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37557 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31452 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10776 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30394 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10143 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38812 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/29571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31455 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36246 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/34701 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8225 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34220 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12135 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41335 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10857 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4484 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11199 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->