### PR TITLE
Make MediaStreamTrackProcessor::VideoFrameObserverWrapper::m_observer a UniqueRef

### DIFF
--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
@@ -100,22 +100,16 @@ void MediaStreamTrackProcessor::tryEnqueueingVideoFrame()
 
 Ref<MediaStreamTrackProcessor::VideoFrameObserverWrapper> MediaStreamTrackProcessor::VideoFrameObserverWrapper::create(ScriptExecutionContextIdentifier identifier, MediaStreamTrackProcessor& processor, Ref<RealtimeMediaSource>&& source, unsigned short maxVideoFramesCount)
 {
-    auto wrapper = adoptRef(*new VideoFrameObserverWrapper);
-    wrapper->initialize(identifier, processor, WTFMove(source), maxVideoFramesCount);
-    return wrapper;
-}
-
-MediaStreamTrackProcessor::VideoFrameObserverWrapper::VideoFrameObserverWrapper()
-{
-}
-
-void MediaStreamTrackProcessor::VideoFrameObserverWrapper::initialize(ScriptExecutionContextIdentifier identifier, MediaStreamTrackProcessor& processor, Ref<RealtimeMediaSource>&& source, unsigned short maxVideoFramesCount)
-{
 #if PLATFORM(COCOA)
     if (source->deviceType() == CaptureDevice::DeviceType::Camera)
         maxVideoFramesCount = 1;
 #endif
-    m_observer = makeUnique<VideoFrameObserver>(identifier, WeakPtr { processor }, WTFMove(source), maxVideoFramesCount);
+    return adoptRef(*new VideoFrameObserverWrapper(identifier, processor, WTFMove(source), maxVideoFramesCount));
+}
+
+MediaStreamTrackProcessor::VideoFrameObserverWrapper::VideoFrameObserverWrapper(ScriptExecutionContextIdentifier identifier, MediaStreamTrackProcessor& processor, Ref<RealtimeMediaSource>&& source, unsigned short maxVideoFramesCount)
+    : m_observer(makeUniqueRef<VideoFrameObserver>(identifier, processor, WTFMove(source), maxVideoFramesCount))
+{
 }
 
 void MediaStreamTrackProcessor::VideoFrameObserverWrapper::start()

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
@@ -98,11 +98,9 @@ private:
         RefPtr<WebCodecsVideoFrame> takeVideoFrame(ScriptExecutionContext& context) { return m_observer->takeVideoFrame(context); }
 
     private:
-        VideoFrameObserverWrapper();
+        VideoFrameObserverWrapper(ScriptExecutionContextIdentifier, MediaStreamTrackProcessor&, Ref<RealtimeMediaSource>&&, unsigned short maxVideoFramesCount);
 
-        void initialize(ScriptExecutionContextIdentifier, MediaStreamTrackProcessor&, Ref<RealtimeMediaSource>&&, unsigned short maxVideoFramesCount);
-
-        std::unique_ptr<VideoFrameObserver> m_observer;
+        UniqueRef<VideoFrameObserver> m_observer;
     };
 
     class Source final


### PR DESCRIPTION
#### d1ab07a92e50d93ef8f4a342d9a0478307c9d1bc
<pre>
Make MediaStreamTrackProcessor::VideoFrameObserverWrapper::m_observer a UniqueRef
<a href="https://rdar.apple.com/121372402">rdar://121372402</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=267853">https://bugs.webkit.org/show_bug.cgi?id=267853</a>

Reviewed by Eric Carlson.

A UniqueRef is better than a std::unique_ptr and we do not need the initialize method any longer.

* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp:
(WebCore::MediaStreamTrackProcessor::VideoFrameObserverWrapper::create):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserverWrapper::VideoFrameObserverWrapper):
(WebCore::MediaStreamTrackProcessor::VideoFrameObserverWrapper::initialize): Deleted.
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h:

Canonical link: <a href="https://commits.webkit.org/273396@main">https://commits.webkit.org/273396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4e0efb8d645bdbc4c1f94321fd8efbcebf11f09

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38021 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31825 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30705 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31445 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10527 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39267 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31886 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36559 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8648 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34574 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12485 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8077 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11242 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11542 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->