### PR TITLE
Avoid setURL() call in DOMParser()

### DIFF
--- a/Source/WebCore/xml/DOMParser.cpp
+++ b/Source/WebCore/xml/DOMParser.cpp
@@ -41,15 +41,18 @@ Ref<DOMParser> DOMParser::create(Document& contextDocument)
 
 ExceptionOr<Ref<Document>> DOMParser::parseFromString(const String& string, const String& contentType)
 {
+    URL url = { };
+    if (m_contextDocument)
+        url = m_contextDocument->url();
     RefPtr<Document> document;
     if (contentType == "text/html"_s)
-        document = HTMLDocument::create(nullptr, m_settings, URL { });
+        document = HTMLDocument::create(nullptr, m_settings, url);
     else if (contentType == "application/xhtml+xml"_s)
-        document = XMLDocument::createXHTML(nullptr, m_settings, URL { });
+        document = XMLDocument::createXHTML(nullptr, m_settings, url);
     else if (contentType == "image/svg+xml"_s)
-        document = SVGDocument::create(nullptr, m_settings, URL { });
+        document = SVGDocument::create(nullptr, m_settings, url);
     else if (contentType == "text/xml"_s || contentType == "application/xml"_s) {
-        document = XMLDocument::create(nullptr, m_settings, URL { });
+        document = XMLDocument::create(nullptr, m_settings, url);
         document->overrideMIMEType(contentType);
     } else
         return Exception { ExceptionCode::TypeError };
@@ -57,10 +60,8 @@ ExceptionOr<Ref<Document>> DOMParser::parseFromString(const String& string, cons
     if (m_contextDocument)
         document->setContextDocument(*m_contextDocument.get());
     document->setMarkupUnsafe(string, { });
-    if (m_contextDocument) {
-        document->setURL(m_contextDocument->url());
+    if (m_contextDocument)
         document->setSecurityOriginPolicy(m_contextDocument->securityOriginPolicy());
-    }
     return document.releaseNonNull();
 }
 


### PR DESCRIPTION
#### b1dfeeeebad5575ca3a66a30e6e29bfb66dc89f2
<pre>
Avoid setURL() call in DOMParser()
<a href="https://bugs.webkit.org/show_bug.cgi?id=267758">https://bugs.webkit.org/show_bug.cgi?id=267758</a>

Reviewed by NOBODY (OOPS!).

Instead let the Document constructor worry about it. We might be able
to elide that call as well as the HTML Standard sets it directly.

* Source/WebCore/xml/DOMParser.cpp:
(WebCore::DOMParser::parseFromString):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1dfeeeebad5575ca3a66a30e6e29bfb66dc89f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37495 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31412 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35950 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30367 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30998 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10090 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10173 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38761 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31400 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36209 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8182 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34176 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12098 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10815 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->