### PR TITLE
[UnifiedPDF] Printing a main frame containing a PDF should print the PDF and not the plugin

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.mm
@@ -34,14 +34,10 @@
 
 WK_EXPORT PDFDocument *WKBundlePageGetPDFDocumentInFrame(WKBundlePageRef, WKBundleFrameRef frame)
 {
-#if !ENABLE(LEGACY_PDFKIT_PLUGIN)
+#if ENABLE(PDF_PLUGIN)
+    if (auto* pluginView = WebKit::WebPage::pluginViewForFrame(WebKit::toImpl(frame)->coreLocalFrame()))
+        return pluginView->pdfDocumentForPrinting().autorelease();
+#endif
     UNUSED_PARAM(frame);
     return nil;
-#else
-    auto* pluginView = WebKit::WebPage::pluginViewForFrame(WebKit::toImpl(frame)->coreLocalFrame());
-    if (!pluginView)
-        return nil;
-
-    return pluginView->pdfDocumentForPrinting().autorelease();
-#endif
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -163,10 +163,6 @@ private:
 
     void installPDFDocument() override;
 
-
-    RetainPtr<PDFDocument> pdfDocumentForPrinting() const override { return m_pdfDocument; }
-    WebCore::FloatSize pdfDocumentSizeForPrinting() const override;
-
     void geometryDidChange(const WebCore::IntSize& pluginSize, const WebCore::AffineTransform& pluginToRootViewTransform) override;
     void deviceScaleFactorChanged(float) override;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1244,11 +1244,6 @@ void PDFPlugin::destroyScrollbar(ScrollbarOrientation orientation)
     }
 }
 
-FloatSize PDFPlugin::pdfDocumentSizeForPrinting() const
-{
-    return FloatSize([[m_pdfDocument pageAtIndex:0] boundsForBox:kPDFDisplayBoxCropBox].size);
-}
-
 void PDFPlugin::installPDFDocument()
 {
     ASSERT(isMainRunLoop());

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -108,8 +108,8 @@ public:
 
     bool isLocked() const;
 
-    virtual RetainPtr<PDFDocument> pdfDocumentForPrinting() const = 0;
-    virtual WebCore::FloatSize pdfDocumentSizeForPrinting() const = 0;
+    RetainPtr<PDFDocument> pdfDocumentForPrinting() const { return m_pdfDocument; }
+    WebCore::FloatSize pdfDocumentSizeForPrinting() const;
 
     virtual void geometryDidChange(const WebCore::IntSize& pluginSize, const WebCore::AffineTransform& pluginToRootViewTransform);
     virtual void visibilityDidChange(bool);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -35,6 +35,7 @@
 #import "WebPage.h"
 #import "WebPageProxyMessages.h"
 #import <CoreFoundation/CoreFoundation.h>
+#import <PDFKit/PDFKit.h>
 #import <WebCore/AXObjectCache.h>
 #import <WebCore/ArchiveResource.h>
 #import <WebCore/Chrome.h>
@@ -262,6 +263,11 @@ void PDFPluginBase::visibilityDidChange(bool visible)
     else
         m_frame->page()->removePDFHUD(*this);
 #endif
+}
+
+FloatSize PDFPluginBase::pdfDocumentSizeForPrinting() const
+{
+    return FloatSize { [[m_pdfDocument pageAtIndex:0] boundsForBox:kPDFDisplayBoxCropBox].size };
 }
 
 void PDFPluginBase::invalidateRect(const IntRect& rect)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -105,9 +105,6 @@ private:
     WebCore::IntSize contentsSize() const override;
     unsigned firstPageHeight() const override;
 
-    RetainPtr<PDFDocument> pdfDocumentForPrinting() const override;
-    WebCore::FloatSize pdfDocumentSizeForPrinting() const override;
-
     void scheduleRenderingUpdate();
 
     void updateLayout();

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -508,16 +508,6 @@ unsigned UnifiedPDFPlugin::firstPageHeight() const
     return static_cast<unsigned>(CGCeiling(m_documentLayout.boundsForPageAtIndex(0).height()));
 }
 
-RetainPtr<PDFDocument> UnifiedPDFPlugin::pdfDocumentForPrinting() const
-{
-    return nil;
-}
-
-FloatSize UnifiedPDFPlugin::pdfDocumentSizeForPrinting() const
-{
-    return { };
-}
-
 RefPtr<FragmentedSharedBuffer> UnifiedPDFPlugin::liveResourceData() const
 {
     return nullptr;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -601,19 +601,16 @@ void WebPage::getPlatformEditorStateCommon(const LocalFrame& frame, EditorState&
 
 void WebPage::getPDFFirstPageSize(WebCore::FrameIdentifier frameID, CompletionHandler<void(WebCore::FloatSize)>&& completionHandler)
 {
-#if !ENABLE(LEGACY_PDFKIT_PLUGIN)
-    return completionHandler({ });
-#else
     RefPtr webFrame = WebProcess::singleton().webFrame(frameID);
     if (!webFrame)
         return completionHandler({ });
 
-    auto* pluginView = pluginViewForFrame(webFrame->coreLocalFrame());
-    if (!pluginView)
-        return completionHandler({ });
-    
-    completionHandler(FloatSize(pluginView->pdfDocumentSizeForPrinting()));
+#if ENABLE(PDF_PLUGIN)
+    if (auto* pluginView = pluginViewForFrame(webFrame->coreLocalFrame()))
+        return completionHandler(pluginView->pdfDocumentSizeForPrinting());
 #endif
+
+    completionHandler({ });
 }
 
 #if ENABLE(DATA_DETECTION)


### PR DESCRIPTION
#### 83e647adbd3621ba3de4e883189ebb4c0c4ea500
<pre>
[UnifiedPDF] Printing a main frame containing a PDF should print the PDF and not the plugin
<a href="https://bugs.webkit.org/show_bug.cgi?id=267898">https://bugs.webkit.org/show_bug.cgi?id=267898</a>
<a href="https://rdar.apple.com/119632457">rdar://119632457</a>

Reviewed by Tim Horton.

UnifiedPDFPlugin returns a nil PDFDocumentRef (and an empty size) when a
print is initiated, which means that a print operation on a main frame
PDF yields unexpected results.

This patch addresses the issue by devirtualizing the
pdfDocument[size]forPrinting family of functions, and instead letting
both PDF plugin implementations share the definition now housed in
PDFPluginBase.

Furthermore, we remove some conditional code in WebPage and WKBundlePage
that avoided querying the UnifiedPDF plugin for the associated PDF
document size and reference.

* Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.mm:
(WKBundlePageGetPDFDocumentInFrame):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::pdfDocumentSizeForPrinting const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::pdfDocumentForPrinting const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::pdfDocumentSizeForPrinting const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::pdfDocumentForPrinting const): Deleted.
(WebKit::UnifiedPDFPlugin::pdfDocumentSizeForPrinting const): Deleted.
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getPDFFirstPageSize):

Canonical link: <a href="https://commits.webkit.org/273357@main">https://commits.webkit.org/273357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5e2e510e3ba4ebc57698da209873d8231c79be2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37933 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31750 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30661 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10463 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10517 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39180 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/31999 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36509 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10643 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8572 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34517 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12416 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8057 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11167 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11478 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->