### PR TITLE
Generate serialization for WebCore::PaymentSessionError

### DIFF
--- a/Source/WebCore/Modules/applepay/PaymentSessionError.h
+++ b/Source/WebCore/Modules/applepay/PaymentSessionError.h
@@ -41,7 +41,7 @@ public:
     PaymentSessionError(RetainPtr<NSError>&&);
 
     ApplePaySessionError sessionError() const;
-    NSError *platformError() const;
+    RetainPtr<NSError> platformError() const;
 
 private:
     ApplePaySessionError unknownError() const;

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentSessionErrorCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentSessionErrorCocoa.mm
@@ -68,9 +68,9 @@ ApplePaySessionError PaymentSessionError::sessionError() const
     return unknownError();
 }
 
-NSError *PaymentSessionError::platformError() const
+RetainPtr<NSError> PaymentSessionError::platformError() const
 {
-    return m_platformError.get();
+    return m_platformError;
 }
 
 ApplePaySessionError PaymentSessionError::unknownError() const

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
@@ -382,20 +382,6 @@ bool ArgumentCoder<WebCore::ApplePaySessionPaymentRequest::MerchantCapabilities>
     return true;
 }
 
-void ArgumentCoder<WebCore::PaymentSessionError>::encode(Encoder& encoder, const WebCore::PaymentSessionError& error)
-{
-    encoder << error.platformError();
-}
-
-std::optional<WebCore::PaymentSessionError> ArgumentCoder<WebCore::PaymentSessionError>::decode(Decoder& decoder)
-{
-    auto platformError = decoder.decode<RetainPtr<NSError>>();
-    if (!platformError)
-        return std::nullopt;
-
-    return { WTFMove(*platformError) };
-}
-
 #endif // ENABLE(APPLEPAY)
 
 void ArgumentCoder<WebCore::Font>::encodePlatformData(Encoder& encoder, const WebCore::Font& font)

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -110,6 +110,10 @@ enum class WebCore::ApplePaySessionPaymentRequestShippingType : uint8_t {
     ServicePickup,
 };
 
+class WebCore::PaymentSessionError {
+    [SecureCodingAllowed=[NSError.class]] RetainPtr<NSError> platformError();
+};
+
 headers: <pal/cocoa/PassKitSoftLink.h>
 class WebCore::PaymentMethod {
     [Precondition='PAL::isPassKitCoreFrameworkAvailable()', SecureCodingAllowed=[PAL::getPKPaymentMethodClass()], Validator='m_pkPaymentMethod'] RetainPtr<PKPaymentMethod> m_pkPaymentMethod;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -249,11 +249,6 @@ template<> struct ArgumentCoder<WebCore::ApplePaySessionPaymentRequest::Merchant
     static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::ApplePaySessionPaymentRequest::MerchantCapabilities&);
 };
 
-template<> struct ArgumentCoder<WebCore::PaymentSessionError> {
-    static void encode(Encoder&, const WebCore::PaymentSessionError&);
-    static std::optional<WebCore::PaymentSessionError> decode(Decoder&);
-};
-
 #endif
 
 #if ENABLE(VIDEO)


### PR DESCRIPTION
#### 7abb62bcfc50a818b22d4b670c8c15ea66c61bdd
<pre>
Generate serialization for WebCore::PaymentSessionError
<a href="https://bugs.webkit.org/show_bug.cgi?id=267744">https://bugs.webkit.org/show_bug.cgi?id=267744</a>
<a href="https://rdar.apple.com/121226874">rdar://121226874</a>

Reviewed by Alex Christensen.

* Source/WebCore/Modules/applepay/PaymentSessionError.h:
* Source/WebCore/Modules/applepay/cocoa/PaymentSessionErrorCocoa.mm:
(WebCore::PaymentSessionError::platformError const):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::ArgumentCoder&lt;WebCore::PaymentSessionError&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::PaymentSessionError&gt;::decode): Deleted.
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.h:

Canonical link: <a href="https://commits.webkit.org/273511@main">https://commits.webkit.org/273511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f75b31a8d2eee43d785ae5c102bb88de6d3fa95

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38305 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32049 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36763 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30861 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12253 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10763 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10781 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39550 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32127 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36740 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8856 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34817 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12677 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11476 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4616 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->