### PR TITLE
Reduce use of downcast<>() in WebCore

### DIFF
--- a/Source/WebCore/bindings/js/JSTrackCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTrackCustom.cpp
@@ -46,11 +46,11 @@ JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* g
         break;
 
     case TrackBase::AudioTrack:
-        return wrap(lexicalGlobalObject, globalObject, downcast<AudioTrack>(track));
+        return wrap(lexicalGlobalObject, globalObject, uncheckedDowncast<AudioTrack>(track));
     case TrackBase::VideoTrack:
-        return wrap(lexicalGlobalObject, globalObject, downcast<VideoTrack>(track));
+        return wrap(lexicalGlobalObject, globalObject, uncheckedDowncast<VideoTrack>(track));
     case TrackBase::TextTrack:
-        return wrap(lexicalGlobalObject, globalObject, downcast<TextTrack>(track));
+        return wrap(lexicalGlobalObject, globalObject, uncheckedDowncast<TextTrack>(track));
     }
 
     return jsNull();

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -280,7 +280,6 @@ JSC::JSValue ScriptModuleLoader::evaluate(JSC::JSGlobalObject* jsGlobalObject, J
         if (RefPtr frame = downcast<Document>(*m_context).frame())
             RELEASE_AND_RETURN(scope, frame->script().evaluateModule(sourceURL, *moduleRecord, awaitedValue, resumeMode));
     } else {
-        ASSERT(is<WorkerOrWorkletGlobalScope>(*m_context));
         if (auto* script = downcast<WorkerOrWorkletGlobalScope>(*m_context).script())
             RELEASE_AND_RETURN(scope, script->evaluateModule(*moduleRecord, awaitedValue, resumeMode));
     }

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -318,8 +318,6 @@ void CSSFontFace::setFeatureSettings(CSSValue& featureSettings)
 
 void CSSFontFace::setSizeAdjust(CSSValue& value)
 {
-    ASSERT(is<CSSPrimitiveValue>(value));
-
     mutableProperties().setProperty(CSSPropertySizeAdjust, &value);
 
     auto& sizeAdjustValue = downcast<CSSPrimitiveValue>(value);

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -297,7 +297,7 @@ bool CSSValue::equals(const CSSValue& other) const
         return visitDerived([&](auto& typedThis) {
             using ValueType = std::remove_reference_t<decltype(typedThis)>;
             static_assert(!std::is_same_v<decltype(&ValueType::equals), decltype(&CSSValue::equals)>);
-            return typedThis.equals(downcast<ValueType>(other));
+            return typedThis.equals(uncheckedDowncast<ValueType>(other));
         });
     }
     if (auto* thisList = dynamicDowncast<CSSValueList>(*this))

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -773,14 +773,14 @@ RefPtr<CSSFunctionValue> transformOperationAsCSSValue(const TransformOperation& 
     switch (operation.type()) {
     // translate
     case TransformOperation::Type::TranslateX:
-        return CSSFunctionValue::create(CSSValueTranslateX, translateLengthAsCSSValue(downcast<TranslateTransformOperation>(operation).x()));
+        return CSSFunctionValue::create(CSSValueTranslateX, translateLengthAsCSSValue(uncheckedDowncast<TranslateTransformOperation>(operation).x()));
     case TransformOperation::Type::TranslateY:
-        return CSSFunctionValue::create(CSSValueTranslateY, translateLengthAsCSSValue(downcast<TranslateTransformOperation>(operation).y()));
+        return CSSFunctionValue::create(CSSValueTranslateY, translateLengthAsCSSValue(uncheckedDowncast<TranslateTransformOperation>(operation).y()));
     case TransformOperation::Type::TranslateZ:
-        return CSSFunctionValue::create(CSSValueTranslateZ, translateLengthAsCSSValue(downcast<TranslateTransformOperation>(operation).z()));
+        return CSSFunctionValue::create(CSSValueTranslateZ, translateLengthAsCSSValue(uncheckedDowncast<TranslateTransformOperation>(operation).z()));
     case TransformOperation::Type::Translate:
     case TransformOperation::Type::Translate3D: {
-        auto& translate = downcast<TranslateTransformOperation>(operation);
+        auto& translate = uncheckedDowncast<TranslateTransformOperation>(operation);
         if (!translate.is3DOperation()) {
             if (!includeLength(translate.y()))
                 return CSSFunctionValue::create(CSSValueTranslate, translateLengthAsCSSValue(translate.x()));
@@ -794,14 +794,14 @@ RefPtr<CSSFunctionValue> transformOperationAsCSSValue(const TransformOperation& 
     }
     // scale
     case TransformOperation::Type::ScaleX:
-        return CSSFunctionValue::create(CSSValueScaleX, CSSPrimitiveValue::create(downcast<ScaleTransformOperation>(operation).x()));
+        return CSSFunctionValue::create(CSSValueScaleX, CSSPrimitiveValue::create(uncheckedDowncast<ScaleTransformOperation>(operation).x()));
     case TransformOperation::Type::ScaleY:
-        return CSSFunctionValue::create(CSSValueScaleY, CSSPrimitiveValue::create(downcast<ScaleTransformOperation>(operation).y()));
+        return CSSFunctionValue::create(CSSValueScaleY, CSSPrimitiveValue::create(uncheckedDowncast<ScaleTransformOperation>(operation).y()));
     case TransformOperation::Type::ScaleZ:
-        return CSSFunctionValue::create(CSSValueScaleZ, CSSPrimitiveValue::create(downcast<ScaleTransformOperation>(operation).z()));
+        return CSSFunctionValue::create(CSSValueScaleZ, CSSPrimitiveValue::create(uncheckedDowncast<ScaleTransformOperation>(operation).z()));
     case TransformOperation::Type::Scale:
     case TransformOperation::Type::Scale3D: {
-        auto& scale = downcast<ScaleTransformOperation>(operation);
+        auto& scale = uncheckedDowncast<ScaleTransformOperation>(operation);
         if (!scale.is3DOperation()) {
             if (scale.x() == scale.y())
                 return CSSFunctionValue::create(CSSValueScale, CSSPrimitiveValue::create(scale.x()));
@@ -815,24 +815,24 @@ RefPtr<CSSFunctionValue> transformOperationAsCSSValue(const TransformOperation& 
     }
     // rotate
     case TransformOperation::Type::RotateX:
-        return CSSFunctionValue::create(CSSValueRotateX, CSSPrimitiveValue::create(downcast<RotateTransformOperation>(operation).angle(), CSSUnitType::CSS_DEG));
+        return CSSFunctionValue::create(CSSValueRotateX, CSSPrimitiveValue::create(uncheckedDowncast<RotateTransformOperation>(operation).angle(), CSSUnitType::CSS_DEG));
     case TransformOperation::Type::RotateY:
-        return CSSFunctionValue::create(CSSValueRotateX, CSSPrimitiveValue::create(downcast<RotateTransformOperation>(operation).angle(), CSSUnitType::CSS_DEG));
+        return CSSFunctionValue::create(CSSValueRotateX, CSSPrimitiveValue::create(uncheckedDowncast<RotateTransformOperation>(operation).angle(), CSSUnitType::CSS_DEG));
     case TransformOperation::Type::RotateZ:
-        return CSSFunctionValue::create(CSSValueRotateZ, CSSPrimitiveValue::create(downcast<RotateTransformOperation>(operation).angle(), CSSUnitType::CSS_DEG));
+        return CSSFunctionValue::create(CSSValueRotateZ, CSSPrimitiveValue::create(uncheckedDowncast<RotateTransformOperation>(operation).angle(), CSSUnitType::CSS_DEG));
     case TransformOperation::Type::Rotate:
-        return CSSFunctionValue::create(CSSValueRotate, CSSPrimitiveValue::create(downcast<RotateTransformOperation>(operation).angle(), CSSUnitType::CSS_DEG));
+        return CSSFunctionValue::create(CSSValueRotate, CSSPrimitiveValue::create(uncheckedDowncast<RotateTransformOperation>(operation).angle(), CSSUnitType::CSS_DEG));
     case TransformOperation::Type::Rotate3D: {
-        auto& rotate = downcast<RotateTransformOperation>(operation);
+        auto& rotate = uncheckedDowncast<RotateTransformOperation>(operation);
         return CSSFunctionValue::create(CSSValueRotate3d, CSSPrimitiveValue::create(rotate.x()), CSSPrimitiveValue::create(rotate.y()), CSSPrimitiveValue::create(rotate.z()), CSSPrimitiveValue::create(rotate.angle(), CSSUnitType::CSS_DEG));
     }
     // skew
     case TransformOperation::Type::SkewX:
-        return CSSFunctionValue::create(CSSValueSkewX, CSSPrimitiveValue::create(downcast<SkewTransformOperation>(operation).angleX(), CSSUnitType::CSS_DEG));
+        return CSSFunctionValue::create(CSSValueSkewX, CSSPrimitiveValue::create(uncheckedDowncast<SkewTransformOperation>(operation).angleX(), CSSUnitType::CSS_DEG));
     case TransformOperation::Type::SkewY:
-        return CSSFunctionValue::create(CSSValueSkewY, CSSPrimitiveValue::create(downcast<SkewTransformOperation>(operation).angleY(), CSSUnitType::CSS_DEG));
+        return CSSFunctionValue::create(CSSValueSkewY, CSSPrimitiveValue::create(uncheckedDowncast<SkewTransformOperation>(operation).angleY(), CSSUnitType::CSS_DEG));
     case TransformOperation::Type::Skew: {
-        auto& skew = downcast<SkewTransformOperation>(operation);
+        auto& skew = uncheckedDowncast<SkewTransformOperation>(operation);
         if (!skew.angleY())
             return CSSFunctionValue::create(CSSValueSkew, CSSPrimitiveValue::create(skew.angleX(), CSSUnitType::CSS_DEG));
         return CSSFunctionValue::create(CSSValueSkew, CSSPrimitiveValue::create(skew.angleX(), CSSUnitType::CSS_DEG),
@@ -840,7 +840,7 @@ RefPtr<CSSFunctionValue> transformOperationAsCSSValue(const TransformOperation& 
     }
     // perspective
     case TransformOperation::Type::Perspective:
-        if (auto perspective = downcast<PerspectiveTransformOperation>(operation).perspective())
+        if (auto perspective = uncheckedDowncast<PerspectiveTransformOperation>(operation).perspective())
             return CSSFunctionValue::create(CSSValuePerspective, zoomAdjustedPixelValueForLength(*perspective, style));
         return CSSFunctionValue::create(CSSValuePerspective, CSSPrimitiveValue::create(CSSValueNone));
     // matrix
@@ -1020,11 +1020,11 @@ Ref<CSSValue> ComputedStyleExtractor::valueForFilter(const RenderStyle& style, c
                 break;
             case FilterOperation::Type::Blur:
                 filterValue = CSSFunctionValue::create(CSSValueBlur,
-                    adjustLengthForZoom(downcast<BlurFilterOperation>(filterOperation).stdDeviation(), style, adjust));
+                    adjustLengthForZoom(uncheckedDowncast<BlurFilterOperation>(filterOperation).stdDeviation(), style, adjust));
                 break;
             case FilterOperation::Type::DropShadow: {
                 // We want our computed style to look like that of a text shadow (has neither spread nor inset style).
-                auto& dropShadowOperation = downcast<DropShadowFilterOperation>(filterOperation);
+                auto& dropShadowOperation = uncheckedDowncast<DropShadowFilterOperation>(filterOperation);
                 ShadowData shadowData({ Length(dropShadowOperation.location().x(), LengthType::Fixed), Length(dropShadowOperation.location().y(), LengthType::Fixed) }, Length(dropShadowOperation.stdDeviation(), LengthType::Fixed), Length(0, LengthType::Fixed), ShadowStyle::Normal, false, dropShadowOperation.color());
                 filterValue = CSSFunctionValue::create(CSSValueDropShadow,
                     valueForShadow(&shadowData, CSSPropertyTextShadow, style, adjust));

--- a/Source/WebCore/css/DeprecatedCSSOMValue.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMValue.cpp
@@ -40,13 +40,13 @@ void DeprecatedCSSOMValue::operator delete(DeprecatedCSSOMValue* value, std::des
 
     switch (value->classType()) {
     case ClassType::Complex:
-        destroyAndFree(downcast<DeprecatedCSSOMComplexValue>(*value));
+        destroyAndFree(uncheckedDowncast<DeprecatedCSSOMComplexValue>(*value));
         break;
     case ClassType::Primitive:
-        destroyAndFree(downcast<DeprecatedCSSOMPrimitiveValue>(*value));
+        destroyAndFree(uncheckedDowncast<DeprecatedCSSOMPrimitiveValue>(*value));
         break;
     case ClassType::List:
-        destroyAndFree(downcast<DeprecatedCSSOMValueList>(*value));
+        destroyAndFree(uncheckedDowncast<DeprecatedCSSOMValueList>(*value));
         break;
     }
 }
@@ -55,9 +55,9 @@ unsigned short DeprecatedCSSOMValue::cssValueType() const
 {
     switch (classType()) {
     case ClassType::Complex:
-        return downcast<DeprecatedCSSOMComplexValue>(*this).cssValueType();
+        return uncheckedDowncast<DeprecatedCSSOMComplexValue>(*this).cssValueType();
     case ClassType::Primitive:
-        return downcast<DeprecatedCSSOMPrimitiveValue>(*this).cssValueType();
+        return uncheckedDowncast<DeprecatedCSSOMPrimitiveValue>(*this).cssValueType();
     case ClassType::List:
         return CSS_VALUE_LIST;
     }
@@ -69,11 +69,11 @@ String DeprecatedCSSOMValue::cssText() const
 {
     switch (classType()) {
     case ClassType::Complex:
-        return downcast<DeprecatedCSSOMComplexValue>(*this).cssText();
+        return uncheckedDowncast<DeprecatedCSSOMComplexValue>(*this).cssText();
     case ClassType::Primitive:
-        return downcast<DeprecatedCSSOMPrimitiveValue>(*this).cssText();
+        return uncheckedDowncast<DeprecatedCSSOMPrimitiveValue>(*this).cssText();
     case ClassType::List:
-        return downcast<DeprecatedCSSOMValueList>(*this).cssText();
+        return uncheckedDowncast<DeprecatedCSSOMValueList>(*this).cssText();
     }
     ASSERT_NOT_REACHED();
     return emptyString();

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -3361,9 +3361,9 @@ class GenerateStyleBuilderGenerated:
     def _generate_animation_property_value_setter(self, to, property):
         to.write(f"auto& list = builderState.style().{property.method_name_for_ensure_animations_or_transitions}();")
         to.write(f"size_t childIndex = 0;")
-        to.write(f"if (is<CSSValueList>(value)) {{")
+        to.write(f"if (auto* valueList = dynamicDowncast<CSSValueList>(value)) {{")
         to.write(f"    // Walk each value and put it into an animation, creating new animations as needed.")
-        to.write(f"    for (auto& currentValue : downcast<CSSValueList>(value)) {{")
+        to.write(f"    for (auto& currentValue : *valueList) {{")
         to.write(f"        if (childIndex >= list.size())")
         to.write(f"            list.append(Animation::create());")
         to.write(f"        builderState.styleMap().mapAnimation{property.name_for_methods}(list.animation(childIndex), currentValue);")

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4849,31 +4849,17 @@ void Element::updateIdForDocument(HTMLDocument& document, const AtomString& oldI
     }
 }
 
-void Element::updateLabel(TreeScope& scope, const AtomString& oldForAttributeValue, const AtomString& newForAttributeValue)
-{
-    ASSERT(hasTagName(labelTag));
-
-    if (!isConnected())
-        return;
-
-    if (oldForAttributeValue == newForAttributeValue)
-        return;
-
-    if (!oldForAttributeValue.isEmpty())
-        scope.removeLabel(oldForAttributeValue, downcast<HTMLLabelElement>(*this));
-    if (!newForAttributeValue.isEmpty())
-        scope.addLabel(newForAttributeValue, downcast<HTMLLabelElement>(*this));
-}
-
 void Element::willModifyAttribute(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue)
 {
     if (name == HTMLNames::idAttr)
         updateId(oldValue, newValue, NotifyObservers::No); // Will notify observers after the attribute is actually changed.
     else if (name == HTMLNames::nameAttr)
         updateName(oldValue, newValue);
-    else if (name == HTMLNames::forAttr && hasTagName(labelTag)) {
-        if (treeScope().shouldCacheLabelsByForAttribute())
-            updateLabel(treeScope(), oldValue, newValue);
+    else if (name == HTMLNames::forAttr) {
+        if (auto* label = dynamicDowncast<HTMLLabelElement>(*this)) {
+            if (treeScope().shouldCacheLabelsByForAttribute())
+                label->updateLabel(treeScope(), oldValue, newValue);
+        }
     }
 
     if (auto recipients = MutationObserverInterestGroup::createForAttributesMutation(*this, name))

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -783,8 +783,6 @@ protected:
     FormAssociatedCustomElement& formAssociatedCustomElementUnsafe() const;
     void ensureFormAssociatedCustomElement();
 
-    void updateLabel(TreeScope&, const AtomString& oldForAttributeValue, const AtomString& newForAttributeValue);
-
     static AtomString makeTargetBlankIfHasDanglingMarkup(const AtomString& target);
 
 private:

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2284,7 +2284,7 @@ void Node::moveNodeToNewDocument(Document& oldDocument, Document& newDocument)
 bool isTouchRelatedEventType(const EventTypeInfo& eventType, const EventTarget& target)
 {
 #if ENABLE(TOUCH_EVENTS)
-    if (is<Node>(target) && downcast<Node>(target).document().quirks().shouldDispatchSimulatedMouseEvents(&target))
+    if (auto* node = dynamicDowncast<Node>(target); node && node->document().quirks().shouldDispatchSimulatedMouseEvents(&target))
         return eventType.isInCategory(EventCategory::ExtendedTouchRelated);
 #endif
     UNUSED_PARAM(target);

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -509,7 +509,7 @@ static ExceptionOr<RefPtr<Node>> processContentsBetweenOffsets(Range::ActionType
         }
         break;
     case Node::PROCESSING_INSTRUCTION_NODE: {
-        auto& instruction = downcast<ProcessingInstruction>(*container);
+        auto& instruction = uncheckedDowncast<ProcessingInstruction>(*container);
         endOffset = std::min(endOffset, instruction.data().length());
         startOffset = std::min(startOffset, endOffset);
         if (action == Range::Extract || action == Range::Clone) {
@@ -877,8 +877,8 @@ ExceptionOr<void> Range::surroundContents(Node& newParent)
         return fragment.releaseException();
 
     // Step 4: If newParent has children, replace all with null within newParent.
-    if (newParent.hasChildNodes())
-        downcast<ContainerNode>(newParent).replaceAll(nullptr);
+    if (auto* containerNode = dynamicDowncast<ContainerNode>(newParent); containerNode && containerNode->hasChildNodes())
+        containerNode->replaceAll(nullptr);
 
     // Step 5: Insert newParent into context object.
     auto insertResult = insertNode(newParent);

--- a/Source/WebCore/dom/ScopedEventQueue.cpp
+++ b/Source/WebCore/dom/ScopedEventQueue.cpp
@@ -45,7 +45,7 @@ ScopedEventQueue& ScopedEventQueue::singleton()
 
 void ScopedEventQueue::enqueueEvent(Ref<Event>&& event)
 {
-    ASSERT(is<Node>(event->target()));
+    ASSERT(event->target());
     auto& target = downcast<Node>(*event->target());
     ScopedEvent scopedEvent = { WTFMove(event), target };
     if (m_scopingLevel)

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -786,7 +786,7 @@ void ScriptExecutionContext::postTaskToResponsibleDocument(Function<void(Documen
         return;
     }
 
-    if (auto document = downcast<WorkletGlobalScope>(this)->responsibleDocument())
+    if (auto document = downcast<WorkletGlobalScope>(*this).responsibleDocument())
         callback(*document);
 }
 

--- a/Source/WebCore/editing/ChangeListTypeCommand.cpp
+++ b/Source/WebCore/editing/ChangeListTypeCommand.cpp
@@ -47,8 +47,8 @@ static std::optional<std::pair<ChangeListTypeCommand::Type, Ref<HTMLElement>>> l
     auto commonAncestor = commonInclusiveAncestor<ComposedTree>(*startNode, *endNode);
 
     RefPtr<HTMLElement> listToReplace;
-    if (is<HTMLUListElement>(commonAncestor) || is<HTMLOListElement>(commonAncestor))
-        listToReplace = downcast<HTMLElement>(commonAncestor);
+    if (auto* htmlElement = dynamicDowncast<HTMLElement>(commonAncestor); is<HTMLUListElement>(htmlElement) || is<HTMLOListElement>(htmlElement))
+        listToReplace = htmlElement;
     else
         listToReplace = enclosingList(commonAncestor);
 

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -218,6 +218,20 @@ auto HTMLLabelElement::insertedIntoAncestor(InsertionType insertionType, Contain
     return result;
 }
 
+void HTMLLabelElement::updateLabel(TreeScope& scope, const AtomString& oldForAttributeValue, const AtomString& newForAttributeValue)
+{
+    if (!isConnected())
+        return;
+
+    if (oldForAttributeValue == newForAttributeValue)
+        return;
+
+    if (!oldForAttributeValue.isEmpty())
+        scope.removeLabel(oldForAttributeValue, *this);
+    if (!newForAttributeValue.isEmpty())
+        scope.addLabel(newForAttributeValue, *this);
+}
+
 void HTMLLabelElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     if (oldParentOfRemovedTree.isInTreeScope() && removalType.treeScopeChanged) {

--- a/Source/WebCore/html/HTMLLabelElement.h
+++ b/Source/WebCore/html/HTMLLabelElement.h
@@ -38,6 +38,7 @@ public:
     WEBCORE_EXPORT HTMLFormElement* form() const;
 
     bool willRespondToMouseClickEventsWithEditability(Editability) const final;
+    void updateLabel(TreeScope&, const AtomString& oldForAttributeValue, const AtomString& newForAttributeValue);
 
 private:
     HTMLLabelElement(const QualifiedName&, Document&);


### PR DESCRIPTION
#### 8e4af45308bd2a51542bf417ce1eca208e472ade
<pre>
Reduce use of downcast&lt;&gt;() in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=267840">https://bugs.webkit.org/show_bug.cgi?id=267840</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/bindings/js/JSTrackCustom.cpp:
(WebCore::toJS):
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::evaluate):
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::setSizeAdjust):
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::equals const):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::transformOperationAsCSSValue):
(WebCore::ComputedStyleExtractor::valueForFilter):
* Source/WebCore/css/DeprecatedCSSOMValue.cpp:
(WebCore::DeprecatedCSSOMValue::operator delete):
(WebCore::DeprecatedCSSOMValue::cssValueType const):
(WebCore::DeprecatedCSSOMValue::cssText const):
* Source/WebCore/css/process-css-properties.py:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::willModifyAttribute):
(WebCore::Element::updateLabel): Deleted.
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::isTouchRelatedEventType):
* Source/WebCore/dom/Range.cpp:
(WebCore::processContentsBetweenOffsets):
(WebCore::Range::surroundContents):
* Source/WebCore/dom/ScopedEventQueue.cpp:
(WebCore::ScopedEventQueue::enqueueEvent):
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::postTaskToResponsibleDocument):
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::isLegacyAppleStyleSpan):
(WebCore::isStyleSpanOrSpanWithOnlyStyleAttribute):
(WebCore::isSpanWithoutAttributesOrUnstyledStyleSpan):
(WebCore::isEmptyFontTag):
(WebCore::ApplyStyleCommand::applyBlockStyle):
(WebCore::ApplyStyleCommand::applyRelativeFontStyleChange):
(WebCore::dummySpanAncestorForNode):
(WebCore::ApplyStyleCommand::removeEmbeddingUpToEnclosingBlock):
(WebCore::ApplyStyleCommand::applyInlineStyleToNodeRange):
(WebCore::ApplyStyleCommand::removeConflictingInlineStyleFromRun):
(WebCore::ApplyStyleCommand::applyInlineStyleToPushDown):
(WebCore::ApplyStyleCommand::pushDownInlineStyleAroundNode):
(WebCore::ApplyStyleCommand::removeInlineStyle):
(WebCore::ApplyStyleCommand::shouldSplitTextElement):
(WebCore::ApplyStyleCommand::surroundNodeRangeWithElement):
(WebCore::ApplyStyleCommand::applyInlineStyleChange):
* Source/WebCore/editing/BreakBlockquoteCommand.cpp:
(WebCore::BreakBlockquoteCommand::doApply):
* Source/WebCore/editing/ChangeListTypeCommand.cpp:
(WebCore::listConversionTypeForSelection):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::cloneParagraphUnderNewElement):
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::isSpecialHTMLElement):
(WebCore::DeleteSelectionCommand::handleGeneralDelete):
(WebCore::DeleteSelectionCommand::fixupWhitespace):
(WebCore::DeleteSelectionCommand::doApply):
* Source/WebCore/editing/Editing.cpp:
(WebCore::enclosingList):
(WebCore::isMailBlockquote):
(WebCore::elementIfBlockFlow):
(WebCore::isBlockFlowElement):
(WebCore::deprecatedEnclosingBlockFlowElement):
(WebCore::rendererForCaretPainting):
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::fontWeightValueIsBold):
(WebCore::EditingStyle::overrideTypingStyleAt):
(WebCore::EditingStyle::styleIsPresentInComputedStyleOfNode const):
(WebCore::EditingStyle::wrappingStyleForSerialization):
(WebCore::EditingStyle::mergeStyle):
(WebCore::loneFontFamilyName):
(WebCore::EditingStyle::mergeStyleFromRulesForSerialization):
(WebCore::EditingStyle::legacyFontSize const):
(WebCore::EditingStyle::styleAtSelectionStart):
(WebCore::StyleChange::StyleChange):
(WebCore::StyleChange::extractTextStyles):
(WebCore::diffTextDecorations):
* Source/WebCore/html/HTMLLabelElement.cpp:
(WebCore::HTMLLabelElement::updateLabel):
* Source/WebCore/html/HTMLLabelElement.h:

Canonical link: <a href="https://commits.webkit.org/273311@main">https://commits.webkit.org/273311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1400f4b7b69b6bfbc28be86acb7efb74d09fd8e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37735 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31602 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30539 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10303 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10364 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38987 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31822 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31619 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36387 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10468 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34373 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12270 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11001 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4514 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11333 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->