### PR TITLE
[iOS] [UIAsyncTextInput] WKWebView AutoFill input assistant item doesn't show up in the keyboard

### DIFF
--- a/Source/WebKit/Shared/ios/WebAutocorrectionContext.h
+++ b/Source/WebKit/Shared/ios/WebAutocorrectionContext.h
@@ -37,7 +37,7 @@ struct WebAutocorrectionContext {
     String markedText;
     String selectedText;
     String contextAfter;
-    EditingRange markedTextRange;
+    EditingRange selectedRangeInMarkedText;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/ios/WebAutocorrectionContext.serialization.in
+++ b/Source/WebKit/Shared/ios/WebAutocorrectionContext.serialization.in
@@ -27,7 +27,7 @@ struct WebKit::WebAutocorrectionContext {
     String markedText;
     String selectedText;
     String contextAfter;
-    WebKit::EditingRange markedTextRange;
+    WebKit::EditingRange selectedRangeInMarkedText;
 };
 
 #endif

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12888,9 +12888,10 @@ static BOOL shouldUseMachineReadableCodeMenuFromImageAnalysisResult(CocoaImageAn
             context.markedText.string = webContext.markedText;
             context.selectedText.string = webContext.selectedText;
             context.contextAfter.string = webContext.contextAfter;
+            NSRange selectedRangeInMarkedText = webContext.selectedRangeInMarkedText;
             context.selectedRangeInMarkedText = {
-                .location = webContext.markedTextRange.location,
-                .length = webContext.markedTextRange.length,
+                .location = selectedRangeInMarkedText.location,
+                .length = selectedRangeInMarkedText.length
             };
             break;
         }
@@ -14751,7 +14752,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [correction setSelectedText:nsStringNilIfEmpty(webCorrection.selectedText)];
     [correction setMarkedText:nsStringNilIfEmpty(webCorrection.markedText)];
     [correction setContextAfterSelection:nsStringNilIfEmpty(webCorrection.contextAfter)];
-    [correction setRangeInMarkedText:webCorrection.markedTextRange];
+    [correction setRangeInMarkedText:webCorrection.selectedRangeInMarkedText];
     return correction.autorelease();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2709,7 +2709,7 @@ WebAutocorrectionContext WebPage::autocorrectionContext()
     String markedText;
     String selectedText;
     String contextAfter;
-    EditingRange markedTextRange;
+    EditingRange selectedRangeInMarkedText;
 
     VisiblePosition startPosition = frame->selection().selection().start();
     VisiblePosition endPosition = frame->selection().selection().end();
@@ -2725,8 +2725,8 @@ WebAutocorrectionContext WebPage::autocorrectionContext()
         auto markedTextAfter = plainTextForContext(makeSimpleRange(endPosition, compositionRange->end));
         markedText = markedTextBefore + selectedText + markedTextAfter;
         if (!markedText.isEmpty()) {
-            markedTextRange.location = markedTextBefore.length();
-            markedTextRange.length = selectedText.length();
+            selectedRangeInMarkedText.location = markedTextBefore.length();
+            selectedRangeInMarkedText.length = selectedText.length();
         }
     } else {
         auto firstPositionInEditableContent = startOfEditableContent(startPosition);
@@ -2768,7 +2768,7 @@ WebAutocorrectionContext WebPage::autocorrectionContext()
     correction.markedText = WTFMove(markedText);
     correction.selectedText = WTFMove(selectedText);
     correction.contextAfter = WTFMove(contextAfter);
-    correction.markedTextRange = WTFMove(markedTextRange);
+    correction.selectedRangeInMarkedText = WTFMove(selectedRangeInMarkedText);
     return correction;
 }
 

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -238,6 +238,8 @@ typedef NS_OPTIONS(NSInteger, UIWKDocumentRequestFlags) {
 @property (nonatomic, copy) NSString *contextBeforeSelection;
 @property (nonatomic, copy) NSString *selectedText;
 @property (nonatomic, copy) NSString *contextAfterSelection;
+@property (nonatomic, copy) NSString *markedText;
+@property (nonatomic) NSRange rangeInMarkedText;
 @end
 
 typedef NS_ENUM(NSInteger, UIWKGestureType) {

--- a/Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm
@@ -259,18 +259,24 @@ TEST(AutocorrectionTests, AutocorrectionContextBeforeAndAfterEditing)
     EXPECT_TRUE(contextBeforeInsertingText.contextBeforeSelection.isEmpty());
     EXPECT_TRUE(contextBeforeInsertingText.selectedText.isEmpty());
     EXPECT_TRUE(contextBeforeInsertingText.contextAfterSelection.isEmpty());
+    EXPECT_TRUE(contextBeforeInsertingText.markedText.isNull());
+    EXPECT_TRUE(NSEqualRanges(contextBeforeInsertingText.selectedRangeInMarkedText, NSMakeRange(NSNotFound, 0)));
 
     [contentView insertText:@"hello"];
     auto contextAfterInsertingText = [webView autocorrectionContext];
     EXPECT_WK_STREQ("hello", contextAfterInsertingText.contextBeforeSelection);
     EXPECT_TRUE(contextAfterInsertingText.selectedText.isEmpty());
     EXPECT_TRUE(contextAfterInsertingText.contextAfterSelection.isEmpty());
+    EXPECT_TRUE(contextAfterInsertingText.markedText.isNull());
+    EXPECT_TRUE(NSEqualRanges(contextAfterInsertingText.selectedRangeInMarkedText, NSMakeRange(NSNotFound, 0)));
 
     [contentView selectAll:nil];
     auto contextAfterSelecting = [webView autocorrectionContext];
     EXPECT_TRUE(contextAfterSelecting.contextBeforeSelection.isEmpty());
     EXPECT_WK_STREQ("hello", contextAfterSelecting.selectedText);
     EXPECT_TRUE(contextAfterSelecting.contextAfterSelection.isEmpty());
+    EXPECT_TRUE(contextAfterSelecting.markedText.isNull());
+    EXPECT_TRUE(NSEqualRanges(contextAfterSelecting.selectedRangeInMarkedText, NSMakeRange(NSNotFound, 0)));
 }
 
 TEST(AutocorrectionTests, AvoidDeadlockWithGPUProcessCreationInEmptyView)

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -58,6 +58,8 @@ struct AutocorrectionContext {
     String contextBeforeSelection;
     String selectedText;
     String contextAfterSelection;
+    String markedText;
+    NSRange selectedRangeInMarkedText;
 };
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -327,6 +327,8 @@ static NSString *overrideBundleIdentifier(id, SEL)
                 dynamic_objc_cast<NSString>(uiContext.contextBefore),
                 dynamic_objc_cast<NSString>(uiContext.selectedText),
                 dynamic_objc_cast<NSString>(uiContext.contextAfter),
+                dynamic_objc_cast<NSString>(uiContext.markedText),
+                uiContext.selectedRangeInMarkedText,
             };
             done = true;
         }];
@@ -334,7 +336,7 @@ static NSString *overrideBundleIdentifier(id, SEL)
 #endif // HAVE(UI_ASYNC_TEXT_INTERACTION)
     {
         [self.textInputContentView requestAutocorrectionContextWithCompletionHandler:[&](UIWKAutocorrectionContext *context) {
-            result = { context.contextBeforeSelection, context.selectedText, context.contextAfterSelection };
+            result = { context.contextBeforeSelection, context.selectedText, context.contextAfterSelection, context.markedText, context.rangeInMarkedText };
             done = true;
         }];
     }


### PR DESCRIPTION
#### 851a94731a2a59de7b93907417f505c76b1082ea
<pre>
[iOS] [UIAsyncTextInput] WKWebView AutoFill input assistant item doesn&apos;t show up in the keyboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=267865">https://bugs.webkit.org/show_bug.cgi?id=267865</a>
<a href="https://rdar.apple.com/121160501">rdar://121160501</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

When async text input is enabled, we use `-requestTextContextForAutocorrectionWithCompletionHandler:`
to surface autocorrection context information to UIKit. The conversion from
`WebAutocorrectionContext::markedTextRange` to `DocumentEditingContext::selectedRangeInMarkedText`
is currently straightforward:

```
editingContext.selectedRangeInMarkedText = {
    .location = correctionContext.selectedRangeInMarkedText.location,
    .length = correctionContext.selectedRangeInMarkedText.length
};
```

…however, this hides a subtle bug, since the &quot;not found&quot; location of `markedTextRange` (an
`EditingRange`) is represented using `WTF::notFound`, while the `selectedRangeInMarkedText`
represents &quot;not found&quot; with `NSNotFound`, directly mirroring `NSRange`. The `NSRange` operator in
`EditingRange` is aware of this difference:

```
operator NSRange() const
{
    if (location == notFound)
        return NSMakeRange(NSNotFound, 0);
    return NSMakeRange(location, length);
}
```

…but we don&apos;t use it in the above code since we set the location and length directly. Fix this by
simply mapping `notFound` to `NSNotFound` when creating the platform context in the async text input
codepath.

Test: AutocorrectionTests.AutocorrectionContextBeforeAndAfterEditing

* Source/WebKit/Shared/ios/WebAutocorrectionContext.h:
* Source/WebKit/Shared/ios/WebAutocorrectionContext.serialization.in:

While we&apos;re here, also rename `markedTextRange` to `selectedRangeInMarkedText`, to clarify what this
range actually represents.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView requestTextContextForAutocorrectionWithCompletionHandler:]):
(+[WKAutocorrectionContext autocorrectionContextWithWebContext:]):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::autocorrectionContext):
* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm:

Augment an existing API test to also verify that when there&apos;s no IME composition range, `markedText`
is `nil` and `selectedRangeInMarkedText` is exactly equal to `{ NSNotFound, 0 }`.

* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[WKWebView autocorrectionContext]):

Canonical link: <a href="https://commits.webkit.org/273316@main">https://commits.webkit.org/273316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa2c34a54000ec28e2cfc7b964f27fc982a65227

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37803 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31655 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11026 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10364 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10422 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39051 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31886 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31687 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36438 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34427 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12318 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8031 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11057 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11383 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->