### PR TITLE
Implement MediaStreamTrackProcessor maxBufferSize support

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-maxBufferSize.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-maxBufferSize.worker-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Tests that multiple read requests are eventually settled
+PASS Tests that multiple write requests are buffered
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-maxBufferSize.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-maxBufferSize.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-maxBufferSize.worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-maxBufferSize.worker.js
@@ -1,0 +1,82 @@
+// META: title=MediaStreamTrackProcessor maxBufferSize
+importScripts("/resources/testharness.js");
+
+function makeVideoFrame(timestamp) {
+  const canvas = new OffscreenCanvas(100, 100);
+  const ctx = canvas.getContext('2d');
+  return new VideoFrame(canvas, {timestamp});
+}
+
+promise_test(async t => {
+  // The generator will be used as the source for the processor to
+  // produce frames in a controlled manner.
+  const generator = new VideoTrackGenerator();
+  t.add_cleanup(() => generator.track.stop());
+  // Use a larger maxBufferSize than the default to ensure no frames
+  // will be dropped.
+  const processor = new MediaStreamTrackProcessor({track: generator.track, maxBufferSize:10});
+  const reader = processor.readable.getReader();
+  const writer = generator.writable.getWriter();
+
+  let numReads = 0;
+  let resolve = null;
+  const promise = new Promise(r => resolve = r);
+
+  const numOperations = 4;
+  // Issue reads without waiting for the frames to arrive.
+  for (let i = 0; i < numOperations; i++) {
+    reader.read().then(dv=> {
+      dv.value.close();
+      if (++numReads == numOperations)
+        resolve();
+    });
+  }
+
+  // Write video frames in different tasks to "slowly" settle the pending read
+  // requests.
+  for (let i = 0; i<numOperations; i++) {
+     await writer.write(makeVideoFrame(i));
+     await new Promise(r=>t.step_timeout(r, 0));
+  }
+
+  return promise;
+
+}, "Tests that multiple read requests are eventually settled");
+
+promise_test(async t => {
+  // The generator will be used as the source for the processor to
+  // produce frames in a controlled manner.
+  const generator = new VideoTrackGenerator();
+  t.add_cleanup(() => generator.track.stop());
+  // Use a larger maxBufferSize than the default to ensure no frames
+  // will be dropped.
+  const processor = new MediaStreamTrackProcessor({track: generator.track, maxBufferSize:10});
+  const reader = processor.readable.getReader();
+  const writer = generator.writable.getWriter();
+
+  const numOperations = 4;
+  // Write video frames as fast as we can with "slower" reads.
+  // requests.
+  for (let i = 0; i<numOperations; i++) {
+     await writer.write(makeVideoFrame(i));
+  }
+
+  let numReads = 0;
+  let resolve = null;
+  const promise = new Promise(r => resolve = r);
+
+  // Issue reads without waiting for the frames to arrive.
+  for (let i = 0; i < numOperations; i++) {
+    await new Promise(r=>t.step_timeout(r, 50));
+    reader.read().then(dv=> {
+      dv.value.close();
+      if (++numReads == numOperations)
+        resolve();
+    });
+  }
+
+  return promise;
+
+}, "Tests that multiple write requests are buffered");
+
+done();

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.idl
@@ -37,4 +37,5 @@
     Conditional=MEDIA_STREAM&WEB_CODECS
 ] dictionary MediaStreamTrackProcessorInit {
     required MediaStreamTrack track;
+    [EnforceRange] unsigned short maxBufferSize;
 };


### PR DESCRIPTION
#### 35a56e6b2d4ab965fadb5efe9bedc6dc3ce9308d
<pre>
Implement MediaStreamTrackProcessor maxBufferSize support
<a href="https://rdar.apple.com/121256478">rdar://121256478</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=267763">https://bugs.webkit.org/show_bug.cgi?id=267763</a>

Reviewed by Eric Carlson.

We add support for buffering some video frames based on maxBufferSize using a Deque.
The size restriction is enforced in the media pipeline to limit buffering even if the worker thread is blocked.
We keep a maxBufferSize of 1 in Cocoa ports for camera sources since they used a limited number of video frames so buffering could stop the camera and fail capture.

* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-maxBufferSize.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-maxBufferSize.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-maxBufferSize.worker.js: Added.
(makeVideoFrame):
(promise_test.async t):
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp:
(WebCore::MediaStreamTrackProcessor::create):
(WebCore::MediaStreamTrackProcessor::MediaStreamTrackProcessor):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserverWrapper::create):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserverWrapper::initialize):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserver::VideoFrameObserver):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserver::takeVideoFrame):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserver::videoFrameAvailable):
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.idl:

Canonical link: <a href="https://commits.webkit.org/273310@main">https://commits.webkit.org/273310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6be84d88c70160e62aad64a29c9ca85df6e53a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37777 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31638 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30576 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31237 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10341 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39029 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31857 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31657 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10504 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34407 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12302 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30972 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8027 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->