### PR TITLE
Add stubs for Digital Credentials API

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2367,6 +2367,20 @@ DiagnosticLoggingEnabled:
     WebCore:
       default: false
 
+DigitalCredentialsEnabled:
+  type: bool
+  status: unstable
+  category: dom
+  humanReadableName: "Digital Credentials API"
+  humanReadableDescription: "Enable the experimental Digital Credentials API"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 DirectoryUploadEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -310,6 +310,10 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/credentialmanagement/CredentialMediationRequirement.idl
     Modules/credentialmanagement/CredentialRequestOptions.idl
     Modules/credentialmanagement/CredentialsContainer.idl
+    Modules/credentialmanagement/DigitalCredential.idl
+    Modules/credentialmanagement/IdentityCredentialProtocol.idl
+    Modules/credentialmanagement/IdentityRequestOptions.idl
+    Modules/credentialmanagement/IdentityRequestProvider.idl
     Modules/credentialmanagement/Navigator+Credentials.idl
 
     Modules/encryptedmedia/MediaKeyEncryptionScheme.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -433,6 +433,10 @@ $(PROJECT_DIR)/Modules/credentialmanagement/CredentialCreationOptions.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/CredentialMediationRequirement.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/CredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/CredentialsContainer.idl
+$(PROJECT_DIR)/Modules/credentialmanagement/DigitalCredential.idl
+$(PROJECT_DIR)/Modules/credentialmanagement/IdentityCredentialProtocol.idl
+$(PROJECT_DIR)/Modules/credentialmanagement/IdentityRequestOptions.idl
+$(PROJECT_DIR)/Modules/credentialmanagement/IdentityRequestProvider.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/Navigator+Credentials.idl
 $(PROJECT_DIR)/Modules/encryptedmedia/MediaKeyEncryptionScheme.idl
 $(PROJECT_DIR)/Modules/encryptedmedia/MediaKeyMessageEvent.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -831,6 +831,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceOrientationEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceOrientationEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceOrientationOrMotionPermissionState.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceOrientationOrMotionPermissionState.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredential.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredential.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDistanceModelType.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDistanceModelType.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDocument+CSSOMView.cpp
@@ -1635,6 +1637,12 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIIRFilterNode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIIRFilterNode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIIRFilterOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIIRFilterOptions.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityCredentialProtocol.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityCredentialProtocol.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityRequestOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityRequestOptions.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityRequestProvider.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityRequestProvider.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdleDeadline.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdleDeadline.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdleRequestCallback.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1,4 +1,4 @@
-# Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2006-2024 Apple Inc. All rights reserved.
 # Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
 # Copyright (C) 2009 Cameron McCormack <cam@mcc.id.au>
 #
@@ -307,6 +307,10 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/credentialmanagement/CredentialMediationRequirement.idl \
     $(WebCore)/Modules/credentialmanagement/CredentialRequestOptions.idl \
     $(WebCore)/Modules/credentialmanagement/CredentialsContainer.idl \
+    $(WebCore)/Modules/credentialmanagement/DigitalCredential.idl \
+    $(WebCore)/Modules/credentialmanagement/IdentityRequestOptions.idl \
+    $(WebCore)/Modules/credentialmanagement/IdentityRequestProvider.idl \
+    $(WebCore)/Modules/credentialmanagement/IdentityCredentialProtocol.idl \
     $(WebCore)/Modules/credentialmanagement/Navigator+Credentials.idl \
     $(WebCore)/Modules/encryptedmedia/MediaKeyEncryptionScheme.idl \
     $(WebCore)/Modules/encryptedmedia/MediaKeyMessageEventInit.idl \

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
@@ -32,9 +32,12 @@
 #include "AbortSignal.h"
 #include "CredentialCreationOptions.h"
 #include "CredentialRequestOptions.h"
+#include "DigitalCredential.h"
 #include "Document.h"
 #include "ExceptionOr.h"
+#include "IdentityRequestOptions.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSDigitalCredential.h"
 #include "Page.h"
 #include "SecurityOrigin.h"
 #include "WebAuthenticationConstants.h"
@@ -139,6 +142,17 @@ void CredentialsContainer::isCreate(CredentialCreationOptions&& options, Credent
 void CredentialsContainer::preventSilentAccess(DOMPromiseDeferred<void>&& promise) const
 {
     promise.resolve();
+}
+
+void CredentialsContainer::requestIdentity(IdentityRequestOptions&& options, DigitalCredentialPromise&& promise)
+{
+    if (options.signal && options.signal->aborted()) {
+        promise.reject(Exception { ExceptionCode::AbortError, "Aborted by AbortSignal."_s });
+        return;
+    }
+    std::span<uint8_t> emptySpan;
+    Ref<ArrayBuffer> emptyArrayBuffer = ArrayBuffer::create(emptySpan);
+    promise.resolve(DigitalCredential::create(WTFMove(emptyArrayBuffer)));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017 Google Inc. All rights reserved.
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 #if ENABLE(WEB_AUTHN)
 
 #include "AuthenticatorCoordinator.h"
+#include "DigitalCredential.h"
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 
@@ -38,11 +39,12 @@ enum class Scope;
 
 namespace WebCore {
 
+class DigitalCredential;
 class Document;
-
+class WeakPtrImplWithEventTargetData;
 struct CredentialCreationOptions;
 struct CredentialRequestOptions;
-class WeakPtrImplWithEventTargetData;
+struct IdentityRequestOptions;
 
 class CredentialsContainer : public RefCounted<CredentialsContainer> {
 public:
@@ -55,6 +57,8 @@ public:
     void isCreate(CredentialCreationOptions&&, CredentialPromise&&);
 
     void preventSilentAccess(DOMPromiseDeferred<void>&&) const;
+
+    void requestIdentity(IdentityRequestOptions&&, DigitalCredentialPromise&&);
 
 private:
     CredentialsContainer(WeakPtr<Document, WeakPtrImplWithEventTargetData>&&);

--- a/Source/WebCore/Modules/credentialmanagement/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalCredential.cpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2017 Google Inc. All rights reserved.
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,15 +23,21 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_AUTHN,
-    EnabledBySetting=WebAuthenticationEnabled,
-    Exposed=Window,
-    SecureContext,
-] interface CredentialsContainer {
-    Promise<BasicCredential?> get(optional CredentialRequestOptions options);
-    Promise<BasicCredential> store(BasicCredential credential);
-    Promise<BasicCredential?> create(optional CredentialCreationOptions options);
-    Promise<undefined> preventSilentAccess();
-    [EnabledBySetting=DigitalCredentialsEnabled] Promise<DigitalCredential> requestIdentity(IdentityRequestOptions options);
-};
+#include "config.h"
+#include "DigitalCredential.h"
+
+namespace WebCore {
+
+Ref<DigitalCredential> DigitalCredential::create(Ref<ArrayBuffer>&& response)
+{
+    return adoptRef(*new DigitalCredential(WTFMove(response)));
+}
+
+DigitalCredential::~DigitalCredential() = default;
+
+DigitalCredential::DigitalCredential(Ref<ArrayBuffer>&& response)
+    : m_response(WTFMove(response))
+{
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/DigitalCredential.h
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalCredential.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2017 Google Inc. All rights reserved.
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,15 +23,34 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_AUTHN,
-    EnabledBySetting=WebAuthenticationEnabled,
-    Exposed=Window,
-    SecureContext,
-] interface CredentialsContainer {
-    Promise<BasicCredential?> get(optional CredentialRequestOptions options);
-    Promise<BasicCredential> store(BasicCredential credential);
-    Promise<BasicCredential?> create(optional CredentialCreationOptions options);
-    Promise<undefined> preventSilentAccess();
-    [EnabledBySetting=DigitalCredentialsEnabled] Promise<DigitalCredential> requestIdentity(IdentityRequestOptions options);
+#pragma once
+
+#include "IDLTypes.h"
+#include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
+
+namespace WebCore {
+
+class DigitalCredential;
+template<typename IDLType> class DOMPromiseDeferred;
+
+using DigitalCredentialPromise = DOMPromiseDeferred<IDLInterface<DigitalCredential>>;
+
+class DigitalCredential : public RefCounted<DigitalCredential> {
+public:
+    static Ref<DigitalCredential> create(Ref<ArrayBuffer>&& response);
+
+    virtual ~DigitalCredential();
+
+    ArrayBuffer* response() const
+    {
+        return m_response.get();
+    };
+
+private:
+    DigitalCredential(Ref<ArrayBuffer>&& response);
+
+    RefPtr<ArrayBuffer> m_response;
 };
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/DigitalCredential.idl
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalCredential.idl
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2017 Google Inc. All rights reserved.
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,14 +24,8 @@
  */
 
 [
-    Conditional=WEB_AUTHN,
-    EnabledBySetting=WebAuthenticationEnabled,
     Exposed=Window,
     SecureContext,
-] interface CredentialsContainer {
-    Promise<BasicCredential?> get(optional CredentialRequestOptions options);
-    Promise<BasicCredential> store(BasicCredential credential);
-    Promise<BasicCredential?> create(optional CredentialCreationOptions options);
-    Promise<undefined> preventSilentAccess();
-    [EnabledBySetting=DigitalCredentialsEnabled] Promise<DigitalCredential> requestIdentity(IdentityRequestOptions options);
+] interface DigitalCredential {
+    [SameObject] readonly attribute ArrayBuffer response;
 };

--- a/Source/WebCore/Modules/credentialmanagement/IdentityCredentialProtocol.h
+++ b/Source/WebCore/Modules/credentialmanagement/IdentityCredentialProtocol.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2017 Google Inc. All rights reserved.
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,15 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_AUTHN,
-    EnabledBySetting=WebAuthenticationEnabled,
-    Exposed=Window,
-    SecureContext,
-] interface CredentialsContainer {
-    Promise<BasicCredential?> get(optional CredentialRequestOptions options);
-    Promise<BasicCredential> store(BasicCredential credential);
-    Promise<BasicCredential?> create(optional CredentialCreationOptions options);
-    Promise<undefined> preventSilentAccess();
-    [EnabledBySetting=DigitalCredentialsEnabled] Promise<DigitalCredential> requestIdentity(IdentityRequestOptions options);
-};
+#pragma once
+
+namespace WebCore {
+
+enum class IdentityCredentialProtocol : uint8_t { Mdoc };
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/IdentityCredentialProtocol.idl
+++ b/Source/WebCore/Modules/credentialmanagement/IdentityCredentialProtocol.idl
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2017 Google Inc. All rights reserved.
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,15 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_AUTHN,
-    EnabledBySetting=WebAuthenticationEnabled,
-    Exposed=Window,
-    SecureContext,
-] interface CredentialsContainer {
-    Promise<BasicCredential?> get(optional CredentialRequestOptions options);
-    Promise<BasicCredential> store(BasicCredential credential);
-    Promise<BasicCredential?> create(optional CredentialCreationOptions options);
-    Promise<undefined> preventSilentAccess();
-    [EnabledBySetting=DigitalCredentialsEnabled] Promise<DigitalCredential> requestIdentity(IdentityRequestOptions options);
+enum IdentityCredentialProtocol {
+    "mdoc",
 };

--- a/Source/WebCore/Modules/credentialmanagement/IdentityRequestOptions.h
+++ b/Source/WebCore/Modules/credentialmanagement/IdentityRequestOptions.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2017 Google Inc. All rights reserved.
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,15 +23,21 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_AUTHN,
-    EnabledBySetting=WebAuthenticationEnabled,
-    Exposed=Window,
-    SecureContext,
-] interface CredentialsContainer {
-    Promise<BasicCredential?> get(optional CredentialRequestOptions options);
-    Promise<BasicCredential> store(BasicCredential credential);
-    Promise<BasicCredential?> create(optional CredentialCreationOptions options);
-    Promise<undefined> preventSilentAccess();
-    [EnabledBySetting=DigitalCredentialsEnabled] Promise<DigitalCredential> requestIdentity(IdentityRequestOptions options);
+#pragma once
+
+#include "AbortSignal.h"
+#include "IdentityRequestProvider.h"
+#include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+struct IdentityRequestProvider;
+
+struct IdentityRequestOptions {
+    RefPtr<AbortSignal> signal;
+    Vector<IdentityRequestProvider> providers;
 };
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/IdentityRequestOptions.idl
+++ b/Source/WebCore/Modules/credentialmanagement/IdentityRequestOptions.idl
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2017 Google Inc. All rights reserved.
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,15 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_AUTHN,
-    EnabledBySetting=WebAuthenticationEnabled,
-    Exposed=Window,
-    SecureContext,
-] interface CredentialsContainer {
-    Promise<BasicCredential?> get(optional CredentialRequestOptions options);
-    Promise<BasicCredential> store(BasicCredential credential);
-    Promise<BasicCredential?> create(optional CredentialCreationOptions options);
-    Promise<undefined> preventSilentAccess();
-    [EnabledBySetting=DigitalCredentialsEnabled] Promise<DigitalCredential> requestIdentity(IdentityRequestOptions options);
+dictionary IdentityRequestOptions {
+    AbortSignal signal;
+    required sequence<IdentityRequestProvider> providers;
 };

--- a/Source/WebCore/Modules/credentialmanagement/IdentityRequestProvider.h
+++ b/Source/WebCore/Modules/credentialmanagement/IdentityRequestProvider.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2017 Google Inc. All rights reserved.
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,15 +23,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_AUTHN,
-    EnabledBySetting=WebAuthenticationEnabled,
-    Exposed=Window,
-    SecureContext,
-] interface CredentialsContainer {
-    Promise<BasicCredential?> get(optional CredentialRequestOptions options);
-    Promise<BasicCredential> store(BasicCredential credential);
-    Promise<BasicCredential?> create(optional CredentialCreationOptions options);
-    Promise<undefined> preventSilentAccess();
-    [EnabledBySetting=DigitalCredentialsEnabled] Promise<DigitalCredential> requestIdentity(IdentityRequestOptions options);
+#pragma once
+
+#include "IdentityCredentialProtocol.h"
+
+namespace WebCore {
+
+struct IdentityRequestProvider {
+    IdentityCredentialProtocol protocol;
 };
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/IdentityRequestProvider.idl
+++ b/Source/WebCore/Modules/credentialmanagement/IdentityRequestProvider.idl
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2017 Google Inc. All rights reserved.
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,15 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=WEB_AUTHN,
-    EnabledBySetting=WebAuthenticationEnabled,
-    Exposed=Window,
-    SecureContext,
-] interface CredentialsContainer {
-    Promise<BasicCredential?> get(optional CredentialRequestOptions options);
-    Promise<BasicCredential> store(BasicCredential credential);
-    Promise<BasicCredential?> create(optional CredentialCreationOptions options);
-    Promise<undefined> preventSilentAccess();
-    [EnabledBySetting=DigitalCredentialsEnabled] Promise<DigitalCredential> requestIdentity(IdentityRequestOptions options);
+dictionary IdentityRequestProvider {
+    required IdentityCredentialProtocol protocol;
 };

--- a/Source/WebCore/Modules/mediastream/RTCIceTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransport.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEB_RTC)
 
+#include "ContextDestructionObserverInlines.h"
 #include "Event.h"
 #include "EventNames.h"
 #include "RTCPeerConnection.h"

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -112,6 +112,7 @@ Modules/cookie-store/CookieStore.cpp
 Modules/cookie-store/CookieStoreManager.cpp
 Modules/credentialmanagement/BasicCredential.cpp
 Modules/credentialmanagement/CredentialsContainer.cpp
+Modules/credentialmanagement/DigitalCredential.cpp
 Modules/credentialmanagement/NavigatorCredentials.cpp
 Modules/entriesapi/DOMFileSystem.cpp
 Modules/entriesapi/ErrorCallback.cpp
@@ -3441,6 +3442,7 @@ JSDetectedText.cpp
 JSDeviceMotionEvent.cpp
 JSDeviceOrientationEvent.cpp
 JSDeviceOrientationOrMotionPermissionState.cpp
+JSDigitalCredential.cpp
 JSDistanceModelType.cpp
 JSDocument.cpp
 JSDocumentAndElementEventHandlers.cpp
@@ -3789,6 +3791,9 @@ JSIDBTransaction.cpp
 JSIDBTransactionDurability.cpp
 JSIDBTransactionMode.cpp
 JSIDBVersionChangeEvent.cpp
+JSIdentityCredentialProtocol.cpp
+JSIdentityRequestOptions.cpp
+JSIdentityRequestProvider.cpp
 JSIdleDeadline.cpp
 JSIdleRequestCallback.cpp
 JSIdleRequestOptions.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -178,6 +178,7 @@ namespace WebCore {
     macro(DecompressionStreamTransform) \
     macro(DelayNode) \
     macro(DeprecationReportBody) \
+    macro(DigitalCredential) \
     macro(DocumentTimeline) \
     macro(DynamicsCompressorNode) \
     macro(ElementInternals) \


### PR DESCRIPTION
#### 6e2d578efd74077877f2c5f0364d9735a6a188f1
<pre>
Add stubs for Digital Credentials API
<a href="https://bugs.webkit.org/show_bug.cgi?id=267844">https://bugs.webkit.org/show_bug.cgi?id=267844</a>
<a href="https://rdar.apple.com/problem/121408392">rdar://problem/121408392</a>

Reviewed by Andy Estes.

Implements the initial stubs based on the draft explainer at:
<a href="https://github.com/WICG/identity-credential/blob/main/digital-credentials-2-proposal.md">https://github.com/WICG/identity-credential/blob/main/digital-credentials-2-proposal.md</a>

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
(WebCore::CredentialsContainer::requestIdentity):
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl:
* Source/WebCore/Modules/credentialmanagement/DigitalCredential.cpp: Copied from Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl.
(WebCore::DigitalCredential::create):
(WebCore::DigitalCredential::DigitalCredential):
* Source/WebCore/Modules/credentialmanagement/DigitalCredential.h: Copied from Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl.
(WebCore::DigitalCredential::response const):
* Source/WebCore/Modules/credentialmanagement/DigitalCredential.idl: Copied from Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl.
* Source/WebCore/Modules/credentialmanagement/IdentityCredentialProtocol.h: Copied from Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl.
* Source/WebCore/Modules/credentialmanagement/IdentityCredentialProtocol.idl: Copied from Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl.
* Source/WebCore/Modules/credentialmanagement/IdentityRequestOptions.h: Copied from Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl.
* Source/WebCore/Modules/credentialmanagement/IdentityRequestOptions.idl: Copied from Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl.
* Source/WebCore/Modules/credentialmanagement/IdentityRequestProvider.h: Copied from Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl.
* Source/WebCore/Modules/credentialmanagement/IdentityRequestProvider.idl: Copied from Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl.
* Source/WebCore/Modules/mediastream/RTCIceTransport.cpp:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:

Canonical link: <a href="https://commits.webkit.org/273545@main">https://commits.webkit.org/273545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7b663f44ddef100c52c724383a776b9d3b2b652

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37730 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38333 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32069 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30870 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10787 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10801 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39579 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/30154 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32148 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36751 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/35458 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8872 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34829 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12699 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/42148 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8150 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11496 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8752 "Found 39 new JSC stress test failures: microbenchmarks/array-from-derived-object-func.js.bytecode-cache, microbenchmarks/array-from-derived-object-func.js.default, microbenchmarks/array-from-derived-object-func.js.dfg-eager, microbenchmarks/array-from-derived-object-func.js.dfg-eager-no-cjit-validate, microbenchmarks/array-from-derived-object-func.js.eager-jettison-no-cjit, microbenchmarks/array-from-derived-object-func.js.no-cjit-collect-continuously, microbenchmarks/array-from-derived-object-func.js.no-cjit-validate-phases, microbenchmarks/array-from-derived-object-func.js.no-llint, microbenchmarks/array-from-object-func.js.bytecode-cache, microbenchmarks/array-from-object-func.js.default ... (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11767 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->