### PR TITLE
[Part 2] Update/Remove tests relying on 'getPropertyCSSValue'

### DIFF
--- a/LayoutTests/fast/css/border-width-large-expected.txt
+++ b/LayoutTests/fast/css/border-width-large-expected.txt
@@ -1,10 +1,10 @@
 Test for WebKit bug 18294 : Strange Result for getComputedStyle on borderWidth set in em
 
 PASS computedStyle.getPropertyValue('border-width') is '12000px 11000px 10000px 9010px'
-PASS computedStyle.getPropertyCSSValue('border-top-width').cssText is '12000px'
-PASS computedStyle.getPropertyCSSValue('border-right-width').cssText is '11000px'
-PASS computedStyle.getPropertyCSSValue('border-bottom-width').cssText is '10000px'
-PASS computedStyle.getPropertyCSSValue('border-left-width').cssText is '9010px'
+PASS computedStyle.borderTopWidth is '12000px'
+PASS computedStyle.borderRightWidth is '11000px'
+PASS computedStyle.borderBottomWidth is '10000px'
+PASS computedStyle.borderLeftWidth is '9010px'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css/border-width-large.html
+++ b/LayoutTests/fast/css/border-width-large.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <title>Test for WebKit bug 18294 : Strange Result for getComputedStyle on borderWidth set in em</title>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description">Test for WebKit bug <a href="https://bugs.webkit.org/show_bug.cgi?id=18294">18294</a> : Strange Result for getComputedStyle on borderWidth set in em</p>
@@ -20,14 +20,13 @@
     test.style.borderWidth = "120em 110em 100em 90.1em";
     var computedStyle = window.getComputedStyle(test, null);
     shouldBe("computedStyle.getPropertyValue('border-width')", "'12000px 11000px 10000px 9010px'");
-    shouldBe("computedStyle.getPropertyCSSValue('border-top-width').cssText","'12000px'");
-    shouldBe("computedStyle.getPropertyCSSValue('border-right-width').cssText","'11000px'");
-    shouldBe("computedStyle.getPropertyCSSValue('border-bottom-width').cssText","'10000px'");
-    shouldBe("computedStyle.getPropertyCSSValue('border-left-width').cssText","'9010px'");
+    shouldBe("computedStyle.borderTopWidth","'12000px'");
+    shouldBe("computedStyle.borderRightWidth","'11000px'");
+    shouldBe("computedStyle.borderBottomWidth","'10000px'");
+    shouldBe("computedStyle.borderLeftWidth","'9010px'");
     // clean up after ourselves
     var tests_container = document.getElementById("tests_container");
     tests_container.parentNode.removeChild(tests_container);
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/css/getComputedStyle/computed-style-page-break-inside-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-page-break-inside-expected.txt
@@ -3,8 +3,8 @@ Test that page-break-inside property is not inherited
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS window.getComputedStyle(parent).getPropertyCSSValue('page-break-inside').getStringValue() is "avoid"
-PASS window.getComputedStyle(child).getPropertyCSSValue('page-break-inside').getStringValue() is "auto"
+PASS window.getComputedStyle(parent).pageBreakInside is "avoid"
+PASS window.getComputedStyle(child).pageBreakInside is "auto"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css/getComputedStyle/computed-style-page-break-inside.html
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-page-break-inside.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -14,11 +14,10 @@ var child = document.createElement("div");
 parent.appendChild(child);
 document.body.appendChild(parent);
 
-shouldBe("window.getComputedStyle(parent).getPropertyCSSValue('page-break-inside').getStringValue()", '"avoid"');
-shouldBe("window.getComputedStyle(child).getPropertyCSSValue('page-break-inside').getStringValue()", '"auto"');
+shouldBe("window.getComputedStyle(parent).pageBreakInside", '"avoid"');
+shouldBe("window.getComputedStyle(child).pageBreakInside", '"auto"');
 
 document.body.removeChild(parent);
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/css/inherited-properties-explicit-expected.txt
+++ b/LayoutTests/fast/css/inherited-properties-explicit-expected.txt
@@ -1,9 +1,12 @@
-PASS test('test1a', 'margin-left') is "0px"
-PASS test('test1b', 'margin-left') is "0px"
-PASS test('test2a', 'margin-left') is "5px"
-PASS test('test2b', 'margin-left') is "5px"
-PASS test('test3a', 'margin-left') is "10px"
-PASS test('test3b', 'margin-left') is "10px"
+PASS test('test1a') is "0px"
+PASS test('test1b') is "0px"
+PASS test('test2a') is "5px"
+PASS test('test2b') is "5px"
+PASS test('test3a') is "10px"
+PASS test('test3b') is "10px"
+PASS successfullyParsed is true
+
+TEST COMPLETE
 Test that the matched declaration cache handles explicitly inherited properties correctly.
 
 

--- a/LayoutTests/fast/css/inherited-properties-explicit.html
+++ b/LayoutTests/fast/css/inherited-properties-explicit.html
@@ -1,4 +1,5 @@
-<script src="../../resources/js-test-pre.js"></script>
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
 <script>
 if (window.testRunner)
     testRunner.dumpAsText();
@@ -38,13 +39,12 @@ Test that the matched declaration cache handles explicitly inherited properties 
 <script>
 function test(e, p) {
     var testDiv = document.getElementById(e);
-    var cssValue = window.getComputedStyle(testDiv).getPropertyCSSValue(p);
-    return cssValue.cssText;
+    return getComputedStyle(testDiv).marginLeft;
 }
-shouldBeEqualToString("test('test1a', 'margin-left')", "0px");
-shouldBeEqualToString("test('test1b', 'margin-left')", "0px");
-shouldBeEqualToString("test('test2a', 'margin-left')", "5px");
-shouldBeEqualToString("test('test2b', 'margin-left')", "5px");
-shouldBeEqualToString("test('test3a', 'margin-left')", "10px");
-shouldBeEqualToString("test('test3b', 'margin-left')", "10px");
+shouldBeEqualToString("test('test1a')", "0px");
+shouldBeEqualToString("test('test1b')", "0px");
+shouldBeEqualToString("test('test2a')", "5px");
+shouldBeEqualToString("test('test2b')", "5px");
+shouldBeEqualToString("test('test3a')", "10px");
+shouldBeEqualToString("test('test3b')", "10px");
 </script>

--- a/LayoutTests/fast/css/inherited-properties-rare-text.html
+++ b/LayoutTests/fast/css/inherited-properties-rare-text.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <script>
 if (window.testRunner)
     testRunner.dumpAsText();
@@ -12,10 +13,10 @@ if (window.testRunner)
 <script>
 function test(e, p) {
     var testDiv = document.getElementById(e);
-    var cssValue = window.getComputedStyle(testDiv).getPropertyCSSValue(p);
-    document.write(e + " " + p + ": " + cssValue.cssText + "<br>");
+    var value = window.getComputedStyle(testDiv).getPropertyValue(p);
+    document.write(e + " " + p + ": " + value + "<br>");
 }
-    
+
 test('test1', 'font-feature-settings');
 test('test2', 'font-feature-settings');
 test('test1', '-webkit-font-smoothing');

--- a/LayoutTests/fast/css/large-value-csstext.html
+++ b/LayoutTests/fast/css/large-value-csstext.html
@@ -20,8 +20,8 @@
     var output = document.getElementById('output');
 
     var rule = document.styleSheets[0].cssRules[0];
-    output.innerHTML += rule.style.getPropertyCSSValue('border-top-left-radius').cssText + "<br>";
-    output.innerHTML += rule.style.getPropertyCSSValue('border-top-right-radius').cssText;
+    output.innerHTML += rule.style.borderTopLeftRadius + "<br>";
+    output.innerHTML += rule.style.borderTopRightRadius;
   </script>
 </body>
 </html>

--- a/LayoutTests/transitions/multiple-text-shadow-transition.html
+++ b/LayoutTests/transitions/multiple-text-shadow-transition.html
@@ -44,7 +44,8 @@
     function checkShadow()
     {
         var container = document.getElementById('container');
-        var shadow = window.getComputedStyle(container).getPropertyCSSValue('text-shadow');
+        var shadow = window.getComputedStyle(container).textShadow;
+        shadow = shadow.replace(/rgb([^)]*)/g, "color").split(",");
         
         var result = document.getElementById('result');
         if (shadow.length == 5)


### PR DESCRIPTION
#### 5c32022a6685577c3d1621fcbf1ca827ec50e509
<pre>
[Part 2] Update/Remove tests relying on &apos;getPropertyCSSValue&apos;

<a href="https://bugs.webkit.org/show_bug.cgi?id=266052">https://bugs.webkit.org/show_bug.cgi?id=266052</a>
<a href="https://rdar.apple.com/problem/119700175">rdar://problem/119700175</a>

Reviewed by Tim Nguyen.

This PR is to update tests relying on historical &apos;CSS&apos; properties and make it easier to remove them in future.

Partial Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=184925 ,
<a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=184988 and
<a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=185165

&gt; Rebaselined Tests &amp; Expectations:
* LayoutTests/fast/css/border-width-large.html:
* LayoutTests/fast/css/border-width-large-expected.txt:
* LayoutTests/fast/css/getComputedStyle/computed-style-font.html:
* LayoutTests/fast/css/getComputedStyle/computed-style-font-expected.txt:
* LayoutTests/fast/css/inherited-properties-explicit.html:
* LayoutTests/fast/css/inherited-properties-explicit-expected.txt:
* LayoutTests/fast/css/inherited-properties-rare-text.html:
* LayoutTests/transitions/multiple-text-shadow-transition.html:
* LayoutTests/fast/css/large-value-csstext.html:

Canonical link: <a href="https://commits.webkit.org/273265@main">https://commits.webkit.org/273265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff44289b4aff0fcdd4117f3b107757cd66a608fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37625 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31512 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30446 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10199 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10270 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31182 "Found 2 new test failures: http/tests/websocket/tests/hybi/url-parsing.html, imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-baseline-006.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38879 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31728 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36293 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34271 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12188 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30825 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8003 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10914 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->