### PR TITLE
Timer::stop can short-circuit in most cases

### DIFF
--- a/Source/WebCore/platform/Timer.cpp
+++ b/Source/WebCore/platform/Timer.cpp
@@ -278,7 +278,7 @@ void TimerBase::start(Seconds nextFireInterval, Seconds repeatInterval)
     setNextFireTime(MonotonicTime::now() + nextFireInterval);
 }
 
-void TimerBase::stop()
+void TimerBase::stopSlowCase()
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(m_thread));
 

--- a/Source/WebCore/platform/Timer.h
+++ b/Source/WebCore/platform/Timer.h
@@ -63,8 +63,8 @@ public:
     void startRepeating(Seconds repeatInterval) { start(repeatInterval, repeatInterval); }
     void startOneShot(Seconds delay) { start(delay, 0_s); }
 
-    WEBCORE_EXPORT void stop();
-    bool isActive() const;
+    inline void stop();
+    inline bool isActive() const;
 
     MonotonicTime nextFireTime() const { return m_heapItem ? m_heapItem->time : MonotonicTime { }; }
     WEBCORE_EXPORT Seconds nextFireInterval() const;
@@ -86,6 +86,8 @@ public:
 
 private:
     virtual void fired() = 0;
+
+    WEBCORE_EXPORT void stopSlowCase();
 
     void checkConsistency() const;
     void checkHeapIndex() const;
@@ -152,6 +154,12 @@ private:
     
     Function<void()> m_function;
 };
+
+inline void TimerBase::stop()
+{
+    if (m_heapItem)
+        stopSlowCase();
+}
 
 inline bool TimerBase::isActive() const
 {


### PR DESCRIPTION
#### 741a55f3d6f1dda9857b4d20d45a9f9125af9426
<pre>
Timer::stop can short-circuit in most cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=267746">https://bugs.webkit.org/show_bug.cgi?id=267746</a>

Reviewed by Yusuke Suzuki and Darin Adler.

Add a fast path for when the timer isn&apos;t scheduled.

* Source/WebCore/platform/Timer.cpp:
(WebCore::TimerBase::stopSlowCase):
(WebCore::TimerBase::stop): Deleted.
* Source/WebCore/platform/Timer.h:
(WebCore::TimerBase::stop):

Canonical link: <a href="https://commits.webkit.org/273212@main">https://commits.webkit.org/273212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac825803ab2b81f5ee2760ce3f5d43fa32d614cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37399 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31335 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10619 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30292 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35242 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11449 "Found 1 new test failure: fast/events/ios/select-all-with-existing-selection.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10014 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10078 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/30990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38663 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31508 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36132 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34098 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12024 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10748 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4451 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11081 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->