### PR TITLE
[JSC] use UNLIKELY in Intl APIs for rare cases

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlCollatorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCollatorPrototype.cpp
@@ -113,7 +113,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlCollatorPrototypeGetterCompare, (JSGlobalObject* gl
     // 10.3.3 Intl.Collator.prototype.compare (ECMA-402 2.0)
     // 1. Let collator be this Collator object.
     IntlCollator* collator = jsDynamicCast<IntlCollator*>(JSValue::decode(thisValue));
-    if (!collator)
+    if (UNLIKELY(!collator))
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.Collator.prototype.compare called on value that's not a Collator"_s));
 
     JSBoundFunction* boundCompare = collator->boundCompare();
@@ -144,7 +144,7 @@ JSC_DEFINE_HOST_FUNCTION(intlCollatorPrototypeFuncResolvedOptions, (JSGlobalObje
 
     // 10.3.5 Intl.Collator.prototype.resolvedOptions() (ECMA-402 2.0)
     IntlCollator* collator = jsDynamicCast<IntlCollator*>(callFrame->thisValue());
-    if (!collator)
+    if (UNLIKELY(!collator))
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.Collator.prototype.resolvedOptions called on value that's not a Collator"_s));
 
     RELEASE_AND_RETURN(scope, JSValue::encode(collator->resolvedOptions(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlDisplayNamesPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDisplayNamesPrototype.cpp
@@ -80,7 +80,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDisplayNamesPrototypeFuncOf, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* displayNames = jsDynamicCast<IntlDisplayNames*>(callFrame->thisValue());
-    if (!displayNames)
+    if (UNLIKELY(!displayNames))
         return throwVMTypeError(globalObject, scope, "Intl.DisplayNames.prototype.of called on value that's not a DisplayNames"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(displayNames->of(globalObject, callFrame->argument(0))));
@@ -93,7 +93,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDisplayNamesPrototypeFuncResolvedOptions, (JSGlobal
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* displayNames = jsDynamicCast<IntlDisplayNames*>(callFrame->thisValue());
-    if (!displayNames)
+    if (UNLIKELY(!displayNames))
         return throwVMTypeError(globalObject, scope, "Intl.DisplayNames.prototype.resolvedOptions called on value that's not a DisplayNames"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(displayNames->resolvedOptions(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlDurationFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormatPrototype.cpp
@@ -83,7 +83,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDurationFormatPrototypeFuncFormat, (JSGlobalObject*
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* durationFormat = jsDynamicCast<IntlDurationFormat*>(callFrame->thisValue());
-    if (!durationFormat)
+    if (UNLIKELY(!durationFormat))
         return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.format called on value that's not a DurationFormat"_s);
 
     JSValue argument = callFrame->argument(0);
@@ -103,7 +103,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDurationFormatPrototypeFuncFormatToParts, (JSGlobal
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* durationFormat = jsDynamicCast<IntlDurationFormat*>(callFrame->thisValue());
-    if (!durationFormat)
+    if (UNLIKELY(!durationFormat))
         return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.formatToParts called on value that's not a DurationFormat"_s);
 
     JSValue argument = callFrame->argument(0);
@@ -123,7 +123,7 @@ JSC_DEFINE_HOST_FUNCTION(intlDurationFormatPrototypeFuncResolvedOptions, (JSGlob
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* durationFormat = jsDynamicCast<IntlDurationFormat*>(callFrame->thisValue());
-    if (!durationFormat)
+    if (UNLIKELY(!durationFormat))
         return throwVMTypeError(globalObject, scope, "Intl.DurationFormat.prototype.resolvedOptions called on value that's not a DurationFormat"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(durationFormat->resolvedOptions(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlListFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlListFormatPrototype.cpp
@@ -82,7 +82,7 @@ JSC_DEFINE_HOST_FUNCTION(intlListFormatPrototypeFuncFormat, (JSGlobalObject* glo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* listFormat = jsDynamicCast<IntlListFormat*>(callFrame->thisValue());
-    if (!listFormat)
+    if (UNLIKELY(!listFormat))
         return throwVMTypeError(globalObject, scope, "Intl.ListFormat.prototype.format called on value that's not a ListFormat"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(listFormat->format(globalObject, callFrame->argument(0))));
@@ -95,7 +95,7 @@ JSC_DEFINE_HOST_FUNCTION(intlListFormatPrototypeFuncFormatToParts, (JSGlobalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* listFormat = jsDynamicCast<IntlListFormat*>(callFrame->thisValue());
-    if (!listFormat)
+    if (UNLIKELY(!listFormat))
         return throwVMTypeError(globalObject, scope, "Intl.ListFormat.prototype.formatToParts called on value that's not a ListFormat"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(listFormat->formatToParts(globalObject, callFrame->argument(0))));
@@ -108,7 +108,7 @@ JSC_DEFINE_HOST_FUNCTION(intlListFormatPrototypeFuncResolvedOptions, (JSGlobalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* listFormat = jsDynamicCast<IntlListFormat*>(callFrame->thisValue());
-    if (!listFormat)
+    if (UNLIKELY(!listFormat))
         return throwVMTypeError(globalObject, scope, "Intl.ListFormat.prototype.resolvedOptions called on value that's not a ListFormat"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(listFormat->resolvedOptions(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp
@@ -118,7 +118,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncMaximize, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.maximize called on value that's not a Locale"_s);
 
     IntlLocale* newLocale = IntlLocale::create(vm, globalObject->localeStructure());
@@ -134,7 +134,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncMinimize, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.minimize called on value that's not a Locale"_s);
 
     IntlLocale* newLocale = IntlLocale::create(vm, globalObject->localeStructure());
@@ -150,7 +150,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncToString, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.toString called on value that's not a Locale"_s);
 
     const String& fullString = locale->toString();
@@ -164,7 +164,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterBaseName, (JSGlobalObject* glo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.baseName called on value that's not a Locale"_s);
 
     const String& baseName = locale->baseName();
@@ -178,7 +178,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCalendar, (JSGlobalObject* glo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.calendar called on value that's not a Locale"_s);
 
     const String& calendar = locale->calendar();
@@ -192,7 +192,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetCalendars, (JSGlobalObject* g
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getCalendars called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->calendars(globalObject)));
@@ -205,7 +205,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCaseFirst, (JSGlobalObject* gl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.caseFirst called on value that's not a Locale"_s);
 
     const String& caseFirst = locale->caseFirst();
@@ -219,7 +219,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterCollation, (JSGlobalObject* gl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.collation called on value that's not a Locale"_s);
 
     const String& collation = locale->collation();
@@ -233,7 +233,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetCollations, (JSGlobalObject* 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getCollations called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->collations(globalObject)));
@@ -246,7 +246,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterHourCycle, (JSGlobalObject* gl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.hourCycle called on value that's not a Locale"_s);
 
     const String& hourCycle = locale->hourCycle();
@@ -260,7 +260,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetHourCycles, (JSGlobalObject* 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getHourCycles called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->hourCycles(globalObject)));
@@ -273,7 +273,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterNumeric, (JSGlobalObject* glob
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.numeric called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(jsBoolean(locale->numeric() == TriState::True)));
@@ -286,7 +286,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterNumberingSystem, (JSGlobalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.numberingSystem called on value that's not a Locale"_s);
 
     const String& numberingSystem = locale->numberingSystem();
@@ -300,7 +300,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetNumberingSystems, (JSGlobalOb
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getNumberingSystems called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->numberingSystems(globalObject)));
@@ -313,7 +313,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterLanguage, (JSGlobalObject* glo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.language called on value that's not a Locale"_s);
 
     const String& language = locale->language();
@@ -327,7 +327,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterScript, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.script called on value that's not a Locale"_s);
 
     const String& script = locale->script();
@@ -341,7 +341,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlLocalePrototypeGetterRegion, (JSGlobalObject* globa
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(JSValue::decode(thisValue));
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.region called on value that's not a Locale"_s);
 
     const String& region = locale->region();
@@ -355,7 +355,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetTimeZones, (JSGlobalObject* g
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getTimeZones called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->timeZones(globalObject)));
@@ -368,7 +368,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetTextInfo, (JSGlobalObject* gl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getTextInfo called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->textInfo(globalObject)));
@@ -381,7 +381,7 @@ JSC_DEFINE_HOST_FUNCTION(intlLocalePrototypeFuncGetWeekInfo, (JSGlobalObject* gl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* locale = jsDynamicCast<IntlLocale*>(callFrame->thisValue());
-    if (!locale)
+    if (UNLIKELY(!locale))
         return throwVMTypeError(globalObject, scope, "Intl.Locale.prototype.getWeekInfo called on value that's not a Locale"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(locale->weekInfo(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlPluralRulesPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRulesPrototype.cpp
@@ -90,7 +90,7 @@ JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncSelect, (JSGlobalObject* gl
     // https://tc39.github.io/ecma402/#sec-intl.pluralrules.prototype.select
     IntlPluralRules* pluralRules = jsDynamicCast<IntlPluralRules*>(callFrame->thisValue());
 
-    if (!pluralRules)
+    if (UNLIKELY(!pluralRules))
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.PluralRules.prototype.select called on value that's not a PluralRules"_s));
 
     double value = callFrame->argument(0).toNumber(globalObject);
@@ -107,7 +107,7 @@ JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncSelectRange, (JSGlobalObjec
 
     // https://tc39.es/proposal-intl-numberformat-v3/out/pluralrules/diff.html#sec-intl.pluralrules.prototype.selectrange
     IntlPluralRules* pluralRules = jsDynamicCast<IntlPluralRules*>(callFrame->thisValue());
-    if (!pluralRules)
+    if (UNLIKELY(!pluralRules))
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.PluralRules.prototype.selectRange called on value that's not a PluralRules"_s));
 
     JSValue startValue = callFrame->argument(0);
@@ -135,7 +135,7 @@ JSC_DEFINE_HOST_FUNCTION(intlPluralRulesPrototypeFuncResolvedOptions, (JSGlobalO
     // https://tc39.github.io/ecma402/#sec-intl.pluralrules.prototype.resolvedoptions
     IntlPluralRules* pluralRules = jsDynamicCast<IntlPluralRules*>(callFrame->thisValue());
 
-    if (!pluralRules)
+    if (UNLIKELY(!pluralRules))
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.PluralRules.prototype.resolvedOptions called on value that's not a PluralRules"_s));
 
     RELEASE_AND_RETURN(scope, JSValue::encode(pluralRules->resolvedOptions(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormatPrototype.cpp
@@ -83,7 +83,7 @@ JSC_DEFINE_HOST_FUNCTION(intlRelativeTimeFormatPrototypeFuncFormat, (JSGlobalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* relativeTimeFormat = jsDynamicCast<IntlRelativeTimeFormat*>(callFrame->thisValue());
-    if (!relativeTimeFormat)
+    if (UNLIKELY(!relativeTimeFormat))
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.RelativeTimeFormat.prototype.format called on value that's not a RelativeTimeFormat"_s));
 
     double value = callFrame->argument(0).toNumber(globalObject);
@@ -102,7 +102,7 @@ JSC_DEFINE_HOST_FUNCTION(intlRelativeTimeFormatPrototypeFuncFormatToParts, (JSGl
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* relativeTimeFormat = jsDynamicCast<IntlRelativeTimeFormat*>(callFrame->thisValue());
-    if (!relativeTimeFormat)
+    if (UNLIKELY(!relativeTimeFormat))
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.RelativeTimeFormat.prototype.formatToParts called on value that's not a RelativeTimeFormat"_s));
 
     double value = callFrame->argument(0).toNumber(globalObject);
@@ -121,7 +121,7 @@ JSC_DEFINE_HOST_FUNCTION(intlRelativeTimeFormatPrototypeFuncResolvedOptions, (JS
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* relativeTimeFormat = jsDynamicCast<IntlRelativeTimeFormat*>(callFrame->thisValue());
-    if (!relativeTimeFormat)
+    if (UNLIKELY(!relativeTimeFormat))
         return JSValue::encode(throwTypeError(globalObject, scope, "Intl.RelativeTimeFormat.prototype.resolvedOptions called on value that's not a RelativeTimeFormat"_s));
 
     RELEASE_AND_RETURN(scope, JSValue::encode(relativeTimeFormat->resolvedOptions(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlSegmentIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegmentIteratorPrototype.cpp
@@ -78,7 +78,7 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmentIteratorPrototypeFuncNext, (JSGlobalObject* 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* segmentIterator = jsDynamicCast<IntlSegmentIterator*>(callFrame->thisValue());
-    if (!segmentIterator)
+    if (UNLIKELY(!segmentIterator))
         return throwVMTypeError(globalObject, scope, "Intl.SegmentIterator.prototype.next called on value that's not a SegmentIterator"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(segmentIterator->next(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlSegmenterPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegmenterPrototype.cpp
@@ -80,7 +80,7 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmenterPrototypeFuncSegment, (JSGlobalObject* glo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* segmenter = jsDynamicCast<IntlSegmenter*>(callFrame->thisValue());
-    if (!segmenter)
+    if (UNLIKELY(!segmenter))
         return throwVMTypeError(globalObject, scope, "Intl.Segmenter.prototype.segment called on value that's not a Segmenter"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(segmenter->segment(globalObject, callFrame->argument(0))));
@@ -93,7 +93,7 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmenterPrototypeFuncResolvedOptions, (JSGlobalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* segmenter = jsDynamicCast<IntlSegmenter*>(callFrame->thisValue());
-    if (!segmenter)
+    if (UNLIKELY(!segmenter))
         return throwVMTypeError(globalObject, scope, "Intl.Segmenter.prototype.resolvedOptions called on value that's not a Segmenter"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(segmenter->resolvedOptions(globalObject)));

--- a/Source/JavaScriptCore/runtime/IntlSegmentsPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegmentsPrototype.cpp
@@ -79,7 +79,7 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmentsPrototypeFuncContaining, (JSGlobalObject* g
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* segments = jsDynamicCast<IntlSegments*>(callFrame->thisValue());
-    if (!segments)
+    if (UNLIKELY(!segments))
         return throwVMTypeError(globalObject, scope, "%Segments.prototype%.containing called on value that's not a Segments"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(segments->containing(globalObject, callFrame->argument(0))));
@@ -92,7 +92,7 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmentsPrototypeFuncIterator, (JSGlobalObject* glo
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* segments = jsDynamicCast<IntlSegments*>(callFrame->thisValue());
-    if (!segments)
+    if (UNLIKELY(!segments))
         return throwVMTypeError(globalObject, scope, "%Segments.prototype%[@@iterator] called on value that's not a Segments"_s);
 
     RELEASE_AND_RETURN(scope, JSValue::encode(segments->createSegmentIterator(globalObject)));


### PR DESCRIPTION
#### ae031c19c82f8e1e84539b22c3547b035e4d55e4
<pre>
[JSC] use UNLIKELY in Intl APIs for rare cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=267738">https://bugs.webkit.org/show_bug.cgi?id=267738</a>
<a href="https://rdar.apple.com/121221571">rdar://121221571</a>

Reviewed by Alexey Shvayka and Justin Michaud.

The case that CallFrame&apos;s `this` is not the desired object
is rare, so we should use `UNLIKELY` for them in Intl APIs.

* Source/JavaScriptCore/runtime/IntlCollatorPrototype.cpp:
(JSC::JSC_DEFINE_CUSTOM_GETTER):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlDisplayNamesPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlDurationFormatPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlListFormatPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlLocalePrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSC_DEFINE_CUSTOM_GETTER):
* Source/JavaScriptCore/runtime/IntlPluralRulesPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlRelativeTimeFormatPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlSegmentIteratorPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlSegmenterPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/IntlSegmentsPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/273221@main">https://commits.webkit.org/273221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ef98ea8988c6c5ec9eea22f8cd9680aae0240ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37362 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31315 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30276 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/9987 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10056 "Found unexpected failure with change (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38634 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/29434 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36117 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/34535 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34080 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12004 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41147 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7970 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10728 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8589 "Found 231 new JSC stress test failures: microbenchmarks/array-from-derived-object-func.js.bytecode-cache, microbenchmarks/array-from-derived-object-func.js.default, microbenchmarks/array-from-derived-object-func.js.dfg-eager, microbenchmarks/array-from-derived-object-func.js.dfg-eager-no-cjit-validate, microbenchmarks/array-from-derived-object-func.js.eager-jettison-no-cjit, microbenchmarks/array-from-derived-object-func.js.no-cjit-collect-continuously, microbenchmarks/array-from-derived-object-func.js.no-llint, microbenchmarks/array-from-object-func.js.bytecode-cache, microbenchmarks/array-from-object-func.js.default, microbenchmarks/array-from-object-func.js.dfg-eager ... (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11059 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->