### PR TITLE
Fix 'failing' test expectation of 'input-date-validation-message.html'

### DIFF
--- a/LayoutTests/fast/forms/date/input-date-validation-message-expected.txt
+++ b/LayoutTests/fast/forms/date/input-date-validation-message-expected.txt
@@ -6,15 +6,15 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 No message
 PASS testIt("", "", "") is ""
 Value missing
-FAIL testIt("", "", "") should be value missing. Was Fill out this field.
+PASS testIt("", "", "") is "Fill out this field"
 Type mismatch
 PASS testIt("foo", "", "") is ""
 Range overflow
-FAIL testIt("1982-11-02", "", "1970-12-31") should be range overflow. Was Value must be less than or equal to 1970-12-31.
+PASS testIt("1982-11-02", "", "1970-12-31") is "Value must be less than or equal to 1970-12-31"
 Range underflow
-FAIL testIt("1982-11-02", "1990-05-25", "1990-12-24") should be range underflow. Was Value must be greater than or equal to 1990-05-25.
+PASS testIt("1982-11-02", "1990-05-25", "1990-12-24") is "Value must be greater than or equal to 1990-05-25"
 Step mismatch
-FAIL testIt("1982-11-02", "", "", "123") should be step mismatch. Was Enter a valid value.
+PASS testIt("1982-11-02", "", "", "123") is "Enter a valid value"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/date/input-date-validation-message.html
+++ b/LayoutTests/fast/forms/date/input-date-validation-message.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -25,22 +25,21 @@ shouldBeEqualToString('testIt("", "", "")', '');
 
 debug('Value missing')
 input.setAttribute("required", "");
-shouldBeEqualToString('testIt("", "", "")', 'value missing');
+shouldBeEqualToString('testIt("", "", "")', 'Fill out this field');
 input.removeAttribute("required");
 
 debug('Type mismatch');
 shouldBeEqualToString('testIt("foo", "", "")', '');
 
 debug('Range overflow')
-shouldBeEqualToString('testIt("1982-11-02", "", "1970-12-31")', 'range overflow');
+shouldBeEqualToString('testIt("1982-11-02", "", "1970-12-31")', 'Value must be less than or equal to 1970-12-31');
 
 debug('Range underflow')
-shouldBeEqualToString('testIt("1982-11-02", "1990-05-25", "1990-12-24")', 'range underflow');
+shouldBeEqualToString('testIt("1982-11-02", "1990-05-25", "1990-12-24")', 'Value must be greater than or equal to 1990-05-25');
 
 debug('Step mismatch')
-shouldBeEqualToString('testIt("1982-11-02", "", "", "123")', 'step mismatch');
+shouldBeEqualToString('testIt("1982-11-02", "", "", "123")', 'Enter a valid value');
 
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>


### PR DESCRIPTION
#### 15904f94fa7a97638ec60c4785345864fd288d1c
<pre>
Fix &apos;failing&apos; test expectation of &apos;input-date-validation-message.html&apos;

<a href="https://bugs.webkit.org/show_bug.cgi?id=267761">https://bugs.webkit.org/show_bug.cgi?id=267761</a>

Reviewed by Aditya Keerthi.

This patch is to update test to use &apos;js-test.js&apos; and also fix &apos;invalidation message&apos; being incorrect
in test from the expectation leading to test failures.

* LayoutTests/fast/forms/date/input-date-validation-message.html: Updated
* LayoutTests/fast/forms/date/input-date-validation-message-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/273237@main">https://commits.webkit.org/273237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65da9715a1d79b06f58cccc8b08ea865e6e78e9c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37464 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31386 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30330 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10063 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31045 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38729 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31368 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36173 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34148 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30687 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10791 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4466 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11136 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->