### PR TITLE
Rename VideoFullscreenInterfaceAVKit to VideoFullscreenInterfaceIOS

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -552,7 +552,7 @@ platform/ios/UIFoundationSoftLink.mm
 platform/ios/UIViewControllerUtilities.mm
 platform/ios/UserAgentIOS.mm
 platform/ios/ValidationBubbleIOS.mm
-platform/ios/VideoFullscreenInterfaceAVKit.mm @no-unify
+platform/ios/VideoFullscreenInterfaceIOS.mm @no-unify
 platform/ios/WebAVPlayerController.mm
 platform/ios/WebBackgroundTaskController.mm
 platform/ios/WebCoreMotionManager.mm

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -150,7 +150,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 #include "RuntimeApplicationChecks.h"
-#include "VideoFullscreenInterfaceAVKit.h"
+#include "VideoFullscreenInterfaceIOS.h"
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Source/WebCore/platform/graphics/PlatformVideoFullscreenInterface.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoFullscreenInterface.h
@@ -28,13 +28,13 @@
 namespace WebCore {
 
 class NullVideoFullscreenInterface;
-class VideoFullscreenInterfaceAVKit;
+class VideoFullscreenInterfaceIOS;
 class VideoFullscreenInterfaceMac;
 
 #if PLATFORM(WATCHOS)
 using PlatformVideoFullscreenInterface = NullVideoFullscreenInterface;
 #elif PLATFORM(IOS_FAMILY)
-using PlatformVideoFullscreenInterface = VideoFullscreenInterfaceAVKit;
+using PlatformVideoFullscreenInterface = VideoFullscreenInterfaceIOS;
 #elif PLATFORM(MAC)
 using PlatformVideoFullscreenInterface = VideoFullscreenInterfaceMac;
 #endif

--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceIOS.h
@@ -61,14 +61,14 @@ namespace WebCore {
 class FloatRect;
 class FloatSize;
 
-class VideoFullscreenInterfaceAVKit final
+class VideoFullscreenInterfaceIOS final
     : public VideoPresentationModelClient
     , public PlaybackSessionModelClient
     , public VideoFullscreenCaptions
-    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoFullscreenInterfaceAVKit, WTF::DestructionThread::MainRunLoop> {
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoFullscreenInterfaceIOS, WTF::DestructionThread::MainRunLoop> {
 public:
-    WEBCORE_EXPORT static Ref<VideoFullscreenInterfaceAVKit> create(PlaybackSessionInterfaceAVKit&);
-    virtual ~VideoFullscreenInterfaceAVKit();
+    WEBCORE_EXPORT static Ref<VideoFullscreenInterfaceIOS> create(PlaybackSessionInterfaceAVKit&);
+    WEBCORE_EXPORT virtual ~VideoFullscreenInterfaceIOS();
     WEBCORE_EXPORT void setVideoPresentationModel(VideoPresentationModel*);
     PlaybackSessionInterfaceAVKit& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
@@ -166,12 +166,12 @@ public:
 #if !RELEASE_LOG_DISABLED
     const void* logIdentifier() const;
     const Logger* loggerPtr() const;
-    const char* logClassName() const { return "VideoFullscreenInterfaceAVKit"; };
+    const char* logClassName() const { return "VideoFullscreenInterfaceIOS"; };
     WTFLogChannel& logChannel() const;
 #endif
 
 private:
-    WEBCORE_EXPORT VideoFullscreenInterfaceAVKit(PlaybackSessionInterfaceAVKit&);
+    WEBCORE_EXPORT VideoFullscreenInterfaceIOS(PlaybackSessionInterfaceAVKit&);
 
     void doSetup();
     void finalizeSetup();

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -36,7 +36,7 @@
 #import "PlaybackSessionModelMediaElement.h"
 #import "RenderVideo.h"
 #import "TimeRanges.h"
-#import "VideoFullscreenInterfaceAVKit.h"
+#import "VideoFullscreenInterfaceIOS.h"
 #import "VideoPresentationModelVideoElement.h"
 #import "WebCoreThreadRun.h"
 #import <QuartzCore/CoreAnimation.h>
@@ -212,7 +212,7 @@ private:
 
     HashSet<CheckedPtr<PlaybackSessionModelClient>> m_playbackClients;
     HashSet<CheckedPtr<VideoPresentationModelClient>> m_presentationClients;
-    RefPtr<VideoFullscreenInterfaceAVKit> m_interface;
+    RefPtr<VideoFullscreenInterfaceIOS> m_interface;
     RefPtr<VideoPresentationModelVideoElement> m_presentationModel;
     RefPtr<PlaybackSessionModelMediaElement> m_playbackModel;
     RefPtr<HTMLVideoElement> m_videoElement;
@@ -1009,7 +1009,7 @@ void VideoFullscreenControllerContext::setUpFullscreen(HTMLVideoElement& videoEl
         WebThreadLock();
 
         Ref<PlaybackSessionInterfaceAVKit> sessionInterface = PlaybackSessionInterfaceAVKit::create(*this);
-        m_interface = VideoFullscreenInterfaceAVKit::create(sessionInterface.get());
+        m_interface = VideoFullscreenInterfaceIOS::create(sessionInterface.get());
         m_interface->setVideoPresentationModel(this);
 
         m_videoFullscreenView = adoptNS([PAL::allocUIViewInstance() init]);

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -43,7 +43,7 @@
 #import <WebCore/MediaPlayerEnums.h>
 #import <WebCore/NullVideoFullscreenInterface.h>
 #import <WebCore/TimeRanges.h>
-#import <WebCore/VideoFullscreenInterfaceAVKit.h>
+#import <WebCore/VideoFullscreenInterfaceIOS.h>
 #import <WebCore/VideoFullscreenInterfaceMac.h>
 #import <WebCore/WebAVPlayerLayer.h>
 #import <WebCore/WebAVPlayerLayerView.h>

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -39,7 +39,7 @@
 #import "WebPageProxy.h"
 #import "WebPreferences.h"
 #import <WebCore/LocalizedStrings.h>
-#import <WebCore/VideoFullscreenInterfaceAVKit.h>
+#import <WebCore/VideoFullscreenInterfaceIOS.h>
 #import <pal/spi/cocoa/AVKitSPI.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakObjCPtr.h>

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -47,7 +47,7 @@
 #import <WebCore/GeometryUtilities.h>
 #import <WebCore/IntRect.h>
 #import <WebCore/LocalizedStrings.h>
-#import <WebCore/VideoFullscreenInterfaceAVKit.h>
+#import <WebCore/VideoFullscreenInterfaceIOS.h>
 #import <WebCore/VideoPresentationModel.h>
 #import <WebCore/ViewportArguments.h>
 #import <objc/runtime.h>


### PR DESCRIPTION
#### 78ed1f1974b1a600f57bba1b75cc714d53548034
<pre>
Rename VideoFullscreenInterfaceAVKit to VideoFullscreenInterfaceIOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=267884">https://bugs.webkit.org/show_bug.cgi?id=267884</a>
<a href="https://rdar.apple.com/121399424">rdar://121399424</a>

Reviewed by Andy Estes.

Rename VideoFullscreenInterfaceAVKit to VideoFullscreenInterfaceIOS for future
refactoring.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.cpp:
* Source/WebCore/platform/graphics/PlatformVideoFullscreenInterface.h:
* Source/WebCore/platform/ios/VideoFullscreenInterfaceIOS.h: Renamed from Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h.
* Source/WebCore/platform/ios/VideoFullscreenInterfaceIOS.mm: Renamed from Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm.
(clearUIColor):
(boolString):
(-[WebAVPlayerViewControllerDelegate fullscreenInterface]):
(-[WebAVPlayerViewControllerDelegate setFullscreenInterface:]):
(-[WebAVPlayerViewControllerDelegate playerViewControllerWillStartPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate playerViewControllerDidStartPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate playerViewController:failedToStartPictureInPictureWithError:]):
(-[WebAVPlayerViewControllerDelegate playerViewControllerWillStopPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate playerViewControllerDidStopPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate playerViewControllerShouldAutomaticallyDismissAtPictureInPictureStart:]):
(convertToExitFullScreenReason):
(-[WebAVPlayerViewControllerDelegate playerViewController:shouldExitFullScreenWithReason:]):
(-[WebAVPlayerViewControllerDelegate playerViewController:restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:]):
(-[WebAVPlayerViewControllerDelegate playerViewControllerShouldStartPictureInPictureFromInlineWhenEnteringBackground:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureControllerWillStartPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureControllerDidStartPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureController:failedToStartPictureInPictureWithError:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureControllerWillStopPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureControllerDidStopPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureController:restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:]):
(WebAVPictureInPictureContentViewController_initWithController):
(WebAVPictureInPictureContentViewController_controller):
(WebAVPictureInPictureContentViewController_playerLayer):
(WebAVPictureInPictureContentViewController_setPlayerLayer):
(WebAVPictureInPictureContentViewController_viewWillLayoutSubviews):
(WebAVPictureInPictureContentViewController_dealloc):
(allocWebAVPictureInPictureContentViewControllerInstance):
(-[WebAVPlayerViewController initWithFullscreenInterface:]):
(-[WebAVPlayerViewController configurePlayerViewControllerWithFullscreenInterface:]):
(-[WebAVPlayerViewController dealloc]):
(-[WebAVPlayerViewController playerViewControllerShouldHandleDoneButtonTap:]):
(-[WebAVPlayerViewController setWebKitOverrideRouteSharingPolicy:routingContextUID:]):
(-[WebAVPlayerViewController enterFullScreenAnimated:completionHandler:]):
(-[WebAVPlayerViewController exitFullScreenAnimated:completionHandler:]):
(-[WebAVPlayerViewController observeValueForKeyPath:ofObject:change:context:]):
(-[WebAVPlayerViewController initObserver]):
(-[WebAVPlayerViewController removeObserver]):
(-[WebAVPlayerViewController MY_NO_RETURN]):
(-[WebAVPlayerViewController isPictureInPicturePossible]):
(-[WebAVPlayerViewController isPictureInPictureActive]):
(-[WebAVPlayerViewController pictureInPictureActive]):
(-[WebAVPlayerViewController pictureInPictureWasStartedWhenEnteringBackground]):
(-[WebAVPlayerViewController view]):
(-[WebAVPlayerViewController flashPlaybackControlsWithDuration:]):
(-[WebAVPlayerViewController showsPlaybackControls]):
(-[WebAVPlayerViewController setShowsPlaybackControls:]):
(-[WebAVPlayerViewController setAllowsPictureInPicturePlayback:]):
(-[WebAVPlayerViewController setDelegate:]):
(-[WebAVPlayerViewController setPlayerController:]):
(-[WebAVPlayerViewController avPlayerViewController]):
(-[WebAVPlayerViewController removeFromParentViewController]):
(-[WebAVPlayerViewController logIdentifier]):
(-[WebAVPlayerViewController loggerPtr]):
(-[WebAVPlayerViewController logChannel]):
(VideoFullscreenInterfaceIOS::create):
(VideoFullscreenInterfaceIOS::VideoFullscreenInterfaceIOS):
(VideoFullscreenInterfaceIOS::~VideoFullscreenInterfaceIOS):
(VideoFullscreenInterfaceIOS::playerController const):
(VideoFullscreenInterfaceIOS::avPlayerViewController const):
(VideoFullscreenInterfaceIOS::setVideoPresentationModel):
(VideoFullscreenInterfaceIOS::hasVideoChanged):
(VideoFullscreenInterfaceIOS::videoDimensionsChanged):
(VideoFullscreenInterfaceIOS::externalPlaybackChanged):
(VideoFullscreenInterfaceIOS::pictureInPictureWasStartedWhenEnteringBackground const):
(fallbackViewController):
(VideoFullscreenInterfaceIOS::presentingViewController):
(VideoFullscreenInterfaceIOS::applicationDidBecomeActive):
(VideoFullscreenInterfaceIOS::setupFullscreen):
(VideoFullscreenInterfaceIOS::enterFullscreen):
(VideoFullscreenInterfaceIOS::exitFullscreen):
(VideoFullscreenInterfaceIOS::exitFullscreenWithoutAnimationToMode):
(VideoFullscreenInterfaceIOS::cleanupFullscreen):
(VideoFullscreenInterfaceIOS::invalidate):
(VideoFullscreenInterfaceIOS::setPlayerIdentifier):
(VideoFullscreenInterfaceIOS::requestHideAndExitFullscreen):
(VideoFullscreenInterfaceIOS::preparedToReturnToInline):
(VideoFullscreenInterfaceIOS::preparedToExitFullscreen):
(VideoFullscreenInterfaceIOS::mayAutomaticallyShowVideoPictureInPicture const):
(VideoFullscreenInterfaceIOS::prepareForPictureInPictureStop):
(VideoFullscreenInterfaceIOS::willStartPictureInPicture):
(VideoFullscreenInterfaceIOS::didStartPictureInPicture):
(VideoFullscreenInterfaceIOS::failedToStartPictureInPicture):
(VideoFullscreenInterfaceIOS::willStopPictureInPicture):
(VideoFullscreenInterfaceIOS::didStopPictureInPicture):
(VideoFullscreenInterfaceIOS::prepareForPictureInPictureStopWithCompletionHandler):
(VideoFullscreenInterfaceIOS::shouldExitFullscreenWithReason):
(VideoFullscreenInterfaceIOS::setHasVideoContentLayer):
(VideoFullscreenInterfaceIOS::setInlineRect):
(VideoFullscreenInterfaceIOS::doSetup):
(VideoFullscreenInterfaceIOS::preparedToReturnToStandby):
(VideoFullscreenInterfaceIOS::finalizeSetup):
(VideoFullscreenInterfaceIOS::doEnterFullscreen):
(VideoFullscreenInterfaceIOS::doExitFullscreen):
(VideoFullscreenInterfaceIOS::exitFullscreenHandler):
(VideoFullscreenInterfaceIOS::enterFullscreenHandler):
(VideoFullscreenInterfaceIOS::returnToStandby):
(VideoFullscreenInterfaceIOS::watchdogTimerFired):
(VideoFullscreenInterfaceIOS::setMode):
(VideoFullscreenInterfaceIOS::clearMode):
(VideoFullscreenInterfaceIOS::isPlayingVideoInEnhancedFullscreen const):
(VideoFullscreenInterfaceIOS::logIdentifier const):
(VideoFullscreenInterfaceIOS::loggerPtr const):
(VideoFullscreenInterfaceIOS::logChannel const):
(WebCore::setSupportsPictureInPicture):
(WebCore::supportsPictureInPicture):
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
(VideoFullscreenControllerContext::setUpFullscreen):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:

Canonical link: <a href="https://commits.webkit.org/273363@main">https://commits.webkit.org/273363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b671a651cec9e63b5337dd90498889828c2d899

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37858 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31696 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30625 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31311 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10404 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10495 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39105 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31746 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36470 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8506 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34461 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12362 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8063 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11106 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11424 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->