### PR TITLE
Make sure we protect the GraphicsContextGL before calling its member functions

### DIFF
--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -343,7 +343,7 @@ ExceptionOr<RefPtr<ImageBitmap>> OffscreenCanvas::transferToImageBitmap()
         if (!buffer)
             return { RefPtr<ImageBitmap> { nullptr } };
 
-        auto* gc3d = webGLContext->graphicsContextGL();
+        RefPtr gc3d = webGLContext->graphicsContextGL();
         gc3d->drawSurfaceBufferToImageBuffer(GraphicsContextGL::SurfaceBuffer::DrawingBuffer, *buffer);
 
         // FIXME: The transfer algorithm requires that the canvas effectively

--- a/Source/WebCore/html/canvas/ANGLEInstancedArrays.cpp
+++ b/Source/WebCore/html/canvas/ANGLEInstancedArrays.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(ANGLEInstancedArrays);
 ANGLEInstancedArrays::ANGLEInstancedArrays(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::ANGLEInstancedArrays)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_instanced_arrays"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_instanced_arrays"_s);
 }
 
 ANGLEInstancedArrays::~ANGLEInstancedArrays() = default;

--- a/Source/WebCore/html/canvas/EXTBlendMinMax.cpp
+++ b/Source/WebCore/html/canvas/EXTBlendMinMax.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTBlendMinMax);
 EXTBlendMinMax::EXTBlendMinMax(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTBlendMinMax)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_blend_minmax"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_blend_minmax"_s);
 }
 
 EXTBlendMinMax::~EXTBlendMinMax() = default;

--- a/Source/WebCore/html/canvas/EXTClipControl.cpp
+++ b/Source/WebCore/html/canvas/EXTClipControl.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTClipControl);
 EXTClipControl::EXTClipControl(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTClipControl)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_clip_control"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_clip_control"_s);
 }
 
 EXTClipControl::~EXTClipControl() = default;
@@ -52,7 +52,7 @@ void EXTClipControl::clipControlEXT(GCGLenum origin, GCGLenum depth)
     if (isContextLost())
         return;
     auto& context = this->context();
-    context.graphicsContextGL()->clipControlEXT(origin, depth);
+    context.protectedGraphicsContextGL()->clipControlEXT(origin, depth);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/EXTColorBufferFloat.cpp
+++ b/Source/WebCore/html/canvas/EXTColorBufferFloat.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTColorBufferFloat);
 EXTColorBufferFloat::EXTColorBufferFloat(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTColorBufferFloat)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_color_buffer_float"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_color_buffer_float"_s);
 
     // https://github.com/KhronosGroup/WebGL/pull/2830
     // Spec requires EXT_float_blend to be turned on implicitly here.

--- a/Source/WebCore/html/canvas/EXTColorBufferHalfFloat.cpp
+++ b/Source/WebCore/html/canvas/EXTColorBufferHalfFloat.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTColorBufferHalfFloat);
 EXTColorBufferHalfFloat::EXTColorBufferHalfFloat(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTColorBufferHalfFloat)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_color_buffer_half_float"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_color_buffer_half_float"_s);
 }
 
 EXTColorBufferHalfFloat::~EXTColorBufferHalfFloat() = default;

--- a/Source/WebCore/html/canvas/EXTConservativeDepth.cpp
+++ b/Source/WebCore/html/canvas/EXTConservativeDepth.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTConservativeDepth);
 EXTConservativeDepth::EXTConservativeDepth(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTConservativeDepth)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_conservative_depth"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_conservative_depth"_s);
 }
 
 EXTConservativeDepth::~EXTConservativeDepth() = default;

--- a/Source/WebCore/html/canvas/EXTDepthClamp.cpp
+++ b/Source/WebCore/html/canvas/EXTDepthClamp.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTDepthClamp);
 EXTDepthClamp::EXTDepthClamp(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTDepthClamp)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_depth_clamp"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_depth_clamp"_s);
 }
 
 EXTDepthClamp::~EXTDepthClamp() = default;

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
@@ -44,7 +44,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTDisjointTimerQuery);
 EXTDisjointTimerQuery::EXTDisjointTimerQuery(WebGLRenderingContext& context)
     : WebGLExtension(context, WebGLExtensionName::EXTDisjointTimerQuery)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_disjoint_timer_query"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_disjoint_timer_query"_s);
 }
 
 EXTDisjointTimerQuery::~EXTDisjointTimerQuery() = default;
@@ -84,10 +84,10 @@ void EXTDisjointTimerQuery::deleteQueryEXT(WebGLTimerQueryEXT* query)
     if (query == context.m_activeQuery) {
         context.m_activeQuery = nullptr;
         ASSERT(query->target() == GraphicsContextGL::TIME_ELAPSED_EXT);
-        context.graphicsContextGL()->endQueryEXT(GraphicsContextGL::TIME_ELAPSED_EXT);
+        context.protectedGraphicsContextGL()->endQueryEXT(GraphicsContextGL::TIME_ELAPSED_EXT);
     }
 
-    query->deleteObject(locker, context.graphicsContextGL());
+    query->deleteObject(locker, context.protectedGraphicsContextGL().get());
 }
 
 GCGLboolean EXTDisjointTimerQuery::isQueryEXT(WebGLTimerQueryEXT* query)
@@ -97,7 +97,7 @@ GCGLboolean EXTDisjointTimerQuery::isQueryEXT(WebGLTimerQueryEXT* query)
     auto& context = this->context();
     if (!context.validateIsWebGLObject(query))
         return false;
-    return context.graphicsContextGL()->isQueryEXT(query->object());
+    return context.protectedGraphicsContextGL()->isQueryEXT(query->object());
 }
 
 void EXTDisjointTimerQuery::beginQueryEXT(GCGLenum target, WebGLTimerQueryEXT& query)
@@ -132,7 +132,7 @@ void EXTDisjointTimerQuery::beginQueryEXT(GCGLenum target, WebGLTimerQueryEXT& q
 
     context.m_activeQuery = &query;
 
-    context.graphicsContextGL()->beginQueryEXT(target, query.object());
+    context.protectedGraphicsContextGL()->beginQueryEXT(target, query.object());
 }
 
 void EXTDisjointTimerQuery::endQueryEXT(GCGLenum target)
@@ -155,7 +155,7 @@ void EXTDisjointTimerQuery::endQueryEXT(GCGLenum target)
         return;
     }
 
-    context.graphicsContextGL()->endQueryEXT(target);
+    context.protectedGraphicsContextGL()->endQueryEXT(target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
     context.scriptExecutionContext()->eventLoop().queueMicrotask([query = WTFMove(context.m_activeQuery)] {
@@ -186,7 +186,7 @@ void EXTDisjointTimerQuery::queryCounterEXT(WebGLTimerQueryEXT& query, GCGLenum 
 
     query.setTarget(target);
 
-    context.graphicsContextGL()->queryCounterEXT(query.object(), target);
+    context.protectedGraphicsContextGL()->queryCounterEXT(query.object(), target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
     context.scriptExecutionContext()->eventLoop().queueMicrotask([&] {
@@ -211,7 +211,7 @@ WebGLAny EXTDisjointTimerQuery::getQueryEXT(GCGLenum target, GCGLenum pname)
             return context.m_activeQuery;
         return nullptr;
     case GraphicsContextGL::QUERY_COUNTER_BITS_EXT:
-        return context.graphicsContextGL()->getQueryiEXT(target, pname);
+        return context.protectedGraphicsContextGL()->getQueryiEXT(target, pname);
     }
     context.synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getQueryEXT", "invalid parameter name");
     return nullptr;
@@ -240,11 +240,11 @@ WebGLAny EXTDisjointTimerQuery::getQueryObjectEXT(WebGLTimerQueryEXT& query, GCG
     case GraphicsContextGL::QUERY_RESULT_EXT:
         if (!query.isResultAvailable())
             return 0;
-        return static_cast<unsigned long long>(context.graphicsContextGL()->getQueryObjectui64EXT(query.object(), pname));
+        return static_cast<unsigned long long>(context.protectedGraphicsContextGL()->getQueryObjectui64EXT(query.object(), pname));
     case GraphicsContextGL::QUERY_RESULT_AVAILABLE_EXT:
         if (!query.isResultAvailable())
             return false;
-        return static_cast<bool>(context.graphicsContextGL()->getQueryObjectiEXT(query.object(), pname));
+        return static_cast<bool>(context.protectedGraphicsContextGL()->getQueryObjectiEXT(query.object(), pname));
     }
     context.synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "getQueryObjectEXT", "invalid parameter name");
     return nullptr;

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
@@ -40,7 +40,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTDisjointTimerQueryWebGL2);
 EXTDisjointTimerQueryWebGL2::EXTDisjointTimerQueryWebGL2(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTDisjointTimerQueryWebGL2)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_disjoint_timer_query"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_disjoint_timer_query"_s);
 }
 
 EXTDisjointTimerQueryWebGL2::~EXTDisjointTimerQueryWebGL2() = default;
@@ -73,7 +73,7 @@ void EXTDisjointTimerQueryWebGL2::queryCounterEXT(WebGLQuery& query, GCGLenum ta
 
     query.setTarget(target);
 
-    context.graphicsContextGL()->queryCounterEXT(query.object(), target);
+    context.protectedGraphicsContextGL()->queryCounterEXT(query.object(), target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
     context.scriptExecutionContext()->eventLoop().queueMicrotask([&] {

--- a/Source/WebCore/html/canvas/EXTFloatBlend.cpp
+++ b/Source/WebCore/html/canvas/EXTFloatBlend.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTFloatBlend);
 EXTFloatBlend::EXTFloatBlend(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTFloatBlend)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_float_blend"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_float_blend"_s);
 }
 
 EXTFloatBlend::~EXTFloatBlend() = default;

--- a/Source/WebCore/html/canvas/EXTFragDepth.cpp
+++ b/Source/WebCore/html/canvas/EXTFragDepth.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTFragDepth);
 EXTFragDepth::EXTFragDepth(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTFragDepth)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_frag_depth"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_frag_depth"_s);
 }
 
 EXTFragDepth::~EXTFragDepth() = default;

--- a/Source/WebCore/html/canvas/EXTPolygonOffsetClamp.cpp
+++ b/Source/WebCore/html/canvas/EXTPolygonOffsetClamp.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTPolygonOffsetClamp);
 EXTPolygonOffsetClamp::EXTPolygonOffsetClamp(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTPolygonOffsetClamp)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_polygon_offset_clamp"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_polygon_offset_clamp"_s);
 }
 
 EXTPolygonOffsetClamp::~EXTPolygonOffsetClamp() = default;
@@ -52,7 +52,7 @@ void EXTPolygonOffsetClamp::polygonOffsetClampEXT(GCGLfloat factor, GCGLfloat un
     if (isContextLost())
         return;
     auto& context = this->context();
-    context.graphicsContextGL()->polygonOffsetClampEXT(factor, units, clamp);
+    context.protectedGraphicsContextGL()->polygonOffsetClampEXT(factor, units, clamp);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/EXTRenderSnorm.cpp
+++ b/Source/WebCore/html/canvas/EXTRenderSnorm.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTRenderSnorm);
 EXTRenderSnorm::EXTRenderSnorm(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTRenderSnorm)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_render_snorm"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_render_snorm"_s);
 }
 
 EXTRenderSnorm::~EXTRenderSnorm() = default;

--- a/Source/WebCore/html/canvas/EXTShaderTextureLOD.cpp
+++ b/Source/WebCore/html/canvas/EXTShaderTextureLOD.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTShaderTextureLOD);
 EXTShaderTextureLOD::EXTShaderTextureLOD(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTShaderTextureLOD)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_shader_texture_lod"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_shader_texture_lod"_s);
 }
 
 EXTShaderTextureLOD::~EXTShaderTextureLOD() = default;

--- a/Source/WebCore/html/canvas/EXTTextureCompressionBPTC.cpp
+++ b/Source/WebCore/html/canvas/EXTTextureCompressionBPTC.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTTextureCompressionBPTC);
 EXTTextureCompressionBPTC::EXTTextureCompressionBPTC(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTTextureCompressionBPTC)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_compression_bptc"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_compression_bptc"_s);
 
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_RGBA_BPTC_UNORM_EXT);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT);

--- a/Source/WebCore/html/canvas/EXTTextureCompressionRGTC.cpp
+++ b/Source/WebCore/html/canvas/EXTTextureCompressionRGTC.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTTextureCompressionRGTC);
 EXTTextureCompressionRGTC::EXTTextureCompressionRGTC(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTTextureCompressionRGTC)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_compression_rgtc"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_compression_rgtc"_s);
 
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_RED_RGTC1_EXT);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SIGNED_RED_RGTC1_EXT);

--- a/Source/WebCore/html/canvas/EXTTextureFilterAnisotropic.cpp
+++ b/Source/WebCore/html/canvas/EXTTextureFilterAnisotropic.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTTextureFilterAnisotropic);
 EXTTextureFilterAnisotropic::EXTTextureFilterAnisotropic(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTTextureFilterAnisotropic)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_filter_anisotropic"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_filter_anisotropic"_s);
 }
 
 EXTTextureFilterAnisotropic::~EXTTextureFilterAnisotropic() = default;

--- a/Source/WebCore/html/canvas/EXTTextureMirrorClampToEdge.cpp
+++ b/Source/WebCore/html/canvas/EXTTextureMirrorClampToEdge.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTTextureMirrorClampToEdge);
 EXTTextureMirrorClampToEdge::EXTTextureMirrorClampToEdge(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTTextureMirrorClampToEdge)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_mirror_clamp_to_edge"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_mirror_clamp_to_edge"_s);
 }
 
 EXTTextureMirrorClampToEdge::~EXTTextureMirrorClampToEdge() = default;

--- a/Source/WebCore/html/canvas/EXTTextureNorm16.cpp
+++ b/Source/WebCore/html/canvas/EXTTextureNorm16.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTTextureNorm16);
 EXTTextureNorm16::EXTTextureNorm16(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTTextureNorm16)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_norm16"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_norm16"_s);
 }
 
 EXTTextureNorm16::~EXTTextureNorm16() = default;

--- a/Source/WebCore/html/canvas/EXTsRGB.cpp
+++ b/Source/WebCore/html/canvas/EXTsRGB.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(EXTsRGB);
 EXTsRGB::EXTsRGB(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::EXTsRGB)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_sRGB"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_sRGB"_s);
 }
 
 EXTsRGB::~EXTsRGB() = default;

--- a/Source/WebCore/html/canvas/KHRParallelShaderCompile.cpp
+++ b/Source/WebCore/html/canvas/KHRParallelShaderCompile.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(KHRParallelShaderCompile);
 KHRParallelShaderCompile::KHRParallelShaderCompile(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::KHRParallelShaderCompile)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_KHR_parallel_shader_compile"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_KHR_parallel_shader_compile"_s);
 }
 
 KHRParallelShaderCompile::~KHRParallelShaderCompile() = default;

--- a/Source/WebCore/html/canvas/NVShaderNoperspectiveInterpolation.cpp
+++ b/Source/WebCore/html/canvas/NVShaderNoperspectiveInterpolation.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(NVShaderNoperspectiveInterpolation);
 NVShaderNoperspectiveInterpolation::NVShaderNoperspectiveInterpolation(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::NVShaderNoperspectiveInterpolation)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_NV_shader_noperspective_interpolation"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_NV_shader_noperspective_interpolation"_s);
 }
 
 NVShaderNoperspectiveInterpolation::~NVShaderNoperspectiveInterpolation() = default;

--- a/Source/WebCore/html/canvas/OESDrawBuffersIndexed.cpp
+++ b/Source/WebCore/html/canvas/OESDrawBuffersIndexed.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(OESDrawBuffersIndexed);
 OESDrawBuffersIndexed::OESDrawBuffersIndexed(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESDrawBuffersIndexed)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_draw_buffers_indexed"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_draw_buffers_indexed"_s);
 }
 
 OESDrawBuffersIndexed::~OESDrawBuffersIndexed() = default;
@@ -52,7 +52,7 @@ void OESDrawBuffersIndexed::enableiOES(GCGLenum target, GCGLuint index)
     if (isContextLost())
         return;
     auto& context = this->context();
-    context.graphicsContextGL()->enableiOES(target, index);
+    context.protectedGraphicsContextGL()->enableiOES(target, index);
 }
 
 void OESDrawBuffersIndexed::disableiOES(GCGLenum target, GCGLuint index)
@@ -60,7 +60,7 @@ void OESDrawBuffersIndexed::disableiOES(GCGLenum target, GCGLuint index)
     if (isContextLost())
         return;
     auto& context = this->context();
-    context.graphicsContextGL()->disableiOES(target, index);
+    context.protectedGraphicsContextGL()->disableiOES(target, index);
 }
 
 void OESDrawBuffersIndexed::blendEquationiOES(GCGLuint buf, GCGLenum mode)
@@ -68,7 +68,7 @@ void OESDrawBuffersIndexed::blendEquationiOES(GCGLuint buf, GCGLenum mode)
     if (isContextLost())
         return;
     auto& context = this->context();
-    context.graphicsContextGL()->blendEquationiOES(buf, mode);
+    context.protectedGraphicsContextGL()->blendEquationiOES(buf, mode);
 }
 
 void OESDrawBuffersIndexed::blendEquationSeparateiOES(GCGLuint buf, GCGLenum modeRGB, GCGLenum modeAlpha)
@@ -76,7 +76,7 @@ void OESDrawBuffersIndexed::blendEquationSeparateiOES(GCGLuint buf, GCGLenum mod
     if (isContextLost())
         return;
     auto& context = this->context();
-    context.graphicsContextGL()->blendEquationSeparateiOES(buf, modeRGB, modeAlpha);
+    context.protectedGraphicsContextGL()->blendEquationSeparateiOES(buf, modeRGB, modeAlpha);
 }
 
 void OESDrawBuffersIndexed::blendFunciOES(GCGLuint buf, GCGLenum src, GCGLenum dst)
@@ -84,7 +84,7 @@ void OESDrawBuffersIndexed::blendFunciOES(GCGLuint buf, GCGLenum src, GCGLenum d
     if (isContextLost())
         return;
     auto& context = this->context();
-    context.graphicsContextGL()->blendFunciOES(buf, src, dst);
+    context.protectedGraphicsContextGL()->blendFunciOES(buf, src, dst);
 }
 
 void OESDrawBuffersIndexed::blendFuncSeparateiOES(GCGLuint buf, GCGLenum srcRGB, GCGLenum dstRGB, GCGLenum srcAlpha, GCGLenum dstAlpha)
@@ -92,7 +92,7 @@ void OESDrawBuffersIndexed::blendFuncSeparateiOES(GCGLuint buf, GCGLenum srcRGB,
     if (isContextLost())
         return;
     auto& context = this->context();
-    context.graphicsContextGL()->blendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha);
+    context.protectedGraphicsContextGL()->blendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha);
 }
 
 void OESDrawBuffersIndexed::colorMaskiOES(GCGLuint buf, GCGLboolean red, GCGLboolean green, GCGLboolean blue, GCGLboolean alpha)
@@ -107,7 +107,7 @@ void OESDrawBuffersIndexed::colorMaskiOES(GCGLuint buf, GCGLboolean red, GCGLboo
         context.m_colorMask[2] = blue;
         context.m_colorMask[3] = alpha;
     }
-    context.graphicsContextGL()->colorMaskiOES(buf, red, green, blue, alpha);
+    context.protectedGraphicsContextGL()->colorMaskiOES(buf, red, green, blue, alpha);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/OESElementIndexUint.cpp
+++ b/Source/WebCore/html/canvas/OESElementIndexUint.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(OESElementIndexUint);
 OESElementIndexUint::OESElementIndexUint(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESElementIndexUint)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_element_index_uint"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_element_index_uint"_s);
 }
 
 OESElementIndexUint::~OESElementIndexUint() = default;

--- a/Source/WebCore/html/canvas/OESFBORenderMipmap.cpp
+++ b/Source/WebCore/html/canvas/OESFBORenderMipmap.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(OESFBORenderMipmap);
 OESFBORenderMipmap::OESFBORenderMipmap(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESFBORenderMipmap)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_fbo_render_mipmap"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_fbo_render_mipmap"_s);
 }
 
 OESFBORenderMipmap::~OESFBORenderMipmap() = default;

--- a/Source/WebCore/html/canvas/OESSampleVariables.cpp
+++ b/Source/WebCore/html/canvas/OESSampleVariables.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(OESSampleVariables);
 OESSampleVariables::OESSampleVariables(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESSampleVariables)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_sample_variables"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_sample_variables"_s);
 }
 
 OESSampleVariables::~OESSampleVariables() = default;

--- a/Source/WebCore/html/canvas/OESShaderMultisampleInterpolation.cpp
+++ b/Source/WebCore/html/canvas/OESShaderMultisampleInterpolation.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(OESShaderMultisampleInterpolation);
 OESShaderMultisampleInterpolation::OESShaderMultisampleInterpolation(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESShaderMultisampleInterpolation)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_shader_multisample_interpolation"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_shader_multisample_interpolation"_s);
 }
 
 OESShaderMultisampleInterpolation::~OESShaderMultisampleInterpolation() = default;

--- a/Source/WebCore/html/canvas/OESStandardDerivatives.cpp
+++ b/Source/WebCore/html/canvas/OESStandardDerivatives.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(OESStandardDerivatives);
 OESStandardDerivatives::OESStandardDerivatives(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESStandardDerivatives)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_standard_derivatives"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_standard_derivatives"_s);
 }
 
 OESStandardDerivatives::~OESStandardDerivatives() = default;

--- a/Source/WebCore/html/canvas/OESTextureFloat.cpp
+++ b/Source/WebCore/html/canvas/OESTextureFloat.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(OESTextureFloat);
 OESTextureFloat::OESTextureFloat(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESTextureFloat)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_float"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_float"_s);
 
     // Spec requires WEBGL_color_buffer_float to be turned on implicitly here.
     // Enable it both in the backend and in WebKit.

--- a/Source/WebCore/html/canvas/OESTextureFloatLinear.cpp
+++ b/Source/WebCore/html/canvas/OESTextureFloatLinear.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(OESTextureFloatLinear);
 OESTextureFloatLinear::OESTextureFloatLinear(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESTextureFloatLinear)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_float_linear"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_float_linear"_s);
 }
 
 OESTextureFloatLinear::~OESTextureFloatLinear() = default;

--- a/Source/WebCore/html/canvas/OESTextureHalfFloat.cpp
+++ b/Source/WebCore/html/canvas/OESTextureHalfFloat.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(OESTextureHalfFloat);
 OESTextureHalfFloat::OESTextureHalfFloat(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESTextureHalfFloat)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_half_float"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_half_float"_s);
 
     // Spec requires EXT_color_buffer_half_float to be turned on implicitly here.
     // Enable it both in the backend and in WebKit.

--- a/Source/WebCore/html/canvas/OESTextureHalfFloatLinear.cpp
+++ b/Source/WebCore/html/canvas/OESTextureHalfFloatLinear.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(OESTextureHalfFloatLinear);
 OESTextureHalfFloatLinear::OESTextureHalfFloatLinear(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::OESTextureHalfFloatLinear)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_half_float_linear"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_texture_half_float_linear"_s);
 }
 
 OESTextureHalfFloatLinear::~OESTextureHalfFloatLinear() = default;

--- a/Source/WebCore/html/canvas/OESVertexArrayObject.cpp
+++ b/Source/WebCore/html/canvas/OESVertexArrayObject.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(OESVertexArrayObject);
 OESVertexArrayObject::OESVertexArrayObject(WebGLRenderingContext& context)
     : WebGLExtension(context, WebGLExtensionName::OESVertexArrayObject)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_vertex_array_object"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_vertex_array_object"_s);
 }
 
 OESVertexArrayObject::~OESVertexArrayObject() = default;
@@ -79,7 +79,7 @@ void OESVertexArrayObject::deleteVertexArrayOES(WebGLVertexArrayObjectOES* array
     if (!arrayObject->isDefaultObject() && arrayObject == context.m_boundVertexArrayObject)
         context.setBoundVertexArrayObject(locker, nullptr);
 
-    arrayObject->deleteObject(locker, context.graphicsContextGL());
+    arrayObject->deleteObject(locker, context.protectedGraphicsContextGL().get());
 }
 
 GCGLboolean OESVertexArrayObject::isVertexArrayOES(WebGLVertexArrayObjectOES* arrayObject)
@@ -89,7 +89,7 @@ GCGLboolean OESVertexArrayObject::isVertexArrayOES(WebGLVertexArrayObjectOES* ar
     auto& context = this->context();
     if (!context.validateIsWebGLObject(arrayObject))
         return false;
-    return context.graphicsContextGL()->isVertexArray(arrayObject->object());
+    return context.protectedGraphicsContextGL()->isVertexArray(arrayObject->object());
 }
 
 void OESVertexArrayObject::bindVertexArrayOES(WebGLVertexArrayObjectOES* arrayObject)
@@ -103,7 +103,7 @@ void OESVertexArrayObject::bindVertexArrayOES(WebGLVertexArrayObjectOES* arrayOb
     if (!context.validateNullableWebGLObject("bindVertexArrayOES", arrayObject))
         return;
 
-    auto* contextGL = context.graphicsContextGL();
+    RefPtr contextGL = context.graphicsContextGL();
     if (arrayObject && !arrayObject->isDefaultObject() && arrayObject->object()) {
         contextGL->bindVertexArray(arrayObject->object());
         context.setBoundVertexArrayObject(locker, arrayObject);

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -2546,7 +2546,7 @@ void WebGL2RenderingContext::deleteVertexArray(WebGLVertexArrayObject* arrayObje
         setBoundVertexArrayObject(locker, m_defaultVertexArrayObject.get());
     }
 
-    arrayObject->deleteObject(locker, graphicsContextGL());
+    arrayObject->deleteObject(locker, protectedGraphicsContextGL().get());
 }
 
 GCGLboolean WebGL2RenderingContext::isVertexArray(WebGLVertexArrayObject* arrayObject)

--- a/Source/WebCore/html/canvas/WebGLBuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLBuffer.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 RefPtr<WebGLBuffer> WebGLBuffer::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createBuffer();
+    auto object = context.protectedGraphicsContextGL()->createBuffer();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLBuffer { context, object });

--- a/Source/WebCore/html/canvas/WebGLClipCullDistance.cpp
+++ b/Source/WebCore/html/canvas/WebGLClipCullDistance.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLClipCullDistance);
 WebGLClipCullDistance::WebGLClipCullDistance(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLClipCullDistance)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_clip_cull_distance"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_clip_cull_distance"_s);
 }
 
 WebGLClipCullDistance::~WebGLClipCullDistance() = default;

--- a/Source/WebCore/html/canvas/WebGLColorBufferFloat.cpp
+++ b/Source/WebCore/html/canvas/WebGLColorBufferFloat.cpp
@@ -37,9 +37,10 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLColorBufferFloat);
 WebGLColorBufferFloat::WebGLColorBufferFloat(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLColorBufferFloat)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_CHROMIUM_color_buffer_float_rgba"_s);
+    RefPtr graphicsContextGL = context.graphicsContextGL();
+    graphicsContextGL->ensureExtensionEnabled("GL_CHROMIUM_color_buffer_float_rgba"_s);
     // Optimistically enable RGB floating-point render targets also, if possible.
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_CHROMIUM_color_buffer_float_rgb"_s);
+    graphicsContextGL->ensureExtensionEnabled("GL_CHROMIUM_color_buffer_float_rgb"_s);
 
     // https://github.com/KhronosGroup/WebGL/pull/2830
     // Spec requires EXT_float_blend to be turned on implicitly here.

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureASTC.cpp
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureASTC.cpp
@@ -36,11 +36,12 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLCompressedTextureASTC);
 
 WebGLCompressedTextureASTC::WebGLCompressedTextureASTC(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLCompressedTextureASTC)
-    , m_isHDRSupported(context.graphicsContextGL()->supportsExtension("GL_KHR_texture_compression_astc_hdr"_s))
-    , m_isLDRSupported(context.graphicsContextGL()->supportsExtension("GL_KHR_texture_compression_astc_ldr"_s))
+    , m_isHDRSupported(context.protectedGraphicsContextGL()->supportsExtension("GL_KHR_texture_compression_astc_hdr"_s))
+    , m_isLDRSupported(context.protectedGraphicsContextGL()->supportsExtension("GL_KHR_texture_compression_astc_ldr"_s))
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_KHR_texture_compression_astc_hdr"_s);
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_KHR_texture_compression_astc_ldr"_s);
+    RefPtr graphicsContextGL = context.graphicsContextGL();
+    graphicsContextGL->ensureExtensionEnabled("GL_KHR_texture_compression_astc_hdr"_s);
+    graphicsContextGL->ensureExtensionEnabled("GL_KHR_texture_compression_astc_ldr"_s);
 
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_RGBA_ASTC_4x4_KHR);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_RGBA_ASTC_5x4_KHR);

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureETC.cpp
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureETC.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLCompressedTextureETC);
 WebGLCompressedTextureETC::WebGLCompressedTextureETC(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLCompressedTextureETC)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_compressed_texture_etc"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_compressed_texture_etc"_s);
 
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_R11_EAC);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SIGNED_R11_EAC);

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureETC1.cpp
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureETC1.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLCompressedTextureETC1);
 WebGLCompressedTextureETC1::WebGLCompressedTextureETC1(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLCompressedTextureETC1)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_compressed_ETC1_RGB8_texture"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_compressed_ETC1_RGB8_texture"_s);
 
     context.addCompressedTextureFormat(GraphicsContextGL::ETC1_RGB8_OES);
 }

--- a/Source/WebCore/html/canvas/WebGLCompressedTexturePVRTC.cpp
+++ b/Source/WebCore/html/canvas/WebGLCompressedTexturePVRTC.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLCompressedTexturePVRTC);
 WebGLCompressedTexturePVRTC::WebGLCompressedTexturePVRTC(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLCompressedTexturePVRTC)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_IMG_texture_compression_pvrtc"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_IMG_texture_compression_pvrtc"_s);
 
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_RGB_PVRTC_4BPPV1_IMG);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_RGB_PVRTC_2BPPV1_IMG);

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureS3TC.cpp
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureS3TC.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLCompressedTextureS3TC);
 WebGLCompressedTextureS3TC::WebGLCompressedTextureS3TC(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLCompressedTextureS3TC)
 {
-    auto* gcgl = context.graphicsContextGL();
+    RefPtr gcgl = context.graphicsContextGL();
     gcgl->ensureExtensionEnabled("GL_EXT_texture_compression_dxt1"_s);
     gcgl->ensureExtensionEnabled("GL_ANGLE_texture_compression_dxt3"_s);
     gcgl->ensureExtensionEnabled("GL_ANGLE_texture_compression_dxt5"_s);

--- a/Source/WebCore/html/canvas/WebGLCompressedTextureS3TCsRGB.cpp
+++ b/Source/WebCore/html/canvas/WebGLCompressedTextureS3TCsRGB.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLCompressedTextureS3TCsRGB);
 WebGLCompressedTextureS3TCsRGB::WebGLCompressedTextureS3TCsRGB(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLCompressedTextureS3TCsRGB)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_compression_s3tc_srgb"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_texture_compression_s3tc_srgb"_s);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SRGB_S3TC_DXT1_EXT);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT);
     context.addCompressedTextureFormat(GraphicsContextGL::COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT);

--- a/Source/WebCore/html/canvas/WebGLDebugShaders.cpp
+++ b/Source/WebCore/html/canvas/WebGLDebugShaders.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLDebugShaders);
 WebGLDebugShaders::WebGLDebugShaders(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLDebugShaders)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_translated_shader_source"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_translated_shader_source"_s);
 }
 
 WebGLDebugShaders::~WebGLDebugShaders() = default;
@@ -56,7 +56,7 @@ String WebGLDebugShaders::getTranslatedShaderSource(WebGLShader& shader)
     auto& context = this->context();
     if (!context.validateWebGLObject("getTranslatedShaderSource", shader))
         return emptyString();
-    return context.graphicsContextGL()->getTranslatedShaderSourceANGLE(shader.object());
+    return context.protectedGraphicsContextGL()->getTranslatedShaderSourceANGLE(shader.object());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
@@ -40,7 +40,7 @@ std::unique_ptr<WebGLDefaultFramebuffer> WebGLDefaultFramebuffer::create(WebGLRe
 WebGLDefaultFramebuffer::WebGLDefaultFramebuffer(WebGLRenderingContextBase& context)
     : m_context(context)
 {
-    auto attributes = m_context.graphicsContextGL()->contextAttributes();
+    auto attributes = m_context.protectedGraphicsContextGL()->contextAttributes();
     m_hasStencil = attributes.stencil;
     m_hasDepth = attributes.depth;
     if (!attributes.preserveDrawingBuffer) {
@@ -54,7 +54,7 @@ WebGLDefaultFramebuffer::WebGLDefaultFramebuffer(WebGLRenderingContextBase& cont
 
 void WebGLDefaultFramebuffer::reshape(IntSize size)
 {
-    m_context.graphicsContextGL()->reshape(size.width(), size.height());
+    m_context.protectedGraphicsContextGL()->reshape(size.width(), size.height());
 }
 
 void WebGLDefaultFramebuffer::markBuffersClear(GCGLbitfield clearBuffers)

--- a/Source/WebCore/html/canvas/WebGLDepthTexture.cpp
+++ b/Source/WebCore/html/canvas/WebGLDepthTexture.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLDepthTexture);
 WebGLDepthTexture::WebGLDepthTexture(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLDepthTexture)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_OES_depth_texture"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_OES_depth_texture"_s);
 }
 
 WebGLDepthTexture::~WebGLDepthTexture() = default;

--- a/Source/WebCore/html/canvas/WebGLDrawBuffers.cpp
+++ b/Source/WebCore/html/canvas/WebGLDrawBuffers.cpp
@@ -37,14 +37,14 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLDrawBuffers);
 WebGLDrawBuffers::WebGLDrawBuffers(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLDrawBuffers)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_draw_buffers"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_draw_buffers"_s);
 }
 
 WebGLDrawBuffers::~WebGLDrawBuffers() = default;
 
 bool WebGLDrawBuffers::supported(WebGLRenderingContextBase& context)
 {
-    return context.graphicsContextGL()->supportsExtension("GL_EXT_draw_buffers"_s);
+    return context.protectedGraphicsContextGL()->supportsExtension("GL_EXT_draw_buffers"_s);
 }
 
 void WebGLDrawBuffers::drawBuffersWEBGL(const Vector<GCGLenum>& buffers)
@@ -65,7 +65,7 @@ void WebGLDrawBuffers::drawBuffersWEBGL(const Vector<GCGLenum>& buffers)
         }
         // Because the backbuffer is simulated on all current WebKit ports, we need to change BACK to COLOR_ATTACHMENT0.
         GCGLenum value[1] { bufs[0] == GraphicsContextGL::BACK ? GraphicsContextGL::COLOR_ATTACHMENT0 : GraphicsContextGL::NONE };
-        context.graphicsContextGL()->drawBuffersEXT(value);
+        context.protectedGraphicsContextGL()->drawBuffersEXT(value);
         context.setBackDrawBuffer(bufs[0]);
     } else {
         if (n > context.maxDrawBuffers()) {

--- a/Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.cpp
+++ b/Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLDrawInstancedBaseVertexBaseInstance);
 WebGLDrawInstancedBaseVertexBaseInstance::WebGLDrawInstancedBaseVertexBaseInstance(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLDrawInstancedBaseVertexBaseInstance)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_base_vertex_base_instance"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_base_vertex_base_instance"_s);
 }
 
 WebGLDrawInstancedBaseVertexBaseInstance::~WebGLDrawInstancedBaseVertexBaseInstance() = default;
@@ -66,7 +66,7 @@ void WebGLDrawInstancedBaseVertexBaseInstance::drawArraysInstancedBaseInstanceWE
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context };
 
-        context.graphicsContextGL()->drawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance);
+        context.protectedGraphicsContextGL()->drawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance);
     }
 
     context.markContextChangedAndNotifyCanvasObserver();
@@ -89,7 +89,7 @@ void WebGLDrawInstancedBaseVertexBaseInstance::drawElementsInstancedBaseVertexBa
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context };
 
-        context.graphicsContextGL()->drawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, offset, instanceCount, baseVertex, baseInstance);
+        context.protectedGraphicsContextGL()->drawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, offset, instanceCount, baseVertex, baseInstance);
     }
 
     context.markContextChangedAndNotifyCanvasObserver();

--- a/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
+++ b/Source/WebCore/html/canvas/WebGLMultiDraw.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLMultiDraw);
 WebGLMultiDraw::WebGLMultiDraw(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLMultiDraw)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_multi_draw"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_multi_draw"_s);
 
     // Spec requires ANGLE_instanced_arrays to be turned on implicitly here.
     // Enable it both in the backend and in WebKit.
@@ -78,7 +78,7 @@ void WebGLMultiDraw::multiDrawArraysWEBGL(GCGLenum mode, Int32List&& firstsList,
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context };
 
-        context.graphicsContextGL()->multiDrawArraysANGLE(mode, GCGLSpanTuple { firstsList.data() + firstsOffset, countsList.data() + countsOffset, static_cast<size_t>(drawcount) });
+        context.protectedGraphicsContextGL()->multiDrawArraysANGLE(mode, GCGLSpanTuple { firstsList.data() + firstsOffset, countsList.data() + countsOffset, static_cast<size_t>(drawcount) });
     }
 
     context.markContextChangedAndNotifyCanvasObserver();
@@ -108,7 +108,7 @@ void WebGLMultiDraw::multiDrawArraysInstancedWEBGL(GCGLenum mode, Int32List&& fi
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context };
 
-        context.graphicsContextGL()->multiDrawArraysInstancedANGLE(mode, GCGLSpanTuple { firstsList.data() +  firstsOffset, countsList.data() + countsOffset, instanceCountsList.data() + instanceCountsOffset, static_cast<size_t>(drawcount) });
+        context.protectedGraphicsContextGL()->multiDrawArraysInstancedANGLE(mode, GCGLSpanTuple { firstsList.data() +  firstsOffset, countsList.data() + countsOffset, instanceCountsList.data() + instanceCountsOffset, static_cast<size_t>(drawcount) });
     }
 
     context.markContextChangedAndNotifyCanvasObserver();
@@ -137,7 +137,7 @@ void WebGLMultiDraw::multiDrawElementsWEBGL(GCGLenum mode, Int32List&& countsLis
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context };
 
-        context.graphicsContextGL()->multiDrawElementsANGLE(mode, GCGLSpanTuple { countsList.data() + countsOffset, offsetsList.data() + offsetsOffset, static_cast<size_t>(drawcount) }, type);
+        context.protectedGraphicsContextGL()->multiDrawElementsANGLE(mode, GCGLSpanTuple { countsList.data() + countsOffset, offsetsList.data() + offsetsOffset, static_cast<size_t>(drawcount) }, type);
     }
 
     context.markContextChangedAndNotifyCanvasObserver();
@@ -167,7 +167,7 @@ void WebGLMultiDraw::multiDrawElementsInstancedWEBGL(GCGLenum mode, Int32List&& 
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context };
 
-        context.graphicsContextGL()->multiDrawElementsInstancedANGLE(mode, GCGLSpanTuple { countsList.data() + countsOffset, offsetsList.data() + offsetsOffset, instanceCountsList.data() + instanceCountsOffset, static_cast<size_t>(drawcount) }, type);
+        context.protectedGraphicsContextGL()->multiDrawElementsInstancedANGLE(mode, GCGLSpanTuple { countsList.data() + countsOffset, offsetsList.data() + offsetsOffset, instanceCountsList.data() + instanceCountsOffset, static_cast<size_t>(drawcount) }, type);
     }
 
     context.markContextChangedAndNotifyCanvasObserver();

--- a/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
+++ b/Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLMultiDrawInstancedBaseVertexBaseInstance);
 WebGLMultiDrawInstancedBaseVertexBaseInstance::WebGLMultiDrawInstancedBaseVertexBaseInstance(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLMultiDrawInstancedBaseVertexBaseInstance)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_base_vertex_base_instance"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_base_vertex_base_instance"_s);
 
     // Spec requires WEBGL_multi_draw to be turned on implicitly here.
     // Enable it both in the backend and in WebKit.
@@ -79,7 +79,7 @@ void WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawArraysInstancedBase
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context };
 
-        context.graphicsContextGL()->multiDrawArraysInstancedBaseInstanceANGLE(mode, GCGLSpanTuple { firstsList.data() +  firstsOffset, countsList.data() + countsOffset, instanceCountsList.data() + instanceCountsOffset, baseInstancesList.data() + baseInstancesOffset, static_cast<size_t>(drawcount) });
+        context.protectedGraphicsContextGL()->multiDrawArraysInstancedBaseInstanceANGLE(mode, GCGLSpanTuple { firstsList.data() +  firstsOffset, countsList.data() + countsOffset, instanceCountsList.data() + instanceCountsOffset, baseInstancesList.data() + baseInstancesOffset, static_cast<size_t>(drawcount) });
     }
 
     context.markContextChangedAndNotifyCanvasObserver();
@@ -111,7 +111,7 @@ void WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawElementsInstancedBa
     {
         ScopedInspectorShaderProgramHighlight scopedHighlight { context };
 
-        context.graphicsContextGL()->multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, GCGLSpanTuple { countsList.data() + countsOffset, offsetsList.data() + offsetsOffset, instanceCountsList.data() + instanceCountsOffset, baseVerticesList.data() + baseVerticesOffset, baseInstancesList.data() + baseInstancesOffset, static_cast<size_t>(drawcount) }, type);
+        context.protectedGraphicsContextGL()->multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, GCGLSpanTuple { countsList.data() + countsOffset, offsetsList.data() + offsetsOffset, instanceCountsList.data() + instanceCountsOffset, baseVerticesList.data() + baseVerticesOffset, baseInstancesList.data() + baseInstancesOffset, static_cast<size_t>(drawcount) }, type);
     }
 
     context.markContextChangedAndNotifyCanvasObserver();

--- a/Source/WebCore/html/canvas/WebGLPolygonMode.cpp
+++ b/Source/WebCore/html/canvas/WebGLPolygonMode.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLPolygonMode);
 WebGLPolygonMode::WebGLPolygonMode(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLPolygonMode)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_polygon_mode"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_polygon_mode"_s);
     context.printToConsole(MessageLevel::Warning, "WebGL: non-portable extension enabled: WEBGL_polygon_mode"_s);
 }
 
@@ -53,7 +53,7 @@ void WebGLPolygonMode::polygonModeWEBGL(GCGLenum face, GCGLenum mode)
     if (isContextLost())
         return;
     auto& context = this->context();
-    context.graphicsContextGL()->polygonModeANGLE(face, mode);
+    context.protectedGraphicsContextGL()->polygonModeANGLE(face, mode);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLProgram.cpp
+++ b/Source/WebCore/html/canvas/WebGLProgram.cpp
@@ -56,7 +56,7 @@ Lock& WebGLProgram::instancesLock()
 
 RefPtr<WebGLProgram> WebGLProgram::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createProgram();
+    auto object = context.protectedGraphicsContextGL()->createProgram();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLProgram { context, object });
@@ -225,13 +225,13 @@ void WebGLProgram::cacheInfoIfNeeded()
     if (!object())
         return;
 
-    GraphicsContextGL* context = graphicsContextGL();
+    RefPtr context = graphicsContextGL();
     if (!context)
         return;
     GCGLint linkStatus = context->getProgrami(object(), GraphicsContextGL::LINK_STATUS);
     m_linkStatus = linkStatus;
     if (m_linkStatus) {
-        cacheActiveAttribLocations(context);
+        cacheActiveAttribLocations(context.get());
         m_requiredTransformFeedbackBufferCount = m_requiredTransformFeedbackBufferCountAfterNextLink;
     }
     m_infoValid = true;

--- a/Source/WebCore/html/canvas/WebGLProvokingVertex.cpp
+++ b/Source/WebCore/html/canvas/WebGLProvokingVertex.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLProvokingVertex);
 WebGLProvokingVertex::WebGLProvokingVertex(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLProvokingVertex)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_provoking_vertex"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_provoking_vertex"_s);
 }
 
 WebGLProvokingVertex::~WebGLProvokingVertex() = default;
@@ -52,7 +52,7 @@ void WebGLProvokingVertex::provokingVertexWEBGL(GCGLenum provokeMode)
     if (isContextLost())
         return;
     auto& context = this->context();
-    context.graphicsContextGL()->provokingVertexANGLE(provokeMode);
+    context.protectedGraphicsContextGL()->provokingVertexANGLE(provokeMode);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/WebGLQuery.cpp
+++ b/Source/WebCore/html/canvas/WebGLQuery.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
     
 RefPtr<WebGLQuery> WebGLQuery::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createQuery();
+    auto object = context.protectedGraphicsContextGL()->createQuery();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLQuery { context, object });

--- a/Source/WebCore/html/canvas/WebGLRenderSharedExponent.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderSharedExponent.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLRenderSharedExponent);
 WebGLRenderSharedExponent::WebGLRenderSharedExponent(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLRenderSharedExponent)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_QCOM_render_shared_exponent"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_QCOM_render_shared_exponent"_s);
 }
 
 WebGLRenderSharedExponent::~WebGLRenderSharedExponent() = default;

--- a/Source/WebCore/html/canvas/WebGLRenderbuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderbuffer.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 RefPtr<WebGLRenderbuffer> WebGLRenderbuffer::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createRenderbuffer();
+    auto object = context.protectedGraphicsContextGL()->createRenderbuffer();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLRenderbuffer { context, object });

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1381,7 +1381,7 @@ bool WebGLRenderingContextBase::deleteObject(const AbstractLocker& locker, WebGL
     if (object->object())
         // We need to pass in context here because we want
         // things in this context unbound.
-        object->deleteObject(locker, graphicsContextGL());
+        object->deleteObject(locker, protectedGraphicsContextGL().get());
     return true;
 }
 
@@ -1531,7 +1531,7 @@ void WebGLRenderingContextBase::detachShader(WebGLProgram& program, WebGLShader&
         return;
     }
     m_context->detachShader(program.object(), shader.object());
-    shader.onDetached(locker, graphicsContextGL());
+    shader.onDetached(locker, protectedGraphicsContextGL().get());
 }
 
 void WebGLRenderingContextBase::disable(GCGLenum cap)
@@ -4540,7 +4540,7 @@ void WebGLRenderingContextBase::useProgram(WebGLProgram* program)
 
     if (m_currentProgram != program) {
         if (m_currentProgram)
-            m_currentProgram->onDetached(locker, graphicsContextGL());
+            m_currentProgram->onDetached(locker, protectedGraphicsContextGL().get());
         m_currentProgram = program;
         m_context->useProgram(objectOrZero(program));
         if (program)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -424,6 +424,8 @@ public:
     WEBCORE_EXPORT void simulateEventForTesting(SimulatedEventForTesting);
 
     GraphicsContextGL* graphicsContextGL() const { return m_context.get(); }
+    RefPtr<GraphicsContextGL> protectedGraphicsContextGL() const { return m_context; }
+
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
 
     void reshape(int width, int height) override;

--- a/Source/WebCore/html/canvas/WebGLSampler.cpp
+++ b/Source/WebCore/html/canvas/WebGLSampler.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 
 RefPtr<WebGLSampler> WebGLSampler::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createSampler();
+    auto object = context.protectedGraphicsContextGL()->createSampler();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLSampler { context, object });

--- a/Source/WebCore/html/canvas/WebGLShader.cpp
+++ b/Source/WebCore/html/canvas/WebGLShader.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 RefPtr<WebGLShader> WebGLShader::create(WebGLRenderingContextBase& context, GCGLenum type)
 {
-    auto object = context.graphicsContextGL()->createShader(type);
+    auto object = context.protectedGraphicsContextGL()->createShader(type);
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLShader(context, object, type));

--- a/Source/WebCore/html/canvas/WebGLStencilTexturing.cpp
+++ b/Source/WebCore/html/canvas/WebGLStencilTexturing.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLStencilTexturing);
 WebGLStencilTexturing::WebGLStencilTexturing(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLStencilTexturing)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_stencil_texturing"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_ANGLE_stencil_texturing"_s);
 }
 
 WebGLStencilTexturing::~WebGLStencilTexturing() = default;

--- a/Source/WebCore/html/canvas/WebGLSync.cpp
+++ b/Source/WebCore/html/canvas/WebGLSync.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 RefPtr<WebGLSync> WebGLSync::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->fenceSync(GraphicsContextGL::SYNC_GPU_COMMANDS_COMPLETE, 0);
+    auto object = context.protectedGraphicsContextGL()->fenceSync(GraphicsContextGL::SYNC_GPU_COMMANDS_COMPLETE, 0);
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLSync { context, object });
@@ -69,7 +69,7 @@ void WebGLSync::updateCache(WebGLRenderingContextBase& context)
         return;
 
     m_allowCacheUpdate = false;
-    m_syncStatus = context.graphicsContextGL()->getSynci(m_sync, GraphicsContextGL::SYNC_STATUS);
+    m_syncStatus = context.protectedGraphicsContextGL()->getSynci(m_sync, GraphicsContextGL::SYNC_STATUS);
     if (m_syncStatus == GraphicsContextGL::UNSIGNALED)
         scheduleAllowCacheUpdate(context);
 }

--- a/Source/WebCore/html/canvas/WebGLTexture.cpp
+++ b/Source/WebCore/html/canvas/WebGLTexture.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 
 RefPtr<WebGLTexture> WebGLTexture::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createTexture();
+    auto object = context.protectedGraphicsContextGL()->createTexture();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLTexture { context, object });

--- a/Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp
+++ b/Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 
 RefPtr<WebGLTimerQueryEXT> WebGLTimerQueryEXT::create(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createQueryEXT();
+    auto object = context.protectedGraphicsContextGL()->createQueryEXT();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLTimerQueryEXT { context, object });

--- a/Source/WebCore/html/canvas/WebGLTransformFeedback.cpp
+++ b/Source/WebCore/html/canvas/WebGLTransformFeedback.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 
 RefPtr<WebGLTransformFeedback> WebGLTransformFeedback::create(WebGL2RenderingContext& context)
 {
-    auto object = context.graphicsContextGL()->createTransformFeedback();
+    auto object = context.protectedGraphicsContextGL()->createTransformFeedback();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLTransformFeedback { context, object });

--- a/Source/WebCore/html/canvas/WebGLUtilities.cpp
+++ b/Source/WebCore/html/canvas/WebGLUtilities.cpp
@@ -43,51 +43,51 @@ bool ScopedInspectorShaderProgramHighlight::shouldApply(WebGLRenderingContextBas
 
 void ScopedInspectorShaderProgramHighlight::showHighlight()
 {
-    auto& gl = *m_context->graphicsContextGL();
+    Ref gl = *m_context->graphicsContextGL();
     // When OES_draw_buffers_indexed extension is enabled,
     // these state queries return the state for draw buffer 0.
     // Constant blend color is always the same for all draw buffers.
-    gl.getFloatv(GraphicsContextGL::BLEND_COLOR, m_savedBlend.color);
-    m_savedBlend.equationRGB = gl.getInteger(GraphicsContextGL::BLEND_EQUATION_RGB);
-    m_savedBlend.equationAlpha = gl.getInteger(GraphicsContextGL::BLEND_EQUATION_ALPHA);
-    m_savedBlend.srcRGB = gl.getInteger(GraphicsContextGL::BLEND_SRC_RGB);
-    m_savedBlend.dstRGB = gl.getInteger(GraphicsContextGL::BLEND_DST_RGB);
-    m_savedBlend.srcAlpha = gl.getInteger(GraphicsContextGL::BLEND_SRC_ALPHA);
-    m_savedBlend.dstAlpha = gl.getInteger(GraphicsContextGL::BLEND_DST_ALPHA);
-    m_savedBlend.enabled = gl.isEnabled(GraphicsContextGL::BLEND);
+    gl->getFloatv(GraphicsContextGL::BLEND_COLOR, m_savedBlend.color);
+    m_savedBlend.equationRGB = gl->getInteger(GraphicsContextGL::BLEND_EQUATION_RGB);
+    m_savedBlend.equationAlpha = gl->getInteger(GraphicsContextGL::BLEND_EQUATION_ALPHA);
+    m_savedBlend.srcRGB = gl->getInteger(GraphicsContextGL::BLEND_SRC_RGB);
+    m_savedBlend.dstRGB = gl->getInteger(GraphicsContextGL::BLEND_DST_RGB);
+    m_savedBlend.srcAlpha = gl->getInteger(GraphicsContextGL::BLEND_SRC_ALPHA);
+    m_savedBlend.dstAlpha = gl->getInteger(GraphicsContextGL::BLEND_DST_ALPHA);
+    m_savedBlend.enabled = gl->isEnabled(GraphicsContextGL::BLEND);
 
     static const GCGLfloat red = 111.0 / 255.0;
     static const GCGLfloat green = 168.0 / 255.0;
     static const GCGLfloat blue = 220.0 / 255.0;
     static const GCGLfloat alpha = 2.0 / 3.0;
-    gl.blendColor(red, green, blue, alpha);
+    gl->blendColor(red, green, blue, alpha);
 
     if (m_context->m_oesDrawBuffersIndexed) {
-        gl.enableiOES(GraphicsContextGL::BLEND, 0);
-        gl.blendEquationiOES(0, GraphicsContextGL::FUNC_ADD);
-        gl.blendFunciOES(0, GraphicsContextGL::CONSTANT_COLOR, GraphicsContextGL::ONE_MINUS_SRC_ALPHA);
+        gl->enableiOES(GraphicsContextGL::BLEND, 0);
+        gl->blendEquationiOES(0, GraphicsContextGL::FUNC_ADD);
+        gl->blendFunciOES(0, GraphicsContextGL::CONSTANT_COLOR, GraphicsContextGL::ONE_MINUS_SRC_ALPHA);
     } else {
-        gl.enable(GraphicsContextGL::BLEND);
-        gl.blendEquation(GraphicsContextGL::FUNC_ADD);
-        gl.blendFunc(GraphicsContextGL::CONSTANT_COLOR, GraphicsContextGL::ONE_MINUS_SRC_ALPHA);
+        gl->enable(GraphicsContextGL::BLEND);
+        gl->blendEquation(GraphicsContextGL::FUNC_ADD);
+        gl->blendFunc(GraphicsContextGL::CONSTANT_COLOR, GraphicsContextGL::ONE_MINUS_SRC_ALPHA);
     }
 }
 
 void ScopedInspectorShaderProgramHighlight::hideHighlight()
 {
-    auto& gl = *m_context->graphicsContextGL();
-    gl.blendColor(m_savedBlend.color[0], m_savedBlend.color[1], m_savedBlend.color[2], m_savedBlend.color[3]);
+    Ref gl = *m_context->graphicsContextGL();
+    gl->blendColor(m_savedBlend.color[0], m_savedBlend.color[1], m_savedBlend.color[2], m_savedBlend.color[3]);
 
     if (m_context->m_oesDrawBuffersIndexed) {
-        gl.blendEquationSeparateiOES(0, m_savedBlend.equationRGB, m_savedBlend.equationAlpha);
-        gl.blendFuncSeparateiOES(0, m_savedBlend.srcRGB, m_savedBlend.dstRGB, m_savedBlend.srcAlpha, m_savedBlend.dstAlpha);
+        gl->blendEquationSeparateiOES(0, m_savedBlend.equationRGB, m_savedBlend.equationAlpha);
+        gl->blendFuncSeparateiOES(0, m_savedBlend.srcRGB, m_savedBlend.dstRGB, m_savedBlend.srcAlpha, m_savedBlend.dstAlpha);
         if (!m_savedBlend.enabled)
-            gl.disableiOES(GraphicsContextGL::BLEND, 0);
+            gl->disableiOES(GraphicsContextGL::BLEND, 0);
     } else {
-        gl.blendEquationSeparate(m_savedBlend.equationRGB, m_savedBlend.equationAlpha);
-        gl.blendFuncSeparate(m_savedBlend.srcRGB, m_savedBlend.dstRGB, m_savedBlend.srcAlpha, m_savedBlend.dstAlpha);
+        gl->blendEquationSeparate(m_savedBlend.equationRGB, m_savedBlend.equationAlpha);
+        gl->blendFuncSeparate(m_savedBlend.srcRGB, m_savedBlend.dstRGB, m_savedBlend.srcAlpha, m_savedBlend.dstAlpha);
         if (!m_savedBlend.enabled)
-            gl.disable(GraphicsContextGL::BLEND);
+            gl->disable(GraphicsContextGL::BLEND);
     }
 }
 

--- a/Source/WebCore/html/canvas/WebGLUtilities.h
+++ b/Source/WebCore/html/canvas/WebGLUtilities.h
@@ -89,7 +89,7 @@ private:
     static constexpr PixelStoreParameters tightUnpack { 1, 0, 0, 0, 0 };
     void set(const PixelStoreParameters& oldValues, const PixelStoreParameters& newValues)
     {
-        auto* context = m_context->graphicsContextGL();
+        RefPtr context = m_context->graphicsContextGL();
         if (oldValues.alignment != newValues.alignment)
             context->pixelStorei(GraphicsContextGL::UNPACK_ALIGNMENT, newValues.alignment);
         if (oldValues.rowLength != newValues.rowLength)
@@ -114,14 +114,14 @@ public:
     {
         if (!m_context)
             return;
-        m_context->graphicsContextGL()->disable(GraphicsContextGL::RASTERIZER_DISCARD);
+        m_context->protectedGraphicsContextGL()->disable(GraphicsContextGL::RASTERIZER_DISCARD);
     }
 
     ~ScopedDisableRasterizerDiscard()
     {
         if (!m_context)
             return;
-        m_context->graphicsContextGL()->enable(GraphicsContextGL::RASTERIZER_DISCARD);
+        m_context->protectedGraphicsContextGL()->enable(GraphicsContextGL::RASTERIZER_DISCARD);
     }
 
 private:
@@ -138,9 +138,9 @@ public:
             return;
         GCGLenum value[1] { GraphicsContextGL::COLOR_ATTACHMENT0 };
         if (m_context->isWebGL2())
-            m_context->graphicsContextGL()->drawBuffers(value);
+            m_context->protectedGraphicsContextGL()->drawBuffers(value);
         else
-            m_context->graphicsContextGL()->drawBuffersEXT(value);
+            m_context->protectedGraphicsContextGL()->drawBuffersEXT(value);
     }
 
     ~ScopedEnableBackbuffer()
@@ -149,9 +149,9 @@ public:
             return;
         GCGLenum value[1] { GraphicsContextGL::NONE };
         if (m_context->isWebGL2())
-            m_context->graphicsContextGL()->drawBuffers(value);
+            m_context->protectedGraphicsContextGL()->drawBuffers(value);
         else
-            m_context->graphicsContextGL()->drawBuffersEXT(value);
+            m_context->protectedGraphicsContextGL()->drawBuffersEXT(value);
     }
 
 private:
@@ -166,14 +166,14 @@ public:
     {
         if (!m_context)
             return;
-        m_context->graphicsContextGL()->disable(GraphicsContextGL::SCISSOR_TEST);
+        m_context->protectedGraphicsContextGL()->disable(GraphicsContextGL::SCISSOR_TEST);
     }
 
     ~ScopedDisableScissorTest()
     {
         if (!m_context)
             return;
-        m_context->graphicsContextGL()->enable(GraphicsContextGL::SCISSOR_TEST);
+        m_context->protectedGraphicsContextGL()->enable(GraphicsContextGL::SCISSOR_TEST);
     }
 
 private:
@@ -190,7 +190,7 @@ public:
 
     ~ScopedWebGLRestoreFramebuffer()
     {
-        auto* gl = m_context.graphicsContextGL();
+        RefPtr gl = m_context.graphicsContextGL();
         if (m_context.isWebGL2()) {
             auto& context2 = downcast<WebGL2RenderingContext>(m_context);
             gl->bindFramebuffer(GraphicsContextGL::READ_FRAMEBUFFER, objectOrZero(context2.m_readFramebufferBinding));
@@ -213,7 +213,7 @@ public:
 
     ~ScopedWebGLRestoreRenderbuffer()
     {
-        auto* gl = m_context.graphicsContextGL();
+        RefPtr gl = m_context.graphicsContextGL();
         gl->bindRenderbuffer(GraphicsContextGL::RENDERBUFFER, objectOrZero(m_context.m_renderbufferBinding));
     }
     WebGLRenderingContextBase& m_context;
@@ -249,7 +249,7 @@ public:
             // Not part of WebGL, does not need to be restored.
             return;
         }
-        auto* gl = m_context.graphicsContextGL();
+        RefPtr gl = m_context.graphicsContextGL();
         gl->bindTexture(m_target, texture);
     }
 private:

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObject.cpp
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObject.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
     
 RefPtr<WebGLVertexArrayObject> WebGLVertexArrayObject::create(WebGLRenderingContextBase& context, Type type)
 {
-    auto object = context.graphicsContextGL()->createVertexArray();
+    auto object = context.protectedGraphicsContextGL()->createVertexArray();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLVertexArrayObject { context, object, type });

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp
@@ -47,7 +47,7 @@ void WebGLVertexArrayObjectBase::setElementArrayBuffer(const AbstractLocker& loc
     if (buffer)
         buffer->onAttached();
     if (m_boundElementArrayBuffer)
-        m_boundElementArrayBuffer->onDetached(locker, context()->graphicsContextGL());
+        m_boundElementArrayBuffer->onDetached(locker, context()->protectedGraphicsContextGL().get());
     m_boundElementArrayBuffer = buffer;
     
 }
@@ -70,7 +70,7 @@ void WebGLVertexArrayObjectBase::setVertexAttribState(const AbstractLocker& lock
     if (buffer)
         buffer->onAttached();
     if (state.bufferBinding)
-        state.bufferBinding->onDetached(locker, context()->graphicsContextGL());
+        state.bufferBinding->onDetached(locker, context()->protectedGraphicsContextGL().get());
     state.bufferBinding = buffer;
     if (!state.validateBinding())
         m_allEnabledAttribBuffersBoundCache = false;
@@ -89,13 +89,13 @@ void WebGLVertexArrayObjectBase::setVertexAttribState(const AbstractLocker& lock
 void WebGLVertexArrayObjectBase::unbindBuffer(const AbstractLocker& locker, WebGLBuffer& buffer)
 {
     if (m_boundElementArrayBuffer == &buffer) {
-        m_boundElementArrayBuffer->onDetached(locker, context()->graphicsContextGL());
+        m_boundElementArrayBuffer->onDetached(locker, context()->protectedGraphicsContextGL().get());
         m_boundElementArrayBuffer = nullptr;
     }
     
     for (auto& state : m_vertexAttribState) {
         if (state.bufferBinding == &buffer) {
-            buffer.onDetached(locker, context()->graphicsContextGL());
+            buffer.onDetached(locker, context()->protectedGraphicsContextGL().get());
             state.bufferBinding = nullptr;
             if (!state.validateBinding())
                 m_allEnabledAttribBuffersBoundCache = false;

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.cpp
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.cpp
@@ -40,7 +40,7 @@ Ref<WebGLVertexArrayObjectOES> WebGLVertexArrayObjectOES::createDefault(WebGLRen
 
 RefPtr<WebGLVertexArrayObjectOES> WebGLVertexArrayObjectOES::createUser(WebGLRenderingContextBase& context)
 {
-    auto object = context.graphicsContextGL()->createVertexArray();
+    auto object = context.protectedGraphicsContextGL()->createVertexArray();
     if (!object)
         return nullptr;
     return adoptRef(*new WebGLVertexArrayObjectOES { context, object, Type::User });


### PR DESCRIPTION
#### c9354bc74322940912c8e4a0143a4c35019a6fc8
<pre>
Make sure we protect the GraphicsContextGL before calling its member functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=267856">https://bugs.webkit.org/show_bug.cgi?id=267856</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer):
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::endFrame):
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::transferToImageBitmap):
* Source/WebCore/html/canvas/ANGLEInstancedArrays.cpp:
(WebCore::ANGLEInstancedArrays::ANGLEInstancedArrays):
* Source/WebCore/html/canvas/EXTBlendMinMax.cpp:
(WebCore::EXTBlendMinMax::EXTBlendMinMax):
* Source/WebCore/html/canvas/EXTClipControl.cpp:
(WebCore::EXTClipControl::EXTClipControl):
(WebCore::EXTClipControl::clipControlEXT):
* Source/WebCore/html/canvas/EXTColorBufferFloat.cpp:
(WebCore::EXTColorBufferFloat::EXTColorBufferFloat):
* Source/WebCore/html/canvas/EXTColorBufferHalfFloat.cpp:
(WebCore::EXTColorBufferHalfFloat::EXTColorBufferHalfFloat):
* Source/WebCore/html/canvas/EXTConservativeDepth.cpp:
(WebCore::EXTConservativeDepth::EXTConservativeDepth):
* Source/WebCore/html/canvas/EXTDepthClamp.cpp:
(WebCore::EXTDepthClamp::EXTDepthClamp):
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp:
(WebCore::EXTDisjointTimerQuery::EXTDisjointTimerQuery):
(WebCore::EXTDisjointTimerQuery::deleteQueryEXT):
(WebCore::EXTDisjointTimerQuery::isQueryEXT):
(WebCore::EXTDisjointTimerQuery::beginQueryEXT):
(WebCore::EXTDisjointTimerQuery::endQueryEXT):
(WebCore::EXTDisjointTimerQuery::queryCounterEXT):
(WebCore::EXTDisjointTimerQuery::getQueryEXT):
(WebCore::EXTDisjointTimerQuery::getQueryObjectEXT):
* Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp:
(WebCore::EXTDisjointTimerQueryWebGL2::EXTDisjointTimerQueryWebGL2):
(WebCore::EXTDisjointTimerQueryWebGL2::queryCounterEXT):
* Source/WebCore/html/canvas/EXTFloatBlend.cpp:
(WebCore::EXTFloatBlend::EXTFloatBlend):
* Source/WebCore/html/canvas/EXTFragDepth.cpp:
(WebCore::EXTFragDepth::EXTFragDepth):
* Source/WebCore/html/canvas/EXTPolygonOffsetClamp.cpp:
(WebCore::EXTPolygonOffsetClamp::EXTPolygonOffsetClamp):
(WebCore::EXTPolygonOffsetClamp::polygonOffsetClampEXT):
* Source/WebCore/html/canvas/EXTRenderSnorm.cpp:
(WebCore::EXTRenderSnorm::EXTRenderSnorm):
* Source/WebCore/html/canvas/EXTShaderTextureLOD.cpp:
(WebCore::EXTShaderTextureLOD::EXTShaderTextureLOD):
* Source/WebCore/html/canvas/EXTTextureCompressionBPTC.cpp:
(WebCore::EXTTextureCompressionBPTC::EXTTextureCompressionBPTC):
* Source/WebCore/html/canvas/EXTTextureCompressionRGTC.cpp:
(WebCore::EXTTextureCompressionRGTC::EXTTextureCompressionRGTC):
* Source/WebCore/html/canvas/EXTTextureFilterAnisotropic.cpp:
(WebCore::EXTTextureFilterAnisotropic::EXTTextureFilterAnisotropic):
* Source/WebCore/html/canvas/EXTTextureMirrorClampToEdge.cpp:
(WebCore::EXTTextureMirrorClampToEdge::EXTTextureMirrorClampToEdge):
* Source/WebCore/html/canvas/EXTTextureNorm16.cpp:
(WebCore::EXTTextureNorm16::EXTTextureNorm16):
* Source/WebCore/html/canvas/EXTsRGB.cpp:
(WebCore::EXTsRGB::EXTsRGB):
* Source/WebCore/html/canvas/KHRParallelShaderCompile.cpp:
(WebCore::KHRParallelShaderCompile::KHRParallelShaderCompile):
* Source/WebCore/html/canvas/NVShaderNoperspectiveInterpolation.cpp:
(WebCore::NVShaderNoperspectiveInterpolation::NVShaderNoperspectiveInterpolation):
* Source/WebCore/html/canvas/OESDrawBuffersIndexed.cpp:
(WebCore::OESDrawBuffersIndexed::OESDrawBuffersIndexed):
(WebCore::OESDrawBuffersIndexed::enableiOES):
(WebCore::OESDrawBuffersIndexed::disableiOES):
(WebCore::OESDrawBuffersIndexed::blendEquationiOES):
(WebCore::OESDrawBuffersIndexed::blendEquationSeparateiOES):
(WebCore::OESDrawBuffersIndexed::blendFunciOES):
(WebCore::OESDrawBuffersIndexed::blendFuncSeparateiOES):
(WebCore::OESDrawBuffersIndexed::colorMaskiOES):
* Source/WebCore/html/canvas/OESElementIndexUint.cpp:
(WebCore::OESElementIndexUint::OESElementIndexUint):
* Source/WebCore/html/canvas/OESFBORenderMipmap.cpp:
(WebCore::OESFBORenderMipmap::OESFBORenderMipmap):
* Source/WebCore/html/canvas/OESSampleVariables.cpp:
(WebCore::OESSampleVariables::OESSampleVariables):
* Source/WebCore/html/canvas/OESShaderMultisampleInterpolation.cpp:
(WebCore::OESShaderMultisampleInterpolation::OESShaderMultisampleInterpolation):
* Source/WebCore/html/canvas/OESStandardDerivatives.cpp:
(WebCore::OESStandardDerivatives::OESStandardDerivatives):
* Source/WebCore/html/canvas/OESTextureFloat.cpp:
(WebCore::OESTextureFloat::OESTextureFloat):
* Source/WebCore/html/canvas/OESTextureFloatLinear.cpp:
(WebCore::OESTextureFloatLinear::OESTextureFloatLinear):
* Source/WebCore/html/canvas/OESTextureHalfFloat.cpp:
(WebCore::OESTextureHalfFloat::OESTextureHalfFloat):
* Source/WebCore/html/canvas/OESTextureHalfFloatLinear.cpp:
(WebCore::OESTextureHalfFloatLinear::OESTextureHalfFloatLinear):
* Source/WebCore/html/canvas/OESVertexArrayObject.cpp:
(WebCore::OESVertexArrayObject::OESVertexArrayObject):
(WebCore::OESVertexArrayObject::deleteVertexArrayOES):
(WebCore::OESVertexArrayObject::isVertexArrayOES):
(WebCore::OESVertexArrayObject::bindVertexArrayOES):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::deleteVertexArray):
* Source/WebCore/html/canvas/WebGLBuffer.cpp:
(WebCore::WebGLBuffer::create):
* Source/WebCore/html/canvas/WebGLClipCullDistance.cpp:
(WebCore::WebGLClipCullDistance::WebGLClipCullDistance):
* Source/WebCore/html/canvas/WebGLColorBufferFloat.cpp:
(WebCore::WebGLColorBufferFloat::WebGLColorBufferFloat):
* Source/WebCore/html/canvas/WebGLCompressedTextureASTC.cpp:
(WebCore::WebGLCompressedTextureASTC::WebGLCompressedTextureASTC):
* Source/WebCore/html/canvas/WebGLCompressedTextureETC.cpp:
(WebCore::WebGLCompressedTextureETC::WebGLCompressedTextureETC):
* Source/WebCore/html/canvas/WebGLCompressedTextureETC1.cpp:
(WebCore::WebGLCompressedTextureETC1::WebGLCompressedTextureETC1):
* Source/WebCore/html/canvas/WebGLCompressedTexturePVRTC.cpp:
(WebCore::WebGLCompressedTexturePVRTC::WebGLCompressedTexturePVRTC):
* Source/WebCore/html/canvas/WebGLCompressedTextureS3TC.cpp:
(WebCore::WebGLCompressedTextureS3TC::WebGLCompressedTextureS3TC):
* Source/WebCore/html/canvas/WebGLCompressedTextureS3TCsRGB.cpp:
(WebCore::WebGLCompressedTextureS3TCsRGB::WebGLCompressedTextureS3TCsRGB):
* Source/WebCore/html/canvas/WebGLDebugShaders.cpp:
(WebCore::WebGLDebugShaders::WebGLDebugShaders):
(WebCore::WebGLDebugShaders::getTranslatedShaderSource):
* Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp:
(WebCore::WebGLDefaultFramebuffer::WebGLDefaultFramebuffer):
(WebCore::WebGLDefaultFramebuffer::reshape):
* Source/WebCore/html/canvas/WebGLDepthTexture.cpp:
(WebCore::WebGLDepthTexture::WebGLDepthTexture):
* Source/WebCore/html/canvas/WebGLDrawBuffers.cpp:
(WebCore::WebGLDrawBuffers::WebGLDrawBuffers):
(WebCore::WebGLDrawBuffers::supported):
(WebCore::WebGLDrawBuffers::drawBuffersWEBGL):
* Source/WebCore/html/canvas/WebGLDrawInstancedBaseVertexBaseInstance.cpp:
(WebCore::WebGLDrawInstancedBaseVertexBaseInstance::WebGLDrawInstancedBaseVertexBaseInstance):
(WebCore::WebGLDrawInstancedBaseVertexBaseInstance::drawArraysInstancedBaseInstanceWEBGL):
(WebCore::WebGLDrawInstancedBaseVertexBaseInstance::drawElementsInstancedBaseVertexBaseInstanceWEBGL):
* Source/WebCore/html/canvas/WebGLFramebuffer.cpp:
(WebCore::WebGLFramebuffer::create):
(WebCore::WebGLFramebuffer::createOpaque):
(WebCore::WebGLFramebuffer::setAttachmentForBoundFramebuffer):
(WebCore::WebGLFramebuffer::removeAttachmentFromBoundFramebuffer):
(WebCore::WebGLFramebuffer::drawBuffersIfNecessary):
(WebCore::WebGLFramebuffer::setAttachmentInternal):
* Source/WebCore/html/canvas/WebGLMultiDraw.cpp:
(WebCore::WebGLMultiDraw::WebGLMultiDraw):
(WebCore::WebGLMultiDraw::multiDrawArraysWEBGL):
(WebCore::WebGLMultiDraw::multiDrawArraysInstancedWEBGL):
(WebCore::WebGLMultiDraw::multiDrawElementsWEBGL):
(WebCore::WebGLMultiDraw::multiDrawElementsInstancedWEBGL):
* Source/WebCore/html/canvas/WebGLMultiDrawInstancedBaseVertexBaseInstance.cpp:
(WebCore::WebGLMultiDrawInstancedBaseVertexBaseInstance::WebGLMultiDrawInstancedBaseVertexBaseInstance):
(WebCore::WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawArraysInstancedBaseInstanceWEBGL):
(WebCore::WebGLMultiDrawInstancedBaseVertexBaseInstance::multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL):
* Source/WebCore/html/canvas/WebGLPolygonMode.cpp:
(WebCore::WebGLPolygonMode::WebGLPolygonMode):
(WebCore::WebGLPolygonMode::polygonModeWEBGL):
* Source/WebCore/html/canvas/WebGLProgram.cpp:
(WebCore::WebGLProgram::create):
(WebCore::WebGLProgram::cacheInfoIfNeeded):
* Source/WebCore/html/canvas/WebGLProvokingVertex.cpp:
(WebCore::WebGLProvokingVertex::WebGLProvokingVertex):
(WebCore::WebGLProvokingVertex::provokingVertexWEBGL):
* Source/WebCore/html/canvas/WebGLQuery.cpp:
(WebCore::WebGLQuery::create):
* Source/WebCore/html/canvas/WebGLRenderSharedExponent.cpp:
(WebCore::WebGLRenderSharedExponent::WebGLRenderSharedExponent):
* Source/WebCore/html/canvas/WebGLRenderbuffer.cpp:
(WebCore::WebGLRenderbuffer::create):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::deleteObject):
(WebCore::WebGLRenderingContextBase::detachShader):
(WebCore::WebGLRenderingContextBase::useProgram):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::protectedGraphicsContextGL const):
* Source/WebCore/html/canvas/WebGLSampler.cpp:
(WebCore::WebGLSampler::create):
* Source/WebCore/html/canvas/WebGLShader.cpp:
(WebCore::WebGLShader::create):
* Source/WebCore/html/canvas/WebGLStencilTexturing.cpp:
(WebCore::WebGLStencilTexturing::WebGLStencilTexturing):
* Source/WebCore/html/canvas/WebGLSync.cpp:
(WebCore::WebGLSync::create):
(WebCore::WebGLSync::updateCache):
* Source/WebCore/html/canvas/WebGLTexture.cpp:
(WebCore::WebGLTexture::create):
* Source/WebCore/html/canvas/WebGLTimerQueryEXT.cpp:
(WebCore::WebGLTimerQueryEXT::create):
* Source/WebCore/html/canvas/WebGLTransformFeedback.cpp:
(WebCore::WebGLTransformFeedback::create):
* Source/WebCore/html/canvas/WebGLUtilities.cpp:
(WebCore::ScopedInspectorShaderProgramHighlight::showHighlight):
(WebCore::ScopedInspectorShaderProgramHighlight::hideHighlight):
* Source/WebCore/html/canvas/WebGLUtilities.h:
(WebCore::ScopedTightUnpackParameters::set):
(WebCore::ScopedDisableRasterizerDiscard::ScopedDisableRasterizerDiscard):
(WebCore::ScopedDisableRasterizerDiscard::~ScopedDisableRasterizerDiscard):
(WebCore::ScopedEnableBackbuffer::ScopedEnableBackbuffer):
(WebCore::ScopedEnableBackbuffer::~ScopedEnableBackbuffer):
(WebCore::ScopedDisableScissorTest::ScopedDisableScissorTest):
(WebCore::ScopedDisableScissorTest::~ScopedDisableScissorTest):
(WebCore::ScopedWebGLRestoreFramebuffer::~ScopedWebGLRestoreFramebuffer):
(WebCore::ScopedWebGLRestoreRenderbuffer::~ScopedWebGLRestoreRenderbuffer):
(WebCore::ScopedWebGLRestoreTexture::~ScopedWebGLRestoreTexture):
* Source/WebCore/html/canvas/WebGLVertexArrayObject.cpp:
(WebCore::WebGLVertexArrayObject::create):
* Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.cpp:
(WebCore::WebGLVertexArrayObjectBase::setElementArrayBuffer):
(WebCore::WebGLVertexArrayObjectBase::setVertexAttribState):
(WebCore::WebGLVertexArrayObjectBase::unbindBuffer):
* Source/WebCore/html/canvas/WebGLVertexArrayObjectOES.cpp:
(WebCore::WebGLVertexArrayObjectOES::createUser):

Canonical link: <a href="https://commits.webkit.org/273304@main">https://commits.webkit.org/273304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23fbd68c6fa625358ee1cbd5a7d4d107e88102d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37767 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31630 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/10987 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30568 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31228 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10333 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10391 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39018 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31849 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31646 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36414 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8421 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34401 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12296 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11028 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4509 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11360 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->