### PR TITLE
[git-webkit] Prefer hash over identifier in relationships

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/trace.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/trace.py
@@ -121,6 +121,8 @@ class Relationship(object):
                 secondary = match.group('secondary')
                 if secondary:
                     secondary = UNPACK_SECONDARY_RE.match(secondary).groups()[0]
+                if secondary and Commit.HASH_RE.match(secondary):
+                    primary, secondary = secondary, primary
                 return type, [ref.rstrip() for ref in [primary, secondary] if ref]
         return None, []
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py
@@ -42,7 +42,7 @@ class TestRelationship(TestCase):
             ))
         )
         self.assertEqual(
-            ('original', ['123@main', '0123456789ab']), Relationship.parse(Commit(
+            ('original', ['0123456789ab', '123@main']), Relationship.parse(Commit(
                 hash='deadbeef1234', revision=1234, identifier='1234@main',
                 message='Cherry-pick 123@main (0123456789ab). <rdar://54321>',
             ))
@@ -80,7 +80,7 @@ class TestRelationship(TestCase):
 
     def test_revert(self):
         self.assertEqual(
-            ('reverts', ['1230@main', '0123456789ab']), Relationship.parse(Commit(
+            ('reverts', ['0123456789ab', '1230@main']), Relationship.parse(Commit(
                 hash='deadbeef1234', revision=1234, identifier='1234@main',
                 message='Reverts 1230@main (0123456789ab)',
             ))
@@ -94,7 +94,7 @@ class TestRelationship(TestCase):
 
     def test_follow_up(self):
         self.assertEqual(
-            ('follow-up to', ['1230@main', '0123456789ab']), Relationship.parse(Commit(
+            ('follow-up to', ['0123456789ab', '1230@main']), Relationship.parse(Commit(
                 hash='deadbeef1234', revision=1234, identifier='1234@main',
                 message='Fix following 1230@main (0123456789ab)',
             ))
@@ -120,7 +120,7 @@ class TestRelationship(TestCase):
 
     def test_double_revert(self):
         self.assertEqual(
-            ('original', ['1230@main', '0123456789ab']), Relationship.parse(Commit(
+            ('original', ['0123456789ab', '1230@main']), Relationship.parse(Commit(
                 hash='deadbeef1234', revision=1234, identifier='1234@main',
                 message='Reverts "Revert 1230@main (0123456789ab)"',
             ))


### PR DESCRIPTION
#### 273218f4e46a364786cbcbad9046a2632ca15c3a
<pre>
[git-webkit] Prefer hash over identifier in relationships
<a href="https://bugs.webkit.org/show_bug.cgi?id=267889">https://bugs.webkit.org/show_bug.cgi?id=267889</a>
<a href="https://rdar.apple.com/121400016">rdar://121400016</a>

Reviewed by Dewei Zhu.

Users can create identifiers from branches which aren&apos;t linear, so it&apos;s possible
that a branch identifier refers more than one commit in the history of the repository.
Since hashes are more stable, if a relationship uses both, prefer the hash.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/trace.py:
(Relationship.parse): Prefer hash commit reference when parsing relationships, even if the hash
reference is the secondary reference.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/trace_unittest.py:
(TestRelationship.test_cherry_pick):
(TestRelationship.test_revert):
(TestRelationship.test_follow_up):
(TestRelationship.test_double_revert):

Canonical link: <a href="https://commits.webkit.org/274747@main">https://commits.webkit.org/274747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/086604ba72f4926d319a0a74f7d0d2f47bd8d562

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37859 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31697 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11097 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30636 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11873 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31310 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10405 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/35350 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10465 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39106 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31937 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36478 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10579 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8508 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34471 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/35062 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12363 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11107 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5254 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11425 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->