### PR TITLE
[web-animations] add interpolation support for the `display` property

### DIFF
--- a/LayoutTests/imported/blink/fast/css-generated-content/pseudo-animation-display-expected.txt
+++ b/LayoutTests/imported/blink/fast/css-generated-content/pseudo-animation-display-expected.txt
@@ -1,4 +1,4 @@
 Tests that an attempt to animate the display property of a pseudo element is ignored, and that the animation proceeds as expected.
 PASS: left was 100px
-PASS: display was block
+FAIL: display was not block
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-interpolation-expected.txt
@@ -1,28 +1,28 @@
 
-FAIL CSS Transitions: property <display> from [block] to [none] at (-1) should be [block] assert_equals: expected "block " but got "none "
-FAIL CSS Transitions: property <display> from [block] to [none] at (0) should be [block] assert_equals: expected "block " but got "none "
-FAIL CSS Transitions: property <display> from [block] to [none] at (0.1) should be [block] assert_equals: expected "block " but got "none "
-FAIL CSS Transitions: property <display> from [block] to [none] at (0.9) should be [block] assert_equals: expected "block " but got "none "
+PASS CSS Transitions: property <display> from [block] to [none] at (-1) should be [block]
+PASS CSS Transitions: property <display> from [block] to [none] at (0) should be [block]
+PASS CSS Transitions: property <display> from [block] to [none] at (0.1) should be [block]
+PASS CSS Transitions: property <display> from [block] to [none] at (0.9) should be [block]
 PASS CSS Transitions: property <display> from [block] to [none] at (1) should be [none]
 PASS CSS Transitions: property <display> from [block] to [none] at (1.5) should be [none]
-FAIL CSS Transitions with transition: all: property <display> from [block] to [none] at (-1) should be [block] assert_equals: expected "block " but got "none "
-FAIL CSS Transitions with transition: all: property <display> from [block] to [none] at (0) should be [block] assert_equals: expected "block " but got "none "
-FAIL CSS Transitions with transition: all: property <display> from [block] to [none] at (0.1) should be [block] assert_equals: expected "block " but got "none "
-FAIL CSS Transitions with transition: all: property <display> from [block] to [none] at (0.9) should be [block] assert_equals: expected "block " but got "none "
+PASS CSS Transitions with transition: all: property <display> from [block] to [none] at (-1) should be [block]
+PASS CSS Transitions with transition: all: property <display> from [block] to [none] at (0) should be [block]
+PASS CSS Transitions with transition: all: property <display> from [block] to [none] at (0.1) should be [block]
+PASS CSS Transitions with transition: all: property <display> from [block] to [none] at (0.9) should be [block]
 PASS CSS Transitions with transition: all: property <display> from [block] to [none] at (1) should be [none]
 PASS CSS Transitions with transition: all: property <display> from [block] to [none] at (1.5) should be [none]
 PASS CSS Animations: property <display> from [block] to [none] at (-1) should be [block]
 PASS CSS Animations: property <display> from [block] to [none] at (0) should be [block]
 PASS CSS Animations: property <display> from [block] to [none] at (0.1) should be [block]
 PASS CSS Animations: property <display> from [block] to [none] at (0.9) should be [block]
-FAIL CSS Animations: property <display> from [block] to [none] at (1) should be [none] assert_equals: expected "none " but got "block "
-FAIL CSS Animations: property <display> from [block] to [none] at (1.5) should be [none] assert_equals: expected "none " but got "block "
+PASS CSS Animations: property <display> from [block] to [none] at (1) should be [none]
+PASS CSS Animations: property <display> from [block] to [none] at (1.5) should be [none]
 PASS Web Animations: property <display> from [block] to [none] at (-1) should be [block]
 PASS Web Animations: property <display> from [block] to [none] at (0) should be [block]
 PASS Web Animations: property <display> from [block] to [none] at (0.1) should be [block]
 PASS Web Animations: property <display> from [block] to [none] at (0.9) should be [block]
-FAIL Web Animations: property <display> from [block] to [none] at (1) should be [none] assert_equals: expected "none " but got "block "
-FAIL Web Animations: property <display> from [block] to [none] at (1.5) should be [none] assert_equals: expected "none " but got "block "
+PASS Web Animations: property <display> from [block] to [none] at (1) should be [none]
+PASS Web Animations: property <display> from [block] to [none] at (1.5) should be [none]
 PASS CSS Transitions: property <display> from [none] to [block] at (-1) should be [block]
 PASS CSS Transitions: property <display> from [none] to [block] at (0) should be [block]
 PASS CSS Transitions: property <display> from [none] to [block] at (0.1) should be [block]
@@ -35,14 +35,14 @@ PASS CSS Transitions with transition: all: property <display> from [none] to [bl
 PASS CSS Transitions with transition: all: property <display> from [none] to [block] at (0.9) should be [block]
 PASS CSS Transitions with transition: all: property <display> from [none] to [block] at (1) should be [block]
 PASS CSS Transitions with transition: all: property <display> from [none] to [block] at (1.5) should be [block]
-FAIL CSS Animations: property <display> from [none] to [block] at (-1) should be [none] assert_equals: expected "none " but got "block "
-FAIL CSS Animations: property <display> from [none] to [block] at (0) should be [none] assert_equals: expected "none " but got "block "
+PASS CSS Animations: property <display> from [none] to [block] at (-1) should be [none]
+PASS CSS Animations: property <display> from [none] to [block] at (0) should be [none]
 PASS CSS Animations: property <display> from [none] to [block] at (0.1) should be [block]
 PASS CSS Animations: property <display> from [none] to [block] at (0.9) should be [block]
 PASS CSS Animations: property <display> from [none] to [block] at (1) should be [block]
 PASS CSS Animations: property <display> from [none] to [block] at (1.5) should be [block]
-FAIL Web Animations: property <display> from [none] to [block] at (-1) should be [none] assert_equals: expected "none " but got "block "
-FAIL Web Animations: property <display> from [none] to [block] at (0) should be [none] assert_equals: expected "none " but got "block "
+PASS Web Animations: property <display> from [none] to [block] at (-1) should be [none]
+PASS Web Animations: property <display> from [none] to [block] at (0) should be [none]
 PASS Web Animations: property <display> from [none] to [block] at (0.1) should be [block]
 PASS Web Animations: property <display> from [none] to [block] at (0.9) should be [block]
 PASS Web Animations: property <display> from [none] to [block] at (1) should be [block]
@@ -61,16 +61,16 @@ PASS CSS Transitions with transition: all: property <display> from [inline] to [
 PASS CSS Transitions with transition: all: property <display> from [inline] to [block] at (0.6) should be [block]
 PASS CSS Transitions with transition: all: property <display> from [inline] to [block] at (1) should be [block]
 PASS CSS Transitions with transition: all: property <display> from [inline] to [block] at (1.5) should be [block]
-FAIL CSS Animations: property <display> from [inline] to [block] at (-0.3) should be [inline] assert_equals: expected "inline " but got "block "
-FAIL CSS Animations: property <display> from [inline] to [block] at (0) should be [inline] assert_equals: expected "inline " but got "block "
-FAIL CSS Animations: property <display> from [inline] to [block] at (0.3) should be [inline] assert_equals: expected "inline " but got "block "
+PASS CSS Animations: property <display> from [inline] to [block] at (-0.3) should be [inline]
+PASS CSS Animations: property <display> from [inline] to [block] at (0) should be [inline]
+PASS CSS Animations: property <display> from [inline] to [block] at (0.3) should be [inline]
 PASS CSS Animations: property <display> from [inline] to [block] at (0.5) should be [block]
 PASS CSS Animations: property <display> from [inline] to [block] at (0.6) should be [block]
 PASS CSS Animations: property <display> from [inline] to [block] at (1) should be [block]
 PASS CSS Animations: property <display> from [inline] to [block] at (1.5) should be [block]
-FAIL Web Animations: property <display> from [inline] to [block] at (-0.3) should be [inline] assert_equals: expected "inline " but got "block "
-FAIL Web Animations: property <display> from [inline] to [block] at (0) should be [inline] assert_equals: expected "inline " but got "block "
-FAIL Web Animations: property <display> from [inline] to [block] at (0.3) should be [inline] assert_equals: expected "inline " but got "block "
+PASS Web Animations: property <display> from [inline] to [block] at (-0.3) should be [inline]
+PASS Web Animations: property <display> from [inline] to [block] at (0) should be [inline]
+PASS Web Animations: property <display> from [inline] to [block] at (0.3) should be [inline]
 PASS Web Animations: property <display> from [inline] to [block] at (0.5) should be [block]
 PASS Web Animations: property <display> from [inline] to [block] at (0.6) should be [block]
 PASS Web Animations: property <display> from [inline] to [block] at (1) should be [block]
@@ -111,16 +111,16 @@ PASS CSS Transitions with transition: all: property <display> from [none] to [no
 PASS CSS Transitions with transition: all: property <display> from [none] to [none] at (0.9) should be [none]
 PASS CSS Transitions with transition: all: property <display> from [none] to [none] at (1) should be [none]
 PASS CSS Transitions with transition: all: property <display> from [none] to [none] at (1.5) should be [none]
-FAIL CSS Animations: property <display> from [none] to [none] at (-1) should be [none] assert_equals: expected "none " but got "block "
-FAIL CSS Animations: property <display> from [none] to [none] at (0) should be [none] assert_equals: expected "none " but got "block "
-FAIL CSS Animations: property <display> from [none] to [none] at (0.1) should be [none] assert_equals: expected "none " but got "block "
-FAIL CSS Animations: property <display> from [none] to [none] at (0.9) should be [none] assert_equals: expected "none " but got "block "
-FAIL CSS Animations: property <display> from [none] to [none] at (1) should be [none] assert_equals: expected "none " but got "block "
-FAIL CSS Animations: property <display> from [none] to [none] at (1.5) should be [none] assert_equals: expected "none " but got "block "
-FAIL Web Animations: property <display> from [none] to [none] at (-1) should be [none] assert_equals: expected "none " but got "block "
-FAIL Web Animations: property <display> from [none] to [none] at (0) should be [none] assert_equals: expected "none " but got "block "
-FAIL Web Animations: property <display> from [none] to [none] at (0.1) should be [none] assert_equals: expected "none " but got "block "
-FAIL Web Animations: property <display> from [none] to [none] at (0.9) should be [none] assert_equals: expected "none " but got "block "
-FAIL Web Animations: property <display> from [none] to [none] at (1) should be [none] assert_equals: expected "none " but got "block "
-FAIL Web Animations: property <display> from [none] to [none] at (1.5) should be [none] assert_equals: expected "none " but got "block "
+PASS CSS Animations: property <display> from [none] to [none] at (-1) should be [none]
+PASS CSS Animations: property <display> from [none] to [none] at (0) should be [none]
+PASS CSS Animations: property <display> from [none] to [none] at (0.1) should be [none]
+PASS CSS Animations: property <display> from [none] to [none] at (0.9) should be [none]
+PASS CSS Animations: property <display> from [none] to [none] at (1) should be [none]
+PASS CSS Animations: property <display> from [none] to [none] at (1.5) should be [none]
+PASS Web Animations: property <display> from [none] to [none] at (-1) should be [none]
+PASS Web Animations: property <display> from [none] to [none] at (0) should be [none]
+PASS Web Animations: property <display> from [none] to [none] at (0.1) should be [none]
+PASS Web Animations: property <display> from [none] to [none] at (0.9) should be [none]
+PASS Web Animations: property <display> from [none] to [none] at (1) should be [none]
+PASS Web Animations: property <display> from [none] to [none] at (1.5) should be [none]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-dont-cancel.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-dont-cancel.tentative-expected.txt
@@ -1,11 +1,8 @@
-hello
-hello
-hello
-hello
+hello hello
 
-FAIL display:none animating to display:inline should be inline for the whole animation. assert_equals: The display should be inline during the animation. expected "inline" but got "block"
-FAIL A CSS variable of display:none animating to display:inline should be inline for the whole animation. assert_equals: The display should be inline during the animation. expected "inline" but got "block"
-FAIL Animating from display:none to display:none should not cancel the animation. assert_equals: The display should be none and the animation should keep running. expected "none" but got "block"
-FAIL Animating from display:none to display:none with an intermediate variable should not cancel the animation. assert_equals: The display should be none and the animation should keep running. expected "none" but got "block"
-FAIL Animating a variable of "none" which gets set to display elsewhere should not cancel the animation. assert_equals: The display should be none and the animation should keep running. expected "none" but got "block"
+PASS display:none animating to display:inline should be inline for the whole animation.
+PASS A CSS variable of display:none animating to display:inline should be inline for the whole animation.
+PASS Animating from display:none to display:none should not cancel the animation.
+PASS Animating from display:none to display:none with an intermediate variable should not cancel the animation.
+PASS Animating a variable of "none" which gets set to display elsewhere should not cancel the animation.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/animations/display-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/animations/display-interpolation-expected.txt
@@ -13,18 +13,18 @@ PASS CSS Transitions with transition: all: property <display> from [none] to [fl
 PASS CSS Transitions with transition: all: property <display> from [none] to [flex] at (0.6) should be [flex]
 PASS CSS Transitions with transition: all: property <display> from [none] to [flex] at (1) should be [flex]
 PASS CSS Transitions with transition: all: property <display> from [none] to [flex] at (1.5) should be [flex]
-PASS CSS Animations: property <display> from [none] to [flex] at (-0.3) should be [block]
-PASS CSS Animations: property <display> from [none] to [flex] at (0) should be [block]
-PASS CSS Animations: property <display> from [none] to [flex] at (0.3) should be [block]
-PASS CSS Animations: property <display> from [none] to [flex] at (0.5) should be [block]
-PASS CSS Animations: property <display> from [none] to [flex] at (0.6) should be [block]
-PASS CSS Animations: property <display> from [none] to [flex] at (1) should be [block]
-PASS CSS Animations: property <display> from [none] to [flex] at (1.5) should be [block]
-PASS Web Animations: property <display> from [none] to [flex] at (-0.3) should be [block]
-PASS Web Animations: property <display> from [none] to [flex] at (0) should be [block]
-PASS Web Animations: property <display> from [none] to [flex] at (0.3) should be [block]
-PASS Web Animations: property <display> from [none] to [flex] at (0.5) should be [block]
-PASS Web Animations: property <display> from [none] to [flex] at (0.6) should be [block]
-PASS Web Animations: property <display> from [none] to [flex] at (1) should be [block]
-PASS Web Animations: property <display> from [none] to [flex] at (1.5) should be [block]
+FAIL CSS Animations: property <display> from [none] to [flex] at (-0.3) should be [block] assert_equals: expected "block " but got "none "
+FAIL CSS Animations: property <display> from [none] to [flex] at (0) should be [block] assert_equals: expected "block " but got "none "
+FAIL CSS Animations: property <display> from [none] to [flex] at (0.3) should be [block] assert_equals: expected "block " but got "flex "
+FAIL CSS Animations: property <display> from [none] to [flex] at (0.5) should be [block] assert_equals: expected "block " but got "flex "
+FAIL CSS Animations: property <display> from [none] to [flex] at (0.6) should be [block] assert_equals: expected "block " but got "flex "
+FAIL CSS Animations: property <display> from [none] to [flex] at (1) should be [block] assert_equals: expected "block " but got "flex "
+FAIL CSS Animations: property <display> from [none] to [flex] at (1.5) should be [block] assert_equals: expected "block " but got "flex "
+FAIL Web Animations: property <display> from [none] to [flex] at (-0.3) should be [block] assert_equals: expected "block " but got "none "
+FAIL Web Animations: property <display> from [none] to [flex] at (0) should be [block] assert_equals: expected "block " but got "none "
+FAIL Web Animations: property <display> from [none] to [flex] at (0.3) should be [block] assert_equals: expected "block " but got "flex "
+FAIL Web Animations: property <display> from [none] to [flex] at (0.5) should be [block] assert_equals: expected "block " but got "flex "
+FAIL Web Animations: property <display> from [none] to [flex] at (0.6) should be [block] assert_equals: expected "block " but got "flex "
+FAIL Web Animations: property <display> from [none] to [flex] at (1) should be [block] assert_equals: expected "block " but got "flex "
+FAIL Web Animations: property <display> from [none] to [flex] at (1.5) should be [block] assert_equals: expected "block " but got "flex "
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/animations/display-interpolation.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/animations/display-interpolation.tentative-expected.txt
@@ -1,16 +1,16 @@
 
-FAIL CSS Animations: property <display> from [grid] to [flex] at (-0.3) should be [grid] assert_equals: expected "grid " but got "block "
-FAIL CSS Animations: property <display> from [grid] to [flex] at (0) should be [grid] assert_equals: expected "grid " but got "block "
-FAIL CSS Animations: property <display> from [grid] to [flex] at (0.3) should be [grid] assert_equals: expected "grid " but got "block "
-FAIL CSS Animations: property <display> from [grid] to [flex] at (0.5) should be [flex] assert_equals: expected "flex " but got "block "
-FAIL CSS Animations: property <display> from [grid] to [flex] at (0.6) should be [flex] assert_equals: expected "flex " but got "block "
-FAIL CSS Animations: property <display> from [grid] to [flex] at (1) should be [flex] assert_equals: expected "flex " but got "block "
-FAIL CSS Animations: property <display> from [grid] to [flex] at (1.5) should be [flex] assert_equals: expected "flex " but got "block "
-FAIL Web Animations: property <display> from [grid] to [flex] at (-0.3) should be [grid] assert_equals: expected "grid " but got "block "
-FAIL Web Animations: property <display> from [grid] to [flex] at (0) should be [grid] assert_equals: expected "grid " but got "block "
-FAIL Web Animations: property <display> from [grid] to [flex] at (0.3) should be [grid] assert_equals: expected "grid " but got "block "
-FAIL Web Animations: property <display> from [grid] to [flex] at (0.5) should be [flex] assert_equals: expected "flex " but got "block "
-FAIL Web Animations: property <display> from [grid] to [flex] at (0.6) should be [flex] assert_equals: expected "flex " but got "block "
-FAIL Web Animations: property <display> from [grid] to [flex] at (1) should be [flex] assert_equals: expected "flex " but got "block "
-FAIL Web Animations: property <display> from [grid] to [flex] at (1.5) should be [flex] assert_equals: expected "flex " but got "block "
+PASS CSS Animations: property <display> from [grid] to [flex] at (-0.3) should be [grid]
+PASS CSS Animations: property <display> from [grid] to [flex] at (0) should be [grid]
+PASS CSS Animations: property <display> from [grid] to [flex] at (0.3) should be [grid]
+PASS CSS Animations: property <display> from [grid] to [flex] at (0.5) should be [flex]
+PASS CSS Animations: property <display> from [grid] to [flex] at (0.6) should be [flex]
+PASS CSS Animations: property <display> from [grid] to [flex] at (1) should be [flex]
+PASS CSS Animations: property <display> from [grid] to [flex] at (1.5) should be [flex]
+PASS Web Animations: property <display> from [grid] to [flex] at (-0.3) should be [grid]
+PASS Web Animations: property <display> from [grid] to [flex] at (0) should be [grid]
+PASS Web Animations: property <display> from [grid] to [flex] at (0.3) should be [grid]
+PASS Web Animations: property <display> from [grid] to [flex] at (0.5) should be [flex]
+PASS Web Animations: property <display> from [grid] to [flex] at (0.6) should be [flex]
+PASS Web Animations: property <display> from [grid] to [flex] at (1) should be [flex]
+PASS Web Animations: property <display> from [grid] to [flex] at (1.5) should be [flex]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/display.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/display.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Display can be held by animation assert_equals: Display when progress = 0 expected "block" but got "none"
+PASS Display can be held by animation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001-expected.txt
@@ -15,7 +15,6 @@ PASS non-animatable property 'transitionProperty' is not accessed when using a p
 PASS non-animatable property 'transitionTimingFunction' is not accessed when using a property-indexed keyframe object
 PASS non-animatable property 'contain' is not accessed when using a property-indexed keyframe object
 PASS non-animatable property 'direction' is not accessed when using a property-indexed keyframe object
-PASS non-animatable property 'display' is not accessed when using a property-indexed keyframe object
 PASS non-animatable property 'textCombineUpright' is not accessed when using a property-indexed keyframe object
 PASS non-animatable property 'textOrientation' is not accessed when using a property-indexed keyframe object
 PASS non-animatable property 'unicodeBidi' is not accessed when using a property-indexed keyframe object
@@ -40,7 +39,6 @@ PASS non-animatable property 'transitionProperty' is not accessed when using a k
 PASS non-animatable property 'transitionTimingFunction' is not accessed when using a keyframe sequence
 PASS non-animatable property 'contain' is not accessed when using a keyframe sequence
 PASS non-animatable property 'direction' is not accessed when using a keyframe sequence
-PASS non-animatable property 'display' is not accessed when using a keyframe sequence
 PASS non-animatable property 'textCombineUpright' is not accessed when using a keyframe sequence
 PASS non-animatable property 'textOrientation' is not accessed when using a keyframe sequence
 PASS non-animatable property 'unicodeBidi' is not accessed when using a keyframe sequence

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
@@ -37,7 +37,6 @@ const gNonAnimatableProps = [
   'transitionTimingFunction',
   'contain',
   'direction',
-  'display',
   'textCombineUpright',
   'textOrientation',
   'unicodeBidi',

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2303,7 +2303,7 @@ bool KeyframeEffect::ticksContinuouslyWhileActive() const
     auto targetHasDisplayContents = [&]() {
         return m_target && !m_pseudoElementIdentifier && m_target->hasDisplayContents();
     };
-    if (!renderer() && !targetHasDisplayContents())
+    if (!renderer() && !m_blendingKeyframes.properties().contains(CSSPropertyDisplay) && !targetHasDisplayContents())
         return false;
 
     if (isCompletelyAccelerated() && isRunningAccelerated()) {

--- a/Source/WebCore/animation/StyleOriginatedAnimation.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.cpp
@@ -201,7 +201,7 @@ void StyleOriginatedAnimation::setTimeline(RefPtr<AnimationTimeline>&& newTimeli
     WebAnimation::setTimeline(WTFMove(newTimeline));
 }
 
-void StyleOriginatedAnimation::cancel()
+void StyleOriginatedAnimation::cancel(WebAnimation::Silently silently)
 {
     auto cancelationTime = 0_s;
 
@@ -213,14 +213,14 @@ void StyleOriginatedAnimation::cancel()
         }
     }
 
-    WebAnimation::cancel();
+    WebAnimation::cancel(silently);
 
     invalidateDOMEvents(shouldFireEvents, cancelationTime);
 }
 
-void StyleOriginatedAnimation::cancelFromStyle()
+void StyleOriginatedAnimation::cancelFromStyle(WebAnimation::Silently silently)
 {
-    cancel();
+    cancel(silently);
     disassociateFromOwningElement();
 }
 

--- a/Source/WebCore/animation/StyleOriginatedAnimation.h
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.h
@@ -50,7 +50,7 @@ public:
     const std::optional<const Styleable> owningElement() const;
     const Animation& backingAnimation() const { return m_backingAnimation; }
     void setBackingAnimation(const Animation&);
-    void cancelFromStyle();
+    void cancelFromStyle(WebAnimation::Silently = WebAnimation::Silently::No);
 
     std::optional<double> bindingsStartTime() const final;
     std::optional<double> bindingsCurrentTime() const final;
@@ -63,7 +63,7 @@ public:
     ExceptionOr<void> bindingsPause() override;
 
     void setTimeline(RefPtr<AnimationTimeline>&&) final;
-    void cancel() final;
+    void cancel(WebAnimation::Silently = WebAnimation::Silently::No) final;
 
     void tick() override;
 

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -706,7 +706,7 @@ Seconds WebAnimation::effectEndTime() const
     return m_effect ? m_effect->endTime() : 0_s;
 }
 
-void WebAnimation::cancel()
+void WebAnimation::cancel(Silently silently)
 {
     LOG_WITH_STREAM(Animations, stream << "WebAnimation " << this << " cancel() (current time is " << currentTime() << ")");
 
@@ -762,7 +762,7 @@ void WebAnimation::cancel()
     // 3. Make animation's start time unresolved.
     m_startTime = std::nullopt;
 
-    timingDidChange(DidSeek::No, SynchronouslyNotify::No);
+    timingDidChange(DidSeek::No, SynchronouslyNotify::No, silently);
 
     invalidateEffect();
 

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -102,7 +102,8 @@ public:
     using FinishedPromise = DOMPromiseProxyWithResolveCallback<IDLInterface<WebAnimation>>;
     FinishedPromise& finished() { return m_finishedPromise.get(); }
 
-    virtual void cancel();
+    enum class Silently : bool { No, Yes };
+    virtual void cancel(Silently = Silently::No);
     ExceptionOr<void> finish();
     ExceptionOr<void> play();
     void updatePlaybackRate(double);
@@ -175,7 +176,6 @@ protected:
 private:
     enum class DidSeek : bool { No, Yes };
     enum class SynchronouslyNotify : bool { No, Yes };
-    enum class Silently : bool { No, Yes };
     enum class RespectHoldTime : bool { No, Yes };
     enum class AutoRewind : bool { No, Yes };
     enum class TimeToRunPendingTask : uint8_t { NotScheduled, ASAP, WhenReady };

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1542,6 +1542,8 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyClear);
         if (first.position != second.position)
             changingProperties.m_properties.set(CSSPropertyPosition);
+        if (first.effectiveDisplay != second.effectiveDisplay)
+            changingProperties.m_properties.set(CSSPropertyDisplay);
         if (first.floating != second.floating)
             changingProperties.m_properties.set(CSSPropertyFloat);
         if (first.tableLayout != second.tableLayout)
@@ -1550,7 +1552,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyTextDecorationLine);
 
         // Non animated styles are followings.
-        // effectiveDisplay
         // originalDisplay
         // unicodeBidi
         // usesViewportUnits

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -28,6 +28,7 @@
 
 #include "ContentData.h"
 #include "InspectorInstrumentation.h"
+#include "KeyframeEffectStack.h"
 #include "PseudoElement.h"
 #include "RenderCounter.h"
 #include "RenderDescendantIterator.h"
@@ -83,16 +84,28 @@ void RenderTreeUpdater::GeneratedContent::updateCounters()
     update();
 }
 
+static KeyframeEffectStack* keyframeEffectStackForElementAndPseudoId(const Element& element, PseudoId pseudoId)
+{
+    return element.keyframeEffectStack(pseudoId == PseudoId::None ? std::nullopt : std::optional(Style::PseudoElementIdentifier { pseudoId }));
+}
+
 static bool elementIsTargetedByKeyframeEffectRequiringPseudoElement(const Element* element, PseudoId pseudoId)
 {
     if (auto* pseudoElement = dynamicDowncast<PseudoElement>(element))
         return elementIsTargetedByKeyframeEffectRequiringPseudoElement(pseudoElement->hostElement(), pseudoId);
 
     if (element) {
-        if (auto* stack = element->keyframeEffectStack(pseudoId == PseudoId::None ? std::nullopt : std::optional(Style::PseudoElementIdentifier { pseudoId })))
+        if (auto* stack = keyframeEffectStackForElementAndPseudoId(*element, pseudoId))
             return stack->requiresPseudoElement();
     }
 
+    return false;
+}
+
+static bool elementHasDisplayAnimationForPseudoId(const Element& element, PseudoId pseudoId)
+{
+    if (auto* stack = keyframeEffectStackForElementAndPseudoId(element, pseudoId))
+        return stack->containsProperty(CSSPropertyDisplay);
     return false;
 }
 
@@ -130,7 +143,9 @@ void RenderTreeUpdater::GeneratedContent::updatePseudoElement(Element& current, 
 
     auto* updateStyle = elementUpdate.style ? elementUpdate.style->getCachedPseudoStyle({ pseudoId }) : nullptr;
 
-    if (!needsPseudoElement(updateStyle) && !elementIsTargetedByKeyframeEffectRequiringPseudoElement(&current, pseudoId)) {
+    auto hasDisplayAnimation = elementHasDisplayAnimationForPseudoId(current, pseudoId);
+
+    if (!needsPseudoElement(updateStyle) && !elementIsTargetedByKeyframeEffectRequiringPseudoElement(&current, pseudoId) && !hasDisplayAnimation) {
         if (pseudoElement) {
             if (pseudoId == PseudoId::Before)
                 removeBeforePseudoElement(current, m_updater.m_builder);
@@ -166,9 +181,17 @@ void RenderTreeUpdater::GeneratedContent::updatePseudoElement(Element& current, 
         pseudoElement->storeDisplayContentsOrNoneStyle(makeUnique<RenderStyle>(WTFMove(pseudoElementUpdateStyle)));
     } else {
         auto pseudoElementUpdateStyle = RenderStyle::cloneIncludingPseudoElements(*updateStyle);
-        Style::ElementUpdate pseudoElementUpdate { makeUnique<RenderStyle>(WTFMove(pseudoElementUpdateStyle)), styleChange, elementUpdate.recompositeLayer };
+        // FIXME: using hasDisplayAnimation is not the right way to go here, we need to track whether
+        // the style update yielded a change here so we may have to track this on the RenderStyle itself,
+        // as the provided elementUpdate here is from the parent and will not have the correct animationsAffectedDisplay
+        // flag set.
+        Style::ElementUpdate pseudoElementUpdate { makeUnique<RenderStyle>(WTFMove(pseudoElementUpdateStyle)), styleChange, elementUpdate.recompositeLayer, hasDisplayAnimation };
         m_updater.updateElementRenderer(*pseudoElement, WTFMove(pseudoElementUpdate));
-        pseudoElement->clearDisplayContentsOrNoneStyle();
+        if (updateStyle->display() == DisplayType::None) {
+            auto pseudoElementUpdateStyle = RenderStyle::cloneIncludingPseudoElements(*updateStyle);
+            pseudoElement->storeDisplayContentsOrNoneStyle(makeUnique<RenderStyle>(WTFMove(pseudoElementUpdateStyle)));
+        } else
+            pseudoElement->clearDisplayContentsOrNoneStyle();
     }
 
     auto* pseudoElementRenderer = pseudoElement->renderer();

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -46,6 +46,7 @@ struct ElementUpdate {
     std::unique_ptr<RenderStyle> style;
     Change change { Change::None };
     bool recompositeLayer { false };
+    bool animationsAffectedDisplay { false };
 };
 
 struct TextUpdate {

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -303,12 +303,12 @@ void Styleable::willChangeRenderer() const
     }
 }
 
-void Styleable::cancelStyleOriginatedAnimations() const
+void Styleable::cancelStyleOriginatedAnimations(const WeakStyleOriginatedAnimations& animationsToCancelSilently) const
 {
     if (auto* animations = this->animations()) {
         for (auto& animation : *animations) {
             if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation.get())) {
-                styleOriginatedAnimation->cancelFromStyle();
+                styleOriginatedAnimation->cancelFromStyle(animationsToCancelSilently.contains(styleOriginatedAnimation) ? WebAnimation::Silently::Yes : WebAnimation::Silently::No);
                 setLastStyleChangeEventStyle(nullptr);
             }
         }
@@ -346,7 +346,7 @@ void Styleable::updateCSSAnimations(const RenderStyle* currentStyle, const Rende
     auto& keyframeEffectStack = ensureKeyframeEffectStack();
 
     // In case this element is newly getting a "display: none" we need to cancel all of its animations and disregard new ones.
-    if (currentStyle && currentStyle->display() != DisplayType::None && newStyle.display() == DisplayType::None) {
+    if ((!currentStyle || currentStyle->display() != DisplayType::None) && newStyle.display() == DisplayType::None) {
         for (auto& cssAnimation : animationsCreatedByMarkup())
             cssAnimation->cancelFromStyle();
         keyframeEffectStack.setCSSAnimationList(nullptr);
@@ -725,6 +725,10 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
 
 void Styleable::updateCSSTransitions(const RenderStyle& currentStyle, const RenderStyle& newStyle, WeakStyleOriginatedAnimations& newStyleOriginatedAnimations) const
 {
+    // In case this element previous had "display: none" we can stop considering transitions altogether.
+    if (currentStyle.display() == DisplayType::None)
+        return;
+
     // In case this element is newly getting a "display: none" we need to cancel all of its transitions and disregard new ones.
     if (currentStyle.hasTransitions() && currentStyle.display() != DisplayType::None && newStyle.display() == DisplayType::None) {
         if (hasRunningTransitions()) {

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -177,7 +177,7 @@ struct Styleable {
     void elementWasRemoved() const;
 
     void willChangeRenderer() const;
-    void cancelStyleOriginatedAnimations() const;
+    void cancelStyleOriginatedAnimations(const WeakStyleOriginatedAnimations& = { }) const;
 
     void animationWasAdded(WebAnimation&) const;
     void animationWasRemoved(WebAnimation&) const;


### PR DESCRIPTION
#### 22a69d35e830b5325dac67ef368c1b774bd6e805
<pre>
[web-animations] add interpolation support for the `display` property
<a href="https://bugs.webkit.org/show_bug.cgi?id=267762">https://bugs.webkit.org/show_bug.cgi?id=267762</a>
<a href="https://rdar.apple.com/121662911">rdar://121662911</a>

Reviewed by NOBODY (OOPS!).

* LayoutTests/imported/blink/fast/css-generated-content/pseudo-animation-display-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-interpolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-dont-cancel.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/animations/display-interpolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/animations/display-interpolation.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-rule-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-rule-pseudo-elements-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/display.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):
(WebCore::AnimationPropertyWrapperBase::normalizesProgressForDiscreteInterpolation const):
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
(WebCore::blendStandardProperty):
* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::animationTimingDidChange):
(WebCore::DocumentTimeline::styleOriginatedAnimationsWereCreated):
* Source/WebCore/animation/DocumentTimeline.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::ticksContinuouslyWhileActive const):
* Source/WebCore/animation/StyleOriginatedAnimation.cpp:
(WebCore::StyleOriginatedAnimation::cancel):
(WebCore::StyleOriginatedAnimation::cancelFromStyle):
* Source/WebCore/animation/StyleOriginatedAnimation.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::cancel):
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::isEffectInvalidationSuspended const):
(WebCore::WebAnimation::isEffectInvalidationSuspended): Deleted.
* Source/WebCore/animation/WebAnimationTypes.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateElementRenderer):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveElement):
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
* Source/WebCore/style/StyleUpdate.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::cancelStyleOriginatedAnimations const):
(WebCore::Styleable::updateCSSAnimations const):
(WebCore::updateCSSTransitionsForStyleableAndProperty):
(WebCore::Styleable::updateCSSTransitions const):
* Source/WebCore/style/Styleable.h:
(WebCore::Styleable::cancelStyleOriginatedAnimations):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e8229aaf5594c24adb978568abb7e113b26aec8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47401 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40752 "Failed to checkout and rebase branch from PR 22974") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47050 "Failed to checkout and rebase branch from PR 22974") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27894 "Failed to checkout and rebase branch from PR 22974") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21233 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45325 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/27894 "Failed to checkout and rebase branch from PR 22974") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/27894 "Failed to checkout and rebase branch from PR 22974") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/39682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2794 "Failed to checkout and rebase branch from PR 22974") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/27894 "Failed to checkout and rebase branch from PR 22974") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/39971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49062 "Failed to checkout and rebase branch from PR 22974") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19711 "Failed to checkout and rebase branch from PR 22974") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16279 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/49062 "Failed to checkout and rebase branch from PR 22974") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/21032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/38782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/49062 "Failed to checkout and rebase branch from PR 22974") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20706 "Failed to checkout and rebase branch from PR 22974") | | | 
<!--EWS-Status-Bubble-End-->