### PR TITLE
Adopt more smart pointers under Source/WebCore/history/

### DIFF
--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -80,38 +80,39 @@ static inline void logBackForwardCacheFailureDiagnosticMessage(Page* page, const
 static bool canCacheFrame(LocalFrame& frame, DiagnosticLoggingClient& diagnosticLoggingClient, unsigned indentLevel)
 {
     PCLOG("+---");
-    FrameLoader& frameLoader = frame.loader();
+    CheckedRef frameLoader = frame.loader();
 
     // Prevent page caching if a subframe is still in provisional load stage.
     // We only do this check for subframes because the main frame is reused when navigating to a new page.
-    if (!frame.isMainFrame() && frameLoader.state() == FrameState::Provisional) {
+    if (!frame.isMainFrame() && frameLoader->state() == FrameState::Provisional) {
         PCLOG("   -Frame is in provisional load stage");
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::provisionalLoadKey());
         return false;
     }
 
-    if (frame.isMainFrame() && frameLoader.stateMachine().isDisplayingInitialEmptyDocument()) {
+    if (frame.isMainFrame() && frameLoader->stateMachine().isDisplayingInitialEmptyDocument()) {
         PCLOG("   -MainFrame is displaying initial empty document");
         return false;
     }
 
-    if (!frame.document()) {
+    RefPtr document = frame.document();
+    if (!document) {
         PCLOG("   -Frame has no document");
         return false;
     }
 
-    if (frame.document()->shouldPreventEnteringBackForwardCacheForTesting()) {
+    if (document->shouldPreventEnteringBackForwardCacheForTesting()) {
         PCLOG("   -Back/Forward caching is disabled for testing");
         return false;
     }
 
-    if (!frame.document()->frame()) {
+    if (!document->frame()) {
         PCLOG("   -Document is detached from frame");
         ASSERT_NOT_REACHED();
         return false;
     }
 
-    DocumentLoader* documentLoader = frameLoader.documentLoader();
+    RefPtr documentLoader = frameLoader->documentLoader();
     if (!documentLoader) {
         PCLOG("   -There is no DocumentLoader object");
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::noDocumentLoaderKey());
@@ -119,7 +120,7 @@ static bool canCacheFrame(LocalFrame& frame, DiagnosticLoggingClient& diagnostic
     }
 
     URL currentURL = documentLoader->url();
-    URL newURL = frameLoader.provisionalDocumentLoader() ? frameLoader.provisionalDocumentLoader()->url() : URL();
+    URL newURL = frameLoader->provisionalDocumentLoader() ? frameLoader->provisionalDocumentLoader()->url() : URL();
     if (!newURL.isEmpty())
         PCLOG(" Determining if frame can be cached navigating from (", currentURL.string(), ") to (", newURL.string(), "):");
     else
@@ -127,7 +128,7 @@ static bool canCacheFrame(LocalFrame& frame, DiagnosticLoggingClient& diagnostic
 
     bool isCacheable = true;
 
-    if (frame.isMainFrame() && frame.document()->quirks().shouldBypassBackForwardCache()) {
+    if (frame.isMainFrame() && document->quirks().shouldBypassBackForwardCache()) {
         PCLOG("   -Disabled by site-specific quirk");
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::siteSpecificQuirkKey());
         isCacheable = false;
@@ -139,12 +140,12 @@ static bool canCacheFrame(LocalFrame& frame, DiagnosticLoggingClient& diagnostic
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::isErrorPageKey());
         isCacheable = false;
     }
-    if (frame.isMainFrame() && frame.document() && frame.document()->url().protocolIs("https"_s) && documentLoader->response().cacheControlContainsNoStore()) {
+    if (frame.isMainFrame() && document && document->url().protocolIs("https"_s) && documentLoader->response().cacheControlContainsNoStore()) {
         PCLOG("   -Frame is HTTPS, and cache control prohibits storing");
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::httpsNoStoreKey());
         isCacheable = false;
     }
-    if (frame.isMainFrame() && !frameLoader.history().currentItem()) {
+    if (frame.isMainFrame() && !frameLoader->history().currentItem()) {
         PCLOG("   -Main frame has no current history item");
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::noCurrentHistoryItemKey());
         isCacheable = false;
@@ -154,7 +155,7 @@ static bool canCacheFrame(LocalFrame& frame, DiagnosticLoggingClient& diagnostic
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::visuallyEmptyKey());
         isCacheable = false;
     }
-    if (frameLoader.quickRedirectComing()) {
+    if (frameLoader->quickRedirectComing()) {
         PCLOG("   -Quick redirect is coming");
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::quirkRedirectComingKey());
         isCacheable = false;
@@ -177,14 +178,14 @@ static bool canCacheFrame(LocalFrame& frame, DiagnosticLoggingClient& diagnostic
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::applicationCacheKey());
         isCacheable = false;
     }
-    if (!frameLoader.client().canCachePage()) {
+    if (!frameLoader->client().canCachePage()) {
         PCLOG("   -The client says this frame cannot be cached");
         logBackForwardCacheFailureDiagnosticMessage(diagnosticLoggingClient, DiagnosticLoggingKeys::deniedByClientKey());
         isCacheable = false;
     }
 
     for (auto* child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
-        auto* localChild = dynamicDowncast<LocalFrame>(child);
+        RefPtr localChild = dynamicDowncast<LocalFrame>(child);
         if (!localChild)
             continue;
         if (!canCacheFrame(*localChild, diagnosticLoggingClient, indentLevel + 1))
@@ -204,8 +205,8 @@ static bool canCachePage(Page& page)
     unsigned indentLevel = 0;
     PCLOG("--------\n Determining if page can be cached:");
 
-    DiagnosticLoggingClient& diagnosticLoggingClient = page.diagnosticLoggingClient();
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
+    CheckedRef diagnosticLoggingClient = page.diagnosticLoggingClient();
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
     if (!localMainFrame)
         return false;
     bool isCacheable = canCacheFrame(*localMainFrame, diagnosticLoggingClient, indentLevel + 1);
@@ -278,9 +279,9 @@ static bool canCachePage(Page& page)
 
     // If this is a same-origin navigation and the navigated-to main resource serves the
     // `Clear-Site-Data: "cache"` HTTP header, then we shouldn't cache the current page.
-    if (auto* provisionalDocumentLoader = localMainFrame->loader().provisionalDocumentLoader()) {
+    if (RefPtr provisionalDocumentLoader = localMainFrame->loader().provisionalDocumentLoader()) {
         if (provisionalDocumentLoader->responseClearSiteDataValues().contains(ClearSiteDataValue::Cache)) {
-            if (auto* topDocument = localMainFrame->document()) {
+            if (RefPtr topDocument = localMainFrame->document()) {
                 if (topDocument->securityOrigin().isSameOriginAs(SecurityOrigin::create(provisionalDocumentLoader->response().url()))) {
                     PCLOG("   -`Clear-Site-Data: cache` HTTP header is present");
                     isCacheable = false;
@@ -294,7 +295,7 @@ static bool canCachePage(Page& page)
     else
         PCLOG(" Page CANNOT be cached\n--------");
 
-    diagnosticLoggingClient.logDiagnosticMessageWithResult(DiagnosticLoggingKeys::backForwardCacheKey(), DiagnosticLoggingKeys::canCacheKey(), isCacheable ? DiagnosticLoggingResultPass : DiagnosticLoggingResultFail, ShouldSample::No);
+    diagnosticLoggingClient->logDiagnosticMessageWithResult(DiagnosticLoggingKeys::backForwardCacheKey(), DiagnosticLoggingKeys::canCacheKey(), isCacheable ? DiagnosticLoggingResultPass : DiagnosticLoggingResultFail, ShouldSample::No);
     return isCacheable;
 }
 
@@ -364,20 +365,20 @@ unsigned BackForwardCache::frameCount() const
 void BackForwardCache::markPagesForDeviceOrPageScaleChanged(Page& page)
 {
     for (auto& item : m_items) {
-        CachedPage& cachedPage = *item->m_cachedPage;
+        CheckedRef cachedPage = *item->m_cachedPage;
         auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
-        if (localMainFrame == &cachedPage.cachedMainFrame()->view()->frame())
-            cachedPage.markForDeviceOrPageScaleChanged();
+        if (localMainFrame == &cachedPage->cachedMainFrame()->view()->frame())
+            cachedPage->markForDeviceOrPageScaleChanged();
     }
 }
 
 void BackForwardCache::markPagesForContentsSizeChanged(Page& page)
 {
     for (auto& item : m_items) {
-        CachedPage& cachedPage = *item->m_cachedPage;
+        CheckedRef cachedPage = *item->m_cachedPage;
         auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
-        if (localMainFrame == &cachedPage.cachedMainFrame()->view()->frame())
-            cachedPage.markForContentsSizeChanged();
+        if (localMainFrame == &cachedPage->cachedMainFrame()->view()->frame())
+            cachedPage->markForContentsSizeChanged();
     }
 }
 
@@ -386,7 +387,7 @@ void BackForwardCache::markPagesForCaptionPreferencesChanged()
 {
     for (auto& item : m_items) {
         ASSERT(item->m_cachedPage);
-        item->m_cachedPage->markForCaptionPreferencesChanged();
+        CheckedRef { *item->m_cachedPage }->markForCaptionPreferencesChanged();
     }
 }
 #endif
@@ -425,15 +426,15 @@ static void destroyRenderTree(LocalFrame& mainFrame)
             continue;
         if (!frame->document())
             continue;
-        auto& document = *frame->document();
-        if (document.hasLivingRenderTree())
-            document.destroyRenderTree();
+        Ref document = *frame->document();
+        if (document->hasLivingRenderTree())
+            document->destroyRenderTree();
     }
 }
 
 static void firePageHideEventRecursively(LocalFrame& frame)
 {
-    auto* document = frame.document();
+    RefPtr document = frame.document();
     if (!document)
         return;
 
@@ -441,25 +442,23 @@ static void firePageHideEventRecursively(LocalFrame& frame)
     // that the parent document's ignore-opens-during-unload counter should be incremented while the
     // pagehide event is being fired in its subframes:
     // https://html.spec.whatwg.org/multipage/browsers.html#unload-a-document
-    IgnoreOpensDuringUnloadCountIncrementer ignoreOpensDuringUnloadCountIncrementer(document);
+    IgnoreOpensDuringUnloadCountIncrementer ignoreOpensDuringUnloadCountIncrementer(document.get());
 
     frame.loader().stopLoading(UnloadEventPolicy::UnloadAndPageHide);
 
-    for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
-        RefPtr localChild = dynamicDowncast<LocalFrame>(child.get());
-        if (!localChild)
-            continue;
-        firePageHideEventRecursively(*localChild);
+    for (auto* child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
+        if (RefPtr localChild = dynamicDowncast<LocalFrame>(*child))
+            firePageHideEventRecursively(*localChild);
     }
 }
 
 std::unique_ptr<CachedPage> BackForwardCache::trySuspendPage(Page& page, ForceSuspension forceSuspension)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
     if (!localMainFrame)
         return nullptr;
 
-    localMainFrame->loader().stopForBackForwardCache();
+    localMainFrame->checkedLoader()->stopForBackForwardCache();
 
     if (forceSuspension == ForceSuspension::No && !canCache(page))
         return nullptr;
@@ -470,8 +469,8 @@ std::unique_ptr<CachedPage> BackForwardCache::trySuspendPage(Page& page, ForceSu
 
     // Focus the main frame, defocusing a focused subframe (if we have one). We do this here,
     // before the page enters the back/forward cache, while we still can dispatch DOM blur/focus events.
-    if (CheckedRef focusController { page.focusController() }; focusController->focusedLocalFrame())
-        focusController->setFocusedFrame(localMainFrame);
+    if (CheckedRef focusController = page.focusController(); focusController->focusedLocalFrame())
+        focusController->setFocusedFrame(localMainFrame.get());
 
     // Fire the pagehide event in all frames.
     firePageHideEventRecursively(*localMainFrame);
@@ -480,7 +479,7 @@ std::unique_ptr<CachedPage> BackForwardCache::trySuspendPage(Page& page, ForceSu
 
     // Stop all loads again before checking if we can still cache the page after firing the pagehide
     // event, since the page may have started ping loads in its pagehide event handler.
-    localMainFrame->loader().stopForBackForwardCache();
+    localMainFrame->checkedLoader()->stopForBackForwardCache();
 
     // Check that the page is still page-cacheable after firing the pagehide event. The JS event handlers
     // could have altered the page in a way that could prevent caching.
@@ -539,7 +538,7 @@ std::unique_ptr<CachedPage> BackForwardCache::take(HistoryItem& item, Page* page
     }
 
     m_items.remove(&item);
-    std::unique_ptr<CachedPage> cachedPage = item.takeCachedPage();
+    auto cachedPage = item.takeCachedPage();
 
     RELEASE_LOG(BackForwardCache, "BackForwardCache::take item: %s, size: %u / %u", item.identifier().toString().utf8().data(), pageCount(), maxSize());
 
@@ -565,7 +564,7 @@ void BackForwardCache::removeAllItemsForPage(Page& page)
         ++it;
         if (&(*current)->m_cachedPage->page() == &page) {
             RELEASE_LOG(BackForwardCache, "BackForwardCache::removeAllItemsForPage removing item: %s, size: %u / %u", (*current)->identifier().toString().utf8().data(), pageCount() - 1, maxSize());
-            (*current)->setCachedPage(nullptr);
+            RefPtr { *current }->setCachedPage(nullptr);
             m_items.remove(current);
         }
     }
@@ -573,7 +572,7 @@ void BackForwardCache::removeAllItemsForPage(Page& page)
 
 CachedPage* BackForwardCache::get(HistoryItem& item, Page* page)
 {
-    CachedPage* cachedPage = item.m_cachedPage.get();
+    CheckedPtr cachedPage = item.m_cachedPage.get();
     if (!cachedPage) {
         if (item.m_pruningReason != PruningReason::None)
             logBackForwardCacheFailureDiagnosticMessage(page, pruningReasonToDiagnosticLoggingKey(item.m_pruningReason));
@@ -586,7 +585,7 @@ CachedPage* BackForwardCache::get(HistoryItem& item, Page* page)
         remove(item);
         return nullptr;
     }
-    return cachedPage;
+    return cachedPage.get();
 }
 
 void BackForwardCache::remove(HistoryItem& item)
@@ -605,7 +604,7 @@ void BackForwardCache::remove(HistoryItem& item)
 void BackForwardCache::prune(PruningReason pruningReason)
 {
     while (pageCount() > maxSize()) {
-        auto oldestItem = m_items.takeFirst();
+        RefPtr oldestItem = m_items.takeFirst();
         oldestItem->setCachedPage(nullptr);
         oldestItem->m_pruningReason = pruningReason;
         RELEASE_LOG(BackForwardCache, "BackForwardCache::prune removing item: %s, size: %u / %u", oldestItem->identifier().toString().utf8().data(), pageCount(), maxSize());
@@ -621,7 +620,7 @@ void BackForwardCache::clearEntriesForOrigins(const HashSet<RefPtr<SecurityOrigi
         auto itemOrigin = SecurityOrigin::create((*current)->url());
         if (origins.contains(itemOrigin.ptr())) {
             RELEASE_LOG(BackForwardCache, "BackForwardCache::clearEntriesForOrigins removing item: %s, size: %u / %u", (*current)->identifier().toString().utf8().data(), pageCount() - 1, maxSize());
-            (*current)->setCachedPage(nullptr);
+            RefPtr { *current }->setCachedPage(nullptr);
             m_items.remove(current);
         }
     }

--- a/Source/WebCore/history/BackForwardController.cpp
+++ b/Source/WebCore/history/BackForwardController.cpp
@@ -56,6 +56,16 @@ RefPtr<HistoryItem> BackForwardController::forwardItem()
     return itemAtIndex(1);
 }
 
+Ref<Page> BackForwardController::protectedPage() const
+{
+    return m_page.get();
+}
+
+Ref<BackForwardClient> BackForwardController::protectedClient() const
+{
+    return m_client;
+}
+
 bool BackForwardController::canGoBackOrForward(int distance) const
 {
     if (!distance)
@@ -72,7 +82,7 @@ void BackForwardController::goBackOrForward(int distance)
     if (!distance)
         return;
 
-    auto historyItem = itemAtIndex(distance);
+    RefPtr historyItem = itemAtIndex(distance);
     if (!historyItem) {
         if (distance > 0) {
             if (int forwardCount = this->forwardCount())
@@ -86,67 +96,68 @@ void BackForwardController::goBackOrForward(int distance)
     if (!historyItem)
         return;
 
-    m_page.goToItem(*historyItem, FrameLoadType::IndexedBackForward, ShouldTreatAsContinuingLoad::No);
+    protectedPage()->goToItem(*historyItem, FrameLoadType::IndexedBackForward, ShouldTreatAsContinuingLoad::No);
 }
 
 bool BackForwardController::goBack()
 {
-    auto historyItem = backItem();
+    RefPtr historyItem = backItem();
     if (!historyItem)
         return false;
 
-    m_page.goToItem(*historyItem, FrameLoadType::Back, ShouldTreatAsContinuingLoad::No);
+    protectedPage()->goToItem(*historyItem, FrameLoadType::Back, ShouldTreatAsContinuingLoad::No);
     return true;
 }
 
 bool BackForwardController::goForward()
 {
-    auto historyItem = forwardItem();
+    RefPtr historyItem = forwardItem();
     if (!historyItem)
         return false;
 
-    m_page.goToItem(*historyItem, FrameLoadType::Forward, ShouldTreatAsContinuingLoad::No);
+    protectedPage()->goToItem(*historyItem, FrameLoadType::Forward, ShouldTreatAsContinuingLoad::No);
     return true;
 }
 
 void BackForwardController::addItem(Ref<HistoryItem>&& item)
 {
-    m_client->addItem(WTFMove(item));
+    protectedClient()->addItem(WTFMove(item));
 }
 
 void BackForwardController::setCurrentItem(HistoryItem& item)
 {
-    m_client->goToItem(item);
+    protectedClient()->goToItem(item);
 }
 
 bool BackForwardController::containsItem(const HistoryItem& item) const
 {
-    return m_client->containsItem(item);
+    return protectedClient()->containsItem(item);
 }
 
 unsigned BackForwardController::count() const
 {
-    return m_client->backListCount() + 1 + m_client->forwardListCount();
+    Ref client = m_client;
+    return client->backListCount() + 1 + client->forwardListCount();
 }
 
 unsigned BackForwardController::backCount() const
 {
-    return m_client->backListCount();
+    return protectedClient()->backListCount();
 }
 
 unsigned BackForwardController::forwardCount() const
 {
-    return m_client->forwardListCount();
+    return protectedClient()->forwardListCount();
 }
 
 RefPtr<HistoryItem> BackForwardController::itemAtIndex(int i)
 {
-    return m_client->itemAtIndex(i);
+    return protectedClient()->itemAtIndex(i);
 }
 
 void BackForwardController::close()
 {
-    m_client->close();
+    protectedClient()->close();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -28,6 +28,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -67,7 +68,10 @@ public:
     WEBCORE_EXPORT RefPtr<HistoryItem> forwardItem();
 
 private:
-    Page& m_page;
+    Ref<Page> protectedPage() const;
+    Ref<BackForwardClient> protectedClient() const;
+
+    SingleThreadWeakRef<Page> m_page;
     Ref<BackForwardClient> m_client;
 };
 

--- a/Source/WebCore/history/CachedFrame.h
+++ b/Source/WebCore/history/CachedFrame.h
@@ -49,6 +49,7 @@ public:
 
     Document* document() const { return m_document.get(); }
     FrameView* view() const { return m_view.get(); }
+    RefPtr<FrameView> protectedView() const;
     const URL& url() const { return m_url; }
     bool isMainFrame() { return m_isMainFrame; }
 

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -80,20 +80,18 @@ CachedPage::~CachedPage()
 static void firePageShowEvent(Page& page)
 {
     // Dispatching JavaScript events can cause frame destruction.
-    auto& mainFrame = page.mainFrame();
+    Ref mainFrame = page.mainFrame();
 
     Vector<Ref<LocalFrame>> childFrames;
-    for (auto* child = mainFrame.tree().traverseNextInPostOrder(CanWrap::Yes); child; child = child->tree().traverseNextInPostOrder(CanWrap::No)) {
-        auto* localChild = dynamicDowncast<LocalFrame>(child);
-        if (!localChild)
-            continue;
-        childFrames.append(*localChild);
+    for (auto* child = mainFrame->tree().traverseNextInPostOrder(CanWrap::Yes); child; child = child->tree().traverseNextInPostOrder(CanWrap::No)) {
+        if (RefPtr localChild = dynamicDowncast<LocalFrame>(child))
+            childFrames.append(localChild.releaseNonNull());
     }
 
     for (auto& child : childFrames) {
-        if (!child->tree().isDescendantOf(&mainFrame))
+        if (!child->tree().isDescendantOf(mainFrame.ptr()))
             continue;
-        auto* document = child->document();
+        RefPtr document = child->document();
         if (!document)
             continue;
 
@@ -109,16 +107,16 @@ public:
     CachedPageRestorationScope(Page& page)
         : m_page(page)
     {
-        m_page.setIsRestoringCachedPage(true);
+        m_page->setIsRestoringCachedPage(true);
     }
 
     ~CachedPageRestorationScope()
     {
-        m_page.setIsRestoringCachedPage(false);
+        m_page->setIsRestoringCachedPage(false);
     }
 
 private:
-    Page& m_page;
+    SingleThreadWeakRef<Page> m_page;
 };
 
 void CachedPage::restore(Page& page)
@@ -128,7 +126,7 @@ void CachedPage::restore(Page& page)
     ASSERT(m_cachedMainFrame->view()->frame().isMainFrame());
     ASSERT(!page.subframeCount());
 
-    auto& mainFrame = page.mainFrame();
+    Ref mainFrame = page.mainFrame();
     RefPtr localMainFrame = dynamicDowncast<LocalFrame>(mainFrame);
 
     CachedPageRestorationScope restorationScope(page);
@@ -145,7 +143,7 @@ void CachedPage::restore(Page& page)
             localMainFrame->selection().suppressScrolling();
 
         bool hadProhibitsScrolling = false;
-        auto* frameView = mainFrame.virtualView();
+        RefPtr frameView = mainFrame->virtualView();
         if (frameView) {
             hadProhibitsScrolling = frameView->prohibitsScrolling();
             frameView->setProhibitsScrolling(true);
@@ -156,14 +154,12 @@ void CachedPage::restore(Page& page)
         if (frameView)
             frameView->setProhibitsScrolling(hadProhibitsScrolling);
         if (localMainFrame)
-            localMainFrame->selection().restoreScrolling();
+            localMainFrame->checkedSelection()->restoreScrolling();
 #endif
     }
 
-    if (m_needsDeviceOrPageScaleChanged) {
-        if (auto* localMainFrame = dynamicDowncast<LocalFrame>(mainFrame))
-            localMainFrame->deviceOrPageScaleFactorChanged();
-    }
+    if (m_needsDeviceOrPageScaleChanged && localMainFrame)
+        localMainFrame->deviceOrPageScaleFactorChanged();
 
     page.setNeedsRecalcStyleInAllFrames();
 
@@ -173,15 +169,15 @@ void CachedPage::restore(Page& page)
 #endif
 
     if (m_needsUpdateContentsSize) {
-        if (auto* frameView = mainFrame.virtualView())
+        if (RefPtr frameView = mainFrame->virtualView())
             frameView->updateContentsSize();
     }
 
     firePageShowEvent(page);
 
     for (auto& domain : m_loadedSubresourceDomains) {
-        if (auto* localMainFrame = dynamicDowncast<LocalFrame>(mainFrame))
-            localMainFrame->loader().client().didLoadFromRegistrableDomain(WTFMove(domain));
+        if (localMainFrame)
+            localMainFrame->checkedLoader()->client().didLoadFromRegistrableDomain(WTFMove(domain));
     }
 
     clear();

--- a/Source/WebCore/history/CachedPage.h
+++ b/Source/WebCore/history/CachedPage.h
@@ -28,6 +28,7 @@
 #include "CachedFrame.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -44,7 +45,7 @@ public:
     WEBCORE_EXPORT void restore(Page&);
     void clear();
 
-    Page& page() const { return m_page; }
+    Page& page() const { return m_page.get(); }
     Document* document() const { return m_cachedMainFrame->document(); }
     DocumentLoader* documentLoader() const { return m_cachedMainFrame->documentLoader(); }
     RefPtr<DocumentLoader> protectedDocumentLoader() const;
@@ -62,7 +63,7 @@ public:
     void markForContentsSizeChanged() { m_needsUpdateContentsSize = true; }
 
 private:
-    Page& m_page;
+    SingleThreadWeakRef<Page> m_page;
     MonotonicTime m_expirationTime;
     std::unique_ptr<CachedFrame> m_cachedMainFrame;
 #if ENABLE(VIDEO)

--- a/Source/WebCore/page/DiagnosticLoggingClient.h
+++ b/Source/WebCore/page/DiagnosticLoggingClient.h
@@ -27,6 +27,7 @@
 
 #include "DiagnosticLoggingDomain.h"
 #include <variant>
+#include <wtf/CheckedPtr.h>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
@@ -44,7 +45,7 @@ struct DiagnosticLoggingDictionary {
     void set(String key, Payload value) { dictionary.set(WTFMove(key), WTFMove(value)); }
 };
 
-class DiagnosticLoggingClient {
+class DiagnosticLoggingClient : public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual void logDiagnosticMessage(const String& message, const String& description, ShouldSample) = 0;

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1279,6 +1279,11 @@ void LocalFrame::frameWasDisconnectedFromOwner() const
     protectedDocument()->detachFromFrame();
 }
 
+CheckedRef<FrameSelection> LocalFrame::checkedSelection() const
+{
+    return document()->selection();
+}
+
 #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)
 
 void LocalFrame::didAccessWindowProxyPropertyViaOpener(WindowProxyProperty property)

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -162,6 +162,7 @@ public:
 
     FrameSelection& selection() { return document()->selection(); }
     const FrameSelection& selection() const { return document()->selection(); }
+    CheckedRef<FrameSelection> checkedSelection() const;
     ScriptController& script() { return m_script; }
     const ScriptController& script() const { return m_script; }
     CheckedRef<ScriptController> checkedScript();


### PR DESCRIPTION
#### 40e9c18174eebf0b67720ece5abe096eb763d90f
<pre>
Adopt more smart pointers under Source/WebCore/history/
<a href="https://bugs.webkit.org/show_bug.cgi?id=267877">https://bugs.webkit.org/show_bug.cgi?id=267877</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::canCacheFrame):
(WebCore::canCachePage):
(WebCore::BackForwardCache::markPagesForDeviceOrPageScaleChanged):
(WebCore::BackForwardCache::markPagesForContentsSizeChanged):
(WebCore::BackForwardCache::markPagesForCaptionPreferencesChanged):
(WebCore::destroyRenderTree):
(WebCore::firePageHideEventRecursively):
(WebCore::BackForwardCache::trySuspendPage):
(WebCore::BackForwardCache::take):
(WebCore::BackForwardCache::removeAllItemsForPage):
(WebCore::BackForwardCache::get):
(WebCore::BackForwardCache::prune):
(WebCore::BackForwardCache::clearEntriesForOrigins):
* Source/WebCore/history/BackForwardController.cpp:
(WebCore::BackForwardController::protectedPage const):
(WebCore::BackForwardController::protectedClient const):
(WebCore::BackForwardController::goBackOrForward):
(WebCore::BackForwardController::goBack):
(WebCore::BackForwardController::goForward):
(WebCore::BackForwardController::addItem):
(WebCore::BackForwardController::setCurrentItem):
(WebCore::BackForwardController::containsItem const):
(WebCore::BackForwardController::count const):
(WebCore::BackForwardController::backCount const):
(WebCore::BackForwardController::forwardCount const):
(WebCore::BackForwardController::itemAtIndex):
(WebCore::BackForwardController::close):
* Source/WebCore/history/BackForwardController.h:
* Source/WebCore/history/CachedFrame.cpp:
(WebCore::CachedFrameBase::protectedView const):
(WebCore::CachedFrameBase::restore):
(WebCore::CachedFrame::CachedFrame):
(WebCore::CachedFrame::open):
(WebCore::CachedFrame::destroy):
* Source/WebCore/history/CachedFrame.h:
* Source/WebCore/history/CachedPage.cpp:
(WebCore::firePageShowEvent):
(WebCore::CachedPageRestorationScope::CachedPageRestorationScope):
(WebCore::CachedPageRestorationScope::~CachedPageRestorationScope):
(WebCore::CachedPage::restore):
* Source/WebCore/history/CachedPage.h:
(WebCore::CachedPage::page const):
* Source/WebCore/page/DiagnosticLoggingClient.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::checkedSelection const):
* Source/WebCore/page/LocalFrame.h:

Canonical link: <a href="https://commits.webkit.org/273326@main">https://commits.webkit.org/273326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e60d7d4dfa5b398e6209907e80cee321d9a1e9d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/13995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37837 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11066 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10390 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39084 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31917 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31723 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36455 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8490 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34445 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11086 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4524 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->