### PR TITLE
[Win] Crash in GLContext::makeContextCurrent under WCSceneContext::makeContextCurrent

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
@@ -73,7 +73,8 @@ void WCScene::initialize(WCSceneContext& context)
 {
     // The creation of the TextureMapper needs an active OpenGL context.
     m_context = &context;
-    m_context->makeContextCurrent();
+    if (!m_context->makeContextCurrent())
+        return;
     m_textureMapper = m_context->createTextureMapper();
 }
 
@@ -85,7 +86,8 @@ WCScene::WCScene(WebCore::ProcessIdentifier webProcessIdentifier, bool usesOffsc
 
 WCScene::~WCScene()
 {
-    m_context->makeContextCurrent();
+    if (!m_context->makeContextCurrent())
+        return;
     m_textureMapper = nullptr;
 }
 

--- a/Source/WebKit/GPUProcess/graphics/wc/WCSceneContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCSceneContext.cpp
@@ -42,6 +42,8 @@ WCSceneContext::~WCSceneContext() = default;
 
 bool WCSceneContext::makeContextCurrent()
 {
+    if (!m_glContext)
+        return false;
     return m_glContext->makeContextCurrent();
 }
 


### PR DESCRIPTION
#### 4c9e5ce1f2416cc8631758e33ab26db4e1d9e188
<pre>
[Win] Crash in GLContext::makeContextCurrent under WCSceneContext::makeContextCurrent
<a href="https://bugs.webkit.org/show_bug.cgi?id=264550">https://bugs.webkit.org/show_bug.cgi?id=264550</a>

Reviewed by Don Olmstead.

Running layout tests was randomly observing assertion failures in GPU
process due to OpenGL context creation failures for Windows port. It
was relatively reproducible with the following invocation:

&gt; python .\Tools\Scripts\run-webkit-tests --debug --iter=100 -f --no-retry --no-show compositing/shared-backing/backing-sharing-compositing-change.html compositing/shared-backing/move-sharing-child.html

In that cases, the HWND was already closed in UI process. We have to
check the GLContext validity and the return value of
makeContextCurrent in GPU process.

* Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp:
* Source/WebKit/GPUProcess/graphics/wc/WCSceneContext.cpp:

Canonical link: <a href="https://commits.webkit.org/273315@main">https://commits.webkit.org/273315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76246c8dc1353d4d1e904b7e06be2c571e0b52fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/34989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13874 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37733 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31600 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30538 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10302 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10362 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/38985 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36386 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10466 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34372 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12268 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/10999 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4517 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11331 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->