### PR TITLE
Add an option key to override the source app bundle ID when creating attributed strings from HTML

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/NSAttributedStringPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/NSAttributedStringPrivate.h
@@ -45,6 +45,13 @@ WK_EXTERN NSAttributedStringDocumentReadingOptionKey const _WKAllowNetworkLoadsO
     NS_SWIFT_NAME(allowNetworkLoads) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 /*!
+ @abstract Bundle identifier of the application to which network activity is attributed.
+ The value is an NSString.
+*/
+WK_EXTERN NSAttributedStringDocumentReadingOptionKey const _WKSourceApplicationBundleIdentifierOption
+    NS_SWIFT_NAME(sourceApplicationBundleIdentifier) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+/*!
  @discussion Private extension of @link //apple_ref/occ/NSAttributedString NSAttributedString @/link to
  translate HTML content into attributed strings using WebKit.
  */


### PR DESCRIPTION
#### 7e5dfd055f5e1d802a0075d868f69a6820484375
<pre>
Add an option key to override the source app bundle ID when creating attributed strings from HTML
<a href="https://bugs.webkit.org/show_bug.cgi?id=267781">https://bugs.webkit.org/show_bug.cgi?id=267781</a>
<a href="https://rdar.apple.com/119002423">rdar://119002423</a>

Reviewed by Aditya Keerthi.

Add support for `_WKSourceApplicationBundleIdentifierOption`, which allows clients to indirectly set
a `-_sourceApplicationBundleIdentifier` on the website data store used when loading content when
serializing `NSAttributedString` from HTML or web archive data.

Test: WKWebView.AttributedStringWithSourceApplicationBundleID

* Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm:
(sourceApplicationBundleIdentifier):
(+[_WKAttributedStringWebViewCache configuration]):
(+[_WKAttributedStringWebViewCache maybeUpdateShouldAllowNetworkLoads:]):
(+[_WKAttributedStringWebViewCache maybeUpdateSourceApplicationBundleIdentifier:]):

Drive-by fix: ensure that we properly invalidate the globally cached configuration when going from
a source app bundle ID to no bundle ID, or when removing `_WKAllowNetworkLoadsOption`.

(+[_WKAttributedStringWebViewCache invalidateGlobalConfigurationIfNeeded:]):
* Source/WebKit/UIProcess/API/Cocoa/NSAttributedStringPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm:

Canonical link: <a href="https://commits.webkit.org/273245@main">https://commits.webkit.org/273245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc2aa20b691f448e97918c26f94d86c064420c5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37514 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31427 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/35970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10736 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30377 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31012 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10103 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38779 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31629 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31416 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36220 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8194 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34189 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12113 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7991 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10830 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11177 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->