### PR TITLE
Invalidate GlyphDisplayListCache entries in more places

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2296,6 +2296,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/EventRegion.h
     rendering/FloatingObjects.h
     rendering/GapRects.h
+    rendering/GlyphDisplayListCacheRemoval.h
     rendering/HitTestLocation.h
     rendering/HitTestRequest.h
     rendering/HitTestResult.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2560,6 +2560,7 @@ rendering/GridLayoutFunctions.cpp
 rendering/GridMasonryLayout.cpp
 rendering/GridTrackSizingAlgorithm.cpp
 rendering/GlyphDisplayListCache.cpp
+rendering/GlyphDisplayListCacheRemoval.cpp
 rendering/HitTestLocation.cpp
 rendering/HitTestResult.cpp
 rendering/HitTestingTransformState.cpp

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContent.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContent.cpp
@@ -26,35 +26,18 @@
 #include "config.h"
 #include "InlineDisplayContent.h"
 
-#include "TextPainter.h"
-
-
 namespace WebCore {
 namespace InlineDisplay {
-
-static void invalidateGlyphCache(Boxes& boxes, size_t firstBoxIndex, size_t numberOfBoxes)
-{
-    ASSERT(firstBoxIndex + numberOfBoxes <= boxes.size());
-    for (size_t index = 0; index < numberOfBoxes; ++index)
-        TextPainter::removeGlyphDisplayList(boxes[firstBoxIndex + index]);
-}
-
-static void invalidateGlyphCache(Boxes& boxes)
-{
-    invalidateGlyphCache(boxes, 0, boxes.size());
-}
 
 void Content::clear()
 {
     lines.clear();
-    invalidateGlyphCache(boxes);
     boxes.clear();
 }
 
 void Content::set(Content&& newContent)
 {
     lines = WTFMove(newContent.lines);
-    invalidateGlyphCache(boxes);
     boxes = WTFMove(newContent.boxes);
 }
 
@@ -73,7 +56,6 @@ void Content::insert(Content&& newContent, size_t lineIndex, size_t boxIndex)
 void Content::remove(size_t firstLineIndex, size_t numberOfLines, size_t firstBoxIndex, size_t numberOfBoxes)
 {
     lines.remove(firstLineIndex, numberOfLines);
-    invalidateGlyphCache(boxes, firstBoxIndex, numberOfBoxes);
     boxes.remove(firstBoxIndex, numberOfBoxes);
 }
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp
@@ -90,12 +90,6 @@ IteratorRange<const InlineDisplay::Box*> InlineContent::boxesForRect(const Layou
     return { &boxes[firstBox], &boxes[lastBox] + 1 };
 }
 
-InlineContent::~InlineContent()
-{
-    for (auto& box : m_displayContent.boxes)
-        TextPainter::removeGlyphDisplayList(box);
-}
-
 const RenderObject& InlineContent::rendererForLayoutBox(const Layout::Box& layoutBox) const
 {
     return lineLayout().rendererForLayoutBox(layoutBox);

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
@@ -54,7 +54,6 @@ struct InlineContent : public CanMakeWeakPtr<InlineContent> {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
     InlineContent(const LineLayout&);
-    ~InlineContent();
 
     InlineDisplay::Content& displayContent() { return m_displayContent; }
     const InlineDisplay::Content& displayContent() const { return m_displayContent; }

--- a/Source/WebCore/rendering/GlyphDisplayListCache.cpp
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.cpp
@@ -27,6 +27,8 @@
 #include "GlyphDisplayListCache.h"
 
 #include "DisplayListItems.h"
+#include "InlineDisplayBox.h"
+#include "LegacyInlineTextBox.h"
 
 namespace WebCore {
 
@@ -74,7 +76,8 @@ unsigned GlyphDisplayListCache::size() const
     return m_entries.size();
 }
 
-DisplayList::DisplayList* GlyphDisplayListCache::get(const void* run, const FontCascade& font, GraphicsContext& context, const TextRun& textRun)
+template <typename LayoutRun>
+DisplayList::DisplayList* GlyphDisplayListCache::getDisplayList(const LayoutRun* run, const FontCascade& font, GraphicsContext& context, const TextRun& textRun)
 {
     if (MemoryPressureHandler::singleton().isUnderMemoryPressure()) {
         if (!m_entries.isEmpty()) {
@@ -90,17 +93,30 @@ DisplayList::DisplayList* GlyphDisplayListCache::get(const void* run, const Font
     if (auto entry = m_entriesForLayoutRun.get(run))
         return &entry->displayList();
 
-    if (auto entry = m_entries.find<GlyphDisplayListCacheKeyTranslator>(GlyphDisplayListCacheKey { textRun, font, context }); entry != m_entries.end())
+    if (auto entry = m_entries.find<GlyphDisplayListCacheKeyTranslator>(GlyphDisplayListCacheKey { textRun, font, context }); entry != m_entries.end()) {
+        const_cast<LayoutRun*>(run)->setIsInGlyphDisplayListCache();
         return &m_entriesForLayoutRun.add(run, Ref { entry->get() }).iterator->value->displayList();
+    }
 
     if (auto displayList = font.displayListForTextRun(context, textRun)) {
         Ref entry = GlyphDisplayListCacheEntry::create(WTFMove(displayList), textRun, font, context);
         if (canShareDisplayList(entry->displayList()))
             m_entries.add(entry.get());
+        const_cast<LayoutRun*>(run)->setIsInGlyphDisplayListCache();
         return &m_entriesForLayoutRun.add(run, WTFMove(entry)).iterator->value->displayList();
     }
 
     return nullptr;
+}
+
+DisplayList::DisplayList* GlyphDisplayListCache::get(const LegacyInlineTextBox& run, const FontCascade& font, GraphicsContext& context, const TextRun& textRun)
+{
+    return getDisplayList(&run, font, context, textRun);
+}
+
+DisplayList::DisplayList* GlyphDisplayListCache::get(const InlineDisplay::Box& run, const FontCascade& font, GraphicsContext& context, const TextRun& textRun)
+{
+    return getDisplayList(&run, font, context, textRun);
 }
 
 DisplayList::DisplayList* GlyphDisplayListCache::getIfExists(const void* run)

--- a/Source/WebCore/rendering/GlyphDisplayListCache.h
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.h
@@ -107,8 +107,8 @@ public:
 
     static GlyphDisplayListCache& singleton();
 
-    DisplayList::DisplayList* get(const LegacyInlineTextBox& run, const FontCascade& font, GraphicsContext& context, const TextRun& textRun) { return get(&run, font, context, textRun); }
-    DisplayList::DisplayList* get(const InlineDisplay::Box& run, const FontCascade& font, GraphicsContext& context, const TextRun& textRun) { return get(&run, font, context, textRun); }
+    DisplayList::DisplayList* get(const LegacyInlineTextBox& run, const FontCascade& font, GraphicsContext& context, const TextRun& textRun);
+    DisplayList::DisplayList* get(const InlineDisplay::Box& run, const FontCascade& font, GraphicsContext& context, const TextRun& textRun);
 
     DisplayList::DisplayList* getIfExists(const LegacyInlineTextBox& run) { return getIfExists(&run); }
     DisplayList::DisplayList* getIfExists(const InlineDisplay::Box& run) { return getIfExists(&run); }
@@ -122,7 +122,7 @@ public:
 private:
     static bool canShareDisplayList(const DisplayList::DisplayList&);
 
-    DisplayList::DisplayList* get(const void* run, const FontCascade&, GraphicsContext&, const TextRun&);
+    template <typename LayoutRun> DisplayList::DisplayList* getDisplayList(const LayoutRun*, const FontCascade&, GraphicsContext&, const TextRun&);
     DisplayList::DisplayList* getIfExists(const void* run);
     void remove(const void* run);
 

--- a/Source/WebCore/rendering/GlyphDisplayListCacheRemoval.cpp
+++ b/Source/WebCore/rendering/GlyphDisplayListCacheRemoval.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GlyphDisplayListCacheRemoval.h"
+
+#include "GlyphDisplayListCache.h"
+
+namespace WebCore {
+
+void removeBoxFromGlyphDisplayListCache(const LegacyInlineTextBox& run)
+{
+    GlyphDisplayListCache::singleton().remove(run);
+}
+
+void removeBoxFromGlyphDisplayListCache(const InlineDisplay::Box& run)
+{
+    GlyphDisplayListCache::singleton().remove(run);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/GlyphDisplayListCacheRemoval.h
+++ b/Source/WebCore/rendering/GlyphDisplayListCacheRemoval.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+class LegacyInlineTextBox;
+
+namespace InlineDisplay {
+struct Box;
+}
+
+void removeBoxFromGlyphDisplayListCache(const LegacyInlineTextBox&);
+void removeBoxFromGlyphDisplayListCache(const InlineDisplay::Box&);
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/LegacyInlineBox.h
+++ b/Source/WebCore/rendering/LegacyInlineBox.h
@@ -342,6 +342,7 @@ private:
         ADD_BOOLEAN_BITFIELD(behavesLikeText, BehavesLikeText); // Whether or not this object represents text with a non-zero height. Includes non-image list markers, text boxes, br.
         ADD_BOOLEAN_BITFIELD(forceRightExpansion, ForceRightExpansion);
         ADD_BOOLEAN_BITFIELD(forceLeftExpansion, ForceLeftExpansion);
+        ADD_BOOLEAN_BITFIELD(isInGlyphDisplayListCache, IsInGlyphDisplayListCache);
 
     private:
         mutable unsigned m_determinedIfNextOnLineExists : 1;
@@ -390,6 +391,8 @@ protected:
     bool canHaveRightExpansion() const { return m_bitfields.canHaveRightExpansion(); }
     bool forceRightExpansion() const { return m_bitfields.forceRightExpansion(); }
     bool forceLeftExpansion() const { return m_bitfields.forceLeftExpansion(); }
+    bool isInGlyphDisplayListCache() const { return m_bitfields.isInGlyphDisplayListCache(); }
+    void setIsInGlyphDisplayListCache(bool inCache = true) { m_bitfields.setIsInGlyphDisplayListCache(inCache); }
     
     // For LegacyInlineFlowBox and LegacyInlineTextBox
     bool extracted() const { return m_bitfields.extracted(); }

--- a/Source/WebCore/rendering/LegacyInlineTextBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineTextBox.cpp
@@ -32,6 +32,7 @@
 #include "ElementRuleCollector.h"
 #include "EventRegion.h"
 #include "FloatRoundedRect.h"
+#include "GlyphDisplayListCache.h"
 #include "GraphicsContext.h"
 #include "HitTestResult.h"
 #include "ImageBuffer.h"
@@ -61,7 +62,6 @@
 #include "TextBoxSelectableRange.h"
 #include "TextDecorationPainter.h"
 #include "TextPaintStyle.h"
-#include "TextPainter.h"
 #include <stdio.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/text/CString.h>
@@ -86,7 +86,8 @@ LegacyInlineTextBox::~LegacyInlineTextBox()
 {
     if (!knownToHaveNoOverflow() && gTextBoxesWithOverflow)
         gTextBoxesWithOverflow->remove(this);
-    TextPainter::removeGlyphDisplayList(*this);
+    if (isInGlyphDisplayListCache())
+        removeBoxFromGlyphDisplayListCache(*this);
 }
 
 bool LegacyInlineTextBox::hasTextContent() const

--- a/Source/WebCore/rendering/LegacyInlineTextBox.h
+++ b/Source/WebCore/rendering/LegacyInlineTextBox.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "GlyphDisplayListCacheRemoval.h"
 #include "LegacyInlineBox.h"
 #include "RenderText.h"
 #include "TextBoxSelectableRange.h"
@@ -87,6 +88,7 @@ public:
     using LegacyInlineBox::setForceRightExpansion;
     using LegacyInlineBox::forceLeftExpansion;
     using LegacyInlineBox::setForceLeftExpansion;
+    using LegacyInlineBox::setIsInGlyphDisplayListCache;
 
     LayoutUnit baselinePosition(FontBaseline) const final;
     LayoutUnit lineHeight() const final;
@@ -99,6 +101,8 @@ public:
     LayoutUnit logicalRightVisualOverflow() const { return logicalOverflowRect().maxX(); }
 
     virtual void dirtyOwnLineBoxes() { dirtyLineBoxes(); }
+
+    void removeFromGlyphDisplayListCache();
 
 #if ENABLE(TREE_DEBUGGING)
     void outputLineBox(WTF::TextStream&, bool mark, int depth) const final;
@@ -168,6 +172,14 @@ private:
     unsigned m_start { 0 };
     unsigned m_len { 0 };
 };
+
+inline void LegacyInlineTextBox::removeFromGlyphDisplayListCache()
+{
+    if (isInGlyphDisplayListCache()) {
+        removeBoxFromGlyphDisplayListCache(*this);
+        setIsInGlyphDisplayListCache(false);
+    }
+}
 
 LayoutRect snappedSelectionRect(const LayoutRect&, float logicalRight, float selectionTop, float selectionHeight, bool isHorizontal);
 

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -30,6 +30,7 @@
 #include "FilterOperations.h"
 #include "LegacyRenderSVGResourceClipper.h"
 #include "PathOperation.h"
+#include "RenderLayer.h"
 #include "RenderStyle.h"
 #include "SVGClipPathElement.h"
 #include "SVGElementTypeHelpers.h"

--- a/Source/WebCore/rendering/TextPainter.h
+++ b/Source/WebCore/rendering/TextPainter.h
@@ -64,15 +64,9 @@ public:
     void setGlyphDisplayListIfNeeded(const LayoutRun& run, const PaintInfo& paintInfo, const TextRun& textRun)
     {
         if (!TextPainter::shouldUseGlyphDisplayList(paintInfo))
-            TextPainter::removeGlyphDisplayList(run);
+            const_cast<LayoutRun&>(run).removeFromGlyphDisplayListCache();
         else
             m_glyphDisplayList = GlyphDisplayListCache::singleton().get(run, m_font, m_context, textRun);
-    }
-
-    template<typename LayoutRun>
-    static void removeGlyphDisplayList(const LayoutRun& run)
-    {
-        GlyphDisplayListCache::singleton().remove(run);
     }
 
     static bool shouldUseGlyphDisplayList(const PaintInfo&);


### PR DESCRIPTION
#### fe1e4812260edf0b2117c1f78ddecd7c3d584f86
<pre>
Invalidate GlyphDisplayListCache entries in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=267843">https://bugs.webkit.org/show_bug.cgi?id=267843</a>
<a href="https://rdar.apple.com/119833765">rdar://119833765</a>

Reviewed by Simon Fraser.

With IFC, we currently remove entries from the GlyphDisplayListCache in
the InlineDisplay::Content destructor, and in some of the
LayoutIntegration::InlineContent mutation methods. But we are not
removing enough entries, since we use InlineDisplay::Box pointers as the
GlyphDisplayListCache::m_entriesForLayoutRun keys, but we store
InlineDisplay::Box objects in vectors, so they can move around in memory.

This can cause us to replay the wrong display list, if we&apos;re unlucky
enough to place an InlineDisplay::Box at the same address as one of the
stale pointers. (This is not a security issue, since we only use the
InlineDisplay::Box pointer as an opaque key, and we always hold a strong
reference to the display list stored in the map.)

Change to remove entries from the GlyphDisplayListCache in the
destructor of InlineDisplay::Box instead. Store a bit on InlineDisplay::Box
and LegacyInlineTextBox to record whether the box is present in the
GlyphDisplayListCache, and only attempt to remove it if the bit is set.
This avoids the overhead of hashing the pointer and looking up the
GlyphDisplayListCache map in the common case of the cache not being
engaged (and, for InlineDisplay::Box, if it&apos;s not a text box).

(This does add an explicit destructor to InlineDisplay::Box, but the
class already has a non-trivial destructor due to the CheckedPtr it
stores.)

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h:
(WebCore::InlineDisplay::Box::setIsInGlyphDisplayListCache):
(WebCore::InlineDisplay::Box::Box):
(WebCore::InlineDisplay::Box::~Box):
(WebCore::InlineDisplay::Box::removeFromGlyphDisplayListCache):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContent.cpp:
(WebCore::InlineDisplay::Content::clear):
(WebCore::InlineDisplay::Content::set):
(WebCore::InlineDisplay::Content::remove):
(WebCore::InlineDisplay::invalidateGlyphCache): Deleted.
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.cpp:
(WebCore::LayoutIntegration::InlineContent::~InlineContent): Deleted.
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h:
* Source/WebCore/rendering/GlyphDisplayListCache.cpp:
(WebCore::GlyphDisplayListCache::getDisplayList):
(WebCore::GlyphDisplayListCache::get):
* Source/WebCore/rendering/GlyphDisplayListCache.h:
(WebCore::GlyphDisplayListCache::get): Deleted.
* Source/WebCore/rendering/GlyphDisplayListCacheRemoval.cpp: Added.
(WebCore::removeBoxFromGlyphDisplayListCache):
* Source/WebCore/rendering/GlyphDisplayListCacheRemoval.h: Added.
* Source/WebCore/rendering/LegacyInlineBox.h:
(WebCore::LegacyInlineBox::isInGlyphDisplayListCache const):
(WebCore::LegacyInlineBox::setIsInGlyphDisplayListCache):
* Source/WebCore/rendering/LegacyInlineTextBox.cpp:
(WebCore::LegacyInlineTextBox::~LegacyInlineTextBox):
* Source/WebCore/rendering/LegacyInlineTextBox.h:
(WebCore::LegacyInlineTextBox::removeFromGlyphDisplayListCache):
* Source/WebCore/rendering/TextPainter.h:
(WebCore::TextPainter::setGlyphDisplayListIfNeeded):
(WebCore::TextPainter::removeGlyphDisplayList): Deleted.

Canonical link: <a href="https://commits.webkit.org/273320@main">https://commits.webkit.org/273320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf3c26a55864763afe680a6c5f360638503dd975

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35060 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37820 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11047 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11838 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31276 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10371 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31371 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39066 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31702 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36444 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34433 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12328 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8034 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11069 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11391 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->