### PR TITLE
Adopt more smart pointers in ImageControlsMac.cpp

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1245,6 +1245,7 @@ public:
     WEBCORE_EXPORT void postTask(Task&&) final; // Executes the task on context's thread asynchronously.
 
     WEBCORE_EXPORT EventLoopTaskGroup& eventLoop() final;
+    CheckedRef<EventLoopTaskGroup> checkedEventLoop() { return eventLoop(); }
     WindowEventLoop& windowEventLoop();
 
     ScriptedAnimationController* scriptedAnimationController() { return m_scriptedAnimationController.get(); }

--- a/Source/WebCore/dom/mac/ImageControlsMac.h
+++ b/Source/WebCore/dom/mac/ImageControlsMac.h
@@ -29,6 +29,7 @@
 
 namespace WebCore {
 
+class Element;
 class Event;
 class HTMLElement;
 class Node;
@@ -37,7 +38,7 @@ namespace ImageControlsMac {
 
 #if ENABLE(SERVICE_CONTROLS)
 
-bool isImageControlsButtonElement(const Node&);
+bool isImageControlsButtonElement(const Element&);
 bool isInsideImageControls(const Node&);
 void createImageControls(HTMLElement&);
 bool handleEvent(HTMLElement&, Event&);


### PR DESCRIPTION
#### fcb692633ae1fe8a3efc30a40ea948973bcb1893
<pre>
Adopt more smart pointers in ImageControlsMac.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=267860">https://bugs.webkit.org/show_bug.cgi?id=267860</a>

Reviewed by Brent Fulgham.

* Source/WebCore/dom/Document.h:
(WebCore::Document::checkedEventLoop):
* Source/WebCore/dom/mac/ImageControlsMac.cpp:
(WebCore::ImageControlsMac::hasImageControls):
(WebCore::ImageControlsMac::isImageControlsButtonElement):
(WebCore::ImageControlsMac::isInsideImageControls):
(WebCore::ImageControlsMac::createImageControls):
(WebCore::ImageControlsMac::handleEvent):
(WebCore::ImageControlsMac::updateImageControls):
(WebCore::ImageControlsMac::destroyImageControls):
* Source/WebCore/dom/mac/ImageControlsMac.h:

Canonical link: <a href="https://commits.webkit.org/273308@main">https://commits.webkit.org/273308@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91666c87b8c5a56ded0c754867511d6e0c36d1dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37783 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31643 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36188 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11004 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30579 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10344 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10405 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39034 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31665 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36424 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34411 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12307 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11041 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4512 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11372 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->