### PR TITLE
Add webRequest event listener bindings and a basic test for them

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -512,6 +512,7 @@ $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPITabs.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigation.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigationEvent.idl
+$(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequest.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWindows.idl
 $(PROJECT_DIR)/WebProcess/Extensions/Interfaces/WebExtensionAPIWindowsEvent.idl

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -88,6 +88,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigation.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigation.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigationEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebNavigationEvent.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebRequest.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebRequest.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebRequestEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWebRequestEvent.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/JSWebExtensionAPIWindows.h

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -825,9 +825,10 @@ EXTENSION_INTERFACES = \
     WebExtensionAPIStorageArea \
     WebExtensionAPITabs \
     WebExtensionAPITest \
-    WebExtensionAPIWebRequestEvent \
     WebExtensionAPIWebNavigation \
     WebExtensionAPIWebNavigationEvent \
+    WebExtensionAPIWebRequest \
+    WebExtensionAPIWebRequestEvent \
     WebExtensionAPIWindows \
     WebExtensionAPIWindowsEvent \
 #

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -930,6 +930,11 @@
 		337822472947FBA5002106BB /* WebExtensionUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 337822452947FBA4002106BB /* WebExtensionUtilities.h */; };
 		337822482947FBA5002106BB /* WebExtensionUtilities.mm in Sources */ = {isa = PBXBuildFile; fileRef = 337822462947FBA4002106BB /* WebExtensionUtilities.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		3378F2FD2B1FCA6A00362EF3 /* WebExtensionMatchedRuleParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 3378F2FB2B1FCA5C00362EF3 /* WebExtensionMatchedRuleParameters.h */; };
+		3399E1522B59EFD7008BFB60 /* JSWebExtensionAPIWebNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = 3399E14F2B59EFD6008BFB60 /* JSWebExtensionAPIWebNavigation.h */; };
+		3399E1532B59EFD7008BFB60 /* JSWebExtensionAPIWebRequest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3399E1502B59EFD7008BFB60 /* JSWebExtensionAPIWebRequest.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		3399E1542B59EFD7008BFB60 /* JSWebExtensionAPIWebRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 3399E1512B59EFD7008BFB60 /* JSWebExtensionAPIWebRequest.h */; };
+		3399E1562B59F0F0008BFB60 /* WebExtensionAPIWebRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 3399E1552B59F0E5008BFB60 /* WebExtensionAPIWebRequest.h */; };
+		3399E1582B59F0FC008BFB60 /* WebExtensionAPIWebRequestCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3399E1572B59F0FC008BFB60 /* WebExtensionAPIWebRequestCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		33AE61252B20F13B00E1C215 /* PDFKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 3178AF9720E2A7F80074DE94 /* PDFKitSPI.h */; };
 		33B5A80C2AFD298100A15D40 /* WebExtensionFrameParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 33B5A80B2AFD298100A15D40 /* WebExtensionFrameParameters.h */; };
 		33B5A80F2AFD5DE800A15D40 /* WebExtensionContextAPIWebNavigationCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 33B5A80E2AFD5DE800A15D40 /* WebExtensionContextAPIWebNavigationCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -4751,6 +4756,12 @@
 		337822462947FBA4002106BB /* WebExtensionUtilities.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionUtilities.mm; sourceTree = "<group>"; };
 		3378F2FB2B1FCA5C00362EF3 /* WebExtensionMatchedRuleParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionMatchedRuleParameters.h; sourceTree = "<group>"; };
 		3378F2FC2B1FCA5C00362EF3 /* WebExtensionMatchedRuleParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionMatchedRuleParameters.serialization.in; sourceTree = "<group>"; };
+		3399E14E2B59ECEB008BFB60 /* WebExtensionAPIWebRequest.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIWebRequest.idl; sourceTree = "<group>"; };
+		3399E14F2B59EFD6008BFB60 /* JSWebExtensionAPIWebNavigation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIWebNavigation.h; sourceTree = "<group>"; };
+		3399E1502B59EFD7008BFB60 /* JSWebExtensionAPIWebRequest.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPIWebRequest.mm; sourceTree = "<group>"; };
+		3399E1512B59EFD7008BFB60 /* JSWebExtensionAPIWebRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPIWebRequest.h; sourceTree = "<group>"; };
+		3399E1552B59F0E5008BFB60 /* WebExtensionAPIWebRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIWebRequest.h; sourceTree = "<group>"; };
+		3399E1572B59F0FC008BFB60 /* WebExtensionAPIWebRequestCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIWebRequestCocoa.mm; sourceTree = "<group>"; };
 		33B5A80B2AFD298100A15D40 /* WebExtensionFrameParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionFrameParameters.h; sourceTree = "<group>"; };
 		33B5A80D2AFD2B2300A15D40 /* WebExtensionFrameParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionFrameParameters.serialization.in; sourceTree = "<group>"; };
 		33B5A80E2AFD5DE800A15D40 /* WebExtensionContextAPIWebNavigationCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIWebNavigationCocoa.mm; sourceTree = "<group>"; };
@@ -9298,6 +9309,7 @@
 				1C15497B2926BF6F001B9E5B /* WebExtensionAPITest.h */,
 				3375A37329429DF50028536D /* WebExtensionAPIWebNavigation.h */,
 				33F6833D293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h */,
+				3399E1552B59F0E5008BFB60 /* WebExtensionAPIWebRequest.h */,
 				337042032B58A2430077FF78 /* WebExtensionAPIWebRequestEvent.h */,
 				1C5ACFAF2A96F9F200C041C0 /* WebExtensionAPIWindows.h */,
 				1C5ACFB12A96FA0000C041C0 /* WebExtensionAPIWindowsEvent.h */,
@@ -9329,6 +9341,7 @@
 				1C1549792926BF02001B9E5B /* WebExtensionAPITestCocoa.mm */,
 				3375A37029429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm */,
 				33F6833F293FFB3F005C63C0 /* WebExtensionAPIWebNavigationEventCocoa.mm */,
+				3399E1572B59F0FC008BFB60 /* WebExtensionAPIWebRequestCocoa.mm */,
 				337042052B58A2550077FF78 /* WebExtensionAPIWebRequestEventCocoa.mm */,
 				1C5ACFB72A96FA3200C041C0 /* WebExtensionAPIWindowsCocoa.mm */,
 				1C5ACFB32A96FA1900C041C0 /* WebExtensionAPIWindowsEventCocoa.mm */,
@@ -9498,6 +9511,7 @@
 				1CDA62A02925DA3700D90390 /* WebExtensionAPITest.idl */,
 				33066F09293A90DC008C5749 /* WebExtensionAPIWebNavigation.idl */,
 				3302293F2938263E001F00FA /* WebExtensionAPIWebNavigationEvent.idl */,
+				3399E14E2B59ECEB008BFB60 /* WebExtensionAPIWebRequest.idl */,
 				337041FF2B5895C00077FF78 /* WebExtensionAPIWebRequestEvent.idl */,
 				1C5ACF9E2A96E15400C041C0 /* WebExtensionAPIWindows.idl */,
 				1C5ACF9D2A96E15400C041C0 /* WebExtensionAPIWindowsEvent.idl */,
@@ -14366,9 +14380,12 @@
 				1C5ACFA92A96F8D400C041C0 /* JSWebExtensionAPITabs.mm */,
 				1C15497D2926C05A001B9E5B /* JSWebExtensionAPITest.h */,
 				1C15497E2926C05A001B9E5B /* JSWebExtensionAPITest.mm */,
+				3399E14F2B59EFD6008BFB60 /* JSWebExtensionAPIWebNavigation.h */,
 				3375A3762942A19C0028536D /* JSWebExtensionAPIWebNavigation.mm */,
 				33F68335293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.h */,
 				33F68336293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.mm */,
+				3399E1512B59EFD7008BFB60 /* JSWebExtensionAPIWebRequest.h */,
+				3399E1502B59EFD7008BFB60 /* JSWebExtensionAPIWebRequest.mm */,
 				337042012B58A0880077FF78 /* JSWebExtensionAPIWebRequestEvent.h */,
 				337042002B58A0880077FF78 /* JSWebExtensionAPIWebRequestEvent.mm */,
 				1C5ACFA12A96F8C200C041C0 /* JSWebExtensionAPIWindows.h */,
@@ -15584,6 +15601,8 @@
 				B626B7BE2B4F1E3A008E8DD1 /* JSWebExtensionAPIStorage.h in Headers */,
 				B63C10352B51C0C5004A69B8 /* JSWebExtensionAPIStorageArea.h in Headers */,
 				1C5ACFAC2A96F8D500C041C0 /* JSWebExtensionAPITabs.h in Headers */,
+				3399E1522B59EFD7008BFB60 /* JSWebExtensionAPIWebNavigation.h in Headers */,
+				3399E1542B59EFD7008BFB60 /* JSWebExtensionAPIWebRequest.h in Headers */,
 				1C5ACFA52A96F8C400C041C0 /* JSWebExtensionAPIWindows.h in Headers */,
 				1C5ACFA82A96F8C400C041C0 /* JSWebExtensionAPIWindowsEvent.h in Headers */,
 				1C5DC46F290B27260061EC62 /* JSWebExtensionWrappable.h in Headers */,
@@ -16073,6 +16092,7 @@
 				1C15497C2926BF75001B9E5B /* WebExtensionAPITest.h in Headers */,
 				3375A37529429DF50028536D /* WebExtensionAPIWebNavigation.h in Headers */,
 				33F6833E293FFA4B005C63C0 /* WebExtensionAPIWebNavigationEvent.h in Headers */,
+				3399E1562B59F0F0008BFB60 /* WebExtensionAPIWebRequest.h in Headers */,
 				337042042B58A2430077FF78 /* WebExtensionAPIWebRequestEvent.h in Headers */,
 				1C5ACFB02A96F9F200C041C0 /* WebExtensionAPIWindows.h in Headers */,
 				1C5ACFB22A96FA0000C041C0 /* WebExtensionAPIWindowsEvent.h in Headers */,
@@ -18395,6 +18415,7 @@
 				1C15497F2926C073001B9E5B /* JSWebExtensionAPITest.mm in Sources */,
 				3375A3772942A19D0028536D /* JSWebExtensionAPIWebNavigation.mm in Sources */,
 				33F68338293FF6F5005C63C0 /* JSWebExtensionAPIWebNavigationEvent.mm in Sources */,
+				3399E1532B59EFD7008BFB60 /* JSWebExtensionAPIWebRequest.mm in Sources */,
 				337042022B58A0B70077FF78 /* JSWebExtensionAPIWebRequestEvent.mm in Sources */,
 				1C5ACFA62A96F8C400C041C0 /* JSWebExtensionAPIWindows.mm in Sources */,
 				1C5ACFA72A96F8C400C041C0 /* JSWebExtensionAPIWindowsEvent.mm in Sources */,
@@ -18736,6 +18757,7 @@
 				1C15497A2926BF03001B9E5B /* WebExtensionAPITestCocoa.mm in Sources */,
 				3375A37129429DDA0028536D /* WebExtensionAPIWebNavigationCocoa.mm in Sources */,
 				33F68340293FFB3F005C63C0 /* WebExtensionAPIWebNavigationEventCocoa.mm in Sources */,
+				3399E1582B59F0FC008BFB60 /* WebExtensionAPIWebRequestCocoa.mm in Sources */,
 				337042062B58A2550077FF78 /* WebExtensionAPIWebRequestEventCocoa.mm in Sources */,
 				1C5ACFB82A96FA3200C041C0 /* WebExtensionAPIWindowsCocoa.mm in Sources */,
 				1C5ACFB42A96FA1900C041C0 /* WebExtensionAPIWindowsEventCocoa.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -234,6 +234,16 @@ WebExtensionAPIWebNavigation& WebExtensionAPINamespace::webNavigation()
     return *m_webNavigation;
 }
 
+WebExtensionAPIWebRequest& WebExtensionAPINamespace::webRequest()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest
+
+    if (!m_webRequest)
+        m_webRequest = WebExtensionAPIWebRequest::create(forMainWorld(), runtime(), extensionContext());
+
+    return *m_webRequest;
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionAPIWebRequest.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+namespace WebKit {
+
+WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onBeforeRequest()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRequest
+
+    if (!m_onBeforeRequestEvent)
+        m_onBeforeRequestEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnBeforeRequest);
+
+    return *m_onBeforeRequestEvent;
+}
+
+WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onBeforeSendHeaders()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeSendHeaders
+
+    if (!m_onBeforeSendHeadersEvent)
+        m_onBeforeSendHeadersEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnBeforeSendHeaders);
+
+    return *m_onBeforeSendHeadersEvent;
+}
+
+WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onSendHeaders()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onSendHeaders
+
+    if (!m_onSendHeadersEvent)
+        m_onSendHeadersEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnSendHeaders);
+
+    return *m_onSendHeadersEvent;
+}
+
+WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onHeadersReceived()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onHeadersReceived
+
+    if (!m_onHeadersReceivedEvent)
+        m_onHeadersReceivedEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnHeadersReceived);
+
+    return *m_onHeadersReceivedEvent;
+}
+
+WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onAuthRequired()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onAuthRequired
+
+    if (!m_onAuthRequiredEvent)
+        m_onAuthRequiredEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnAuthRequired);
+
+    return *m_onAuthRequiredEvent;
+}
+
+WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onBeforeRedirect()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRedirect
+
+    if (!m_onBeforeRedirectEvent)
+        m_onBeforeRedirectEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnBeforeRedirect);
+
+    return *m_onBeforeRedirectEvent;
+}
+
+WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onResponseStarted()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onResponseStarted
+
+    if (!m_onResponseStartedEvent)
+        m_onResponseStartedEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnResponseStarted);
+
+    return *m_onResponseStartedEvent;
+}
+
+WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onCompleted()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onCompleted
+
+    if (!m_onCompletedEvent)
+        m_onCompletedEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnCompleted);
+
+    return *m_onCompletedEvent;
+}
+
+WebExtensionAPIWebRequestEvent& WebExtensionAPIWebRequest::onErrorOccurred()
+{
+    // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onErrorOccurred
+
+    if (!m_onErrorOccurredEvent)
+        m_onErrorOccurredEvent = WebExtensionAPIWebRequestEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::WebRequestOnErrorOccurred);
+
+    return *m_onErrorOccurredEvent;
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
@@ -45,6 +45,7 @@
 #include "WebExtensionAPITabs.h"
 #include "WebExtensionAPITest.h"
 #include "WebExtensionAPIWebNavigation.h"
+#include "WebExtensionAPIWebRequest.h"
 #include "WebExtensionAPIWindows.h"
 
 namespace WebKit {
@@ -79,6 +80,7 @@ public:
     WebExtensionAPITest& test();
     WebExtensionAPIWindows& windows();
     WebExtensionAPIWebNavigation& webNavigation();
+    WebExtensionAPIWebRequest& webRequest();
 #endif
 
 private:
@@ -99,6 +101,7 @@ private:
     RefPtr<WebExtensionAPITest> m_test;
     RefPtr<WebExtensionAPIWindows> m_windows;
     RefPtr<WebExtensionAPIWebNavigation> m_webNavigation;
+    RefPtr<WebExtensionAPIWebRequest> m_webRequest;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequest.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#include "JSWebExtensionAPIWebRequest.h"
+#include "WebExtensionAPIObject.h"
+#include "WebExtensionAPIWebRequestEvent.h"
+
+namespace WebKit {
+
+class WebPage;
+
+class WebExtensionAPIWebRequest : public WebExtensionAPIObject, public JSWebExtensionWrappable {
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebRequest, webRequest);
+
+public:
+#if PLATFORM(COCOA)
+    WebExtensionAPIWebRequestEvent& onBeforeRequest();
+    WebExtensionAPIWebRequestEvent& onBeforeSendHeaders();
+    WebExtensionAPIWebRequestEvent& onSendHeaders();
+    WebExtensionAPIWebRequestEvent& onHeadersReceived();
+    WebExtensionAPIWebRequestEvent& onAuthRequired();
+    WebExtensionAPIWebRequestEvent& onBeforeRedirect();
+    WebExtensionAPIWebRequestEvent& onResponseStarted();
+    WebExtensionAPIWebRequestEvent& onCompleted();
+    WebExtensionAPIWebRequestEvent& onErrorOccurred();
+
+private:
+    RefPtr<WebExtensionAPIWebRequestEvent> m_onBeforeRequestEvent;
+    RefPtr<WebExtensionAPIWebRequestEvent> m_onBeforeSendHeadersEvent;
+    RefPtr<WebExtensionAPIWebRequestEvent> m_onSendHeadersEvent;
+    RefPtr<WebExtensionAPIWebRequestEvent> m_onHeadersReceivedEvent;
+    RefPtr<WebExtensionAPIWebRequestEvent> m_onAuthRequiredEvent;
+    RefPtr<WebExtensionAPIWebRequestEvent> m_onBeforeRedirectEvent;
+    RefPtr<WebExtensionAPIWebRequestEvent> m_onResponseStartedEvent;
+    RefPtr<WebExtensionAPIWebRequestEvent> m_onCompletedEvent;
+    RefPtr<WebExtensionAPIWebRequestEvent> m_onErrorOccurredEvent;
+
+#endif
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl
@@ -66,6 +66,8 @@
 
     [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIWebNavigation webNavigation;
 
+    [MainWorldOnly, Dynamic] readonly attribute WebExtensionAPIWebRequest webRequest;
+
     [Dynamic] readonly attribute WebExtensionAPITest test;
 
 };

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequest.idl
@@ -26,10 +26,18 @@
 [
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,
-] interface WebExtensionAPIWebRequestEvent {
+    NeedsPageWithCallbackHandler,
+    ReturnsPromiseWhenCallbackIsOmitted,
+] interface WebExtensionAPIWebRequest {
 
-    [NeedsPage, RaisesException] void addListener([CallbackHandler] function listener, [NSDictionary, Optional] any filter, [Optional] any extraInfoSpec);
-    [NeedsPage] void removeListener([CallbackHandler] function listener);
-    boolean hasListener([CallbackHandler] function listener);
+    readonly attribute WebExtensionAPIWebRequestEvent onBeforeRequest;
+    readonly attribute WebExtensionAPIWebRequestEvent onBeforeSendHeaders;
+    readonly attribute WebExtensionAPIWebRequestEvent onSendHeaders;
+    readonly attribute WebExtensionAPIWebRequestEvent onHeadersReceived;
+    readonly attribute WebExtensionAPIWebRequestEvent onAuthRequired;
+    readonly attribute WebExtensionAPIWebRequestEvent onBeforeRedirect;
+    readonly attribute WebExtensionAPIWebRequestEvent onResponseStarted;
+    readonly attribute WebExtensionAPIWebRequestEvent onCompleted;
+    readonly attribute WebExtensionAPIWebRequestEvent onErrorOccurred;
 
 };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm
@@ -31,6 +31,28 @@
 
 namespace TestWebKitAPI {
 
+static auto *webRequestManifest = @{ @"manifest_version": @3, @"permissions": @[ @"webRequest" ], @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO } };
+
+TEST(WKWebExtensionAPIWebRequest, EventListenerTest)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        // Setup
+        @"function listener() { browser.test.notifyFail('This listener should not have been called') }",
+        @"browser.test.assertFalse(browser.webRequest.onCompleted.hasListener(listener), 'Should not have listener')",
+
+        // Test
+        @"browser.webRequest.onCompleted.addListener(listener)",
+        @"browser.test.assertTrue(browser.webRequest.onCompleted.hasListener(listener), 'Should have listener')",
+        @"browser.webRequest.onCompleted.removeListener(listener)",
+        @"browser.test.assertFalse(browser.webRequest.onCompleted.hasListener(listener), 'Should not have listener')",
+
+        // Finish
+        @"browser.test.notifyPass()"
+    ]);
+
+    Util::loadAndRunExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+}
+
 TEST(WKWebExtensionAPIWebRequest, Initialization)
 {
     NSString *error;


### PR DESCRIPTION
#### f808a2b2b9e3ac58ffa028da52c07dd3441cd7a8
<pre>
Add webRequest event listener bindings and a basic test for them
<a href="https://bugs.webkit.org/show_bug.cgi?id=267747">https://bugs.webkit.org/show_bug.cgi?id=267747</a>
<a href="https://rdar.apple.com/114823223">rdar://114823223</a>

Reviewed by Timothy Hatcher.

* Source/WebKit/DerivedSources-input.xcfilelist: Add new files.
* Source/WebKit/DerivedSources-output.xcfilelist: Ditto.
* Source/WebKit/DerivedSources.make: Add the new idl file.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj: Add new files.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::webRequest): Create the WebExtensionAPIWebRequest object and return it.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm: Added.
(WebKit::WebExtensionAPIWebRequest::onBeforeRequest): Create the listener and return it.
(WebKit::WebExtensionAPIWebRequest::onBeforeSendHeaders): Ditto.
(WebKit::WebExtensionAPIWebRequest::onSendHeaders): Ditto.
(WebKit::WebExtensionAPIWebRequest::onHeadersReceived): Ditto.
(WebKit::WebExtensionAPIWebRequest::onAuthRequired): Ditto.
(WebKit::WebExtensionAPIWebRequest::onBeforeRedirect): Ditto.
(WebKit::WebExtensionAPIWebRequest::onResponseStarted): Ditto.
(WebKit::WebExtensionAPIWebRequest::onCompleted): Ditto.
(WebKit::WebExtensionAPIWebRequest::onErrorOccurred): Ditto.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequest.h: Added.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPINamespace.idl: Add the webRequest binding on the browser object.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequest.idl: Copied from Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm:
(TestWebKitAPI::TEST): Add a test around the basic addListener/removeListener/hasListener functionality.

Canonical link: <a href="https://commits.webkit.org/273223@main">https://commits.webkit.org/273223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b6f68f68c4d4f27ff6d669cfa099b46598f9b23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37485 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31403 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35941 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10705 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10081 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38751 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31388 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34167 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12090 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7971 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10807 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->