### PR TITLE
[WTF] Add LazyRef & LazyUniqueRef

### DIFF
--- a/Source/JavaScriptCore/runtime/LazyPropertyInlines.h
+++ b/Source/JavaScriptCore/runtime/LazyPropertyInlines.h
@@ -48,7 +48,7 @@ void LazyProperty<OwnerType, ElementType>::initLater(const Func&)
     // may be used for things. We address this problem by indirecting through a global const
     // variable. The "theFunc" variable is guaranteed to be native-aligned, i.e. at least a
     // multiple of 4.
-    static const FuncType theFunc = &callFunc<Func>;
+    static constexpr FuncType theFunc = &callFunc<Func>;
     m_pointer = lazyTag | bitwise_cast<uintptr_t>(&theFunc);
 }
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -238,6 +238,31 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
 
     VMInspector::instance().add(this);
 
+    // Set up lazy initializers.
+    {
+        m_hasOwnPropertyCache.initLater([](VM&, auto& ref) {
+            ref.set(HasOwnPropertyCache::create());
+        });
+
+        m_megamorphicCache.initLater([](VM&, auto& ref) {
+            ref.set(makeUniqueRef<MegamorphicCache>());
+        });
+
+        m_shadowChicken.initLater([](VM&, auto& ref) {
+            ref.set(makeUniqueRef<ShadowChicken>());
+        });
+
+        m_heapProfiler.initLater([](VM& vm, auto& ref) {
+            ref.set(makeUniqueRef<HeapProfiler>(vm));
+        });
+
+        m_watchdog.initLater([](VM& vm, auto& ref) {
+            ref.set(adoptRef(*new Watchdog(&vm)));
+            vm.ensureTerminationException();
+            vm.requestEntryScopeService(EntryScopeService::Watchdog);
+        });
+    }
+
     updateSoftReservedZoneSize(Options::softReservedZoneSize());
     setLastStackTop(Thread::current());
     stringSplitIndice.reserveInitialCapacity(256);
@@ -432,8 +457,8 @@ VM::~VM()
     if (Wasm::Worklist* worklist = Wasm::existingWorklistOrNull())
         worklist->stopAllPlansForContext(*this);
 #endif
-    if (UNLIKELY(m_watchdog))
-        m_watchdog->willDestroyVM(this);
+    if (auto* watchdog = this->watchdog(); UNLIKELY(watchdog))
+        watchdog->willDestroyVM(this);
     m_traps.willDestroyVM();
     m_isInService = false;
     WTF::storeStoreFence();
@@ -563,23 +588,6 @@ VM*& VM::sharedInstanceInternal()
 {
     static VM* sharedInstance;
     return sharedInstance;
-}
-
-Watchdog& VM::ensureWatchdog()
-{
-    if (!m_watchdog) {
-        m_watchdog = adoptRef(new Watchdog(this));
-        ensureTerminationException();
-        requestEntryScopeService(EntryScopeService::Watchdog);
-    }
-    return *m_watchdog;
-}
-
-HeapProfiler& VM::ensureHeapProfiler()
-{
-    if (!m_heapProfiler)
-        m_heapProfiler = makeUnique<HeapProfiler>(*this);
-    return *m_heapProfiler;
 }
 
 #if ENABLE(SAMPLING_PROFILER)
@@ -1473,13 +1481,6 @@ Ref<Waiter> VM::syncWaiter()
     return m_syncWaiter;
 }
 
-void VM::ensureShadowChicken()
-{
-    if (m_shadowChicken)
-        return;
-    m_shadowChicken = makeUnique<ShadowChicken>();
-}
-
 JSCell* VM::sentinelSetBucketSlow()
 {
     ASSERT(!m_sentinelSetBucket);
@@ -1763,16 +1764,10 @@ void MicrotaskQueue::visitAggregateImpl(Visitor& visitor)
 }
 DEFINE_VISIT_AGGREGATE(MicrotaskQueue);
 
-void VM::ensureMegamorphicCacheSlow()
-{
-    ASSERT(!m_megamorphicCache);
-    m_megamorphicCache = makeUnique<MegamorphicCache>();
-}
-
 void VM::invalidateStructureChainIntegrity(StructureChainIntegrityEvent)
 {
-    if (m_megamorphicCache)
-        m_megamorphicCache->bumpEpoch();
+    if (auto* megamorphicCache = this->megamorphicCache())
+        megamorphicCache->bumpEpoch();
 }
 
 #if ENABLE(WEBASSEMBLY)

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -813,6 +813,8 @@
 		E320BFE52A7CB712003C0B3A /* unumberrangeformatter.h in Headers */ = {isa = PBXBuildFile; fileRef = E320BFE32A7CB712003C0B3A /* unumberrangeformatter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E320BFE62A7CB712003C0B3A /* localematcher.h in Headers */ = {isa = PBXBuildFile; fileRef = E320BFE42A7CB712003C0B3A /* localematcher.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E324FAA328C9ADBA007089DF /* StringSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = E324FAA228C9ADBA007089DF /* StringSearch.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E32AB5012B5CE35D00B9FAAE /* LazyRef.h in Headers */ = {isa = PBXBuildFile; fileRef = E32AB4FF2B5CE35D00B9FAAE /* LazyRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E32AB5022B5CE35D00B9FAAE /* LazyUniqueRef.h in Headers */ = {isa = PBXBuildFile; fileRef = E32AB5002B5CE35D00B9FAAE /* LazyUniqueRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E336674A2722551100259122 /* Int128.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E33667492722550900259122 /* Int128.cpp */; };
 		E3618AB92AD8C4BA00DA7E43 /* ButterflyArray.h in Headers */ = {isa = PBXBuildFile; fileRef = E3618AB82AD8C4B900DA7E43 /* ButterflyArray.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E361DB532891159C00B2A2B8 /* FastFloat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E361DB512891159B00B2A2B8 /* FastFloat.cpp */; };
@@ -1737,6 +1739,8 @@
 		E324FAA228C9ADBA007089DF /* StringSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringSearch.h; sourceTree = "<group>"; };
 		E32561122611B5B600A72CC5 /* RobinHoodHashSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RobinHoodHashSet.h; sourceTree = "<group>"; };
 		E32A207323C5902D0034A092 /* NakedRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NakedRef.h; sourceTree = "<group>"; };
+		E32AB4FF2B5CE35D00B9FAAE /* LazyRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LazyRef.h; sourceTree = "<group>"; };
+		E32AB5002B5CE35D00B9FAAE /* LazyUniqueRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LazyUniqueRef.h; sourceTree = "<group>"; };
 		E33667492722550900259122 /* Int128.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Int128.cpp; sourceTree = "<group>"; };
 		E339C163244B4E8700359DA9 /* DataRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DataRef.h; sourceTree = "<group>"; };
 		E33D5F871FBED66700BF625E /* RecursableLambda.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RecursableLambda.h; sourceTree = "<group>"; };
@@ -2187,6 +2191,8 @@
 				7C9692941F66306E00267A9E /* KeyValuePair.h */,
 				C2BCFC3E1F61D13000C9222C /* Language.cpp */,
 				C2BCFC3F1F61D13000C9222C /* Language.h */,
+				E32AB4FF2B5CE35D00B9FAAE /* LazyRef.h */,
+				E32AB5002B5CE35D00B9FAAE /* LazyUniqueRef.h */,
 				539EB0621D55284200C82EF7 /* LEBDecoder.h */,
 				337B2D6826546EAA00DDFD3D /* LikelyDenseUnsignedIntegerSet.cpp */,
 				337B2D6926546EAA00DDFD3D /* LikelyDenseUnsignedIntegerSet.h */,
@@ -3208,6 +3214,8 @@
 				DD3DC86F27A4BF8E007E5B61 /* JSValueMalloc.h in Headers */,
 				DD3DC99727A4BF8E007E5B61 /* KeyValuePair.h in Headers */,
 				DD3DC8BF27A4BF8E007E5B61 /* Language.h in Headers */,
+				E32AB5012B5CE35D00B9FAAE /* LazyRef.h in Headers */,
+				E32AB5022B5CE35D00B9FAAE /* LazyUniqueRef.h in Headers */,
 				DDF307D327C086DF006A526F /* LChar.h in Headers */,
 				DD3DC88927A4BF8E007E5B61 /* LEBDecoder.h in Headers */,
 				6311592628989A55006A9A12 /* LibraryPathDiagnostics.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -131,6 +131,8 @@ set(WTF_PUBLIC_HEADERS
     KeyValuePair.h
     LEBDecoder.h
     Language.h
+    LazyRef.h
+    LazyUniqueRef.h
     LikelyDenseUnsignedIntegerSet.h
     ListDump.h
     ListHashSet.h

--- a/Source/WTF/wtf/LazyRef.h
+++ b/Source/WTF/wtf/LazyRef.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
+#include <wtf/Ref.h>
+#include <wtf/StdLibExtras.h>
+
+namespace WTF {
+
+template<typename OwnerType, typename T>
+class LazyRef {
+    WTF_MAKE_NONCOPYABLE(LazyRef);
+    WTF_MAKE_NONMOVABLE(LazyRef);
+public:
+    LazyRef() = default;
+
+    template<typename Func>
+    LazyRef(const Func& func)
+    {
+        initLater(func);
+    }
+
+    typedef T* (*FuncType)(OwnerType&, LazyRef&);
+
+    ~LazyRef()
+    {
+        ASSERT(!(m_pointer & initializingTag));
+        if (m_pointer & lazyTag)
+            return;
+        uintptr_t pointer = std::exchange(m_pointer, 0);
+        if (pointer)
+            bitwise_cast<T*>(pointer)->deref();
+    }
+
+    bool isInitialized() const { return !(m_pointer & lazyTag); }
+
+    const T& get(const OwnerType& owner) const
+    {
+        return const_cast<LazyRef&>(*this).get(const_cast<OwnerType&>(owner));
+    }
+
+    T& get(OwnerType& owner)
+    {
+        ASSERT(m_pointer);
+        ASSERT(!(m_pointer & initializingTag));
+        if (UNLIKELY(m_pointer & lazyTag)) {
+            FuncType func = *bitwise_cast<FuncType*>(m_pointer & ~(lazyTag | initializingTag));
+            return *func(owner, *this);
+        }
+        return *bitwise_cast<T*>(m_pointer);
+    }
+
+    const T* getIfExists() const
+    {
+        return const_cast<LazyRef&>(*this).getIfExists();
+    }
+
+    T* getIfExists()
+    {
+        ASSERT(m_pointer);
+        if (m_pointer & lazyTag)
+            return nullptr;
+        return bitwise_cast<T*>(m_pointer);
+    }
+
+    T* ptr(OwnerType& owner) RETURNS_NONNULL { &get(owner); }
+    T* ptr(const OwnerType& owner) const RETURNS_NONNULL { return &get(owner); }
+
+    template<typename Func>
+    void initLater(const Func&)
+    {
+        static_assert(alignof(T) >= 4);
+        RELEASE_ASSERT(isStatelessLambda<Func>());
+        // Logically we just want to stuff the function pointer into m_pointer, but then we'd be sad
+        // because a function pointer is not guaranteed to be a multiple of anything. The tag bits
+        // may be used for things. We address this problem by indirecting through a global const
+        // variable. The "theFunc" variable is guaranteed to be native-aligned, i.e. at least a
+        // multiple of 4.
+        static constexpr FuncType theFunc = &callFunc<Func>;
+        m_pointer = lazyTag | bitwise_cast<uintptr_t>(&theFunc);
+    }
+
+    void set(Ref<T>&& ref)
+    {
+        Ref<T> local = WTFMove(ref);
+        m_pointer = bitwise_cast<uintptr_t>(&local.leakRef());
+    }
+
+private:
+    static const uintptr_t lazyTag = 1;
+    static const uintptr_t initializingTag = 2;
+
+    template<typename Func>
+    static T* callFunc(OwnerType& owner, LazyRef& ref)
+    {
+        ref.m_pointer |= initializingTag;
+        callStatelessLambda<void, Func>(owner, ref);
+        RELEASE_ASSERT(!(ref.m_pointer & lazyTag));
+        RELEASE_ASSERT(!(ref.m_pointer & initializingTag));
+        return bitwise_cast<T*>(ref.m_pointer);
+    }
+
+    uintptr_t m_pointer { 0 };
+};
+
+} // namespace WTF
+
+using WTF::LazyRef;

--- a/Source/WTF/wtf/LazyUniqueRef.h
+++ b/Source/WTF/wtf/LazyUniqueRef.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/UniqueRef.h>
+
+namespace WTF {
+
+template<typename OwnerType, typename T>
+class LazyUniqueRef {
+    WTF_MAKE_NONCOPYABLE(LazyUniqueRef);
+    WTF_MAKE_NONMOVABLE(LazyUniqueRef);
+public:
+    LazyUniqueRef() = default;
+
+    template<typename Func>
+    LazyUniqueRef(const Func& func)
+    {
+        initLater(func);
+    }
+
+    typedef T* (*FuncType)(OwnerType&, LazyUniqueRef&);
+
+    ~LazyUniqueRef()
+    {
+        ASSERT(!(m_pointer & initializingTag));
+        if (m_pointer & lazyTag)
+            return;
+        uintptr_t pointer = std::exchange(m_pointer, 0);
+        if (pointer)
+            delete bitwise_cast<T*>(pointer);
+    }
+
+    bool isInitialized() const { return !(m_pointer & lazyTag); }
+
+    const T& get(const OwnerType& owner) const
+    {
+        return const_cast<LazyUniqueRef&>(*this).get(const_cast<OwnerType&>(owner));
+    }
+
+    T& get(OwnerType& owner)
+    {
+        ASSERT(m_pointer);
+        ASSERT(!(m_pointer & initializingTag));
+        if (UNLIKELY(m_pointer & lazyTag)) {
+            FuncType func = *bitwise_cast<FuncType*>(m_pointer & ~(lazyTag | initializingTag));
+            return *func(owner, *this);
+        }
+        return *bitwise_cast<T*>(m_pointer);
+    }
+
+    const T* getIfExists() const
+    {
+        return const_cast<LazyUniqueRef&>(*this).getIfExists();
+    }
+
+    T* getIfExists()
+    {
+        ASSERT(m_pointer);
+        if (m_pointer & lazyTag)
+            return nullptr;
+        return bitwise_cast<T*>(m_pointer);
+    }
+
+    T* ptr(OwnerType& owner) RETURNS_NONNULL { &get(owner); }
+    T* ptr(const OwnerType& owner) const RETURNS_NONNULL { return &get(owner); }
+
+    template<typename Func>
+    void initLater(const Func&)
+    {
+        static_assert(alignof(T) >= 4);
+        RELEASE_ASSERT(isStatelessLambda<Func>());
+        // Logically we just want to stuff the function pointer into m_pointer, but then we'd be sad
+        // because a function pointer is not guaranteed to be a multiple of anything. The tag bits
+        // may be used for things. We address this problem by indirecting through a global const
+        // variable. The "theFunc" variable is guaranteed to be native-aligned, i.e. at least a
+        // multiple of 4.
+        static constexpr FuncType theFunc = &callFunc<Func>;
+        m_pointer = lazyTag | bitwise_cast<uintptr_t>(&theFunc);
+    }
+
+    void set(UniqueRef<T>&& ref)
+    {
+        UniqueRef<T> local = WTFMove(ref);
+        m_pointer = bitwise_cast<uintptr_t>(local.moveToUniquePtr().release());
+    }
+
+private:
+    static const uintptr_t lazyTag = 1;
+    static const uintptr_t initializingTag = 2;
+
+    template<typename Func>
+    static T* callFunc(OwnerType& owner, LazyUniqueRef& ref)
+    {
+        ref.m_pointer |= initializingTag;
+        callStatelessLambda<void, Func>(owner, ref);
+        RELEASE_ASSERT(!(ref.m_pointer & lazyTag));
+        RELEASE_ASSERT(!(ref.m_pointer & initializingTag));
+        return bitwise_cast<T*>(ref.m_pointer);
+    }
+
+    uintptr_t m_pointer { 0 };
+};
+
+} // namespace WTF
+
+using WTF::LazyUniqueRef;

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -63,6 +63,8 @@ set(TestWTF_SOURCES
     Tests/WTF/IteratorRange.cpp
     Tests/WTF/JSONValue.cpp
     Tests/WTF/LEBDecoder.cpp
+    Tests/WTF/LazyRef.cpp
+    Tests/WTF/LazyUniqueRef.cpp
     Tests/WTF/LifecycleLogger.cpp
     Tests/WTF/LineEnding.cpp
     Tests/WTF/ListHashSet.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1099,6 +1099,8 @@
 		E35FC7B222B82A7300F32F98 /* JSLockTakesWebThreadLock.mm in Sources */ = {isa = PBXBuildFile; fileRef = E35FC7B122B82A6D00F32F98 /* JSLockTakesWebThreadLock.mm */; };
 		E36B87A3276221870059D2F9 /* EmbeddedFixedVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E36B87A2276221860059D2F9 /* EmbeddedFixedVector.cpp */; };
 		E373D7911F2CF35200C6FAAF /* Signals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3953F951F2CF32100A76A2E /* Signals.cpp */; };
+		E376DF9C2B5D0A2900DBF31F /* LazyRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E376DF942B5D0A2900DBF31F /* LazyRef.cpp */; };
+		E376DF9E2B5D0A5C00DBF31F /* LazyUniqueRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E376DF9D2B5D0A5C00DBF31F /* LazyUniqueRef.cpp */; };
 		E38A0D351FD50CC300E98C8B /* Threading.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38A0D341FD50CBC00E98C8B /* Threading.cpp */; };
 		E38D65CA23A45FAA0063D69A /* PackedRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38D65C823A45FA90063D69A /* PackedRef.cpp */; };
 		E38D65CB23A45FAA0063D69A /* PackedRefPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38D65C923A45FA90063D69A /* PackedRefPtr.cpp */; };
@@ -3412,6 +3414,8 @@
 		E35B908123F60DD0000011FF /* LocalizedDeviceModel.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LocalizedDeviceModel.mm; sourceTree = "<group>"; };
 		E35FC7B122B82A6D00F32F98 /* JSLockTakesWebThreadLock.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSLockTakesWebThreadLock.mm; sourceTree = "<group>"; };
 		E36B87A2276221860059D2F9 /* EmbeddedFixedVector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EmbeddedFixedVector.cpp; sourceTree = "<group>"; };
+		E376DF942B5D0A2900DBF31F /* LazyRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LazyRef.cpp; sourceTree = "<group>"; };
+		E376DF9D2B5D0A5C00DBF31F /* LazyUniqueRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LazyUniqueRef.cpp; sourceTree = "<group>"; };
 		E388887020C9098100E632BC /* WorkerPool.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WorkerPool.cpp; sourceTree = "<group>"; };
 		E38A0D341FD50CBC00E98C8B /* Threading.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Threading.cpp; sourceTree = "<group>"; };
 		E38D65C823A45FA90063D69A /* PackedRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PackedRef.cpp; sourceTree = "<group>"; };
@@ -5293,6 +5297,8 @@
 				266FAFD215E5775200F61D5B /* IntegerToStringConversion.cpp */,
 				7CEB62A92236086C0069CBB0 /* IteratorRange.cpp */,
 				7A0509401FB9F04400B33FB8 /* JSONValue.cpp */,
+				E376DF942B5D0A2900DBF31F /* LazyRef.cpp */,
+				E376DF9D2B5D0A5C00DBF31F /* LazyUniqueRef.cpp */,
 				531C1D8D1DF8EF72006E979F /* LEBDecoder.cpp */,
 				A57D54F71F3397B400A97AA7 /* LifecycleLogger.cpp */,
 				A57D54F81F3397B400A97AA7 /* LifecycleLogger.h */,
@@ -6279,6 +6285,8 @@
 				53FCDE6B229EFFB900598ECF /* IsoHeap.cpp in Sources */,
 				7CEB62AB223609DE0069CBB0 /* IteratorRange.cpp in Sources */,
 				7A0509411FB9F06400B33FB8 /* JSONValue.cpp in Sources */,
+				E376DF9C2B5D0A2900DBF31F /* LazyRef.cpp in Sources */,
+				E376DF9E2B5D0A5C00DBF31F /* LazyUniqueRef.cpp in Sources */,
 				531C1D8E1DF8EF72006E979F /* LEBDecoder.cpp in Sources */,
 				A57D54F91F3397B400A97AA7 /* LifecycleLogger.cpp in Sources */,
 				93E2C5551FD3204100E1DF6A /* LineEnding.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/LazyRef.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/LazyRef.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "RefLogger.h"
+#include <wtf/LazyRef.h>
+#include <wtf/RefPtr.h>
+
+namespace TestWebKitAPI {
+
+class LazyRefHolder {
+public:
+    LazyRefHolder(const char* name)
+        : m_log(name)
+        , m_ref(
+            [](LazyRefHolder& holder, auto& ref) {
+                ref.set(Ref { holder.m_log });
+            })
+    {
+    }
+
+    DerivedRefLogger& log() { return m_log; }
+    RefLogger& ref() { return m_ref.get(*this); }
+    RefLogger* refIfExists() { return m_ref.getIfExists(); }
+
+private:
+    DerivedRefLogger m_log;
+    LazyRef<LazyRefHolder, RefLogger> m_ref;
+};
+
+TEST(WTF_LazyRef, Basic)
+{
+    {
+        LazyRefHolder holder("a");
+        EXPECT_EQ(holder.refIfExists(), nullptr);
+        EXPECT_EQ(&holder.ref(), &holder.log());
+        EXPECT_EQ(&holder.ref().name, &holder.log().name);
+        EXPECT_EQ(holder.refIfExists(), &holder.log());
+    }
+    EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
+
+    {
+        LazyRefHolder holder("a");
+    }
+    EXPECT_STREQ("" , takeLogStr().c_str());
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/LazyUniqueRef.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/LazyUniqueRef.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "LifecycleLogger.h"
+#include <wtf/LazyUniqueRef.h>
+
+namespace TestWebKitAPI {
+
+class LazyUniqueRefHolder {
+public:
+    LazyUniqueRefHolder()
+        : m_ref(
+            [](LazyUniqueRefHolder& holder, auto& ref) {
+                ref.set(makeUniqueRefWithoutFastMallocCheck<LifecycleLogger>("a"));
+            })
+    {
+    }
+
+    LifecycleLogger& ref() { return m_ref.get(*this); }
+    LifecycleLogger* refIfExists() { return m_ref.getIfExists(); }
+
+private:
+    LazyUniqueRef<LazyUniqueRefHolder, LifecycleLogger> m_ref;
+};
+
+TEST(WTF_LazyUniqueRef, Basic)
+{
+    {
+        LazyUniqueRefHolder holder;
+        EXPECT_EQ(holder.refIfExists(), nullptr);
+        EXPECT_NE(&holder.ref(), nullptr);
+    }
+    EXPECT_STREQ("construct(a) destruct(a) ", takeLogStr().c_str());
+
+    {
+        LazyUniqueRefHolder holder;
+    }
+    EXPECT_STREQ("" , takeLogStr().c_str());
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 339bfd3e4a54c1e215bc300530670cfb2350b04d
<pre>
[WTF] Add LazyRef &amp; LazyUniqueRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=267830">https://bugs.webkit.org/show_bug.cgi?id=267830</a>
<a href="https://rdar.apple.com/121328458">rdar://121328458</a>

Reviewed by Ryosuke Niwa.

This patch adds LazyRef and LazyUniqueRef. This is similar to LazyProperty in JSC.
We can set *stateless* lambda in the constructor side of the owner object so that it offers clean interface for lazy initialization,
which does not mess up the owner object&apos;s interface.
For example,

    LazyUniqueRef&lt;VM, Property&gt; m_property;
    Property&amp; property() { return m_property.get(*this); }

First parameter is owner, which needs to be passed to `get`. And then, this `get` will automatically initialize if it is not initialized.
And the initialization code can be freely customized, but you do not need to define it as a VM&apos;s member! Instead, you can define it as a lambda inside VM.cpp.

    // This lambda needs to be stateless. So it must not capture anything (otherwise, it hits crash because of RELEASE_ASSERT anyway).
    m_property.initLater(
        [](VM&amp; vm, auto&amp; ref) {
            // You can do whatever. Even you can invoke the other property which can be further lazily initialized (so, it implicitly creates dependency graph of initialization).
            ref.set(Property::create());
            // And further, you can do anything after setting it. So these operations can see Property&amp; via `vm.property()`.
        });

Or you can set lambda in constructor, so like, VM&apos;s constructor list,

    : m_property(
        [](VM&amp; vm, auto&amp; ref) {
            // You can do whatever. Even you can invoke the other property which can be further lazily initialized (so, it implicitly creates dependency graph of initialization).
            ref.set(Property::create());
            // And further, you can do anything after setting it. So these operations can see Property&amp; via `vm.property()`.
        })
    , m_other()
    , ...

This patch applies this to some of JSC::VM&apos;s fields, making definitions much cleaner by moving all messy parts into VM.cpp side and clean up VM.h&apos;s interface.

* Source/JavaScriptCore/runtime/HasOwnPropertyCache.h:
(JSC::HasOwnPropertyCache::Entry::offsetOfStructureID): Deleted.
(JSC::HasOwnPropertyCache::Entry::offsetOfImpl): Deleted.
(JSC::HasOwnPropertyCache::Entry::offsetOfResult): Deleted.
(JSC::HasOwnPropertyCache::operator delete): Deleted.
(JSC::HasOwnPropertyCache::create): Deleted.
(JSC::HasOwnPropertyCache::hash): Deleted.
(JSC::HasOwnPropertyCache::get): Deleted.
(JSC::HasOwnPropertyCache::tryAdd): Deleted.
(JSC::HasOwnPropertyCache::clear): Deleted.
(JSC::HasOwnPropertyCache::clearBuffer): Deleted.
(JSC::VM::ensureHasOwnPropertyCache): Deleted.
* Source/JavaScriptCore/runtime/LazyPropertyInlines.h:
(JSC::ElementType&gt;::initLater):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::~VM):
(JSC::VM::invalidateStructureChainIntegrity):
(JSC::VM::ensureWatchdog): Deleted.
(JSC::VM::ensureHeapProfiler): Deleted.
(JSC::VM::ensureShadowChicken): Deleted.
(JSC::VM::ensureMegamorphicCacheSlow): Deleted.
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::watchdog):
(JSC::VM::ensureWatchdog):
(JSC::VM::heapProfiler):
(JSC::VM::ensureHeapProfiler):
(JSC::VM::hasOwnPropertyCache):
(JSC::VM::ensureHasOwnPropertyCache):
(JSC::VM::megamorphicCache):
(JSC::VM::ensureMegamorphicCache):
(JSC::VM::shadowChicken):
(JSC::VM::ensureShadowChicken):
(JSC::VM::heapProfiler const): Deleted.
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/LazyRef.h: Added.
(WTF::LazyRef::~LazyRef):
(WTF::LazyRef::isInitialized const):
(WTF::LazyRef::get const):
(WTF::LazyRef::get):
(WTF::LazyRef::getIfExists const):
(WTF::LazyRef::getIfExists):
(WTF::LazyRef::initLater):
(WTF::LazyRef::set):
(WTF::LazyRef::callFunc):
* Source/WTF/wtf/LazyUniqueRef.h: Added.
(WTF::LazyUniqueRef::~LazyUniqueRef):
(WTF::LazyUniqueRef::isInitialized const):
(WTF::LazyUniqueRef::get const):
(WTF::LazyUniqueRef::get):
(WTF::LazyUniqueRef::getIfExists const):
(WTF::LazyUniqueRef::getIfExists):
(WTF::LazyUniqueRef::initLater):
(WTF::LazyUniqueRef::set):
(WTF::LazyUniqueRef::callFunc):

Canonical link: <a href="https://commits.webkit.org/273287@main">https://commits.webkit.org/273287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24267b3aad7acdf690ab449e87f04a39e0cde3f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34992 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37736 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31603 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10955 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30546 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10310 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10365 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38988 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/29721 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31620 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36389 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/34872 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34375 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12271 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41496 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11002 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8629 "Found 231 new JSC stress test failures: microbenchmarks/array-from-derived-object-func.js.bytecode-cache, microbenchmarks/array-from-derived-object-func.js.default, microbenchmarks/array-from-derived-object-func.js.dfg-eager, microbenchmarks/array-from-derived-object-func.js.dfg-eager-no-cjit-validate, microbenchmarks/array-from-derived-object-func.js.eager-jettison-no-cjit, microbenchmarks/array-from-derived-object-func.js.no-cjit-collect-continuously, microbenchmarks/array-from-derived-object-func.js.no-llint, microbenchmarks/array-from-object-func.js.bytecode-cache, microbenchmarks/array-from-object-func.js.default, microbenchmarks/array-from-object-func.js.dfg-eager ... (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4498 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11334 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->