### PR TITLE
HTMLImageElement.natural{Width,Height} should return intrinsic dimensions

### DIFF
--- a/LayoutTests/fast/dom/HTMLImageElement/image-natural-width-height-svg-expected.txt
+++ b/LayoutTests/fast/dom/HTMLImageElement/image-natural-width-height-svg-expected.txt
@@ -1,0 +1,9 @@
+
+
+PASS naturalWidth/Height of SVG in <img>, width/height in pixels
+FAIL naturalWidth/Height of SVG in <img>, width in pixels; height unspecified assert_equals: expected "500x0" but got "300x150"
+FAIL naturalWidth/Height of SVG in <img>, width in pixels; percentage height assert_equals: expected "500x0" but got "300x150"
+PASS naturalWidth/Height of SVG in <img>, width/height in pixels; viewBox
+FAIL naturalWidth/Height of SVG in <img>, width/height unspecified; viewBox assert_equals: expected "0x0" but got "800x600"
+FAIL naturalWidth/Height of SVG in <img>, width in pixels; height unspecified; viewBox assert_equals: expected "400x0" but got "800x600"
+

--- a/LayoutTests/fast/dom/HTMLImageElement/image-natural-width-height-svg.html
+++ b/LayoutTests/fast/dom/HTMLImageElement/image-natural-width-height-svg.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<style>
+img {
+  width: 200px;
+}
+</style>
+<body></body>
+<script>
+function makeSvgImageUrl(sizingAttributes) {
+  var s = "<svg xmlns='http://www.w3.org/2000/svg' ";
+  s += sizingAttributes;
+  s += "><circle cx='50%' cy='50%' r='50%' fill='blue'/></svg>";
+  return "data:image/svg+xml," + encodeURIComponent(s);
+}
+
+function assertImageDimensions(img, expected) {
+  assert_equals(img.naturalWidth + "x" + img.naturalHeight, expected.width + "x" + expected.height);
+}
+
+function makeTest(sizingAttributes, expected, description) {
+  var t = async_test("naturalWidth/Height of SVG in <img>, " + description);
+  var img = document.body.appendChild(new Image());
+  img.onload = t.step_func(function() {
+    assertImageDimensions(img, expected);
+
+    requestAnimationFrame(function() {
+      setTimeout(t.step_func(function() {
+        assertImageDimensions(img, expected);
+        t.done();
+      }), 0);
+    });
+  });
+  img.src = makeSvgImageUrl(sizingAttributes);
+}
+
+makeTest("width='500' height='400'", { width: 500, height: 400 }, "width/height in pixels");
+makeTest("width='500'", { width: 500, height: 0 }, "width in pixels; height unspecified");
+makeTest("width='500' height='100%'", { width: 500, height: 0 }, "width in pixels; percentage height");
+makeTest("width='500' height='400' viewBox='0 0 800 600'", { width: 500, height: 400 }, "width/height in pixels; viewBox");
+makeTest("viewBox='0 0 800 600'", { width: 0, height: 0 }, "width/height unspecified; viewBox");
+makeTest("width='400' viewBox='0 0 800 600'", { width: 400, height: 0 }, "width in pixels; height unspecified; viewBox");
+</script>

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2010-2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -594,7 +594,7 @@ unsigned HTMLImageElement::naturalWidth() const
     if (!m_imageLoader->image())
         return 0;
 
-    return m_imageLoader->image()->unclampedImageSizeForRenderer(renderer(), effectiveImageDevicePixelRatio()).width().toUnsigned();
+    return m_imageLoader->image()->unclampedImageSizeForRenderer(renderer(), effectiveImageDevicePixelRatio(), CachedImage::IntrinsicSize).width().toUnsigned();
 }
 
 unsigned HTMLImageElement::naturalHeight() const
@@ -602,7 +602,7 @@ unsigned HTMLImageElement::naturalHeight() const
     if (!m_imageLoader->image())
         return 0;
 
-    return m_imageLoader->image()->unclampedImageSizeForRenderer(renderer(), effectiveImageDevicePixelRatio()).height().toUnsigned();
+    return m_imageLoader->image()->unclampedImageSizeForRenderer(renderer(), effectiveImageDevicePixelRatio(), CachedImage::IntrinsicSize).height().toUnsigned();
 }
 
 bool HTMLImageElement::isURLAttribute(const Attribute& attribute) const


### PR DESCRIPTION
<pre>
HTMLImageElement.natural{Width,Height} should return intrinsic dimensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=267750">https://bugs.webkit.org/show_bug.cgi?id=267750</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Blink / Chromium but partially with Gecko / Firefox.

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=179030">https://src.chromium.org/viewvc/blink?view=revision&revision=179030</a>

As per HTML Specification [1]:

"The IDL attributes naturalWidth and naturalHeight must return the
intrinsic width and height of the image, in CSS pixels, if the image is
available, or else 0."

[1] <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a>

Change HTMLImageElement::natural{Width,Height} to request the intrinsic
size from CachedImage::IntrinsicSize by passing IntrinsicSize as the third parameter.
This makes the attributes return more appropriate values for SVG-images in `<img>`.

* Source/WebCore/html/HTMLImageElement.cpp:
(HTMLImageElement::naturalWidth):
(HTMLImageElement::naturalHeight):
* LayoutTests/fast/dom/HTMLImageElement/image-natural-width-height-svg.html: Add Test Case
* LayoutTests/fast/dom/HTMLImageElement/image-natural-width-height-svg-expected.txt: Add Test Case Expectation (It progresses two tests)
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/763f6aa0867a7c75f66b0f74d2c18f99f9d970ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37412 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35870 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10632 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30297 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/current-pixel-density/basic.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/intrinsicsize/intrinsicsize-with-responsive-images.tentative.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11488 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30921 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10023 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10102 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31001 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/current-pixel-density/basic.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/intrinsicsize/intrinsicsize-with-responsive-images.tentative.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38676 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31547 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31315 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/current-pixel-density/basic.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/intrinsicsize/intrinsicsize-with-responsive-images.tentative.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36137 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/current-pixel-density/basic.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/intrinsicsize/intrinsicsize-with-responsive-images.tentative.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10205 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8098 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/current-pixel-density/basic.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/intrinsicsize/intrinsicsize-with-responsive-images.tentative.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34105 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30636 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10753 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11090 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->