### PR TITLE
[UIAsyncTextInput] Update async text input integration after rdar://121227027

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12759,6 +12759,16 @@ static BOOL shouldUseMachineReadableCodeMenuFromImageAnalysisResult(CocoaImageAn
     [self changeSelectionWithTouchAt:point withSelectionTouch:touch baseIsStart:boundaryIsStart withFlags:flags];
 }
 
+- (void)updateSelectionWithExtentPoint:(CGPoint)point boundary:(UITextGranularity)granularity completionHandler:(void (^)(BOOL selectionEndIsMoving))completionHandler
+{
+    [self updateSelectionWithExtentPoint:point withBoundary:granularity completionHandler:completionHandler];
+}
+
+- (void)selectTextInGranularity:(UITextGranularity)granularity atPoint:(CGPoint)point completionHandler:(void (^)(void))completionHandler
+{
+    [self selectTextWithGranularity:granularity atPoint:point completionHandler:completionHandler];
+}
+
 - (void)moveSelectionAtBoundary:(UITextGranularity)granularity inStorageDirection:(UITextStorageDirection)direction completionHandler:(void (^)(void))completionHandler
 {
     [self moveSelectionAtBoundary:granularity inDirection:direction completionHandler:completionHandler];


### PR DESCRIPTION
#### 081e519da458e7220532b058a84e6667da5a7808
<pre>
[UIAsyncTextInput] Update async text input integration after <a href="https://rdar.apple.com/121227027">rdar://121227027</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=267795">https://bugs.webkit.org/show_bug.cgi?id=267795</a>
<a href="https://rdar.apple.com/121011826">rdar://121011826</a>

Reviewed by Aditya Keerthi.

Make some minor adjustments to async text input adoption, following the changes in <a href="https://rdar.apple.com/121227027">rdar://121227027</a>.

* Source/WebCore/platform/ios/WebEvent.mm:
(-[WebEvent initWithKeyEntry:]):

Use `-state` instead of `-type`, if available.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView updateSelectionWithExtentPoint:boundary:completionHandler:]):
(-[WKContentView selectTextInGranularity:atPoint:completionHandler:]):

These delegate method names have changed; maintain binary compatibility by implementing both the old
and new names.

Canonical link: <a href="https://commits.webkit.org/273253@main">https://commits.webkit.org/273253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/728015f73d48b6cc3ab8cd1b455eff3249fd6c0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37563 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31456 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10782 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31043 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10148 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38818 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31671 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31457 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36244 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10317 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34218 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12139 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7996 "Failed to compile WebKit") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10861 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4479 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11203 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->