### PR TITLE
Fix LayoutTest transitions/flex-transitions.html by syncing from Blink / Chromium upstream

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1977,7 +1977,6 @@ webkit.org/b/137883 transitions/cubic-bezier-overflow-svg-length.html [ Pass Fai
 webkit.org/b/137883 transitions/cubic-bezier-overflow-transform.html [ Pass Failure ]
 webkit.org/b/137883 transitions/delay.html [ Pass Failure ]
 webkit.org/b/137883 transitions/equivalent-background-image-no-transition.html [ Pass Failure ]
-webkit.org/b/137883 transitions/flex-transitions.html [ Pass Failure ]
 webkit.org/b/137883 transitions/interrupt-transform-transition.html [ Pass Failure ]
 webkit.org/b/137883 transitions/interrupt-zero-duration.html [ Pass Failure ]
 webkit.org/b/137883 transitions/interrupted-accelerated-transition.html [ Pass Failure ]

--- a/LayoutTests/transitions/flex-transitions-expected.txt
+++ b/LayoutTests/transitions/flex-transitions-expected.txt
@@ -1,5 +1,9 @@
-PASS - "flex" property for "row1" element at 0.5s saw something close to: 2,0,0
-PASS - "flex" property for "column1" element at 0.5s saw something close to: 0.5,0,10
-PASS - "flex" property for "negative1" element at 0.5s saw something close to: 1,0.5,75
-PASS - "flex" property for "no-flex1" element at 0.5s saw something close to: 0.5,0,0
+PASS - "flex" property for "row1" element at 0.2s saw something close to: 140,0,0
+PASS - "flex" property for "column1" element at 0.2s saw something close to: 80,0,40
+PASS - "flex" property for "negative1" element at 0.2s saw something close to: 100,100,60
+PASS - "flex" property for "no-flex1" element at 0.2s saw something close to: 80,0,0
+PASS - "flex" property for "row1" element at 0.8s saw something close to: 260,0,0
+PASS - "flex" property for "column1" element at 0.8s saw something close to: 20,0,160
+PASS - "flex" property for "negative1" element at 0.8s saw something close to: 100,100,90
+PASS - "flex" property for "no-flex1" element at 0.8s saw something close to: 20,0,0
 

--- a/LayoutTests/transitions/flex-transitions.html
+++ b/LayoutTests/transitions/flex-transitions.html
@@ -1,11 +1,12 @@
-<!DOCTYPE>
+<!DOCTYPE html>
 <html>
 <head>
 <style>
 .flexbox {
-    display: -webkit-flexbox;
+    display: flex;
     width: 100px;
     height: 100px;
+    margin-bottom: 10px;
 }
 .flexbox :nth-child(1) {
     background-color: blue;
@@ -14,52 +15,60 @@
     background-color: green;
 }
 .flexbox div {
-    -webkit-transition-property: -webkit-flex;
-    -webkit-transition-duration: 1s;
-    -webkit-transition-timing-function: linear;
+    transition-property: flex;
+    transition-duration: 1s;
+    transition-timing-function: linear;
 }
 
 #flex-row div {
-    flex: 1 0 0px;
+    flex: 100 0 0px;
 }
+
 .final #row1 {
-    flex: 3 0 0px;
+    flex: 300 0 0px;
 }
 
 #flex-column {
     flex-direction: column;
 }
+
 #flex-column div {
-    flex: 1 0 0px;
+    flex: 100 0 0px;
 }
+
 .final #column1 {
-    flex: 0 0 20px;
+    flex: 0 0 200px;
 }
 
 #flex-negative div {
-    flex: 1 1 50px;
+    flex: 100 100 50px;
 }
+
 .final #negative1 {
-    flex: 1 100px;
+    flex: 100 100 100px;
 }
 
 #flex-no-flex div {
-    -webkit-flex: 1 0 0px;
-}
-.final #no-flex1 {
-    -webkit-flex: 0 0 0px;
+    flex: 100 0 0px;
 }
 
+.final #no-flex1 {
+    flex: 0 0 0px;
+}
 </style>
   <script src="resources/transition-test-helpers.js"></script>
   <script type="text/javascript">
 
-    const expectedValues = [
+const expectedValues = [
       // [time, element-id, property, expected-value, tolerance]
-      [0.5, 'row1', 'flex', [2, 0, 0], .5],
-      [0.5, 'column1', 'flex', [.5, 0, 10], 3],
-      [0.5, 'negative1', 'flex', [1, .5, 75], 3],
-      [0.5, 'no-flex1', 'flex', [.5, 0, 0], .4],
+      [0.2, 'row1',      'flex', [140, 0,     0], 10],
+      [0.2, 'column1',   'flex', [80,  0,    40], 10],
+      [0.2, 'negative1', 'flex', [100, 100,  60], 10],
+      [0.2, 'no-flex1',  'flex', [80,  0,     0], 10],
+      [0.8, 'row1',      'flex', [260, 0,     0], 10],
+      [0.8, 'column1',   'flex', [20,  0,   160], 10],
+      [0.8, 'negative1', 'flex', [100, 100,  90], 10],
+      [0.8, 'no-flex1',  'flex', [20,  0,     0], 10],
     ];
 
     function setupTest()
@@ -67,7 +76,7 @@
       document.body.className = 'final';
     }
   
-    runTransitionTest(expectedValues, setupTest, usePauseAPI);
+    runTransitionTest(expectedValues, setupTest);
   </script>
 </head>
 <body>


### PR DESCRIPTION
#### 744d1201a37974e2c5235684ddf3a83659dbe6ae
<pre>
Fix LayoutTest transitions/flex-transitions.html by syncing from Blink / Chromium upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=125894">https://bugs.webkit.org/show_bug.cgi?id=125894</a>

Reviewed by Antoine Quint.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/40cc24abe770f2fd20d9a09c60cf87502c28063a">https://chromium.googlesource.com/chromium/blink/+/40cc24abe770f2fd20d9a09c60cf87502c28063a</a> &amp;
<a href="https://source.chromium.org/chromium/chromium/src/+/cb4809f7770d86811559c3f39ed0cbc308a73887">https://source.chromium.org/chromium/chromium/src/+/cb4809f7770d86811559c3f39ed0cbc308a73887</a>

Update the expected results to account for the fact that flex-grow and
flex-shrink don&apos;t interpolate smoothly to or from zero. Also update the test to
use values of similar magnitudes for each part of the property shorthand, to
allow the tolerance to be applied meaningfully.

* LayoutTests/transitions/flex-transitions.html: Updated
* LayoutTests/transitions/flex-transitions-expected.txt: Ditto
* LayoutTests/TestExpectations: Remove the test expectation

Canonical link: <a href="https://commits.webkit.org/273266@main">https://commits.webkit.org/273266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10292b8993f581567febb73ab828a259db4f467a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37614 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31503 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30437 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31088 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10190 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38868 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36285 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34263 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30819 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/8006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10905 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11242 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->