### PR TITLE
Remove `:-khtml-drag` pseudo-class alias

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos-expected.txt
@@ -1,6 +1,8 @@
 
 PASS ":-internal-animating-full-screen-transition" should be an invalid selector
 PASS ":-internal-html-document" should be an invalid selector
+PASS ":-khtml-drag" should be an invalid selector
+PASS ":-webkit-animating-full-screen-transition" should be an invalid selector
 PASS "::-apple-attachment-controls-container" should be an invalid selector
 PASS "::-internal-loading-auto-fill-button" should be an invalid selector
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos.html
@@ -10,6 +10,8 @@
 // Pseudo-classes
 test_invalid_selector(":-internal-animating-full-screen-transition");
 test_invalid_selector(":-internal-html-document");
+test_invalid_selector(":-khtml-drag");
+test_invalid_selector(":-webkit-animating-full-screen-transition");
 
 // Pseudo-elements
 test_invalid_selector("::-apple-attachment-controls-container");

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -64,9 +64,6 @@
             "status": "non-standard"
         },
         "-webkit-drag": {
-            "aliases": [
-                "-khtml-drag"
-            ],
             "comment": "Currently has no standard equivalent.",
             "status": "non-standard"
         },

--- a/Source/WebCore/css/process-css-pseudo-selectors.py
+++ b/Source/WebCore/css/process-css-pseudo-selectors.py
@@ -81,10 +81,6 @@ class InputValidator:
             if not name.startswith('-'):
                 return True
 
-            # FIXME: Remove this case with `:-khtml-drag` alias.
-            if name.startswith('-khtml-'):
-                return True
-
             return name.startswith('-apple-') or name.startswith('-internal-') or name.startswith('-webkit-')
 
         for pseudo_name, pseudo_data in input_data[pseudo_type].items():


### PR DESCRIPTION
#### 157eda4fb5e3aef864392c4da1f6958d8e89d458
<pre>
Remove `:-khtml-drag` pseudo-class alias
<a href="https://bugs.webkit.org/show_bug.cgi?id=267805">https://bugs.webkit.org/show_bug.cgi?id=267805</a>
<a href="https://rdar.apple.com/121303391">rdar://121303391</a>

Reviewed by Anne van Kesteren.

Chrome has unshipped this for a while, let&apos;s give it a try. Firefox has never shipped this.

A quick Github search for `:-khtml-drag` shows a small number of hits: <a href="https://github.com/search?q=%3A-khtml-drag&amp">https://github.com/search?q=%3A-khtml-drag&amp</a>;type=code

- Styling for dragging elements will change for the few sites that were using this.
- None of the hits are using `:-khtml-drag` in a selector list, which means this change wouldn&apos;t accidentally un-apply declarations for a different selector

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos.html:
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/process-css-pseudo-selectors.py:
(InputValidator.validate_fields.is_known_prefix):

Canonical link: <a href="https://commits.webkit.org/273261@main">https://commits.webkit.org/273261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7879cccea7b8de05fac4e6c3de0951aea888e2fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/36926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37597 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31487 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10817 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31070 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10174 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10245 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38851 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31703 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31486 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36268 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8256 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34246 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/30802 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7999 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10890 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11228 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->