### PR TITLE
Make <input type=checkbox switch> iOS-zooming compatible with other ports

### DIFF
--- a/LayoutTests/fast/forms/switch/zoom-computed-style-expected.txt
+++ b/LayoutTests/fast/forms/switch/zoom-computed-style-expected.txt
@@ -1,0 +1,5 @@
+PASS getComputedStyle(control).zoom is "1"
+PASS getComputedStyle(controlZoom).zoom is "5"
+PASS getComputedStyle(control).width is getComputedStyle(controlZoom).width
+PASS getComputedStyle(control).height is getComputedStyle(controlZoom).height
+

--- a/LayoutTests/fast/forms/switch/zoom-computed-style.html
+++ b/LayoutTests/fast/forms/switch/zoom-computed-style.html
@@ -1,0 +1,11 @@
+<script src="../../../resources/js-test-pre.js"></script>
+<input type=checkbox switch>
+<input type=checkbox switch style=zoom:5>
+<script>
+const [control, controlZoom] = document.querySelectorAll("input");
+
+shouldBeEqualToString("getComputedStyle(control).zoom", "1");
+shouldBeEqualToString("getComputedStyle(controlZoom).zoom", "5");
+shouldBe("getComputedStyle(control).width", "getComputedStyle(controlZoom).width");
+shouldBe("getComputedStyle(control).height", "getComputedStyle(controlZoom).height");
+</script>

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -725,9 +725,8 @@ void RenderThemeIOS::adjustSwitchStyle(RenderStyle& style, const Element* elemen
 {
     // FIXME: Deduplicate sizing with the generic code somehow.
     if (style.width().isAuto() || style.height().isAuto()) {
-        auto size = std::max(style.computedFontSize(), logicalSwitchHeight);
-        style.setLogicalWidth({ size * (logicalSwitchWidth / logicalSwitchHeight), LengthType::Fixed });
-        style.setLogicalHeight({ size, LengthType::Fixed });
+        style.setLogicalWidth({ logicalSwitchWidth * style.effectiveZoom(), LengthType::Fixed });
+        style.setLogicalHeight({ logicalSwitchHeight * style.effectiveZoom(), LengthType::Fixed });
     }
 
     adjustSwitchStyleDisplay(style);


### PR DESCRIPTION
#### 7c24c6f0873d402fb1cdd125b3668b2adddc5692
<pre>
Make &lt;input type=checkbox switch&gt; iOS-zooming compatible with other ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=267757">https://bugs.webkit.org/show_bug.cgi?id=267757</a>
<a href="https://rdar.apple.com/121248632">rdar://121248632</a>

Reviewed by Aditya Keerthi.

This ensures that on iOS builds that can paint a switch, the following
tests pass as expected:

- fast/forms/switch/zoom-approximates-transform-rtl.html
- fast/forms/switch/zoom-approximates-transform-vertical-lr.html
- fast/forms/switch/zoom-approximates-transform-vertical-rl.html
- fast/forms/switch/zoom-approximates-transform.html

Without this fix there would be some amount of zooming on iOS due to it
currently aligning with the font-size, but only for very large zoom
values.

Also add a new test that demonstrates this does not impact
getComputedStyle() across platforms.

* LayoutTests/fast/forms/switch/zoom-computed-style-expected.txt: Added.
* LayoutTests/fast/forms/switch/zoom-computed-style.html: Added.
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::adjustSwitchStyle const):

Canonical link: <a href="https://commits.webkit.org/273289@main">https://commits.webkit.org/273289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5ea72d4bde99efcd65279b09d2235f9d6e5bcbd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37599 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31489 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36036 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10819 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30423 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10176 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10246 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38853 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31489 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36270 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8258 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34248 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30805 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8015 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10892 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11229 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->