### PR TITLE
REGRESSION(268459@main): PointerEvent pointerup `button` value does not match pointerdown

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerup_button_value_matches_corresponding_pointerdown-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerup_button_value_matches_corresponding_pointerdown-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Test that the 'button' property of a pointerup event matches the 'button' property of the corresponding pointerdown event
+

--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerup_button_value_matches_corresponding_pointerdown.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerup_button_value_matches_corresponding_pointerdown.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML>
+<title>Button value of corresponding pointerup/pointerdown are equivalent</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="pointerevent_support.js"></script>
+
+<input id="target" style="margin: 20px">
+
+<script>
+  'use strict';
+  const target = document.getElementById("target");
+
+  promise_test(async test => {
+    const test_pointer = "testPointer";
+
+    let actions = new test_driver.Actions();
+    actions = actions.addPointer(test_pointer, "mouse")
+      .pointerMove(0,0, {sourceName:test_pointer, origin:target})
+      .pointerDown({sourceName:test_pointer, button:actions.ButtonType.RIGHT})
+      .pointerUp({sourceName:test_pointer, button:actions.ButtonType.RIGHT});
+    target.addEventListener("contextmenu", event => { event.preventDefault(); });
+    let pointerdown_promise = getEvent("pointerdown", target, test);
+    let pointerup_promise = getEvent("pointerup", target, test);
+
+    await actions.send();
+    let pointerdown_event = await pointerdown_promise;
+    let pointerup_event = await pointerup_promise;
+
+    assert_equals(pointerup_event.button, pointerdown_event.button, "The 'button' property of a pointerup event should match the 'button' property of the corresponding pointerdown event");
+  }, "Test that the 'button' property of a pointerup event matches the 'button' property of the corresponding pointerdown event");
+</script>

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -350,10 +350,12 @@ RefPtr<PointerEvent> PointerCaptureController::pointerEventForMouseEvent(const M
 
     MouseButton newButton = mouseEvent.button();
     MouseButton previousMouseButton = capturingData ? capturingData->previousMouseButton : MouseButton::PointerHasNotChanged;
-    MouseButton button = [newButton, previousMouseButton, type = pointerEventType(type)] {
-        if (newButton == previousMouseButton)
-            return PointerEvent::buttonForType(type);
-        return PointerEvent::typeIsUpOrDown(type) ? newButton : MouseButton::PointerHasNotChanged;
+    MouseButton button = [&] {
+        if (!PointerEvent::typeIsUpOrDown(pointerEventType(type))) {
+            if (newButton == previousMouseButton || !pointerIsPressed)
+                return MouseButton::PointerHasNotChanged;
+        }
+        return newButton;
     }();
 
     // https://w3c.github.io/pointerevents/#chorded-button-interactions


### PR DESCRIPTION
#### 29875ec3a5944d06ac0ccdee2c3d0a32cd311a08
<pre>
REGRESSION(268459@main): PointerEvent pointerup `button` value does not match pointerdown
<a href="https://bugs.webkit.org/show_bug.cgi?id=267008">https://bugs.webkit.org/show_bug.cgi?id=267008</a>
<a href="https://rdar.apple.com/120429508">rdar://120429508</a>

Reviewed by Wenson Hsieh.

In 268459@main, we unified the cases where a pointer event&apos;s &apos;button&apos;
value would be &apos;-1&apos;, i.e. indicating that buttons or touch/pen contact
haven&apos;t changed since the last event. Unfortunately, this regressed a
longstanding behavior of corresponding pointerup/pointerdown events
having matching &apos;button&apos; values.

It turns out that we should hold off on our logic to produce the &apos;-1&apos;
value until we&apos;ve ensured that the pointerup/pointerdown case has been
dealt with, and not the other way around. Furthermore, we should consult
whether or not the pointer is pressed before producing the &apos;-1&apos; value.

This patch fixes both of these logic errors, and introduces a WPT to
protect against future regressions in this case.

* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerup_button_value_matches_corresponding_pointerdown-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerup_button_value_matches_corresponding_pointerdown.html: Added.
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::pointerEventForMouseEvent):

Canonical link: <a href="https://commits.webkit.org/273263@main">https://commits.webkit.org/273263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16e5e758c8b042ea2cf24e959c306f7bd3268026

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37605 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31495 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10825 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30430 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31078 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10183 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38859 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31709 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31494 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36276 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34254 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30810 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8001 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->