### PR TITLE
[run-webkit-tests] Fix unit tests with a different git path

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/subprocess.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/subprocess.py
@@ -106,6 +106,8 @@ class Subprocess(ContextStack):
                     continue
                 elif re.match(self.args[count], args[count]):
                     continue
+                elif not count and self.args[count].split('/')[-1] == args[count]:
+                    continue
                 return False
 
             if self.cwd is not None and cwd != self.cwd:
@@ -143,7 +145,7 @@ class Subprocess(ContextStack):
         candidates = []
         while current:
             for completion in current.completions:
-                if completion.args[0] == program:
+                if completion.args[0] == program or completion.args[0].split('/')[-1] == program:
                     candidates.append(completion)
                 if current.ordered:
                     break

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/hooks/prepare-commit-msg
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/hooks/prepare-commit-msg
@@ -16,7 +16,7 @@ def main(file_name=None, source=None, sha=None):
     with open(file_name, 'w') as commit_message_file:
         if sha:
             commit_message_file.write(subprocess.check_output(
-                ['/usr/bin/git', 'log', 'HEAD', '-1', '--pretty=format:%B'],
+                ['git', 'log', 'HEAD', '-1', '--pretty=format:%B'],
                 **(dict(encoding='utf-8') if sys.version_info > (3, 5) else dict())
             ))
         else:
@@ -32,7 +32,7 @@ def main(file_name=None, source=None, sha=None):
                 commit_message_file.write('# {}\n'.format(line))
             commit_message_file.write('\n')
         for line in subprocess.check_output(
-            ['/usr/bin/git', 'status'],
+            ['git', 'status'],
             **(dict(encoding='utf-8') if sys.version_info > (3, 5) else dict())
         ).splitlines():
             commit_message_file.write('# {}\n'.format(line))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/publish_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/publish_unittest.py
@@ -29,7 +29,7 @@ from datetime import datetime
 
 from webkitcorepy import OutputCapture, testing
 from webkitcorepy.mocks import Terminal as MockTerminal
-from webkitscmpy import program, mocks
+from webkitscmpy import program, mocks, local
 
 
 class TestPublish(testing.PathTestCase):
@@ -81,7 +81,7 @@ class TestPublish(testing.PathTestCase):
                 '    branch-b is a branch, referencing 2.3@branch-b',
                 'User specified 1 branch and 0 tags, request comprises 1 commit',
                 "Inferred 'origin' as the target remote",
-                "Invoking '/usr/bin/git push --atomic origin 790725a6d79e:refs/heads/branch-b'",
+                "Invoking '{} push --atomic origin 790725a6d79e:refs/heads/branch-b'".format(local.Git.executable()),
             ],
         )
 


### PR DESCRIPTION
#### 9052093b92b3f5db5d1a124acb40f7659de85445
<pre>
[run-webkit-tests] Fix unit tests with a different git path
<a href="https://bugs.webkit.org/show_bug.cgi?id=267794">https://bugs.webkit.org/show_bug.cgi?id=267794</a>
<a href="https://rdar.apple.com/121288444">rdar://121288444</a>

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/subprocess.py:
(Subprocess.CommandRoute.matches): Allow commands to match without the exact path.
(Subprocess.completion_generator_for): Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/hooks/prepare-commit-msg:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/publish_unittest.py:
(TestPublish.test_git): Use production &apos;git&apos; path.

Canonical link: <a href="https://commits.webkit.org/273299@main">https://commits.webkit.org/273299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a40e6c5feac04aa9489775898b7bdc544ac87a8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37558 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31453 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36005 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30396 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10145 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/35120 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38813 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31666 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31452 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36242 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10314 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34215 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/34795 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12136 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10858 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4502 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->