### PR TITLE
Update layout tests for the unified HTTP stack

### DIFF
--- a/LayoutTests/http/tests/preload/download_resources_from_invalid_headers-expected.txt
+++ b/LayoutTests/http/tests/preload/download_resources_from_invalid_headers-expected.txt
@@ -10,7 +10,6 @@ PASS internals.isPreloaded('../×ž×©××‘×™×/dummy.css'); is false
 PASS internals.isPreloaded('../rÃ©sÃ´Ã»rcÃ¨s/square.png'); is false
 PASS internals.isPreloaded('../resources/Ahem{.ttf,.woff}'); is true
 PASS internals.isPreloaded('../resources/test.mp4'); is false
-PASS internals.isPreloaded('../resources/test.mp4'); is true
 PASS internals.isPreloaded('../security/resources/cap	tions.vtt'); is true
 PASS internals.isPreloaded('../resources/dummy.xml?badvalue'); is false
 PASS internals.isPreloaded('../resources/dummy   .xml'); is true

--- a/LayoutTests/http/tests/preload/resources/nph-invalid_resources_from_header.pl
+++ b/LayoutTests/http/tests/preload/resources/nph-invalid_resources_from_header.pl
@@ -8,7 +8,6 @@ Link: <   ../resources/dummy.js >; rel=preload; as=script
 Link: <../משאבים/dummy.css>; rel=preload; as=style
 Link: <../résôûrcès/dummy.css>; rel=preload; as=style
 Link: <../resources/Ahem{.ttf,.woff}>; rel=preload; as=font; crossorigin
-Link: <../resources/test\f.mp4>; rel=preload; as=video
 Link: <../security/resources/cap\ttions.vtt>; rel=preload; as=track
 Link: <../resources/dummy   .xml>; rel=preload; as=fetch
 Link: <../resources/dumm>y.xml>; rel=preload
@@ -37,7 +36,6 @@ Content-Type: text/html
     // Invalid URLs get preloaded (and get terminated further down the stack)
     shouldBeTrue("internals.isPreloaded('../resources/Ahem{.ttf,.woff}');");
     shouldBeFalse("internals.isPreloaded('../resources/test.mp4');");
-    shouldBeTrue("internals.isPreloaded('../resources/test\f.mp4');");
     shouldBeTrue("internals.isPreloaded('../security/resources/cap\ttions.vtt');");
     shouldBeFalse("internals.isPreloaded('../resources/dummy.xml?badvalue');");
     shouldBeTrue("internals.isPreloaded('../resources/dummy   .xml');");

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/directive-parsing-03-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/directive-parsing-03-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Unrecognized Content-Security-Policy directive 'aaa'.
+CONSOLE MESSAGE: Unrecognized Content-Security-Policy directive 'aêaa'.
 
 CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/script.js because it does not appear in the script-src directive of the Content Security Policy.
 This script should not execute even though there are parse errors in the policy.

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/directive-parsing-03.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/directive-parsing-03.html
@@ -12,6 +12,6 @@ if (window.testRunner) {
   <p>
     This script should not execute even though there are parse errors in the policy.
   </p>
-  <iframe src="http://127.0.0.1:8000/security/contentSecurityPolicy/resources/nph-echo-script-src.pl?should_run=no&q=http://127.0.0.1:8000/security/contentSecurityPolicy/resources/script.js&csp=script-src%20'none'%3B%20a%07aa%20%3B%20"></iframe>
+  <iframe src="http://127.0.0.1:8000/security/contentSecurityPolicy/resources/nph-echo-script-src.pl?should_run=no&q=http://127.0.0.1:8000/security/contentSecurityPolicy/resources/script.js&csp=script-src%20'none'%3B%20a%EAaa%20%3B%20"></iframe>
 </body>
 </html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/source-list-parsing-04-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/source-list-parsing-04-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/script.js because it does not appear in the script-src directive of the Content Security Policy.
-CONSOLE MESSAGE: The value for Content Security Policy directive 'script-src' contains an invalid character: 'https:  '. Non-whitespace characters outside ASCII 0x21-0x7E must be percent-encoded, as described in RFC 3986, section 2.1: http://tools.ietf.org/html/rfc3986#section-2.1.
+CONSOLE MESSAGE: The value for Content Security Policy directive 'script-src' contains an invalid character: 'https:  Ãª'. Non-whitespace characters outside ASCII 0x21-0x7E must be percent-encoded, as described in RFC 3986, section 2.1: http://tools.ietf.org/html/rfc3986#section-2.1.
 CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/resources/script.js because it does not appear in the script-src directive of the Content Security Policy.
 None of these scripts should execute even though there are parse errors in the policy.
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/source-list-parsing-04.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/source-list-parsing-04.html
@@ -5,7 +5,7 @@
 <script>
 var tests = [
     ['no',  'script-src https:  taco', 'resources/script.js'],
-    ['yes', 'script-src https:  \x08', 'resources/script.js'],
+    ['yes', 'script-src https:  \xEA', 'resources/script.js'],
     ['no',  'script-src \'none\'', 'resources/script.js'],
     ['yes', '\t\t\tscript-src    http://127.0.0.1:8000  \t\t  https:', 'resources/script.js']
 ];

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -592,6 +592,9 @@ imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-element.html [ Fa
 
 webkit.org/b/260640 [ Release arm64 ] editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html [ Pass Failure ]
 
+# Failure on the CFNetwork HTTP stack, fixed in the unified HTTP stack
+http/tests/inspector/network/resource-request-headers.html [ Failure ]
+
 ### END OF (1) Classified failures with bug reports
 ########################################
 
@@ -1425,7 +1428,6 @@ webkit.org/b/229454 [ BigSur Debug ] http/tests/inspector/network/resource-timin
 
 webkit.org/b/229460 [ BigSur Debug ] http/tests/inspector/network/ping-type.html [ Pass Failure ]
 
-webkit.org/b/230056 [ BigSur Debug ] http/tests/inspector/network/resource-request-headers.html [ Pass Failure ]
 webkit.org/b/230056 [ BigSur Debug ] http/tests/inspector/network/har/har-page-aggressive-gc.html [ Pass Failure ]
 
 webkit.org/b/229561 http/tests/navigation/page-cache-video.html [ Pass Failure ]

--- a/LayoutTests/platform/mac-wk2/http/tests/inspector/network/resource-request-headers-expected.txt
+++ b/LayoutTests/platform/mac-wk2/http/tests/inspector/network/resource-request-headers-expected.txt
@@ -26,9 +26,7 @@ PASS: Resource should be created.
 PASS: Resource should receive a Response.
 PASS: Resource should have a 401 status code.
 PASS: Response should have a 'WWW-Authenticate' response header for the failure.
-FAIL: 'Authorization' header value should be for badUsername:badPassword.
-    Expected: "Basic YmFkVXNlcm5hbWU6YmFkUGFzc3dvcmQ="
-    Actual: undefined
+PASS: 'Authorization' header value should be for badUsername:badPassword.
 
 -- Running test case: Resource.Metrics.RequestHeaders.BasicAuth.Success
 PASS: Resource should be created.


### PR DESCRIPTION
#### e70acdf22cc938c4c2c3194251d6208171960122
<pre>
Update layout tests for the unified HTTP stack
<a href="https://bugs.webkit.org/show_bug.cgi?id=268193">https://bugs.webkit.org/show_bug.cgi?id=268193</a>
<a href="https://rdar.apple.com/121281240">rdar://121281240</a>

Reviewed by Alex Christensen.

1. &quot;directive-parsing-03&quot; and &quot;source-list-parsing-04&quot; are changed to use a non-ASCII character instead of a disallowed character in HTTP field value. The new HTTP parser sanitizes and converts invalid characters to spaces.
2. Disallowed character is removed from &quot;download_resources_from_invalid_headers&quot; since it already covers other cases.
3. The failure expectation in &quot;resource-request-headers&quot; is removed since the new HTTP stack now passes the test. It is marked as a known failure until the new stack is enabled.

* LayoutTests/http/tests/preload/download_resources_from_invalid_headers-expected.txt:
* LayoutTests/http/tests/preload/resources/nph-invalid_resources_from_header.pl:
* LayoutTests/http/tests/security/contentSecurityPolicy/directive-parsing-03-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/directive-parsing-03.html:
* LayoutTests/http/tests/security/contentSecurityPolicy/source-list-parsing-04-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/source-list-parsing-04.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/http/tests/inspector/network/resource-request-headers-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e70acdf22cc938c4c2c3194251d6208171960122

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40263 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33563 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31924 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33025 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12218 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12142 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41522 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34107 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34147 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38044 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/directive-parsing-03.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36216 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14157 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/33119 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13128 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13471 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->