### PR TITLE
[GLib] Write bwrapinfo.json to disk for xdg-desktop-portal

### DIFF
--- a/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
@@ -152,7 +152,30 @@ static String effectiveApplicationId()
     return makeString("org.webkit.app-", uuid.toString());
 }
 
-static int createFlatpakInfo()
+static void createBwrapInfo(GSubprocessLauncher* launcher, Vector<CString>& args, const char* instanceID)
+{
+    // This is the hardcoded path expected in xdg-desktop-portal's xdp_app_info_load_bwrap_info() used
+    // by xdp_app_info_map_pids() for the Realtime portal.
+    GUniquePtr<char> instancePath(g_build_filename(g_get_user_runtime_dir(), ".flatpak", instanceID, nullptr));
+    GUniquePtr<char> bwrapInfoPath(g_build_filename(instancePath.get(), "bwrapinfo.json", nullptr));
+
+    if (g_mkdir_with_parents(instancePath.get(), 0700) == -1) {
+        g_warning("Failed to create '%s': %s", instancePath.get(), g_strerror(errno));
+        return;
+    }
+
+    int bwrapInfoFD = open(bwrapInfoPath.get(), O_CREAT | O_RDWR | O_TRUNC, 0644);
+    if (bwrapInfoFD == -1) {
+        g_warning("Failed to create '%s': %s", bwrapInfoPath.get(), g_strerror(errno));
+        return;
+    }
+
+    GUniquePtr<char> bwrapInfoFdStr(g_strdup_printf("%d", bwrapInfoFD));
+    g_subprocess_launcher_take_fd(launcher, bwrapInfoFD, bwrapInfoFD);
+    args.appendVector(Vector<CString>({ "--info-fd", bwrapInfoFdStr.get() }));
+}
+
+static int createFlatpakInfo(const char* instanceID)
 {
     static NeverDestroyed<GUniquePtr<char>> data;
     static size_t size;
@@ -160,6 +183,7 @@ static int createFlatpakInfo()
     if (!data.get()) {
         GUniquePtr<GKeyFile> keyFile(g_key_file_new());
         g_key_file_set_string(keyFile.get(), "Application", "name", effectiveApplicationId().utf8().data());
+        g_key_file_set_string(keyFile.get(), "Instance", "instance-id", instanceID);
         data->reset(g_key_file_to_data(keyFile.get(), &size, nullptr));
     }
 
@@ -848,7 +872,8 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
     // full permissions unless it can identify you as a snap or flatpak.
     // The easiest method is for us to pretend to be a flatpak and if that
     // fails just blocking portals entirely as it just becomes a sandbox escape.
-    int flatpakInfoFd = createFlatpakInfo();
+    GUniquePtr<char> instanceID(g_strdup_printf("webkit-%d-%lu", getpid(), launchOptions.processIdentifier.toUInt64()));
+    int flatpakInfoFd = createFlatpakInfo(instanceID.get());
     if (flatpakInfoFd != -1) {
         g_subprocess_launcher_take_fd(launcher, flatpakInfoFd, flatpakInfoFd);
         GUniquePtr<char> flatpakInfoFdStr(g_strdup_printf("%d", flatpakInfoFd));
@@ -857,6 +882,8 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
             "--ro-bind-data", flatpakInfoFdStr.get(), "/.flatpak-info"
         }));
     }
+
+    createBwrapInfo(launcher, sandboxArgs, instanceID.get());
 
     if (launchOptions.processType == ProcessLauncher::ProcessType::Web) {
 #if PLATFORM(WAYLAND)


### PR DESCRIPTION
#### b9361c774194d8be63e58375908afa5b1eb9a30f
<pre>
[GLib] Write bwrapinfo.json to disk for xdg-desktop-portal
<a href="https://bugs.webkit.org/show_bug.cgi?id=238403">https://bugs.webkit.org/show_bug.cgi?id=238403</a>

Reviewed by Michael Catanzaro.

The Realtime portal in xdg-desktop-portal reads bwrapinfo.json
to get the child pid.

* Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp:
(WebKit::createBwrapInfo):
(WebKit::createFlatpakInfo):
(WebKit::bubblewrapSpawn):

Canonical link: <a href="https://commits.webkit.org/273334@main">https://commits.webkit.org/273334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8ea6c23de6a75e98860d8c7df791abce7761e88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37799 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31653 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30586 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31258 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10357 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10441 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39047 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36431 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10521 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34418 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12316 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8042 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11053 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11381 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->