### PR TITLE
Increase smart pointer adoption in dom/messageports

### DIFF
--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -167,6 +167,8 @@ public:
     void clear();
 
     MappedTakeType take(const KeyType&); // efficient combination of get with remove
+    MappedTakeType take(iterator);
+    MappedTakeType takeFirst();
 
     // An alternate version of find() that finds the object by hashing and comparing
     // with some other type, to avoid the cost of type conversion. HashTranslator
@@ -537,12 +539,23 @@ inline void HashMap<T, U, V, W, X, Y>::clear()
 template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y>
 auto HashMap<T, U, V, W, MappedTraits, Y>::take(const KeyType& key) -> MappedTakeType
 {
-    iterator it = find(key);
+    return take(find(key));
+}
+
+template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y>
+auto HashMap<T, U, V, W, MappedTraits, Y>::take(iterator it) -> MappedTakeType
+{
     if (it == end())
         return MappedTraits::take(MappedTraits::emptyValue());
     auto value = MappedTraits::take(WTFMove(it->value));
     remove(it);
     return value;
+}
+
+template<typename T, typename U, typename V, typename W, typename MappedTraits, typename Y>
+auto HashMap<T, U, V, W, MappedTraits, Y>::takeFirst() -> MappedTakeType
+{
+    return take(begin());
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y>

--- a/Source/WebCore/dom/messageports/MessagePortChannel.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.cpp
@@ -52,12 +52,17 @@ MessagePortChannel::MessagePortChannel(MessagePortChannelRegistry& registry, con
     m_processes[1] = port2.processIdentifier;
     m_entangledToProcessProtectors[1] = this;
 
-    m_registry->messagePortChannelCreated(*this);
+    checkedRegistry()->messagePortChannelCreated(*this);
 }
 
 MessagePortChannel::~MessagePortChannel()
 {
-    m_registry->messagePortChannelDestroyed(*this);
+    checkedRegistry()->messagePortChannelDestroyed(*this);
+}
+
+CheckedRef<MessagePortChannelRegistry> MessagePortChannel::checkedRegistry() const
+{
+    return m_registry;
 }
 
 std::optional<ProcessIdentifier> MessagePortChannel::processForPort(const MessagePortIdentifier& port)
@@ -118,10 +123,6 @@ void MessagePortChannel::closePort(const MessagePortIdentifier& port)
     m_processes[i] = std::nullopt;
     m_isClosed[i] = true;
 
-    // This set of steps is to guarantee that the lock is unlocked before the
-    // last ref to this object is released.
-    Ref protectedThis { *this };
-
     m_pendingMessages[i].clear();
     m_pendingMessagePortTransfers[i].clear();
     m_pendingMessageProtectors[i] = nullptr;
@@ -161,7 +162,7 @@ void MessagePortChannel::takeAllMessagesForPort(const MessagePortIdentifier& por
         return;
     }
 
-    ASSERT(m_pendingMessageProtectors[i]);
+    ASSERT(m_pendingMessageProtectors[i] == this);
 
     Vector<MessageWithMessagePorts> result;
     result.swap(m_pendingMessages[i]);
@@ -171,13 +172,13 @@ void MessagePortChannel::takeAllMessagesForPort(const MessagePortIdentifier& por
     LOG(MessagePorts, "There are %zu messages to take for port %s. Taking them now, messages in flight is now %" PRIu64, result.size(), port.logString().utf8().data(), m_messageBatchesInFlight);
 
     auto size = result.size();
-    callback(WTFMove(result), [size, this, port, protectedThis = WTFMove(m_pendingMessageProtectors[i])] {
+    callback(WTFMove(result), [size, port, protectedThis = WTFMove(m_pendingMessageProtectors[i])] {
         UNUSED_PARAM(port);
 #if LOG_DISABLED
         UNUSED_PARAM(size);
 #endif
-        --m_messageBatchesInFlight;
-        LOG(MessagePorts, "Message port channel %s was notified that a batch of %zu message port messages targeted for port %s just completed dispatch, in flight is now %" PRIu64, logString().utf8().data(), size, port.logString().utf8().data(), m_messageBatchesInFlight);
+        --(protectedThis->m_messageBatchesInFlight);
+        LOG(MessagePorts, "Message port channel %s was notified that a batch of %zu message port messages targeted for port %s just completed dispatch, in flight is now %" PRIu64, protectedThis->logString().utf8().data(), size, port.logString().utf8().data(), protectedThis->m_messageBatchesInFlight);
 
     });
 }

--- a/Source/WebCore/dom/messageports/MessagePortChannel.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.h
@@ -67,6 +67,8 @@ public:
 private:
     MessagePortChannel(MessagePortChannelRegistry&, const MessagePortIdentifier& port1, const MessagePortIdentifier& port2);
 
+    CheckedRef<MessagePortChannelRegistry> checkedRegistry() const;
+
     MessagePortIdentifier m_ports[2];
     bool m_isClosed[2] { false, false };
     std::optional<ProcessIdentifier> m_processes[2];

--- a/Source/WebCore/dom/messageports/MessagePortChannelProvider.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProvider.cpp
@@ -31,28 +31,31 @@
 #include "WorkerGlobalScope.h"
 #include "WorkletGlobalScope.h"
 #include <wtf/MainThread.h>
+#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 
-static MessagePortChannelProvider* globalProvider;
+static WeakPtr<MessagePortChannelProvider>& globalProvider()
+{
+    static MainThreadNeverDestroyed<WeakPtr<MessagePortChannelProvider>> globalProvider;
+    return globalProvider;
+}
 
 MessagePortChannelProvider& MessagePortChannelProvider::singleton()
 {
     ASSERT(isMainThread());
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [] {
-        if (!globalProvider)
-            globalProvider = new MessagePortChannelProviderImpl;
-    });
-
+    auto& globalProvider = WebCore::globalProvider();
+    if (!globalProvider)
+        globalProvider = new MessagePortChannelProviderImpl;
     return *globalProvider;
 }
 
 void MessagePortChannelProvider::setSharedProvider(MessagePortChannelProvider& provider)
 {
     RELEASE_ASSERT(isMainThread());
+    auto& globalProvider = WebCore::globalProvider();
     RELEASE_ASSERT(!globalProvider);
-    globalProvider = &provider;
+    globalProvider = provider;
 }
 
 MessagePortChannelProvider& MessagePortChannelProvider::fromContext(ScriptExecutionContext& context)

--- a/Source/WebCore/dom/messageports/MessagePortChannelProvider.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProvider.h
@@ -35,7 +35,7 @@ class ScriptExecutionContext;
 struct MessagePortIdentifier;
 struct MessageWithMessagePorts;
 
-class MessagePortChannelProvider {
+class MessagePortChannelProvider : public CanMakeWeakPtr<MessagePortChannelProvider> {
 public:
     static MessagePortChannelProvider& fromContext(ScriptExecutionContext&);
     static MessagePortChannelProvider& singleton();

--- a/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-class MessagePortChannelRegistry : public CanMakeCheckedPtr {
+class MessagePortChannelRegistry : public CanMakeWeakPtr<MessagePortChannelRegistry>, public CanMakeCheckedPtr {
 public:
     WEBCORE_EXPORT MessagePortChannelRegistry();
 

--- a/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
+++ b/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
 class WorkerOrWorkletGlobalScope;
 
-class WorkerMessagePortChannelProvider final : public MessagePortChannelProvider {
+class WorkerMessagePortChannelProvider final : public MessagePortChannelProvider, public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit WorkerMessagePortChannelProvider(WorkerOrWorkletGlobalScope&);
@@ -48,7 +48,7 @@ private:
     void postMessageToRemote(MessageWithMessagePorts&&, const MessagePortIdentifier& remoteTarget) final;
     void takeAllMessagesForPort(const MessagePortIdentifier&, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&) final;
 
-    WorkerOrWorkletGlobalScope& m_scope;
+    WeakRef<WorkerOrWorkletGlobalScope> m_scope;
 
     uint64_t m_lastCallbackIdentifier { 0 };
     HashMap<uint64_t, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, Function<void()>&&)>> m_takeAllMessagesCallbacks;


### PR DESCRIPTION
#### de7ac2345de454bc2cda2202ecc2db5e50cc991f
<pre>
Increase smart pointer adoption in dom/messageports
<a href="https://bugs.webkit.org/show_bug.cgi?id=267862">https://bugs.webkit.org/show_bug.cgi?id=267862</a>

Reviewed by Geoffrey Garen.

* Source/WTF/wtf/HashMap.h:
(WTF::Y&gt;::take):
(WTF::Y&gt;::takeFirst):
* Source/WebCore/dom/messageports/MessagePortChannel.cpp:
(WebCore::MessagePortChannel::MessagePortChannel):
(WebCore::MessagePortChannel::~MessagePortChannel):
(WebCore::MessagePortChannel::checkedRegistry const):
(WebCore::MessagePortChannel::closePort):
(WebCore::MessagePortChannel::takeAllMessagesForPort):
* Source/WebCore/dom/messageports/MessagePortChannel.h:
* Source/WebCore/dom/messageports/MessagePortChannelProvider.cpp:
(WebCore::globalProvider):
(WebCore::MessagePortChannelProvider::singleton):
(WebCore::MessagePortChannelProvider::setSharedProvider):
* Source/WebCore/dom/messageports/MessagePortChannelProvider.h:
* Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.cpp:
(WebCore::MessagePortChannelProviderImpl::createNewMessagePortChannel):
(WebCore::MessagePortChannelProviderImpl::entangleLocalPortInThisProcessToRemote):
(WebCore::MessagePortChannelProviderImpl::messagePortDisentangled):
(WebCore::MessagePortChannelProviderImpl::messagePortClosed):
(WebCore::MessagePortChannelProviderImpl::postMessageToRemote):
(WebCore::MessagePortChannelProviderImpl::takeAllMessagesForPort):
(WebCore::MessagePortChannelProviderImpl::MessagePortChannelProviderImpl): Deleted.
* Source/WebCore/dom/messageports/MessagePortChannelRegistry.h:
* Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.cpp:
(WebCore::WorkerMessagePortChannelProvider::~WorkerMessagePortChannelProvider):
(WebCore::WorkerMessagePortChannelProvider::takeAllMessagesForPort):
* Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h:

Canonical link: <a href="https://commits.webkit.org/273313@main">https://commits.webkit.org/273313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2d56ab841b8fe85685aedb15586d921ef7ffa7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37797 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31651 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11020 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30587 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10358 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39045 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/29771 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31882 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31683 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/34938 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10519 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34420 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12314 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41556 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11051 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4515 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->