### PR TITLE
Move contextDocument from DOMParser() to parseFromString()

### DIFF
--- a/Source/WebCore/xml/DOMParser.h
+++ b/Source/WebCore/xml/DOMParser.h
@@ -29,16 +29,13 @@ class Settings;
 
 class DOMParser : public RefCounted<DOMParser> {
 public:
-    static Ref<DOMParser> create(Document& contextDocument);
+    static Ref<DOMParser> create();
     ~DOMParser();
 
-    ExceptionOr<Ref<Document>> parseFromString(const String&, const String& contentType);
+    ExceptionOr<Ref<Document>> parseFromString(Document&, const String&, const String&);
 
 private:
-    explicit DOMParser(Document& contextDocument);
-
-    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_contextDocument;
-    const Ref<const Settings> m_settings;
+    explicit DOMParser();
 };
 
 }

--- a/Source/WebCore/xml/DOMParser.idl
+++ b/Source/WebCore/xml/DOMParser.idl
@@ -20,7 +20,7 @@
 [
     Exposed=Window
 ] interface DOMParser {
-    [CallWith=CurrentDocument] constructor();
+    constructor();
 
-    [NewObject] Document parseFromString(DOMString string, DOMString contentType);
+    [NewObject, CallWith=CurrentDocument] Document parseFromString(DOMString string, DOMString contentType);
 };


### PR DESCRIPTION
#### c8ab93db0419b06515ed5248b9e94a9e28114a43
<pre>
Move contextDocument from DOMParser() to parseFromString()
<a href="https://bugs.webkit.org/show_bug.cgi?id=267759">https://bugs.webkit.org/show_bug.cgi?id=267759</a>

Reviewed by NOBODY (OOPS!).

Per the HTML Standard the URL comes from the current document
responsible for invoking parseFromString(). Not the current document
responsible for constructing DOMParser.

This also incorporates this change:
<a href="https://bugs.webkit.org/show_bug.cgi?id=267758">https://bugs.webkit.org/show_bug.cgi?id=267758</a>

* Source/WebCore/xml/DOMParser.cpp:
(WebCore::DOMParser::DOMParser):
(WebCore::DOMParser::create):
(WebCore::DOMParser::parseFromString):
* Source/WebCore/xml/DOMParser.h:
* Source/WebCore/xml/DOMParser.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8ab93db0419b06515ed5248b9e94a9e28114a43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37453 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31376 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35909 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/15992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10673 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30320 "Found 6 new test failures: imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/constructors.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-base-pushstate.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-base.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-moretests.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-pushstate.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10053 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10118 "Found 6 new test failures: imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/constructors.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-base-pushstate.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-base.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-moretests.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-pushstate.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31035 "Found 6 new test failures: imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/constructors.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-base-pushstate.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-base.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-moretests.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-pushstate.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38718 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31563 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31358 "Found 6 new test failures: imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/constructors.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-base-pushstate.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-base.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-moretests.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-pushstate.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36163 "Found 6 new test failures: imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/constructors.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-base-pushstate.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-base.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-moretests.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-pushstate.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10235 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8137 "Found 6 new test failures: imported/w3c/web-platform-tests/WebIDL/ecmascript-binding/constructors.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-base-pushstate.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-base.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-moretests.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url-pushstate.html, imported/w3c/web-platform-tests/domparsing/DOMParser-parseFromString-url.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34137 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12062 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10782 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11126 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->