### PR TITLE
Use CommonAtomStrings for common content types

### DIFF
--- a/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
@@ -123,7 +123,7 @@ void Clipboard::readText(Ref<DeferredPromise>&& promise)
 
     String text;
     for (size_t index = 0; index < allInfo->size(); ++index) {
-        if (allInfo->at(index).webSafeTypesByFidelity.contains("text/plain"_s)) {
+        if (allInfo->at(index).webSafeTypesByFidelity.contains(textPlainContentTypeAtom())) {
             PasteboardPlainText plainTextReader;
             pasteboard->read(plainTextReader, PlainTextURLReadingPolicy::IgnoreURL, index);
             text = WTFMove(plainTextReader.text);
@@ -147,7 +147,7 @@ void Clipboard::writeText(const String& data, Ref<DeferredPromise>&& promise)
     }
 
     PasteboardCustomData customData;
-    customData.writeString("text/plain"_s, data);
+    customData.writeString(textPlainContentTypeAtom(), data);
     customData.setOrigin(document->originIdentifierForPasteboard());
     Pasteboard::createForCopyAndPaste(PagePasteboardContext::create(frame->pageID()))->writeCustomData({ WTFMove(customData) });
     promise->resolve();
@@ -242,7 +242,7 @@ void Clipboard::getType(ClipboardItem& item, const String& type, Ref<DeferredPro
         resultAsString = WTFMove(plainTextReader.text);
     }
 
-    if (type == "text/html"_s) {
+    if (type == textHTMLContentTypeAtom()) {
         WebContentMarkupReader markupReader { *frame };
         activePasteboard().read(markupReader, WebContentReadingPolicy::OnlyRichTextTypes, itemIndex);
         resultAsString = markupReader.takeMarkup();

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
@@ -62,7 +62,7 @@ static RefPtr<Document> documentFromClipboard(const Clipboard* clipboard)
 
 static FileReaderLoader::ReadType readTypeForMIMEType(const String& type)
 {
-    if (type == "text/uri-list"_s || type == "text/plain"_s || type == "text/html"_s)
+    if (type == "text/uri-list"_s || type == textPlainContentTypeAtom() || type == textHTMLContentTypeAtom())
         return FileReaderLoader::ReadAsText;
     return FileReaderLoader::ReadAsArrayBuffer;
 }
@@ -303,7 +303,7 @@ void ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::sanitizeDataIfNee
         m_data = { page->applyLinkDecorationFiltering(urlStringToSanitize, LinkDecorationFilteringTrigger::Copy) };
     }
 
-    if (m_type == "text/html"_s) {
+    if (m_type == textHTMLContentTypeAtom()) {
         auto markupToSanitize = dataAsString();
         if (markupToSanitize.isEmpty())
             return;

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -128,12 +128,12 @@ static String normalizeType(const String& type)
         return type;
 
     auto lowercaseType = type.trim(isASCIIWhitespace).convertToASCIILowercase();
-    if (lowercaseType == "text"_s || lowercaseType.startsWith("text/plain;"_s))
+    if (lowercaseType == "text"_s || lowercaseType.startsWith(textPlainContentTypeAtom()))
         return textPlainContentTypeAtom();
     if (lowercaseType == "url"_s || lowercaseType.startsWith("text/uri-list;"_s))
         return "text/uri-list"_s;
     if (lowercaseType.startsWith("text/html;"_s))
-        return "text/html"_s;
+        return textHTMLContentTypeAtom();
 
     return lowercaseType;
 }
@@ -182,7 +182,7 @@ String DataTransfer::getDataForItem(Document& document, const String& type) cons
             });
         }
 
-        if (lowercaseType == "text/html"_s && DeprecatedGlobalSettings::customPasteboardDataEnabled()) {
+        if (lowercaseType == textHTMLContentTypeAtom() && DeprecatedGlobalSettings::customPasteboardDataEnabled()) {
             // If the pasteboard contains files and the page requests 'text/html', we only read from rich text types to prevent file
             // paths from leaking (e.g. from plain text data on the pasteboard) since we sanitize cross-origin markup. However, if
             // custom pasteboard data is disabled, then we can't ensure that the markup we deliver is sanitized, so we fall back to
@@ -211,7 +211,7 @@ String DataTransfer::readStringFromPasteboard(Document& document, const String& 
     if (!Pasteboard::isSafeTypeForDOMToReadAndWrite(lowercaseType))
         return { };
 
-    if (!is<StaticPasteboard>(*m_pasteboard) && lowercaseType == "text/html"_s) {
+    if (!is<StaticPasteboard>(*m_pasteboard) && lowercaseType == textHTMLContentTypeAtom()) {
         if (!document.frame())
             return { };
         WebContentMarkupReader reader { document.protectedFrame().releaseNonNull() };
@@ -357,8 +357,8 @@ Vector<String> DataTransfer::types(AddFilesType addFilesType) const
 
         if (safeTypes.contains("text/uri-list"_s))
             types.append("text/uri-list"_s);
-        if (safeTypes.contains("text/html"_s) && DeprecatedGlobalSettings::customPasteboardDataEnabled())
-            types.append("text/html"_s);
+        if (safeTypes.contains(textHTMLContentTypeAtom()) && DeprecatedGlobalSettings::customPasteboardDataEnabled())
+            types.append(textHTMLContentTypeAtom());
         return types;
     }
 
@@ -445,7 +445,7 @@ Ref<DataTransfer> DataTransfer::createForInputEvent(const String& plainText, con
 {
     auto pasteboard = makeUnique<StaticPasteboard>();
     pasteboard->writeString(textPlainContentTypeAtom(), plainText);
-    pasteboard->writeString("text/html"_s, htmlText);
+    pasteboard->writeString(textHTMLContentTypeAtom(), htmlText);
     return adoptRef(*new DataTransfer(StoreMode::Readonly, WTFMove(pasteboard), Type::InputEvent));
 }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -925,7 +925,7 @@ void Document::setMarkupUnsafe(const String& markup, OptionSet<ParserContentPoli
 {
     auto policy = OptionSet<ParserContentPolicy> { ParserContentPolicy::AllowScriptingContent } | parserContentPolicy;
     setParserContentPolicy(policy);
-    if (this->contentType() == "text/html"_s) {
+    if (this->contentType() == textHTMLContentTypeAtom()) {
         auto body = HTMLBodyElement::create(*this);
         if (LIKELY(tryFastParsingHTMLFragment(StringView { markup }.substring(markup.find(isNotASCIIWhitespace<UChar>)), *this, body, body, policy))) {
             auto html = HTMLHtmlElement::create(*this);
@@ -1866,13 +1866,13 @@ void Document::setDocumentURI(const String& uri)
 String Document::suggestedMIMEType() const
 {
     if (isXHTMLDocument())
-        return "application/xhtml+xml"_s;
+        return applicationXHTMLContentTypeAtom();
     if (isSVGDocument())
-        return "image/svg+xml"_s;
+        return imageSVGContentTypeAtom();
     if (xmlStandalone())
-        return "text/xml"_s;
+        return textXMLContentTypeAtom();
     if (isHTMLDocument())
-        return "text/html"_s;
+        return textHTMLContentTypeAtom();
     if (DocumentLoader* loader = this->loader())
         return loader->responseMIMEType();
     return String();

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -37,6 +37,7 @@
 #include "CachedResourceLoader.h"
 #include "ChangeListTypeCommand.h"
 #include "ClipboardEvent.h"
+#include "CommonAtomStrings.h"
 #include "CompositionEvent.h"
 #include "CompositionHighlight.h"
 #include "CreateLinkCommand.h"
@@ -438,7 +439,7 @@ static Ref<DataTransfer> createDataTransferForClipboardEvent(Document& document,
         return DataTransfer::createForCopyAndPaste(document, DataTransfer::StoreMode::ReadWrite, makeUnique<StaticPasteboard>());
     case ClipboardEventKind::PasteAsPlainText:
         if (DeprecatedGlobalSettings::customPasteboardDataEnabled()) {
-            auto plainTextType = "text/plain"_s;
+            auto plainTextType = textPlainContentTypeAtom();
             auto plainText = Pasteboard::createForCopyAndPaste(PagePasteboardContext::create(document.pageID()))->readString(plainTextType);
             auto pasteboard = makeUnique<StaticPasteboard>();
             pasteboard->writeString(plainTextType, plainText);

--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -1160,7 +1160,7 @@ BOOL HTMLConverter::_addAttachmentForElement(Element& element, NSURL *url, BOOL 
     if (!fileWrapper && dataSource) {
         if (auto resource = dataSource->subresource(url)) {
             auto& mimeType = resource->mimeType();
-            if (!usePlaceholder || mimeType != "text/html"_s) {
+            if (!usePlaceholder || mimeType != textHTMLContentTypeAtom()) {
                 fileWrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:resource->data().makeContiguous()->createNSData().get()]);
                 [fileWrapper setPreferredFilename:suggestedFilenameWithMIMEType(url, mimeType)];
             } else

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2044,7 +2044,7 @@ bool DocumentLoader::maybeLoadEmpty()
             frameLoader()->client().dispatchDidChangeProvisionalURL();
     }
 
-    String mimeType = shouldLoadEmpty ? "text/html"_s : frameLoader()->client().generatedMIMETypeForURLScheme(m_request.url().protocol());
+    String mimeType = shouldLoadEmpty ? textHTMLContentTypeAtom() : frameLoader()->client().generatedMIMETypeForURLScheme(m_request.url().protocol());
     m_response = ResourceResponse(m_request.url(), mimeType, 0, "UTF-8"_s);
 
     if (!frameLoader()->stateMachine().isDisplayingInitialEmptyDocument()) {
@@ -2062,7 +2062,7 @@ bool DocumentLoader::maybeLoadEmpty()
 
 void DocumentLoader::loadErrorDocument()
 {
-    m_response = ResourceResponse(m_request.url(), "text/html"_s, 0, "UTF-8"_s);
+    m_response = ResourceResponse(m_request.url(), textHTMLContentTypeAtom(), 0, "UTF-8"_s);
     SetForScope isInFinishedLoadingOfEmptyDocument { m_isInFinishedLoadingOfEmptyDocument, true };
 
     commitIfReady();

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -416,7 +416,7 @@ void FrameLoader::initForSynthesizedDocument(const URL&)
     Ref frame = m_frame.get();
     Ref loader = m_client->createDocumentLoader(ResourceRequest(URL({ }, emptyString())), SubstituteData());
     loader->attachToFrame(frame);
-    loader->setResponse(ResourceResponse(URL(), "text/html"_s, 0, String()));
+    loader->setResponse(ResourceResponse(URL(), textHTMLContentTypeAtom(), 0, String()));
     loader->setCommitted(true);
     setDocumentLoader(WTFMove(loader));
 
@@ -1561,7 +1561,7 @@ SubstituteData FrameLoader::defaultSubstituteDataForURL(const URL& url)
     ASSERT(!srcdoc.isNull());
     CString encodedSrcdoc = srcdoc.string().utf8();
 
-    ResourceResponse response(URL(), "text/html"_s, encodedSrcdoc.length(), "UTF-8"_s);
+    ResourceResponse response(URL(), textHTMLContentTypeAtom(), encodedSrcdoc.length(), "UTF-8"_s);
     return SubstituteData(SharedBuffer::create(encodedSrcdoc.data(), encodedSrcdoc.length()), URL(), response, SubstituteData::SessionHistoryVisibility::Hidden);
 }
 

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -754,7 +754,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(const String& markupString, Lo
         if (responseURL.isEmpty())
             return nullptr;
 
-        auto extension = MIMETypeRegistry::preferredExtensionForMIMEType("text/html"_s);
+        auto extension = MIMETypeRegistry::preferredExtensionForMIMEType(textHTMLContentTypeAtom());
         if (!extension.isEmpty())
             extension = makeString(".", extension);
         auto mainFrameFilePathWithExtension = mainFrameFilePath.endsWith(extension) ? mainFrameFilePath : makeString(mainFrameFilePath, extension);
@@ -800,7 +800,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::createFromSelection(LocalFrame* frame
     // Wrap the frameset document in an iframe so it can be pasted into
     // another document (which will have a body or frameset of its own). 
     String iframeMarkup = "<iframe frameborder=\"no\" marginwidth=\"0\" marginheight=\"0\" width=\"98%%\" height=\"98%%\" src=\"" + frame->loader().documentLoader()->response().url().string() + "\"></iframe>";
-    auto iframeResource = ArchiveResource::create(utf8Buffer(iframeMarkup), aboutBlankURL(), "text/html"_s, "UTF-8"_s, String());
+    auto iframeResource = ArchiveResource::create(utf8Buffer(iframeMarkup), aboutBlankURL(), textHTMLContentTypeAtom(), "UTF-8"_s, String());
 
     return create(iframeResource.releaseNonNull(), { }, { archive.releaseNonNull() });
 }

--- a/Source/WebCore/mathml/MathMLSelectElement.cpp
+++ b/Source/WebCore/mathml/MathMLSelectElement.cpp
@@ -76,12 +76,12 @@ bool MathMLSelectElement::isMathMLEncoding(const AtomString& value)
 
 bool MathMLSelectElement::isSVGEncoding(const AtomString& value)
 {
-    return value == "image/svg+xml"_s || value == "SVG1.1"_s;
+    return value == imageSVGContentTypeAtom() || value == "SVG1.1"_s;
 }
 
 bool MathMLSelectElement::isHTMLEncoding(const AtomString& value)
 {
-    return value == "application/xhtml+xml"_s || value == "text/html"_s;
+    return value == applicationXHTMLContentTypeAtom() || value == textHTMLContentTypeAtom();
 }
 
 bool MathMLSelectElement::childShouldCreateRenderer(const Node& child) const

--- a/Source/WebCore/platform/CommonAtomStrings.h
+++ b/Source/WebCore/platform/CommonAtomStrings.h
@@ -33,6 +33,8 @@ namespace WebCore {
 #define WEBCORE_COMMON_ATOM_STRINGS_FOR_EACH_KEYWORD(macro) \
     macro(all, "all") \
     macro(alternative, "alternative") \
+    macro(applicationXHTMLContentType, "application/xhtml+xml") \
+    macro(applicationXMLContentType, "application/xml") \
     macro(auto, "auto") \
     macro(captions, "captions") \
     macro(commentary, "commentary") \
@@ -40,6 +42,7 @@ namespace WebCore {
     macro(eager, "eager") \
     macro(email, "email") \
     macro(false, "false") \
+    macro(imageSVGContentType, "image/svg+xml") \
     macro(lazy, "lazy") \
     macro(main, "main") \
     macro(manual, "manual") \
@@ -56,7 +59,9 @@ namespace WebCore {
     macro(subtitles, "subtitles") \
     macro(tel, "tel") \
     macro(text, "text") \
+    macro(textHTMLContentType, "text/html") \
     macro(textPlainContentType, "text/plain") \
+    macro(textXMLContentType, "text/xml") \
     macro(true, "true") \
     macro(url, "url") \
     macro(xml, "xml") \

--- a/Source/WebCore/platform/Pasteboard.cpp
+++ b/Source/WebCore/platform/Pasteboard.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 
 bool Pasteboard::isSafeTypeForDOMToReadAndWrite(const String& type)
 {
-    return type == textPlainContentTypeAtom() || type == "text/html"_s || type == "text/uri-list"_s;
+    return type == textPlainContentTypeAtom() || type == textHTMLContentTypeAtom() || type == "text/uri-list"_s;
 }
 
 bool Pasteboard::canExposeURLToDOMWhenPasteboardContainsFiles(const String& urlString)

--- a/Source/WebCore/platform/StaticPasteboard.cpp
+++ b/Source/WebCore/platform/StaticPasteboard.cpp
@@ -106,7 +106,7 @@ PasteboardCustomData StaticPasteboard::takeCustomData()
 
 void StaticPasteboard::writeMarkup(const String& markup)
 {
-    m_customData.writeString("text/html"_s, markup);
+    m_customData.writeString(textHTMLContentTypeAtom(), markup);
 }
 
 void StaticPasteboard::writePlainText(const String& text, SmartReplaceOption)

--- a/Source/WebCore/platform/gtk/PasteboardGtk.cpp
+++ b/Source/WebCore/platform/gtk/PasteboardGtk.cpp
@@ -21,6 +21,7 @@
 #include "Pasteboard.h"
 
 #include "Color.h"
+#include "CommonAtomStrings.h"
 #include "DragData.h"
 #include "Image.h"
 #include "MIMETypeRegistry.h"
@@ -101,9 +102,9 @@ static ClipboardDataType selectionDataTypeFromHTMLClipboardType(const String& ty
 {
     // From the Mac port: Ignore any trailing charset - JS strings are
     // Unicode, which encapsulates the charset issue.
-    if (type == "text/plain"_s)
+    if (type == textPlainContentTypeAtom())
         return ClipboardDataTypeText;
-    if (type == "text/html"_s)
+    if (type == textHTMLContentTypeAtom())
         return ClipboardDataTypeMarkup;
     if (type == "Files"_s || type == "text/uri-list"_s)
         return ClipboardDataTypeURIList;
@@ -310,7 +311,7 @@ void Pasteboard::read(PasteboardWebContentReader& reader, WebContentReadingPolic
             return;
     }
 
-    if (types.contains("text/plain"_s) || types.contains("text/plain;charset=utf-8"_s)) {
+    if (types.contains(textPlainContentTypeAtom()) || types.contains("text/plain;charset=utf-8"_s)) {
         auto text = platformStrategies()->pasteboardStrategy()->readTextFromClipboard(m_name);
         if (!text.isNull() && reader.readPlainText(text))
             return;
@@ -358,9 +359,9 @@ Vector<String> Pasteboard::typesSafeForBindings(const String& origin)
         }
 
         if (m_selectionData->hasText())
-            types.add("text/plain"_s);
+            types.add(textPlainContentTypeAtom());
         if (m_selectionData->hasMarkup())
-            types.add("text/html"_s);
+            types.add(textHTMLContentTypeAtom());
         if (m_selectionData->hasURIList())
             types.add("text/uri-list"_s);
 
@@ -377,13 +378,13 @@ Vector<String> Pasteboard::typesForLegacyUnsafeBindings()
 
     Vector<String> types;
     if (m_selectionData->hasText()) {
-        types.append("text/plain"_s);
+        types.append(textPlainContentTypeAtom());
         types.append("Text"_s);
         types.append("text"_s);
     }
 
     if (m_selectionData->hasMarkup())
-        types.append("text/html"_s);
+        types.append(textHTMLContentTypeAtom());
 
     if (m_selectionData->hasURIList()) {
         types.append("text/uri-list"_s);

--- a/Source/WebCore/platform/ios/PasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PasteboardIOS.mm
@@ -27,6 +27,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "CommonAtomStrings.h"
 #import "DeprecatedGlobalSettings.h"
 #import "DragData.h"
 #import "Image.h"
@@ -539,7 +540,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if ([cocoaType isEqualToString:(NSString *)kUTTypePlainText]
         || [cocoaType isEqualToString:(NSString *)kUTTypeUTF8PlainText]
         || [cocoaType isEqualToString:(NSString *)kUTTypeUTF16PlainText]) {
-        resultTypes.add("text/plain"_s);
+        resultTypes.add(textPlainContentTypeAtom());
         return;
     }
     if ([cocoaType isEqualToString:(NSString *)kUTTypeURL]) {
@@ -547,7 +548,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         return;
     }
     if ([cocoaType isEqualToString:(NSString *)kUTTypeHTML]) {
-        resultTypes.add("text/html"_s);
+        resultTypes.add(textHTMLContentTypeAtom());
         // We don't return here for App compatibility.
     }
 ALLOW_DEPRECATED_DECLARATIONS_END

--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "ColorCocoa.h"
+#import "CommonAtomStrings.h"
 #import "Image.h"
 #import "NSURLUtilities.h"
 #import "Pasteboard.h"
@@ -358,10 +359,10 @@ int64_t PlatformPasteboard::changeCount() const
 String PlatformPasteboard::platformPasteboardTypeForSafeTypeForDOMToReadAndWrite(const String& domType, IncludeImageTypes includeImageTypes)
 {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if (domType == "text/plain"_s)
+    if (domType == textPlainContentTypeAtom())
         return kUTTypePlainText;
 
-    if (domType == "text/html"_s)
+    if (domType == textHTMLContentTypeAtom())
         return kUTTypeHTML;
 
     if (domType == "text/uri-list"_s)

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -670,7 +670,7 @@ void Pasteboard::addHTMLClipboardTypesForCocoaType(ListHashSet<String>& resultTy
 
     // UTI may not do these right, so make sure we get the right, predictable result
     if (cocoaType == String(legacyStringPasteboardType()) || cocoaType == String(NSPasteboardTypeString)) {
-        resultTypes.add("text/plain"_s);
+        resultTypes.add(textPlainContentTypeAtom());
         return;
     }
     if (cocoaType == String(legacyURLPasteboardType())) {

--- a/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
@@ -30,6 +30,7 @@
 
 #import "Color.h"
 #import "ColorMac.h"
+#import "CommonAtomStrings.h"
 #import "LegacyNSPasteboardTypes.h"
 #import "Pasteboard.h"
 #import "SharedBuffer.h"
@@ -343,10 +344,10 @@ int64_t PlatformPasteboard::changeCount() const
 
 String PlatformPasteboard::platformPasteboardTypeForSafeTypeForDOMToReadAndWrite(const String& domType, IncludeImageTypes includeImageTypes)
 {
-    if (domType == "text/plain"_s)
+    if (domType == textPlainContentTypeAtom())
         return legacyStringPasteboardType();
 
-    if (domType == "text/html"_s)
+    if (domType == textHTMLContentTypeAtom())
         return legacyHTMLPasteboardType();
 
     if (domType == "text/uri-list"_s)
@@ -476,9 +477,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 static NSPasteboardType modernPasteboardTypeForWebSafeMIMEType(const String& webSafeType)
 {
-    if (webSafeType == "text/plain"_s)
+    if (webSafeType == textPlainContentTypeAtom())
         return NSPasteboardTypeString;
-    if (webSafeType == "text/html"_s)
+    if (webSafeType == textHTMLContentTypeAtom())
         return NSPasteboardTypeHTML;
     if (webSafeType == "text/uri-list"_s)
         return NSPasteboardTypeURL;
@@ -491,9 +492,9 @@ enum class ContainsFileURL : bool { No, Yes };
 static String webSafeMIMETypeForModernPasteboardType(NSPasteboardType platformType, ContainsFileURL containsFileURL)
 {
     if ([platformType isEqual:NSPasteboardTypeString] && containsFileURL == ContainsFileURL::No)
-        return "text/plain"_s;
+        return textPlainContentTypeAtom();
     if ([platformType isEqual:NSPasteboardTypeHTML] || [platformType isEqual:NSPasteboardTypeRTF] || [platformType isEqual:NSPasteboardTypeRTFD])
-        return "text/html"_s;
+        return textHTMLContentTypeAtom();
     if ([platformType isEqual:NSPasteboardTypeURL] && containsFileURL == ContainsFileURL::No)
         return "text/uri-list"_s;
     if ([platformType isEqual:NSPasteboardTypePNG] || [platformType isEqual:NSPasteboardTypeTIFF])

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -31,6 +31,7 @@
 #include "CachedImage.h"
 #include "ClipboardUtilitiesWin.h"
 #include "Color.h"
+#include "CommonAtomStrings.h"
 #include "Document.h"
 #include "DocumentFragment.h"
 #include "Editor.h"
@@ -242,7 +243,7 @@ static void addMimeTypesForFormat(ListHashSet<String>& results, const FORMATETC&
     if (format.cfFormat == urlFormat()->cfFormat || format.cfFormat == urlWFormat()->cfFormat)
         results.add("text/uri-list"_s);
     if (format.cfFormat == plainTextWFormat()->cfFormat || format.cfFormat == plainTextFormat()->cfFormat)
-        results.add("text/plain"_s);
+        results.add(textPlainContentTypeAtom());
 }
 
 std::optional<PasteboardCustomData> Pasteboard::readPasteboardCustomData()
@@ -275,9 +276,9 @@ Vector<String> Pasteboard::typesSafeForBindings(const String& origin)
             domPasteboardTypes.add(type);
     }
 
-    domPasteboardTypes.add("text/plain"_s);
+    domPasteboardTypes.add(textPlainContentTypeAtom());
     domPasteboardTypes.add("text/uri-list"_s);
-    domPasteboardTypes.add("text/html"_s);
+    domPasteboardTypes.add(textHTMLContentTypeAtom());
 
     return copyToVector(domPasteboardTypes);
 }

--- a/Source/WebCore/xml/DOMParser.cpp
+++ b/Source/WebCore/xml/DOMParser.cpp
@@ -19,6 +19,7 @@
 #include "config.h"
 #include "DOMParser.h"
 
+#include "CommonAtomStrings.h"
 #include "HTMLDocument.h"
 #include "SVGDocument.h"
 #include "SecurityOriginPolicy.h"
@@ -39,16 +40,16 @@ Ref<DOMParser> DOMParser::create(Document& contextDocument)
     return adoptRef(*new DOMParser(contextDocument));
 }
 
-ExceptionOr<Ref<Document>> DOMParser::parseFromString(const String& string, const String& contentType)
+ExceptionOr<Ref<Document>> DOMParser::parseFromString(const String& string, const AtomString& contentType)
 {
     RefPtr<Document> document;
-    if (contentType == "text/html"_s)
+    if (contentType == textHTMLContentTypeAtom())
         document = HTMLDocument::create(nullptr, m_settings, URL { });
-    else if (contentType == "application/xhtml+xml"_s)
+    else if (contentType == applicationXHTMLContentTypeAtom())
         document = XMLDocument::createXHTML(nullptr, m_settings, URL { });
-    else if (contentType == "image/svg+xml"_s)
+    else if (contentType == imageSVGContentTypeAtom())
         document = SVGDocument::create(nullptr, m_settings, URL { });
-    else if (contentType == "text/xml"_s || contentType == "application/xml"_s) {
+    else if (contentType == textXMLContentTypeAtom() || contentType == applicationXMLContentTypeAtom()) {
         document = XMLDocument::create(nullptr, m_settings, URL { });
         document->overrideMIMEType(contentType);
     } else

--- a/Source/WebCore/xml/DOMParser.h
+++ b/Source/WebCore/xml/DOMParser.h
@@ -32,7 +32,7 @@ public:
     static Ref<DOMParser> create(Document& contextDocument);
     ~DOMParser();
 
-    ExceptionOr<Ref<Document>> parseFromString(const String&, const String& contentType);
+    ExceptionOr<Ref<Document>> parseFromString(const String&, const AtomString& contentType);
 
 private:
     explicit DOMParser(Document& contextDocument);

--- a/Source/WebCore/xml/DOMParser.idl
+++ b/Source/WebCore/xml/DOMParser.idl
@@ -22,5 +22,5 @@
 ] interface DOMParser {
     [CallWith=CurrentDocument] constructor();
 
-    [NewObject] Document parseFromString(DOMString string, DOMString contentType);
+    [NewObject] Document parseFromString(DOMString string, [AtomString] DOMString contentType);
 };

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -25,6 +25,7 @@
 
 #include "Blob.h"
 #include "CachedResourceRequestInitiatorTypes.h"
+#include "CommonAtomStrings.h"
 #include "ContentSecurityPolicy.h"
 #include "CrossOriginAccessControl.h"
 #include "DOMFormData.h"

--- a/Source/WebCore/xml/XSLTProcessor.cpp
+++ b/Source/WebCore/xml/XSLTProcessor.cpp
@@ -27,6 +27,7 @@
 
 #include "DOMImplementation.h"
 #include "CachedResourceLoader.h"
+#include "CommonAtomStrings.h"
 #include "ContentSecurityPolicy.h"
 #include "DocumentFragment.h"
 #include "FrameLoader.h"
@@ -71,7 +72,7 @@ Ref<Document> XSLTProcessor::createDocumentFromSource(const String& sourceString
     String documentSource = sourceString;
 
     RefPtr<Document> result;
-    if (sourceMIMEType == "text/plain"_s) {
+    if (sourceMIMEType == textPlainContentTypeAtom()) {
         result = XMLDocument::createXHTML(frame, ownerDocument->settings(), sourceIsDocument ? ownerDocument->url() : URL());
         transformTextStringToXHTMLDocumentString(documentSource);
     } else
@@ -127,7 +128,7 @@ RefPtr<DocumentFragment> XSLTProcessor::transformToFragment(Node& sourceNode, Do
 
     // If the output document is HTML, default to HTML method.
     if (outputDocument.isHTMLDocument())
-        resultMIMEType = "text/html"_s;
+        resultMIMEType = textHTMLContentTypeAtom();
 
     if (!transformToString(sourceNode, resultMIMEType, resultString, resultEncoding))
         return nullptr;

--- a/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
+++ b/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
@@ -276,11 +276,11 @@ static inline String resultMIMEType(xmlDocPtr resultDoc, xsltStylesheetPtr sheet
         resultType = (const xmlChar*)"html";
 
     if (xmlStrEqual(resultType, (const xmlChar*)"html"))
-        return "text/html"_s;
+        return textHTMLContentTypeAtom();
     if (xmlStrEqual(resultType, (const xmlChar*)"text"))
-        return "text/plain"_s;
+        return textPlainContentTypeAtom();
 
-    return "application/xml"_s;
+    return applicationXMLContentTypeAtom();
 }
 
 bool XSLTProcessor::transformToString(Node& sourceNode, String& mimeType, String& resultString, String& resultEncoding)
@@ -300,7 +300,7 @@ bool XSLTProcessor::transformToString(Node& sourceNode, String& mimeType, String
     xsltMaxDepth = 1000;
 
     xmlChar* origMethod = sheet->method;
-    if (!origMethod && mimeType == "text/html"_s)
+    if (!origMethod && mimeType == textHTMLContentTypeAtom())
         sheet->method = reinterpret_cast<xmlChar*>(const_cast<char*>("html"));
 
     bool success = false;


### PR DESCRIPTION
#### 90c9323b6933707de1dbc69ddd32c354ef622967
<pre>
Use CommonAtomStrings for common content types
<a href="https://bugs.webkit.org/show_bug.cgi?id=267828">https://bugs.webkit.org/show_bug.cgi?id=267828</a>

Reviewed by Yusuke Suzuki and Alexey Shvayka.

Defined common AtomString for &quot;application/xhtml+xml&quot;, &quot;application/xml&quot;, &quot;image/svg+xml&quot;,
&quot;text/html&quot;, and &quot;text/xml&quot;, and deployed them throughout the codebase.

* Source/WebCore/Modules/async-clipboard/Clipboard.cpp:
(WebCore::Clipboard::readText):
(WebCore::Clipboard::writeText):
(WebCore::Clipboard::getType):
* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
(WebCore::readTypeForMIMEType):
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::sanitizeDataIfNeeded):
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::normalizeType):
(WebCore::DataTransfer::getDataForItem const):
(WebCore::DataTransfer::readStringFromPasteboard const):
(WebCore::DataTransfer::types const):
(WebCore::DataTransfer::createForInputEvent):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setMarkupUnsafe):
(WebCore::Document::suggestedMIMEType const):
* Source/WebCore/editing/Editor.cpp:
(WebCore::createDataTransferForClipboardEvent):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::_addAttachmentForElement):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::maybeLoadEmpty):
(WebCore::DocumentLoader::loadErrorDocument):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::initForSynthesizedDocument):
(WebCore::FrameLoader::defaultSubstituteDataForURL):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::create):
(WebCore::LegacyWebArchive::createFromSelection):
* Source/WebCore/mathml/MathMLSelectElement.cpp:
(WebCore::MathMLSelectElement::isSVGEncoding):
(WebCore::MathMLSelectElement::isHTMLEncoding):
* Source/WebCore/platform/CommonAtomStrings.h:
* Source/WebCore/platform/Pasteboard.cpp:
(WebCore::Pasteboard::isSafeTypeForDOMToReadAndWrite):
* Source/WebCore/platform/StaticPasteboard.cpp:
(WebCore::StaticPasteboard::writeMarkup):
* Source/WebCore/platform/gtk/PasteboardGtk.cpp:
(WebCore::selectionDataTypeFromHTMLClipboardType):
(WebCore::Pasteboard::read):
(WebCore::Pasteboard::typesSafeForBindings):
(WebCore::Pasteboard::typesForLegacyUnsafeBindings):
* Source/WebCore/platform/ios/PasteboardIOS.mm:
(WebCore::Pasteboard::addHTMLClipboardTypesForCocoaType):
* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::safeTypeForDOMToReadAndWriteForPlatformType):
(WebCore::PlatformPasteboard::platformPasteboardTypeForSafeTypeForDOMToReadAndWrite):
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::Pasteboard::addHTMLClipboardTypesForCocoaType):
* Source/WebCore/platform/mac/PlatformPasteboardMac.mm:
(WebCore::PlatformPasteboard::platformPasteboardTypeForSafeTypeForDOMToReadAndWrite):
(WebCore::modernPasteboardTypeForWebSafeMIMEType):
(WebCore::webSafeMIMETypeForModernPasteboardType):
* Source/WebCore/platform/win/PasteboardWin.cpp:
(WebCore::addMimeTypesForFormat):
(WebCore::Pasteboard::typesSafeForBindings):
* Source/WebCore/xml/DOMParser.cpp:
(WebCore::DOMParser::parseFromString):
* Source/WebCore/xml/DOMParser.h:
* Source/WebCore/xml/DOMParser.idl:
* Source/WebCore/xml/XMLHttpRequest.cpp:
* Source/WebCore/xml/XSLTProcessor.cpp:
(WebCore::XSLTProcessor::createDocumentFromSource):
(WebCore::XSLTProcessor::transformToFragment):
* Source/WebCore/xml/XSLTProcessorLibxslt.cpp:
(WebCore::resultMIMEType):
(WebCore::XSLTProcessor::transformToString):

Canonical link: <a href="https://commits.webkit.org/273272@main">https://commits.webkit.org/273272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f12a853f2b03afe077d2da5eac8dbc609614ccc9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37678 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31555 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36101 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30491 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10249 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10318 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38931 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31776 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31566 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36339 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34321 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12229 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10958 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4493 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11292 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->