### PR TITLE
[@starting-style] Add parsing support

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-name-defining-rules-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-name-defining-rules-expected.txt
@@ -1,5 +1,5 @@
 XXXX
 
-FAIL @keyframes and @layer in @starting-style apply assert_equals: @keyframes applied expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Load @font-face from @starting-style rule assert_equals: expected "80px" but got "57.78125px"
+PASS @keyframes and @layer in @starting-style apply
+PASS Load @font-face from @starting-style rule
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-transitions/starting-style-name-defining-rules-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-transitions/starting-style-name-defining-rules-expected.txt
@@ -1,5 +1,0 @@
-XXXX
-
-FAIL @keyframes and @layer in @starting-style apply assert_equals: @keyframes applied expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
-FAIL Load @font-face from @starting-style rule assert_equals: expected "80px" but got "56px"
-

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1312,6 +1312,20 @@ CSSScrollbarWidthEnabled:
     WebCore:
       default: false
 
+CSSStartingStyleAtRuleEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS @starting-style rule"
+  humanReadableDescription: "Enable CSS @starting-style rule"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSTextBoxTrimEnabled:
   type: bool
   status: preview

--- a/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
@@ -115,6 +115,9 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<C
         return createWrapper<CSSPropertyRule>(globalObject, WTFMove(rule));
     case StyleRuleType::Scope:
         return createWrapper<CSSScopeRule>(globalObject, WTFMove(rule));
+    case StyleRuleType::StartingStyle:
+        // FIXME: Implement.
+        return createWrapper<CSSRule>(globalObject, WTFMove(rule));
     case StyleRuleType::Unknown:
     case StyleRuleType::Charset:
     case StyleRuleType::Margin:

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -69,13 +69,14 @@ public:
     bool isPageRule() const { return type() == StyleRuleType::Page; }
     bool isStyleRule() const { return type() == StyleRuleType::Style || type() == StyleRuleType::StyleWithNesting; }
     bool isStyleRuleWithNesting() const { return type() == StyleRuleType::StyleWithNesting; }
-    bool isGroupRule() const { return type() == StyleRuleType::Media || type() == StyleRuleType::Supports || type() == StyleRuleType::LayerBlock || type() == StyleRuleType::Container || type() == StyleRuleType::Scope; }
+    bool isGroupRule() const { return type() == StyleRuleType::Media || type() == StyleRuleType::Supports || type() == StyleRuleType::LayerBlock || type() == StyleRuleType::Container || type() == StyleRuleType::Scope || type() == StyleRuleType::StartingStyle; }
     bool isSupportsRule() const { return type() == StyleRuleType::Supports; }
     bool isImportRule() const { return type() == StyleRuleType::Import; }
     bool isLayerRule() const { return type() == StyleRuleType::LayerBlock || type() == StyleRuleType::LayerStatement; }
     bool isContainerRule() const { return type() == StyleRuleType::Container; }
     bool isPropertyRule() const { return type() == StyleRuleType::Property; }
     bool isScopeRule() const { return type() == StyleRuleType::Scope; }
+    bool isStartingStyleRule() const { return type() == StyleRuleType::StartingStyle; }
 
     Ref<StyleRuleBase> copy() const;
 
@@ -413,6 +414,16 @@ private:
     WeakPtr<const StyleSheetContents> m_styleSheetOwner;
 };
 
+class StyleRuleStartingStyle final : public StyleRuleGroup {
+public:
+    static Ref<StyleRuleStartingStyle> create(Vector<Ref<StyleRuleBase>>&&);
+    Ref<StyleRuleStartingStyle> copy() const { return adoptRef(*new StyleRuleStartingStyle(*this)); }
+
+private:
+    StyleRuleStartingStyle(Vector<Ref<StyleRuleBase>>&&);
+    StyleRuleStartingStyle(const StyleRuleStartingStyle&) = default;
+};
+
 // This is only used by the CSS parser.
 class StyleRuleCharset final : public StyleRuleBase {
 public:
@@ -552,4 +563,8 @@ SPECIALIZE_TYPE_TRAITS_END()
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleScope)
     static bool isType(const WebCore::StyleRuleBase& rule) { return rule.isScopeRule(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleStartingStyle)
+    static bool isType(const WebCore::StyleRuleBase& rule) { return rule.isStartingStyleRule(); }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/css/StyleRuleType.h
+++ b/Source/WebCore/css/StyleRuleType.h
@@ -53,6 +53,7 @@ enum class StyleRuleType : uint8_t {
     Property,
     StyleWithNesting,
     Scope,
+    StartingStyle,
 };
 
 static constexpr auto firstUnexposedStyleRuleType = StyleRuleType::LayerBlock;

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -549,6 +549,7 @@ bool StyleSheetContents::traverseSubresources(const Function<bool(const CachedRe
         case StyleRuleType::Margin:
         case StyleRuleType::Property:
         case StyleRuleType::Scope:
+        case StyleRuleType::StartingStyle:
             return false;
         };
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/parser/CSSAtRuleID.cpp
+++ b/Source/WebCore/css/parser/CSSAtRuleID.cpp
@@ -55,6 +55,7 @@ CSSAtRuleID cssAtRuleID(StringView name)
         { "page",                  CSSAtRulePage },
         { "property",              CSSAtRuleProperty },
         { "scope",                 CSSAtRuleScope },
+        { "starting-style",        CSSAtRuleStartingStyle },
         { "styleset",              CSSAtRuleStyleset },
         { "stylistic",             CSSAtRuleStylistic },
         { "supports",              CSSAtRuleSupports },

--- a/Source/WebCore/css/parser/CSSAtRuleID.h
+++ b/Source/WebCore/css/parser/CSSAtRuleID.h
@@ -62,6 +62,7 @@ enum CSSAtRuleID {
 
     CSSAtRuleFontPaletteValues,
     CSSAtRuleScope,
+    CSSAtRuleStartingStyle,
 };
 
 CSSAtRuleID cssAtRuleID(StringView name);

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -101,6 +101,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , cssPaintingAPIEnabled { document.settings().cssPaintingAPIEnabled() }
 #endif
     , cssScopeAtRuleEnabled { document.settings().cssScopeAtRuleEnabled() }
+    , cssStartingStyleAtRuleEnabled { document.settings().cssStartingStyleAtRuleEnabled() }
     , cssTextUnderlinePositionLeftRightEnabled { document.settings().cssTextUnderlinePositionLeftRightEnabled() }
     , cssWordBreakAutoPhraseEnabled { document.settings().cssWordBreakAutoPhraseEnabled() }
     , popoverAttributeEnabled { document.settings().popoverAttributeEnabled() }

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -92,6 +92,7 @@ struct CSSParserContext {
     bool cssNestingEnabled : 1 { false };
     bool cssPaintingAPIEnabled : 1 { false };
     bool cssScopeAtRuleEnabled : 1 { false };
+    bool cssStartingStyleAtRuleEnabled : 1 { false };
     bool cssTextUnderlinePositionLeftRightEnabled : 1 { false };
     bool cssWordBreakAutoPhraseEnabled : 1 { false };
     bool popoverAttributeEnabled : 1 { false };

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -156,6 +156,7 @@ private:
     RefPtr<StyleRuleContainer> consumeContainerRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleProperty> consumePropertyRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleScope> consumeScopeRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
+    RefPtr<StyleRuleStartingStyle> consumeStartingStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
 
     RefPtr<StyleRuleKeyframe> consumeKeyframeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);
     RefPtr<StyleRuleBase> consumeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block);

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -100,6 +100,7 @@ static RuleFlatteningStrategy flatteningStrategyForStyleRuleType(StyleRuleType s
     // FIXME: implement support for this and move this case up.
     // https://bugs.webkit.org/show_bug.cgi?id=264496
     case StyleRuleType::Scope:
+    case StyleRuleType::StartingStyle:
 
     case StyleRuleType::Unknown:
     case StyleRuleType::Charset:

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -271,7 +271,8 @@ void ElementRuleCollector::transferMatchedRules(DeclarationOrigin declarationOri
             matchedRule.ruleData->propertyAllowlist(),
             matchedRule.styleScopeOrdinal,
             FromStyleAttribute::No,
-            matchedRule.cascadeLayerPriority
+            matchedRule.cascadeLayerPriority,
+            matchedRule.ruleData->isStartingStyle()
         }, declarationOrigin);
     }
 }

--- a/Source/WebCore/style/MatchResult.h
+++ b/Source/WebCore/style/MatchResult.h
@@ -42,6 +42,7 @@ struct MatchedProperties {
     ScopeOrdinal styleScopeOrdinal { ScopeOrdinal::Element };
     FromStyleAttribute fromStyleAttribute { FromStyleAttribute::No };
     CascadeLayerPriority cascadeLayerPriority { RuleSet::cascadeLayerPriorityForUnlayered };
+    IsStartingStyle isStartingStyle { IsStartingStyle::No };
 };
 
 struct MatchResult {
@@ -68,7 +69,8 @@ inline bool operator==(const MatchedProperties& a, const MatchedProperties& b)
         && a.allowlistType == b.allowlistType
         && a.styleScopeOrdinal == b.styleScopeOrdinal
         && a.fromStyleAttribute == b.fromStyleAttribute
-        && a.cascadeLayerPriority == b.cascadeLayerPriority;
+        && a.cascadeLayerPriority == b.cascadeLayerPriority
+        && a.isStartingStyle == b.isStartingStyle;
 }
 
 inline void add(Hasher& hasher, const MatchedProperties& matchedProperties)
@@ -79,7 +81,8 @@ inline void add(Hasher& hasher, const MatchedProperties& matchedProperties)
         matchedProperties.allowlistType,
         matchedProperties.styleScopeOrdinal,
         matchedProperties.fromStyleAttribute,
-        matchedProperties.cascadeLayerPriority
+        matchedProperties.cascadeLayerPriority,
+        matchedProperties.isStartingStyle
     );
 }
 

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -196,6 +196,9 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
     if (m_maximumCascadeLayerPriorityForRollback && !includePropertiesForRollback())
         return false;
 
+    if (matchedProperties.isStartingStyle == IsStartingStyle::Yes && !m_includedProperties.contains(PropertyType::StartingStyle))
+        return false;
+
     auto propertyAllowlist = matchedProperties.allowlistType;
     bool hasImportantProperties = false;
 

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -44,7 +44,8 @@ public:
         Inherited = 1 << 1,
         ExplicitlyInherited = 1 << 2,
         AfterAnimation = 1 << 3,
-        AfterTransition = 1 << 4
+        AfterTransition = 1 << 4,
+        StartingStyle = 1 << 5,
     };
     static constexpr OptionSet<PropertyType> allProperties() { return { PropertyType::NonInherited,  PropertyType::Inherited }; }
 

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -159,16 +159,17 @@ static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector* se
     return PropertyAllowlist::None;
 }
 
-RuleData::RuleData(const StyleRule& styleRule, unsigned selectorIndex, unsigned selectorListIndex, unsigned position)
+RuleData::RuleData(const StyleRule& styleRule, unsigned selectorIndex, unsigned selectorListIndex, unsigned position, IsStartingStyle isStartingStyle)
     : m_styleRule(&styleRule)
     , m_selectorIndex(selectorIndex)
     , m_selectorListIndex(selectorListIndex)
     , m_position(position)
-    , m_matchBasedOnRuleHash(static_cast<unsigned>(computeMatchBasedOnRuleHash(*selector())))
+    , m_matchBasedOnRuleHash(enumToUnderlyingType(computeMatchBasedOnRuleHash(*selector())))
     , m_canMatchPseudoElement(selectorCanMatchPseudoElement(*selector()))
     , m_containsUncommonAttributeSelector(computeContainsUncommonAttributeSelector(*selector()))
     , m_linkMatchType(SelectorChecker::determineLinkMatchType(selector()))
-    , m_propertyAllowlist(static_cast<unsigned>(determinePropertyAllowlist(selector())))
+    , m_propertyAllowlist(enumToUnderlyingType(determinePropertyAllowlist(selector())))
+    , m_isStartingStyle(enumToUnderlyingType(isStartingStyle))
     , m_isEnabled(true)
     , m_descendantSelectorIdentifierHashes(SelectorFilter::collectHashes(*selector()))
 {

--- a/Source/WebCore/style/RuleData.h
+++ b/Source/WebCore/style/RuleData.h
@@ -36,11 +36,13 @@ enum class MatchBasedOnRuleHash : unsigned {
     ClassC
 };
 
+enum class IsStartingStyle : bool { No, Yes };
+
 class RuleData {
 public:
     static const unsigned maximumSelectorComponentCount = 8192;
 
-    RuleData(const StyleRule&, unsigned selectorIndex, unsigned selectorListIndex, unsigned position);
+    RuleData(const StyleRule&, unsigned selectorIndex, unsigned selectorListIndex, unsigned position, IsStartingStyle);
 
     unsigned position() const { return m_position; }
 
@@ -63,6 +65,7 @@ public:
     bool containsUncommonAttributeSelector() const { return m_containsUncommonAttributeSelector; }
     unsigned linkMatchType() const { return m_linkMatchType; }
     PropertyAllowlist propertyAllowlist() const { return static_cast<PropertyAllowlist>(m_propertyAllowlist); }
+    IsStartingStyle isStartingStyle() const { return static_cast<IsStartingStyle>(m_isStartingStyle); }
     bool isEnabled() const { return m_isEnabled; }
     void setEnabled(bool value) { m_isEnabled = value; }
 
@@ -76,12 +79,13 @@ private:
     unsigned m_selectorIndex : 16;
     unsigned m_selectorListIndex : 16;
     // If we have more rules than 2^bitcount here we'll get confused about rule order.
-    unsigned m_position : 22;
+    unsigned m_position : 21;
     unsigned m_matchBasedOnRuleHash : 3;
     unsigned m_canMatchPseudoElement : 1;
     unsigned m_containsUncommonAttributeSelector : 1;
     unsigned m_linkMatchType : 2; //  SelectorChecker::LinkMatchMask
     unsigned m_propertyAllowlist : 2;
+    unsigned m_isStartingStyle : 1;
     unsigned m_isEnabled : 1;
     SelectorFilter::Hashes m_descendantSelectorIdentifierHashes;
 };

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -113,7 +113,7 @@ static bool shouldHaveBucketForAttributeName(const CSSSelector& attributeSelecto
 
 void RuleSet::addRule(const StyleRule& rule, unsigned selectorIndex, unsigned selectorListIndex)
 {
-    RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleCount);
+    RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleCount, IsStartingStyle::No);
     addRule(WTFMove(ruleData), 0, 0, 0);
 }
 

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -195,6 +195,14 @@ void RuleSetBuilder::addChildRule(Ref<StyleRuleBase> rule)
         popCascadeLayer(layerRule->name());
         return;
     }
+
+    case StyleRuleType::StartingStyle: {
+        SetForScope startingStyleScope { m_isStartingStyle, IsStartingStyle::Yes };
+        auto startingStyleRule = uncheckedDowncast<StyleRuleStartingStyle>(WTFMove(rule));
+        addChildRules(startingStyleRule->childRules());
+        return;
+    }
+
     case StyleRuleType::CounterStyle:
     case StyleRuleType::FontFace:
     case StyleRuleType::FontPaletteValues:
@@ -272,7 +280,7 @@ void RuleSetBuilder::addStyleRuleWithSelectorList(const CSSSelectorList& selecto
     if (!selectorList.isEmpty()) {
         unsigned selectorListIndex = 0;
         for (size_t selectorIndex = 0; selectorIndex != notFound; selectorIndex = selectorList.indexOfNextSelectorAfter(selectorIndex)) {
-            RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleSet->ruleCount());
+            RuleData ruleData(rule, selectorIndex, selectorListIndex, m_ruleSet->ruleCount(), m_isStartingStyle);
             m_mediaQueryCollector.addRuleIfNeeded(ruleData);
             m_ruleSet->addRule(WTFMove(ruleData), m_currentCascadeLayerIdentifier, m_currentContainerQueryIdentifier, m_currentScopeIdentifier);
             ++selectorListIndex;

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -91,6 +91,8 @@ private:
     RuleSet::ContainerQueryIdentifier m_currentContainerQueryIdentifier { 0 };
     RuleSet::ScopeRuleIdentifier m_currentScopeIdentifier { 0 };
 
+    IsStartingStyle m_isStartingStyle { IsStartingStyle::No };
+
     Vector<RuleSet::ResolverMutatingRule> m_collectedResolverMutatingRules;
     bool requiresStaticMediaQueryEvaluation { false };
 };


### PR DESCRIPTION
#### bfcf9bf5da23fd0e272fa6b63fd1f6830322a576
<pre>
[@starting-style] Add parsing support
<a href="https://bugs.webkit.org/show_bug.cgi?id=267855">https://bugs.webkit.org/show_bug.cgi?id=267855</a>
<a href="https://rdar.apple.com/121373181">rdar://121373181</a>

Reviewed by Matthieu Dubet.

Add support for parsing @starting-style rules.

<a href="https://drafts.csswg.org/css-transitions-2/#at-ruledef-starting-style">https://drafts.csswg.org/css-transitions-2/#at-ruledef-starting-style</a>

The styles are not actually used yet.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-name-defining-rules-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Add a setting. Not enabled yet.

* Source/WebCore/bindings/js/JSCSSRuleCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleBase::visitDerived):
(WebCore::StyleRuleBase::createCSSOMWrapper const):
(WebCore::StyleRuleScope::styleSheetContents const):
(WebCore::StyleRuleScope::setStyleSheetContents):
(WebCore::StyleRuleStartingStyle::create):
(WebCore::StyleRuleStartingStyle::StyleRuleStartingStyle):

Add a StyleRule.

* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleBase::isGroupRule const):
(WebCore::StyleRuleBase::isStartingStyleRule const):
(isType):
* Source/WebCore/css/StyleRuleType.h:
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::traverseSubresources const):
* Source/WebCore/css/parser/CSSAtRuleID.cpp:
(WebCore::cssAtRuleID):
* Source/WebCore/css/parser/CSSAtRuleID.h:
* Source/WebCore/css/parser/CSSParserContext.cpp:
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeAtRule):
(WebCore::CSSParserImpl::consumeStartingStyleRule):

Parse the rule. This is simple as there are no arguments to parse.

* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::flatteningStrategyForStyleRuleType):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::transferMatchedRules):
* Source/WebCore/style/MatchResult.h:
(WebCore::Style::operator==):
(WebCore::Style::add):

Pass if a given declaration belongs to starting-style.

* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::addMatch):

Skip @starting-style rules unless we are building a before-change RenderStyle.
With this patch we always skip.

* Source/WebCore/style/PropertyCascade.h:
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::RuleData::RuleData):
* Source/WebCore/style/RuleData.h:
(WebCore::Style::RuleData::isStartingStyle const):

Remember if the rule is part of a starting-style.

* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRule):

Gather child rules from @starting-style.

(WebCore::Style::RuleSetBuilder::addStyleRuleWithSelectorList):
* Source/WebCore/style/RuleSetBuilder.h:

Canonical link: <a href="https://commits.webkit.org/273351@main">https://commits.webkit.org/273351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af22af6e0290a68e191771a9f732b27975cd0713

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37931 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31748 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11176 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10466 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10516 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39178 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/29871 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31804 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36508 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/35082 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34516 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41719 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8051 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11165 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11476 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->