### PR TITLE
Increase adoption of dynamicDowncast<Document>

### DIFF
--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -211,11 +211,10 @@ int DOMTimer::install(ScriptExecutionContext& context, Function<void(ScriptExecu
     if (NestedTimersMap* nestedTimers = NestedTimersMap::instanceForContext(context))
         nestedTimers->add(timer->m_timeoutId, timer.get());
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
-    if (is<Document>(context)) {
-        auto& document = downcast<Document>(context);
-        document.contentChangeObserver().didInstallDOMTimer(timer.get(), timeout, type == Type::SingleShot);
+    if (RefPtr document = dynamicDowncast<Document>(context)) {
+        document->contentChangeObserver().didInstallDOMTimer(timer.get(), timeout, type == Type::SingleShot);
         if (DeferDOMTimersForScope::isDeferring())
-            document.domTimerHoldingTank().add(timer.get());
+            document->domTimerHoldingTank().add(timer.get());
     }
 #endif
     return timer->m_timeoutId;
@@ -230,11 +229,10 @@ void DOMTimer::removeById(ScriptExecutionContext& context, int timeoutId)
         return;
 
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
-    if (is<Document>(context)) {
-        auto& document = downcast<Document>(context);
-        if (auto* timer = document.findTimeout(timeoutId)) {
-            document.contentChangeObserver().didRemoveDOMTimer(*timer);
-            if (auto* holdingTank = document.domTimerHoldingTankIfExists())
+    if (RefPtr document = dynamicDowncast<Document>(context)) {
+        if (auto* timer = document->findTimeout(timeoutId)) {
+            document->contentChangeObserver().didRemoveDOMTimer(*timer);
+            if (auto* holdingTank = document->domTimerHoldingTankIfExists())
                 holdingTank->remove(*timer);
         }
     }

--- a/Source/WebCore/page/NavigatorBase.cpp
+++ b/Source/WebCore/page/NavigatorBase.cpp
@@ -169,7 +169,7 @@ ServiceWorkerContainer& NavigatorBase::serviceWorker()
 
 ExceptionOr<ServiceWorkerContainer&> NavigatorBase::serviceWorker(ScriptExecutionContext& context)
 {
-    if (is<Document>(context) && downcast<Document>(context).isSandboxed(SandboxOrigin))
+    if (RefPtr document = dynamicDowncast<Document>(context); document && document->isSandboxed(SandboxOrigin))
         return Exception { ExceptionCode::SecurityError, "Service Worker is disabled because the context is sandboxed and lacks the 'allow-same-origin' flag"_s };
     return serviceWorker();
 }

--- a/Source/WebCore/page/PerformanceMark.cpp
+++ b/Source/WebCore/page/PerformanceMark.cpp
@@ -44,14 +44,11 @@ static double performanceNow(ScriptExecutionContext& scriptExecutionContext)
     // FIXME: We should consider moving the Performance object to be owned by the
     // the ScriptExecutionContext to avoid this.
 
-    if (is<Document>(scriptExecutionContext)) {
-        if (auto window = downcast<Document>(scriptExecutionContext).domWindow())
+    if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
+        if (auto window = document->domWindow())
             return window->performance().now();
-        return 0;
-    }
-
-    if (is<WorkerGlobalScope>(scriptExecutionContext))
-        return downcast<WorkerGlobalScope>(scriptExecutionContext).performance().now();
+    } else if (RefPtr workerGlobal = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext))
+        return workerGlobal->performance().now();
 
     return 0;
 }

--- a/Source/WebCore/page/PerformanceObserver.cpp
+++ b/Source/WebCore/page/PerformanceObserver.cpp
@@ -38,14 +38,12 @@ namespace WebCore {
 PerformanceObserver::PerformanceObserver(ScriptExecutionContext& scriptExecutionContext, Ref<PerformanceObserverCallback>&& callback)
     : m_callback(WTFMove(callback))
 {
-    if (is<Document>(scriptExecutionContext)) {
-        auto& document = downcast<Document>(scriptExecutionContext);
-        if (auto* window = document.domWindow())
+    if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
+        if (auto* window = document->domWindow())
             m_performance = &window->performance();
-    } else if (is<WorkerGlobalScope>(scriptExecutionContext)) {
-        auto& workerGlobalScope = downcast<WorkerGlobalScope>(scriptExecutionContext);
-        m_performance = &workerGlobalScope.performance();
-    } else
+    } else if (RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext))
+        m_performance = &workerGlobalScope->performance();
+    else
         ASSERT_NOT_REACHED();
 }
 
@@ -152,7 +150,7 @@ Vector<String> PerformanceObserver::supportedEntryTypes(ScriptExecutionContext& 
         "navigation"_s,
     };
 
-    if (is<Document>(context) && downcast<Document>(context).supportsPaintTiming())
+    if (RefPtr document = dynamicDowncast<Document>(context); document && document->supportsPaintTiming())
         entryTypes.append("paint"_s);
 
     entryTypes.append("resource"_s);

--- a/Source/WebCore/page/PerformanceUserTiming.cpp
+++ b/Source/WebCore/page/PerformanceUserTiming.cpp
@@ -100,7 +100,8 @@ ExceptionOr<Ref<PerformanceMark>> PerformanceUserTiming::mark(JSC::JSGlobalObjec
     if (markOptions && markOptions->startTime)
         timestamp = m_performance.monotonicTimeFromRelativeTime(*markOptions->startTime);
 
-    InspectorInstrumentation::performanceMark(context.get(), markName, timestamp, is<Document>(context) ? downcast<Document>(context.get()).frame() : nullptr);
+    RefPtr document = dynamicDowncast<Document>(context);
+    InspectorInstrumentation::performanceMark(context.get(), markName, timestamp, document ? document->protectedFrame().get() : nullptr);
 
     auto mark = PerformanceMark::create(globalObject, context, markName, WTFMove(markOptions));
     if (mark.hasException())

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -157,9 +157,8 @@ void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::Ses
         parentWorkerGlobalScope->thread().addChildThread(thread);
         if (auto* parentWorkerClient = parentWorkerGlobalScope->workerClient())
             thread->setWorkerClient(parentWorkerClient->createNestedWorkerClient(thread.get()).moveToUniquePtr());
-    } else if (is<Document>(m_scriptExecutionContext.get())) {
-        auto& document = downcast<Document>(*m_scriptExecutionContext);
-        if (auto* page = document.page()) {
+    } else if (RefPtr document = dynamicDowncast<Document>(m_scriptExecutionContext.get())) {
+        if (auto* page = document->page()) {
             if (auto workerClient = page->chrome().createWorkerClient(thread.get()))
                 thread->setWorkerClient(WTFMove(workerClient));
         }

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -87,7 +87,7 @@ ServiceWorkerContainer::ServiceWorkerContainer(ScriptExecutionContext* context, 
     , m_navigator(navigator)
 {
     // We should queue messages until the DOMContentLoaded event has fired or startMessages() has been called.
-    if (is<Document>(context) && downcast<Document>(*context).parsing())
+    if (RefPtr document = dynamicDowncast<Document>(context); document && document->parsing())
         m_shouldDeferMessageEvents = true;
 }
 
@@ -137,7 +137,6 @@ ServiceWorker* ServiceWorkerContainer::controller() const
 
 void ServiceWorkerContainer::addRegistration(const String& relativeScriptURL, const RegistrationOptions& options, Ref<DeferredPromise>&& promise)
 {
-    auto* context = scriptExecutionContext();
     if (m_isStopped) {
         promise->reject(Exception(ExceptionCode::InvalidStateError));
         return;
@@ -150,9 +149,11 @@ void ServiceWorkerContainer::addRegistration(const String& relativeScriptURL, co
 
     ServiceWorkerJobData jobData(ensureSWClientConnection().serverConnectionIdentifier(), contextIdentifier());
 
-    jobData.scriptURL = context->completeURL(relativeScriptURL);
+    auto& context = *scriptExecutionContext();
+    jobData.scriptURL = context.completeURL(relativeScriptURL);
 
-    CheckedPtr contentSecurityPolicy = is<Document>(context) ? downcast<Document>(context)->contentSecurityPolicy() : nullptr;
+    RefPtr document = dynamicDowncast<Document>(context);
+    CheckedPtr contentSecurityPolicy = document ? document->contentSecurityPolicy() : nullptr;
     if (contentSecurityPolicy && !contentSecurityPolicy->allowWorkerFromSource(jobData.scriptURL)) {
         promise->reject(Exception { ExceptionCode::SecurityError });
         return;
@@ -164,7 +165,7 @@ void ServiceWorkerContainer::addRegistration(const String& relativeScriptURL, co
         return;
     }
 
-    Page* page = is<Document>(context) ? downcast<Document>(context)->page() : nullptr;
+    auto* page = document ? document->page() : nullptr;
     jobData.isFromServiceWorkerPage = page && page->isServiceWorkerPage();
     if (!jobData.scriptURL.protocolIsInHTTPFamily() && !jobData.isFromServiceWorkerPage) {
         CONTAINER_RELEASE_LOG_ERROR("addRegistration: Invalid scriptURL scheme is not HTTP or HTTPS");
@@ -180,7 +181,7 @@ void ServiceWorkerContainer::addRegistration(const String& relativeScriptURL, co
     }
 
     if (!options.scope.isEmpty())
-        jobData.scopeURL = context->completeURL(options.scope);
+        jobData.scopeURL = context.completeURL(options.scope);
     else
         jobData.scopeURL = URL(jobData.scriptURL, "./"_s);
 
@@ -199,11 +200,11 @@ void ServiceWorkerContainer::addRegistration(const String& relativeScriptURL, co
 
     CONTAINER_RELEASE_LOG("addRegistration: Registering service worker. jobID=%" PRIu64, jobData.identifier().jobIdentifier.toUInt64());
 
-    jobData.clientCreationURL = context->url();
-    jobData.topOrigin = context->topOrigin().data();
+    jobData.clientCreationURL = context.url();
+    jobData.topOrigin = context.topOrigin().data();
     jobData.workerType = options.type;
     jobData.type = ServiceWorkerJobType::Register;
-    jobData.domainForCachePartition = context->domainForCachePartition();
+    jobData.domainForCachePartition = context.domainForCachePartition();
     jobData.registrationOptions = options;
 
     scheduleJob(makeUnique<ServiceWorkerJob>(*this, WTFMove(promise), WTFMove(jobData)));
@@ -211,8 +212,8 @@ void ServiceWorkerContainer::addRegistration(const String& relativeScriptURL, co
 
 void ServiceWorkerContainer::willSettleRegistrationPromise(bool success)
 {
-    auto* context = scriptExecutionContext();
-    Page* page = is<Document>(context) ? downcast<Document>(*context).page() : nullptr;
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
+    auto* page = document ? document->page() : nullptr;
     if (!page || !page->isServiceWorkerPage())
         return;
     
@@ -575,9 +576,9 @@ SWClientConnection& ServiceWorkerContainer::ensureSWClientConnection()
 {
     ASSERT(scriptExecutionContext());
     if (!m_swConnection || m_swConnection->isClosed()) {
-        auto& context = *scriptExecutionContext();
-        if (is<WorkerGlobalScope>(context))
-            m_swConnection = &downcast<WorkerGlobalScope>(context).swClientConnection();
+        // Using RefPtr here results in an m_adoptionIsRequired assert.
+        if (auto* workerGlobal = dynamicDowncast<WorkerGlobalScope>(*scriptExecutionContext()))
+            m_swConnection = &workerGlobal->swClientConnection();
         else
             m_swConnection = &mainThreadConnection();
     }
@@ -694,8 +695,8 @@ ServiceWorkerOrClientIdentifier ServiceWorkerContainer::contextIdentifier()
 {
     ASSERT(m_creationThread.ptr() == &Thread::current());
     ASSERT(scriptExecutionContext());
-    if (is<ServiceWorkerGlobalScope>(*scriptExecutionContext()))
-        return downcast<ServiceWorkerGlobalScope>(*scriptExecutionContext()).thread().identifier();
+    if (RefPtr serviceWorkerGlobal = dynamicDowncast<ServiceWorkerGlobalScope>(*scriptExecutionContext()))
+        return serviceWorkerGlobal->thread().identifier();
     return scriptExecutionContext()->identifier();
 }
 


### PR DESCRIPTION
#### ea8a714efddddf317f73a618443745ea65228523
<pre>
Increase adoption of dynamicDowncast&lt;Document&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=267861">https://bugs.webkit.org/show_bug.cgi?id=267861</a>

Reviewed by Chris Dumez.

And cleanup some nearby code while there.

* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimer::install):
(WebCore::DOMTimer::removeById):
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::IntersectionObserver):
(WebCore::IntersectionObserver::~IntersectionObserver):
(WebCore::IntersectionObserver::computeIntersectionState const):
(WebCore::IntersectionObserver::nowTimestamp const):
* Source/WebCore/page/NavigatorBase.cpp:
* Source/WebCore/page/PerformanceMark.cpp:
(WebCore::performanceNow):
* Source/WebCore/page/PerformanceObserver.cpp:
(WebCore::PerformanceObserver::PerformanceObserver):
(WebCore::PerformanceObserver::supportedEntryTypes):
* Source/WebCore/page/PerformanceUserTiming.cpp:
(WebCore::PerformanceUserTiming::mark):
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::startWorkerGlobalScope):
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::ServiceWorkerContainer):
(WebCore::ServiceWorkerContainer::addRegistration):
(WebCore::ServiceWorkerContainer::willSettleRegistrationPromise):
(WebCore::ServiceWorkerContainer::ensureSWClientConnection):
(WebCore::ServiceWorkerContainer::contextIdentifier):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::open):
(WebCore::XMLHttpRequest::prepareToSend):

Canonical link: <a href="https://commits.webkit.org/273378@main">https://commits.webkit.org/273378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/346e01be16b33380d073e19667347d3602ec272c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37979 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31789 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30686 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31408 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10498 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31514 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39227 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36540 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34553 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12454 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8068 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11208 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->