### PR TITLE
Use the highest QOS available when detecting content with DataDetectors

### DIFF
--- a/Source/WebCore/PAL/pal/cocoa/DataDetectorsCoreSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/DataDetectorsCoreSoftLink.h
@@ -71,4 +71,7 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, DataDetectorsCore, DDScanQueryCreate, DDScanQ
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, DataDetectorsCore, DDScanQueryCreateFromString, DDScanQueryRef, (CFAllocatorRef allocator, CFStringRef string, CFRange range), (allocator, string, range))
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, DataDetectorsCore, DDScannerCopyResultsWithOptions, CFArrayRef, (DDScannerRef scanner, DDScannerCopyResultsOptions options), (scanner, options))
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(PAL, DataDetectorsCore, DDResultDisableURLSchemeChecking, void, (), ())
+#if HAVE(DDSCANNER_QOS_CONFIGURATION)
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_HEADER(PAL, DataDetectorsCore, DDScannerSetQOS, void, (DDScannerRef scanner, DDQOS qos), (scanner, qos))
+#endif
 #endif // ENABLE(DATA_DETECTION)

--- a/Source/WebCore/PAL/pal/cocoa/DataDetectorsCoreSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/DataDetectorsCoreSoftLink.mm
@@ -70,4 +70,7 @@ SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, DataDetectorsCore, DDScanQueryCre
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, DataDetectorsCore, DDScanQueryCreateFromString, DDScanQueryRef, (CFAllocatorRef allocator, CFStringRef string, CFRange range), (allocator, string, range), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, DataDetectorsCore, DDScannerCopyResultsWithOptions, CFArrayRef, (DDScannerRef scanner, DDScannerCopyResultsOptions options), (scanner, options), PAL_EXPORT)
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, DataDetectorsCore, DDResultDisableURLSchemeChecking, void, (), (), PAL_EXPORT)
+#if HAVE(DDSCANNER_QOS_CONFIGURATION)
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, DataDetectorsCore, DDScannerSetQOS, void, (DDScannerRef scanner, DDQOS qos), (scanner, qos), PAL_EXPORT)
+#endif
 #endif // ENABLE(DATA_DETECTION)

--- a/Source/WebCore/PAL/pal/spi/cocoa/DataDetectorsCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/DataDetectorsCoreSPI.h
@@ -30,6 +30,8 @@ typedef struct __DDResult *DDResultRef;
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <DataDetectorsCore/DDBinderKeys_Private.h>
+#import <DataDetectorsCore/DDScanQuery_Private.h>
+#import <DataDetectorsCore/DDScanner.h>
 #import <DataDetectorsCore/DDScannerResult.h>
 #import <DataDetectorsCore/DataDetectorsCore.h>
 
@@ -86,6 +88,14 @@ typedef enum __DDTextFragmentType {
     DDTextFragmentTypeIgnoreCRLF =  0x2,
 } DDTextFragmentMode;
 
+#if HAVE(DDSCANNER_QOS_CONFIGURATION)
+typedef enum __DDQOS {
+    DDQOSRegular = 0
+    DDQOSEnhanced = 2,
+    DDQOSHighest = 4,
+} DDQOS;
+#endif
+
 extern CFStringRef const DDBinderHttpURLKey;
 extern CFStringRef const DDBinderWebURLKey;
 extern CFStringRef const DDBinderMailURLKey;
@@ -113,12 +123,44 @@ typedef struct __DDQueryRange {
     DDQueryOffset end;
 } DDQueryRange;
 
+typedef struct __DDQueryFragment {
+    CFStringRef string;
+    void *identifier;
+    CFRange range;
+    CFIndex absoluteOffset;
+    CFIndex contextOffset:26;
+    DDTextCoalescingType coalescing:3;
+    DDTextFragmentMode mode:2;
+    Boolean lineBreakDoesNotCoalesce:1;
+} DDQueryFragment;
+
+struct __DDScanQuery {
+    uint8_t _cfBase[16]; // 16 bytes; the size of the real type, CFRuntimeBase.
+    DDQueryFragment *fragments;
+    CFIndex capacity;
+    CFIndex numberOfFragments;
+    void (*releaseCallBack)(void * context, void * identifier);
+    void *context;
+};
+
 #endif // !USE(APPLE_INTERNAL_SDK)
 
 static_assert(sizeof(DDQueryOffset) == 8, "DDQueryOffset is no longer 8 bytes. Update the definition of DDQueryOffset in this file to match the new size.");
 
 typedef struct __DDScanQuery *DDScanQueryRef;
 typedef struct __DDScanner *DDScannerRef;
+
+#if !USE(APPLE_INTERNAL_SDK)
+static inline DDQueryFragment *DDScanQueryGetFragmentAtIndex(DDScanQueryRef query, CFIndex anIndex)
+{
+    return &query->fragments[anIndex];
+}
+
+static inline CFIndex _DDScanQueryGetNumberOfFragments(DDScanQueryRef query)
+{
+    return query->numberOfFragments;
+}
+#endif
 
 typedef CFIndex DDScannerCopyResultsOptions;
 typedef CFIndex DDScannerOptions;
@@ -148,7 +190,11 @@ bool DDResultHasProperties(DDResultRef, CFIndex propertySet);
 CFArrayRef DDResultGetSubResults(DDResultRef);
 DDQueryRange DDResultGetQueryRangeForURLification(DDResultRef);
 void DDResultDisableURLSchemeChecking();
+
+#if HAVE(DDSCANNER_QOS_CONFIGURATION)
+void DDScannerSetQOS(DDScannerRef, DDQOS);
+#endif
+
 WTF_EXTERN_C_END
 
 #endif
-

--- a/Source/WebCore/editing/cocoa/DataDetection.h
+++ b/Source/WebCore/editing/cocoa/DataDetection.h
@@ -31,6 +31,7 @@
 #import "FloatRect.h"
 #import "SimpleRange.h"
 #import <wtf/OptionSet.h>
+
 #import <wtf/RetainPtr.h>
 
 #if HAVE(SECURE_ACTION_CONTEXT)
@@ -43,6 +44,10 @@ using WKDDActionContext = DDActionContext;
 OBJC_CLASS NSArray;
 OBJC_CLASS NSDictionary;
 
+typedef struct __DDResult *DDResultRef;
+typedef struct __DDScanQuery *DDScanQueryRef;
+typedef struct __DDScanner *DDScannerRef;
+
 namespace WebCore {
 
 class Document;
@@ -50,6 +55,7 @@ class HTMLDivElement;
 class HTMLElement;
 class HitTestResult;
 class QualifiedName;
+class LocalFrame;
 struct TextRecognitionDataDetector;
 
 struct DetectedItem {
@@ -63,7 +69,8 @@ public:
 #if PLATFORM(MAC)
     WEBCORE_EXPORT static std::optional<DetectedItem> detectItemAroundHitTestResult(const HitTestResult&);
 #endif
-    WEBCORE_EXPORT static NSArray *detectContentInRange(const SimpleRange&, OptionSet<DataDetectorType>, std::optional<double> referenceDate);
+    WEBCORE_EXPORT static void detectContentInFrame(LocalFrame*, OptionSet<DataDetectorType>, std::optional<double>, CompletionHandler<void(NSArray *)>&&);
+    WEBCORE_EXPORT static NSArray * detectContentInRange(const SimpleRange&, OptionSet<DataDetectorType>, std::optional<double> referenceDate);
     WEBCORE_EXPORT static std::optional<double> extractReferenceDate(NSDictionary *);
     WEBCORE_EXPORT static void removeDataDetectedLinksInDocument(Document&);
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -325,7 +325,7 @@ public:
 
     Frame& mainFrame() { return m_mainFrame.get(); }
     const Frame& mainFrame() const { return m_mainFrame.get(); }
-    Ref<Frame> protectedMainFrame() const;
+    WEBCORE_EXPORT Ref<Frame> protectedMainFrame() const;
     WEBCORE_EXPORT void setMainFrame(Ref<Frame>&&);
     const URL& mainFrameURL() const { return m_mainFrameURL; }
     WEBCORE_EXPORT void setMainFrameURL(const URL&);

--- a/Source/WebKit/Shared/Cocoa/DataDetectionResult.h
+++ b/Source/WebKit/Shared/Cocoa/DataDetectionResult.h
@@ -35,6 +35,7 @@
 namespace WebKit {
 
 struct DataDetectionResult {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
     RetainPtr<NSArray> results;
 };
 


### PR DESCRIPTION
#### 0d7c0048ca22e42c1c974a3a832562d8fec781e0
<pre>
Use the highest QOS available when detecting content with DataDetectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=267879">https://bugs.webkit.org/show_bug.cgi?id=267879</a>
<a href="https://rdar.apple.com/118585870">rdar://118585870</a>

Reviewed by Aditya Keerthi.

Use the highest QOS available when creating a DDScanner.

To facilitate this, make the content data detection mechanism async.

* Source/WebCore/PAL/pal/spi/cocoa/DataDetectorsCoreSPI.h:
* Source/WebCore/editing/cocoa/DataDetection.h:
* Source/WebCore/editing/cocoa/DataDetection.mm:
(WebCore::buildQuery):
(WebCore::workQueue):
(WebCore::parseAllResultRanges):
(WebCore::DDQueryFragmentCore::operator== const):
(WebCore::getFragmentsFromQuery):
(WebCore::processDataDetectorScannerResults):
(WebCore::DataDetection::detectContentInFrame):
(WebCore::DataDetection::detectContentInRange):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
* Source/WebKit/Shared/Cocoa/DataDetectionResult.h:
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm:
(-[WKWebProcessPlugInRangeHandle detectDataWithTypes:context:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::detectDataInFrame):
(WebKit::WebPage::detectDataInAllFrames):

Canonical link: <a href="https://commits.webkit.org/274699@main">https://commits.webkit.org/274699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7454edf527f9c99a38ef7d933990dc06afe1a4c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42340 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/35698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16137 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15847 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43619 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36137 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12021 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16230 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16278 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5235 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->