### PR TITLE
Embedder should be able to ignore app utilities links

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -97,8 +97,18 @@
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/NavigationStateAdditions.mm>)
 #import <WebKitAdditions/NavigationStateAdditions.mm>
-#else
-#define NAVIGATION_STATE_DECIDE_POLICY_FOR_NAVIGATION_ACTION_ADDITIONS
+#endif
+
+#ifndef DEFINE_NAVIGATION_STATE_APPLICATION_UTILITIES_LINK_HANDLER
+#define DEFINE_NAVIGATION_STATE_APPLICATION_UTILITIES_LINK_HANDLER
+#endif
+
+#ifndef NAVIGATION_STATE_TRY_INTERCEPT_NAVIGATION
+#define NAVIGATION_STATE_TRY_INTERCEPT_NAVIGATION
+#endif
+
+#ifndef NAVIGATION_STATE_DECIDE_POLICY_FOR_NAVIGATION_ACTION_ALLOW_WITHOUT_APP_LINK
+#define NAVIGATION_STATE_DECIDE_POLICY_FOR_NAVIGATION_ACTION_ALLOW_WITHOUT_APP_LINK
 #endif
 
 namespace WebKit {
@@ -405,8 +415,12 @@ static void trySOAuthorization(Ref<API::NavigationAction>&& navigationAction, We
 #endif
 }
 
+DEFINE_NAVIGATION_STATE_APPLICATION_UTILITIES_LINK_HANDLER
+
 static void tryInterceptNavigation(Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, WTF::Function<void(bool)>&& completionHandler)
 {
+    NAVIGATION_STATE_TRY_INTERCEPT_NAVIGATION
+
 #if HAVE(APP_LINKS)
     if (navigationAction->shouldOpenAppLinks()) {
         auto url = navigationAction->request().url();
@@ -466,8 +480,6 @@ static bool isUnsupportedWebExtensionNavigation(API::NavigationAction& navigatio
 
 void NavigationState::NavigationClient::decidePolicyForNavigationAction(WebPageProxy& webPageProxy, Ref<API::NavigationAction>&& navigationAction, Ref<WebFramePolicyListenerProxy>&& listener)
 {
-    NAVIGATION_STATE_DECIDE_POLICY_FOR_NAVIGATION_ACTION_ADDITIONS
-
     bool subframeNavigation = navigationAction->targetFrame() && !navigationAction->targetFrame()->isMainFrame();
 
     RefPtr<API::WebsitePolicies> defaultWebsitePolicies;
@@ -581,6 +593,8 @@ void NavigationState::NavigationClient::decidePolicyForNavigationAction(WebPageP
                 break;
 
             case _WKNavigationActionPolicyAllowWithoutTryingAppLink:
+                NAVIGATION_STATE_DECIDE_POLICY_FOR_NAVIGATION_ACTION_ALLOW_WITHOUT_APP_LINK
+
                 trySOAuthorization(WTFMove(navigationAction), webPageProxy, [localListener = WTFMove(localListener), websitePolicies = WTFMove(apiWebsitePolicies)] (bool optimizedLoad) {
                     if (optimizedLoad) {
                         localListener->ignore(WasNavigationIntercepted::Yes);


### PR DESCRIPTION
#### 101cda37cddc0d04789cca1c0ac3a217ebb69dd6
<pre>
Embedder should be able to ignore app utilities links
<a href="https://bugs.webkit.org/show_bug.cgi?id=267874">https://bugs.webkit.org/show_bug.cgi?id=267874</a>
<a href="https://rdar.apple.com/121389168">rdar://121389168</a>

Reviewed by Brady Eidson.

Currently we unconditionally handle all WKApplicationUtilities links in WebKit without notifying the
embedder via the navigation delegate.

To be more consistent with other types of link handling, we should instead notify the navigation
delegate about such links, and only handle them in WebKit if the embedder responds to the delegate
callback telling us to process that link (e.g. via WKNavigationActionPolicyAllow).

* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::tryInterceptNavigation):
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationAction):

Canonical link: <a href="https://commits.webkit.org/273331@main">https://commits.webkit.org/273331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9303cfd964341c23a89b0f144cd364a5d4bf92c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37853 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11091 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31307 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10399 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39100 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31935 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31744 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10573 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/8504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/34458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8040 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->