### PR TITLE
[LBSE] Fix css3/masking failures

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3108,7 +3108,7 @@ void RenderLayer::setupClipPath(GraphicsContext& context, GraphicsContextStateSa
             if (!coordinateSystemOriginTranslation.isZero())
                 context.translate(coordinateSystemOriginTranslation);
 
-            svgClipper->applyPathClipping(context, svgReferenceBox, *graphicsElement);
+            svgClipper->applyPathClipping(context, renderer(), svgReferenceBox, *graphicsElement);
 
             if (!coordinateSystemOriginTranslation.isZero())
                 context.translate(-coordinateSystemOriginTranslation);

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -96,7 +96,7 @@ SVGGraphicsElement* RenderSVGResourceClipper::shouldApplyPathClipping() const
     return clipPathElement().shouldApplyPathClipping();
 }
 
-void RenderSVGResourceClipper::applyPathClipping(GraphicsContext& context, const FloatRect& objectBoundingBox, SVGGraphicsElement& graphicsElement)
+void RenderSVGResourceClipper::applyPathClipping(GraphicsContext& context, const RenderLayerModelObject& targetRenderer, const FloatRect& objectBoundingBox, SVGGraphicsElement& graphicsElement)
 {
     ASSERT(hasLayer());
     ASSERT(layer()->isSelfPaintingLayer());
@@ -113,6 +113,9 @@ void RenderSVGResourceClipper::applyPathClipping(GraphicsContext& context, const
     if (clipPathUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX) {
         clipPathTransform.translate(objectBoundingBox.location());
         clipPathTransform.scale(objectBoundingBox.size());
+    } else if (!targetRenderer.isSVGLayerAwareRenderer()) {
+        clipPathTransform.translate(objectBoundingBox.x(), objectBoundingBox.y());
+        clipPathTransform.scale(targetRenderer.style().effectiveZoom());
     }
     if (layer()->isTransformed())
         clipPathTransform.multiply(layer()->transform()->toAffineTransform());
@@ -159,7 +162,7 @@ void RenderSVGResourceClipper::applyMaskClipping(PaintInfo& paintInfo, const Ren
         contentTransform.scale(objectBoundingBox.width(), objectBoundingBox.height());
     } else if (!targetRenderer.isSVGLayerAwareRenderer()) {
         contentTransform.translate(objectBoundingBox.x(), objectBoundingBox.y());
-        contentTransform.scale(style().effectiveZoom());
+        contentTransform.scale(targetRenderer.style().effectiveZoom());
     }
 
     // Figure out if we need to push a transparency layer to render our mask.

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
@@ -40,7 +40,7 @@ public:
     inline SVGClipPathElement& clipPathElement() const;
 
     SVGGraphicsElement* shouldApplyPathClipping() const;
-    void applyPathClipping(GraphicsContext&, const FloatRect& objectBoundingBox, SVGGraphicsElement&);
+    void applyPathClipping(GraphicsContext&, const RenderLayerModelObject& targetRenderer, const FloatRect& objectBoundingBox, SVGGraphicsElement&);
     void applyMaskClipping(PaintInfo&, const RenderLayerModelObject& targetRenderer, const FloatRect& objectBoundingBox);
 
     FloatRect resourceBoundingBox(const RenderObject&, RepaintRectCalculation);


### PR DESCRIPTION
#### cd5c5e4262c563c5183170f4a59d6e0e77cc84cb
<pre>
[LBSE] Fix css3/masking failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=267775">https://bugs.webkit.org/show_bug.cgi?id=267775</a>

Reviewed by Nikolas Zimmermann.

Fix several of these tests by doing two fixes:
- make applyMaskClipping take effective zoom into account.
- correct transformations when applyPathClipping is called by
  a non SVG renderer.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::setupClipPath):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::applyPathClipping):
(WebCore::RenderSVGResourceClipper::applyMaskClipping):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.h:

Canonical link: <a href="https://commits.webkit.org/273273@main">https://commits.webkit.org/273273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07aad8b74b83df3edd4b7ad24957e5f15175f104

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37684 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31559 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30497 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31155 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10255 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38936 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31782 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31573 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36341 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34320 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12233 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8008 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10962 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11296 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->