### PR TITLE
[WGSL] Failed constant conversion should clean the invalid constant

### DIFF
--- a/Source/WebGPU/WGSL/tests/invalid/division.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/division.wgsl
@@ -85,11 +85,11 @@ fn testAbstractFloat()
 {
     // CHECK-L: value Infinity cannot be represented as '<AbstractFloat>'
     _ = 42.0 / 0.0;
-    // CHECK-L: value Infinity cannot be represented as '<AbstractFloat>'
+    // CHECK-L: value vec2(42, Infinity) cannot be represented as 'vec2<<AbstractFloat>>'
     _ = 42.0 / vec2(1.0, 0.0);
-    // CHECK-L: value Infinity cannot be represented as '<AbstractFloat>'
+    // CHECK-L: value vec2(Infinity, Infinity) cannot be represented as 'vec2<<AbstractFloat>>'
     _ = vec2(42.0) / 0.0;
-    // CHECK-L: value Infinity cannot be represented as '<AbstractFloat>'
+    // CHECK-L: value vec2(42, Infinity) cannot be represented as 'vec2<<AbstractFloat>>'
     _ = vec2(42.0) / vec2(1.0, 0.0);
 
     // CHECK-NOT-L: division by zero
@@ -123,11 +123,11 @@ fn testF32()
 {
     // CHECK-L: value Infinity cannot be represented as 'f32'
     _ = 42f / 0f;
-    // CHECK-L: value Infinity cannot be represented as 'f32'
+    // CHECK-L: value vec2(42f, Infinity) cannot be represented as 'vec2<f32>'
     _ = 42f / vec2(1f, 0f);
-    // CHECK-L: value Infinity cannot be represented as 'f32'
+    // CHECK-L: value vec2(Infinity, Infinity) cannot be represented as 'vec2<f32>'
     _ = vec2(42f) / 0f;
-    // CHECK-L: value Infinity cannot be represented as 'f32'
+    // CHECK-L: value vec2(42f, Infinity) cannot be represented as 'vec2<f32>'
     _ = vec2(42f) / vec2(1f, 0f);
 
     let x = 42f;
@@ -194,6 +194,13 @@ fn testF32Compound()
     // y[0] /= 0;
     // skip-CHECK-NOT-L: division by zero
     // y[0] /= vec2(1, 0);
+}
+
+fn testDivisorOverflow()
+{
+    // CHECK-L: value 8144182087775404032 cannot be represented as 'i32'
+    let x = 1;
+    _ = x / 8144182087775404419;
 }
 
 @compute @workgroup_size(1)

--- a/Source/WebGPU/WGSL/tests/invalid/modulo.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/modulo.wgsl
@@ -85,11 +85,11 @@ fn testAbstractFloat()
 {
     // CHECK-L: value NaN cannot be represented as '<AbstractFloat>'
     _ = 42.0 % 0.0;
-    // CHECK-L: value NaN cannot be represented as '<AbstractFloat>'
+    // CHECK-L: value vec2(0, NaN) cannot be represented as 'vec2<<AbstractFloat>>'
     _ = 42.0 % vec2(1.0, 0.0);
-    // CHECK-L: value NaN cannot be represented as '<AbstractFloat>'
+    // CHECK-L: value vec2(NaN, NaN) cannot be represented as 'vec2<<AbstractFloat>>'
     _ = vec2(42.0) % 0.0;
-    // CHECK-L: value NaN cannot be represented as '<AbstractFloat>'
+    // CHECK-L: value vec2(0, NaN) cannot be represented as 'vec2<<AbstractFloat>>'
     _ = vec2(42.0) % vec2(1.0, 0.0);
 
     // CHECK-NOT-L: modulo by zero
@@ -123,11 +123,11 @@ fn testF32()
 {
     // CHECK-L: value NaN cannot be represented as 'f32'
     _ = 42f % 0f;
-    // CHECK-L: value NaN cannot be represented as 'f32'
+    // CHECK-L: value vec2(0f, NaN) cannot be represented as 'vec2<f32>'
     _ = 42f % vec2(1f, 0f);
-    // CHECK-L: value NaN cannot be represented as 'f32'
+    // CHECK-L: value vec2(NaN, NaN) cannot be represented as 'vec2<f32>'
     _ = vec2(42f) % 0f;
-    // CHECK-L: value NaN cannot be represented as 'f32'
+    // CHECK-L: value vec2(0f, NaN) cannot be represented as 'vec2<f32>'
     _ = vec2(42f) % vec2(1f, 0f);
 
     let x = 42f;


### PR DESCRIPTION
#### 8e62e079b8ab55343fa35e533d41505728711209
<pre>
[WGSL] Failed constant conversion should clean the invalid constant
<a href="https://bugs.webkit.org/show_bug.cgi?id=267780">https://bugs.webkit.org/show_bug.cgi?id=267780</a>
<a href="https://rdar.apple.com/121247554">rdar://121247554</a>

Reviewed by Mike Wyrzykowski.

If a constant is not valid in its target type, we should clean it so it&apos;s not further
used in subsequent checks.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitVariable):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::bitcast):
(WGSL::TypeChecker::chooseOverload):
(WGSL::TypeChecker::convertValue):
(WGSL::TypeChecker::convertValueImpl):
(WGSL::TypeChecker::setConstantValue):
* Source/WebGPU/WGSL/tests/invalid/division.wgsl:
* Source/WebGPU/WGSL/tests/invalid/modulo.wgsl:

Canonical link: <a href="https://commits.webkit.org/273296@main">https://commits.webkit.org/273296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe1e5cff16fa7abf3aec3f3141a54cbe0c66030c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37507 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31423 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30375 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31008 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10100 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10209 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38773 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31665 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36216 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8191 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34185 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12107 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8021 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10824 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11173 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->