### PR TITLE
[EME] Blocked encrypted samples are not enqueued after a CDM is attached to a SourceBuffer (affects netflix.com)

### DIFF
--- a/LayoutTests/http/tests/media/fairplay/fps-mse-attach-cdm-after-key-exchange-expected.txt
+++ b/LayoutTests/http/tests/media/fairplay/fps-mse-attach-cdm-after-key-exchange-expected.txt
@@ -1,0 +1,25 @@
+PROMISE: requestMediaKeySystemAccess resolved
+PROMISE: createMediaKeys resolved
+FETCH: resources/cert.der OK
+PROMISE: keys.setServerCertificate resolved
+Created mediaSource
+EVENT(sourceopen)
+-
+Appending Encrypted Video Header
+Created sourceBuffer
+FETCH: content/elementary-stream-video-header-keyid-2.m4v OK
+EVENT(encrypted)
+EVENT(message)
+PROMISE: licenseResponse resolved
+PROMISE: session.update() resolved
+EVENT(updateend)
+-
+Appending Encrypted Video Payload
+FETCH: content/elementary-stream-video-payload.m4v OK
+EVENT(updateend)
+RUN(video.play())
+PROMISE: setMediaKeys() resolved
+EVENT(playing)
+PROMISE: playing event dispatched
+END OF TEST
+

--- a/LayoutTests/http/tests/media/fairplay/fps-mse-attach-cdm-after-key-exchange.html
+++ b/LayoutTests/http/tests/media/fairplay/fps-mse-attach-cdm-after-key-exchange.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ SampleBufferContentKeySessionSupportEnabled=true ] -->
 <html>
 <head>
-    <title>fps-mse-play-while-not-in-dom</title>
+    <title>fps-mse-attach-cdm-after-key-exchange</title>
     <script src=../../../media-resources/video-test.js></script>
     <script src=support.js></script>
     <script src="eme2016.js"></script>
@@ -11,8 +11,8 @@
     });
 
     async function startTest() {
-        window.video = document.createElement('video');
-        let keys = await startEME({video: video, setMediaKeys: true, capabilities: [{
+        window.video = document.querySelector('video');
+        let keys = await startEME({video: video, setMediaKeys: false, capabilities: [{
             initDataTypes: ['sinf'],
             videoCapabilities: [{ contentType: 'video/mp4', robustness: '' }],
             distinctiveIdentifier: 'not-allowed',
@@ -36,10 +36,17 @@
         await fetchAndAppend(sourceBuffer, 'content/elementary-stream-video-payload.m4v');
 
         run('video.play()');
-        await waitForEventWithTimeout(video, 'playing', 10000, 'Did not play in time');
+        let playingEvent = waitForEventWithTimeout(video, 'playing', 10000, 'Did not play in time');
+
+        await video.setMediaKeys(keys);
+        consoleWrite('PROMISE: setMediaKeys() resolved');
+
+        await playingEvent;
+        consoleWrite('PROMISE: playing event dispatched');
     }
     </script>
 </head>
 <body>
+    <video controls width="480"></video>
 </body>
 </html>

--- a/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-audio-only.html
+++ b/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-audio-only.html
@@ -12,7 +12,7 @@
 
     async function startTest() {
         window.audio = document.querySelector('audio');
-        let keys = await startEME({video: audio, capabilities: [{
+        let keys = await startEME({video: audio, setMediaKeys: true, capabilities: [{
             initDataTypes: ['sinf'],
             audioCapabilities: [{ contentType: 'audio/mp4', robustness: '' }],
             distinctiveIdentifier: 'not-allowed',
@@ -28,7 +28,7 @@
         consoleWrite('-');
         consoleWrite('Appending Encrypted Audio Header');
 
-        let {sourceBuffer: sourceBuffer, session: session} = await createBufferAppendAndWaitForEncrypted(audio, mediaSource, 'audio/mp4', 'content/elementary-stream-audio-header-keyid-1.m4a');
+        let {sourceBuffer: sourceBuffer, session: session} = await createBufferAppendAndWaitForEncrypted(audio, mediaSource, keys, 'audio/mp4', 'content/elementary-stream-audio-header-keyid-1.m4a');
 
         consoleWrite('-');
         consoleWrite('Appending Encrypted Audio Payload');

--- a/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-key-renewal.html
+++ b/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-key-renewal.html
@@ -12,7 +12,7 @@
 
     async function startTest() {
         let video = document.querySelector('video');
-        let keys = await startEME({video: video, capabilities: [{
+        let keys = await startEME({video: video, setMediaKeys: true, capabilities: [{
             initDataTypes: ['sinf'],
             audioCapabilities: [{ contentType: 'audio/mp4', robustness: '' }],
             videoCapabilities: [{ contentType: 'video/mp4', robustness: '' }],
@@ -30,7 +30,7 @@
         consoleWrite('Appending Encrypted Video Buffer 1');
 
         let {sourceBuffer: sourceBuffer1, session: session1} =
-            await createBufferAppendAndWaitForEncrypted(video, mediaSource, 'video/mp4', 'content/elementary-stream-video-header-keyid-2.m4v');
+            await createBufferAppendAndWaitForEncrypted(video, mediaSource, keys, 'video/mp4', 'content/elementary-stream-video-header-keyid-2.m4v');
 
         consoleWrite('-');
         consoleWrite('Appending Encrypted Video Payload');

--- a/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-key-rotation.html
+++ b/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-key-rotation.html
@@ -12,7 +12,7 @@
 
     async function startTest() {
         let video = document.querySelector('video');
-        let keys = await startEME({video: video, capabilities: [{
+        let keys = await startEME({video: video, setMediaKeys: true, capabilities: [{
             initDataTypes: ['sinf'],
             audioCapabilities: [{ contentType: 'audio/mp4', robustness: '' }],
             videoCapabilities: [{ contentType: 'video/mp4', robustness: '' }],
@@ -30,7 +30,7 @@
         consoleWrite('Appending Encrypted Video Buffer 1');
 
         let {sourceBuffer: sourceBuffer1, session: session1} =
-            await createBufferAppendAndWaitForEncrypted(video, mediaSource, 'video/mp4', 'content/elementary-stream-video-header-keyid-2.m4v');
+            await createBufferAppendAndWaitForEncrypted(video, mediaSource, keys, 'video/mp4', 'content/elementary-stream-video-header-keyid-2.m4v');
 
         consoleWrite('-');
         consoleWrite('Appending Encrypted Video Payload');
@@ -40,7 +40,7 @@
         consoleWrite('-');
         consoleWrite('Appending Encrypted Video Buffer 2');
 
-        session2 = await fetchAppendAndWaitForEncrypted(video, sourceBuffer1, 'content/elementary-stream-video-header-keyid-4.m4v');
+        session2 = await fetchAppendAndWaitForEncrypted(video, keys, sourceBuffer1, 'content/elementary-stream-video-header-keyid-4.m4v');
 
         consoleWrite('Setting timestampOffset = buffered.end()');
         sourceBuffer1.timestampOffset = sourceBuffer1.buffered.end(0);

--- a/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-multiple-keys.html
+++ b/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-multiple-keys.html
@@ -12,7 +12,7 @@
 
     async function startTest() {
         let video = document.querySelector('video');
-        let keys = await startEME({video: video, capabilities: [{
+        let keys = await startEME({video: video, setMediaKeys: true, capabilities: [{
             initDataTypes: ['sinf'],
             audioCapabilities: [{ contentType: 'audio/mp4', robustness: '' }],
             videoCapabilities: [{ contentType: 'video/mp4', robustness: '' }],
@@ -30,13 +30,13 @@
         consoleWrite('Appending Encrypted Audio Header');
 
         let {sourceBuffer: sourceBuffer1, session: session1} =
-            await createBufferAppendAndWaitForEncrypted(video, mediaSource, 'audio/mp4', 'content/elementary-stream-audio-header-keyid-1.m4a');
+            await createBufferAppendAndWaitForEncrypted(video, mediaSource, keys, 'audio/mp4', 'content/elementary-stream-audio-header-keyid-1.m4a');
 
         consoleWrite('-');
         consoleWrite('Appending Encrypted Video Header');
 
         let {sourceBuffer: sourceBuffer2, session: session2} =
-            await createBufferAppendAndWaitForEncrypted(video, mediaSource, 'video/mp4', 'content/elementary-stream-video-header-keyid-2.m4v');
+            await createBufferAppendAndWaitForEncrypted(video, mediaSource, keys, 'video/mp4', 'content/elementary-stream-video-header-keyid-2.m4v');
 
         consoleWrite('-');
         consoleWrite('Appending Encrypted Audio Payload');

--- a/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-same-key.html
+++ b/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-same-key.html
@@ -12,7 +12,7 @@
 
     async function startTest() {
         let video = document.querySelector('video');
-        let keys = await startEME({video: video, capabilities: [{
+        let keys = await startEME({video: video, setMediaKeys: true, capabilities: [{
             initDataTypes: ['sinf'],
             audioCapabilities: [{ contentType: 'audio/mp4', robustness: '' }],
             videoCapabilities: [{ contentType: 'video/mp4', robustness: '' }],
@@ -29,7 +29,7 @@
         consoleWrite('-');
         consoleWrite('Appending Encrypted Audio Header');
 
-        let {sourceBuffer: sourceBuffer1, session: session1} = await createBufferAppendAndWaitForEncrypted(video, mediaSource, 'audio/mp4', 'content/elementary-stream-audio-header-keyid-1.m4a');
+        let {sourceBuffer: sourceBuffer1, session: session1} = await createBufferAppendAndWaitForEncrypted(video, mediaSource, keys, 'audio/mp4', 'content/elementary-stream-audio-header-keyid-1.m4a');
 
         consoleWrite('-');
         consoleWrite('Appending Encrypted Video Header');

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -95,6 +95,8 @@ imported/w3c/web-platform-tests/pointerevents [ Pass ]
 imported/w3c/web-platform-tests/speech-api [ Pass ]
 
 http/tests/media/fairplay [ Pass ]
+http/tests/media/fairplay/fps-mse-attach-cdm-after-key-exchange.html [ Skip ] # Requires SampleBufferContentKeySessionSupportEnabled
+
 media/track/track-description-cue.html [ Pass ]
 media/track/track-extended-descriptions.html [ Pass ]
 media/media-source/remoteplayback-from-source-element.html [ Pass ]

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6820,7 +6820,7 @@ void HTMLMediaElement::enterFullscreen(VideoFullscreenMode mode)
 
 #if ENABLE(FULLSCREEN_API) && ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)
 #if PLATFORM(IOS_FAMILY)
-    bool videoUsesElementFullscreen = document().settings().videoFullscreenRequiresElementFullscreen();
+    bool videoUsesElementFullscreen = document().settings().videoFullscreenRequiresElementFullscreen() && !document().settings().newThing();
 #else
     constexpr bool videoUsesElementFullscreen = true;
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -137,6 +137,7 @@ public:
 
     using KeyStatusesChangedObserver = Observer<void()>;
     void addKeyStatusesChangedObserver(const KeyStatusesChangedObserver&);
+    void removeKeyStatusesChangedObserver(const KeyStatusesChangedObserver&);
 
     void sessionKeyStatusesChanged(const CDMInstanceSessionFairPlayStreamingAVFObjC&);
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -706,7 +706,14 @@ bool CDMInstanceFairPlayStreamingAVFObjC::isAnyKeyUsable(const Keys& keys) const
 
 void CDMInstanceFairPlayStreamingAVFObjC::addKeyStatusesChangedObserver(const KeyStatusesChangedObserver& observer)
 {
+    ASSERT(!m_keyStatusChangedObservers.contains(observer));
     m_keyStatusChangedObservers.add(observer);
+}
+
+void CDMInstanceFairPlayStreamingAVFObjC::removeKeyStatusesChangedObserver(const KeyStatusesChangedObserver& observer)
+{
+    ASSERT(m_keyStatusChangedObservers.contains(observer));
+    m_keyStatusChangedObservers.remove(observer);
 }
 
 void CDMInstanceFairPlayStreamingAVFObjC::sessionKeyStatusesChanged(const CDMInstanceSessionFairPlayStreamingAVFObjC&)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -198,7 +198,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     bool trackIsBlocked(TrackID) const;
 
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
-    void keyStatusesChanged();
+    void tryToEnqueueBlockedSamples();
 #endif
 
     void setTrackChangeCallbacks(const InitializationSegment&, bool initialized);


### PR DESCRIPTION
#### d7336d4f5da69f80f35c36f8083e53d3c6217dda
<pre>
[EME] Blocked encrypted samples are not enqueued after a CDM is attached to a SourceBuffer (affects netflix.com)
<a href="https://bugs.webkit.org/show_bug.cgi?id=267804">https://bugs.webkit.org/show_bug.cgi?id=267804</a>
<a href="https://rdar.apple.com/120879185">rdar://120879185</a>

Reviewed by Jean-Yves Avenard and Jer Noble.

When SourceBuffer attempts to enqueue an encrypted sample before either a CDM is attached or a
usable key is present it adds the sample to a list of &quot;blocked&quot; samples. The intention was to later
enqueue these samples once a CDM was attached and usable keys were present, however this would
never occur for two reasons:

1. While SourceBufferPrivateAVFObjC had a key status observer that would enqueue blocked samples
when called, it was never added to the attached CDM and therefore never called.
2. Even if the observer were added, if key status resolved to a terminal state prior to the CDM
being attached then the observer would never be called.

These issues manifested in sporadic playback failures on netflix.com (and possibly other EME sites).

Addressed (1) by adding SourceBufferPrivateAVFObjC&apos;s key status observer to the attached CDM.
Addressed (2) by attempting to enqueue blocked samples immediately at CDM attachment time.

Added a layout test.

* LayoutTests/http/tests/media/fairplay/eme2016.js:
(async startEME):
(async fetchAppendAndWaitForEncrypted):
(async createBufferAppendAndWaitForEncrypted):
* LayoutTests/http/tests/media/fairplay/fps-mse-attach-cdm-after-key-exchange-expected.txt: Added.
* LayoutTests/http/tests/media/fairplay/fps-mse-attach-cdm-after-key-exchange.html: Copied from LayoutTests/http/tests/media/fairplay/fps-mse-play-while-not-in-dom.html.
* LayoutTests/http/tests/media/fairplay/fps-mse-play-while-not-in-dom.html:
* LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-audio-only.html:
* LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-key-renewal.html:
* LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-key-rotation.html:
* LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-multiple-keys.html:
* LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-same-key.html:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::enterFullscreen):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::addKeyStatusesChangedObserver):
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::removeKeyStatusesChangedObserver):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::SourceBufferPrivateAVFObjC):
(WebCore::SourceBufferPrivateAVFObjC::setCDMInstance):
(WebCore::SourceBufferPrivateAVFObjC::attemptToDecrypt):
(WebCore::SourceBufferPrivateAVFObjC::tryToEnqueueBlockedSamples):
(WebCore::SourceBufferPrivateAVFObjC::keyStatusesChanged): Renamed to tryToEnqueueBlockedSamples.

Canonical link: <a href="https://commits.webkit.org/273340@main">https://commits.webkit.org/273340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e78e706a1df280b2df62d9f4b44a57004cde0e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37849 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31688 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36250 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11083 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10394 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39096 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31931 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31733 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36463 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34454 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31057 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8045 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11097 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->