### PR TITLE
Make the SVG parser interpret `form feed` as whitespace

### DIFF
--- a/LayoutTests/svg/transforms/svg-formFeed-as-whitespace-expected.html
+++ b/LayoutTests/svg/transforms/svg-formFeed-as-whitespace-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <div>Form-feed should be treated as whitespace. Only green rects should be visible.</div>
+    <svg xmlns="http://www.w3.org/2000/svg">
+    	<rect x="100" y="100" width="50" height="50" fill="green"/>
+        <rect x="200" y="100" width="50" height="50" fill="green"/>
+        <rect x="300" y="100" width="50" height="50" fill="green"/>
+        <rect x="400" y="100" width="50" height="50" fill="green"/>
+        <rect x="500" y="100" width="50" height="50" fill="green"/>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/svg/transforms/svg-formFeed-as-whitespace.html
+++ b/LayoutTests/svg/transforms/svg-formFeed-as-whitespace.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div>Form-feed should be treated as whitespace. Only green rects should be visible.</div>
+
+<svg xmlns="http://www.w3.org/2000/svg">
+<rect x="100" y="100" width="50" height="50" fill="red"/>
+<!-- Use char code for HORIZONTAL TAB &#09; -->
+<rect x="50" y="50" width="50" height="50" fill="green" transform="translate(50&#09;50)"/>
+
+<rect x="200" y="100" width="50" height="50" fill="red"/>
+<!-- Use char code for LINE FEED &#10; -->
+<rect x="50" y="50" width="50" height="50" fill="green" transform="translate(150&#10;50)"/>
+
+<rect x="300" y="100" width="50" height="50" fill="red"/>
+<!-- Use char code for FORM FEED &#12; -->
+<rect x="50" y="50" width="50" height="50" fill="green" transform="translate(250&#12;50)"/>
+
+<rect x="400" y="100" width="50" height="50" fill="red"/>
+<!-- Use char code for CARRIAGE RETURN &#13; -->
+<rect x="50" y="50" width="50" height="50" fill="green" transform="translate(350&#13;50)"/>
+
+<rect x="500" y="100" width="50" height="50" fill="red"/>
+<!-- Use char code for SPACE &#32; -->
+<rect x="50" y="50" width="50" height="50" fill="green" transform="translate(450&#32;50)"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/transforms/svg-line-tabulation-as-not-whitespace-expected.html
+++ b/LayoutTests/svg/transforms/svg-line-tabulation-as-not-whitespace-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <div>Line Tabulation should not be treated as whitespace. Only green rects should be visible.</div>
+    <svg xmlns="http://www.w3.org/2000/svg">
+    	<rect x="100" y="100" width="50" height="50" fill="green"/>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/svg/transforms/svg-line-tabulation-as-not-whitespace.html
+++ b/LayoutTests/svg/transforms/svg-line-tabulation-as-not-whitespace.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div>Line Tabulation should not be treated as whitespace. Only green rects should be visible.</div>
+
+<svg xmlns="http://www.w3.org/2000/svg">
+<rect x="100" y="100" width="50" height="50" fill="red"/>
+<!-- Use char code for LINE TABULATION &#11; -->
+<rect x="100" y="100" width="50" height="50" fill="green" transform="translate(150&#11;50)"/>
+</svg>
+</body>
+</html>

--- a/Source/WebCore/svg/SVGParserUtilities.cpp
+++ b/Source/WebCore/svg/SVGParserUtilities.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2002, 2003 The Karbon Developers
  * Copyright (C) 2006 Alexander Kellett <lypanov@kde.org>
  * Copyright (C) 2006, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2007-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -278,7 +278,7 @@ std::optional<HashSet<String>> parseGlyphName(StringView string)
 
             // walk backwards from the ; to ignore any whitespace
             auto inputEnd = buffer.position() - 1;
-            while (inputStart < inputEnd && isSVGSpace(*inputEnd))
+            while (inputStart < inputEnd && isASCIIWhitespace(*inputEnd))
                 --inputEnd;
 
             values.add(String(inputStart, inputEnd - inputStart + 1));

--- a/Source/WebCore/svg/SVGParserUtilities.h
+++ b/Source/WebCore/svg/SVGParserUtilities.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2002, 2003 The Karbon Developers
  * Copyright (C) 2006, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -55,34 +55,26 @@ std::optional<FloatPoint> parseFloatPoint(StringParsingBuffer<UChar>&);
 std::optional<std::pair<UnicodeRanges, HashSet<String>>> parseKerningUnicodeString(StringView);
 std::optional<HashSet<String>> parseGlyphName(StringView);
 
-
-// SVG allows several different whitespace characters:
-// http://www.w3.org/TR/SVG/paths.html#PathDataBNF
-template<typename CharacterType> constexpr bool isSVGSpace(CharacterType c)
-{
-    return c == ' ' || c == '\t' || c == '\n' || c == '\r';
-}
-
 template<typename CharacterType> constexpr bool isSVGSpaceOrComma(CharacterType c)
 {
-    return isSVGSpace(c) || c == ',';
+    return isASCIIWhitespace(c) || c == ',';
 }
 
 template<typename CharacterType> constexpr bool skipOptionalSVGSpaces(const CharacterType*& ptr, const CharacterType* end)
 {
-    skipWhile<isSVGSpace>(ptr, end);
+    skipWhile<isASCIIWhitespace>(ptr, end);
     return ptr < end;
 }
 
 template<typename CharacterType> constexpr bool skipOptionalSVGSpaces(StringParsingBuffer<CharacterType>& characters)
 {
-    skipWhile<isSVGSpace>(characters);
+    skipWhile<isASCIIWhitespace>(characters);
     return characters.hasCharactersRemaining();
 }
 
 template<typename CharacterType> constexpr bool skipOptionalSVGSpacesOrDelimiter(const CharacterType*& ptr, const CharacterType* end, char delimiter = ',')
 {
-    if (ptr < end && !isSVGSpace(*ptr) && *ptr != delimiter)
+    if (ptr < end && !isASCIIWhitespace(*ptr) && *ptr != delimiter)
         return false;
     if (skipOptionalSVGSpaces(ptr, end)) {
         if (ptr < end && *ptr == delimiter) {
@@ -98,7 +90,7 @@ template<typename CharacterType> constexpr bool skipOptionalSVGSpacesOrDelimiter
     if (!characters.hasCharactersRemaining())
         return false;
 
-    if (!isSVGSpace(*characters) && *characters != delimiter)
+    if (!isASCIIWhitespace(*characters) && *characters != delimiter)
         return false;
 
     // There are only spaces in the remaining characters.

--- a/Source/WebCore/svg/SVGStringList.cpp
+++ b/Source/WebCore/svg/SVGStringList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,7 +36,7 @@ bool SVGStringList::parse(StringView data, UChar delimiter)
     clearItems();
 
     auto isSVGSpaceOrDelimiter = [delimiter](auto c) {
-        return isSVGSpace(c) || c == delimiter;
+        return isASCIIWhitespace(c) || c == delimiter;
     };
 
     return readCharactersForParsing(data, [&](auto buffer) {


### PR DESCRIPTION
#### 15c6cea827c0761eb8c1b8638fc12568bf4170b3
<pre>
Make the SVG parser interpret `form feed` as whitespace

<a href="https://bugs.webkit.org/show_bug.cgi?id=77755">https://bugs.webkit.org/show_bug.cgi?id=77755</a>
<a href="https://rdar.apple.com/problem/95488677">rdar://problem/95488677</a>

Reviewed by Anne van Kesteren.

This patch is to align WebKit with Chromium / Blink, Gecko / Firefox and Web Specification [1]:

[1] <a href="https://lists.w3.org/Archives/Public/public-svg-wg/2014AprJun/0068.html">https://lists.w3.org/Archives/Public/public-svg-wg/2014AprJun/0068.html</a>

This patch uses &apos;isASCIIWhite&apos; across SVG Parser and code base to enable it to handle &apos;form feed&apos;.

It is inspired by following change in Blink, which enables &apos;leading&apos; and &apos;trailing&apos; whitespace
in SVG Attributes [2]:

[2] <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=175785

Credits to Jacob Goldstein  &lt;jacobg@adobe.com&gt; for &apos;test case&apos;.

* Source/WebCore/svg/SVGParserUtilities.cpp:
(parseGlyphName):
* Source/WebCore/svg/SVGParserUtilities.h:
(isSVGSpace): Deleted
(isSVGSpaceOrComma): Updated
(skipOptionalSVGSpaces):
(skipOptionalSVGSpacesOrDelimiter): Both templates
* Source/WebCore/svg/SVGStringList.cpp:
(SVGStringList::parse):
* LayoutTests/svg/transforms/svg-formFeed-as-whitespace.html: Add Test Case
* LayoutTests/svg/transforms/svg-formFeed-as-whitespace-expected.html: Add Test Case Expectation
* LayoutTests/svg/transforms/svg-line-tabulation-as-not-whitespace.html: Add Test Case
* LayoutTests/svg/transforms/svg-line-tabulation-as-not-whitespace-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/273353@main">https://commits.webkit.org/273353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/384b9bff54f16729d033c88715ca7c775465e642

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37942 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31757 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11187 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11945 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31379 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10471 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10526 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39190 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32008 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31815 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36514 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34524 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12423 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31139 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8054 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11175 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->