### PR TITLE
REGRESSION(265672@main) Netflix.com video is zoomed in and cropped in Fullscreen

### DIFF
--- a/Source/WebCore/rendering/RenderVideo.h
+++ b/Source/WebCore/rendering/RenderVideo.h
@@ -85,7 +85,6 @@ private:
     void updatePlayer();
 
     bool foregroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect, unsigned maxDepthToTest) const final;
-    bool inElementOrVideoFullscreen() const;
 
     LayoutSize m_cachedImageSize;
 };


### PR DESCRIPTION
#### f9bd5344132b3fdf437774846f98166ea40067cc
<pre>
REGRESSION(265672@main) Netflix.com video is zoomed in and cropped in Fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=267837">https://bugs.webkit.org/show_bug.cgi?id=267837</a>
<a href="https://rdar.apple.com/120803564">rdar://120803564</a>

Reviewed by Mike Wyrzykowski.

At certain combinations of screen aspect ratio and content aspect ratio, Netflix.com content
becomes zoomed-in-and-cropped when in fullscreen mode.

Netflix sizes the &lt;video&gt; element to 100% width, and a fixed height, where that height is much
taller than the height of the viewport. It then relies on `object-fit: contain` to resize the
video content within that larger element space.

265672@main attempted to correct for &quot;pixel cracks&quot; at certain combinations of content aspect
ratio and window aspect ratio by detecting that situation and slightly resizing the videoBox
to &quot;cover&quot; the viewport rather than &quot;contain&quot; it. However with Netflix.com&apos;s layout, this
calculation resulted in making the videoBox much larger than necessary.

Revert 265672@main, and its follow-up fixes, 265672@main and 265672@main.

* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::videoBox const):
(WebCore::RenderVideo::updatePlayer):
(WebCore::contentSizeAlmostEqualsFrameSize): Deleted.
(WebCore::RenderVideo::inElementOrVideoFullscreen const): Deleted.
* Source/WebCore/rendering/RenderVideo.h:

Canonical link: <a href="https://commits.webkit.org/273277@main">https://commits.webkit.org/273277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5ac2d3ecbf67435a1c4fab3f0faae6cc2f8724a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37696 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31569 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10915 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30509 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31167 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10267 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10334 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38948 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31791 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31585 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36357 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10433 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8352 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34336 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12242 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8012 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10972 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11306 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->