### PR TITLE
Send data for browser.storage to the UI process

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -258,6 +258,7 @@ $(PROJECT_DIR)/Shared/Extensions/WebExtensionFrameParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionMatchedRuleParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionMenuItem.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionMessageSenderParameters.serialization.in
+$(PROJECT_DIR)/Shared/Extensions/WebExtensionStorage.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionTab.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionTabParameters.serialization.in
 $(PROJECT_DIR)/Shared/Extensions/WebExtensionWindow.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -578,6 +578,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Extensions/WebExtensionMatchedRuleParameters.serialization.in \
 	Shared/Extensions/WebExtensionMenuItem.serialization.in \
 	Shared/Extensions/WebExtensionMessageSenderParameters.serialization.in \
+	Shared/Extensions/WebExtensionStorage.serialization.in \
 	Shared/Extensions/WebExtensionTab.serialization.in \
 	Shared/Extensions/WebExtensionWindow.serialization.in \
 	Shared/FileSystemSyncAccessHandleInfo.serialization.in \

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -472,6 +472,8 @@ def types_that_cannot_be_forward_declared():
         'WebKit::WebExtensionRegisteredScriptParameters',
         'WebKit::WebExtensionScriptInjectionParameters',
         'WebKit::WebExtensionScriptInjectionResultParameters',
+        'WebKit::WebExtensionStorageAccessLevel',
+        'WebKit::WebExtensionStorageType',
         'WebKit::WebExtensionTab::ImageFormat',
         'WebKit::WebExtensionTabParameters',
         'WebKit::WebExtensionTabQueryParameters',

--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
@@ -45,8 +45,9 @@ struct WebExtensionContextParameters {
     Ref<API::Data> localizationJSON;
     Ref<API::Data> manifestJSON;
 
-    double manifestVersion;
-    bool testingMode;
+    double manifestVersion { 0 };
+    bool testingMode { false };
+    bool isSessionStorageAllowedInContentScripts { false };
 
     std::optional<WebCore::PageIdentifier> backgroundPageIdentifier;
     Vector<WebExtensionContext::PageIdentifierTuple> popupPageIdentifiers;

--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
@@ -33,6 +33,7 @@ struct WebKit::WebExtensionContextParameters {
 
     double manifestVersion;
     bool testingMode;
+    bool isSessionStorageAllowedInContentScripts;
 
     std::optional<WebCore::PageIdentifier> backgroundPageIdentifier;
     Vector<WebKit::WebExtensionContext::PageIdentifierTuple> popupPageIdentifiers;

--- a/Source/WebKit/Shared/Extensions/WebExtensionStorage.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionStorage.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+# Copyright (C) 2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -22,13 +22,17 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-headers: "WebExtensionContext.h"
+headers: "WebExtensionStorageAccessLevel.h" "WebExtensionStorageType.h"
 
-enum class WebKit::WebExtensionContextInstallReason : uint8_t {
-    None,
-    ExtensionInstall,
-    ExtensionUpdate,
-    BrowserUpdate,
-};
+enum class WebKit::WebExtensionStorageAccessLevel : uint8_t {
+    TrustedContexts,
+    TrustedAndUntrustedContexts,
+}
+
+enum class WebKit::WebExtensionStorageType : uint8_t {
+    Local,
+    Session,
+    Sync,
+}
 
 #endif

--- a/Source/WebKit/Shared/Extensions/WebExtensionStorageAccessLevel.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionStorageAccessLevel.h
@@ -23,14 +23,34 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WK_WEB_EXTENSIONS,
-    ReturnsPromiseWhenCallbackIsOmitted,
-] interface WebExtensionAPIStorage {
+#pragma once
 
-    readonly attribute WebExtensionAPIStorageArea local;
-    [Dynamic] readonly attribute WebExtensionAPIStorageArea session;
-    readonly attribute WebExtensionAPIStorageArea sync;
+#if ENABLE(WK_WEB_EXTENSIONS)
 
-    readonly attribute WebExtensionAPIEvent onChanged;
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+enum class WebExtensionStorageAccessLevel : uint8_t {
+    TrustedContexts,
+    TrustedAndUntrustedContexts,
 };
+
+} // namespace WebKit
+
+namespace WTF {
+
+template<> struct EnumTraits<WebKit::WebExtensionStorageAccessLevel> {
+    using values = EnumValues<
+        WebKit::WebExtensionStorageAccessLevel,
+        WebKit::WebExtensionStorageAccessLevel::TrustedContexts,
+        WebKit::WebExtensionStorageAccessLevel::TrustedAndUntrustedContexts
+    >;
+};
+
+template<> struct DefaultHash<WebKit::WebExtensionStorageAccessLevel> : IntHash<WebKit::WebExtensionStorageAccessLevel> { };
+template<> struct HashTraits<WebKit::WebExtensionStorageAccessLevel> : StrongEnumHashTraits<WebKit::WebExtensionStorageAccessLevel> { };
+
+} // namespace WTF
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/WebExtensionStorageType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionStorageType.h
@@ -23,14 +23,48 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WK_WEB_EXTENSIONS,
-    ReturnsPromiseWhenCallbackIsOmitted,
-] interface WebExtensionAPIStorage {
+#pragma once
 
-    readonly attribute WebExtensionAPIStorageArea local;
-    [Dynamic] readonly attribute WebExtensionAPIStorageArea session;
-    readonly attribute WebExtensionAPIStorageArea sync;
+#if ENABLE(WK_WEB_EXTENSIONS)
 
-    readonly attribute WebExtensionAPIEvent onChanged;
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+enum class WebExtensionStorageType : uint8_t {
+    Local,
+    Session,
+    Sync,
 };
+
+inline String toAPIPrefixString(WebExtensionStorageType storageType)
+{
+    switch (storageType) {
+    case WebExtensionStorageType::Local:
+        return "browser.local"_s;
+    case WebExtensionStorageType::Session:
+        return "browser.session"_s;
+    case WebExtensionStorageType::Sync:
+        return "browser.sync"_s;
+    }
+}
+
+} // namespace WebKit
+
+namespace WTF {
+
+template<> struct EnumTraits<WebKit::WebExtensionStorageType> {
+    using values = EnumValues<
+        WebKit::WebExtensionStorageType,
+        WebKit::WebExtensionStorageType::Local,
+        WebKit::WebExtensionStorageType::Session,
+        WebKit::WebExtensionStorageType::Sync
+    >;
+};
+
+template<> struct DefaultHash<WebKit::WebExtensionStorageType> : IntHash<WebKit::WebExtensionStorageType> { };
+template<> struct HashTraits<WebKit::WebExtensionStorageType> : StrongEnumHashTraits<WebKit::WebExtensionStorageType> { };
+
+} // namespace WTF
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionContext.h"
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+#import "WebExtensionConstants.h"
+#import "WebExtensionStorageAccessLevel.h"
+#import "WebExtensionStorageType.h"
+#import "WebExtensionUtilities.h"
+
+namespace WebKit {
+
+void WebExtensionContext::storageGet(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionStorageType storageType, const IPC::DataReference& dataReference, CompletionHandler<void(std::optional<IPC::DataReference>, ErrorString)>&& completionHandler)
+{
+    static NSString * const callingAPIName = [NSString stringWithFormat:@"%@.get()", (NSString *)toAPIPrefixString(storageType)];
+
+    String errorString;
+    if (!extensionCanAccessWebPage(webPageProxyIdentifier, errorString)) {
+        completionHandler(std::nullopt, toErrorString(callingAPIName, nil, errorString));
+        return;
+    }
+
+    // FIXME: <https://webkit.org/b/267649> Get values from StorageAPISQLiteStore.
+    completionHandler(std::nullopt, std::nullopt);
+}
+
+void WebExtensionContext::storageGetBytesInUse(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionStorageType storageType, const Vector<String>& keys, CompletionHandler<void(std::optional<size_t> size, ErrorString)>&& completionHandler)
+{
+    static NSString * const callingAPIName = [NSString stringWithFormat:@"%@.getBytesInUse()", (NSString *)toAPIPrefixString(storageType)];
+
+    String errorString;
+    if (!extensionCanAccessWebPage(webPageProxyIdentifier, errorString)) {
+        completionHandler(std::nullopt, toErrorString(callingAPIName, nil, errorString));
+        return;
+    }
+
+    // FIXME: <https://webkit.org/b/267649> Get storage size from StorageAPISQLiteStore.
+    completionHandler(std::nullopt, std::nullopt);
+}
+
+void WebExtensionContext::storageSet(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionStorageType storageType, const IPC::DataReference& dataReference, CompletionHandler<void(ErrorString)>&& completionHandler)
+{
+    static NSString * const callingAPIName = [NSString stringWithFormat:@"%@.set()", (NSString *)toAPIPrefixString(storageType)];
+
+    String errorString;
+    if (!extensionCanAccessWebPage(webPageProxyIdentifier, errorString)) {
+        completionHandler(toErrorString(callingAPIName, nil, errorString));
+        return;
+    }
+
+    // FIXME: <https://webkit.org/b/267649> Set values for StorageAPISQLiteStore.
+    completionHandler(std::nullopt);
+}
+
+void WebExtensionContext::storageRemove(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionStorageType storageType, const Vector<String>& keys, CompletionHandler<void(ErrorString)>&& completionHandler)
+{
+    static NSString * const callingAPIName = [NSString stringWithFormat:@"%@.remove()", (NSString *)toAPIPrefixString(storageType)];
+
+    String errorString;
+    if (!extensionCanAccessWebPage(webPageProxyIdentifier, errorString)) {
+        completionHandler(toErrorString(callingAPIName, nil, errorString));
+        return;
+    }
+
+    // FIXME: <https://webkit.org/b/267649> Remove values from StorageAPISQLiteStore.
+    completionHandler(std::nullopt);
+}
+
+void WebExtensionContext::storageClear(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionStorageType storageType, CompletionHandler<void(ErrorString)>&& completionHandler)
+{
+    static NSString * const callingAPIName = [NSString stringWithFormat:@"%@.clear()", (NSString *)toAPIPrefixString(storageType)];
+
+    String errorString;
+    if (!extensionCanAccessWebPage(webPageProxyIdentifier, errorString)) {
+        completionHandler(toErrorString(callingAPIName, nil, errorString));
+        return;
+    }
+
+    // FIXME: <https://webkit.org/b/267649> Clear values in StorageAPISQLiteStore.
+    completionHandler(std::nullopt);
+}
+
+void WebExtensionContext::storageSetAccessLevel(WebPageProxyIdentifier webPageProxyIdentifier, WebExtensionStorageType storageType, const WebExtensionStorageAccessLevel accessLevel, CompletionHandler<void(ErrorString)>&& completionHandler)
+{
+    static NSString * const callingAPIName = @"browser.session.setAccessLevel()";
+
+    String errorString;
+    if (!extensionCanAccessWebPage(webPageProxyIdentifier, errorString)) {
+        completionHandler(toErrorString(callingAPIName, nil, errorString));
+        return;
+    }
+
+    setSessionStorageAllowedInContentScripts(accessLevel == WebExtensionStorageAccessLevel::TrustedAndUntrustedContexts);
+
+    completionHandler(std::nullopt);
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)
+

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -66,6 +66,7 @@ WebExtensionContextParameters WebExtensionContext::parameters() const
         extension().serializeManifest(),
         extension().manifestVersion(),
         inTestingMode(),
+        isSessionStorageAllowedInContentScripts(),
         backgroundPageIdentifier(),
         popupPageIdentifiers(),
         tabPageIdentifiers()

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -237,6 +237,7 @@ public:
     void setBaseURL(URL&&);
 
     bool isURLForThisExtension(const URL&) const;
+    bool extensionCanAccessWebPage(WebPageProxyIdentifier, ErrorString);
 
     bool hasCustomUniqueIdentifier() const { return m_customUniqueIdentifier; }
 
@@ -503,6 +504,10 @@ private:
     void loadRegisteredContentScripts();
     RetainPtr<_WKWebExtensionRegisteredScriptsSQLiteStore> registeredContentScriptsStore();
 
+    // Storage
+    void setSessionStorageAllowedInContentScripts(bool);
+    bool isSessionStorageAllowedInContentScripts() const { return m_isSessionStorageAllowedInContentScripts; }
+
     void fetchCookies(WebsiteDataStore&, const URL&, const WebExtensionCookieFilterParameters&, CompletionHandler<void(Vector<WebExtensionCookieParameters>&&, ErrorString)>&&);
 
     // Action APIs
@@ -607,6 +612,14 @@ private:
     void scriptingGetRegisteredScripts(const Vector<String>&, CompletionHandler<void(Vector<WebExtensionRegisteredScriptParameters> scripts)>&&);
     void scriptingUnregisterContentScripts(const Vector<String>&, CompletionHandler<void(WebExtensionDynamicScripts::Error)>&&);
     bool createInjectedContentForScripts(const Vector<WebExtensionRegisteredScriptParameters>&, WebExtensionDynamicScripts::WebExtensionRegisteredScript::FirstTimeRegistration, InjectedContentVector&, NSString *callingAPIName, NSString **errorMessage);
+
+    // Storage APIs
+    void storageGet(WebPageProxyIdentifier, WebExtensionStorageType, const IPC::DataReference&, CompletionHandler<void(std::optional<IPC::DataReference>, ErrorString)>&&);
+    void storageGetBytesInUse(WebPageProxyIdentifier, WebExtensionStorageType, const Vector<String>& keys, CompletionHandler<void(std::optional<size_t>, ErrorString)>&&);
+    void storageSet(WebPageProxyIdentifier, WebExtensionStorageType, const IPC::DataReference&, CompletionHandler<void(ErrorString)>&&);
+    void storageRemove(WebPageProxyIdentifier, WebExtensionStorageType, const Vector<String>& keys, CompletionHandler<void(ErrorString)>&&);
+    void storageClear(WebPageProxyIdentifier, WebExtensionStorageType, CompletionHandler<void(ErrorString)>&&);
+    void storageSetAccessLevel(WebPageProxyIdentifier, WebExtensionStorageType, WebExtensionStorageAccessLevel, CompletionHandler<void(ErrorString)>&&);
 
     // Tabs APIs
     void tabsCreate(WebPageProxyIdentifier, const WebExtensionTabParameters&, CompletionHandler<void(std::optional<WebExtensionTabParameters>, WebExtensionTab::Error)>&&);
@@ -752,6 +765,8 @@ private:
 
     MenuItemMap m_menuItems;
     MenuItemVector m_mainMenuItems;
+
+    bool m_isSessionStorageAllowedInContentScripts { false };
 };
 
 template<typename T>

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -107,6 +107,14 @@ messages -> WebExtensionContext {
     ScriptingGetRegisteredScripts(Vector<String> scriptIDs) -> (Vector<WebKit::WebExtensionRegisteredScriptParameters> scripts);
     ScriptingUnregisterContentScripts(Vector<String> scriptIDs) -> (WebKit::WebExtensionDynamicScripts::Error error);
 
+    // Storage APIs
+    StorageGet(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionStorageType storageType, IPC::DataReference data) -> (std::optional<IPC::DataReference> data, WebKit::WebExtensionContext::ErrorString error);
+    StorageGetBytesInUse(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionStorageType storageType, Vector<String> keys) -> (std::optional<size_t> size, WebKit::WebExtensionContext::ErrorString error);
+    StorageSet(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionStorageType storageType, IPC::DataReference dataReference) -> (WebKit::WebExtensionContext::ErrorString error);
+    StorageRemove(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionStorageType storageType, Vector<String> keys) -> (WebKit::WebExtensionContext::ErrorString error);
+    StorageClear(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionStorageType storageType) -> (WebKit::WebExtensionContext::ErrorString error);
+    StorageSetAccessLevel(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionStorageType storageType, WebKit::WebExtensionStorageAccessLevel accessLevel) -> (WebKit::WebExtensionContext::ErrorString error);
+
     // Tabs APIs
     TabsCreate(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionTabParameters creationParameters) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);
     TabsUpdate(WebKit::WebExtensionTabIdentifier tabIdentifier, WebKit::WebExtensionTabParameters updateParameters) -> (std::optional<WebKit::WebExtensionTabParameters> tabParameters, WebKit::WebExtensionTab::Error error);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1952,6 +1952,9 @@
 		B6A292362B18FCF30061930E /* _WKWebExtensionSQLiteStore.h in Headers */ = {isa = PBXBuildFile; fileRef = B6A292342B18FCF20061930E /* _WKWebExtensionSQLiteStore.h */; };
 		B6A2923D2B193ED50061930E /* _WKWebExtensionSQLiteDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = B6A2923B2B193ED40061930E /* _WKWebExtensionSQLiteDatabase.h */; };
 		B6A2923E2B193ED50061930E /* _WKWebExtensionSQLiteDatabase.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6A2923C2B193ED50061930E /* _WKWebExtensionSQLiteDatabase.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		B6B1565C2B5E177A004F9894 /* WebExtensionStorageType.h in Headers */ = {isa = PBXBuildFile; fileRef = B6B156582B5E1779004F9894 /* WebExtensionStorageType.h */; };
+		B6B1565E2B5E177A004F9894 /* WebExtensionStorageAccessLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = B6B1565A2B5E177A004F9894 /* WebExtensionStorageAccessLevel.h */; };
+		B6B156612B5E2618004F9894 /* WebExtensionContextAPIStorageCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6B156602B5E2618004F9894 /* WebExtensionContextAPIStorageCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B6BF18352B1A49EF00FA39D3 /* _WKWebExtensionSQLiteStatement.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6BF18332B1A49EE00FA39D3 /* _WKWebExtensionSQLiteStatement.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B6BF18362B1A49EF00FA39D3 /* _WKWebExtensionSQLiteStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = B6BF18342B1A49EE00FA39D3 /* _WKWebExtensionSQLiteStatement.h */; };
 		B6BF18392B1A510500FA39D3 /* _WKWebExtensionSQLiteRow.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6BF18372B1A510500FA39D3 /* _WKWebExtensionSQLiteRow.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -6923,6 +6926,11 @@
 		B6A292342B18FCF20061930E /* _WKWebExtensionSQLiteStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionSQLiteStore.h; sourceTree = "<group>"; };
 		B6A2923B2B193ED40061930E /* _WKWebExtensionSQLiteDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionSQLiteDatabase.h; sourceTree = "<group>"; };
 		B6A2923C2B193ED50061930E /* _WKWebExtensionSQLiteDatabase.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionSQLiteDatabase.mm; sourceTree = "<group>"; };
+		B6B156582B5E1779004F9894 /* WebExtensionStorageType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionStorageType.h; sourceTree = "<group>"; };
+		B6B156592B5E1779004F9894 /* WebExtensionStorage.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebExtensionStorage.serialization.in; sourceTree = "<group>"; };
+		B6B1565A2B5E177A004F9894 /* WebExtensionStorageAccessLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionStorageAccessLevel.h; sourceTree = "<group>"; };
+		B6B1565B2B5E177A004F9894 /* WebExtensionContextParameters.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebExtensionContextParameters.serialization.in; sourceTree = "<group>"; };
+		B6B156602B5E2618004F9894 /* WebExtensionContextAPIStorageCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIStorageCocoa.mm; sourceTree = "<group>"; };
 		B6BF18332B1A49EE00FA39D3 /* _WKWebExtensionSQLiteStatement.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionSQLiteStatement.mm; sourceTree = "<group>"; };
 		B6BF18342B1A49EE00FA39D3 /* _WKWebExtensionSQLiteStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionSQLiteStatement.h; sourceTree = "<group>"; };
 		B6BF18372B1A510500FA39D3 /* _WKWebExtensionSQLiteRow.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionSQLiteRow.mm; sourceTree = "<group>"; };
@@ -9262,6 +9270,7 @@
 				1C9A15D22ABE2F4B002CC12A /* WebExtensionContextAPIPortCocoa.mm */,
 				1C4A14C72ABBBA3900A1018C /* WebExtensionContextAPIRuntimeCocoa.mm */,
 				B624FF142ABE4CB000F6EDF6 /* WebExtensionContextAPIScriptingCocoa.mm */,
+				B6B156602B5E2618004F9894 /* WebExtensionContextAPIStorageCocoa.mm */,
 				1C1D9C862AAA4143007DE31E /* WebExtensionContextAPITabsCocoa.mm */,
 				1C1549812926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm */,
 				33B5A80E2AFD5DE800A15D40 /* WebExtensionContextAPIWebNavigationCocoa.mm */,
@@ -12910,6 +12919,7 @@
 				2DA301A92B036CDA00F3B129 /* WebExtensionContext.serialization.in */,
 				1C0234BF28A00DCF00AC1E5B /* WebExtensionContextIdentifier.h */,
 				1C0234BE28A00DCF00AC1E5B /* WebExtensionContextParameters.h */,
+				B6B1565B2B5E177A004F9894 /* WebExtensionContextParameters.serialization.in */,
 				1C3BEB482887415100E66E38 /* WebExtensionControllerIdentifier.h */,
 				1C3BEB46288740AE00E66E38 /* WebExtensionControllerParameters.h */,
 				1C4B7BBF28E7A43F00B7265A /* WebExtensionControllerParameters.serialization.in */,
@@ -12934,6 +12944,9 @@
 				B69E1A672AFF5F0B000FB98E /* WebExtensionRegisteredScriptParameters.h */,
 				B6D031082AC1F631006C8E0B /* WebExtensionScriptInjectionParameters.h */,
 				B624FF1A2ABE503000F6EDF6 /* WebExtensionScriptInjectionResultParameters.h */,
+				B6B156592B5E1779004F9894 /* WebExtensionStorage.serialization.in */,
+				B6B1565A2B5E177A004F9894 /* WebExtensionStorageAccessLevel.h */,
+				B6B156582B5E1779004F9894 /* WebExtensionStorageType.h */,
 				1C4957A22A983E39007D0B64 /* WebExtensionTab.serialization.in */,
 				1C66BDD82A8ADB8A009D4452 /* WebExtensionTabIdentifier.h */,
 				1C4957A02A983E2B007D0B64 /* WebExtensionTabParameters.h */,
@@ -16127,6 +16140,8 @@
 				B69E1A682AFF5F0C000FB98E /* WebExtensionRegisteredScriptParameters.h in Headers */,
 				B6D0310A2AC1F631006C8E0B /* WebExtensionScriptInjectionParameters.h in Headers */,
 				B624FF1B2ABE503000F6EDF6 /* WebExtensionScriptInjectionResultParameters.h in Headers */,
+				B6B1565E2B5E177A004F9894 /* WebExtensionStorageAccessLevel.h in Headers */,
+				B6B1565C2B5E177A004F9894 /* WebExtensionStorageType.h in Headers */,
 				1C66BDDC2A8ADB94009D4452 /* WebExtensionTab.h in Headers */,
 				1C66BDDA2A8ADB8A009D4452 /* WebExtensionTabIdentifier.h in Headers */,
 				1C4957A12A983E2B007D0B64 /* WebExtensionTabParameters.h in Headers */,
@@ -18776,6 +18791,7 @@
 				1C9A15D32ABE2F4B002CC12A /* WebExtensionContextAPIPortCocoa.mm in Sources */,
 				1C4A14C82ABBBA3900A1018C /* WebExtensionContextAPIRuntimeCocoa.mm in Sources */,
 				B624FF152ABE4CB100F6EDF6 /* WebExtensionContextAPIScriptingCocoa.mm in Sources */,
+				B6B156612B5E2618004F9894 /* WebExtensionContextAPIStorageCocoa.mm in Sources */,
 				1C1D9C872AAA4143007DE31E /* WebExtensionContextAPITabsCocoa.mm in Sources */,
 				1C1549822926E7CC001B9E5B /* WebExtensionContextAPITestCocoa.mm in Sources */,
 				33B5A80F2AFD5DE800A15D40 /* WebExtensionContextAPIWebNavigationCocoa.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
@@ -36,12 +36,22 @@
 
 namespace WebKit {
 
+bool WebExtensionAPIStorage::isPropertyAllowed(ASCIILiteral propertyName, WebPage*)
+{
+    if (propertyName == "session"_s)
+        return extensionContext().isSessionStorageAllowedInContentScripts() || isForMainWorld();
+
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
 WebExtensionAPIStorageArea& WebExtensionAPIStorage::local()
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/local
 
     if (!m_local)
-        m_local = WebExtensionAPIStorageArea::create(forMainWorld(), runtime(), extensionContext(), StorageType::Local);
+        m_local = WebExtensionAPIStorageArea::create(forMainWorld(), runtime(), extensionContext(), WebExtensionStorageType::Local);
+
     return *m_local;
 }
 
@@ -50,7 +60,8 @@ WebExtensionAPIStorageArea& WebExtensionAPIStorage::session()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/session
 
     if (!m_session)
-        m_session = WebExtensionAPIStorageArea::create(forMainWorld(), runtime(), extensionContext(), StorageType::Session);
+        m_session = WebExtensionAPIStorageArea::create(forMainWorld(), runtime(), extensionContext(), WebExtensionStorageType::Session);
+
     return *m_session;
 }
 
@@ -59,7 +70,8 @@ WebExtensionAPIStorageArea& WebExtensionAPIStorage::sync()
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync
 
     if (!m_sync)
-        m_sync = WebExtensionAPIStorageArea::create(forMainWorld(), runtime(), extensionContext(), StorageType::Sync);
+        m_sync = WebExtensionAPIStorageArea::create(forMainWorld(), runtime(), extensionContext(), WebExtensionStorageType::Sync);
+
     return *m_sync;
 }
 
@@ -69,6 +81,7 @@ WebExtensionAPIEvent& WebExtensionAPIStorage::onChanged()
 
     if (!m_onChanged)
         m_onChanged = WebExtensionAPIEvent::create(forMainWorld(), runtime(), extensionContext(), WebExtensionEventListenerType::StorageOnChanged);
+
     return *m_onChanged;
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorage.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorage.h
@@ -41,6 +41,8 @@ class WebExtensionAPIStorage : public WebExtensionAPIObject, public JSWebExtensi
 
 public:
 #if PLATFORM(COCOA)
+    bool isPropertyAllowed(ASCIILiteral propertyName, WebPage*);
+
     WebExtensionAPIStorageArea& local();
     WebExtensionAPIStorageArea& session();
     WebExtensionAPIStorageArea& sync();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
@@ -31,10 +31,9 @@
 #include "JSWebExtensionWrappable.h"
 #include "WebExtensionAPIEvent.h"
 #include "WebExtensionAPIObject.h"
+#include "WebExtensionStorageType.h"
 
 namespace WebKit {
-
-enum class StorageType { Local, Session, Sync };
 
 class WebExtensionAPIStorageArea : public WebExtensionAPIObject, public JSWebExtensionWrappable {
     WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIStorageArea, storageArea);
@@ -43,19 +42,16 @@ public:
 #if PLATFORM(COCOA)
     bool isPropertyAllowed(ASCIILiteral propertyName, WebPage*);
 
-    void get(id items, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void getBytesInUse(id keys, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void set(NSDictionary *items, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void remove(id keys, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void clear(Ref<WebExtensionCallbackHandler>&&);
+    void get(WebPage*, id items, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getBytesInUse(WebPage*, id keys, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void set(WebPage*, NSDictionary *items, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void remove(WebPage*, id keys, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void clear(WebPage*, Ref<WebExtensionCallbackHandler>&&);
+
+    double quotaBytes();
 
     // Exposed only by storage.session.
-    void setAccessLevel(NSDictionary *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-
-    WebExtensionAPIEvent& onChanged();
-
-    // Exposed by both storage.local and storage.sync.
-    double quotaBytes();
+    void setAccessLevel(WebPage*, NSDictionary * , Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     // Exposed only by storage.sync.
     double quotaBytesPerItem();
@@ -63,14 +59,16 @@ public:
     NSUInteger maxWriteOperationsPerHour();
     NSUInteger maxWriteOperationsPerMinute();
 
+    WebExtensionAPIEvent& onChanged();
+
 private:
-    explicit WebExtensionAPIStorageArea(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, StorageType type)
+    explicit WebExtensionAPIStorageArea(ForMainWorld forMainWorld, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context, WebExtensionStorageType type)
         : WebExtensionAPIObject(forMainWorld, runtime, context)
         , m_type(type)
     {
     }
 
-    StorageType m_type;
+    WebExtensionStorageType m_type { WebExtensionStorageType::Local };
     RefPtr<WebExtensionAPIEvent> m_onChanged;
 #endif
 };

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -79,6 +79,7 @@ Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(const WebExt
         context.m_manifest = parseJSON(parameters.manifestJSON.get());
         context.m_manifestVersion = parameters.manifestVersion;
         context.m_testingMode = parameters.testingMode;
+        context.m_isSessionStorageAllowedInContentScripts = parameters.isSessionStorageAllowedInContentScripts;
 
         if (parameters.backgroundPageIdentifier) {
             if (newPage && parameters.backgroundPageIdentifier.value() == newPage->identifier())

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl
@@ -26,19 +26,19 @@
 [
     Conditional=WK_WEB_EXTENSIONS,
     ReturnsPromiseWhenCallbackIsOmitted,
+    NeedsPageWithCallbackHandler,
 ] interface WebExtensionAPIStorageArea {
 
-    [RaisesException] void get([Optional, NSObject, DOMString] any keys, [Optional, CallbackHandler] function callback);
-    [RaisesException] void getBytesInUse([Optional, NSObject, DOMString] any items, [Optional, CallbackHandler] function callback);
+    [RaisesException] void get([Optional, NSObject, DOMString] any items, [Optional, CallbackHandler] function callback);
+    [RaisesException] void getBytesInUse([Optional, NSObject, DOMString] any keys, [Optional, CallbackHandler] function callback);
     [RaisesException] void set([NSDictionary] any items, [Optional, CallbackHandler] function callback);
     [RaisesException] void remove([NSObject] any keys, [Optional, CallbackHandler] function callback);
-    void clear([Optional, CallbackHandler] function callback);
+    [NeedsPage] void clear([Optional, CallbackHandler] function callback);
 
-    [MainWorldOnly, RaisesException, Dynamic] void setAccessLevel([NSDictionary] any accessOptions, [Optional, CallbackHandler] function callback);
+    [RaisesException, Dynamic, MainWorldOnly] void setAccessLevel([NSDictionary] any accessOptions, [Optional, CallbackHandler] function callback);
 
     readonly attribute WebExtensionAPIEvent onChanged;
 
-    // Exposed by both storage.local and storage.sync.
     [ImplementedAs=quotaBytes] readonly attribute double QUOTA_BYTES;
 
     // Properties exposed by storage.sync.

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -113,6 +113,11 @@ void WebExtensionContextProxy::addTabPageIdentifier(WebCore::PageIdentifier page
 {
     if (auto* page = WebProcess::singleton().webPage(pageIdentifier))
         addTabPage(*page, tabIdentifier, windowIdentifier);
+}
+
+void WebExtensionContextProxy::setStorageAccessLevel(bool allowedInContentScripts)
+{
+    m_isSessionStorageAllowedInContentScripts = allowedInContentScripts;
 }
 
 void WebExtensionContextProxy::enumerateFramesAndNamespaceObjects(const Function<void(WebFrame&, WebExtensionAPINamespace&)>& function, DOMWrapperWorld& world)

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -80,6 +80,8 @@ public:
 
     _WKWebExtensionLocalization *localization() { return m_localization.get(); }
 
+    bool isSessionStorageAllowedInContentScripts() { return m_isSessionStorageAllowedInContentScripts; }
+
     bool inTestingMode() { return m_testingMode; }
 
     static WebCore::DOMWrapperWorld& mainWorld() { return WebCore::mainThreadNormalWorld(); }
@@ -153,6 +155,9 @@ private:
     void dispatchRuntimeInstalledEvent(WebExtensionContext::InstallReason, String previousVersion);
     void dispatchRuntimeStartupEvent();
 
+    // Storage
+    void setStorageAccessLevel(bool);
+
     // Tabs
     void dispatchTabsCreatedEvent(const WebExtensionTabParameters&);
     void dispatchTabsUpdatedEvent(const WebExtensionTabParameters&, const WebExtensionTabParameters& changedParameters);
@@ -180,6 +185,7 @@ private:
     RetainPtr<NSDictionary> m_manifest;
     double m_manifestVersion { 0 };
     bool m_testingMode { false };
+    bool m_isSessionStorageAllowedInContentScripts { false };
     RefPtr<WebCore::DOMWrapperWorld> m_contentScriptWorld;
     WeakFrameSet m_extensionContentFrames;
     WeakPtr<WebPage> m_backgroundPage;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -60,6 +60,9 @@ messages -> WebExtensionContextProxy {
     DispatchRuntimeInstalledEvent(WebKit::WebExtensionContext::InstallReason installReason, String previousVersion)
     DispatchRuntimeStartupEvent()
 
+    // Storage
+    SetStorageAccessLevel(bool allowedInContentScripts)
+
     // Tabs Events
     DispatchTabsCreatedEvent(WebKit::WebExtensionTabParameters tabParameters)
     DispatchTabsUpdatedEvent(WebKit::WebExtensionTabParameters tabParameters, WebKit::WebExtensionTabParameters changedParameters)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
@@ -27,6 +27,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#import "HTTPServer.h"
 #import "WebExtensionUtilities.h"
 
 namespace TestWebKitAPI {
@@ -46,30 +47,145 @@ static auto *storageManifest = @{
         @"type": @"module",
         @"persistent": @NO,
     },
+
+    @"content_scripts": @[ @{
+        @"js": @[ @"content.js" ],
+        @"matches": @[ @"*://localhost/*" ],
+    } ],
 };
 
 TEST(WKWebExtensionAPIStorage, Errors)
 {
     auto *backgroundScript = Util::constructScript(@[
-        @"browser.test.assertThrows(() => browser.storage.local.get({ 'key': () => { 'function' } }), /it is not JSON-serializable/i)",
-        @"browser.test.assertThrows(() => browser.storage.local.get(Date.now()), /an invalid parameter was passed/i)",
+        @"browser.test.assertThrows(() => browser?.storage?.local?.get({ 'key': () => { 'function' } }), /it is not JSON-serializable/i)",
+        @"browser.test.assertThrows(() => browser?.storage?.local?.get(Date.now()), /'items' value is invalid, because an object or a string or an array of strings or null is expected, but a number was provided/i)",
 
+        @"browser.test.assertThrows(() => browser?.storage?.local?.getBytesInUse({}), /'keys' value is invalid, because a string or an array of strings or null is expected, but an object was provided/i)",
+        @"browser.test.assertThrows(() => browser?.storage?.local?.getBytesInUse([1]), /'keys' value is invalid, because a string or an array of strings or null is expected, but an array of other values was provided/i)",
 
-        @"browser.test.assertThrows(() => browser.storage.local.getBytesInUse({}), /'keys' value is invalid, because a string or an array of strings or null is expected, but an object was provided/i)",
-        @"browser.test.assertThrows(() => browser.storage.local.getBytesInUse([1]), /'keys' value is invalid, because a string or an array of strings or null is expected, but an array of other values was provided/i)",
+        @"browser.test.assertThrows(() => browser?.storage?.local?.set(), /A required argument is missing/i)",
+        @"browser.test.assertThrows(() => browser?.storage?.local?.set([]), /'items' value is invalid, because an object is expected/i)",
+        @"browser.test.assertThrows(() => browser?.storage?.local?.set({ 'key': () => { 'function' } }), /it is not JSON-serializable/i)",
 
-        @"browser.test.assertThrows(() => browser.storage.local.set(), /A required argument is missing/i)",
-        @"browser.test.assertThrows(() => browser.storage.local.set([]), /'items' value is invalid, because an object is expected/i)",
-        @"browser.test.assertThrows(() => browser.storage.local.set({ 'key': () => { 'function' } }), /it is not JSON-serializable/i)",
+        @"browser.test.assertThrows(() => browser?.storage?.local?.remove(), /A required argument is missing/i)",
+        @"browser.test.assertThrows(() => browser?.storage?.local?.remove({}), /'keys' value is invalid, because a string or an array of strings is expected, but an object was provided/i)",
+        @"browser.test.assertThrows(() => browser?.storage?.local?.remove([1]), /'keys' value is invalid, because a string or an array of strings is expected, but an array of other values was provided/i)",
 
-        @"browser.test.assertThrows(() => browser.storage.local.remove(), /A required argument is missing/i)",
-        @"browser.test.assertThrows(() => browser.storage.local.remove({}), /'keys' value is invalid, because a string or an array of strings is expected, but an object was provided/i)",
-        @"browser.test.assertThrows(() => browser.storage.local.remove([1]), /'keys' value is invalid, because a string or an array of strings is expected, but an array of other values was provided/i)",
+        @"browser.test.assertThrows(() => browser?.storage?.session?.setAccessLevel('INVALID_ACCESS_LEVEL'), /'accessOptions' value is invalid, because an object is expected/i)",
+        @"browser.test.assertThrows(() => browser?.storage?.session?.setAccessLevel({ 'accessLevel': 'INVALID_ACCESS_LEVEL' }), /'accessLevel' value is invalid, because it must specify either 'TRUSTED_CONTEXTS' or 'TRUSTED_AND_UNTRUSTED_CONTEXTS'/i)",
 
         @"browser.test.notifyPass()"
     ]);
 
     Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIStorage, UndefinedProperties)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser?.storage?.local?.setAccessLevel, undefined)",
+        @"browser.test.assertEq(browser?.storage?.sync?.setAccessLevel, undefined)",
+
+        @"browser.test.assertEq(browser?.storage?.local?.QUOTA_BYTES_PER_ITEM, undefined)",
+        @"browser.test.assertEq(browser?.storage?.session?.QUOTA_BYTES_PER_ITEM, undefined)",
+
+        @"browser.test.assertEq(browser?.storage?.local?.MAX_ITEMS, undefined)",
+        @"browser.test.assertEq(browser?.storage?.session?.MAX_ITEMS, undefined)",
+
+        @"browser.test.assertEq(browser?.storage?.local?.MAX_WRITE_OPERATIONS_PER_HOUR, undefined)",
+        @"browser.test.assertEq(browser?.storage?.session?.MAX_WRITE_OPERATIONS_PER_HOUR, undefined)",
+
+        @"browser.test.assertEq(browser?.storage?.local?.MAX_WRITE_OPERATIONS_PER_MINUTE, undefined)",
+        @"browser.test.assertEq(browser?.storage?.session?.MAX_WRITE_OPERATIONS_PER_MINUTE, undefined)",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedContexts)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.runtime.onMessage.addListener(async (message, sender, sendResponse) => {",
+        @"  browser.test.assertEq(message, 'Ready')",
+
+        @"  const tabs = await browser?.tabs?.query({ active: true, currentWindow: true })",
+        @"  const tabId = tabs[0].id",
+
+        @"  await browser?.storage?.session?.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' })",
+
+        @"  const response = await browser.test.assertSafeResolve(() => browser?.tabs?.sendMessage(tabId, { content: 'Access level set' }))",
+        @"  browser.test.assertEq(response?.content, undefined)",
+
+        @"  browser.test.notifyPass()",
+        @"})"
+    ]);
+
+    auto *contentScript = Util::constructScript(@[
+        @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
+        @"  browser.test.assertEq(message?.content, 'Access level set', 'Should receive the correct message content')",
+
+        @"  sendResponse({ content: browser?.storage?.session })",
+        @"})",
+
+        @"setTimeout(() => browser.runtime.sendMessage('Ready'), 1000)"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:storageManifest resources:@{ @"background.js": backgroundScript, @"content.js": contentScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedAndUntrustedContexts)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.runtime.onMessage.addListener(async (message, sender, sendResponse) => {",
+        @"  browser.test.assertEq(message, 'Ready')",
+
+        @"  const tabs = await browser?.tabs?.query({ active: true, currentWindow: true })",
+        @"  const tabId = tabs[0].id",
+
+        @"  await browser?.storage?.session?.setAccessLevel({ accessLevel: 'TRUSTED_AND_UNTRUSTED_CONTEXTS' })",
+
+        @"  const response = await browser.test.assertSafeResolve(() => browser?.tabs?.sendMessage(tabId, { content: 'Access level set' }))",
+        @"  browser.test.assertEq(response?.content, 'object')",
+
+        @"  browser.test.notifyPass()",
+        @"})"
+    ]);
+
+    auto *contentScript = Util::constructScript(@[
+        @"browser.runtime.onMessage.addListener((message, sender, sendResponse) => {",
+        @"  browser.test.assertEq(message?.content, 'Access level set', 'Should receive the correct message content')",
+
+        @"  sendResponse({ content: typeof browser?.storage?.session })",
+        @"})",
+
+        @"setTimeout(() => browser.runtime.sendMessage('Ready'), 1000)"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:storageManifest resources:@{ @"background.js": backgroundScript, @"content.js": contentScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
+
+    [manager loadAndRun];
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 0e52b5dc8c72b2d398724308508dc149ac4b6c39
<pre>
Send data for browser.storage to the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=267782">https://bugs.webkit.org/show_bug.cgi?id=267782</a>
<a href="https://rdar.apple.com/121279041">rdar://121279041</a>

Reviewed by Timothy Hatcher.

This patch sends the data to be added or removed from storage over to the UI process. Next and
final steps for the Storage API is to adopt the _WKWebExtensionSQLiteStore to manage the data added
with this API. This is being tracked in <a href="https://webkit.org/b/267649.">https://webkit.org/b/267649.</a>

In addition, this patch adds support for browser.session.setAccessLevel. To do this, add a boolean
representing the access level to WebExtensionContextParameters so that the value can be read when
determining to expose the &apos;session&apos; API.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_cannot_be_forward_declared):
* Source/WebKit/Shared/Extensions/WebExtensionConstants.h:
* Source/WebKit/Shared/Extensions/WebExtensionContext.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h:
* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionStorageType.h:
Copied from Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorage.h.
(WebKit::toAPIPrefixString):
* Source/WebKit/Shared/Extensions/WebExtensionStorageType.serialization.in:
Copied from Source/WebKit/Shared/Extensions/WebExtensionContext.serialization.in.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm: Added.
(WebKit::WebExtensionContext::storageGet):
(WebKit::WebExtensionContext::storageGetBytesInUse):
(WebKit::WebExtensionContext::storageSet):
(WebKit::WebExtensionContext::storageRemove):
(WebKit::WebExtensionContext::storageClear):
(WebKit::WebExtensionContext::storageSetAccessLevel):
(WebKit::WebExtensionContext::isValidStorageRequest):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::load):
(WebKit::WebExtensionContext::getTab):
(WebKit::WebExtensionContext::isBackgroundWebView):
(WebKit::WebExtensionContext::setSessionStorageAllowedInContentScripts):
Set the access level and send a message to update the value on the WebExtensionContextParameters.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::parameters const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::isSessionStorageAllowedInContentScripts const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::isPropertyAllowed):
(WebKit::WebExtensionAPIStorageArea::get):
(WebKit::WebExtensionAPIStorageArea::getBytesInUse):
(WebKit::WebExtensionAPIStorageArea::set):
(WebKit::WebExtensionAPIStorageArea::remove):
(WebKit::WebExtensionAPIStorageArea::clear):
(WebKit::WebExtensionAPIStorageArea::setAccessLevel):
(WebKit::WebExtensionAPIStorageArea::onChanged):
(WebKit::WebExtensionAPIStorageArea::quotaBytes):
(WebKit::WebExtensionAPIStorageArea::quotaBytesPerItem):
(WebKit::WebExtensionAPIStorageArea::maxItems):
(WebKit::WebExtensionAPIStorageArea::maxWriteOperationsPerHour):
(WebKit::WebExtensionAPIStorageArea::maxWriteOperationsPerMinute):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm:
(WebKit::WebExtensionAPIStorage::isPropertyAllowed):
(WebKit::WebExtensionAPIStorage::local):
(WebKit::WebExtensionAPIStorage::session):
(WebKit::WebExtensionAPIStorage::sync):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorage.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h:
(WebKit::WebExtensionAPIStorageArea::WebExtensionAPIStorageArea):
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::getOrCreate):
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorage.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::WebExtensionContextProxy::setStorageAccessLevel):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/273286@main">https://commits.webkit.org/273286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2783b5ebc1598a49d7e8a5d425c16e3037fe42d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/34994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37739 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31605 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/36152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10958 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/35536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/11761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/10307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/35262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/31294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38991 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/31825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/31623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/10472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/8392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/34378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11004 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4497 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->