### PR TITLE
Adopt more smart pointers in WebCore/css/calc/

### DIFF
--- a/Source/WebCore/css/calc/CSSCalcExpressionNodeParser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcExpressionNodeParser.cpp
@@ -67,7 +67,7 @@ RefPtr<CSSCalcExpressionNode> CSSCalcExpressionNodeParser::parseCalc(CSSParserTo
             if (operationNode->isMinOrMaxNode())
                 operationNode->setAllowsNegativePercentageReference();
 
-            for (auto& child : operationNode->children())
+            for (Ref child : operationNode->children())
                 setAllowsNegativePercentageReferenceIfNeeded(child);
         }
     };
@@ -314,7 +314,7 @@ bool CSSCalcExpressionNodeParser::parseValue(CSSParserTokenRange& tokens, CSSVal
     case IdentToken: {
         if (checkRoundKeyword(functionID, result, token.id()))
             return true;
-        auto value = m_symbolTable.get(token.id());
+        auto value = m_symbolTable->get(token.id());
         value = value ? value : getConstantTable().get(token.id());
         if (!value)
             return false;

--- a/Source/WebCore/css/calc/CSSCalcExpressionNodeParser.h
+++ b/Source/WebCore/css/calc/CSSCalcExpressionNodeParser.h
@@ -56,7 +56,7 @@ private:
     bool parseCalcValue(CSSParserTokenRange&, CSSValueID, int depth, RefPtr<CSSCalcExpressionNode>&);
 
     CalculationCategory m_destinationCategory;
-    const CSSCalcSymbolTable& m_symbolTable;
+    SingleThreadWeakRef<const CSSCalcSymbolTable> m_symbolTable;
 };
 
 }

--- a/Source/WebCore/css/calc/CSSCalcInvertNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcInvertNode.cpp
@@ -33,13 +33,13 @@ namespace WebCore {
 
 std::unique_ptr<CalcExpressionNode> CSSCalcInvertNode::createCalcExpression(const CSSToLengthConversionData& conversionData) const
 {
-    auto childNode = m_child->createCalcExpression(conversionData);
+    auto childNode = protectedChild()->createCalcExpression(conversionData);
     return makeUnique<CalcExpressionInversion>(WTFMove(childNode));
 }
 
 double CSSCalcInvertNode::doubleValue(CSSUnitType unitType) const
 {
-    auto childValue = m_child->doubleValue(unitType);
+    auto childValue = protectedChild()->doubleValue(unitType);
     if (!childValue)
         return std::numeric_limits<double>::infinity();
     return 1.0 / childValue;
@@ -47,7 +47,7 @@ double CSSCalcInvertNode::doubleValue(CSSUnitType unitType) const
 
 double CSSCalcInvertNode::computeLengthPx(const CSSToLengthConversionData& conversionData) const
 {
-    auto childValue = m_child->computeLengthPx(conversionData);
+    auto childValue = protectedChild()->computeLengthPx(conversionData);
     if (!childValue)
         return std::numeric_limits<double>::infinity();
     return 1.0 / childValue;

--- a/Source/WebCore/css/calc/CSSCalcInvertNode.h
+++ b/Source/WebCore/css/calc/CSSCalcInvertNode.h
@@ -38,6 +38,7 @@ public:
 
     const CSSCalcExpressionNode& child() const { return m_child.get(); }
     CSSCalcExpressionNode& child() { return m_child.get(); }
+    Ref<CSSCalcExpressionNode> protectedChild() const { return m_child; }
 
     void setChild(Ref<CSSCalcExpressionNode>&& child) { m_child = WTFMove(child); }
 

--- a/Source/WebCore/css/calc/CSSCalcNegateNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcNegateNode.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 
 std::unique_ptr<CalcExpressionNode> CSSCalcNegateNode::createCalcExpression(const CSSToLengthConversionData& conversionData) const
 {
-    auto childNode = m_child->createCalcExpression(conversionData);
+    auto childNode = protectedChild()->createCalcExpression(conversionData);
     return makeUnique<CalcExpressionNegation>(WTFMove(childNode));
 }
 

--- a/Source/WebCore/css/calc/CSSCalcNegateNode.h
+++ b/Source/WebCore/css/calc/CSSCalcNegateNode.h
@@ -38,6 +38,7 @@ public:
 
     const CSSCalcExpressionNode& child() const { return m_child.get(); }
     CSSCalcExpressionNode& child() { return m_child.get(); }
+    Ref<CSSCalcExpressionNode> protectedChild() const { return m_child; }
 
     void setChild(Ref<CSSCalcExpressionNode>&& child) { m_child = WTFMove(child); }
 

--- a/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h
+++ b/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h
@@ -63,6 +63,8 @@ public:
     void canonicalizeUnit();
 
     const CSSPrimitiveValue& value() const { return m_value.get(); }
+    Ref<CSSPrimitiveValue> protectedValue() const { return m_value; }
+
     double doubleValue(CSSUnitType) const final;
 
 private:

--- a/Source/WebCore/css/calc/CSSCalcSymbolTable.h
+++ b/Source/WebCore/css/calc/CSSCalcSymbolTable.h
@@ -28,12 +28,13 @@
 #include "CSSValueKeywords.h"
 #include <optional>
 #include <wtf/HashMap.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 enum class CSSUnitType : uint8_t;
 
-class CSSCalcSymbolTable {
+class CSSCalcSymbolTable : public CanMakeSingleThreadWeakPtr<CSSCalcSymbolTable> {
 public:
     struct Value {
         CSSUnitType type;

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -75,6 +75,7 @@ public:
     void dump(TextStream&) const;
 
     const CSSCalcExpressionNode& expressionNode() const { return m_expression; }
+    Ref<CSSCalcExpressionNode> protectedExpressionNode() const;
 
 private:
     explicit CSSCalcValue(Ref<CSSCalcExpressionNode>&&, bool shouldClampToNonNegative = false);


### PR DESCRIPTION
#### 3a18304f032d6b9a64343fe60d4bb3e317263787
<pre>
Adopt more smart pointers in WebCore/css/calc/
<a href="https://bugs.webkit.org/show_bug.cgi?id=267870">https://bugs.webkit.org/show_bug.cgi?id=267870</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/css/calc/CSSCalcExpressionNodeParser.cpp:
(WebCore::CSSCalcExpressionNodeParser::parseCalc):
(WebCore::CSSCalcExpressionNodeParser::parseValue):
* Source/WebCore/css/calc/CSSCalcExpressionNodeParser.h:
* Source/WebCore/css/calc/CSSCalcInvertNode.cpp:
(WebCore::CSSCalcInvertNode::createCalcExpression const):
(WebCore::CSSCalcInvertNode::doubleValue const):
(WebCore::CSSCalcInvertNode::computeLengthPx const):
* Source/WebCore/css/calc/CSSCalcInvertNode.h:
* Source/WebCore/css/calc/CSSCalcNegateNode.cpp:
(WebCore::CSSCalcNegateNode::createCalcExpression const):
* Source/WebCore/css/calc/CSSCalcNegateNode.h:
* Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
(WebCore::determineCategory):
(WebCore::CSSCalcOperationNode::canCombineAllChildren const):
(WebCore::CSSCalcOperationNode::combineChildren):
(WebCore::CSSCalcOperationNode::simplifyRecursive):
(WebCore::CSSCalcOperationNode::simplifyNode):
(WebCore::CSSCalcOperationNode::createCalcExpression const):
(WebCore::CSSCalcOperationNode::collectComputedStyleDependencies const):
(WebCore::functionPrefixForOperator):
(WebCore::CSSCalcOperationNode::buildCSSTextRecursive):
* Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp:
(WebCore::CSSCalcPrimitiveValueNode::customCSSText const):
(WebCore::CSSCalcPrimitiveValueNode::primitiveType const):
(WebCore::CSSCalcPrimitiveValueNode::isNegative const):
(WebCore::CSSCalcPrimitiveValueNode::negate):
(WebCore::CSSCalcPrimitiveValueNode::invert):
(WebCore::CSSCalcPrimitiveValueNode::add):
(WebCore::CSSCalcPrimitiveValueNode::multiply):
(WebCore::CSSCalcPrimitiveValueNode::convertToUnitType):
(WebCore::CSSCalcPrimitiveValueNode::canonicalizeUnit):
(WebCore::CSSCalcPrimitiveValueNode::createCalcExpression const):
(WebCore::CSSCalcPrimitiveValueNode::doubleValue const):
(WebCore::CSSCalcPrimitiveValueNode::computeLengthPx const):
(WebCore::CSSCalcPrimitiveValueNode::collectComputedStyleDependencies const):
(WebCore::CSSCalcPrimitiveValueNode::isZero const):
(WebCore::CSSCalcPrimitiveValueNode::dump const):
* Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.h:
* Source/WebCore/css/calc/CSSCalcSymbolTable.h:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::createCSS):
(WebCore::CSSCalcValue::createCalculationValue const):
(WebCore::CSSCalcValue::collectComputedStyleDependencies const):
(WebCore::CSSCalcValue::customCSSText const):
(WebCore::CSSCalcValue::doubleValue const):
(WebCore::CSSCalcValue::computeLengthPx const):
(WebCore::CSSCalcValue::protectedExpressionNode const):
(WebCore::CSSCalcValue::create):
* Source/WebCore/css/calc/CSSCalcValue.h:

Canonical link: <a href="https://commits.webkit.org/273314@main">https://commits.webkit.org/273314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff0736b4d0be282dc775604660dca13276117d42

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37806 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31656 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11029 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30589 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31266 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10362 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10421 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31359 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39054 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31885 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31690 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34424 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12320 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/8032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11059 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4516 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11384 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->