### PR TITLE
[WPE] WPE Platform: use weak references to WPEView in WPEWaylandSeat

### DIFF
--- a/Source/WTF/wtf/glib/GWeakPtr.h
+++ b/Source/WTF/wtf/glib/GWeakPtr.h
@@ -81,6 +81,13 @@ public:
         return *this;
     }
 
+    GWeakPtr& operator=(GWeakPtr&& other)
+    {
+        reset(other.get());
+        other.reset();
+        return *this;
+    }
+
     bool operator!() const { return !m_ptr; }
 
     // This conversion operator allows implicit conversion to bool but not to other integer types.

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
@@ -62,7 +62,7 @@ const struct wl_pointer_listener WaylandSeat::s_pointerListener = {
             return;
 
         auto& seat = *static_cast<WaylandSeat*>(data);
-        seat.m_pointer.view = WPE_VIEW(view);
+        seat.m_pointer.view.reset(WPE_VIEW(view));
         seat.m_pointer.x = wl_fixed_to_double(x);
         seat.m_pointer.y = wl_fixed_to_double(y);
         seat.m_pointer.modifiers = 0;
@@ -290,7 +290,7 @@ const struct wl_keyboard_listener WaylandSeat::s_keyboardListener = {
             return;
 
         auto& seat = *static_cast<WaylandSeat*>(data);
-        seat.m_keyboard.view = WPE_VIEW(view);
+        seat.m_keyboard.view.reset(WPE_VIEW(view));
         seat.m_keyboard.repeat.key = 0;
 
         wpe_view_focus_in(seat.m_keyboard.view.get());
@@ -305,7 +305,7 @@ const struct wl_keyboard_listener WaylandSeat::s_keyboardListener = {
         if (seat.m_keyboard.repeat.source)
             g_source_set_ready_time(seat.m_keyboard.repeat.source.get(), -1);
 
-        GRefPtr<WPEView> view = seat.m_keyboard.view;
+        GRefPtr<WPEView> view = seat.m_keyboard.view.get();
         seat.m_keyboard.view = nullptr;
         seat.m_keyboard.repeat.key = 0;
         seat.m_keyboard.repeat.deadline = { };
@@ -366,7 +366,7 @@ const struct wl_touch_listener WaylandSeat::s_touchListener = {
             return;
 
         auto& seat = *static_cast<WaylandSeat*>(data);
-        seat.m_touch.view = WPE_VIEW(view);
+        seat.m_touch.view.reset(WPE_VIEW(view));
 
         auto addResult = seat.m_touch.points.add(id, std::pair<double, double>(wl_fixed_to_double(x), wl_fixed_to_double(y)));
         auto* event = wpe_event_touch_new(WPE_EVENT_TOUCH_DOWN, seat.m_touch.view.get(), seat.m_touch.source, time, seat.modifiers(),

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h
@@ -33,6 +33,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/Seconds.h>
 #include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GWeakPtr.h>
 
 namespace WPE {
 
@@ -66,7 +67,7 @@ private:
     struct {
         struct wl_pointer* object { nullptr };
         WPEInputSource source { WPE_INPUT_SOURCE_MOUSE };
-        GRefPtr<WPEView> view;
+        GWeakPtr<WPEView> view;
         double x { 0 };
         double y { 0 };
         uint32_t modifiers { 0 };
@@ -87,7 +88,7 @@ private:
     struct {
         struct wl_keyboard* object { nullptr };
         WPEInputSource source { WPE_INPUT_SOURCE_KEYBOARD };
-        GRefPtr<WPEView> view;
+        GWeakPtr<WPEView> view;
         uint32_t modifiers { 0 };
         uint32_t time { 0 };
 
@@ -110,7 +111,7 @@ private:
     struct {
         struct wl_touch* object { nullptr };
         WPEInputSource source { WPE_INPUT_SOURCE_TOUCHSCREEN };
-        GRefPtr<WPEView> view;
+        GWeakPtr<WPEView> view;
         HashMap<int32_t, std::pair<double, double>> points;
     } m_touch;
 };

--- a/Tools/TestWebKitAPI/Tests/WTF/glib/GWeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/glib/GWeakPtr.cpp
@@ -120,6 +120,23 @@ TEST(WTF_GWeakPtr, Move)
         GWeakPtr<GObject> weak(obj);
         EXPECT_EQ(obj, weak.get());
         EXPECT_TRUE(weak);
+        GWeakPtr<GObject> weak2(WTFMove(weak));
+        EXPECT_NULL(weak.get());
+        EXPECT_FALSE(weak);
+        EXPECT_EQ(obj, weak2.get());
+        EXPECT_TRUE(weak2);
+        EXPECT_EQ(obj->ref_count, 1);
+        g_clear_object(&obj);
+        EXPECT_NULL(weak2.get());
+        EXPECT_FALSE(weak2);
+    }
+    EXPECT_NULL(obj);
+
+    {
+        obj = G_OBJECT(g_object_new(G_TYPE_OBJECT, nullptr));
+        GWeakPtr<GObject> weak(obj);
+        EXPECT_EQ(obj, weak.get());
+        EXPECT_TRUE(weak);
         GWeakPtr<GObject> weak2 = WTFMove(weak);
         EXPECT_NULL(weak.get());
         EXPECT_FALSE(weak);


### PR DESCRIPTION
#### 189e402ec1cea8b6d4c01515f2d2ba75fce6df8a
<pre>
[WPE] WPE Platform: use weak references to WPEView in WPEWaylandSeat
<a href="https://bugs.webkit.org/show_bug.cgi?id=267756">https://bugs.webkit.org/show_bug.cgi?id=267756</a>

Reviewed by Adrian Perez de Castro.

We are leaking the view when pointer leave and keyboard leave are not
emitted. Since GWeakPtr is not copyable, we need to add an explicit move
assignment operator to be able to reset the WPEWaylandSeat structs with
foo = { }.

* Source/WTF/wtf/glib/GWeakPtr.h:
(WTF::GWeakPtr::operator=):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h:
* Tools/TestWebKitAPI/Tests/WTF/glib/GWeakPtr.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/273215@main">https://commits.webkit.org/273215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3ff9cf417415fedf3b3f1194e7d96f69d2f958a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37441 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31364 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10661 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11490 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10042 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31023 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38706 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/29473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31346 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36154 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/34597 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34127 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12051 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41223 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10771 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8595 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4452 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->