### PR TITLE
Use UUID::createVersion4Weak for Document constructor

### DIFF
--- a/Source/WTF/wtf/UUID.cpp
+++ b/Source/WTF/wtf/UUID.cpp
@@ -153,6 +153,11 @@ String createVersion4UUIDString()
     return makeString(UUID::createVersion4());
 }
 
+String createVersion4UUIDStringWeak()
+{
+    return makeString(UUID::createVersion4Weak());
+}
+
 String bootSessionUUIDString()
 {
 #if OS(DARWIN)

--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -153,6 +153,7 @@ template<> struct DefaultHash<UUID> : UUIDHash { };
 // 9, A, or B for y.
 
 WTF_EXPORT_PRIVATE String createVersion4UUIDString();
+WTF_EXPORT_PRIVATE String createVersion4UUIDStringWeak();
 
 WTF_EXPORT_PRIVATE String bootSessionUUIDString();
 WTF_EXPORT_PRIVATE bool isVersion4UUID(StringView);
@@ -210,4 +211,5 @@ private:
 }
 
 using WTF::createVersion4UUIDString;
+using WTF::createVersion4UUIDStringWeak;
 using WTF::bootSessionUUIDString;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7182,7 +7182,7 @@ String Document::originIdentifierForPasteboard() const
     if (origin != "null"_s)
         return origin;
     if (!m_uniqueIdentifier)
-        m_uniqueIdentifier = makeString("null:"_s, WTF::UUID::createVersion4());
+        m_uniqueIdentifier = makeString("null:"_s, WTF::UUID::createVersion4Weak());
     return m_uniqueIdentifier;
 }
 
@@ -9653,7 +9653,7 @@ void Document::didInsertAttachmentElement(HTMLAttachmentElement& attachment)
     bool previousIdentifierIsNotUnique = !previousIdentifier.isEmpty() && m_attachmentIdentifierToElementMap.contains(previousIdentifier);
     if (identifier.isEmpty() || previousIdentifierIsNotUnique) {
         previousIdentifier = identifier;
-        identifier = createVersion4UUIDString();
+        identifier = createVersion4UUIDStringWeak();
         attachment.setUniqueIdentifier(identifier);
     }
 

--- a/Source/WebCore/platform/ScriptExecutionContextIdentifier.h
+++ b/Source/WebCore/platform/ScriptExecutionContextIdentifier.h
@@ -34,7 +34,7 @@ namespace WebCore {
 template <>
 class ProcessQualified<WTF::UUID> {
 public:
-    static ProcessQualified generate() { return { WTF::UUID::createVersion4(), Process::identifier() }; }
+    static ProcessQualified generate() { return { WTF::UUID::createVersion4Weak(), Process::identifier() }; }
 
     ProcessQualified()
         : m_object(WTF::UUID::emptyValue)


### PR DESCRIPTION
#### bf3c42ab2dd81e67d87363700fca15e9c24e92d0
<pre>
Use UUID::createVersion4Weak for Document constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=267897">https://bugs.webkit.org/show_bug.cgi?id=267897</a>
<a href="https://rdar.apple.com/121405807">rdar://121405807</a>

Reviewed by Ryosuke Niwa.

We do not need cryptographically random values here. Use UUID::createVersion4Weak.

* Source/WTF/wtf/UUID.cpp:
(WTF::createVersion4UUIDString):
* Source/WTF/wtf/UUID.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::originIdentifierForPasteboard const):
(WebCore::Document::didInsertAttachmentElement):
* Source/WebCore/platform/ScriptExecutionContextIdentifier.h:
(WebCore::ProcessQualified&lt;WTF::UUID&gt;::generate):

Canonical link: <a href="https://commits.webkit.org/273344@main">https://commits.webkit.org/273344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a178b7bc4b15c3481a904ccacf68a5e498dde2ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37894 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31724 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11138 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31345 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10437 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31450 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39141 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/29844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31966 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31780 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/35042 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8542 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/34499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41679 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11137 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4533 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->