### PR TITLE
Remove non-standard `KeyboardEvent.altGraphKey`

### DIFF
--- a/LayoutTests/fast/events/constructors/keyboard-event-constructor-expected.txt
+++ b/LayoutTests/fast/events/constructors/keyboard-event-constructor-expected.txt
@@ -106,7 +106,7 @@ PASS new KeyboardEvent('eventType', { shiftKey: false }).shiftKey is false
 PASS new KeyboardEvent('eventType', { shiftKey: true }).shiftKey is true
 PASS new KeyboardEvent('eventType', { metaKey: false }).metaKey is false
 PASS new KeyboardEvent('eventType', { metaKey: true }).metaKey is true
-PASS new KeyboardEvent('eventType', { modifierAltGraph: true }).getModifierState('AltGraph') is true
+PASS new KeyboardEvent('eventType', { modifierAltGraph: true }).getModifierState('AltGraph') is false
 PASS new KeyboardEvent('eventType', { modifierCapsLock: true }).getModifierState('CapsLock') is true
 PASS new KeyboardEvent('eventType', { bubbles: true, cancelable: true, view: window, detail: 111, key: 'a', code: 'KeyA', keyIdentifier: 'chocolate', location: 222, ctrlKey: true, altKey: true, shiftKey: true, metaKey: true }).bubbles is true
 PASS new KeyboardEvent('eventType', { bubbles: true, cancelable: true, view: window, detail: 111, key: 'a', code: 'KeyA', keyIdentifier: 'chocolate', location: 222, ctrlKey: true, altKey: true, shiftKey: true, metaKey: true }).cancelable is true

--- a/LayoutTests/fast/events/constructors/keyboard-event-constructor.html
+++ b/LayoutTests/fast/events/constructors/keyboard-event-constructor.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -121,7 +121,7 @@ shouldBe("new KeyboardEvent('eventType', { location: KeyboardEvent.DOM_KEY_LOCAT
     shouldBe("new KeyboardEvent('eventType', { " + attr + ": true })." + attr, "true");
 });
 
-shouldBeTrue("new KeyboardEvent('eventType', { modifierAltGraph: true }).getModifierState('AltGraph')");
+shouldBeFalse("new KeyboardEvent('eventType', { modifierAltGraph: true }).getModifierState('AltGraph')");
 shouldBeTrue("new KeyboardEvent('eventType', { modifierCapsLock: true }).getModifierState('CapsLock')");
 
 // All initializers are passed.
@@ -138,6 +138,5 @@ shouldBe("new KeyboardEvent('eventType', { bubbles: true, cancelable: true, view
 shouldBe("new KeyboardEvent('eventType', { bubbles: true, cancelable: true, view: window, detail: 111, key: 'a', code: 'KeyA', keyIdentifier: 'chocolate', location: 222, ctrlKey: true, altKey: true, shiftKey: true, metaKey: true }).shiftKey", "true");
 shouldBe("new KeyboardEvent('eventType', { bubbles: true, cancelable: true, view: window, detail: 111, key: 'a', code: 'KeyA', keyIdentifier: 'chocolate', location: 222, ctrlKey: true, altKey: true, shiftKey: true, metaKey: true }).metaKey", "true");
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/events/constructors/keyboard-event-getModifierState-expected.txt
+++ b/LayoutTests/fast/events/constructors/keyboard-event-getModifierState-expected.txt
@@ -37,7 +37,7 @@ PASS event.getModifierState('Control') is false
 PASS event.getModifierState('Alt') is false
 PASS event.getModifierState('Shift') is false
 PASS event.getModifierState('Meta') is false
-PASS event.getModifierState('AltGraph') is true
+PASS event.getModifierState('AltGraph') is false
 PASS event.getModifierState('CapsLock') is false
 PASS event.getModifierState('Control') is false
 PASS event.getModifierState('Alt') is false
@@ -49,7 +49,7 @@ PASS event.getModifierState('Control') is true
 PASS event.getModifierState('Alt') is true
 PASS event.getModifierState('Shift') is true
 PASS event.getModifierState('Meta') is true
-PASS event.getModifierState('AltGraph') is true
+PASS event.getModifierState('AltGraph') is false
 PASS event.getModifierState('CapsLock') is true
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/events/constructors/keyboard-event-getModifierState.html
+++ b/LayoutTests/fast/events/constructors/keyboard-event-getModifierState.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -53,7 +53,7 @@ shouldBeFalse("event.getModifierState('Control')");
 shouldBeFalse("event.getModifierState('Alt')");
 shouldBeFalse("event.getModifierState('Shift')");
 shouldBeFalse("event.getModifierState('Meta')");
-shouldBeTrue("event.getModifierState('AltGraph')");
+shouldBeFalse("event.getModifierState('AltGraph')");
 shouldBeFalse("event.getModifierState('CapsLock')");
 
 var event = new KeyboardEvent('keydown', { modifierCapsLock: true });
@@ -69,9 +69,8 @@ shouldBeTrue("event.getModifierState('Control')");
 shouldBeTrue("event.getModifierState('Alt')");
 shouldBeTrue("event.getModifierState('Shift')");
 shouldBeTrue("event.getModifierState('Meta')");
-shouldBeTrue("event.getModifierState('AltGraph')");
+shouldBeFalse("event.getModifierState('AltGraph')");
 shouldBeTrue("event.getModifierState('CapsLock')");
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/events/constructors/mouse-event-getModifierState-expected.txt
+++ b/LayoutTests/fast/events/constructors/mouse-event-getModifierState-expected.txt
@@ -37,7 +37,7 @@ PASS event.getModifierState('Control') is false
 PASS event.getModifierState('Alt') is false
 PASS event.getModifierState('Shift') is false
 PASS event.getModifierState('Meta') is false
-PASS event.getModifierState('AltGraph') is true
+PASS event.getModifierState('AltGraph') is false
 PASS event.getModifierState('CapsLock') is false
 PASS event.getModifierState('Control') is false
 PASS event.getModifierState('Alt') is false
@@ -49,7 +49,7 @@ PASS event.getModifierState('Control') is true
 PASS event.getModifierState('Alt') is true
 PASS event.getModifierState('Shift') is true
 PASS event.getModifierState('Meta') is true
-PASS event.getModifierState('AltGraph') is true
+PASS event.getModifierState('AltGraph') is false
 PASS event.getModifierState('CapsLock') is true
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/events/constructors/mouse-event-getModifierState.html
+++ b/LayoutTests/fast/events/constructors/mouse-event-getModifierState.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -53,7 +53,7 @@ shouldBeFalse("event.getModifierState('Control')");
 shouldBeFalse("event.getModifierState('Alt')");
 shouldBeFalse("event.getModifierState('Shift')");
 shouldBeFalse("event.getModifierState('Meta')");
-shouldBeTrue("event.getModifierState('AltGraph')");
+shouldBeFalse("event.getModifierState('AltGraph')");
 shouldBeFalse("event.getModifierState('CapsLock')");
 
 var event = new MouseEvent('mousedown', { modifierCapsLock: true });
@@ -69,9 +69,8 @@ shouldBeTrue("event.getModifierState('Control')");
 shouldBeTrue("event.getModifierState('Alt')");
 shouldBeTrue("event.getModifierState('Shift')");
 shouldBeTrue("event.getModifierState('Meta')");
-shouldBeTrue("event.getModifierState('AltGraph')");
+shouldBeFalse("event.getModifierState('AltGraph')");
 shouldBeTrue("event.getModifierState('CapsLock')");
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/events/init-event-clears-capslock-expected.txt
+++ b/LayoutTests/fast/events/init-event-clears-capslock-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 keyEvent = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, view: window, detail: 0, key: 'a', code: 'KeyA',
-    ctrlKey: true, altKey: true, shiftKey: true, metaKey: true, modifierAltGraph: true, modifierCapsLock: true });
+ctrlKey: true, altKey: true, shiftKey: true, metaKey: true, modifierAltGraph: true, modifierCapsLock: true });
 PASS keyEvent.ctrlKey is true
 PASS keyEvent.shiftKey is true
 PASS keyEvent.altKey is true
@@ -13,7 +13,7 @@ PASS keyEvent.getModifierState("Control") is true
 PASS keyEvent.getModifierState("Shift") is true
 PASS keyEvent.getModifierState("Alt") is true
 PASS keyEvent.getModifierState("Meta") is true
-PASS keyEvent.getModifierState("AltGraph") is true
+PASS keyEvent.getModifierState("AltGraph") is false
 PASS keyEvent.getModifierState("CapsLock") is true
 keyEvent.initKeyboardEvent('keydown', false, false, window, 'U+0041', 0, /* ctrl */ false, /* alt */ false, /* shift */ false, /* meta */ false, /* altGraph */ false)
 PASS keyEvent.ctrlKey is false
@@ -35,10 +35,10 @@ PASS keyEvent.getModifierState("Control") is true
 PASS keyEvent.getModifierState("Shift") is true
 PASS keyEvent.getModifierState("Alt") is true
 PASS keyEvent.getModifierState("Meta") is true
-PASS keyEvent.getModifierState("AltGraph") is true
+PASS keyEvent.getModifierState("AltGraph") is false
 PASS keyEvent.getModifierState("CapsLock") is false
 mouseEvent = new MouseEvent('mousedown', { bubbles: true, cancelable: true, view: window, detail: 0, key: 'a', code: 'KeyA',
-    ctrlKey: true, altKey: true, shiftKey: true, metaKey: true, modifierAltGraph: true, modifierCapsLock: true });
+ctrlKey: true, altKey: true, shiftKey: true, metaKey: true, modifierAltGraph: true, modifierCapsLock: true });
 PASS mouseEvent.ctrlKey is true
 PASS mouseEvent.shiftKey is true
 PASS mouseEvent.altKey is true
@@ -47,7 +47,7 @@ PASS mouseEvent.getModifierState("Control") is true
 PASS mouseEvent.getModifierState("Shift") is true
 PASS mouseEvent.getModifierState("Alt") is true
 PASS mouseEvent.getModifierState("Meta") is true
-PASS mouseEvent.getModifierState("AltGraph") is true
+PASS mouseEvent.getModifierState("AltGraph") is false
 PASS mouseEvent.getModifierState("CapsLock") is true
 mouseEvent.initMouseEvent('mousedown', false, false, window, 0, 0, 0, 0, 0, /* ctrl */ false, /* alt */ false, /* shift */ false, /* meta */ false)
 PASS mouseEvent.ctrlKey is false

--- a/LayoutTests/fast/events/init-event-clears-capslock.html
+++ b/LayoutTests/fast/events/init-event-clears-capslock.html
@@ -7,7 +7,7 @@
 description(`This tests invoking initKeyboardEvent after setting CapsLock state to true via KeyboardEvent's constructor.`);
 
 evalAndLog(`keyEvent = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, view: window, detail: 0, key: 'a', code: 'KeyA',
-    ctrlKey: true, altKey: true, shiftKey: true, metaKey: true, modifierAltGraph: true, modifierCapsLock: true });`);
+ctrlKey: true, altKey: true, shiftKey: true, metaKey: true, modifierAltGraph: true, modifierCapsLock: true });`);
 shouldBeTrue('keyEvent.ctrlKey');
 shouldBeTrue('keyEvent.shiftKey');
 shouldBeTrue('keyEvent.altKey');
@@ -16,7 +16,7 @@ shouldBeTrue('keyEvent.getModifierState("Control")');
 shouldBeTrue('keyEvent.getModifierState("Shift")');
 shouldBeTrue('keyEvent.getModifierState("Alt")');
 shouldBeTrue('keyEvent.getModifierState("Meta")');
-shouldBeTrue('keyEvent.getModifierState("AltGraph")');
+shouldBeFalse('keyEvent.getModifierState("AltGraph")');
 shouldBeTrue('keyEvent.getModifierState("CapsLock")');
 
 evalAndLog(`keyEvent.initKeyboardEvent('keydown', false, false, window, 'U+0041', 0, /* ctrl */ false, /* alt */ false, /* shift */ false, /* meta */ false, /* altGraph */ false)`);
@@ -40,11 +40,11 @@ shouldBeTrue('keyEvent.getModifierState("Control")');
 shouldBeTrue('keyEvent.getModifierState("Shift")');
 shouldBeTrue('keyEvent.getModifierState("Alt")');
 shouldBeTrue('keyEvent.getModifierState("Meta")');
-shouldBeTrue('keyEvent.getModifierState("AltGraph")');
+shouldBeFalse('keyEvent.getModifierState("AltGraph")');
 shouldBeFalse('keyEvent.getModifierState("CapsLock")');
 
 evalAndLog(`mouseEvent = new MouseEvent('mousedown', { bubbles: true, cancelable: true, view: window, detail: 0, key: 'a', code: 'KeyA',
-    ctrlKey: true, altKey: true, shiftKey: true, metaKey: true, modifierAltGraph: true, modifierCapsLock: true });`);
+ctrlKey: true, altKey: true, shiftKey: true, metaKey: true, modifierAltGraph: true, modifierCapsLock: true });`);
 shouldBeTrue('mouseEvent.ctrlKey');
 shouldBeTrue('mouseEvent.shiftKey');
 shouldBeTrue('mouseEvent.altKey');
@@ -53,7 +53,7 @@ shouldBeTrue('mouseEvent.getModifierState("Control")');
 shouldBeTrue('mouseEvent.getModifierState("Shift")');
 shouldBeTrue('mouseEvent.getModifierState("Alt")');
 shouldBeTrue('mouseEvent.getModifierState("Meta")');
-shouldBeTrue('mouseEvent.getModifierState("AltGraph")');
+shouldBeFalse('mouseEvent.getModifierState("AltGraph")');
 shouldBeTrue('mouseEvent.getModifierState("CapsLock")');
 
 evalAndLog(`mouseEvent.initMouseEvent('mousedown', false, false, window, 0, 0, 0, 0, 0, /* ctrl */ false, /* alt */ false, /* shift */ false, /* meta */ false)`);

--- a/LayoutTests/fast/events/init-events-expected.txt
+++ b/LayoutTests/fast/events/init-events-expected.txt
@@ -28,8 +28,6 @@ PASS testInitEvent('Keyboard', '"a", false, true, window, "b", 1001, false, fals
 PASS testInitEvent('Keyboard', '"a", false, true, window, "b", 1001, false, false, true, false, false').shiftKey is true
 PASS testInitEvent('Keyboard', '"a", false, true, window, "b", 1001, false, false, false, false, false').metaKey is false
 PASS testInitEvent('Keyboard', '"a", false, true, window, "b", 1001, false, false, false, true, false').metaKey is true
-PASS testInitEvent('Keyboard', '"a", false, true, window, "b", 1001, false, false, false, false, false').altGraphKey is false
-PASS testInitEvent('Keyboard', '"a", false, true, window, "b", 1001, false, false, false, false, true').altGraphKey is true
 PASS testInitEvent('Keyboard', '"a", false, true, window, "b", 1001, false, false, false, false, true').detail is 0
 PASS testInitEvent('Keyboard', '"a", false, true, window, "b", 1001, false, false, false, false, false').keyCode is 0
 PASS testInitEvent('Keyboard', '"a", false, true, window, "b", 1001, false, false, false, false, false').charCode is 0

--- a/LayoutTests/fast/events/init-events.html
+++ b/LayoutTests/fast/events/init-events.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>
@@ -51,8 +51,6 @@ shouldBe("testInitEvent('Keyboard', '\"a\", false, true, window, \"b\", 1001, fa
 shouldBe("testInitEvent('Keyboard', '\"a\", false, true, window, \"b\", 1001, false, false, true, false, false').shiftKey", "true");
 shouldBe("testInitEvent('Keyboard', '\"a\", false, true, window, \"b\", 1001, false, false, false, false, false').metaKey", "false");
 shouldBe("testInitEvent('Keyboard', '\"a\", false, true, window, \"b\", 1001, false, false, false, true, false').metaKey", "true");
-shouldBe("testInitEvent('Keyboard', '\"a\", false, true, window, \"b\", 1001, false, false, false, false, false').altGraphKey", "false");
-shouldBe("testInitEvent('Keyboard', '\"a\", false, true, window, \"b\", 1001, false, false, false, false, true').altGraphKey", "true");
 shouldBe("testInitEvent('Keyboard', '\"a\", false, true, window, \"b\", 1001, false, false, false, false, true').detail", "0");
 shouldBe("testInitEvent('Keyboard', '\"a\", false, true, window, \"b\", 1001, false, false, false, false, false').keyCode", "0");
 shouldBe("testInitEvent('Keyboard', '\"a\", false, true, window, \"b\", 1001, false, false, false, false, false').charCode", "0");
@@ -191,6 +189,5 @@ shouldBe("testInitEvent('UI', '\"a\", false, false, window, 1001').which", "0");
 
 // WheelEvent has no init function yet; roughly speaking, we are waiting for that part of DOM 3 to stabilize.
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/tabs-with-modifiers-expected.txt
+++ b/LayoutTests/fast/forms/tabs-with-modifiers-expected.txt
@@ -34,28 +34,4 @@ test tab case that should not advance focus
 resetting focus to middle input
 test tab case that should not advance focus
 - keydown event: b
-resetting focus to middle input
-test tab case that should not advance focus
-- keydown event: b
-resetting focus to middle input
-test tab case that should not advance focus
-- keydown event: b
-resetting focus to middle input
-test tab case that should not advance focus
-- keydown event: b
-resetting focus to middle input
-test tab case that should not advance focus
-- keydown event: b
-resetting focus to middle input
-test tab case that should not advance focus
-- keydown event: b
-resetting focus to middle input
-test tab case that should not advance focus
-- keydown event: b
-resetting focus to middle input
-test tab case that should not advance focus
-- keydown event: b
-resetting focus to middle input
-test tab case that should not advance focus
-- keydown event: b
 

--- a/LayoutTests/fast/forms/tabs-with-modifiers.html
+++ b/LayoutTests/fast/forms/tabs-with-modifiers.html
@@ -58,11 +58,11 @@ function addElements(parentElement)
     parentElement.appendChild(input);
 }
 
-function dispatchTab(element, shiftKey, metaKey, ctrlKey, altGraphKey)
+function dispatchTab(element, shiftKey, metaKey, ctrlKey)
 {
     var event = document.createEvent("KeyboardEvents");
     var tabKeyIdentifier = "U+0009";
-    event.initKeyboardEvent("keydown", true, true, document.defaultView, tabKeyIdentifier, 0, ctrlKey, false, shiftKey, metaKey, altGraphKey);
+    event.initKeyboardEvent("keydown", true, true, document.defaultView, tabKeyIdentifier, 0, ctrlKey, false, shiftKey, metaKey);
     element.dispatchEvent(event);
 }
 
@@ -80,13 +80,13 @@ for (i = 0; i < 2; ++i) {
     log("resetting focus to middle input\n");
     middleInput.focus();
     log("test tab case that should advance focus\n");
-    dispatchTab(middleInput, (i & 1) != 0, false, false, false);
+    dispatchTab(middleInput, (i & 1) != 0, false, false);
 }
-for (i = 2; i < 16; ++i) {
+for (i = 2; i < 8; ++i) {
     log("resetting focus to middle input\n");
     middleInput.focus();
     log("test tab case that should not advance focus\n");
-    dispatchTab(middleInput, (i & 1) != 0, (i & 2) != 0, (i & 4) != 0, (i & 8) != 0);
+    dispatchTab(middleInput, (i & 1) != 0, (i & 2) != 0, (i & 4) != 0);
 }
 
 </script>

--- a/Source/WebCore/dom/KeyboardEvent.cpp
+++ b/Source/WebCore/dom/KeyboardEvent.cpp
@@ -161,7 +161,7 @@ Ref<KeyboardEvent> KeyboardEvent::create(const AtomString& type, const Init& ini
 }
 
 void KeyboardEvent::initKeyboardEvent(const AtomString& type, bool canBubble, bool cancelable, RefPtr<WindowProxy>&& view,
-    const AtomString& keyIdentifier, unsigned location, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, bool altGraphKey)
+    const AtomString& keyIdentifier, unsigned location, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey)
 {
     if (isBeingDispatched())
         return;
@@ -171,7 +171,7 @@ void KeyboardEvent::initKeyboardEvent(const AtomString& type, bool canBubble, bo
     m_keyIdentifier = keyIdentifier;
     m_location = location;
 
-    setModifierKeys(ctrlKey, altKey, shiftKey, metaKey, altGraphKey);
+    setModifierKeys(ctrlKey, altKey, shiftKey, metaKey);
 
     m_charCode = std::nullopt;
     m_isComposing = false;

--- a/Source/WebCore/dom/KeyboardEvent.h
+++ b/Source/WebCore/dom/KeyboardEvent.h
@@ -68,7 +68,7 @@ public:
     
     WEBCORE_EXPORT void initKeyboardEvent(const AtomString& type, bool canBubble, bool cancelable, RefPtr<WindowProxy>&&,
         const AtomString& keyIdentifier, unsigned location,
-        bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, bool altGraphKey = false);
+        bool ctrlKey, bool altKey, bool shiftKey, bool metaKey);
     
     const String& key() const { return m_key; }
     const String& code() const { return m_code; }

--- a/Source/WebCore/dom/KeyboardEvent.idl
+++ b/Source/WebCore/dom/KeyboardEvent.idl
@@ -45,7 +45,6 @@
     // Everything below is legacy.
     readonly attribute [AtomString] DOMString keyIdentifier;
     [ImplementedAs=location] readonly attribute unsigned long keyLocation;
-    readonly attribute boolean altGraphKey;
     readonly attribute unsigned long charCode;
     readonly attribute unsigned long keyCode;
     readonly attribute unsigned long which;
@@ -53,7 +52,7 @@
     // FIXME: this does not match the version in the DOM spec.
     undefined initKeyboardEvent([AtomString] DOMString type, optional boolean canBubble = false, optional boolean cancelable = false,
         optional WindowProxy? view = null, optional [AtomString] DOMString keyIdentifier = "undefined", optional unsigned long location = 0,
-        optional boolean ctrlKey = false, optional boolean altKey = false, optional boolean shiftKey = false, optional boolean metaKey = false, optional boolean altGraphKey = false);
+        optional boolean ctrlKey = false, optional boolean altKey = false, optional boolean shiftKey = false, optional boolean metaKey = false);
 };
 
 dictionary KeyboardEventInit : EventModifierInit {

--- a/Source/WebCore/dom/UIEventWithKeyState.cpp
+++ b/Source/WebCore/dom/UIEventWithKeyState.cpp
@@ -55,15 +55,13 @@ bool UIEventWithKeyState::getModifierState(const String& keyIdentifier) const
         return altKey();
     if (keyIdentifier == "Meta"_s)
         return metaKey();
-    if (keyIdentifier == "AltGraph"_s)
-        return altGraphKey();
     if (keyIdentifier == "CapsLock"_s)
         return capsLockKey();
     // FIXME: The specification also has Fn, FnLock, Hyper, NumLock, Super, ScrollLock, Symbol, SymbolLock.
     return false;
 }
 
-void UIEventWithKeyState::setModifierKeys(bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, bool altGraphKey)
+void UIEventWithKeyState::setModifierKeys(bool ctrlKey, bool altKey, bool shiftKey, bool metaKey)
 {
     OptionSet<Modifier> result;
     if (ctrlKey)
@@ -74,8 +72,6 @@ void UIEventWithKeyState::setModifierKeys(bool ctrlKey, bool altKey, bool shiftK
         result.add(Modifier::ShiftKey);
     if (metaKey)
         result.add(Modifier::MetaKey);
-    if (altGraphKey)
-        result.add(Modifier::AltGraphKey);
     m_modifiers = result;
 }
 

--- a/Source/WebCore/dom/UIEventWithKeyState.h
+++ b/Source/WebCore/dom/UIEventWithKeyState.h
@@ -38,7 +38,6 @@ public:
     bool shiftKey() const { return m_modifiers.contains(Modifier::ShiftKey); }
     bool altKey() const { return m_modifiers.contains(Modifier::AltKey); }
     bool metaKey() const { return m_modifiers.contains(Modifier::MetaKey); }
-    bool altGraphKey() const { return m_modifiers.contains(Modifier::AltGraphKey); }
     bool capsLockKey() const { return m_modifiers.contains(Modifier::CapsLockKey); }
 
     OptionSet<Modifier> modifierKeys() const { return m_modifiers; }
@@ -68,7 +67,7 @@ protected:
     {
     }
 
-    void setModifierKeys(bool ctrlKey, bool altKey, bool shiftKey, bool metaKey, bool altGraphKey = false);
+    void setModifierKeys(bool ctrlKey, bool altKey, bool shiftKey, bool metaKey);
 
 private:
     OptionSet<Modifier> m_modifiers;

--- a/Source/WebCore/html/HTMLSelectElementWin.cpp
+++ b/Source/WebCore/html/HTMLSelectElementWin.cpp
@@ -37,8 +37,8 @@ namespace WebCore {
 bool HTMLSelectElement::platformHandleKeydownEvent(KeyboardEvent* event)
 {
     // Allow (Shift) F4 and (Ctrl/Shift) Alt/AltGr + Up/Down arrow to pop the menu, matching Firefox.
-    bool eventShowsMenu = (!event->altKey() && !event->ctrlKey() && event->keyIdentifier() == "F4"_s)
-        || ((event->altGraphKey() || event->altKey()) && (event->keyIdentifier() == "Down"_s || event->keyIdentifier() == "Up"_s));
+    bool eventShowsMenu = ((!event->altKey() && !event->ctrlKey() && event->keyIdentifier() == "F4"_s)
+        || event->altKey()) && (event->keyIdentifier() == "Down"_s || event->keyIdentifier() == "Up"_s);
     if (!eventShowsMenu)
         return false;
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4485,7 +4485,7 @@ void EventHandler::defaultPageUpDownEventHandler(KeyboardEvent& event)
 #if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)
     ASSERT(event.type() == eventNames().keydownEvent);
 
-    if (event.ctrlKey() || event.metaKey() || event.altKey() || event.altGraphKey() || event.shiftKey())
+    if (event.ctrlKey() || event.metaKey() || event.altKey() || event.shiftKey())
         return;
 
     ScrollLogicalDirection direction = event.keyIdentifier() == "PageUp"_s ? ScrollBlockDirectionBackward : ScrollBlockDirectionForward;
@@ -4501,7 +4501,7 @@ void EventHandler::defaultHomeEndEventHandler(KeyboardEvent& event)
 #if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)
     ASSERT(event.type() == eventNames().keydownEvent);
 
-    if (event.ctrlKey() || event.metaKey() || event.altKey() || event.altGraphKey() || event.shiftKey())
+    if (event.ctrlKey() || event.metaKey() || event.altKey() || event.shiftKey())
         return;
 
     ScrollLogicalDirection direction = event.keyIdentifier() == "Home"_s ? ScrollBlockDirectionBackward : ScrollBlockDirectionForward;
@@ -4518,7 +4518,7 @@ void EventHandler::defaultSpaceEventHandler(KeyboardEvent& event)
 
     ASSERT(event.type() == eventNames().keypressEvent);
 
-    if (event.ctrlKey() || event.metaKey() || event.altKey() || event.altGraphKey())
+    if (event.ctrlKey() || event.metaKey() || event.altKey())
         return;
 
     ScrollLogicalDirection direction = event.shiftKey() ? ScrollBlockDirectionBackward : ScrollBlockDirectionForward;
@@ -4545,7 +4545,7 @@ void EventHandler::defaultBackspaceEventHandler(KeyboardEvent& event)
 {
     ASSERT(event.type() == eventNames().keydownEvent);
 
-    if (event.ctrlKey() || event.metaKey() || event.altKey() || event.altGraphKey())
+    if (event.ctrlKey() || event.metaKey() || event.altKey())
         return;
 
     if (!m_frame->editor().behavior().shouldNavigateBackOnBackspace())
@@ -4762,7 +4762,7 @@ void EventHandler::defaultArrowEventHandler(FocusDirection focusDirection, Keybo
         return;
     }
 
-    if (event.ctrlKey() || event.metaKey() || event.altGraphKey() || event.shiftKey())
+    if (event.ctrlKey() || event.metaKey() || event.shiftKey())
         return;
 
     RefPtr page = m_frame->page();
@@ -4785,7 +4785,7 @@ void EventHandler::defaultTabEventHandler(KeyboardEvent& event)
     ASSERT(event.type() == eventNames().keydownEvent);
 
     // We should only advance focus on tabs if no special modifier keys are held down.
-    if (event.ctrlKey() || event.metaKey() || event.altGraphKey())
+    if (event.ctrlKey() || event.metaKey())
         return;
 
     RefPtr page = frame->page();

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMKeyboardEvent.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMKeyboardEvent.cpp
@@ -203,7 +203,7 @@ void webkit_dom_keyboard_event_init_keyboard_event(WebKitDOMKeyboardEvent* self,
     WebCore::KeyboardEvent* item = WebKit::core(self);
     auto convertedType = WTF::AtomString::fromUTF8(type);
     auto convertedKeyIdentifier = WTF::AtomString::fromUTF8(keyIdentifier);
-    item->initKeyboardEvent(convertedType, canBubble, cancelable, WebKit::toWindowProxy(view), convertedKeyIdentifier, location, ctrlKey, altKey, shiftKey, metaKey, altGraphKey);
+    item->initKeyboardEvent(convertedType, canBubble, cancelable, WebKit::toWindowProxy(view), convertedKeyIdentifier, location, ctrlKey, altKey, shiftKey, metaKey);
 }
 
 gchar* webkit_dom_keyboard_event_get_key_identifier(WebKitDOMKeyboardEvent* self)
@@ -264,9 +264,7 @@ gboolean webkit_dom_keyboard_event_get_alt_graph_key(WebKitDOMKeyboardEvent* sel
 {
     WebCore::JSMainThreadNullState state;
     g_return_val_if_fail(WEBKIT_DOM_IS_KEYBOARD_EVENT(self), FALSE);
-    WebCore::KeyboardEvent* item = WebKit::core(self);
-    gboolean result = item->altGraphKey();
-    return result;
+    return FALSE;
 }
 
 G_GNUC_END_IGNORE_DEPRECATIONS;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
@@ -135,7 +135,7 @@ bool PDFPluginTextAnnotation::handleEvent(Event& event)
         auto& keyboardEvent = downcast<KeyboardEvent>(event);
 
         if (keyboardEvent.keyIdentifier() == "U+0009"_s) {
-            if (keyboardEvent.ctrlKey() || keyboardEvent.metaKey() || keyboardEvent.altGraphKey())
+            if (keyboardEvent.ctrlKey() || keyboardEvent.metaKey())
                 return false;
 
             if (keyboardEvent.shiftKey())

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3535,7 +3535,7 @@ bool WebPage::handleKeyEventByRelinquishingFocusToChrome(const KeyboardEvent& ev
     if (event.charCode() != '\t')
         return false;
 
-    if (!event.shiftKey() || event.ctrlKey() || event.metaKey() || event.altGraphKey())
+    if (!event.shiftKey() || event.ctrlKey() || event.metaKey())
         return false;
 
     ASSERT(event.type() == eventNames().keypressEvent);

--- a/Source/WebKitLegacy/mac/DOM/DOMKeyboardEvent.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMKeyboardEvent.mm
@@ -85,8 +85,7 @@
 
 - (BOOL)altGraphKey
 {
-    WebCore::JSMainThreadNullState state;
-    return IMPL->altGraphKey();
+    return false;
 }
 
 - (int)keyCode
@@ -110,7 +109,7 @@
 - (void)initKeyboardEvent:(NSString *)type canBubble:(BOOL)canBubble cancelable:(BOOL)cancelable view:(DOMAbstractView *)view keyIdentifier:(NSString *)inKeyIdentifier location:(unsigned)inLocation ctrlKey:(BOOL)inCtrlKey altKey:(BOOL)inAltKey shiftKey:(BOOL)inShiftKey metaKey:(BOOL)inMetaKey altGraphKey:(BOOL)inAltGraphKey
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->initKeyboardEvent(type, canBubble, cancelable, toWindowProxy(view), inKeyIdentifier, inLocation, inCtrlKey, inAltKey, inShiftKey, inMetaKey, inAltGraphKey);
+    IMPL->initKeyboardEvent(type, canBubble, cancelable, toWindowProxy(view), inKeyIdentifier, inLocation, inCtrlKey, inAltKey, inShiftKey, inMetaKey);
 }
 
 - (void)initKeyboardEvent:(NSString *)type canBubble:(BOOL)canBubble cancelable:(BOOL)cancelable view:(DOMAbstractView *)view keyIdentifier:(NSString *)inKeyIdentifier location:(unsigned)inLocation ctrlKey:(BOOL)inCtrlKey altKey:(BOOL)inAltKey shiftKey:(BOOL)inShiftKey metaKey:(BOOL)inMetaKey
@@ -122,7 +121,7 @@
 - (void)initKeyboardEvent:(NSString *)type canBubble:(BOOL)canBubble cancelable:(BOOL)cancelable view:(DOMAbstractView *)view keyIdentifier:(NSString *)inKeyIdentifier keyLocation:(unsigned)inKeyLocation ctrlKey:(BOOL)inCtrlKey altKey:(BOOL)inAltKey shiftKey:(BOOL)inShiftKey metaKey:(BOOL)inMetaKey altGraphKey:(BOOL)inAltGraphKey
 {
     WebCore::JSMainThreadNullState state;
-    IMPL->initKeyboardEvent(type, canBubble, cancelable, toWindowProxy(view), inKeyIdentifier, inKeyLocation, inCtrlKey, inAltKey, inShiftKey, inMetaKey, inAltGraphKey);
+    IMPL->initKeyboardEvent(type, canBubble, cancelable, toWindowProxy(view), inKeyIdentifier, inKeyLocation, inCtrlKey, inAltKey, inShiftKey, inMetaKey);
 }
 
 - (void)initKeyboardEvent:(NSString *)type canBubble:(BOOL)canBubble cancelable:(BOOL)cancelable view:(DOMAbstractView *)view keyIdentifier:(NSString *)inKeyIdentifier keyLocation:(unsigned)inKeyLocation ctrlKey:(BOOL)inCtrlKey altKey:(BOOL)inAltKey shiftKey:(BOOL)inShiftKey metaKey:(BOOL)inMetaKey


### PR DESCRIPTION
#### f1f9f0045afe3ae23d359d72658b600e4a623ac5
<pre>
Remove non-standard `KeyboardEvent.altGraphKey`

<a href="https://bugs.webkit.org/show_bug.cgi?id=248394">https://bugs.webkit.org/show_bug.cgi?id=248394</a>

Reviewed by Chris Dumez.

This pach aligns WebKit with Gecko / Firefox and Blink / Chromium
by removing non-standard KeyboardEvent.altGraphKey.

It is not in web-specification [1].

[1] <a href="https://www.w3.org/TR/uievents/">https://www.w3.org/TR/uievents/</a>

It was never shipped in Gecko / Firefox while removed in Blink
in 2014 and with commit [2]:

[2] <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=179545

&gt; Files modified:
* Source/WebCore/dom/KeyboardEvent.cpp:
(KeyboardEvent::initKeyboardEvent):
* Source/WebCore/dom/KeyboardEvent.h:
* Source/WebCore/dom/KeyboardEvent.idl:
* Source/WebCore/dom/UIEventWithKeyState.cpp:
(UIEventWithKeyState::getModifierState):
(UIEventWithKeyState::setModifierKeys):
* Source/WebCore/dom/UIEventWithKeyState.h:
* Source/WebCore/html/HTMLSelectElementWin.cpp:
(HTMLSelectElement::platformHandleKeydownEvent):
* Source/WebCore/page/EventHandler.cpp:
(EventHandler::defaultPageUpDownEventHandler):
(EventHandler::defaultHomeEndEventHandler):
(EventHandler::defaultArrowEventHandler():
(EventHandler::defaultTabEventHandler):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMKeyboardEvent.cpp:
(webkit_dom_keyboard_event_init_keyboard_event):
(webkit_dom_keyboard_event_get_alt_graph_key):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm:
(PDFPluginTextAnnotation::value):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebPage::handleKeyEventByRelinquishingFocusToChrome):
* Source/WebKitLegacy/mac/DOM/DOMKeyboardEvent.mm:
((BOOL)altGraphKey):
((void)initKeyboardEvent):

&gt; Tests Rebaselined / Updated:
* LayoutTests/fast/forms/tabs-with-modifiers.html:
* LayoutTests/fast/forms/tabs-with-modifiers-expected.txt:
* LayoutTests/fast/events/init-events.html:
* LayoutTests/fast/events/init-events-expected.txt:
* LayoutTests/fast/events/init-event-clears-capslock.html:
* LayoutTests/fast/events/init-event-clears-capslock-expected.txt:
* LayoutTests/fast/events/constructors/mouse-event-getModifierState.html:
* LayoutTests/fast/events/constructors/mouse-event-getModifierState-expected.txt:
* LayoutTests/fast/events/constructors/keyboard-event-getModifierState.html:
* LayoutTests/fast/events/constructors/keyboard-event-getModifierState-expected.txt:
* LayoutTests/fast/events/constructors/keyboard-event-constructor.html:
* LayoutTests/fast/events/constructors/keyboard-event-constructor-expected.txt:

Canonical link: <a href="https://commits.webkit.org/273379@main">https://commits.webkit.org/273379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95b52b574dfabc24ec3ff67d026a88c1961da68b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14210 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/37403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38028 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31832 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36437 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/16591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/11271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35821 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/16591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/37403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10533 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/16591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/37403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39274 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/16591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/37403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10725 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/11271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/34584 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/37403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8069 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11249 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->