### PR TITLE
Begin using C++ coroutines for WebPageProxy::decidePolicyForNavigationAction

### DIFF
--- a/Source/WebKit/Platform/CoroutineUtilities.h
+++ b/Source/WebKit/Platform/CoroutineUtilities.h
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/CompletionHandler.h>
+
+#if __has_include(<coroutine>)
+#include <coroutine>
+#else
+// FIXME: Remove this once all supported toolchains have non-experimental coroutine support.
+#include <experimental/coroutine>
+namespace std {
+using std::experimental::coroutine_handle;
+using std::experimental::suspend_never;
+using std::experimental::suspend_always;
+}
+#endif
+
+namespace WebKit {
+
+template<typename PromiseType>
+class CoroutineHandle {
+public:
+    CoroutineHandle() = default;
+    CoroutineHandle(std::coroutine_handle<PromiseType>&& handle)
+        : m_handle(std::exchange(handle, nullptr)) { }
+    CoroutineHandle(CoroutineHandle&& other)
+        : m_handle(std::exchange(other.m_handle, nullptr)) { }
+    CoroutineHandle& operator=(CoroutineHandle&& other)
+    {
+        m_handle = std::exchange(other.m_handle, nullptr);
+        return *this;
+    }
+    CoroutineHandle(const CoroutineHandle&) = delete;
+    CoroutineHandle& operator=(const CoroutineHandle&) = delete;
+    ~CoroutineHandle()
+    {
+        if (m_handle)
+            m_handle.destroy();
+    }
+
+    std::coroutine_handle<PromiseType> handle() const { return m_handle; }
+private:
+    std::coroutine_handle<PromiseType> m_handle;
+};
+
+// Name based on https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1056r1.html
+template<typename T>
+class Lazy {
+public:
+    class PromiseBase {
+    public:
+        struct final_awaitable {
+            bool await_ready() const noexcept { return false; }
+            template<typename Promise>
+            std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> coroutine) noexcept { return coroutine.promise().handle(); }
+            void await_resume() noexcept { }
+        };
+        std::suspend_always initial_suspend() { return { }; }
+        final_awaitable final_suspend() noexcept { return { }; }
+        template<typename Promise>
+        void unhandled_exception() { }
+        void setHandle(std::coroutine_handle<> handle) { m_handle = handle; }
+        std::coroutine_handle<> handle() { return m_handle; }
+    private:
+        std::coroutine_handle<> m_handle;
+    };
+    template<typename U>
+    class Promise final : public PromiseBase {
+    public:
+        Lazy<U> get_return_object() { return Lazy<U> { std::coroutine_handle<Promise>::from_promise(*this) }; }
+        void return_value(U&& value) { m_value = WTFMove(value); }
+        U result() && { return std::exchange(m_value, { }); }
+    private:
+        U m_value;
+    };
+    template<std::same_as<void> U>
+    class Promise<U> : public PromiseBase {
+    public:
+        Lazy<void> get_return_object() { return Lazy<void> { std::coroutine_handle<Promise>::from_promise(*this) }; }
+        void return_void() { }
+        void result() { }
+    };
+    using promise_type = Promise<T>;
+
+    class Awaitable {
+    public:
+        Awaitable(std::coroutine_handle<promise_type> coroutine)
+            : m_coroutine(coroutine) { }
+        bool await_ready() const { return m_coroutine.done(); }
+        std::coroutine_handle<> await_suspend(std::coroutine_handle<> handle)
+        {
+            m_coroutine.promise().setHandle(handle);
+            return m_coroutine;
+        }
+        T await_resume() { return WTFMove(this->m_coroutine.promise()).result(); }
+    private:
+        std::coroutine_handle<promise_type> m_coroutine;
+    };
+    Lazy(std::coroutine_handle<promise_type> coroutine)
+        : m_coroutine(std::exchange(coroutine, nullptr)) { }
+    Awaitable operator co_await() const { return { m_coroutine.handle() }; }
+private:
+    CoroutineHandle<promise_type> m_coroutine;
+};
+
+struct Task {
+    struct promise_type {
+        Task get_return_object() { return { std::coroutine_handle<promise_type>::from_promise(*this) }; }
+        std::suspend_never initial_suspend() { return { }; }
+        std::suspend_always final_suspend() noexcept { return { }; }
+        void unhandled_exception() { }
+        void return_void() { }
+    };
+    std::coroutine_handle<promise_type> handle;
+};
+
+class CoroutineCaller {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    CoroutineCaller() = default;
+    void setCoroutine(Function<Task()>&& coroutine)
+    {
+        m_coroutine = std::exchange(coroutine, { });
+        m_coroutine();
+    }
+private:
+    Function<Task()> m_coroutine;
+};
+
+static void callCoroutine(auto coroutine)
+{
+    CoroutineCaller* caller = new CoroutineCaller();
+    caller->setCoroutine([caller, coroutine = WTFMove(coroutine)] () mutable -> Task {
+        co_await coroutine();
+        delete caller;
+    });
+}
+
+template<typename T>
+class AwaitableTaskWithCompletionHandler {
+public:
+    using Task = CompletionHandler<void(CompletionHandler<void(T&&)>&&)>;
+    AwaitableTaskWithCompletionHandler(Task&& task)
+        : m_task(WTFMove(task)) { }
+    bool await_ready() { return !!m_result; }
+    void await_suspend(std::coroutine_handle<> handle)
+    {
+        m_task([this, handle] (T&& result) mutable {
+            m_result = WTFMove(result);
+            handle();
+        });
+    }
+    T await_resume() { return *std::exchange(m_result, { }); }
+private:
+    Task m_task;
+    std::optional<T> m_result;
+};
+
+}

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -115,6 +115,7 @@ extern ASCIILiteral errorAsString(Error);
 #define CONNECTION_STRINGIFY_MACRO(line) CONNECTION_STRINGIFY(line)
 
 #define MESSAGE_CHECK_BASE(assertion, connection) MESSAGE_CHECK_COMPLETION_BASE(assertion, connection, (void)0)
+#define MESSAGE_CHECK_BASE_COROUTINE(assertion, connection) MESSAGE_CHECK_COMPLETION_BASE_COROUTINE(assertion, connection, (void)0)
 
 #define MESSAGE_CHECK_COMPLETION_BASE(assertion, connection, completion) do { \
     if (UNLIKELY(!(assertion))) { \
@@ -122,6 +123,15 @@ extern ASCIILiteral errorAsString(Error);
         (connection)->markCurrentlyDispatchedMessageAsInvalid(); \
         { completion; } \
         return; \
+    } \
+} while (0)
+
+#define MESSAGE_CHECK_COMPLETION_BASE_COROUTINE(assertion, connection, completion) do { \
+    if (UNLIKELY(!(assertion))) { \
+        RELEASE_LOG_FAULT(IPC, __FILE__ " " CONNECTION_STRINGIFY_MACRO(__LINE__) ": Invalid message dispatched %s", WTF_PRETTY_FUNCTION); \
+        (connection)->markCurrentlyDispatchedMessageAsInvalid(); \
+        { completion; } \
+        co_return { }; \
     } \
 } while (0)
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -527,6 +527,9 @@ enum class SameDocumentNavigationType : uint8_t;
 enum class SelectionFlags : uint8_t;
 enum class SelectionTouch : uint8_t;
 enum class ShouldDelayClosingUntilFirstLayerFlush : bool;
+enum class ShouldExpectAppBoundDomainResult : bool;
+enum class ShouldExpectSafeBrowsingResult : bool;
+enum class ShouldWaitForInitialLinkDecorationFilteringData : bool;
 enum class SyntheticEditingCommandType : uint8_t;
 enum class TextRecognitionUpdateResult : uint8_t;
 enum class TextIndicatorStyle : uint8_t;
@@ -540,6 +543,7 @@ enum class WebTextReplacementDataState : uint8_t;
 enum class WebUnifiedTextReplacementSessionDataReplacementType : uint8_t;
 enum class WindowKind : uint8_t;
 
+template<typename> class Lazy;
 template<typename> class MonotonicObjectIdentifier;
 
 using ActivityStateChangeID = uint64_t;
@@ -2548,6 +2552,8 @@ private:
     void didDestroyNavigation(uint64_t navigationID);
 
     void decidePolicyForNavigationAction(Ref<WebProcessProxy>&&, WebFrameProxy&, NavigationActionData&&, CompletionHandler<void(PolicyDecision&&)>&&);
+    Lazy<PolicyDecision> awaitableDecidePolicyForNavigationAction(Ref<WebProcessProxy>&&, WebFrameProxy&, NavigationActionData&&);
+    void continueDecidePolicyForNavigationAction(Ref<API::NavigationAction>&&, WebFrameProxy&, Ref<WebProcessProxy>&&, RefPtr<API::Navigation>&&, FrameInfoData&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, WebCore::ResourceRequest&&, WebCore::ResourceRequest&& originalRequest, RefPtr<WebFrameProxy>&& originatingFrame, std::optional<PolicyDecisionConsoleMessage>&&, CompletionHandler<void(PolicyDecision&&)>&&);
     void decidePolicyForNavigationActionAsync(NavigationActionData&&, CompletionHandler<void(PolicyDecision&&)>&&);
     void decidePolicyForNavigationActionSync(IPC::Connection&, NavigationActionData&&, CompletionHandler<void(PolicyDecision&&)>&&);
     void decidePolicyForNewWindowAction(NavigationActionData&&, const String& frameName, CompletionHandler<void(PolicyDecision&&)>&&);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2571,6 +2571,7 @@
 		FAA4E3012A1575A5003F5E50 /* WebFrameLoaderClient.h in Headers */ = {isa = PBXBuildFile; fileRef = FAA4E2FF2A1575A4003F5E50 /* WebFrameLoaderClient.h */; };
 		FAB955FB2B75E43D0060829C /* CoreIPCNull.h in Headers */ = {isa = PBXBuildFile; fileRef = FAB955F92B75E43D0060829C /* CoreIPCNull.h */; };
 		FABBDEA12B85557500EFAFC4 /* CoreIPCNSURLCredential.mm in Sources */ = {isa = PBXBuildFile; fileRef = FABBDE9E2B85550100EFAFC4 /* CoreIPCNSURLCredential.mm */; };
+		FAD2A1EE2BF6D51000953297 /* CoroutineUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = FAD2A1ED2BF6D4FD00953297 /* CoroutineUtilities.h */; };
 		FEDBDCD61E68D20000A59F8F /* WebInspectorInterruptDispatcherMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEDBDCD41E68D19C00A59F8F /* WebInspectorInterruptDispatcherMessageReceiver.cpp */; };
 		FEDBDCD71E68D20500A59F8F /* WebInspectorInterruptDispatcherMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = FEDBDCD51E68D19C00A59F8F /* WebInspectorInterruptDispatcherMessages.h */; };
 		FEE43FD31E67B0180077D6D1 /* WebInspectorInterruptDispatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = FEE43FD11E67AFC60077D6D1 /* WebInspectorInterruptDispatcher.h */; };
@@ -8302,6 +8303,7 @@
 		FAC8499E2AA01B0C00D407EF /* WebTransportReceiveStreamSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebTransportReceiveStreamSource.h; path = Network/WebTransportReceiveStreamSource.h; sourceTree = "<group>"; };
 		FAC849A02AA01B7900D407EF /* NetworkTransportSendStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkTransportSendStream.cpp; sourceTree = "<group>"; };
 		FAC849A22AA01B7900D407EF /* NetworkTransportSendStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkTransportSendStream.h; sourceTree = "<group>"; };
+		FAD2A1ED2BF6D4FD00953297 /* CoroutineUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoroutineUtilities.h; sourceTree = "<group>"; };
 		FED3C1DA1B447AE800E0EB7F /* APISerializedScriptValueCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = APISerializedScriptValueCocoa.mm; sourceTree = "<group>"; };
 		FEDBDCD41E68D19C00A59F8F /* WebInspectorInterruptDispatcherMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebInspectorInterruptDispatcherMessageReceiver.cpp; sourceTree = "<group>"; };
 		FEDBDCD51E68D19C00A59F8F /* WebInspectorInterruptDispatcherMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebInspectorInterruptDispatcherMessages.h; sourceTree = "<group>"; };
@@ -14603,6 +14605,7 @@
 				1A7E814E1152D2240003695B /* mac */,
 				CE1A0BCA1A48E6C60054EF74 /* spi */,
 				51B15A7D138439B200321AD8 /* unix */,
+				FAD2A1ED2BF6D4FD00953297 /* CoroutineUtilities.h */,
 				ECA680D31E6904B500731D20 /* ExtraPrivateSymbolsForTAPI.h */,
 				ECBFC1DB1E6A4D66000300C7 /* ExtraPublicSymbolsForTAPI.h */,
 				51A7F2F4125BF8D4008AEB1D /* Logging.cpp */,
@@ -16208,6 +16211,7 @@
 				37C21CAE1E994C0C0029D5F9 /* CorePredictionSPI.h in Headers */,
 				1C62900D28EE2CD300C26B60 /* CoreSVGSPI.h in Headers */,
 				F43E893D2AEDBB9000097D2D /* CoreTelephonyUtilities.h in Headers */,
+				FAD2A1EE2BF6D51000953297 /* CoroutineUtilities.h in Headers */,
 				B878B615133428DC006888E9 /* CorrectionPanel.h in Headers */,
 				57597EBD218184900037F924 /* CtapAuthenticator.h in Headers */,
 				526C5722284ADCBC00E08955 /* CtapCcidDriver.h in Headers */,

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.h
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.h
@@ -35,6 +35,7 @@
 #if (_LIBCPP_VERSION >= 14000) && !defined(_LIBCPP_HAS_NO_CXX20_COROUTINES)
 #import <coroutine>
 #else
+// FIXME: Remove this once all supported toolchains have non-experimental coroutine support.
 #import <experimental/coroutine>
 namespace std {
 using std::experimental::coroutine_handle;


### PR DESCRIPTION
#### e90f899882e41a77d0baaa336e347b4e19da3f2f
<pre>
Begin using C++ coroutines for WebPageProxy::decidePolicyForNavigationAction
<a href="https://bugs.webkit.org/show_bug.cgi?id=267827">https://bugs.webkit.org/show_bug.cgi?id=267827</a>

Reviewed by Abrar Rahman Protyasha.

WebKit has a long history with C++ and asynchrony.  Deciding whether to proceed with
a navigation has always had the ability to be done asynchronously.  Before C++11, we
made our own object that contained state and context for a call to indicate continuation.
With <a href="https://commits.webkit.org/193766@main">https://commits.webkit.org/193766@main</a> we finished the transition from this object,
WebCore::PolicyCallback, to C++ lambdas.

Since then, a large and growing amount of our code has developed the ability to do things
asynchronously using WTF::CompletionHandler, a std::function-like object that contains
state and context to use when continuing.  Also since then, C++ has added coroutine support
in C++20, including the co_await keyword.  This has the potential to allow us to more elegantly
write code that does many things asynchronously.

WebPageProxy::decidePolicyForNavigationAction has a growing amount of complexity, with
deeply nested lambdas and many functions calling another function to continue the logic,
trying to break up the logic.  With site isolation, I&apos;ve needed to add many things to this
already complex area of the code, and more are needed still.  I&apos;ve had difficulty passing
parameters from one end of the flow to the other, through the many nested lambdas.  This
has led me to do introduce things like ProvisionalPageProxy&apos;s needsCookieAccessAddedInNetworkProcess,
where I set a bool early in the flow and query the bool much later in the flow.  This needs
a better solution.

In order to begin using C++ coroutines, we need a way to get into a coroutine from a function
with a CompletionHandler parameter, and we also need a way to get from a coroutine to a function
with a CompletionHandler parameter and await its result.  For these two operations, I introduce
CoroutineCaller and AwaitableTaskWithCompletionHandler.  Task is the object that an asynchronous
coroutine returns. Lazy&lt;T&gt; is what a coroutine returns for its resulting T to be awaitable,
analogous to a CompletionHandler&lt;void(T)&gt; which is called with the resulting T.

These primitives are used to make WebPageProxy::decidePolicyForNavigationAction an asynchronous
coroutine.  The introduction of this new technology in such a small scope makes it look like
most of the code is just the CoroutineCaller/AwaitableTaskWithCompletionHandler borders to call
to and from existing code, but as coroutine adoption increases we will see simpler and simpler
code, where we can easily and elegantly add new steps in the logic flow by just awaiting another
asynchronous step or calling a synchronous step directly.

* Source/WebKit/Platform/CoroutineUtilities.h: Added.
(WebKit::CoroutineHandle::CoroutineHandle):
(WebKit::CoroutineHandle::operator=):
(WebKit::CoroutineHandle::~CoroutineHandle):
(WebKit::CoroutineHandle::handle const):
(WebKit::Lazy::PromiseBase::initial_suspend):
(WebKit::Lazy::PromiseBase::unhandled_exception):
(WebKit::Lazy::PromiseBase::setHandle):
(WebKit::Lazy::PromiseBase::handle):
(WebKit::Lazy::Promise&lt;void&gt;::get_return_object):
(WebKit::Lazy::Promise&lt;void&gt;::return_void):
(WebKit::Lazy::Promise&lt;void&gt;::result):
(WebKit::Lazy::Awaitable::Awaitable):
(WebKit::Lazy::Awaitable::await_ready const):
(WebKit::Lazy::Awaitable::await_suspend):
(WebKit::Lazy::Awaitable::await_resume):
(WebKit::Lazy::Lazy):
(WebKit::Lazy::operator co_await const):
(WebKit::Task::promise_type::get_return_object):
(WebKit::Task::promise_type::initial_suspend):
(WebKit::Task::promise_type::unhandled_exception):
(WebKit::Task::promise_type::return_void):
(WebKit::CoroutineCaller::setCoroutine):
(WebKit::callCoroutine):
(WebKit::AwaitableTaskWithCompletionHandler::AwaitableTaskWithCompletionHandler):
(WebKit::AwaitableTaskWithCompletionHandler::await_ready):
(WebKit::AwaitableTaskWithCompletionHandler::await_suspend):
(WebKit::AwaitableTaskWithCompletionHandler::await_resume):
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::awaitableDecidePolicyForNavigationAction):
(WebKit::WebPageProxy::continueDecidePolicyForNavigationAction):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/278995@main">https://commits.webkit.org/278995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46de7108645db74c9a3ec8e02c5576dc3d0cc67a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52103 "20 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55376 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/2815 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54407 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/37864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42400 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1798 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23471 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26367 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2231 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/985 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56973 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2400 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49794 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28458 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49021 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29363 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7637 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28199 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->