### PR TITLE
[WPE] WPE Platform: add monitors API

### DIFF
--- a/Source/WebCore/platform/PlatformScreen.cpp
+++ b/Source/WebCore/platform/PlatformScreen.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "PlatformScreen.h"
 
-#if PLATFORM(COCOA) || PLATFORM(GTK)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
 
 #include "ScreenProperties.h"
 #include <wtf/NeverDestroyed.h>
@@ -72,4 +72,4 @@ const ScreenData* screenData(PlatformDisplayID screenDisplayID)
 
 } // namespace WebCore
 
-#endif // PLATFORM(COCOA) || PLATFORM(GTK)
+#endif // PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))

--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -52,7 +52,7 @@ struct ScreenData {
     DynamicRangeMode preferredDynamicRangeMode { DynamicRangeMode::Standard };
     WEBCORE_EXPORT double screenDPI() const;
 #endif
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
     IntSize screenSize; // In millimeters.
     double dpi;
 #endif

--- a/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
+++ b/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
@@ -28,27 +28,65 @@
 
 #include "DestinationColorSpace.h"
 #include "FloatRect.h"
+#include "HostWindow.h"
+#include "LocalFrameView.h"
 #include "NotImplemented.h"
+#include "ScreenProperties.h"
 #include "Widget.h"
 
 namespace WebCore {
 
-int screenDepth(Widget*)
+#if ENABLE(WPE_PLATFORM)
+static PlatformDisplayID widgetDisplayID(Widget* widget)
 {
+    if (!widget)
+        return 0;
+
+    auto* view = widget->root();
+    if (!view)
+        return 0;
+
+    auto* hostWindow = view->hostWindow();
+    if (!hostWindow)
+        return 0;
+
+    return hostWindow->displayID();
+}
+#endif
+
+int screenDepth(Widget* widget)
+{
+#if ENABLE(WPE_PLATFORM)
+    auto* data = screenData(widgetDisplayID(widget));
+    return data ? data->screenDepth : 24;
+#else
+    UNUSED_PARAM(widget);
     notImplemented();
     return 24;
+#endif
 }
 
-int screenDepthPerComponent(Widget*)
+int screenDepthPerComponent(Widget* widget)
 {
+#if ENABLE(WPE_PLATFORM)
+    auto* data = screenData(widgetDisplayID(widget));
+    return data ? data->screenDepthPerComponent : 8;
+#else
+    UNUSED_PARAM(widget);
     notImplemented();
     return 8;
+#endif
 }
 
-bool screenIsMonochrome(Widget*)
+bool screenIsMonochrome(Widget* widget)
 {
+#if ENABLE(WPE_PLATFORM)
+    return screenDepth(widget) < 2;
+#else
+    UNUSED_PARAM(widget);
     notImplemented();
     return false;
+#endif
 }
 
 bool screenHasInvertedColors()
@@ -58,17 +96,21 @@ bool screenHasInvertedColors()
 
 double screenDPI()
 {
+#if ENABLE(WPE_PLATFORM)
+    auto* data = screenData(primaryScreenDisplayID());
+    return data ? data->dpi : 96.;
+#else
     notImplemented();
     return 96;
-}
-
-void setScreenDPIObserverHandler(Function<void()>&&, void*)
-{
-    notImplemented();
+#endif
 }
 
 FloatRect screenRect(Widget* widget)
 {
+#if ENABLE(WPE_PLATFORM)
+    if (auto* data = screenData(widgetDisplayID(widget)))
+        return data->screenRect;
+#endif
     // WPE can't offer any more useful information about the screen size,
     // so we use the Widget's bounds rectangle (size of which equals the WPE view size).
 
@@ -79,6 +121,10 @@ FloatRect screenRect(Widget* widget)
 
 FloatRect screenAvailableRect(Widget* widget)
 {
+#if ENABLE(WPE_PLATFORM)
+    if (auto* data = screenData(widgetDisplayID(widget)))
+        return data->screenAvailableRect;
+#endif
     return screenRect(widget);
 }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2239,7 +2239,7 @@ header: <WebCore/ScreenProperties.h>
     WebCore::PlatformGPUID gpuID;
     WebCore::DynamicRangeMode preferredDynamicRangeMode;
 #endif
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
     WebCore::IntSize screenSize;
     double dpi;
 #endif

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -105,6 +105,9 @@ struct WebPageCreationParameters {
 
     std::optional<WebCore::FloatRect> viewExposedRect;
 
+    std::optional<uint32_t> displayID;
+    std::optional<unsigned> nominalFramesPerSecond;
+
     bool alwaysShowsHorizontalScroller;
     bool alwaysShowsVerticalScroller;
 

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -46,6 +46,9 @@ headers: "ArgumentCoders.h"
 
     std::optional<WebCore::FloatRect> viewExposedRect;
 
+    std::optional<uint32_t> displayID;
+    std::optional<unsigned> nominalFramesPerSecond;
+
     bool alwaysShowsHorizontalScroller;
     bool alwaysShowsVerticalScroller;
 

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -42,7 +42,7 @@
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
-#if PLATFORM(COCOA) || PLATFORM(GTK)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
 #include <WebCore/ScreenProperties.h>
 #endif
 
@@ -169,7 +169,7 @@ struct WebProcessCreationParameters {
     Vector<String> mediaMIMETypes;
 #endif
 
-#if PLATFORM(COCOA) || PLATFORM(GTK)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
     WebCore::ScreenProperties screenProperties;
 #endif
 

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -118,7 +118,7 @@
     Vector<String> mediaMIMETypes;
 #endif
 
-#if PLATFORM(COCOA) || PLATFORM(GTK)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
     WebCore::ScreenProperties screenProperties;
 #endif
 

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -260,6 +260,7 @@ UIProcess/glib/DisplayLinkGLib.cpp
 UIProcess/glib/DisplayVBlankMonitor.cpp
 UIProcess/glib/DisplayVBlankMonitorDRM.cpp
 UIProcess/glib/DisplayVBlankMonitorTimer.cpp
+UIProcess/glib/ScreenManager.cpp
 UIProcess/glib/WebPageProxyGLib.cpp
 UIProcess/glib/WebProcessPoolGLib.cpp
 UIProcess/glib/WebProcessProxyGLib.cpp
@@ -278,7 +279,7 @@ UIProcess/gtk/KeyBindingTranslator.cpp
 UIProcess/gtk/PointerLockManager.cpp @no-unify
 UIProcess/gtk/PointerLockManagerWayland.cpp @no-unify
 UIProcess/gtk/PointerLockManagerX11.cpp @no-unify
-UIProcess/gtk/ScreenManager.cpp @no-unify
+UIProcess/gtk/ScreenManagerGtk.cpp @no-unify
 UIProcess/gtk/TextCheckerGtk.cpp @no-unify
 UIProcess/gtk/ViewSnapshotStoreGtk3.cpp @no-unify
 UIProcess/gtk/ViewSnapshotStoreGtk4.cpp @no-unify

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -228,6 +228,7 @@ UIProcess/glib/DisplayLinkGLib.cpp
 UIProcess/glib/DisplayVBlankMonitor.cpp
 UIProcess/glib/DisplayVBlankMonitorDRM.cpp
 UIProcess/glib/DisplayVBlankMonitorTimer.cpp
+UIProcess/glib/ScreenManager.cpp
 UIProcess/glib/WebPageProxyGLib.cpp
 UIProcess/glib/WebProcessPoolGLib.cpp
 UIProcess/glib/WebProcessProxyGLib.cpp
@@ -257,6 +258,7 @@ UIProcess/linux/MemoryPressureMonitor.cpp
 UIProcess/soup/WebProcessPoolSoup.cpp
 
 UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
+UIProcess/wpe/ScreenManagerWPE.cpp
 UIProcess/wpe/WebPageProxyWPE.cpp
 
 WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
@@ -155,6 +155,10 @@ private:
     void setViewState(OptionSet<WebCore::ActivityState>);
     void handleKeyboardEvent(struct wpe_input_keyboard_event*);
 
+#if ENABLE(WPE_PLATFORM)
+    void updateDisplayID();
+#endif
+
 #if ENABLE(TOUCH_EVENTS) && ENABLE(WPE_PLATFORM)
     Vector<WebKit::WebPlatformTouchPoint> touchPointsForEvent(WPEEvent*);
 #endif
@@ -176,6 +180,7 @@ private:
 #if ENABLE(WPE_PLATFORM)
     GRefPtr<WPEView> m_wpeView;
     std::unique_ptr<WebKit::AcceleratedBackingStoreDMABuf> m_backingStore;
+    uint32_t m_displayID { 0 };
 #endif
 
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -444,6 +444,8 @@ void RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange(PlatformDisplayID
 
 std::optional<WebCore::FramesPerSecond> RemoteLayerTreeDrawingAreaProxyMac::displayNominalFramesPerSecond()
 {
+    if (!m_displayID)
+        return std::nullopt;
     return displayLink().nominalFramesPerSecond();
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9800,6 +9800,10 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.minimumUnobscuredSize = internals().minimumUnobscuredSize;
     parameters.maximumUnobscuredSize = internals().maximumUnobscuredSize;
     parameters.viewExposedRect = internals().viewExposedRect;
+    if (m_displayID) {
+        parameters.displayID = m_displayID;
+        parameters.nominalFramesPerSecond = drawingArea.displayNominalFramesPerSecond();
+    }
     parameters.alwaysShowsHorizontalScroller = m_alwaysShowsHorizontalScroller;
     parameters.alwaysShowsVerticalScroller = m_alwaysShowsVerticalScroller;
     parameters.suppressScrollbarAnimations = m_suppressScrollbarAnimations;

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.cpp
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.cpp
@@ -40,9 +40,12 @@
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
 #include "ScreenManager.h"
 #include <WebCore/PlatformScreen.h>
+#endif
+
+#if PLATFORM(GTK)
 #include <gtk/gtk.h>
 #endif
 
@@ -52,15 +55,20 @@
 
 namespace WebKit {
 
-#if PLATFORM(GTK)
-static std::optional<uint32_t> findCrtc(int fd, GdkMonitor* monitor)
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
+static std::optional<std::pair<uint32_t, uint32_t>> findCrtc(int fd, PlatformMonitor* monitor)
 {
     drmModeRes* resources = drmModeGetResources(fd);
     if (!resources)
         return std::nullopt;
 
+#if PLATFORM(GTK)
     uint32_t widthMM = gdk_monitor_get_width_mm(monitor);
     uint32_t heightMM = gdk_monitor_get_height_mm(monitor);
+#elif PLATFORM(WPE)
+    uint32_t widthMM = wpe_monitor_get_physical_width(monitor);
+    uint32_t heightMM = wpe_monitor_get_physical_height(monitor);
+#endif
 
     // First find connectors matching the size.
     Vector<drmModeConnector*, 1> connectors;
@@ -87,13 +95,18 @@ static std::optional<uint32_t> findCrtc(int fd, GdkMonitor* monitor)
         return std::nullopt;
     }
 
-    std::optional<uint32_t> returnValue;
+    std::optional<std::pair<uint32_t, uint32_t>> returnValue;
 
     // FIXME: if there are multiple connectors, check other properties.
     if (drmModeEncoder* encoder = drmModeGetEncoder(fd, connectors[0]->encoder_id)) {
         for (int i = 0; i < resources->count_crtcs; ++i) {
             if (resources->crtcs[i] == encoder->crtc_id) {
-                returnValue = i;
+#if PLATFORM(GTK)
+                auto refreshRate = gdk_monitor_get_refresh_rate(monitor);
+#elif PLATFORM(WPE)
+                auto refreshRate = wpe_monitor_get_refresh_rate(monitor);
+#endif
+                returnValue = { i, refreshRate };
                 break;
             }
         }
@@ -107,7 +120,9 @@ static std::optional<uint32_t> findCrtc(int fd, GdkMonitor* monitor)
 
     return returnValue;
 }
-#elif PLATFORM(WPE)
+#endif
+
+#if PLATFORM(WPE)
 static std::optional<std::pair<uint32_t, uint32_t>> findCrtc(int fd)
 {
     drmModeRes* resources = drmModeGetResources(fd);
@@ -177,8 +192,31 @@ static int crtcBitmaskForIndex(uint32_t crtcIndex)
 std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitorDRM::create(PlatformDisplayID displayID)
 {
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+    static bool usingWPEPlatformAPI = !!g_type_class_peek(WPE_TYPE_DISPLAY);
+#endif
+
+#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+    PlatformMonitor* monitor = nullptr;
+    if (usingWPEPlatformAPI) {
+        monitor = ScreenManager::singleton().monitor(displayID ? displayID : WebCore::primaryScreenDisplayID());
+        if (!monitor) {
+            RELEASE_LOG_FAULT(DisplayLink, "Could not create a vblank monitor for display %u: no monitor found", displayID);
+            return nullptr;
+        }
+    }
+#endif
+
+#if PLATFORM(GTK)
+    auto* monitor = ScreenManager::singleton().monitor(displayID ? displayID : WebCore::primaryScreenDisplayID());
+    if (!monitor) {
+        RELEASE_LOG_FAULT(DisplayLink, "Could not create a vblank monitor for display %u: no monitor found", displayID);
+        return nullptr;
+    }
+#endif
+
+#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
     String filename;
-    if (g_type_class_peek(WPE_TYPE_DISPLAY))
+    if (usingWPEPlatformAPI)
         filename = String::fromUTF8(wpe_render_device());
     else
         filename = WebCore::PlatformDisplay::sharedDisplay().drmDeviceFile();
@@ -197,28 +235,21 @@ std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitorDRM::create(PlatformDi
     }
 
 #if PLATFORM(GTK)
-    auto* monitor = ScreenManager::singleton().monitor(displayID ? displayID : WebCore::primaryScreenDisplayID());
-    if (!monitor) {
-        RELEASE_LOG_FAULT(DisplayLink, "Could not create a vblank monitor for display %u: no monitor found", displayID);
-        return nullptr;
-    }
-
-    auto crtcIndex = findCrtc(fd.value(), monitor);
-    if (!crtcIndex) {
-        RELEASE_LOG_FAULT(DisplayLink, "Could not create a vblank monitor for display %u: no CRTC found", displayID);
-        return nullptr;
-    }
-
-    auto crtcBitmask = crtcBitmaskForIndex(crtcIndex.value());
+    auto crtcInfo = findCrtc(fd.value(), monitor);
 #elif PLATFORM(WPE)
+#if ENABLE(WPE_PLATFORM)
+    auto crtcInfo = monitor ? findCrtc(fd.value(), monitor) : findCrtc(fd.value());
+#else
     auto crtcInfo = findCrtc(fd.value());
+#endif
+#endif
+
     if (!crtcInfo) {
         RELEASE_LOG_FAULT(DisplayLink, "Could not create a vblank monitor for display %u: no CRTC found", displayID);
         return nullptr;
     }
 
     auto crtcBitmask = crtcBitmaskForIndex(crtcInfo->first);
-#endif
 
     drmVBlank vblank;
     vblank.request.type = static_cast<drmVBlankSeqType>(DRM_VBLANK_RELATIVE | crtcBitmask);
@@ -230,11 +261,7 @@ std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitorDRM::create(PlatformDi
         return nullptr;
     }
 
-#if PLATFORM(GTK)
-    return makeUnique<DisplayVBlankMonitorDRM>(gdk_monitor_get_refresh_rate(monitor) / 1000, WTFMove(fd), crtcBitmask);
-#elif PLATFORM(WPE)
     return makeUnique<DisplayVBlankMonitorDRM>(crtcInfo->second / 1000, WTFMove(fd), crtcBitmask);
-#endif
 }
 
 DisplayVBlankMonitorDRM::DisplayVBlankMonitorDRM(unsigned refreshRate, UnixFileDescriptor&& fd, int crtcBitmask)

--- a/Source/WebKit/UIProcess/glib/ScreenManager.cpp
+++ b/Source/WebKit/UIProcess/glib/ScreenManager.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScreenManager.h"
+
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
+#include "WebProcessMessages.h"
+#include "WebProcessPool.h"
+
+namespace WebKit {
+
+ScreenManager& ScreenManager::singleton()
+{
+    static NeverDestroyed<ScreenManager> manager;
+    return manager;
+}
+
+PlatformDisplayID ScreenManager::displayID(PlatformMonitor* monitor) const
+{
+    return m_monitorToDisplayIDMap.get(monitor);
+}
+
+PlatformMonitor* ScreenManager::monitor(PlatformDisplayID displayID) const
+{
+    for (const auto& iter : m_monitorToDisplayIDMap) {
+        if (iter.value == displayID)
+            return iter.key;
+    }
+    return nullptr;
+}
+
+void ScreenManager::addMonitor(PlatformMonitor* monitor)
+{
+    m_monitors.append(monitor);
+    m_monitorToDisplayIDMap.add(monitor, generatePlatformDisplayID(monitor));
+}
+
+void ScreenManager::removeMonitor(PlatformMonitor* monitor)
+{
+    m_monitorToDisplayIDMap.remove(monitor);
+    m_monitors.removeFirstMatching([monitor](const auto& item) {
+        return item.get() == monitor;
+    });
+}
+
+void ScreenManager::propertiesDidChange() const
+{
+    auto properties = collectScreenProperties();
+    for (auto& pool : WebProcessPool::allProcessPools())
+        pool->sendToAllProcesses(Messages::WebProcess::SetScreenProperties(properties));
+}
+
+} // namespace WebKit
+
+#endif // PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))

--- a/Source/WebKit/UIProcess/glib/ScreenManager.h
+++ b/Source/WebKit/UIProcess/glib/ScreenManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2023,2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,13 +25,21 @@
 
 #pragma once
 
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
+
 #include <WebCore/ScreenProperties.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Vector.h>
 #include <wtf/glib/GRefPtr.h>
 
+#if PLATFORM(GTK)
 typedef struct _GdkMonitor GdkMonitor;
+using PlatformMonitor = GdkMonitor;
+#elif PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+typedef struct _WPEMonitor WPEMonitor;
+using PlatformMonitor = WPEMonitor;
+#endif
 
 namespace WebKit {
 
@@ -43,20 +51,24 @@ class ScreenManager {
 public:
     static ScreenManager& singleton();
 
-    PlatformDisplayID displayID(GdkMonitor*) const;
-    GdkMonitor* monitor(PlatformDisplayID) const;
+    PlatformDisplayID displayID(PlatformMonitor*) const;
+    PlatformMonitor* monitor(PlatformDisplayID) const;
 
     WebCore::ScreenProperties collectScreenProperties() const;
 
 private:
     ScreenManager();
 
-    void addMonitor(GdkMonitor*);
-    void removeMonitor(GdkMonitor*);
+    static PlatformDisplayID generatePlatformDisplayID(PlatformMonitor*);
+
+    void addMonitor(PlatformMonitor*);
+    void removeMonitor(PlatformMonitor*);
     void propertiesDidChange() const;
 
-    Vector<GRefPtr<GdkMonitor>, 1> m_monitors;
-    HashMap<GdkMonitor*, PlatformDisplayID> m_monitorToDisplayIDMap;
+    Vector<GRefPtr<PlatformMonitor>, 1> m_monitors;
+    HashMap<PlatformMonitor*, PlatformDisplayID> m_monitorToDisplayIDMap;
 };
 
 } // namespace WebKit
+
+#endif // PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -48,12 +48,15 @@
 #include <wpe/wpe.h>
 #endif
 
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
+#include "ScreenManager.h"
+#endif
+
 #if PLATFORM(GTK)
 #if USE(EGL)
 #include "AcceleratedBackingStoreDMABuf.h"
 #endif
 #include "GtkSettingsManager.h"
-#include "ScreenManager.h"
 #endif
 
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
@@ -159,6 +162,11 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 #if PLATFORM(GTK)
     parameters.gtkSettings = GtkSettingsManager::singleton().settingsState();
     parameters.screenProperties = ScreenManager::singleton().collectScreenProperties();
+#endif
+
+#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+    if (usingWPEPlatformAPI)
+        parameters.screenProperties = ScreenManager::singleton().collectScreenProperties();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/wpe/ScreenManagerWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/ScreenManagerWPE.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScreenManager.h"
+
+#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+#include <WebCore/PlatformScreen.h>
+#include <cmath>
+#include <wpe/wpe-platform.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+PlatformDisplayID ScreenManager::generatePlatformDisplayID(WPEMonitor* monitor)
+{
+    return wpe_monitor_get_id(monitor);
+}
+
+ScreenManager::ScreenManager()
+{
+    // FIXME: default might not be the right display.
+    auto* display = wpe_display_get_default();
+    auto monitorsCount = wpe_display_get_n_monitors(display);
+    for (unsigned i = 0; i < monitorsCount; ++i) {
+        if (auto* monitor = wpe_display_get_monitor(display, i))
+            addMonitor(monitor);
+    }
+
+    g_signal_connect(display, "monitor-added", G_CALLBACK(+[](WPEDisplay*, WPEMonitor* monitor, ScreenManager* manager) {
+        manager->addMonitor(monitor);
+        manager->propertiesDidChange();
+    }), this);
+    g_signal_connect(display, "monitor-removed", G_CALLBACK(+[](WPEDisplay*, WPEMonitor* monitor, ScreenManager* manager) {
+        manager->removeMonitor(monitor);
+        manager->propertiesDidChange();
+    }), this);
+}
+
+ScreenProperties ScreenManager::collectScreenProperties() const
+{
+    WPEMonitor* primaryMonitor = nullptr;
+    ScreenProperties properties;
+    for (const auto& iter : m_monitorToDisplayIDMap) {
+        WPEMonitor* monitor = iter.key;
+        if (!properties.primaryDisplayID && (!primaryMonitor || primaryMonitor == monitor))
+            properties.primaryDisplayID = iter.value;
+
+        auto width = wpe_monitor_get_width(monitor);
+        auto height = wpe_monitor_get_height(monitor);
+
+        ScreenData data;
+        data.screenRect = FloatRect(wpe_monitor_get_x(monitor), wpe_monitor_get_y(monitor), width, height);
+        data.screenAvailableRect = data.screenRect;
+        data.screenDepth = 24;
+        data.screenDepthPerComponent = 8;
+        data.screenSize = { wpe_monitor_get_physical_width(monitor), wpe_monitor_get_physical_height(monitor) };
+        static constexpr double millimetresPerInch = 25.4;
+        double diagonalInPixels = std::hypot(width, height);
+        double diagonalInInches = std::hypot(data.screenSize.width(), data.screenSize.height()) / millimetresPerInch;
+        data.dpi = diagonalInPixels / diagonalInInches;
+        properties.screenDataMap.add(iter.value, WTFMove(data));
+    }
+
+    // FIXME: don't use PlatformScreen from the UI process, better use ScreenManager directly.
+    WebCore::setScreenProperties(properties);
+
+    return properties;
+}
+
+} // namespace WebKit
+
+#endif // PLATFORM(WPE) && ENABLE(WPE_PLATFORM)

--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -20,6 +20,7 @@ set(WPEPlatform_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeyUnicode.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymap.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymapXKB.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEMonitor.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEVersion.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEView.cpp
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEEnumTypes.cpp
@@ -38,6 +39,7 @@ set(WPEPlatform_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymap.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymapXKB.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeysyms.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEMonitor.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEView.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/wpe-platform.h
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEConfig.h

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
@@ -33,6 +33,7 @@
 #include <glib-object.h>
 #include <wpe/WPEDefines.h>
 #include <wpe/WPEKeymap.h>
+#include <wpe/WPEMonitor.h>
 #include <wpe/WPEView.h>
 
 G_BEGIN_DECLS
@@ -54,6 +55,9 @@ struct _WPEDisplayClass
     WPEKeymap   *(* get_keymap)                    (WPEDisplay *display,
                                                     GError    **error);
     GList       *(* get_preferred_dma_buf_formats) (WPEDisplay *display);
+    guint        (* get_n_monitors)                (WPEDisplay *display);
+    WPEMonitor  *(* get_monitor)                   (WPEDisplay *display,
+                                                    guint       index);
 
     gpointer padding[32];
 };
@@ -81,6 +85,13 @@ WPE_API gpointer     wpe_display_get_egl_display               (WPEDisplay *disp
 WPE_API WPEKeymap   *wpe_display_get_keymap                    (WPEDisplay *display,
                                                                 GError    **error);
 WPE_API GList       *wpe_display_get_preferred_dma_buf_formats (WPEDisplay *display);
+WPE_API guint        wpe_display_get_n_monitors                (WPEDisplay *display);
+WPE_API WPEMonitor  *wpe_display_get_monitor                   (WPEDisplay *display,
+                                                                guint       index);
+WPE_API void         wpe_display_monitor_added                 (WPEDisplay *display,
+                                                                WPEMonitor *monitor);
+WPE_API void         wpe_display_monitor_removed               (WPEDisplay *display,
+                                                                WPEMonitor *monitor);
 
 WPE_API const char  *wpe_render_node_device                    (void);
 WPE_API const char  *wpe_render_device                         (void);

--- a/Source/WebKit/WPEPlatform/wpe/WPEMonitor.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEMonitor.cpp
@@ -1,0 +1,527 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEMonitor.h"
+
+#include <wtf/glib/WTFGType.h>
+
+/**
+ * WPEMonitor:
+ *
+ */
+struct _WPEMonitorPrivate {
+    guint32 id;
+    int x { -1 };
+    int y { -1 };
+    int width { -1 };
+    int height { -1 };
+    int physicalWidth { -1 };
+    int physicalHeight { -1 };
+    gdouble scale { 1 };
+    int refreshRate { -1 };
+};
+
+WEBKIT_DEFINE_ABSTRACT_TYPE(WPEMonitor, wpe_monitor, G_TYPE_OBJECT)
+
+enum {
+    PROP_0,
+
+    PROP_ID,
+    PROP_X,
+    PROP_Y,
+    PROP_WIDTH,
+    PROP_HEIGHT,
+    PROP_PHYSICAL_WIDTH,
+    PROP_PHYSICAL_HEIGHT,
+    PROP_SCALE,
+    PROP_REFRESH_RATE,
+
+    N_PROPERTIES
+};
+
+static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+
+static void wpeMonitorSetProperty(GObject* object, guint propId, const GValue* value, GParamSpec* paramSpec)
+{
+    auto* monitor = WPE_MONITOR(object);
+
+    switch (propId) {
+    case PROP_ID:
+        monitor->priv->id = g_value_get_uint(value);
+        break;
+    case PROP_X:
+        wpe_monitor_set_position(monitor, g_value_get_int(value), -1);
+        break;
+    case PROP_Y:
+        wpe_monitor_set_position(monitor, -1, g_value_get_int(value));
+        break;
+    case PROP_WIDTH:
+        wpe_monitor_set_size(monitor, g_value_get_int(value), -1);
+        break;
+    case PROP_HEIGHT:
+        wpe_monitor_set_size(monitor, -1, g_value_get_int(value));
+        break;
+    case PROP_PHYSICAL_WIDTH:
+        wpe_monitor_set_physical_size(monitor, g_value_get_int(value), -1);
+        break;
+    case PROP_PHYSICAL_HEIGHT:
+        wpe_monitor_set_physical_size(monitor, -1, g_value_get_int(value));
+        break;
+    case PROP_SCALE:
+        wpe_monitor_set_scale(monitor, g_value_get_double(value));
+        break;
+    case PROP_REFRESH_RATE:
+        wpe_monitor_set_refresh_rate(monitor, g_value_get_int(value));
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
+    }
+}
+
+static void wpeMonitorGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
+{
+    auto* monitor = WPE_MONITOR(object);
+
+    switch (propId) {
+    case PROP_ID:
+        g_value_set_uint(value, wpe_monitor_get_id(monitor));
+        break;
+    case PROP_X:
+        g_value_set_int(value, wpe_monitor_get_x(monitor));
+        break;
+    case PROP_Y:
+        g_value_set_int(value, wpe_monitor_get_y(monitor));
+        break;
+    case PROP_WIDTH:
+        g_value_set_int(value, wpe_monitor_get_width(monitor));
+        break;
+    case PROP_HEIGHT:
+        g_value_set_int(value, wpe_monitor_get_height(monitor));
+        break;
+    case PROP_PHYSICAL_WIDTH:
+        g_value_set_int(value, wpe_monitor_get_physical_width(monitor));
+        break;
+    case PROP_PHYSICAL_HEIGHT:
+        g_value_set_int(value, wpe_monitor_get_physical_height(monitor));
+        break;
+    case PROP_SCALE:
+        g_value_set_double(value, wpe_monitor_get_scale(monitor));
+        break;
+    case PROP_REFRESH_RATE:
+        g_value_set_int(value, wpe_monitor_get_refresh_rate(monitor));
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
+    }
+}
+
+static void wpe_monitor_class_init(WPEMonitorClass* monitorClass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(monitorClass);
+    objectClass->set_property = wpeMonitorSetProperty;
+    objectClass->get_property = wpeMonitorGetProperty;
+
+    /**
+     * WPEMonitor:id:
+     *
+     * The identifier of the monitor.
+     */
+    sObjProperties[PROP_ID] =
+        g_param_spec_uint(
+            "id",
+            nullptr, nullptr,
+            0, G_MAXUINT, 0,
+            static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+
+    /**
+     * WPEMonitor:x:
+     *
+     * The x coordinate of the monitor position in pixels.
+     * Note this is not device pixels, so not affected by #WPEMonitor:scale.
+     */
+    sObjProperties[PROP_X] =
+        g_param_spec_int(
+            "x",
+            nullptr, nullptr,
+            -1, G_MAXINT, -1,
+            WEBKIT_PARAM_READWRITE);
+
+    /**
+     * WPEMonitor:y:
+     *
+     * The y coordinate of the monitor position in pixels.
+     * Note this is not device pixels, so not affected by #WPEMonitor:scale.
+     */
+    sObjProperties[PROP_Y] =
+        g_param_spec_int(
+            "y",
+            nullptr, nullptr,
+            -1, G_MAXINT, -1,
+            WEBKIT_PARAM_READWRITE);
+
+    /**
+     * WPEMonitor:width:
+     *
+     * The width of the monitor in pixels.
+     * Note this is not device pixels, so not affected by #WPEMonitor:scale.
+     */
+    sObjProperties[PROP_WIDTH] =
+        g_param_spec_int(
+            "width",
+            nullptr, nullptr,
+            -1, G_MAXINT, -1,
+            WEBKIT_PARAM_READWRITE);
+
+    /**
+     * WPEMonitor:height:
+     *
+     * The height of the monitor in pixels.
+     * Note this is not device pixels, so not affected by #WPEMonitor:scale.
+     */
+    sObjProperties[PROP_HEIGHT] =
+        g_param_spec_int(
+            "height",
+            nullptr, nullptr,
+            -1, G_MAXINT, -1,
+            WEBKIT_PARAM_READWRITE);
+
+    /**
+     * WPEMonitor:physical-width:
+     *
+     * The physical width of the monitor in millimeters.
+     */
+    sObjProperties[PROP_PHYSICAL_WIDTH] =
+        g_param_spec_int(
+            "physical-width",
+            nullptr, nullptr,
+            -1, G_MAXINT, -1,
+            WEBKIT_PARAM_READWRITE);
+
+    /**
+     * WPEMonitor:physical-height:
+     *
+     * The physical height of the monitor in millimeters.
+     */
+    sObjProperties[PROP_PHYSICAL_HEIGHT] =
+        g_param_spec_int(
+            "physical-height",
+            nullptr, nullptr,
+            -1, G_MAXINT, -1,
+            WEBKIT_PARAM_READWRITE);
+
+    /**
+     * WPEMonitor:scale:
+     *
+     * The scale factor for the monitor.
+     */
+    sObjProperties[PROP_SCALE] =
+        g_param_spec_double(
+            "scale",
+            nullptr, nullptr,
+            1, G_MAXDOUBLE, 1,
+            WEBKIT_PARAM_READWRITE);
+
+    /**
+     * WPEMonitor:refresh-rate:
+     *
+     * The refresh rate of the monitor in milli-Hertz.
+     */
+    sObjProperties[PROP_REFRESH_RATE] =
+        g_param_spec_int(
+            "refresh-rate",
+            nullptr, nullptr,
+            -1, G_MAXINT, -1,
+            WEBKIT_PARAM_READWRITE);
+
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+}
+
+/**
+ * wpe_monitor_get_id:
+ * @monitor: a #WPEMonitor
+ *
+ * Get the @monitor identifier.
+ * The idenifier is a non-zero value to uniquely identify a #WPEMonitor.
+ *
+ * Returns: the monitor identifier
+ */
+guint32 wpe_monitor_get_id(WPEMonitor* monitor)
+{
+    g_return_val_if_fail(WPE_IS_MONITOR(monitor), 0);
+
+    return monitor->priv->id;
+}
+
+/**
+ * wpe_monitor_invalidate:
+ * @monitor: a #WPEMonitor
+ *
+ * Invalidate @monitor. This will release all the platform resources
+ * associated with @monitor. The properties cached will not be
+ * modified so they are still available after invalidation.
+ */
+void wpe_monitor_invalidate(WPEMonitor* monitor)
+{
+    g_return_if_fail(WPE_IS_MONITOR(monitor));
+
+    auto* monitorClass = WPE_MONITOR_GET_CLASS(monitor);
+    if (monitorClass->invalidate)
+        monitorClass->invalidate(monitor);
+}
+
+/**
+ * wpe_monitor_get_x:
+ * @monitor: a #WPEMonitor
+ *
+ * Get the x coordinate of the @monitor position.
+ *
+ * Returns: the x coordinate, or -1 if not available
+ */
+int wpe_monitor_get_x(WPEMonitor* monitor)
+{
+    g_return_val_if_fail(WPE_IS_MONITOR(monitor), -1);
+
+    return monitor->priv->x;
+}
+
+/**
+ * wpe_monitor_get_y:
+ * @monitor: a #WPEMonitor
+ *
+ * Get the y coordinate of the @monitor position.
+ *
+ * Returns: the y coordinate, or -1 if not available
+ */
+int wpe_monitor_get_y(WPEMonitor* monitor)
+{
+    g_return_val_if_fail(WPE_IS_MONITOR(monitor), -1);
+
+    return monitor->priv->y;
+}
+
+/**
+ * wpe_monitor_set_position:
+ * @monitor: a #WPEMonitor
+ * @x: the x coordinate, or -1
+ * @y: the y coordinate, or -1
+ *
+ * Set the position of @monitor
+ */
+void wpe_monitor_set_position(WPEMonitor* monitor, int x, int y)
+{
+    g_return_if_fail(WPE_IS_MONITOR(monitor));
+    g_return_if_fail(x == -1 || x >= 0);
+    g_return_if_fail(y == -1 || y >= 0);
+
+    if (x != -1 && x != monitor->priv->x) {
+        monitor->priv->x = x;
+        g_object_notify_by_pspec(G_OBJECT(monitor), sObjProperties[PROP_X]);
+    }
+
+    if (y != -1 && y != monitor->priv->y) {
+        monitor->priv->y = y;
+        g_object_notify_by_pspec(G_OBJECT(monitor), sObjProperties[PROP_Y]);
+    }
+}
+
+/**
+ * wpe_monitor_get_width:
+ * @monitor: a #WPEMonitor
+ *
+ * Get the width of @monitor.
+ *
+ * Returns: the width of @monitor, or -1 if not available
+ */
+int wpe_monitor_get_width(WPEMonitor* monitor)
+{
+    g_return_val_if_fail(WPE_IS_MONITOR(monitor), -1);
+
+    return monitor->priv->width;
+}
+
+/**
+ * wpe_monitor_get_height:
+ * @monitor: a #WPEMonitor
+ *
+ * Get the height of @monitor.
+ *
+ * Returns: the height of @monitor, or -1 if not available
+ */
+int wpe_monitor_get_height(WPEMonitor* monitor)
+{
+    g_return_val_if_fail(WPE_IS_MONITOR(monitor), -1);
+
+    return monitor->priv->height;
+}
+
+/**
+ * wpe_monitor_set_size:
+ * @monitor: a #WPEMonitor
+ * @width: the width, or -1
+ * @height: the height, o -1
+ *
+ * Set the size of @monitor.
+ */
+void wpe_monitor_set_size(WPEMonitor* monitor, int width, int height)
+{
+    g_return_if_fail(WPE_IS_MONITOR(monitor));
+    g_return_if_fail(width == -1 || width >= 0);
+    g_return_if_fail(height == -1 || height >= 0);
+
+    if (width != -1 && width != monitor->priv->width) {
+        monitor->priv->width = width;
+        g_object_notify_by_pspec(G_OBJECT(monitor), sObjProperties[PROP_WIDTH]);
+    }
+
+    if (height != -1 && height != monitor->priv->height) {
+        monitor->priv->height = height;
+        g_object_notify_by_pspec(G_OBJECT(monitor), sObjProperties[PROP_HEIGHT]);
+    }
+}
+
+/**
+ * wpe_monitor_get_physical_width:
+ * @monitor: a #WPEMonitor
+ *
+ * Get the physical width of @monitor in millimeters.
+ *
+ * Returns: the physical width of @monitor, or -1 if not available
+ */
+int wpe_monitor_get_physical_width(WPEMonitor* monitor)
+{
+    g_return_val_if_fail(WPE_IS_MONITOR(monitor), -1);
+
+    return monitor->priv->physicalWidth;
+}
+
+/**
+ * wpe_monitor_get_physical_height:
+ * @monitor: a #WPEMonitor
+ *
+ * Get the physical height of @monitor in millimeters.
+ *
+ * Returns: the physical height of @monitor, or -1 if not available
+ */
+int wpe_monitor_get_physical_height(WPEMonitor* monitor)
+{
+    g_return_val_if_fail(WPE_IS_MONITOR(monitor), -1);
+
+    return monitor->priv->physicalHeight;
+}
+
+/**
+ * wpe_monitor_set_physical_size:
+ * @monitor: a #WPEMonitor
+ * @width: the physical width, or -1
+ * @height: the physical height, or -1
+ *
+ * Set the physical size of @monitor in millimeters.
+ */
+void wpe_monitor_set_physical_size(WPEMonitor* monitor, int width, int height)
+{
+    g_return_if_fail(WPE_IS_MONITOR(monitor));
+    g_return_if_fail(width == -1 || width >= 0);
+    g_return_if_fail(height == -1 || height >= 0);
+
+    if (width != -1 && width != monitor->priv->physicalWidth) {
+        monitor->priv->physicalWidth = width;
+        g_object_notify_by_pspec(G_OBJECT(monitor), sObjProperties[PROP_PHYSICAL_WIDTH]);
+    }
+
+    if (height != -1 && height != monitor->priv->physicalHeight) {
+        monitor->priv->physicalHeight = height;
+        g_object_notify_by_pspec(G_OBJECT(monitor), sObjProperties[PROP_PHYSICAL_HEIGHT]);
+    }
+}
+
+/**
+ * wpe_monitor_get_scale:
+ * @monitor: a #WPEMonitor
+ *
+ * Get the @monitor scale factor
+ *
+ * Returns: the monitor scale factor
+ */
+gdouble wpe_monitor_get_scale(WPEMonitor* monitor)
+{
+    g_return_val_if_fail(WPE_IS_MONITOR(monitor), 1);
+
+    return monitor->priv->scale;
+}
+
+/**
+ * wpe_monitor_set_scale:
+ * @monitor: a #WPEMonitor
+ * @scale: the scale factor to set
+ *
+ * Set the @monitor scale factor
+ */
+void wpe_monitor_set_scale(WPEMonitor* monitor, double scale)
+{
+    g_return_if_fail(WPE_IS_MONITOR(monitor));
+    g_return_if_fail(scale >= 1);
+
+    if (monitor->priv->scale == scale)
+        return;
+
+    monitor->priv->scale = scale;
+    g_object_notify_by_pspec(G_OBJECT(monitor), sObjProperties[PROP_SCALE]);
+}
+
+/**
+ * wpe_monitor_get_refresh_rate:
+ * @monitor: a #WPEMonitor
+ *
+ * Get the refresh rate of @monitor in milli-Hertz.
+ *
+ * Returns: the refresh rate, or -1 if not available
+ */
+int wpe_monitor_get_refresh_rate(WPEMonitor* monitor)
+{
+    g_return_val_if_fail(WPE_IS_MONITOR(monitor), -1);
+
+    return monitor->priv->refreshRate;
+}
+
+/**
+ * wpe_monitor_set_refresh_rate:
+ * @monitor: a #WPEMonitor
+ * @refresh_rate: the refresh rate
+ *
+ * Set the refresh rate of @monitor in milli-Hertz.
+ *
+ */
+void wpe_monitor_set_refresh_rate(WPEMonitor* monitor, int refreshRate)
+{
+    g_return_if_fail(WPE_IS_MONITOR(monitor));
+    g_return_if_fail(refreshRate == -1 || refreshRate >= 0);
+
+    if (refreshRate == -1 || refreshRate == monitor->priv->refreshRate)
+        return;
+
+    monitor->priv->refreshRate = refreshRate;
+    g_object_notify_by_pspec(G_OBJECT(monitor), sObjProperties[PROP_REFRESH_RATE]);
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEMonitor.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEMonitor.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef WPEMonitor_h
+#define WPEMonitor_h
+
+#if !defined(__WPE_PLATFORM_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/wpe-platform.h> can be included directly."
+#endif
+
+#include <glib-object.h>
+#include <wpe/WPEDefines.h>
+
+G_BEGIN_DECLS
+
+#define WPE_TYPE_MONITOR (wpe_monitor_get_type())
+WPE_DECLARE_DERIVABLE_TYPE (WPEMonitor, wpe_monitor, WPE, MONITOR, GObject)
+
+struct _WPEMonitorClass
+{
+    GObjectClass parent_class;
+
+    void (* invalidate) (WPEMonitor *monitor);
+
+    gpointer padding[32];
+};
+
+WPE_API guint32 wpe_monitor_get_id              (WPEMonitor *monitor);
+WPE_API void    wpe_monitor_invalidate          (WPEMonitor *monitor);
+WPE_API int     wpe_monitor_get_x               (WPEMonitor *monitor);
+WPE_API int     wpe_monitor_get_y               (WPEMonitor *monitor);
+WPE_API void    wpe_monitor_set_position        (WPEMonitor *monitor,
+                                                 int         x,
+                                                 int         y);
+WPE_API int     wpe_monitor_get_width           (WPEMonitor *monitor);
+WPE_API int     wpe_monitor_get_height          (WPEMonitor *monitor);
+WPE_API void    wpe_monitor_set_size            (WPEMonitor *monitor,
+                                                 int         width,
+                                                 int         height);
+WPE_API int     wpe_monitor_get_physical_width  (WPEMonitor *monitor);
+WPE_API int     wpe_monitor_get_physical_height (WPEMonitor *monitor);
+WPE_API void    wpe_monitor_set_physical_size   (WPEMonitor *monitor,
+                                                 int         width,
+                                                 int         height);
+WPE_API gdouble wpe_monitor_get_scale           (WPEMonitor *monitor);
+WPE_API void    wpe_monitor_set_scale           (WPEMonitor *monitor,
+                                                 gdouble     scale);
+WPE_API int     wpe_monitor_get_refresh_rate    (WPEMonitor *monitor);
+WPE_API void    wpe_monitor_set_refresh_rate    (WPEMonitor *monitor,
+                                                 int         refresh_rate);
+
+G_END_DECLS
+
+#endif /* WPEMonitor_h */

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -82,6 +82,7 @@ enum {
     PROP_WIDTH,
     PROP_HEIGHT,
     PROP_SCALE,
+    PROP_MONITOR,
 
     N_PROPERTIES
 };
@@ -140,6 +141,9 @@ static void wpeViewGetProperty(GObject* object, guint propId, GValue* value, GPa
         break;
     case PROP_SCALE:
         g_value_set_double(value, wpe_view_get_scale(view));
+        break;
+    case PROP_MONITOR:
+        g_value_set_object(value, wpe_view_get_monitor(view));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
@@ -224,6 +228,18 @@ static void wpe_view_class_init(WPEViewClass* viewClass)
             nullptr, nullptr,
             1., G_MAXDOUBLE, 1.,
             WEBKIT_PARAM_READWRITE);
+
+    /**
+     * WPEView:monitor:
+     *
+     * The current #WPEMonitor of the view.
+     */
+    sObjProperties[PROP_MONITOR] =
+        g_param_spec_object(
+            "monitor",
+            nullptr, nullptr,
+            WPE_TYPE_MONITOR,
+            WEBKIT_PARAM_READABLE);
 
     g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
 
@@ -569,6 +585,22 @@ void wpe_view_set_state(WPEView* view, WPEViewState state)
     auto previousState = view->priv->state;
     view->priv->state = state;
     g_signal_emit(view, signals[STATE_CHANGED], 0, previousState);
+}
+
+/**
+ * wpe_view_get_monitor:
+ * @view: a #WPEView
+ *
+ * Get current #WPEMonitor of @view
+ *
+ * Returns: (transfer none) (nullable): a #WPEMonitor, or %NULL
+ */
+WPEMonitor* wpe_view_get_monitor(WPEView* view)
+{
+    g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
+
+    auto* viewClass = WPE_VIEW_GET_CLASS(view);
+    return viewClass->get_monitor ? viewClass->get_monitor(view) : nullptr;
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -41,26 +41,28 @@ WPE_DECLARE_DERIVABLE_TYPE (WPEView, wpe_view, WPE, VIEW, GObject)
 typedef struct _WPEBuffer WPEBuffer;
 typedef struct _WPEDisplay WPEDisplay;
 typedef struct _WPEEvent WPEEvent;
+typedef struct _WPEMonitor WPEMonitor;
 
 struct _WPEViewClass
 {
     GObjectClass parent_class;
 
-    gboolean (* render_buffer)                 (WPEView    *view,
-                                                WPEBuffer  *buffer,
-                                                GError    **error);
-    gboolean (* set_fullscreen)                (WPEView    *view,
-                                                gboolean    fullscreen);
-    GList   *(* get_preferred_dma_buf_formats) (WPEView    *view);
-    void     (* set_cursor_from_name)          (WPEView    *view,
-                                                const char *name);
-    void     (* set_cursor_from_bytes)         (WPEView    *view,
-                                                GBytes     *bytes,
-                                                guint       width,
-                                                guint       height,
-                                                guint       stride,
-                                                guint       hotspot_x,
-                                                guint       hotspot_y);
+    gboolean    (* render_buffer)                 (WPEView    *view,
+                                                   WPEBuffer  *buffer,
+                                                   GError    **error);
+    WPEMonitor *(* get_monitor)                   (WPEView    *view);
+    gboolean    (* set_fullscreen)                (WPEView    *view,
+                                                   gboolean    fullscreen);
+    GList      *(* get_preferred_dma_buf_formats) (WPEView    *view);
+    void        (* set_cursor_from_name)          (WPEView    *view,
+                                                   const char *name);
+    void        (* set_cursor_from_bytes)         (WPEView    *view,
+                                                   GBytes     *bytes,
+                                                   guint       width,
+                                                   guint       height,
+                                                   guint       stride,
+                                                   guint       hotspot_x,
+                                                   guint       hotspot_y);
 
     gpointer padding[32];
 };
@@ -115,6 +117,7 @@ WPE_API void         wpe_view_set_cursor_from_bytes         (WPEView     *view,
 WPE_API WPEViewState wpe_view_get_state                     (WPEView     *view);
 WPE_API void         wpe_view_set_state                     (WPEView     *view,
                                                              WPEViewState state);
+WPE_API WPEMonitor  *wpe_view_get_monitor                   (WPEView     *view);
 WPE_API gboolean     wpe_view_fullscreen                    (WPEView     *view);
 WPE_API gboolean     wpe_view_unfullscreen                  (WPEView     *view);
 WPE_API gboolean     wpe_view_render_buffer                 (WPEView     *view,

--- a/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
@@ -5,10 +5,10 @@ configure_file(wpe-platform-wayland-uninstalled.pc.in ${CMAKE_BINARY_DIR}/wpe-pl
 
 set(WPEPlatformWayland_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEMonitorWayland.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEWaylandCursor.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEWaylandCursorTheme.cpp
-    ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEWaylandOutput.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEWaylandSHMPool.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/wayland/linux-dmabuf-unstable-v1-protocol.c

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEMonitorWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEMonitorWayland.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEMonitorWayland.h"
+
+#include <wtf/glib/WTFGType.h>
+
+/**
+ * WPEMonitorWayland:
+ *
+ */
+struct _WPEMonitorWaylandPrivate {
+    struct wl_output* wlOutput;
+};
+WEBKIT_DEFINE_FINAL_TYPE(WPEMonitorWayland, wpe_monitor_wayland, WPE_TYPE_MONITOR, WPEMonitor)
+
+static void wpeMonitorWaylandInvalidate(WPEMonitor* monitor)
+{
+    auto* priv = WPE_MONITOR_WAYLAND(monitor)->priv;
+    if (priv->wlOutput) {
+        if (wl_output_get_version(priv->wlOutput) >= WL_OUTPUT_RELEASE_SINCE_VERSION)
+            wl_output_release(priv->wlOutput);
+        else
+            wl_output_destroy(priv->wlOutput);
+        priv->wlOutput = nullptr;
+    }
+}
+
+static void wpeMonitorWaylandDispose(GObject* object)
+{
+    wpeMonitorWaylandInvalidate(WPE_MONITOR(object));
+
+    G_OBJECT_CLASS(wpe_monitor_wayland_parent_class)->dispose(object);
+}
+
+static void wpe_monitor_wayland_class_init(WPEMonitorWaylandClass* monitorWaylandClass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(monitorWaylandClass);
+    objectClass->dispose = wpeMonitorWaylandDispose;
+
+    WPEMonitorClass* monitorClass = WPE_MONITOR_CLASS(monitorWaylandClass);
+    monitorClass->invalidate = wpeMonitorWaylandInvalidate;
+}
+
+static const struct wl_output_listener outputListener = {
+    // geometry
+    [](void* data, struct wl_output*, int32_t x, int32_t y, int32_t width, int32_t height, int32_t, const char*, const char*, int32_t transform)
+    {
+        WPEMonitor* monitor = WPE_MONITOR(data);
+        wpe_monitor_set_position(monitor, x, y);
+        switch (transform) {
+        case WL_OUTPUT_TRANSFORM_90:
+        case WL_OUTPUT_TRANSFORM_270:
+        case WL_OUTPUT_TRANSFORM_FLIPPED_90:
+        case WL_OUTPUT_TRANSFORM_FLIPPED_270:
+            wpe_monitor_set_physical_size(monitor, height, width);
+            break;
+        default:
+            wpe_monitor_set_physical_size(monitor, width, height);
+            break;
+        }
+    },
+    // mode
+    [](void* data, struct wl_output*, uint32_t flags, int32_t width, int32_t height, int32_t refresh)
+    {
+        if (!(flags & WL_OUTPUT_MODE_CURRENT))
+            return;
+
+        WPEMonitor* monitor = WPE_MONITOR(data);
+        wpe_monitor_set_size(monitor, width, height);
+        wpe_monitor_set_refresh_rate(monitor, refresh);
+    },
+    // done
+    [](void*, struct wl_output*)
+    {
+    },
+    // scale
+    [](void* data, struct wl_output*, int32_t factor)
+    {
+        WPEMonitor* monitor = WPE_MONITOR(data);
+        wpe_monitor_set_scale(monitor, factor);
+    },
+#ifdef WL_OUTPUT_NAME_SINCE_VERSION
+    // name
+    [](void*, struct wl_output*, const char*)
+    {
+    },
+#endif
+#ifdef WL_OUTPUT_DESCRIPTION_SINCE_VERSION
+    // description
+    [](void*, struct wl_output*, const char*)
+    {
+    },
+#endif
+};
+
+WPEMonitor* wpeMonitorWaylandCreate(guint32 id, struct wl_output* wlOutput)
+{
+    auto* monitor = WPE_MONITOR_WAYLAND(g_object_new(WPE_TYPE_MONITOR_WAYLAND, "id", id, nullptr));
+    monitor->priv->wlOutput = wlOutput;
+    wl_output_add_listener(monitor->priv->wlOutput, &outputListener, monitor);
+    return WPE_MONITOR(monitor);
+}
+
+/**
+ * wpe_monitor_wayland_get_wl_output: (skip)
+ * @monitor: a #WPEMonitorWayland
+ *
+ * Get the Wayland output of @monitor
+ *
+ * Returns: (transfer none) (nullable): a Wayland `wl_output`
+ */
+struct wl_output* wpe_monitor_wayland_get_wl_output(WPEMonitorWayland* monitor)
+{
+    g_return_val_if_fail(WPE_IS_MONITOR_WAYLAND(monitor), nullptr);
+
+    return monitor->priv->wlOutput;
+}

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEMonitorWayland.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEMonitorWayland.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,15 +23,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#ifndef WPEMonitorWayland_h
+#define WPEMonitorWayland_h
 
-#include "WPEDisplayWayland.h"
-#include "WPEMonitor.h"
-#include "WPEWaylandCursor.h"
-#include "WPEWaylandSeat.h"
+#if !defined(__WPE_WAYLAND_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/wayland/wpe-wayland.h> can be included directly."
+#endif
 
-struct xdg_wm_base* wpeDisplayWaylandGetXDGWMBase(WPEDisplayWayland*);
-WPE::WaylandSeat* wpeDisplayWaylandGetSeat(WPEDisplayWayland*);
-WPE::WaylandCursor* wpeDisplayWaylandGetCursor(WPEDisplayWayland*);
-WPEMonitor* wpeDisplayWaylandFindMonitor(WPEDisplayWayland*, struct wl_output*);
-struct zwp_linux_dmabuf_v1* wpeDisplayWaylandGetLinuxDMABuf(WPEDisplayWayland*);
+#include <glib-object.h>
+#include <wayland-client.h>
+#include <wpe/wpe-platform.h>
+
+G_BEGIN_DECLS
+
+#define WPE_TYPE_MONITOR_WAYLAND (wpe_monitor_wayland_get_type())
+WPE_API G_DECLARE_FINAL_TYPE (WPEMonitorWayland, wpe_monitor_wayland, WPE, MONITOR_WAYLAND, WPEMonitor)
+
+WPE_API struct wl_output *wpe_monitor_wayland_get_wl_output (WPEMonitorWayland *monitor);
+
+G_END_DECLS
+
+#endif /* WPEMonitorWayland_h */

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEMonitorWaylandPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEMonitorWaylandPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,13 +25,6 @@
 
 #pragma once
 
-#include "WPEDisplayWayland.h"
-#include "WPEMonitor.h"
-#include "WPEWaylandCursor.h"
-#include "WPEWaylandSeat.h"
+#include "WPEMonitorWayland.h"
 
-struct xdg_wm_base* wpeDisplayWaylandGetXDGWMBase(WPEDisplayWayland*);
-WPE::WaylandSeat* wpeDisplayWaylandGetSeat(WPEDisplayWayland*);
-WPE::WaylandCursor* wpeDisplayWaylandGetCursor(WPEDisplayWayland*);
-WPEMonitor* wpeDisplayWaylandFindMonitor(WPEDisplayWayland*, struct wl_output*);
-struct zwp_linux_dmabuf_v1* wpeDisplayWaylandGetLinuxDMABuf(WPEDisplayWayland*);
+WPEMonitor* wpeMonitorWaylandCreate(guint32, struct wl_output*);

--- a/Source/WebKit/WPEPlatform/wpe/wayland/wpe-wayland.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/wpe-wayland.h
@@ -28,6 +28,7 @@
 #define __WPE_WAYLAND_H_INSIDE__
 
 #include <wpe/wayland/WPEDisplayWayland.h>
+#include <wpe/wayland/WPEMonitorWayland.h>
 #include <wpe/wayland/WPEViewWayland.h>
 
 #undef __WPE_WAYLAND_H_INSIDE__

--- a/Source/WebKit/WPEPlatform/wpe/wpe-platform.h
+++ b/Source/WebKit/WPEPlatform/wpe/wpe-platform.h
@@ -42,6 +42,7 @@
 #include <wpe/WPEKeymapXKB.h>
 #include <wpe/WPEKeysyms.h>
 #include <wpe/WPEKeysyms.h>
+#include <wpe/WPEMonitor.h>
 #include <wpe/WPEVersion.h>
 #include <wpe/WPEView.h>
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -751,6 +751,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 
     updateAfterDrawingAreaCreation(parameters);
 
+    if (parameters.displayID)
+        windowScreenDidChange(*parameters.displayID, parameters.nominalFramesPerSecond);
+
     WebStorageNamespaceProvider::incrementUseCount(sessionStorageNamespaceIdentifier());
 
     updatePreferences(parameters.store);

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -604,7 +604,7 @@ private:
     void displayConfigurationChanged(CGDirectDisplayID, CGDisplayChangeSummaryFlags);
 #endif
 
-#if PLATFORM(COCOA) || PLATFORM(GTK)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
     void setScreenProperties(const WebCore::ScreenProperties&);
 #endif
 

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -109,7 +109,7 @@ messages -> WebProcess LegacyReceiver NotRefCounted {
     MarkIsNoLongerPrewarmed()
     GetActivePagesOriginsForTesting() -> (Vector<String> activeOrigins)
 
-#if PLATFORM(COCOA) || PLATFORM(GTK)
+#if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
     SetScreenProperties(struct WebCore::ScreenProperties screenProperties)
 #endif
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -195,7 +195,15 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 
 #if PLATFORM(GTK)
     GtkSettingsManagerProxy::singleton().applySettings(WTFMove(parameters.gtkSettings));
+#endif
+
+#if PLATFORM(GTK)
     WebCore::setScreenProperties(parameters.screenProperties);
+#endif
+
+#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+    if (!m_dmaBufRendererBufferMode.isEmpty())
+        WebCore::setScreenProperties(parameters.screenProperties);
 #endif
 }
 
@@ -248,7 +256,7 @@ void WebProcess::releaseSystemMallocMemory()
 #endif
 }
 
-#if PLATFORM(GTK)
+#if PLATFORM(GTK) || PLATFORM(WPE)
 void WebProcess::setScreenProperties(const WebCore::ScreenProperties& properties)
 {
     WebCore::setScreenProperties(properties);


### PR DESCRIPTION
#### fda6216679915707208bd7794ae22c0c92b808cd
<pre>
[WPE] WPE Platform: add monitors API
<a href="https://bugs.webkit.org/show_bug.cgi?id=265639">https://bugs.webkit.org/show_bug.cgi?id=265639</a>

Reviewed by Adrian Perez de Castro.

Add monitors API with implementation for the wayland platform for now.
This API is used inside WebKit to set the screen properties, set the
platform display ID and get the refresh rate for display link.

* Source/WebCore/platform/PlatformScreen.cpp:
* Source/WebCore/platform/ScreenProperties.h:
* Source/WebCore/platform/wpe/PlatformScreenWPE.cpp:
(WebCore::widgetDisplayID):
(WebCore::screenDepth):
(WebCore::screenDepthPerComponent):
(WebCore::screenIsMonochrome):
(WebCore::screenDPI):
(WebCore::screenRect):
(WebCore::screenAvailableRect):
(WebCore::setScreenDPIObserverHandler): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::m_backend):
(WKWPE::View::~View):
(WKWPE::View::updateDisplayID):
* Source/WebKit/UIProcess/API/wpe/WPEWebView.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.cpp:
(WebKit::findCrtc):
(WebKit::DisplayVBlankMonitorDRM::create):
* Source/WebKit/UIProcess/glib/ScreenManager.cpp: Copied from Source/WebKit/UIProcess/gtk/ScreenManager.h.
(WebKit::ScreenManager::singleton):
(WebKit::ScreenManager::displayID const):
(WebKit::ScreenManager::monitor const):
(WebKit::ScreenManager::addMonitor):
(WebKit::ScreenManager::removeMonitor):
(WebKit::ScreenManager::propertiesDidChange const):
* Source/WebKit/UIProcess/glib/ScreenManager.h: Renamed from Source/WebKit/UIProcess/gtk/ScreenManager.h.
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/UIProcess/gtk/ScreenManagerGtk.cpp: Renamed from Source/WebKit/UIProcess/gtk/ScreenManager.cpp.
(WebKit::ScreenManager::generatePlatformDisplayID):
(WebKit::ScreenManager::ScreenManager):
(WebKit::ScreenManager::collectScreenProperties const):
* Source/WebKit/UIProcess/wpe/ScreenManagerWPE.cpp: Added.
(WebKit::ScreenManager::generatePlatformDisplayID):
(WebKit::ScreenManager::ScreenManager):
(WebKit::ScreenManager::collectScreenProperties const):
* Source/WebKit/WPEPlatform/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
(wpe_display_class_init):
(wpe_display_get_n_monitors):
(wpe_display_get_monitor):
(wpe_display_monitor_added):
(wpe_display_monitor_removed):
(wpeDisplayDispose): Deleted.
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.h:
* Source/WebKit/WPEPlatform/wpe/WPEMonitor.cpp: Added.
(wpeMonitorGetProperty):
(wpe_monitor_class_init):
(wpe_monitor_get_id):
(wpe_monitor_invalidate):
(wpe_monitor_get_x):
(wpe_monitor_get_y):
(wpe_monitor_set_position):
(wpe_monitor_get_width):
(wpe_monitor_get_height):
(wpe_monitor_set_size):
(wpe_monitor_get_physical_width):
(wpe_monitor_get_physical_height):
(wpe_monitor_set_physical_size):
(wpe_monitor_get_scale):
(wpe_monitor_set_scale):
(wpe_monitor_get_refresh_rate):
(wpe_monitor_set_refresh_rate):
* Source/WebKit/WPEPlatform/wpe/WPEMonitor.h: Added.
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpeViewGetProperty):
(wpe_view_class_init):
(wpe_view_get_monitor):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandDispose):
(wpeDisplayWaylandGetNMonitors):
(wpeDisplayWaylandGetMonitor):
(wpeDisplayWaylandFindMonitor):
(wpe_display_wayland_class_init):
(wpeDisplayWaylandGetOutput): Deleted.
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWaylandPrivate.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEMonitorWayland.cpp: Added.
(wpeMonitorWaylandInvalidate):
(wpeMonitorWaylandDispose):
(wpe_monitor_wayland_class_init):
(wpe_monitor_wayland_get_wl_output):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEMonitorWayland.h: Copied from Source/WebKit/WPEPlatform/wpe/wayland/wpe-wayland.h.
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(wpeViewWaylandConstructed):
(wpeViewWaylandDispose):
(wpeViewWaylandGetMonitor):
(wpe_view_wayland_class_init):
* Source/WebKit/WPEPlatform/wpe/wayland/wpe-wayland.h:
* Source/WebKit/WPEPlatform/wpe/wpe-platform.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_historyItemClient):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/274090@main">https://commits.webkit.org/274090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29ca24ddca35e9771bb6c569aac85912e74ae5f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39703 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33148 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38419 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31654 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37689 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32694 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11789 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40959 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33630 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37690 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35831 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13740 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12471 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4912 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13004 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->