### PR TITLE
Use mousePointerEventType() helper instead of hardcoded "mouse" string literal

### DIFF
--- a/Source/WebCore/platform/PlatformMouseEvent.h
+++ b/Source/WebCore/platform/PlatformMouseEvent.h
@@ -27,6 +27,7 @@
 
 #include "IntPoint.h"
 #include "PlatformEvent.h"
+#include "PointerEventTypeNames.h"
 #include "PointerID.h"
 #include <wtf/UUID.h>
 #include <wtf/WindowsExtras.h>
@@ -104,7 +105,7 @@ protected:
     IntPoint m_movementDelta;
     double m_force { 0 };
     PointerID m_pointerId { mousePointerID };
-    String m_pointerType { "mouse"_s };
+    String m_pointerType { mousePointerEventType() };
     int m_clickCount { 0 };
     unsigned m_modifierFlags { 0 };
     unsigned short m_buttons { 0 };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
@@ -33,6 +33,7 @@
 #import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
 #import "UIKitSPIForTesting.h"
+#import <WebCore/PointerEventTypeNames.h>
 #import <WebKit/WKUIDelegatePrivate.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
@@ -649,7 +650,7 @@ TEST(iOSMouseSupport, WebsiteMouseEventPolicies)
     tapAndWait();
 
     NSString *result = [webView objectByEvaluatingJavaScript:@"window.lastPointerEventType"];
-    EXPECT_WK_STREQ("mouse", result);
+    EXPECT_WK_STREQ(WebCore::mousePointerEventType(), result);
 
     EXPECT_TRUE(testHarness.mouseInteraction().enabled);
 


### PR DESCRIPTION
#### 252923d1ee75b036d0bee06d54ec7e0ea4e257cd
<pre>
Use mousePointerEventType() helper instead of hardcoded &quot;mouse&quot; string literal
<a href="https://bugs.webkit.org/show_bug.cgi?id=267848">https://bugs.webkit.org/show_bug.cgi?id=267848</a>
<a href="https://rdar.apple.com/121360954">rdar://121360954</a>

Reviewed by Wenson Hsieh.

The codebase has a couple of spots where we use the string literal
&quot;mouse&quot; to denote a mouse pointer type. In this commit, we replace these
hardcoded literals in favor of the namesake helper declared in
PointerEventTypeNames.h

* Source/WebCore/platform/PlatformMouseEvent.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/273324@main">https://commits.webkit.org/273324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/848c8f848b4016a6139f1ff6b7683ee3437f47a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37792 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31647 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11016 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30584 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11812 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31254 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10355 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10412 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39041 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31876 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31676 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36426 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34413 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12310 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8038 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11047 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->