### PR TITLE
REGRESSION(272844@main): [GStreamer][Debug] ASSERTION FAILED: isMainThread() in WebCore::MediaStreamTrackPrivate::source()

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1878,8 +1878,8 @@ webkit.org/b/264803 fast/mediastream/mediastreamtrack-video-resize-event.html [ 
 webkit.org/b/265865 imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation.html [ Skip ]
 
 # Requires video scaling adaptation.
-webrtc/captureCanvas-webrtc-with-video-scaling-adaptation.html [ Failure ]
 # Uncomment when webkit.org/b/267411 is fixed
+#webrtc/captureCanvas-webrtc-with-video-scaling-adaptation.html [ Failure ]
 #webrtc/video-maxBitrate.html [ Failure ]
 #webrtc/video-maxBitrate-vp8.html [ Failure ]
 
@@ -1910,7 +1910,8 @@ fast/mediastream/get-user-media-constraints.html [ Failure ]
 fast/mediastream/get-user-media-ideal-constraints.html [ Failure ]
 fast/mediastream/mediastreamtrack-video-frameRate-clone-increasing.html [ Failure ]
 fast/mediastream/video-rotation.html [ Skip ]
-webrtc/video-rotation-no-cvo.html [ Failure Timeout ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webrtc/video-rotation-no-cvo.html [ Failure Timeout ]
 webrtc/video-rotation-black.html [ Crash Failure Pass Timeout ]
 
 # No AudioSession category handling in WPE/GTK ports.
@@ -1990,7 +1991,8 @@ webkit.org/b/235885 webrtc/libwebrtc/release-while-getting-stats.html [ Skip ]
 webrtc/video-replace-track.html [ Pass Failure Timeout Crash ]
 
 # GStreamerRtpSenderBackend::setMediaStreamIds() unimplemented.
-webkit.org/b/235885 webrtc/video.html [ Failure ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/235885 webrtc/video.html [ Failure ]
 
 # webrtcbin emits no ICE candidate stats for a PeerConnection managing only one data-channel.
 webkit.org/b/235885 webrtc/candidate-stats.html [ Failure ]
@@ -1999,7 +2001,7 @@ webkit.org/b/262989 imported/w3c/web-platform-tests/webrtc-stats/getStats-remote
 # Pending investigation.
 # Uncomment when webkit.org/b/267411 is fixed
 #webkit.org/b/235885 fast/mediastream/RTCPeerConnection-addIceCandidate.html [ Failure ]
-webkit.org/b/235885 fast/mediastream/RTCPeerConnection-addTrack-reuse-sender.html [ Failure ]
+#webkit.org/b/235885 fast/mediastream/RTCPeerConnection-addTrack-reuse-sender.html [ Failure ]
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-local-pranswer.html [ Failure ]
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-remote-offer.html [ Failure ]
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-remote-pranswer.html [ Failure ]
@@ -2025,7 +2027,7 @@ webkit.org/b/235885 webrtc/filtering-ice-candidate-after-reload.html [ Failure ]
 #webkit.org/b/235885 webrtc/peer-connection-track-end.html [ Failure ]
 #webkit.org/b/235885 webrtc/peerconnection-page-cache-long.html [ Timeout ]
 #webkit.org/b/235885 webrtc/peerconnection-page-cache.html [ Timeout ]
-webkit.org/b/235885 webrtc/video-stats.html [ Failure ]
+#webkit.org/b/235885 webrtc/video-stats.html [ Failure ]
 webkit.org/b/235885 webrtc/vp8-then-h264.html [ Failure Timeout Crash ]
 webkit.org/b/252878 fast/mediastream/mediastreamtrack-video-clone.html [ Crash Failure Timeout Pass ]
 webkit.org/b/213202 fast/mediastream/getUserMedia-grant-persistency3.html [ Failure Pass ]
@@ -2034,8 +2036,8 @@ webkit.org/b/252878 fast/mediastream/video-mediastream-restricted-invisible-auto
 webkit.org/b/252878 http/tests/webrtc/video-mediastream-invisible-autoplay-detached.html [ Pass Timeout ]
 # Uncomment when webkit.org/b/267411 is fixed
 #webkit.org/b/187064 webrtc/video-addTrack.html [ Failure Pass Timeout ]
-webkit.org/b/187064 webrtc/video-rotation.html [ Failure Timeout ]
-webkit.org/b/187064 webrtc/video-with-data-channel.html [ Failure ]
+#webkit.org/b/187064 webrtc/video-rotation.html [ Failure Timeout ]
+#webkit.org/b/187064 webrtc/video-with-data-channel.html [ Failure ]
 webkit.org/b/177533 webrtc/video-interruption.html
 # Uncomment when webkit.org/b/267411 is fixed
 #webkit.org/b/229346 webkit.org/b/235885 webrtc/multi-audio.html [ Timeout Pass Failure ]
@@ -2091,7 +2093,8 @@ webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-ontonec
 webkit.org/b/235885 webrtc/dtmf-gc.html [ Skip ]
 
 webkit.org/b/235885 webrtc/video-h264.html [ Slow ]
-webkit.org/b/235885 webrtc/vp9.html [ Slow Failure ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/235885 webrtc/vp9.html [ Slow Failure ]
 
 # Also skipped on mac, timing out because relying on MediaStream::onactive event which is not exposed.
 webkit.org/b/151344 fast/mediastream/MediaStream-add-ended-tracks.html [ Skip ]
@@ -3671,7 +3674,7 @@ webkit.org/b/261024 svg/text/small-fonts-in-html5.html [ Failure ImageOnlyFailur
 # Uncomment when webkit.org/b/267411 is fixed
 #webkit.org/b/261024 webrtc/video-maxFramerate.html [ Pass Timeout ]
 #webkit.org/b/261024 webrtc/video-replace-muted-track.html [ Pass Timeout ]
-webkit.org/b/261024 webrtc/video-unmute.html [ Pass Timeout ]
+#webkit.org/b/261024 webrtc/video-unmute.html [ Pass Timeout ]
 webkit.org/b/261024 webrtc/video-disabled-black.html [ Crash Pass ]
 
 # Initial css/compositing test import
@@ -3813,6 +3816,19 @@ webkit.org/b/267411 webrtc/video-mute.html [ Pass Timeout Crash ]
 webkit.org/b/267411 webrtc/video-receivers.html [ Pass Crash ]
 webkit.org/b/267411 webrtc/video-remote-mute.html [ Failure Pass Timeout Crash ]
 webkit.org/b/267411 webrtc/video-replace-muted-track.html [ Pass Timeout Crash ]
+webkit.org/b/267411 fast/mediastream/RTCPeerConnection-addTrack-reuse-sender.html [ Failure Crash ]
+webkit.org/b/267411 webrtc/captureCanvas-webrtc-with-video-scaling-adaptation.html [ Failure Crash ]
+webkit.org/b/267411 webrtc/libwebrtc/release-while-creating-offer.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/video-replace-track-to-null.html [ Pass Timeout Crash ]
+webkit.org/b/267411 webrtc/video-rotation-no-cvo.html [ Failure Timeout Crash ]
+webkit.org/b/267411 webrtc/video-rotation.html [ Failure Timeout Crash ]
+webkit.org/b/267411 webrtc/video-stats.html [ Failure Crash ]
+webkit.org/b/267411 webrtc/video-unmute.html [ Pass Timeout Crash ]
+webkit.org/b/267411 webrtc/video-with-data-channel.html [ Failure Crash ]
+webkit.org/b/267411 webrtc/video.html [ Failure Crash ]
+webkit.org/b/267411 webrtc/vp8-then-h264-gpu-process-crash.html [ Pass Timeout Crash ]
+webkit.org/b/267411 webrtc/vp9-profile2.html [ Pass Crash ]
+webkit.org/b/267411 webrtc/vp9.html [ Failure Pass Timeout Crash ]
 
 # End: Common failures between GTK and WPE.
 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1665,7 +1665,7 @@ webkit.org/b/257624 webanimations/accelerated-animations-and-motion-path.html [ 
 # Uncomment when webkit.org/b/267411 is fixed
 #webkit.org/b/257624 webrtc/connection-state.html [ Pass Timeout ]
 #webkit.org/b/257624 webrtc/video-autoplay.html [ Pass Timeout ]
-webkit.org/b/257624 webrtc/video-replace-track-to-null.html [ Pass Timeout ]
+#webkit.org/b/257624 webrtc/video-replace-track-to-null.html [ Pass Timeout ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Flaky tests

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1544,7 +1544,8 @@ webkit.org/b/261024 js/cached-window-properties.html [ Pass Timeout ]
 webkit.org/b/261024 svg/custom/pattern-userSpaceOnUse-userToBaseTransform.xhtml [ Failure Missing Pass ]
 webkit.org/b/261024 svg/hixie/mixed/010.xml [ Failure Missing Pass ]
 webkit.org/b/261024 webgl/1.0.x/conformance/reading/read-pixels-test.html [ Pass Timeout ]
-webkit.org/b/261024 webrtc/vp9.html [ Failure Pass Timeout ]
+# Uncomment when webkit.org/b/267411 is fixed
+#webkit.org/b/261024 webrtc/vp9.html [ Failure Pass Timeout ]
 
 imported/w3c/web-platform-tests/css/filter-effects/background-image-blur-repaint.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/effect-reference-rename-002.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### 8a64069be24e2e1f74a7f5314055bc05fe1ff656
<pre>
REGRESSION(272844@main): [GStreamer][Debug] ASSERTION FAILED: isMainThread() in WebCore::MediaStreamTrackPrivate::source()
<a href="https://bugs.webkit.org/show_bug.cgi?id=267411">https://bugs.webkit.org/show_bug.cgi?id=267411</a>

Unreviewed test gardening.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/273291@main">https://commits.webkit.org/273291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2692434a4dc0949fa8995dfe813e058c0952d23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/35006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37755 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10975 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/35549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/11770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10319 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/31305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/31834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/31634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/39006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10484 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/8407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4500 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->