### PR TITLE
Mail/Other 3rd Party WebKit clients are not displaying html content in Simulator

### DIFF
--- a/Source/WebKit/Configurations/GPUExtension.xcconfig
+++ b/Source/WebKit/Configurations/GPUExtension.xcconfig
@@ -26,5 +26,6 @@
 INFOPLIST_FILE = Shared/AuxiliaryProcessExtensions/GPUExtension-Info.plist;
 INFOPLIST_KEY_CFBundleDisplayName = GPUExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.GPU;
+PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator*] = com.apple.WebKit.GPUExtension;
 EXECUTABLE_NAME = $(PRODUCT_BUNDLE_IDENTIFIER);
 PRODUCT_BUNDLE_NAME = GPUExtension;

--- a/Source/WebKit/Configurations/NetworkingExtension.xcconfig
+++ b/Source/WebKit/Configurations/NetworkingExtension.xcconfig
@@ -26,5 +26,6 @@
 INFOPLIST_FILE = Shared/AuxiliaryProcessExtensions/NetworkingExtension-Info.plist;
 INFOPLIST_KEY_CFBundleDisplayName = NetworkingExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.Networking;
+PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator*] = com.apple.WebKit.NetworkingExtension;
 EXECUTABLE_NAME = $(PRODUCT_BUNDLE_IDENTIFIER);
 PRODUCT_BUNDLE_NAME = NetworkingExtension;

--- a/Source/WebKit/Configurations/WebContentCaptivePortalExtension.xcconfig
+++ b/Source/WebKit/Configurations/WebContentCaptivePortalExtension.xcconfig
@@ -26,5 +26,6 @@
 INFOPLIST_FILE = Shared/AuxiliaryProcessExtensions/WebContentExtension-CaptivePortal-Info.plist;
 INFOPLIST_KEY_CFBundleDisplayName = WebContentCaptivePortalExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.WebContent.CaptivePortal;
+PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator*] = com.apple.WebKit.WebContentCaptivePortalExtension;
 EXECUTABLE_NAME = $(PRODUCT_BUNDLE_IDENTIFIER);
 PRODUCT_BUNDLE_NAME = WebContentCaptivePortalExtension;

--- a/Source/WebKit/Configurations/WebContentExtension.xcconfig
+++ b/Source/WebKit/Configurations/WebContentExtension.xcconfig
@@ -26,5 +26,6 @@
 INFOPLIST_FILE = Shared/AuxiliaryProcessExtensions/WebContentExtension-Info.plist;
 INFOPLIST_KEY_CFBundleDisplayName = WebContentExtension;
 PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.WebContent;
+PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator*] = com.apple.WebKit.WebContentExtension;
 EXECUTABLE_NAME = $(PRODUCT_BUNDLE_IDENTIFIER);
 PRODUCT_BUNDLE_NAME = WebContentExtension;


### PR DESCRIPTION
#### f6f45d4b46488e45f6c84c5be519837619a2cafe
<pre>
Mail/Other 3rd Party WebKit clients are not displaying html content in Simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=267839">https://bugs.webkit.org/show_bug.cgi?id=267839</a>
<a href="https://rdar.apple.com/121338366">rdar://121338366</a>

Reviewed by Chris Dumez.

The cause of this is duplicate bundle IDs for WebKit extensions and WebKit XPC services. This is only an
issue on Simulator, and is addressed in this patch by changing the bundle IDs for WebKit extensions on
Simulator only. This change should only affect Simulator.

* Source/WebKit/Configurations/GPUExtension.xcconfig:
* Source/WebKit/Configurations/NetworkingExtension.xcconfig:
* Source/WebKit/Configurations/WebContentCaptivePortalExtension.xcconfig:
* Source/WebKit/Configurations/WebContentExtension.xcconfig:

Canonical link: <a href="https://commits.webkit.org/273279@main">https://commits.webkit.org/273279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/815270cca3d4f5f3d12c2c98ec77b0553f1a3b7e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37717 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31585 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10936 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30523 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31183 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10286 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10347 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38968 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31804 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36369 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10451 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34357 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12254 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10985 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4494 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11318 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->