### PR TITLE
Set insecure/secure ports for upgrading requests in LayoutTests

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/iframe-upgrade.https.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/iframe-upgrade.https.html
@@ -8,12 +8,9 @@
 </head>
 <body>
 <script>
-// This test is a bit of a hack. UPGRADE doesn't upgrade the port number, so we
-// specify this non-existent URL ('http' over port 8443). If UPGRADE doesn't
-// work, it won't load.
 async_test(t => {
     var iframe = document.createElement('iframe');
-    iframe.src = "HTtp://127.0.0.1:8443/security/resources/post-origin-to-parent.html";
+    iframe.src = "HTtp://127.0.0.1:8000/security/resources/post-origin-to-parent.html";
 
     window.addEventListener('message', t.step_func(e => {
         if (e.source == iframe.contentWindow) {
@@ -27,7 +24,7 @@ async_test(t => {
 
 async_test(t => {
     var iframe = document.createElement('iframe');
-    iframe.src = "hTtP://localhost:8443/security/resources/post-origin-to-parent.html";
+    iframe.src = "hTtP://localhost:8000/security/resources/post-origin-to-parent.html";
 
     window.addEventListener('message', t.step_func(e => {
         if (e.source == iframe.contentWindow) {

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -363,6 +363,7 @@ Page::Page(PageConfiguration&& pageConfiguration)
     , m_loadsSubresources(pageConfiguration.loadsSubresources)
     , m_shouldRelaxThirdPartyCookieBlocking(pageConfiguration.shouldRelaxThirdPartyCookieBlocking)
     , m_httpsUpgradeEnabled(pageConfiguration.httpsUpgradeEnabled)
+    , m_portsForUpgradingInsecureSchemeForTesting(WTFMove(pageConfiguration.portsForUpgradingInsecureSchemeForTesting))
     , m_storageProvider(WTFMove(pageConfiguration.storageProvider))
     , m_modelPlayerProvider(WTFMove(pageConfiguration.modelPlayerProvider))
 #if ENABLE(ATTACHMENT_ELEMENT)
@@ -4631,5 +4632,15 @@ void Page::setSceneIdentifier(String&& sceneIdentifier)
     m_sceneIdentifier = WTFMove(sceneIdentifier);
 }
 #endif
+
+void Page::setPortsForUpgradingInsecureSchemeForTesting(uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort)
+{
+    m_portsForUpgradingInsecureSchemeForTesting = { upgradeFromInsecurePort, upgradeToSecurePort };
+}
+
+std::optional<std::pair<uint16_t, uint16_t>> Page::portsForUpgradingInsecureSchemeForTesting() const
+{
+    return m_portsForUpgradingInsecureSchemeForTesting;
+}
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1076,6 +1076,9 @@ public:
 #endif
     WEBCORE_EXPORT String sceneIdentifier() const;
 
+    std::optional<std::pair<uint16_t, uint16_t>> portsForUpgradingInsecureSchemeForTesting() const;
+    WEBCORE_EXPORT void setPortsForUpgradingInsecureSchemeForTesting(uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort);
+
 private:
     explicit Page(PageConfiguration&&);
 
@@ -1417,6 +1420,8 @@ private:
 
     const bool m_httpsUpgradeEnabled { true };
     mutable MediaSessionGroupIdentifier m_mediaSessionGroupIdentifier;
+
+    std::optional<std::pair<uint16_t, uint16_t>> m_portsForUpgradingInsecureSchemeForTesting;
 
     UniqueRef<StorageProvider> m_storageProvider;
     UniqueRef<ModelPlayerProvider> m_modelPlayerProvider;

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -183,6 +183,7 @@ public:
     bool userScriptsShouldWaitUntilNotification { true };
     ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking { ShouldRelaxThirdPartyCookieBlocking::No };
     bool httpsUpgradeEnabled { true };
+    std::optional<std::pair<uint16_t, uint16_t>> portsForUpgradingInsecureSchemeForTesting;
 
     UniqueRef<StorageProvider> storageProvider;
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -1045,6 +1045,13 @@ void ContentSecurityPolicy::upgradeInsecureRequestIfNeeded(URL& url, InsecureReq
 
     if (url.port() == 80)
         url.setPort(std::nullopt);
+    else if (auto* document = dynamicDowncast<Document>(m_scriptExecutionContext.get()); document && document->page()) {
+        auto portsForUpgradingInsecureScheme = document->page()->portsForUpgradingInsecureSchemeForTesting();
+        if (portsForUpgradingInsecureScheme) {
+            if (url.port() == portsForUpgradingInsecureScheme->first)
+                url.setPort(portsForUpgradingInsecureScheme->second);
+        }
+    }
 }
 
 void ContentSecurityPolicy::setUpgradeInsecureRequests(bool upgradeInsecureRequests)

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -251,6 +251,7 @@ struct WebPageCreationParameters {
     bool userScriptsShouldWaitUntilNotification { true };
     bool loadsSubresources { true };
     std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<String>> allowedNetworkHosts;
+    std::optional<std::pair<uint16_t, uint16_t>> portsForUpgradingInsecureSchemeForTesting;
 
     bool crossOriginAccessControlCheckEnabled { true };
     String processDisplayName;

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -189,6 +189,7 @@ headers: "ArgumentCoders.h"
     bool userScriptsShouldWaitUntilNotification;
     bool loadsSubresources;
     std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<String>> allowedNetworkHosts;
+    std::optional<std::pair<uint16_t, uint16_t>> portsForUpgradingInsecureSchemeForTesting;
 
     bool crossOriginAccessControlCheckEnabled;
     String processDisplayName;

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -223,6 +223,9 @@ public:
     void setAllowTestOnlyIPC(bool enabled) { m_data.allowTestOnlyIPC = enabled; }
     bool allowTestOnlyIPC() const { return m_data.allowTestOnlyIPC; }
 
+    void setPortsForUpgradingInsecureSchemeForTesting(uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort) { m_data.portsForUpgradingInsecureSchemeForTesting = { upgradeFromInsecurePort, upgradeToSecurePort }; }
+    std::optional<std::pair<uint16_t, uint16_t>> portsForUpgradingInsecureSchemeForTesting() const { return m_data.portsForUpgradingInsecureSchemeForTesting; }
+
     void setDelaysWebProcessLaunchUntilFirstLoad(bool);
     bool delaysWebProcessLaunchUntilFirstLoad() const;
 
@@ -264,6 +267,7 @@ private:
         bool allowTestOnlyIPC { false };
         std::optional<bool> delaysWebProcessLaunchUntilFirstLoad { };
         std::optional<double> cpuLimit { };
+        std::optional<std::pair<uint16_t, uint16_t>> portsForUpgradingInsecureSchemeForTesting { };
 
         WTF::String overrideContentSecurityPolicy { };
 

--- a/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
@@ -118,3 +118,8 @@ void WKPageConfigurationSetAllowTestOnlyIPC(WKPageConfigurationRef configuration
 {
     toImpl(configuration)->setAllowTestOnlyIPC(allowTestOnlyIPC);
 }
+
+void WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting(WKPageConfigurationRef configuration, uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort)
+{
+    toImpl(configuration)->setPortsForUpgradingInsecureSchemeForTesting(upgradeFromInsecurePort, upgradeToSecurePort);
+}

--- a/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h
@@ -60,6 +60,8 @@ WK_EXPORT void WKPageConfigurationSetBackgroundCPULimit(WKPageConfigurationRef c
 
 WK_EXPORT void WKPageConfigurationSetAllowTestOnlyIPC(WKPageConfigurationRef configuration, bool allowTestOnlyIPC);
 
+WK_EXPORT void WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting(WKPageConfigurationRef configuration, uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -829,6 +829,21 @@ static NSString *defaultApplicationNameForUserAgent()
     _pageConfiguration->setClientNavigationsRunAtForegroundPriority(clientNavigationsRunAtForegroundPriority);
 }
 
+- (NSArray<NSNumber *> *)_portsForUpgradingInsecureSchemeForTesting
+{
+    auto ports = _pageConfiguration->portsForUpgradingInsecureSchemeForTesting();
+    if (ports)
+        return @[@(ports->first), @(ports->second)];
+    return nil;
+}
+
+- (void)_setPortsForUpgradingInsecureSchemeForTesting:(NSArray<NSNumber *> *)ports
+{
+    if (ports.count != 2 || ports[0].unsignedIntegerValue > std::numeric_limits<uint16_t>::max() || ports[1].unsignedIntegerValue > std::numeric_limits<uint16_t>::max())
+        return;
+    _pageConfiguration->setPortsForUpgradingInsecureSchemeForTesting((uint16_t)ports[0].unsignedIntegerValue, (uint16_t)ports[1].unsignedIntegerValue);
+}
+
 #if PLATFORM(IOS_FAMILY)
 - (BOOL)_alwaysRunsAtForegroundPriority
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -107,6 +107,7 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 @property (nonatomic, setter=_setLoadsSubresources:) BOOL _loadsSubresources WK_API_AVAILABLE(macos(11.0), ios(14.0));
 @property (nonatomic, setter=_setIgnoresAppBoundDomains:) BOOL _ignoresAppBoundDomains WK_API_AVAILABLE(macos(11.0), ios(14.0));
 @property (nonatomic, setter=_setClientNavigationsRunAtForegroundPriority:) BOOL _clientNavigationsRunAtForegroundPriority WK_API_AVAILABLE(macos(13.5), ios(13.4));
+@property (nonatomic, setter=_setPortsForUpgradingInsecureSchemeForTesting:) NSArray<NSNumber *> *_portsForUpgradingInsecureSchemeForTesting WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 #if TARGET_OS_IPHONE
 @property (nonatomic, setter=_setAlwaysRunsAtForegroundPriority:) BOOL _alwaysRunsAtForegroundPriority WK_API_DEPRECATED_WITH_REPLACEMENT("_clientNavigationsRunAtForegroundPriority", ios(9.0, 14.0));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9856,6 +9856,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.loadsSubresources = m_configuration->loadsSubresources();
     parameters.crossOriginAccessControlCheckEnabled = m_configuration->crossOriginAccessControlCheckEnabled();
     parameters.hasResourceLoadClient = !!m_resourceLoadClient;
+    parameters.portsForUpgradingInsecureSchemeForTesting = m_configuration->portsForUpgradingInsecureSchemeForTesting();
 
     std::reference_wrapper<WebUserContentControllerProxy> userContentController(m_userContentController.get());
     if (auto* userContentControllerFromWebsitePolicies = websitePolicies ? websitePolicies->userContentController() : nullptr)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -711,6 +711,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     pageConfiguration.allowedNetworkHosts = parameters.allowedNetworkHosts;
     pageConfiguration.shouldRelaxThirdPartyCookieBlocking = parameters.shouldRelaxThirdPartyCookieBlocking;
     pageConfiguration.httpsUpgradeEnabled = parameters.httpsUpgradeEnabled;
+    pageConfiguration.portsForUpgradingInsecureSchemeForTesting = parameters.portsForUpgradingInsecureSchemeForTesting;
 
     if (!parameters.crossOriginAccessControlCheckEnabled)
         CrossOriginAccessControlCheckDisabler::singleton().setCrossOriginAccessControlCheckEnabled(false);

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -4674,6 +4674,15 @@ IGNORE_WARNINGS_END
     WebCore::ResourceRequest::setHTTPPipeliningEnabled(enabled);
 }
 
+- (void)_setPortsForUpgradingInsecureSchemeForTesting:(uint16_t)insecureUpgradePort withSecurePort:(uint16_t)secureUpgradePort
+{
+    auto* page = core(self);
+    if (!page)
+        return;
+
+    page->setPortsForUpgradingInsecureSchemeForTesting(insecureUpgradePort, secureUpgradePort);
+}
+
 - (void)_didScrollDocumentInFrameView:(WebFrameView *)frameView
 {
     [self hideFormValidationMessage];

--- a/Source/WebKitLegacy/mac/WebView/WebViewPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewPrivate.h
@@ -847,6 +847,8 @@ Could be worth adding to the API.
  */
 + (void)_setHTTPPipeliningEnabled:(BOOL)enabled;
 
+- (void)_setPortsForUpgradingInsecureSchemeForTesting:(uint16_t)insecureUpgradePort withSecurePort:(uint16_t)secureUpgradePort;
+
 @property (nonatomic, copy, getter=_sourceApplicationAuditData, setter=_setSourceApplicationAuditData:) NSData *sourceApplicationAuditData;
 
 - (void)_setFontFallbackPrefersPictographs:(BOOL)flag;

--- a/Tools/DumpRenderTree/TestOptions.cpp
+++ b/Tools/DumpRenderTree/TestOptions.cpp
@@ -209,6 +209,9 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
         { "additionalSupportedImageTypes", TestHeaderKeyType::StringTestRunner },
         { "jscOptions", TestHeaderKeyType::StringTestRunner },
         { "captionDisplayMode", TestHeaderKeyType::StringTestRunner },
+
+        { "insecureUpgradePort", TestHeaderKeyType::UInt16TestRunner },
+        { "secureUpgradePort", TestHeaderKeyType::UInt16TestRunner },
     };
 
     return map;
@@ -230,6 +233,11 @@ template<typename T> T featureValue(std::string key, T defaultValue, const std::
 bool TestOptions::boolTestRunnerFeatureValue(std::string key, bool defaultValue) const
 {
     return featureValue(key, defaultValue, m_features.boolTestRunnerFeatures);
+}
+
+uint16_t TestOptions::uint16TestRunnerFeatureValue(std::string key, uint16_t defaultValue) const
+{
+    return featureValue(key, defaultValue, m_features.uint16TestRunnerFeatures);
 }
 
 std::string TestOptions::stringTestRunnerFeatureValue(std::string key, std::string defaultValue) const

--- a/Tools/DumpRenderTree/TestOptions.h
+++ b/Tools/DumpRenderTree/TestOptions.h
@@ -51,6 +51,8 @@ public:
     std::string additionalSupportedImageTypes() const { return stringTestRunnerFeatureValue("additionalSupportedImageTypes", { }); }
     std::string jscOptions() const { return stringTestRunnerFeatureValue("jscOptions", { }); }
     std::string captionDisplayMode() const { return stringTestRunnerFeatureValue("captionDisplayMode", { }); }
+    uint16_t insecureUpgradePort() const { return uint16TestRunnerFeatureValue("insecureUpgradePort", 80); };
+    uint16_t secureUpgradePort() const { return uint16TestRunnerFeatureValue("secureUpgradePort", 443); };
 
     const auto& boolWebPreferenceFeatures() const { return m_features.boolWebPreferenceFeatures; }
     const auto& doubleWebPreferenceFeatures() const { return m_features.doubleWebPreferenceFeatures; }
@@ -67,6 +69,7 @@ public:
 private:
     bool boolTestRunnerFeatureValue(std::string key, bool defaultValue) const;
     std::string stringTestRunnerFeatureValue(std::string key, std::string defaultValue) const;
+    uint16_t uint16TestRunnerFeatureValue(std::string key, uint16_t defaultValue) const;
 
     TestFeatures m_features;
 };

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -1955,6 +1955,8 @@ static void runTest(const std::string& inputLine)
     gTestRunner->setCustomTimeout(command.timeout.milliseconds());
     gTestRunner->setDumpJSConsoleLogInStdErr(command.dumpJSConsoleLogInStdErr || options.dumpJSConsoleLogInStdErr());
 
+    [[mainFrame webView] _setPortsForUpgradingInsecureSchemeForTesting:options.insecureUpgradePort() withSecurePort:options.secureUpgradePort()];
+
 #if ENABLE(VIDEO)
     [mainFrame _createCaptionPreferencesTestingModeToken];
 #endif

--- a/Tools/TestRunnerShared/TestFeatures.cpp
+++ b/Tools/TestRunnerShared/TestFeatures.cpp
@@ -50,6 +50,7 @@ void merge(TestFeatures& base, TestFeatures additional)
     merge(base.stringWebPreferenceFeatures, additional.stringWebPreferenceFeatures);
     merge(base.boolTestRunnerFeatures, additional.boolTestRunnerFeatures);
     merge(base.doubleTestRunnerFeatures, additional.doubleTestRunnerFeatures);
+    merge(base.uint16TestRunnerFeatures, additional.uint16TestRunnerFeatures);
     merge(base.stringTestRunnerFeatures, additional.stringTestRunnerFeatures);
     merge(base.stringVectorTestRunnerFeatures, additional.stringVectorTestRunnerFeatures);
 }
@@ -67,6 +68,8 @@ bool operator==(const TestFeatures& a, const TestFeatures& b)
     if (a.boolTestRunnerFeatures != b.boolTestRunnerFeatures)
         return false;
     if (a.doubleTestRunnerFeatures != b.doubleTestRunnerFeatures)
+        return false;
+    if (a.uint16TestRunnerFeatures != b.uint16TestRunnerFeatures)
         return false;
     if (a.stringTestRunnerFeatures != b.stringTestRunnerFeatures)
         return false;
@@ -128,6 +131,18 @@ static bool shouldEnableWebGPU(const std::string& pathOrURL)
     return pathContains(pathOrURL, "webgpu/");
 }
 
+static bool shouldSetDefaultPortsForWTR(const std::string& pathOrURL)
+{
+    return pathContains(pathOrURL, "localhost:8000/") || pathContains(pathOrURL, "localhost:8443/")
+        || pathContains(pathOrURL, "127.0.0.1:8000/") || pathContains(pathOrURL, "127.0.0.1:8443/");
+}
+
+static bool shouldSetDefaultPortsForWPT(const std::string& pathOrURL)
+{
+    return pathContains(pathOrURL, "localhost:8800/") || pathContains(pathOrURL, "localhost:9443/")
+        || pathContains(pathOrURL, "127.0.0.1:8800/") || pathContains(pathOrURL, "127.0.0.1:9443/");
+}
+
 TestFeatures hardcodedFeaturesBasedOnPathForTest(const TestCommand& command)
 {
     TestFeatures features;
@@ -146,6 +161,13 @@ TestFeatures hardcodedFeaturesBasedOnPathForTest(const TestCommand& command)
     }
     if (shouldEnableWebGPU(command.pathOrURL))
         features.boolWebPreferenceFeatures.insert({ "WebGPUEnabled", true });
+    if (shouldSetDefaultPortsForWTR(command.pathOrURL)) {
+        features.uint16TestRunnerFeatures.insert({ "insecureUpgradePort", 8000 });
+        features.uint16TestRunnerFeatures.insert({ "secureUpgradePort", 8443 });
+    } else if (shouldSetDefaultPortsForWPT(command.pathOrURL)) {
+        features.uint16TestRunnerFeatures.insert({ "insecureUpgradePort", 8800 });
+        features.uint16TestRunnerFeatures.insert({ "secureUpgradePort", 9443 });
+    }
 
     return features;
 }
@@ -169,6 +191,11 @@ static double parseDoubleTestHeaderValue(const std::string& value)
 static uint32_t parseUInt32TestHeaderValue(const std::string& value)
 {
     return std::stoi(value);
+}
+
+static uint16_t parseUInt16TestHeaderValue(const std::string& value)
+{
+    return static_cast<uint16_t>(std::stoul(value));
 }
 
 static std::string parseStringTestHeaderValueAsRelativePath(const std::string& value, const std::filesystem::path& testPath)
@@ -230,6 +257,9 @@ bool parseTestHeaderFeature(TestFeatures& features, std::string key, std::string
         return true;
     case TestHeaderKeyType::DoubleTestRunner:
         features.doubleTestRunnerFeatures.insert_or_assign(key, parseDoubleTestHeaderValue(value));
+        return true;
+    case TestHeaderKeyType::UInt16TestRunner:
+        features.uint16TestRunnerFeatures.insert_or_assign(key, parseUInt16TestHeaderValue(value));
         return true;
     case TestHeaderKeyType::StringTestRunner:
         features.stringTestRunnerFeatures.insert_or_assign(key, value);

--- a/Tools/TestRunnerShared/TestFeatures.h
+++ b/Tools/TestRunnerShared/TestFeatures.h
@@ -43,6 +43,7 @@ struct TestFeatures {
 
     std::unordered_map<std::string, bool> boolTestRunnerFeatures;
     std::unordered_map<std::string, double> doubleTestRunnerFeatures;
+    std::unordered_map<std::string, uint16_t> uint16TestRunnerFeatures;
     std::unordered_map<std::string, std::string> stringTestRunnerFeatures;
     std::unordered_map<std::string, std::vector<std::string>> stringVectorTestRunnerFeatures;
 };
@@ -61,6 +62,7 @@ enum class TestHeaderKeyType : uint8_t {
 
     BoolTestRunner,
     DoubleTestRunner,
+    UInt16TestRunner,
     StringTestRunner,
     StringRelativePathTestRunner,
     StringURLTestRunner,

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -786,6 +786,7 @@ WKRetainPtr<WKPageConfigurationRef> TestController::generatePageConfiguration(co
 
     m_userContentController = adoptWK(WKUserContentControllerCreate());
     WKPageConfigurationSetUserContentController(pageConfiguration.get(), userContentController());
+    WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting(pageConfiguration.get(), options.insecureUpgradePort(), options.secureUpgradePort());
     return pageConfiguration;
 }
 

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -204,6 +204,10 @@ const TestFeatures& TestOptions::defaults()
             { "viewHeight", 600 },
             { "viewWidth", 800 },
         };
+        features.uint16TestRunnerFeatures = {
+            { "insecureUpgradePort", 80 },
+            { "secureUpgradePort", 443 },
+        };
         features.stringTestRunnerFeatures = {
             { "additionalSupportedImageTypes", { } },
             { "applicationBundleIdentifier", { } },
@@ -269,6 +273,9 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
         { "viewHeight", TestHeaderKeyType::DoubleTestRunner },
         { "viewWidth", TestHeaderKeyType::DoubleTestRunner },
 
+        { "insecureUpgradePort", TestHeaderKeyType::UInt16TestRunner },
+        { "secureUpgradePort", TestHeaderKeyType::UInt16TestRunner },
+
         { "additionalSupportedImageTypes", TestHeaderKeyType::StringTestRunner },
         { "applicationBundleIdentifier", TestHeaderKeyType::StringTestRunner },
         { "applicationManifest", TestHeaderKeyType::StringRelativePathTestRunner },
@@ -317,6 +324,11 @@ bool TestOptions::boolTestRunnerFeatureValue(std::string key) const
 double TestOptions::doubleTestRunnerFeatureValue(std::string key) const
 {
     return testRunnerFeatureValue(key, m_features.doubleTestRunnerFeatures);
+}
+
+uint16_t TestOptions::uint16TestRunnerFeatureValue(std::string key) const
+{
+    return testRunnerFeatureValue(key, m_features.uint16TestRunnerFeatures);
 }
 
 std::string TestOptions::stringTestRunnerFeatureValue(std::string key) const

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -89,6 +89,8 @@ public:
     double deviceScaleFactor() const { return doubleTestRunnerFeatureValue("deviceScaleFactor"); }
     double viewHeight() const { return doubleTestRunnerFeatureValue("viewHeight"); }
     double viewWidth() const { return doubleTestRunnerFeatureValue("viewWidth"); }
+    uint16_t insecureUpgradePort() const { return uint16TestRunnerFeatureValue("insecureUpgradePort"); };
+    uint16_t secureUpgradePort() const { return uint16TestRunnerFeatureValue("secureUpgradePort"); };
     std::string additionalSupportedImageTypes() const { return stringTestRunnerFeatureValue("additionalSupportedImageTypes"); }
     std::string applicationBundleIdentifier() const { return stringTestRunnerFeatureValue("applicationBundleIdentifier"); }
     std::string applicationManifest() const { return stringTestRunnerFeatureValue("applicationManifest"); }
@@ -117,6 +119,7 @@ private:
     bool boolWebPreferenceFeatureValue(std::string key, bool defaultValue) const;
     bool boolTestRunnerFeatureValue(std::string key) const;
     double doubleTestRunnerFeatureValue(std::string key) const;
+    uint16_t uint16TestRunnerFeatureValue(std::string key) const;
     std::string stringTestRunnerFeatureValue(std::string key) const;
     std::vector<std::string> stringVectorTestRunnerFeatureValue(std::string key) const;
 

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -324,6 +324,7 @@ void TestController::platformCreateWebView(WKPageConfigurationRef, const TestOpt
     }
     
     [copiedConfiguration _setAllowTestOnlyIPC:options.allowTestOnlyIPC()];
+    [copiedConfiguration _setPortsForUpgradingInsecureSchemeForTesting:@[@(options.insecureUpgradePort()), @(options.secureUpgradePort())]];
 
     m_mainWebView = makeUnique<PlatformWebView>(copiedConfiguration.get(), options);
     finishCreatingPlatformWebView(m_mainWebView.get(), options);


### PR DESCRIPTION
#### b66901d110655e63b24e80f32f4b19cd69f0ab52
<pre>
Set insecure/secure ports for upgrading requests in LayoutTests
<a href="https://bugs.webkit.org/show_bug.cgi?id=267872">https://bugs.webkit.org/show_bug.cgi?id=267872</a>
<a href="https://rdar.apple.com/121388492">rdar://121388492</a>

Reviewed by Alex Christensen.

Some requests are &quot;upgradable&quot; from insecure to secure (e.g., HTTP -&gt; HTTPS) by
the engine before the resource is loaded. Currently, the only way to test this
is by using a URL with the insecure scheme but using the secure port (e.g.,
http: and port 443). This change adds the capability to test this behavior
while using URLs that are valid. A current example of this is for testing
requests where the document&apos;s CSP declared the &apos;upgrade-insecure-requests&apos;
policy. In the future, this will help with testing upgrading mixed-content.

* LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/iframe-upgrade.https.html:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setPortsForUpgradingInsecureSchemeForTesting):
(WebCore::Page::portsForUpgradingInsecureSchemeForTesting const):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageConfiguration.h:
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::upgradeInsecureRequestIfNeeded const):
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::setPortsForUpgradingInsecureSchemeForTesting):
(API::PageConfiguration::portsForUpgradingInsecureSchemeForTesting const):
* Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp:
(WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting):
* Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration _portsForUpgradingInsecureSchemeForTesting]):
(-[WKWebViewConfiguration _setPortsForUpgradingInsecureSchemeForTesting:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_historyItemClient):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _setPortsForUpgradingInsecureSchemeForTesting:withSecurePort:]):
* Source/WebKitLegacy/mac/WebView/WebViewPrivate.h:
* Tools/DumpRenderTree/TestOptions.cpp:
(WTR::TestOptions::keyTypeMapping):
(WTR::TestOptions::uint16TestRunnerFeatureValue const):
* Tools/DumpRenderTree/TestOptions.h:
(WTR::TestOptions::insecureUpgradePort const):
(WTR::TestOptions::secureUpgradePort const):
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(runTest):
* Tools/TestRunnerShared/TestFeatures.cpp:
(WTR::merge):
(WTR::operator==):
(WTR::shouldSetDefaultPortsForWTR):
(WTR::shouldSetDefaultPortsForWPT):
(WTR::hardcodedFeaturesBasedOnPathForTest):
(WTR::parseUInt16TestHeaderValue):
(WTR::parseTestHeaderFeature):
* Tools/TestRunnerShared/TestFeatures.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::generatePageConfiguration):
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
(WTR::TestOptions::keyTypeMapping):
(WTR::TestOptions::uint16TestRunnerFeatureValue const):
* Tools/WebKitTestRunner/TestOptions.h:
(WTR::TestOptions::insecureUpgradePort const):
(WTR::TestOptions::secureUpgradePort const):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::platformCreateWebView):

Canonical link: <a href="https://commits.webkit.org/273568@main">https://commits.webkit.org/273568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76b9e05fe241b764bc2a02d424caef53d6107259

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38500 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32193 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11741 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30957 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10923 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39747 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32487 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32296 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36872 "Found 1 new test failure: fast/repaint/animation-after-layer-scroll.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11111 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34958 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31634 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8167 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11616 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->