### PR TITLE
Clean up some JSC entitlements.

### DIFF
--- a/Source/JavaScriptCore/Scripts/process-entitlements.sh
+++ b/Source/JavaScriptCore/Scripts/process-entitlements.sh
@@ -97,14 +97,18 @@ function maccatalyst_process_testapi_entitlements()
 
 function ios_family_process_jsc_entitlements()
 {
-    plistbuddy Add :com.apple.private.verified-jit bool YES
-    plistbuddy Add :dynamic-codesigning bool YES
+    if [[ "${WK_PLATFORM_NAME}" != watchos ]]; then
+        plistbuddy Add :com.apple.private.verified-jit bool YES
+        if (( "${WK_PLATFORM_NAME}" == iphoneos && $(( ${SDK_VERSION_ACTUAL} )) >= 170400
+            || "${WK_PLATFORM_NAME}" == appletvos && $(( ${SDK_VERSION_ACTUAL} )) >= 170400
+            || "${WK_PLATFORM_NAME}" == xros && $(( ${SDK_VERSION_ACTUAL} )) >= 10100 ))
+        then
+            plistbuddy Add :com.apple.developer.cs.allow-jit bool YES
+        else
+            plistbuddy Add :dynamic-codesigning bool YES
+        fi
+    fi
     plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
-}
-
-function ios_family_process_testapi_entitlements()
-{
-    ios_family_process_jsc_entitlements
 }
 
 rm -f "${WK_PROCESSED_XCENT_FILE}"
@@ -152,13 +156,13 @@ then
     if [[ "${PRODUCT_NAME}" == jsc ||
           "${PRODUCT_NAME}" == dynbench ||
           "${PRODUCT_NAME}" == minidom ||
+          "${PRODUCT_NAME}" == testapi ||
           "${PRODUCT_NAME}" == testair ||
           "${PRODUCT_NAME}" == testb3 ||
           "${PRODUCT_NAME}" == testdfg ||
           "${PRODUCT_NAME}" == testmasm ||
           "${PRODUCT_NAME}" == testmem ||
           "${PRODUCT_NAME}" == testRegExp ]]; then ios_family_process_jsc_entitlements
-    elif [[ "${PRODUCT_NAME}" == testapi ]]; then ios_family_process_testapi_entitlements
     else echo "Unsupported/unknown product: ${PRODUCT_NAME}"
     fi
 else

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -159,7 +159,7 @@ static bool isJITEnabled()
 {
     bool jitEnabled = !g_jscConfig.jitDisabled;
 #if HAVE(IOS_JIT_RESTRICTIONS)
-    jitEnabled = jitEnabled && processHasEntitlement("dynamic-codesigning"_s);
+    jitEnabled = jitEnabled && (processHasEntitlement("dynamic-codesigning"_s) || processHasEntitlement("com.apple.developer.cs.allow-jit"_s));
 #elif HAVE(MAC_JIT_RESTRICTIONS) && USE(APPLE_INTERNAL_SDK)
     jitEnabled = jitEnabled && processHasEntitlement("com.apple.security.cs.allow-jit"_s);
 #endif
@@ -179,7 +179,7 @@ void ExecutableAllocator::disableJIT()
 
 #if HAVE(IOS_JIT_RESTRICTIONS) || HAVE(MAC_JIT_RESTRICTIONS) && USE(APPLE_INTERNAL_SDK)
 #if HAVE(IOS_JIT_RESTRICTIONS)
-    bool shouldDisableJITMemory = processHasEntitlement("dynamic-codesigning"_s);
+    bool shouldDisableJITMemory = processHasEntitlement("dynamic-codesigning"_s) || processHasEntitlement("com.apple.developer.cs.allow-jit"_s);
 #else
     bool shouldDisableJITMemory = processHasEntitlement("com.apple.security.cs.allow-jit"_s) && !isKernOpenSource();
 #endif

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -370,10 +370,16 @@ fi
 
 function ios_family_process_webcontent_entitlements()
 {
-    if [[ "${WK_PLATFORM_NAME}" != watchos ]]
-    then
+    if [[ "${WK_PLATFORM_NAME}" != watchos ]]; then
         plistbuddy Add :com.apple.private.verified-jit bool YES
-        plistbuddy Add :dynamic-codesigning bool YES
+        if (( "${WK_PLATFORM_NAME}" == iphoneos && $(( ${SDK_VERSION_ACTUAL} )) >= 170400
+            || "${WK_PLATFORM_NAME}" == appletvos && $(( ${SDK_VERSION_ACTUAL} )) >= 170400
+            || "${WK_PLATFORM_NAME}" == xros && $(( ${SDK_VERSION_ACTUAL} )) >= 10100 ))
+        then
+            plistbuddy Add :com.apple.developer.cs.allow-jit bool YES
+        else
+            plistbuddy Add :dynamic-codesigning bool YES
+        fi
     fi
     plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
 


### PR DESCRIPTION
#### 587d1796e7a87d4f66a3b58a8e938c27208d9cd0
<pre>
Clean up some JSC entitlements.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267886">https://bugs.webkit.org/show_bug.cgi?id=267886</a>
<a href="https://rdar.apple.com/121395716">rdar://121395716</a>

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/Scripts/process-entitlements.sh:
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::isJITEnabled):
(JSC::ExecutableAllocator::disableJIT):
* Source/WebKit/Scripts/process-entitlements.sh:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/587d1796e7a87d4f66a3b58a8e938c27208d9cd0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39610 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33092 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31609 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11716 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/37252 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11736 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33415 "Found 2 new test failures: fast/images/avif-as-image.html, fast/images/avif-heif-container-as-image.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40864 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/30974 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33547 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33956 "Found 4 new test failures: fast/images/avif-as-image.html, fast/images/avif-heif-container-as-image.html, fast/images/avif-image-decoding.html, fast/images/avif-image-document.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37641 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/36732 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35775 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13684 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/43591 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12414 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8996 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12948 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->