### PR TITLE
[WGSL] Empty structs should be rejected

### DIFF
--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -802,6 +802,9 @@ Result<AST::Structure::Ref> Parser<Lexer>::parseStructure(AST::Attribute::List&&
             break;
     }
 
+    if (members.isEmpty())
+        FAIL(makeString("structures must have at least one member"));
+
     CONSUME_TYPE(BraceRight);
 
     RETURN_ARENA_NODE(Structure, WTFMove(name), WTFMove(members), WTFMove(attributes), AST::StructureRole::UserDefined);

--- a/Source/WebGPU/WGSL/tests/invalid/empty-struct.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/empty-struct.wgsl
@@ -1,0 +1,4 @@
+// RUN: %not %wgslc | %check
+
+// CHECK-L: structures must have at least one member
+struct S { }

--- a/Source/WebGPU/WGSL/tests/invalid/redeclaration-reordering.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/redeclaration-reordering.wgsl
@@ -1,6 +1,7 @@
 // RUN: %not %wgslc | %check
 
 struct f {
+  x: i32,
 }
 
 // CHECK-L: redeclaration of 'f'


### PR DESCRIPTION
#### 1fcd681a29a87c051da6138b2eb82d9ecc381296
<pre>
[WGSL] Empty structs should be rejected
<a href="https://bugs.webkit.org/show_bug.cgi?id=267771">https://bugs.webkit.org/show_bug.cgi?id=267771</a>
<a href="https://rdar.apple.com/121247449">rdar://121247449</a>

Reviewed by Mike Wyrzykowski.

It&apos;s not valid according to the spec to have a struct with no fields. We make it a
parser failure for now.

* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseStructure):
* Source/WebGPU/WGSL/tests/invalid/empty-struct.wgsl: Added.
* Source/WebGPU/WGSL/tests/invalid/redeclaration-reordering.wgsl:

Canonical link: <a href="https://commits.webkit.org/273294@main">https://commits.webkit.org/273294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33652edd4c987c10d5897e6fe021408314b3cb12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37489 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31407 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30364 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/30995 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10086 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10167 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38755 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31609 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36206 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8177 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34172 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12094 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8019 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10811 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->