### PR TITLE
Make isStatelessLambda check compile-time

### DIFF
--- a/Source/JavaScriptCore/runtime/LazyPropertyInlines.h
+++ b/Source/JavaScriptCore/runtime/LazyPropertyInlines.h
@@ -42,7 +42,7 @@ template<typename OwnerType, typename ElementType>
 template<typename Func>
 void LazyProperty<OwnerType, ElementType>::initLater(const Func&)
 {
-    RELEASE_ASSERT(isStatelessLambda<Func>());
+    static_assert(isStatelessLambda<Func>());
     // Logically we just want to stuff the function pointer into m_pointer, but then we'd be sad
     // because a function pointer is not guaranteed to be a multiple of anything. The tag bits
     // may be used for things. We address this problem by indirecting through a global const

--- a/Source/WTF/wtf/LazyRef.h
+++ b/Source/WTF/wtf/LazyRef.h
@@ -95,7 +95,7 @@ public:
     void initLater(const Func&)
     {
         static_assert(alignof(T) >= 4);
-        RELEASE_ASSERT(isStatelessLambda<Func>());
+        static_assert(isStatelessLambda<Func>());
         // Logically we just want to stuff the function pointer into m_pointer, but then we'd be sad
         // because a function pointer is not guaranteed to be a multiple of anything. The tag bits
         // may be used for things. We address this problem by indirecting through a global const

--- a/Source/WTF/wtf/LazyUniqueRef.h
+++ b/Source/WTF/wtf/LazyUniqueRef.h
@@ -95,7 +95,7 @@ public:
     void initLater(const Func&)
     {
         static_assert(alignof(T) >= 4);
-        RELEASE_ASSERT(isStatelessLambda<Func>());
+        static_assert(isStatelessLambda<Func>());
         // Logically we just want to stuff the function pointer into m_pointer, but then we'd be sad
         // because a function pointer is not guaranteed to be a multiple of anything. The tag bits
         // may be used for things. We address this problem by indirecting through a global const

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -349,7 +349,7 @@ inline void insertIntoBoundedVector(VectorType& vector, size_t size, const Eleme
 WTF_EXPORT_PRIVATE bool isCompilationThread();
 
 template<typename Func>
-bool isStatelessLambda()
+constexpr bool isStatelessLambda()
 {
     return std::is_empty<Func>::value;
 }


### PR DESCRIPTION
#### a7d81ce30e154b29c4626b508aca5433f4cfa170
<pre>
Make isStatelessLambda check compile-time
<a href="https://bugs.webkit.org/show_bug.cgi?id=267847">https://bugs.webkit.org/show_bug.cgi?id=267847</a>
<a href="https://rdar.apple.com/121360002">rdar://121360002</a>

Reviewed by Justin Michaud.

We can ensure that lambda is stateless at compile-time with constexpr isStatelessLambda function.
This patch makes it constexpr, and using static_assert instead of RELEASE_ASSERT in LazyXXX classes.

* Source/JavaScriptCore/runtime/LazyPropertyInlines.h:
(JSC::ElementType&gt;::initLater):
* Source/WTF/wtf/LazyRef.h:
(WTF::LazyRef::initLater):
* Source/WTF/wtf/LazyUniqueRef.h:
(WTF::LazyUniqueRef::initLater):
* Source/WTF/wtf/StdLibExtras.h:
(WTF::isStatelessLambda):

Canonical link: <a href="https://commits.webkit.org/273307@main">https://commits.webkit.org/273307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/980abccf809d89abcac65f9e4903901db42ea725

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37751 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31614 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30554 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31214 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10318 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10375 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39002 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/29734 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31632 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36402 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/34886 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10481 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34389 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12282 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41508 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11014 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8635 "Found 231 new JSC stress test failures: microbenchmarks/array-from-derived-object-func.js.bytecode-cache, microbenchmarks/array-from-derived-object-func.js.default, microbenchmarks/array-from-derived-object-func.js.dfg-eager, microbenchmarks/array-from-derived-object-func.js.dfg-eager-no-cjit-validate, microbenchmarks/array-from-derived-object-func.js.eager-jettison-no-cjit, microbenchmarks/array-from-derived-object-func.js.no-cjit-collect-continuously, microbenchmarks/array-from-derived-object-func.js.no-llint, microbenchmarks/array-from-object-func.js.bytecode-cache, microbenchmarks/array-from-object-func.js.default, microbenchmarks/array-from-object-func.js.dfg-eager ... (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4511 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11346 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->