### PR TITLE
Make `:-webkit-animating-full-screen-transition` an internal pseudo-class

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos-expected.txt
@@ -1,4 +1,5 @@
 
+PASS ":-internal-animating-full-screen-transition" should be an invalid selector
 PASS ":-internal-html-document" should be an invalid selector
 PASS "::-apple-attachment-controls-container" should be an invalid selector
 PASS "::-internal-loading-auto-fill-button" should be an invalid selector

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos.html
@@ -8,6 +8,7 @@
 <script src="../../support/parsing-testcommon.js"></script>
 <script>
 // Pseudo-classes
+test_invalid_selector(":-internal-animating-full-screen-transition");
 test_invalid_selector(":-internal-html-document");
 
 // Pseudo-elements

--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
@@ -86,7 +86,7 @@
     transform-origin: 0 0;
 }
 
-:host(:-webkit-animating-full-screen-transition) .media-controls {
+:host(:-internal-animating-full-screen-transition) .media-controls {
     display: none;
 }
 

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -42,12 +42,10 @@
             "conditional": "ENABLE(ATTACHMENT_ELEMENT)",
             "settings-flag": "DeprecatedGlobalSettings::attachmentElementEnabled"
         },
-        "-internal-html-document": {},
-        "-webkit-animating-full-screen-transition": {
-            "comment": "For UA stylesheet use.",
-            "conditional": "ENABLE(FULLSCREEN_API)",
-            "status": "non-standard"
+        "-internal-animating-full-screen-transition": {
+            "conditional": "ENABLE(FULLSCREEN_API)"
         },
+        "-internal-html-document": {},
         "-webkit-any": {
             "argument": "required",
             "comment": "Alias of :is() with different specificity rules.",

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1053,7 +1053,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
 #if ENABLE(FULLSCREEN_API)
         case CSSSelector::PseudoClass::Fullscreen:
             return matchesFullscreenPseudoClass(element);
-        case CSSSelector::PseudoClass::WebKitAnimatingFullScreenTransition:
+        case CSSSelector::PseudoClass::InternalAnimatingFullScreenTransition:
             return matchesFullScreenAnimatingFullScreenTransitionPseudoClass(element);
         case CSSSelector::PseudoClass::WebKitFullScreenAncestor:
             return matchesFullScreenAncestorPseudoClass(element);

--- a/Source/WebCore/css/process-css-pseudo-selectors.py
+++ b/Source/WebCore/css/process-css-pseudo-selectors.py
@@ -57,7 +57,7 @@ KNOWN_KEY_TYPES = {
 # - an `-internal-` prefix for things only meant to be styled in the user agent stylesheet
 # - an `-apple-` prefix only exposed to certain Apple clients (there is a settings-flag requirement for using this prefix)
 WEBKIT_PREFIX_COUNTS_DO_NOT_INCREASE = {
-    'pseudo-classes': 10,
+    'pseudo-classes': 9,
     'pseudo-elements': 59,
 }
 

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1125,7 +1125,7 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
     case CSSSelector::PseudoClass::WebKitFullScreenAncestor:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenAncestorPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClass::WebKitAnimatingFullScreenTransition:
+    case CSSSelector::PseudoClass::InternalAnimatingFullScreenTransition:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenAnimatingFullScreenTransitionPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -737,7 +737,7 @@ void FullscreenManager::setAnimatingFullscreen(bool flag)
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (m_fullscreenElement)
-        emplace(styleInvalidation, *m_fullscreenElement, { { CSSSelector::PseudoClass::WebKitAnimatingFullScreenTransition, flag } });
+        emplace(styleInvalidation, *m_fullscreenElement, { { CSSSelector::PseudoClass::InternalAnimatingFullScreenTransition, flag } });
     m_isAnimatingFullscreen = flag;
 }
 


### PR DESCRIPTION
#### 8ebf7a9fbf27d9583e19974ed70162cec97886de
<pre>
Make `:-webkit-animating-full-screen-transition` an internal pseudo-class
<a href="https://bugs.webkit.org/show_bug.cgi?id=267803">https://bugs.webkit.org/show_bug.cgi?id=267803</a>
<a href="https://rdar.apple.com/121302758">rdar://121302758</a>

Reviewed by Anne van Kesteren.

All the hits on Github seem to be either MDN docs or WebKit repository clones: <a href="https://github.com/search?q=-webkit-animating-full-screen-transition&amp">https://github.com/search?q=-webkit-animating-full-screen-transition&amp</a>;type=code&amp;p=1

It seems safe to try this and catch issues with live-on.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos.html:
* Source/WebCore/Modules/modern-media-controls/controls/media-controls.css:
(:host(:-internal-animating-full-screen-transition) .media-controls):
(:host(:-webkit-animating-full-screen-transition) .media-controls): Deleted.
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/process-css-pseudo-selectors.py:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::setAnimatingFullscreen):

Canonical link: <a href="https://commits.webkit.org/273259@main">https://commits.webkit.org/273259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8044a89cac9bdd7348676eeba1847ca4a11c0155

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/34886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36925 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37596 "Failed to checkout and rebase branch from PR 23009") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/36033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10816 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/37596 "Failed to checkout and rebase branch from PR 23009") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/35417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/11638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/37596 "Failed to checkout and rebase branch from PR 23009") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/31157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/38850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/31701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/31484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/38850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10345 "Failed to checkout and rebase branch from PR 23009") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/8255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/38850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/30800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/7998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/10889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4487 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->