### PR TITLE
Reduce use a raw pointers in containers in rendering code

### DIFF
--- a/Source/WebCore/rendering/LegacyRootInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.cpp
@@ -802,7 +802,7 @@ LayoutUnit LegacyRootInlineBox::verticalPositionForBox(LegacyInlineBox* box, Ver
     bool isRenderInline = renderer->isRenderInline();
     if (isRenderInline && !firstLine) {
         LayoutUnit cachedPosition;
-        if (verticalPositionCache.get(renderer, baselineType(), cachedPosition))
+        if (verticalPositionCache.get(*renderer, baselineType(), cachedPosition))
             return cachedPosition;
     }
 
@@ -851,7 +851,7 @@ LayoutUnit LegacyRootInlineBox::verticalPositionForBox(LegacyInlineBox* box, Ver
 
     // Store the cached value.
     if (isRenderInline && !firstLine)
-        verticalPositionCache.set(renderer, baselineType(), verticalPosition);
+        verticalPositionCache.set(*renderer, baselineType(), verticalPosition);
 
     return verticalPosition;
 }

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -535,7 +535,7 @@ void RenderFragmentedFlow::setFragmentRangeForBox(const RenderBox& box, RenderFr
 {
     ASSERT(hasFragments());
     ASSERT(startFragment && endFragment && startFragment->fragmentedFlow() == this && endFragment->fragmentedFlow() == this);
-    auto result = m_fragmentRangeMap.set(&box, RenderFragmentContainerRange(startFragment, endFragment));
+    auto result = m_fragmentRangeMap.set(box, RenderFragmentContainerRange(startFragment, endFragment));
     if (result.isNewEntry)
         return;
 

--- a/Source/WebCore/rendering/RenderFragmentedFlow.h
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.h
@@ -237,11 +237,11 @@ protected:
     std::unique_ptr<ContainingFragmentMap> m_lineToFragmentMap;
 
     // Map a box to the list of fragments in which the box is rendered.
-    using RenderFragmentContainerRangeMap = HashMap<const RenderBox*, RenderFragmentContainerRange>;
+    using RenderFragmentContainerRangeMap = HashMap<SingleThreadWeakRef<const RenderBox>, RenderFragmentContainerRange>;
     RenderFragmentContainerRangeMap m_fragmentRangeMap;
 
     // Map a box with a fragment break to the auto height fragment affected by that break. 
-    using RenderBoxToFragmentMap = HashMap<RenderBox*, RenderFragmentContainer*>;
+    using RenderBoxToFragmentMap = HashMap<SingleThreadWeakRef<RenderBox>, SingleThreadWeakRef<RenderFragmentContainer>>;
     RenderBoxToFragmentMap m_breakBeforeToFragmentMap;
     RenderBoxToFragmentMap m_breakAfterToFragmentMap;
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -2158,7 +2158,7 @@ LayoutUnit RenderGrid::gridAreaBreadthForOutOfFlowChild(const RenderBox& child, 
     if (startIsAuto)
         start = borderEdge;
     else {
-        outOfFlowItemLine.set(&child, startLine);
+        outOfFlowItemLine.set(child, startLine);
         start = positions[startLine];
     }
     if (endIsAuto)

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -274,7 +274,7 @@ private:
 
     mutable GridMasonryLayout m_masonryLayout;
 
-    typedef HashMap<const RenderBox*, std::optional<size_t>> OutOfFlowPositionsMap;
+    using OutOfFlowPositionsMap = HashMap<SingleThreadWeakRef<const RenderBox>, std::optional<size_t>>;
     OutOfFlowPositionsMap m_outOfFlowItemColumn;
     OutOfFlowPositionsMap m_outOfFlowItemRow;
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1616,7 +1616,7 @@ void RenderLayerCompositor::adjustOverflowScrollbarContainerLayers(RenderLayer& 
     if (layersClippedByScrollers.isEmpty())
         return;
 
-    HashMap<RenderLayer*, RenderLayer*> overflowScrollToLastContainedLayerMap;
+    HashMap<CheckedPtr<RenderLayer>, CheckedPtr<RenderLayer>> overflowScrollToLastContainedLayerMap;
 
     for (auto* clippedLayer : layersClippedByScrollers) {
         auto* clippingStack = clippedLayer->backing()->ancestorClippingStack();
@@ -1635,7 +1635,7 @@ void RenderLayerCompositor::adjustOverflowScrollbarContainerLayers(RenderLayer& 
         if (it == overflowScrollToLastContainedLayerMap.end())
             continue;
     
-        auto* lastContainedDescendant = it->value;
+        CheckedPtr lastContainedDescendant = it->value;
         if (!lastContainedDescendant || !lastContainedDescendant->isComposited())
             continue;
 

--- a/Source/WebCore/rendering/RenderMultiColumnFlow.h
+++ b/Source/WebCore/rendering/RenderMultiColumnFlow.h
@@ -95,7 +95,7 @@ public:
     // FIXME: Eventually as column and fragment flow threads start nesting, this will end up changing.
     bool shouldCheckColumnBreaks() const override;
 
-    typedef HashMap<const RenderBox*, SingleThreadWeakPtr<RenderMultiColumnSpannerPlaceholder>> SpannerMap;
+    using SpannerMap = HashMap<SingleThreadWeakRef<const RenderBox>, SingleThreadWeakPtr<RenderMultiColumnSpannerPlaceholder>>;
     SpannerMap& spannerMap() { return *m_spannerMap; }
 
 private:

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2163,18 +2163,18 @@ RenderObject::RareDataMap& RenderObject::rareDataMap()
 const RenderObject::RenderObjectRareData& RenderObject::rareData() const
 {
     ASSERT(hasRareData());
-    return *rareDataMap().get(this);
+    return *rareDataMap().get(*this);
 }
 
 RenderObject::RenderObjectRareData& RenderObject::ensureRareData()
 {
     m_stateBitfields.setFlag(StateFlag::HasRareData);
-    return *rareDataMap().ensure(this, [] { return makeUnique<RenderObjectRareData>(); }).iterator->value;
+    return *rareDataMap().ensure(*this, [] { return makeUnique<RenderObjectRareData>(); }).iterator->value;
 }
 
 void RenderObject::removeRareData()
 {
-    rareDataMap().remove(this);
+    rareDataMap().remove(*this);
     m_stateBitfields.clearFlag(StateFlag::HasRareData);
 }
 

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1292,7 +1292,7 @@ private:
     RenderObjectRareData& ensureRareData();
     void removeRareData();
     
-    typedef HashMap<const RenderObject*, std::unique_ptr<RenderObjectRareData>> RareDataMap;
+    using RareDataMap = HashMap<SingleThreadWeakRef<const RenderObject>, std::unique_ptr<RenderObjectRareData>>;
 
     static RareDataMap& rareDataMap();
 

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -988,7 +988,7 @@ void RenderTable::updateColumnCache() const
         m_columnRenderers.append(columnRenderer);
         // FIXME: We should look to compute the effective column index successively from previous values instead of
         // calling colToEffCol(), which is in O(numEffCols()). Although it's unlikely that this is a hot function.
-        m_effectiveColumnIndexMap.add(columnRenderer, colToEffCol(columnIndex));
+        m_effectiveColumnIndexMap.add(*columnRenderer, colToEffCol(columnIndex));
         columnIndex += columnRenderer->span();
     }
     m_columnRenderersValid = true;

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -278,7 +278,7 @@ private:
     mutable Vector<SingleThreadWeakPtr<RenderTableCol>> m_columnRenderers;
 
     unsigned effectiveIndexOfColumn(const RenderTableCol&) const;
-    typedef HashMap<const RenderTableCol*, unsigned> EffectiveColumnIndexMap;
+    using EffectiveColumnIndexMap = HashMap<SingleThreadWeakRef<const RenderTableCol>, unsigned>;
     mutable EffectiveColumnIndexMap m_effectiveColumnIndexMap;
 
     mutable SingleThreadWeakPtr<RenderTableSection> m_head;

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -105,6 +105,7 @@ void RenderTableCell::willBeRemovedFromTree(IsInternalMove isInternalMove)
         return;
     RenderTableSection* section = this->section();
     table()->invalidateCollapsedBorders();
+    section->removeCachedCollapsedBorders(*this);
     section->setNeedsCellRecalc();
 }
 

--- a/Source/WebCore/rendering/RenderWidget.h
+++ b/Source/WebCore/rendering/RenderWidget.h
@@ -48,7 +48,7 @@ public:
     static void scheduleWidgetToMove(Widget&, LocalFrameView*);
 
 private:
-    using WidgetToParentMap = HashMap<RefPtr<Widget>, LocalFrameView*>;
+    using WidgetToParentMap = HashMap<RefPtr<Widget>, SingleThreadWeakPtr<LocalFrameView>>;
     static WidgetToParentMap& widgetNewParentMap();
 
     WEBCORE_EXPORT void moveWidgets();

--- a/Source/WebCore/rendering/VerticalPositionCache.h
+++ b/Source/WebCore/rendering/VerticalPositionCache.h
@@ -35,13 +35,12 @@ class RenderObject;
 class VerticalPositionCache {
     WTF_MAKE_NONCOPYABLE(VerticalPositionCache);
 public:
-    VerticalPositionCache()
-    { }
+    VerticalPositionCache() = default;
     
-    bool get(RenderObject* renderer, FontBaseline baselineType, LayoutUnit& result) const
+    bool get(RenderObject& renderer, FontBaseline baselineType, LayoutUnit& result) const
     {
-        const HashMap<RenderObject*, LayoutUnit>& mapToCheck = baselineType == AlphabeticBaseline ? m_alphabeticPositions : m_ideographicPositions;
-        const HashMap<RenderObject*, LayoutUnit>::const_iterator it = mapToCheck.find(renderer);
+        auto& mapToCheck = baselineType == AlphabeticBaseline ? m_alphabeticPositions : m_ideographicPositions;
+        auto it = mapToCheck.find(renderer);
         if (it == mapToCheck.end())
             return false;
 
@@ -49,7 +48,7 @@ public:
         return true;
     }
     
-    void set(RenderObject* renderer, FontBaseline baselineType, LayoutUnit position)
+    void set(RenderObject& renderer, FontBaseline baselineType, LayoutUnit position)
     {
         if (baselineType == AlphabeticBaseline)
             m_alphabeticPositions.set(renderer, position);
@@ -58,8 +57,8 @@ public:
     }
 
 private:
-    HashMap<RenderObject*, LayoutUnit> m_alphabeticPositions;
-    HashMap<RenderObject*, LayoutUnit> m_ideographicPositions;
+    HashMap<SingleThreadWeakRef<RenderObject>, LayoutUnit> m_alphabeticPositions;
+    HashMap<SingleThreadWeakRef<RenderObject>, LayoutUnit> m_ideographicPositions;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/line/LineLayoutState.h
+++ b/Source/WebCore/rendering/line/LineLayoutState.h
@@ -76,7 +76,7 @@ public:
         void append(Ref<FloatWithRect>&& floatWithRect)
         {
             m_floats.add(floatWithRect.copyRef());
-            m_floatWithRectMap.add(&floatWithRect->renderer(), WTFMove(floatWithRect));
+            m_floatWithRectMap.add(floatWithRect->renderer(), WTFMove(floatWithRect));
         }
         void setLastFloat(FloatingObject* lastFloat) { m_lastFloat = lastFloat; }
         FloatingObject* lastFloat() const { return m_lastFloat; }
@@ -84,7 +84,7 @@ public:
         void setLastCleanFloat(RenderBox& floatBox) { m_lastCleanFloat = &floatBox; }
         RenderBox* lastCleanFloat() const { return m_lastCleanFloat; }
 
-        FloatWithRect* floatWithRect(RenderBox& floatBox) const { return m_floatWithRectMap.get(&floatBox); }
+        FloatWithRect* floatWithRect(RenderBox& floatBox) const { return m_floatWithRectMap.get(floatBox); }
 
         using Iterator = ListHashSet<Ref<FloatWithRect>>::iterator;
         Iterator begin() { return m_floats.begin(); }
@@ -94,7 +94,7 @@ public:
 
     private:
         ListHashSet<Ref<FloatWithRect>> m_floats;
-        HashMap<RenderBox*, Ref<FloatWithRect>> m_floatWithRectMap;
+        HashMap<SingleThreadWeakRef<RenderBox>, Ref<FloatWithRect>> m_floatWithRectMap;
         FloatingObject* m_lastFloat { nullptr };
         RenderBox* m_lastCleanFloat { nullptr };
     };

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.h
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.h
@@ -107,19 +107,19 @@ public:
     static ShapeOutsideInfo& ensureInfo(const RenderBox& key)
     {
         InfoMap& infoMap = ShapeOutsideInfo::infoMap();
-        if (ShapeOutsideInfo* info = infoMap.get(&key))
+        if (ShapeOutsideInfo* info = infoMap.get(key))
             return *info;
-        auto result = infoMap.add(&key, makeUnique<ShapeOutsideInfo>(key));
+        auto result = infoMap.add(key, makeUnique<ShapeOutsideInfo>(key));
         return *result.iterator->value;
     }
-    static void removeInfo(const RenderBox& key) { infoMap().remove(&key); }
-    static ShapeOutsideInfo* info(const RenderBox& key) { return infoMap().get(&key); }
+    static void removeInfo(const RenderBox& key) { infoMap().remove(key); }
+    static ShapeOutsideInfo* info(const RenderBox& key) { return infoMap().get(key); }
 
 private:
     LayoutUnit logicalTopOffset() const;
     LayoutUnit logicalLeftOffset() const;
 
-    typedef HashMap<const RenderBox*, std::unique_ptr<ShapeOutsideInfo>> InfoMap;
+    using InfoMap = HashMap<SingleThreadWeakRef<const RenderBox>, std::unique_ptr<ShapeOutsideInfo>>;
     static InfoMap& infoMap()
     {
         static NeverDestroyed<InfoMap> staticInfoMap;

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -185,7 +185,7 @@ void SVGRenderingContext::prepareToRenderSVGContent(RenderElement& renderer, Pai
             // changes, we need to paint the whole filter region. Otherwise, elements not visible
             // at the time of the initial paint (due to scrolling, window size, etc.) will never
             // be drawn.
-            m_paintInfo->rect = IntRect(m_filter->drawingRegion(m_renderer));
+            m_paintInfo->rect = IntRect(m_filter->drawingRegion(*m_renderer));
         }
     }
 

--- a/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
@@ -40,7 +40,7 @@ void SVGResourcesCache::addResourcesFromRenderer(RenderElement& renderer, const 
         RELEASE_ASSERT_NOT_REACHED();
 #endif
 
-    ASSERT(!m_cache.contains(&renderer));
+    ASSERT(!m_cache.contains(renderer));
 
     // Build a list of all resources associated with the passed RenderObject
     auto newResources = SVGResources::buildCachedResources(renderer, style);
@@ -48,7 +48,7 @@ void SVGResourcesCache::addResourcesFromRenderer(RenderElement& renderer, const 
         return;
 
     // Put object in cache.
-    SVGResources& resources = *m_cache.add(&renderer, WTFMove(newResources)).iterator->value;
+    SVGResources& resources = *m_cache.add(renderer, WTFMove(newResources)).iterator->value;
 
     // Run cycle-detection _afterwards_, so self-references can be caught as well.
     SVGResourcesCycleSolver::resolveCycles(renderer, resources);
@@ -69,7 +69,7 @@ void SVGResourcesCache::removeResourcesFromRenderer(RenderElement& renderer)
         RELEASE_ASSERT_NOT_REACHED();
 #endif
 
-    std::unique_ptr<SVGResources> resources = m_cache.take(&renderer);
+    auto resources = m_cache.take(renderer);
     if (!resources)
         return;
 
@@ -94,7 +94,7 @@ static inline SVGResourcesCache& resourcesCacheFromRenderer(const RenderElement&
 
 SVGResources* SVGResourcesCache::cachedResourcesForRenderer(const RenderElement& renderer)
 {
-    return resourcesCacheFromRenderer(renderer).m_cache.get(&renderer);
+    return resourcesCacheFromRenderer(renderer).m_cache.get(renderer);
 }
 
 static bool hasPaintResourceRequiringRemovalOnClientLayoutChange(LegacyRenderSVGResource* resource)

--- a/Source/WebCore/rendering/svg/SVGResourcesCache.h
+++ b/Source/WebCore/rendering/svg/SVGResourcesCache.h
@@ -75,7 +75,7 @@ private:
     void addResourcesFromRenderer(RenderElement&, const RenderStyle&);
     void removeResourcesFromRenderer(RenderElement&);
 
-    typedef HashMap<const RenderElement*, std::unique_ptr<SVGResources>> CacheMap;
+    using CacheMap = HashMap<SingleThreadWeakRef<const RenderElement>, std::unique_ptr<SVGResources>>;
     CacheMap m_cache;
 };
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -67,7 +67,7 @@ void LegacyRenderSVGResourceClipper::removeAllClientsFromCacheIfNeeded(bool mark
 
 void LegacyRenderSVGResourceClipper::removeClientFromCache(RenderElement& client, bool markForInvalidation)
 {
-    m_clipperMap.remove(&client);
+    m_clipperMap.remove(client);
 
     markClientForInvalidation(client, markForInvalidation ? BoundariesInvalidation : ParentOnlyInvalidation);
 }
@@ -177,14 +177,14 @@ bool LegacyRenderSVGResourceClipper::applyClippingToContext(GraphicsContext& con
     AffineTransform animatedLocalTransform = clipPathElement().animatedLocalTransform();
 
     if (pathOnlyClipping(context, animatedLocalTransform, objectBoundingBox, effectiveZoom)) {
-        auto it = m_clipperMap.find(&renderer);
+        auto it = m_clipperMap.find(renderer);
         if (it != m_clipperMap.end())
             it->value->imageBuffer = nullptr;
 
         return true;
     }
 
-    auto& clipperData = *m_clipperMap.ensure(&renderer, [&]() {
+    auto& clipperData = *m_clipperMap.ensure(renderer, [&]() {
         return makeUnique<ClipperData>();
     }).iterator->value;
 
@@ -339,7 +339,7 @@ FloatRect LegacyRenderSVGResourceClipper::resourceBoundingBox(const RenderObject
 {
     // Resource was not layouted yet. Give back the boundingBox of the object.
     if (selfNeedsLayout()) {
-        m_clipperMap.ensure(&object, [&]() { // For selfNeedsClientInvalidation().
+        m_clipperMap.ensure(object, [&]() { // For selfNeedsClientInvalidation().
             return makeUnique<ClipperData>();
         });
         return object.objectBoundingBox();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
@@ -96,7 +96,7 @@ private:
     void calculateClipContentRepaintRect(RepaintRectCalculation);
 
     EnumeratedArray<RepaintRectCalculation, FloatRect, RepaintRectCalculation::Accurate> m_clipBoundaries;
-    HashMap<const RenderObject*, std::unique_ptr<ClipperData>> m_clipperMap;
+    HashMap<SingleThreadWeakRef<const RenderObject>, std::unique_ptr<ClipperData>> m_clipperMap;
 };
 
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h
@@ -78,13 +78,14 @@ public:
 
     RenderSVGResourceType resourceType() const override { return FilterResourceType; }
 
-    FloatRect drawingRegion(RenderObject*) const;
+    FloatRect drawingRegion(RenderObject&) const;
+
 private:
     void element() const = delete;
 
     ASCIILiteral renderName() const override { return "RenderSVGResourceFilter"_s; }
 
-    HashMap<RenderObject*, std::unique_ptr<FilterData>> m_rendererFilterDataMap;
+    HashMap<SingleThreadWeakRef<RenderObject>, std::unique_ptr<FilterData>> m_rendererFilterDataMap;
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, FilterData::FilterDataState);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
@@ -52,7 +52,7 @@ void LegacyRenderSVGResourceMasker::removeAllClientsFromCacheIfNeeded(bool markF
 
 void LegacyRenderSVGResourceMasker::removeClientFromCache(RenderElement& client, bool markForInvalidation)
 {
-    m_masker.remove(&client);
+    m_masker.remove(client);
 
     markClientForInvalidation(client, markForInvalidation ? BoundariesInvalidation : ParentOnlyInvalidation);
 }
@@ -62,11 +62,11 @@ bool LegacyRenderSVGResourceMasker::applyResource(RenderElement& renderer, const
     ASSERT(context);
     ASSERT_UNUSED(resourceMode, !resourceMode);
 
-    bool missingMaskerData = !m_masker.contains(&renderer);
+    bool missingMaskerData = !m_masker.contains(renderer);
     if (missingMaskerData)
-        m_masker.set(&renderer, makeUnique<MaskerData>());
+        m_masker.set(renderer, makeUnique<MaskerData>());
 
-    MaskerData* maskerData = m_masker.get(&renderer);
+    MaskerData* maskerData = m_masker.get(renderer);
     AffineTransform absoluteTransform = SVGRenderingContext::calculateTransformationToOutermostCoordinateSystem(renderer);
     FloatRect repaintRect = renderer.repaintRectInLocalCoordinates();
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h
@@ -66,7 +66,7 @@ private:
     void calculateMaskContentRepaintRect(RepaintRectCalculation);
 
     EnumeratedArray<RepaintRectCalculation, FloatRect, RepaintRectCalculation::Accurate> m_maskContentBoundaries;
-    HashMap<RenderObject*, std::unique_ptr<MaskerData>> m_masker;
+    HashMap<SingleThreadWeakRef<RenderObject>, std::unique_ptr<MaskerData>> m_masker;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
@@ -57,7 +57,7 @@ void LegacyRenderSVGResourcePattern::removeAllClientsFromCacheIfNeeded(bool mark
 
 void LegacyRenderSVGResourcePattern::removeClientFromCache(RenderElement& client, bool markForInvalidation)
 {
-    m_patternMap.remove(&client);
+    m_patternMap.remove(client);
     markClientForInvalidation(client, markForInvalidation ? RepaintInvalidation : ParentOnlyInvalidation);
 }
 
@@ -79,7 +79,7 @@ PatternData* LegacyRenderSVGResourcePattern::buildPattern(RenderElement& rendere
 {
     ASSERT(!m_shouldCollectPatternAttributes);
 
-    PatternData* currentData = m_patternMap.get(&renderer);
+    PatternData* currentData = m_patternMap.get(renderer);
     if (currentData && currentData->pattern)
         return currentData;
 
@@ -134,7 +134,7 @@ PatternData* LegacyRenderSVGResourcePattern::buildPattern(RenderElement& rendere
     // Various calls above may trigger invalidations in some fringe cases (ImageBuffer allocation
     // failures in the SVG image cache for example). To avoid having our PatternData deleted by
     // removeAllClientsFromCache(), we only make it visible in the cache at the very end.
-    return m_patternMap.set(&renderer, WTFMove(patternData)).iterator->value.get();
+    return m_patternMap.set(renderer, WTFMove(patternData)).iterator->value.get();
 }
 
 bool LegacyRenderSVGResourcePattern::applyResource(RenderElement& renderer, const RenderStyle& style, GraphicsContext*& context, OptionSet<RenderSVGResourceMode> resourceMode)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
@@ -67,7 +67,7 @@ private:
     PatternData* buildPattern(RenderElement&, OptionSet<RenderSVGResourceMode>, GraphicsContext&);
 
     PatternAttributes m_attributes;
-    HashMap<RenderElement*, std::unique_ptr<PatternData>> m_patternMap;
+    HashMap<SingleThreadWeakRef<RenderElement>, std::unique_ptr<PatternData>> m_patternMap;
     bool m_shouldCollectPatternAttributes { true };
 };
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
@@ -300,7 +300,7 @@ void RenderTreeBuilder::MultiColumn::multiColumnDescendantInserted(RenderMultiCo
             // where it would otherwise occur (if it weren't a spanner) to becoming a sibling of the
             // column sets.
             ASSERT(!flow.spannerMap().get(placeholder->spanner()));
-            flow.spannerMap().add(placeholder->spanner(), placeholder);
+            flow.spannerMap().add(*placeholder->spanner(), placeholder);
             ASSERT(!placeholder->firstChild()); // There should be no children here, but if there are, we ought to skip them.
         } else
             descendant = processPossibleSpannerDescendant(flow, subtreeRoot, *descendant);


### PR DESCRIPTION
#### bb14d7e986429bfcad6645ff2d8a6a0d91300b70
<pre>
Reduce use a raw pointers in containers in rendering code
<a href="https://bugs.webkit.org/show_bug.cgi?id=267792">https://bugs.webkit.org/show_bug.cgi?id=267792</a>

Reviewed by Darin Adler.

* Source/WebCore/rendering/LegacyRootInlineBox.cpp:
(WebCore::LegacyRootInlineBox::verticalPositionForBox):
* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
(WebCore::RenderFragmentedFlow::setFragmentRangeForBox):
* Source/WebCore/rendering/RenderFragmentedFlow.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::gridAreaBreadthForOutOfFlowChild):
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::adjustOverflowScrollbarContainerLayers):
* Source/WebCore/rendering/RenderMultiColumnFlow.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::rareData const):
(WebCore::RenderObject::ensureRareData):
(WebCore::RenderObject::removeRareData):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::updateColumnCache const):
* Source/WebCore/rendering/RenderTable.h:
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::willBeRemovedFromTree):
* Source/WebCore/rendering/RenderTableSection.h:
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::originalTextMap):
(WebCore::inlineWrapperForDisplayContentsMap):
(WebCore::RenderText::setRenderedText):
(WebCore::RenderText::momentarilyRevealLastTypedCharacter):
(WebCore::RenderText::setInlineWrapperForDisplayContents):
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::widgetRendererMap):
(WebCore::WidgetHierarchyUpdatesSuspensionScope::moveWidgets):
(WebCore::RenderWidget::setWidget):
(): Deleted.
* Source/WebCore/rendering/RenderWidget.h:
* Source/WebCore/rendering/VerticalPositionCache.h:
(WebCore::VerticalPositionCache::get const):
(WebCore::VerticalPositionCache::set):
(WebCore::VerticalPositionCache::VerticalPositionCache): Deleted.
* Source/WebCore/rendering/line/LineLayoutState.h:
(WebCore::LineLayoutState::FloatList::append):
(WebCore::LineLayoutState::FloatList::floatWithRect const):
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.h:
* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
(WebCore::SVGRenderingContext::prepareToRenderSVGContent):
* Source/WebCore/rendering/svg/SVGResourcesCache.cpp:
(WebCore::SVGResourcesCache::addResourcesFromRenderer):
(WebCore::SVGResourcesCache::removeResourcesFromRenderer):
(WebCore::SVGResourcesCache::cachedResourcesForRenderer):
* Source/WebCore/rendering/svg/SVGResourcesCache.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::removeClientFromCache):
(WebCore::LegacyRenderSVGResourceClipper::applyClippingToContext):
(WebCore::LegacyRenderSVGResourceClipper::resourceBoundingBox):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp:
(WebCore::LegacyRenderSVGResourceFilter::removeClientFromCache):
(WebCore::LegacyRenderSVGResourceFilter::applyResource):
(WebCore::LegacyRenderSVGResourceFilter::postApplyResource):
(WebCore::LegacyRenderSVGResourceFilter::markFilterForRepaint):
(WebCore::LegacyRenderSVGResourceFilter::drawingRegion const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp:
(WebCore::LegacyRenderSVGResourceMasker::removeClientFromCache):
(WebCore::LegacyRenderSVGResourceMasker::applyResource):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp:
(WebCore::LegacyRenderSVGResourcePattern::removeClientFromCache):
(WebCore::LegacyRenderSVGResourcePattern::buildPattern):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp:
(WebCore::RenderTreeBuilder::MultiColumn::multiColumnDescendantInserted):

Canonical link: <a href="https://commits.webkit.org/273264@main">https://commits.webkit.org/273264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be594e3635f2b522c4c84ed4dda6a9161489bd8e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34905 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13759 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37619 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31507 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30445 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10198 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10263 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38873 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31510 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36290 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8278 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34268 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12183 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10909 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4489 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->