### PR TITLE
Use more smart pointers under WebCore/css/parser

### DIFF
--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -578,7 +578,7 @@ WeakPtr<const StyleSheetContents> StyleRuleScope::styleSheetContents() const
 
 void StyleRuleScope::setStyleSheetContents(const StyleSheetContents& sheet)
 {
-    m_styleSheetOwner = &sheet;
+    m_styleSheetOwner = sheet;
 }
 
 Ref<StyleRuleStartingStyle> StyleRuleStartingStyle::create(Vector<Ref<StyleRuleBase>>&& rules)

--- a/Source/WebCore/css/parser/CSSParser.h
+++ b/Source/WebCore/css/parser/CSSParser.h
@@ -62,7 +62,7 @@ public:
 
     bool parseSupportsCondition(const String&);
 
-    static void parseSheetForInspector(const CSSParserContext&, StyleSheetContents*, const String&, CSSParserObserver&);
+    static void parseSheetForInspector(const CSSParserContext&, StyleSheetContents&, const String&, CSSParserObserver&);
     static void parseDeclarationForInspector(const CSSParserContext&, const String&, CSSParserObserver&);
 
     static ParseResult parseValue(MutableStyleProperties&, CSSPropertyID, const String&, bool important, const CSSParserContext&);
@@ -71,7 +71,7 @@ public:
     static RefPtr<CSSValue> parseSingleValue(CSSPropertyID, const String&, const CSSParserContext& = strictCSSParserContext());
 
     WEBCORE_EXPORT bool parseDeclaration(MutableStyleProperties&, const String&);
-    static Ref<ImmutableStyleProperties> parseInlineStyleDeclaration(const String&, const Element*);
+    static Ref<ImmutableStyleProperties> parseInlineStyleDeclaration(const String&, const Element&);
 
     WEBCORE_EXPORT std::optional<CSSSelectorList> parseSelectorList(const String&, StyleSheetContents* = nullptr, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);
 

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -802,7 +802,7 @@ static RefPtr<CSSFunctionValue> parseSimpleTransformValue(CharType*& pos, CharTy
             return nullptr;
 
         pos += argumentStart;
-        auto angle = parseTransformAngleArgument(pos, end);
+        RefPtr angle = parseTransformAngleArgument(pos, end);
         if (!angle)
             return nullptr;
         return CSSFunctionValue::create(transformType, angle.releaseNonNull());

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -118,23 +118,23 @@ CSSParserImpl::CSSParserImpl(const CSSParserContext& context, const String& stri
 {
 }
 
-CSSParser::ParseResult CSSParserImpl::parseValue(MutableStyleProperties* declaration, CSSPropertyID propertyID, const String& string, bool important, const CSSParserContext& context)
+CSSParser::ParseResult CSSParserImpl::parseValue(MutableStyleProperties& declaration, CSSPropertyID propertyID, const String& string, bool important, const CSSParserContext& context)
 {
     CSSParserImpl parser(context, string);
     auto ruleType = context.enclosingRuleType.value_or(StyleRuleType::Style);
     parser.consumeDeclarationValue(parser.tokenizer()->tokenRange(), propertyID, important, ruleType);
     if (parser.topContext().m_parsedProperties.isEmpty())
         return CSSParser::ParseResult::Error;
-    return declaration->addParsedProperties(parser.topContext().m_parsedProperties) ? CSSParser::ParseResult::Changed : CSSParser::ParseResult::Unchanged;
+    return declaration.addParsedProperties(parser.topContext().m_parsedProperties) ? CSSParser::ParseResult::Changed : CSSParser::ParseResult::Unchanged;
 }
 
-CSSParser::ParseResult CSSParserImpl::parseCustomPropertyValue(MutableStyleProperties* declaration, const AtomString& propertyName, const String& string, bool important, const CSSParserContext& context)
+CSSParser::ParseResult CSSParserImpl::parseCustomPropertyValue(MutableStyleProperties& declaration, const AtomString& propertyName, const String& string, bool important, const CSSParserContext& context)
 {
     CSSParserImpl parser(context, string);
     parser.consumeCustomPropertyValue(parser.tokenizer()->tokenRange(), propertyName, important);
     if (parser.topContext().m_parsedProperties.isEmpty())
         return CSSParser::ParseResult::Error;
-    return declaration->addParsedProperties(parser.topContext().m_parsedProperties) ? CSSParser::ParseResult::Changed : CSSParser::ParseResult::Unchanged;
+    return declaration.addParsedProperties(parser.topContext().m_parsedProperties) ? CSSParser::ParseResult::Changed : CSSParser::ParseResult::Unchanged;
 }
 
 static inline void filterProperties(bool important, const ParsedPropertyVector& input, ParsedPropertyVector& output, size_t& unusedEntries, std::bitset<numCSSProperties>& seenProperties, HashSet<AtomString>& seenCustomProperties)
@@ -173,15 +173,15 @@ static Ref<ImmutableStyleProperties> createStyleProperties(ParsedPropertyVector&
     filterProperties(true, parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
     filterProperties(false, parsedProperties, results, unusedEntries, seenProperties, seenCustomProperties);
 
-    Ref<ImmutableStyleProperties> result = ImmutableStyleProperties::createDeduplicating(results.data() + unusedEntries, results.size() - unusedEntries, mode);
+    Ref result = ImmutableStyleProperties::createDeduplicating(results.data() + unusedEntries, results.size() - unusedEntries, mode);
     parsedProperties.clear();
     return result;
 }
 
-Ref<ImmutableStyleProperties> CSSParserImpl::parseInlineStyleDeclaration(const String& string, const Element* element)
+Ref<ImmutableStyleProperties> CSSParserImpl::parseInlineStyleDeclaration(const String& string, const Element& element)
 {
-    CSSParserContext context(element->document());
-    context.mode = strictToCSSParserMode(element->isHTMLElement() && !element->document().inQuirksMode());
+    CSSParserContext context(element.document());
+    context.mode = strictToCSSParserMode(element.isHTMLElement() && !element.document().inQuirksMode());
 
     CSSParserImpl parser(context, string);
     parser.consumeDeclarationList(parser.tokenizer()->tokenRange(), StyleRuleType::Style);
@@ -308,16 +308,16 @@ void CSSParserImpl::parseDeclarationListForInspector(const String& declaration, 
     parser.consumeDeclarationList(parser.tokenizer()->tokenRange(), StyleRuleType::Style);
 }
 
-void CSSParserImpl::parseStyleSheetForInspector(const String& string, const CSSParserContext& context, StyleSheetContents* styleSheet, CSSParserObserver& observer)
+void CSSParserImpl::parseStyleSheetForInspector(const String& string, const CSSParserContext& context, StyleSheetContents& styleSheet, CSSParserObserver& observer)
 {
     CSSParserObserverWrapper wrapper(observer);
-    CSSParserImpl parser(context, string, styleSheet, &wrapper);
+    CSSParserImpl parser(context, string, &styleSheet, &wrapper);
     bool firstRuleValid = parser.consumeRuleList(parser.tokenizer()->tokenRange(), TopLevelRuleList, [&styleSheet](Ref<StyleRuleBase> rule) {
         if (rule->isCharsetRule())
             return;
-        styleSheet->parserAppendRule(WTFMove(rule));
+        styleSheet.parserAppendRule(WTFMove(rule));
     });
-    styleSheet->setHasSyntacticallyValidCSSHeader(firstRuleValid);
+    styleSheet.setHasSyntacticallyValidCSSHeader(firstRuleValid);
 }
 
 static CSSParserImpl::AllowedRulesType computeNewAllowedRules(CSSParserImpl::AllowedRulesType allowedRules, StyleRuleBase* rule)
@@ -625,6 +625,11 @@ Ref<StyleRuleBase> CSSParserImpl::createNestingParentRule()
     return StyleRuleWithNesting::create(WTFMove(properties), m_context.hasDocumentSecurityOrigin, CSSSelectorList { WTFMove(selectorList) }, { });
 }
 
+RefPtr<StyleSheetContents> CSSParserImpl::protectedStyleSheet() const
+{
+    return m_styleSheet;
+}
+
 Vector<Ref<StyleRuleBase>> CSSParserImpl::consumeNestedGroupRules(CSSParserTokenRange block)
 {
     NestingLevelIncrementer incrementer { m_ruleListNestingLevel };
@@ -644,7 +649,7 @@ Vector<Ref<StyleRuleBase>> CSSParserImpl::consumeNestedGroupRules(CSSParserToken
                 // property declarations.
                 rules.append(createNestingParentRule());
 
-                m_styleSheet->setHasNestingRules();
+                protectedStyleSheet()->setHasNestingRules();
 
                 if (m_observerWrapper)
                     m_observerWrapper->observer().markRuleBodyContainsImplicitlyNestedProperties();
@@ -847,7 +852,7 @@ RefPtr<StyleRuleFontFeatureValues> CSSParserImpl::consumeFontFeatureValuesRule(C
 
 RefPtr<StyleRuleFontPaletteValues> CSSParserImpl::consumeFontPaletteValuesRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
 {
-    auto name = CSSPropertyParserHelpers::consumeDashedIdent(prelude);
+    RefPtr name = CSSPropertyParserHelpers::consumeDashedIdent(prelude);
     if (!name || !prelude.atEnd())
         return nullptr; // Parse error; expected custom ident in @font-palette-values header
 
@@ -860,7 +865,7 @@ RefPtr<StyleRuleFontPaletteValues> CSSParserImpl::consumeFontPaletteValuesRule(C
     }
 
     auto declarations = consumeDeclarationListInNewNestingContext(block, StyleRuleType::FontPaletteValues);
-    auto properties = createStyleProperties(declarations, m_context.mode);
+    Ref properties = createStyleProperties(declarations, m_context.mode);
 
     auto fontFamilies = [&] {
         Vector<AtomString> fontFamilies;
@@ -947,7 +952,7 @@ RefPtr<StyleRuleKeyframes> CSSParserImpl::consumeKeyframesRule(CSSParserTokenRan
 
 RefPtr<StyleRulePage> CSSParserImpl::consumePageRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
 {
-    auto selectorList = parsePageSelector(prelude, m_styleSheet.get());
+    auto selectorList = parsePageSelector(prelude, protectedStyleSheet().get());
     if (selectorList.isEmpty())
         return nullptr; // Parse error, invalid @page selector
 
@@ -1010,7 +1015,7 @@ RefPtr<StyleRuleScope> CSSParserImpl::consumeScopeRule(CSSParserTokenRange prelu
                 CSSParserTokenRange selectorListRange = prelude.makeSubRange(selectorListRangeStart, &prelude.peek());
 
                 // Parse the selector list range
-                auto mutableSelectorList = parseMutableCSSSelectorList(selectorListRange, m_context, m_styleSheet.get(), last.has_value() ? CSSParserEnum::IsNestedContext::Yes : CSSParserEnum::IsNestedContext::No, CSSParserEnum::IsForgiving::Yes);
+                auto mutableSelectorList = parseMutableCSSSelectorList(selectorListRange, m_context, protectedStyleSheet().get(), last.has_value() ? CSSParserEnum::IsNestedContext::Yes : CSSParserEnum::IsNestedContext::No, CSSParserEnum::IsForgiving::Yes);
                 if (mutableSelectorList.isEmpty())
                     return false;
 
@@ -1065,9 +1070,9 @@ RefPtr<StyleRuleScope> CSSParserImpl::consumeScopeRule(CSSParserTokenRange prelu
     m_ancestorRuleTypeStack.append(AncestorRuleType::Scope);
     auto rules = consumeNestedGroupRules(block);
     m_ancestorRuleTypeStack.removeLast();
-    auto rule = StyleRuleScope::create(WTFMove(scopeStart), WTFMove(scopeEnd), WTFMove(rules));
-    if (m_styleSheet)
-        rule->setStyleSheetContents(*m_styleSheet);
+    Ref rule = StyleRuleScope::create(WTFMove(scopeStart), WTFMove(scopeEnd), WTFMove(rules));
+    if (RefPtr styleSheet = m_styleSheet)
+        rule->setStyleSheetContents(*styleSheet);
     return rule;
 }
 
@@ -1286,7 +1291,7 @@ static void observeSelectors(CSSParserObserverWrapper& wrapper, CSSParserTokenRa
 RefPtr<StyleRuleBase> CSSParserImpl::consumeStyleRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
 {
     auto preludeCopyForInspector = prelude;
-    auto mutableSelectorList = parseMutableCSSSelectorList(prelude, m_context, m_styleSheet.get(), isNestedContext() ? CSSParserEnum::IsNestedContext::Yes : CSSParserEnum::IsNestedContext::No, CSSParserEnum::IsForgiving::No);
+    auto mutableSelectorList = parseMutableCSSSelectorList(prelude, m_context, protectedStyleSheet().get(), isNestedContext() ? CSSParserEnum::IsNestedContext::Yes : CSSParserEnum::IsNestedContext::No, CSSParserEnum::IsForgiving::No);
 
     if (mutableSelectorList.isEmpty())
         return nullptr; // Parse error, invalid selector list
@@ -1299,7 +1304,7 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeStyleRule(CSSParserTokenRange prelud
             appendImplicitSelectorIfNeeded(*mutableSelector, m_ancestorRuleTypeStack.last());
     }
 
-    auto selectorList = CSSSelectorList { WTFMove(mutableSelectorList) };
+    CSSSelectorList selectorList { WTFMove(mutableSelectorList) };
     ASSERT(!selectorList.isEmpty());
 
     if (m_observerWrapper)
@@ -1316,14 +1321,14 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeStyleRule(CSSParserTokenRange prelud
         }
 
         auto nestedRules = WTFMove(topContext().m_parsedRules);
-        auto properties = createStyleProperties(topContext().m_parsedProperties, m_context.mode);
+        Ref properties = createStyleProperties(topContext().m_parsedProperties, m_context.mode);
 
         // We save memory by creating a simple StyleRule instead of a heavier StyleRuleWithNesting when we don't need the CSS Nesting features.
         if (nestedRules.isEmpty() && !selectorList.hasExplicitNestingParent() && !isNestedContext())
             styleRule = StyleRule::create(WTFMove(properties), m_context.hasDocumentSecurityOrigin, WTFMove(selectorList));
         else {
             styleRule = StyleRuleWithNesting::create(WTFMove(properties), m_context.hasDocumentSecurityOrigin, WTFMove(selectorList), WTFMove(nestedRules));
-            m_styleSheet->setHasNestingRules();
+            protectedStyleSheet()->setHasNestingRules();
         }
     });
 
@@ -1352,12 +1357,12 @@ void CSSParserImpl::consumeBlockContent(CSSParserTokenRange range, StyleRuleType
     };
 
     auto consumeNestedQualifiedRule = [&] {
-        auto rule = consumeQualifiedRule(range, AllowedRulesType::RegularRules);
+        RefPtr rule = consumeQualifiedRule(range, AllowedRulesType::RegularRules);
         if (!rule)
             return false;
         if (!rule->isStyleRule())
             return false;
-        topContext().m_parsedRules.append(*rule);
+        topContext().m_parsedRules.append(rule.releaseNonNull());
         return true;
     };
 
@@ -1397,14 +1402,14 @@ void CSSParserImpl::consumeBlockContent(CSSParserTokenRange range, StyleRuleType
         }
         case AtKeywordToken: {
             if (nestedRulesAllowed()) {
-                auto rule = consumeAtRule(range, RegularRules);
+                RefPtr rule = consumeAtRule(range, RegularRules);
                 if (!rule)
                     break;
                 if (!rule->isGroupRule())
                     break;
-                topContext().m_parsedRules.append(*rule);
+                topContext().m_parsedRules.append(rule.releaseNonNull());
             } else {
-                auto rule = consumeAtRule(range, NoRules);
+                RefPtr rule = consumeAtRule(range, NoRules);
                 ASSERT_UNUSED(rule, !rule);
             }
             break;

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -90,9 +90,9 @@ public:
         NoRules, // For parsing at-rules inside declaration lists (without nesting support)
     };
 
-    static CSSParser::ParseResult parseValue(MutableStyleProperties*, CSSPropertyID, const String&, bool important, const CSSParserContext&);
-    static CSSParser::ParseResult parseCustomPropertyValue(MutableStyleProperties*, const AtomString& propertyName, const String&, bool important, const CSSParserContext&);
-    static Ref<ImmutableStyleProperties> parseInlineStyleDeclaration(const String&, const Element*);
+    static CSSParser::ParseResult parseValue(MutableStyleProperties&, CSSPropertyID, const String&, bool important, const CSSParserContext&);
+    static CSSParser::ParseResult parseCustomPropertyValue(MutableStyleProperties&, const AtomString& propertyName, const String&, bool important, const CSSParserContext&);
+    static Ref<ImmutableStyleProperties> parseInlineStyleDeclaration(const String&, const Element&);
     static bool parseDeclarationList(MutableStyleProperties*, const String&, const CSSParserContext&);
     static RefPtr<StyleRuleBase> parseRule(const String&, const CSSParserContext&, StyleSheetContents*, AllowedRulesType, CSSParserEnum::IsNestedContext = CSSParserEnum::IsNestedContext::No);
     static void parseStyleSheet(const String&, const CSSParserContext&, StyleSheetContents&);
@@ -107,9 +107,9 @@ public:
     RefPtr<StyleRuleBase> consumeAtRule(CSSParserTokenRange&, AllowedRulesType);
 
     static void parseDeclarationListForInspector(const String&, const CSSParserContext&, CSSParserObserver&);
-    static void parseStyleSheetForInspector(const String&, const CSSParserContext&, StyleSheetContents*, CSSParserObserver&);
+    static void parseStyleSheetForInspector(const String&, const CSSParserContext&, StyleSheetContents&, CSSParserObserver&);
 
-    CSSTokenizer* tokenizer() const { return m_tokenizer.get(); };
+    CSSTokenizer* tokenizer() const { return m_tokenizer.get(); }
 
 private:
     struct NestingContext {
@@ -176,6 +176,8 @@ private:
 
     static Vector<double> consumeKeyframeKeyList(CSSParserTokenRange);
 
+    RefPtr<StyleSheetContents> protectedStyleSheet() const;
+
     Ref<StyleRuleBase> createNestingParentRule();
     void runInNewNestingContext(auto&& run);
     NestingContext& topContext()
@@ -215,7 +217,7 @@ private:
     std::unique_ptr<CSSTokenizer> m_tokenizer;
 
     // For the inspector
-    CSSParserObserverWrapper* m_observerWrapper { nullptr };
+    WeakPtr<CSSParserObserverWrapper> m_observerWrapper;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSParserObserverWrapper.h
+++ b/Source/WebCore/css/parser/CSSParserObserverWrapper.h
@@ -31,10 +31,11 @@
 
 #include "CSSParserObserver.h"
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
-class CSSParserObserverWrapper {
+class CSSParserObserverWrapper : public CanMakeWeakPtr<CSSParserObserverWrapper> {
 public:
     explicit CSSParserObserverWrapper(CSSParserObserver& observer)
         : m_observer(observer)

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -236,10 +236,10 @@ static RefPtr<CSSPrimitiveValue> maybeConsumeCSSWideKeyword(CSSParserTokenRange&
 RefPtr<CSSValue> CSSPropertyParser::parseSingleValue(CSSPropertyID property, const CSSParserTokenRange& range, const CSSParserContext& context)
 {
     CSSPropertyParser parser(range, context, nullptr);
-    if (auto value = maybeConsumeCSSWideKeyword(parser.m_range))
+    if (RefPtr value = maybeConsumeCSSWideKeyword(parser.m_range))
         return value;
     
-    RefPtr<CSSValue> value = parser.parseSingleValue(property);
+    RefPtr value = parser.parseSingleValue(property);
     if (!value || !parser.m_range.atEnd())
         return nullptr;
     return value;
@@ -248,7 +248,7 @@ RefPtr<CSSValue> CSSPropertyParser::parseSingleValue(CSSPropertyID property, con
 RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(const AtomString& name, const CSSCustomPropertySyntax& syntax, const CSSParserTokenRange& tokens, Style::BuilderState& builderState, const CSSParserContext& context)
 {
     CSSPropertyParser parser(tokens, context, nullptr, false);
-    RefPtr<CSSCustomPropertyValue> value = parser.parseTypedCustomPropertyValue(name, syntax, builderState);
+    RefPtr value = parser.parseTypedCustomPropertyValue(name, syntax, builderState);
     if (!value || !parser.m_range.atEnd())
         return nullptr;
     return value;
@@ -260,7 +260,7 @@ RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyInitia
         return CSSVariableParser::parseInitialValueForUniversalSyntax(name, tokens);
 
     CSSPropertyParser parser(tokens, context, nullptr, false);
-    RefPtr<CSSCustomPropertyValue> value = parser.parseTypedCustomPropertyValue(name, syntax, builderState);
+    RefPtr value = parser.parseTypedCustomPropertyValue(name, syntax, builderState);
     if (!value || !parser.m_range.atEnd())
         return nullptr;
 
@@ -298,7 +298,7 @@ bool CSSPropertyParser::parseValueStart(CSSPropertyID propertyID, bool important
         if (parseShorthand(propertyID, important))
             return true;
     } else {
-        RefPtr<CSSValue> parsedValue = parseSingleValue(propertyID);
+        RefPtr parsedValue = parseSingleValue(propertyID);
         if (parsedValue && m_range.atEnd()) {
             addProperty(propertyID, CSSPropertyInvalid, WTFMove(parsedValue), important);
             return true;
@@ -306,7 +306,7 @@ bool CSSPropertyParser::parseValueStart(CSSPropertyID propertyID, bool important
     }
 
     if (CSSVariableParser::containsValidVariableReferences(originalRange, m_context)) {
-        auto variable = CSSVariableReferenceValue::create(originalRange, m_context);
+        Ref variable = CSSVariableReferenceValue::create(originalRange, m_context);
         if (isShorthand)
             addExpandedProperty(propertyID, CSSPendingSubstitutionValue::create(propertyID, WTFMove(variable)), important);
         else
@@ -320,7 +320,7 @@ bool CSSPropertyParser::parseValueStart(CSSPropertyID propertyID, bool important
 bool CSSPropertyParser::consumeCSSWideKeyword(CSSPropertyID propertyID, bool important)
 {
     CSSParserTokenRange rangeCopy = m_range;
-    auto value = maybeConsumeCSSWideKeyword(rangeCopy);
+    RefPtr value = maybeConsumeCSSWideKeyword(rangeCopy);
     if (!value)
         return false;
     
@@ -353,7 +353,7 @@ std::pair<RefPtr<CSSValue>, CSSCustomPropertySyntax::Type> CSSPropertyParser::co
         case CSSCustomPropertySyntax::Type::LengthPercentage:
             return consumeLengthOrPercent(range, m_context.mode, ValueRange::All);
         case CSSCustomPropertySyntax::Type::CustomIdent:
-            if (auto value = consumeCustomIdent(range)) {
+            if (RefPtr value = consumeCustomIdent(range)) {
                 if (component.ident.isNull() || value->stringValue() == component.ident)
                     return value;
             }
@@ -398,7 +398,7 @@ std::pair<RefPtr<CSSValue>, CSSCustomPropertySyntax::Type> CSSPropertyParser::co
         }
         case CSSCustomPropertySyntax::Multiplier::SpaceList: {
             CSSValueListBuilder valueList;
-            while (auto value = consumeSingleValue(range, component))
+            while (RefPtr value = consumeSingleValue(range, component))
                 valueList.append(value.releaseNonNull());
             if (valueList.isEmpty())
                 return nullptr;
@@ -410,7 +410,7 @@ std::pair<RefPtr<CSSValue>, CSSCustomPropertySyntax::Type> CSSPropertyParser::co
     };
 
     for (auto& component : syntax.definition) {
-        if (auto value = consumeComponent(m_range, component)) {
+        if (RefPtr value = consumeComponent(m_range, component)) {
             if (m_range.atEnd())
                 return { value, component.type };
         }
@@ -440,7 +440,7 @@ RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(
 
     m_range.consumeWhitespace();
 
-    if (auto value = maybeConsumeCSSWideKeyword(m_range))
+    if (RefPtr value = maybeConsumeCSSWideKeyword(m_range))
         return CSSCustomPropertyValue::createWithID(name, value->valueID());
 
     auto [value, syntaxType] = consumeCustomPropertyValueWithSyntax(syntax);
@@ -522,7 +522,7 @@ bool CSSPropertyParser::parseCounterStyleDescriptor(CSSPropertyID property)
 {
     ASSERT(m_context.propertySettings.cssCounterStyleAtRulesEnabled);
 
-    auto parsedValue = CSSPropertyParsing::parseCounterStyleDescriptor(m_range, property, m_context);
+    RefPtr parsedValue = CSSPropertyParsing::parseCounterStyleDescriptor(m_range, property, m_context);
     if (!parsedValue || !m_range.atEnd())
         return false;
 
@@ -535,7 +535,7 @@ bool CSSPropertyParser::parseFontFaceDescriptor(CSSPropertyID property)
     if (isShorthand(property))
         return parseFontFaceDescriptorShorthand(property);
 
-    auto parsedValue = CSSPropertyParsing::parseFontFaceDescriptor(m_range, property, m_context);
+    RefPtr parsedValue = CSSPropertyParsing::parseFontFaceDescriptor(m_range, property, m_context);
     if (!parsedValue || !m_range.atEnd())
         return false;
 
@@ -578,7 +578,7 @@ bool CSSPropertyParser::parseKeyframeDescriptor(CSSPropertyID propertyID, bool i
 
 bool CSSPropertyParser::parsePropertyDescriptor(CSSPropertyID property)
 {
-    auto parsedValue = CSSPropertyParsing::parsePropertyDescriptor(m_range, property, m_context);
+    RefPtr parsedValue = CSSPropertyParsing::parsePropertyDescriptor(m_range, property, m_context);
     if (!parsedValue || !m_range.atEnd())
         return false;
 
@@ -588,7 +588,7 @@ bool CSSPropertyParser::parsePropertyDescriptor(CSSPropertyID property)
 
 bool CSSPropertyParser::parseFontPaletteValuesDescriptor(CSSPropertyID property)
 {
-    auto parsedValue = CSSPropertyParsing::parseFontPaletteValuesDescriptor(m_range, property, m_context);
+    RefPtr parsedValue = CSSPropertyParsing::parseFontPaletteValuesDescriptor(m_range, property, m_context);
     if (!parsedValue || !m_range.atEnd())
         return false;
 
@@ -670,7 +670,7 @@ bool CSSPropertyParser::consumeFont(bool important)
 
 bool CSSPropertyParser::consumeTextDecorationSkip(bool important)
 {
-    if (RefPtr<CSSPrimitiveValue> skip = consumeIdent<CSSValueNone, CSSValueAuto, CSSValueInk>(m_range)) {
+    if (RefPtr skip = consumeIdent<CSSValueNone, CSSValueAuto, CSSValueInk>(m_range)) {
         switch (skip->valueID()) {
         case CSSValueNone:
             addProperty(CSSPropertyTextDecorationSkipInk, CSSPropertyTextDecorationSkip, skip.releaseNonNull(), important);
@@ -778,7 +778,7 @@ bool CSSPropertyParser::consumeFontSynthesis(bool important)
     };
 
     while (!m_range.atEnd()) {
-        auto ident = consumeIdent<CSSValueWeight, CSSValueStyle, CSSValueSmallCaps>(m_range);
+        RefPtr ident = consumeIdent<CSSValueWeight, CSSValueStyle, CSSValueSmallCaps>(m_range);
         if (!ident)
             return false;
         switch (ident->valueID()) {
@@ -809,10 +809,10 @@ bool CSSPropertyParser::consumeFontSynthesis(bool important)
 
 bool CSSPropertyParser::consumeBorderSpacing(bool important)
 {
-    RefPtr<CSSValue> horizontalSpacing = consumeLength(m_range, m_context.mode, ValueRange::NonNegative, UnitlessQuirk::Allow);
+    RefPtr horizontalSpacing = consumeLength(m_range, m_context.mode, ValueRange::NonNegative, UnitlessQuirk::Allow);
     if (!horizontalSpacing)
         return false;
-    RefPtr<CSSValue> verticalSpacing = horizontalSpacing;
+    RefPtr verticalSpacing = horizontalSpacing;
     if (!m_range.atEnd())
         verticalSpacing = consumeLength(m_range, m_context.mode, ValueRange::NonNegative, UnitlessQuirk::Allow);
     if (!verticalSpacing || !m_range.atEnd())
@@ -1518,11 +1518,11 @@ bool CSSPropertyParser::consume2ValueShorthand(const StylePropertyShorthand& sho
 {
     ASSERT(shorthand.length() == 2);
     const CSSPropertyID* longhands = shorthand.properties();
-    RefPtr<CSSValue> start = parseSingleValue(longhands[0], shorthand.id());
+    RefPtr start = parseSingleValue(longhands[0], shorthand.id());
     if (!start)
         return false;
 
-    RefPtr<CSSValue> end = parseSingleValue(longhands[1], shorthand.id());
+    RefPtr end = parseSingleValue(longhands[1], shorthand.id());
     bool endImplicit = !end;
     if (endImplicit)
         end = start;
@@ -1536,11 +1536,11 @@ bool CSSPropertyParser::consume4ValueShorthand(const StylePropertyShorthand& sho
 {
     ASSERT(shorthand.length() == 4);
     const CSSPropertyID* longhands = shorthand.properties();
-    RefPtr<CSSValue> top = parseSingleValue(longhands[0], shorthand.id());
+    RefPtr top = parseSingleValue(longhands[0], shorthand.id());
     if (!top)
         return false;
 
-    RefPtr<CSSValue> right = parseSingleValue(longhands[1], shorthand.id());
+    RefPtr right = parseSingleValue(longhands[1], shorthand.id());
     RefPtr<CSSValue> bottom;
     RefPtr<CSSValue> left;
     if (right) {
@@ -1635,7 +1635,7 @@ bool CSSPropertyParser::consumeLegacyBreakProperty(CSSPropertyID property, bool 
     // The fragmentation spec says that page-break-(after|before|inside) are to be treated as
     // shorthands for their break-(after|before|inside) counterparts. We'll do the same for the
     // non-standard properties -webkit-column-break-(after|before|inside).
-    RefPtr<CSSPrimitiveValue> keyword = consumeIdent(m_range);
+    RefPtr keyword = consumeIdent(m_range);
     if (!keyword)
         return false;
     if (!m_range.atEnd())
@@ -2002,7 +2002,7 @@ bool CSSPropertyParser::consumeGridItemPositionShorthand(CSSPropertyID shorthand
 {
     const StylePropertyShorthand& shorthand = shorthandForProperty(shorthandId);
     ASSERT(shorthand.length() == 2);
-    RefPtr<CSSValue> startValue = consumeGridLine(m_range);
+    RefPtr startValue = consumeGridLine(m_range);
     if (!startValue)
         return false;
 
@@ -2023,7 +2023,7 @@ bool CSSPropertyParser::consumeGridItemPositionShorthand(CSSPropertyID shorthand
 
 bool CSSPropertyParser::consumeGridAreaShorthand(bool important)
 {
-    RefPtr<CSSValue> rowStartValue = consumeGridLine(m_range);
+    RefPtr rowStartValue = consumeGridLine(m_range);
     if (!rowStartValue)
         return false;
     RefPtr<CSSValue> columnStartValue;
@@ -2091,7 +2091,7 @@ bool CSSPropertyParser::consumeGridTemplateRowsAndAreasAndColumns(CSSPropertyID 
         ++rowCount;
 
         // Handle template-rows's track-size.
-        if (auto value = consumeGridTrackSize(m_range, m_context.mode))
+        if (RefPtr value = consumeGridTrackSize(m_range, m_context.mode))
             templateRows.append(value.releaseNonNull());
         else
             templateRows.append(CSSPrimitiveValue::create(CSSValueAuto));
@@ -2138,7 +2138,7 @@ bool CSSPropertyParser::consumeGridTemplateShorthand(CSSPropertyID shorthandId, 
     if (rowsValue) {
         if (!consumeSlashIncludingWhitespace(m_range))
             return false;
-        RefPtr<CSSValue> columnsValue = consumeGridTemplatesRowsOrColumns(m_range, m_context);
+        RefPtr columnsValue = consumeGridTemplatesRowsOrColumns(m_range, m_context);
         if (!columnsValue || !m_range.atEnd())
             return false;
 
@@ -2260,7 +2260,7 @@ bool CSSPropertyParser::consumePlaceContentShorthand(bool important)
 
     CSSParserTokenRange rangeCopy = m_range;
     bool isBaseline = isBaselineKeyword(m_range.peek().id());
-    RefPtr<CSSValue> alignContentValue = consumeContentDistributionOverflowPosition(m_range, isContentPositionKeyword);
+    RefPtr alignContentValue = consumeContentDistributionOverflowPosition(m_range, isContentPositionKeyword);
     if (!alignContentValue)
         return false;
 
@@ -2272,7 +2272,7 @@ bool CSSPropertyParser::consumePlaceContentShorthand(bool important)
 
     if (m_range.atEnd())
         m_range = rangeCopy;
-    RefPtr<CSSValue> justifyContentValue = consumeContentDistributionOverflowPosition(m_range, isContentPositionOrLeftOrRightKeyword);
+    RefPtr justifyContentValue = consumeContentDistributionOverflowPosition(m_range, isContentPositionOrLeftOrRightKeyword);
     if (!justifyContentValue)
         return false;
     if (!m_range.atEnd())
@@ -2288,13 +2288,13 @@ bool CSSPropertyParser::consumePlaceItemsShorthand(bool important)
     ASSERT(shorthandForProperty(CSSPropertyPlaceItems).length() == 2);
 
     CSSParserTokenRange rangeCopy = m_range;
-    RefPtr<CSSValue> alignItemsValue = consumeAlignItems(m_range);
+    RefPtr alignItemsValue = consumeAlignItems(m_range);
     if (!alignItemsValue)
         return false;
 
     if (m_range.atEnd())
         m_range = rangeCopy;
-    RefPtr<CSSValue> justifyItemsValue = consumeJustifyItems(m_range);
+    RefPtr justifyItemsValue = consumeJustifyItems(m_range);
     if (!justifyItemsValue)
         return false;
 
@@ -2311,13 +2311,13 @@ bool CSSPropertyParser::consumePlaceSelfShorthand(bool important)
     ASSERT(shorthandForProperty(CSSPropertyPlaceSelf).length() == 2);
 
     CSSParserTokenRange rangeCopy = m_range;
-    RefPtr<CSSValue> alignSelfValue = consumeSelfPositionOverflowPosition(m_range, isSelfPositionKeyword);
+    RefPtr alignSelfValue = consumeSelfPositionOverflowPosition(m_range, isSelfPositionKeyword);
     if (!alignSelfValue)
         return false;
 
     if (m_range.atEnd())
         m_range = rangeCopy;
-    RefPtr<CSSValue> justifySelfValue = consumeSelfPositionOverflowPosition(m_range, isSelfPositionOrLeftOrRightKeyword);
+    RefPtr justifySelfValue = consumeSelfPositionOverflowPosition(m_range, isSelfPositionOrLeftOrRightKeyword);
     if (!justifySelfValue)
         return false;
 
@@ -2336,7 +2336,7 @@ bool CSSPropertyParser::consumeOverscrollBehaviorShorthand(bool important)
     if (m_range.atEnd())
         return false;
 
-    RefPtr<CSSValue> overscrollBehaviorX = CSSPropertyParsing::consumeOverscrollBehaviorX(m_range);
+    RefPtr overscrollBehaviorX = CSSPropertyParsing::consumeOverscrollBehaviorX(m_range);
     if (!overscrollBehaviorX)
         return false;
 
@@ -2358,7 +2358,7 @@ bool CSSPropertyParser::consumeOverscrollBehaviorShorthand(bool important)
 
 bool CSSPropertyParser::consumeContainerShorthand(bool important)
 {
-    auto name = consumeContainerName(m_range);
+    RefPtr name = consumeContainerName(m_range);
     if (!name)
         return false;
 
@@ -2391,7 +2391,7 @@ bool CSSPropertyParser::consumeContainIntrinsicSizeShorthand(bool important)
     if (m_range.atEnd())
         return false;
 
-    RefPtr<CSSValue> containIntrinsicWidth = consumeContainIntrinsicSize(m_range);
+    RefPtr containIntrinsicWidth = consumeContainIntrinsicSize(m_range);
     if (!containIntrinsicWidth)
         return false;
 
@@ -2440,7 +2440,7 @@ bool CSSPropertyParser::consumePerspectiveOrigin(bool important)
 
 bool CSSPropertyParser::consumePrefixedPerspective(bool important)
 {
-    if (auto value = CSSPropertyParsing::consumePerspective(m_range, m_context)) {
+    if (RefPtr value = CSSPropertyParsing::consumePerspective(m_range, m_context)) {
         addProperty(CSSPropertyPerspective, CSSPropertyWebkitPerspective, value.releaseNonNull(), important);
         return m_range.atEnd();
     }
@@ -2448,7 +2448,7 @@ bool CSSPropertyParser::consumePrefixedPerspective(bool important)
     if (auto perspective = consumeNumberRaw(m_range)) {
         if (perspective->value < 0)
             return false;
-        auto value = CSSPrimitiveValue::create(perspective->value, CSSUnitType::CSS_PX);
+        Ref value = CSSPrimitiveValue::create(perspective->value, CSSUnitType::CSS_PX);
         addProperty(CSSPropertyPerspective, CSSPropertyWebkitPerspective, WTFMove(value), important);
         return m_range.atEnd();
     }
@@ -2648,7 +2648,7 @@ bool CSSPropertyParser::consumeScrollTimelineShorthand(bool important)
 
     do {
         // A valid scroll-timeline-name is required.
-        if (auto name = CSSPropertyParsing::consumeSingleScrollTimelineName(m_range))
+        if (RefPtr name = CSSPropertyParsing::consumeSingleScrollTimelineName(m_range))
             namesList.append(name.releaseNonNull());
         else
             return false;
@@ -2682,15 +2682,15 @@ bool CSSPropertyParser::consumeViewTimelineShorthand(bool important)
 
     do {
         // A valid view-timeline-name is required.
-        if (auto name = CSSPropertyParsing::consumeSingleScrollTimelineName(m_range))
+        if (RefPtr name = CSSPropertyParsing::consumeSingleScrollTimelineName(m_range))
             namesList.append(name.releaseNonNull());
         else
             return false;
 
         // Both a view-timeline-axis and a view-timeline-inset are optional.
         if (m_range.peek().type() != CommaToken && !m_range.atEnd()) {
-            auto axis = CSSPropertyParsing::consumeAxis(m_range);
-            auto insets = consumeViewTimelineInsetListItem(m_range, m_context);
+            RefPtr axis = CSSPropertyParsing::consumeAxis(m_range);
+            RefPtr insets = consumeViewTimelineInsetListItem(m_range, m_context);
             // Since the order of view-timeline-axis and view-timeline-inset is not guaranteed, let's try view-timeline-axis again.
             if (!axis)
                 axis = CSSPropertyParsing::consumeAxis(m_range);
@@ -2808,10 +2808,10 @@ bool CSSPropertyParser::parseShorthand(CSSPropertyID property, bool important)
     case CSSPropertyWebkitTextStroke:
         return consumeShorthandGreedily(webkitTextStrokeShorthand(), important);
     case CSSPropertyMarker: {
-        RefPtr<CSSValue> marker = parseSingleValue(CSSPropertyMarkerStart);
+        RefPtr marker = parseSingleValue(CSSPropertyMarkerStart);
         if (!marker || !m_range.atEnd())
             return false;
-        auto markerRef = marker.releaseNonNull();
+        Ref markerRef = marker.releaseNonNull();
         addProperty(CSSPropertyMarkerStart, CSSPropertyMarker, markerRef.copyRef(), important);
         addProperty(CSSPropertyMarkerMid, CSSPropertyMarker, markerRef.copyRef(), important);
         addProperty(CSSPropertyMarkerEnd, CSSPropertyMarker, markerRef.copyRef(), important);
@@ -2909,8 +2909,8 @@ bool CSSPropertyParser::parseShorthand(CSSPropertyID property, bool important)
     case CSSPropertyWebkitPerspective:
         return consumePrefixedPerspective(important);
     case CSSPropertyGap: {
-        auto rowGap = CSSPropertyParsing::consumeRowGap(m_range, m_context);
-        auto columnGap = CSSPropertyParsing::consumeColumnGap(m_range, m_context);
+        RefPtr rowGap = CSSPropertyParsing::consumeRowGap(m_range, m_context);
+        RefPtr columnGap = CSSPropertyParsing::consumeColumnGap(m_range, m_context);
         if (!rowGap || !m_range.atEnd())
             return false;
         if (!columnGap)

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -234,7 +234,7 @@ static RefPtr<CSSCalcValue> consumeCalcRawWithKnownTokenTypeFunction(CSSParserTo
     if (!CSSCalcValue::isCalcFunction(functionId))
         return nullptr;
 
-    auto calcValue = CSSCalcValue::create(functionId, consumeFunction(range), category, valueRange, symbolTable);
+    RefPtr calcValue = CSSCalcValue::create(functionId, consumeFunction(range), category, valueRange, symbolTable);
     if (calcValue && calcValue->category() == category)
         return calcValue;
 
@@ -269,7 +269,7 @@ struct IntegerTypeRawKnownTokenTypeFunctionConsumer {
         ASSERT(range.peek().type() == FunctionToken);
 
         auto rangeCopy = range;
-        if (auto value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Number, { }, ValueRange::All)) {
+        if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Number, { }, ValueRange::All)) {
             range = rangeCopy;
             // https://drafts.csswg.org/css-values-4/#integers
             // Rounding to the nearest integer requires rounding in the direction of +∞ when the fractional portion is exactly 0.5.
@@ -337,7 +337,7 @@ struct NumberRawKnownTokenTypeFunctionConsumer {
         ASSERT(range.peek().type() == FunctionToken);
 
         auto rangeCopy = range;
-        if (auto value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Number, symbolTable, valueRange)) {
+        if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Number, symbolTable, valueRange)) {
             if (auto validatedValue = validatedNumberRaw(value->doubleValue(), valueRange)) {
                 range = rangeCopy;
                 return validatedValue;
@@ -433,7 +433,7 @@ struct PercentRawKnownTokenTypeFunctionConsumer {
         ASSERT(range.peek().type() == FunctionToken);
 
         auto rangeCopy = range;
-        if (auto value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Percent, symbolTable, valueRange)) {
+        if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Percent, symbolTable, valueRange)) {
             range = rangeCopy;
 
             // FIXME: Should this validate the calc value as is done for the NumberRaw variant?
@@ -526,7 +526,7 @@ struct LengthRawKnownTokenTypeFunctionConsumer {
         ASSERT(range.peek().type() == FunctionToken);
 
         auto rangeCopy = range;
-        if (auto value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Length, symbolTable, valueRange)) {
+        if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Length, symbolTable, valueRange)) {
             range = rangeCopy;
 
             // FIXME: Should this validate the calc value as is done for the NumberRaw variant?
@@ -675,7 +675,7 @@ struct AngleRawKnownTokenTypeFunctionConsumer {
     static std::optional<AngleRaw> consume(CSSParserTokenRange& range, const CSSCalcSymbolTable& symbolTable, ValueRange valueRange, CSSParserMode, UnitlessQuirk, UnitlessZeroQuirk)
     {
         auto rangeCopy = range;
-        if (auto value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Angle, symbolTable, valueRange)) {
+        if (RefPtr value = consumeCalcRawWithKnownTokenTypeFunction(rangeCopy, CalculationCategory::Angle, symbolTable, valueRange)) {
             range = rangeCopy;
             return { { value->primitiveType(), value->doubleValue() } };
         }
@@ -857,7 +857,7 @@ struct ImageSetTypeCSSPrimitiveValueKnownTokenTypeFunctionConsumer {
 
         auto rangeCopy = range;
         auto typeArg = consumeFunction(rangeCopy);
-        auto result = consumeString(typeArg);
+        RefPtr result = consumeString(typeArg);
 
         if (!result || !typeArg.atEnd())
             return nullptr;
@@ -1611,7 +1611,7 @@ RefPtr<CSSPrimitiveValue> consumeNumberOrPercent(CSSParserTokenRange& range, Val
 
     switch (token.type()) {
     case FunctionToken:
-        if (auto value = NumberCSSPrimitiveValueWithCalcWithKnownTokenTypeFunctionConsumer::consume(range, { }, valueRange, CSSParserMode::HTMLStandardMode, UnitlessQuirk::Forbid, UnitlessZeroQuirk::Forbid))
+        if (RefPtr value = NumberCSSPrimitiveValueWithCalcWithKnownTokenTypeFunctionConsumer::consume(range, { }, valueRange, CSSParserMode::HTMLStandardMode, UnitlessQuirk::Forbid, UnitlessZeroQuirk::Forbid))
             return value;
         return PercentCSSPrimitiveValueWithCalcWithKnownTokenTypeFunctionConsumer::consume(range, { }, valueRange, CSSParserMode::HTMLStandardMode, UnitlessQuirk::Forbid, UnitlessZeroQuirk::Forbid);
 

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
@@ -97,7 +97,7 @@ RefPtr<CSSValueList> CSSPropertyParserWorkerSafe::parseFontFaceSrc(const String&
     range.consumeWhitespace();
     if (range.atEnd())
         return nullptr;
-    auto parsedValue = CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrc(range, parser.context());
+    RefPtr parsedValue = CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrc(range, parser.context());
     if (!parsedValue || !range.atEnd())
         return nullptr;
 
@@ -112,7 +112,7 @@ RefPtr<CSSValue> CSSPropertyParserWorkerSafe::parseFontFaceStyle(const String& s
     range.consumeWhitespace();
     if (range.atEnd())
         return nullptr;
-    auto parsedValue =
+    RefPtr parsedValue =
 #if ENABLE(VARIATION_FONTS)
         CSSPropertyParserHelpersWorkerSafe::consumeFontStyleRange(range, parserContext.mode);
 #else
@@ -132,7 +132,7 @@ RefPtr<CSSValue> CSSPropertyParserWorkerSafe::parseFontFaceWeight(const String& 
     range.consumeWhitespace();
     if (range.atEnd())
         return nullptr;
-    auto parsedValue =
+    RefPtr parsedValue =
 #if ENABLE(VARIATION_FONTS)
         CSSPropertyParserHelpersWorkerSafe::consumeFontWeightAbsoluteRange(range);
 #else
@@ -152,7 +152,7 @@ RefPtr<CSSValue> CSSPropertyParserWorkerSafe::parseFontFaceStretch(const String&
     range.consumeWhitespace();
     if (range.atEnd())
         return nullptr;
-    auto parsedValue =
+    RefPtr parsedValue =
 #if ENABLE(VARIATION_FONTS)
         CSSPropertyParserHelpersWorkerSafe::consumeFontStretchRange(range);
 #else
@@ -172,7 +172,7 @@ RefPtr<CSSValueList> CSSPropertyParserWorkerSafe::parseFontFaceUnicodeRange(cons
     range.consumeWhitespace();
     if (range.atEnd())
         return nullptr;
-    auto parsedValue = CSSPropertyParserHelpersWorkerSafe::consumeFontFaceUnicodeRange(range);
+    RefPtr parsedValue = CSSPropertyParserHelpersWorkerSafe::consumeFontFaceUnicodeRange(range);
     if (!parsedValue || !range.atEnd())
         return nullptr;
 
@@ -187,7 +187,7 @@ RefPtr<CSSValue> CSSPropertyParserWorkerSafe::parseFontFaceFeatureSettings(const
     range.consumeWhitespace();
     if (range.atEnd())
         return nullptr;
-    auto parsedValue = CSSPropertyParserHelpersWorkerSafe::consumeFontFeatureSettings(range);
+    RefPtr parsedValue = CSSPropertyParserHelpersWorkerSafe::consumeFontFeatureSettings(range);
     if (!parsedValue || !range.atEnd())
         return nullptr;
 
@@ -202,7 +202,7 @@ RefPtr<CSSPrimitiveValue> CSSPropertyParserWorkerSafe::parseFontFaceDisplay(cons
     range.consumeWhitespace();
     if (range.atEnd())
         return nullptr;
-    auto parsedValue = CSSPropertyParserHelpersWorkerSafe::consumeFontFaceFontDisplay(range);
+    RefPtr parsedValue = CSSPropertyParserHelpersWorkerSafe::consumeFontFaceFontDisplay(range);
     if (!parsedValue || !range.atEnd())
         return nullptr;
 
@@ -217,7 +217,7 @@ RefPtr<CSSValue> CSSPropertyParserWorkerSafe::parseFontFaceSizeAdjust(const Stri
     range.consumeWhitespace();
     if (range.atEnd())
         return nullptr;
-    auto parsedValue = CSSPropertyParserHelpers::consumePercent(range, ValueRange::NonNegative);
+    RefPtr parsedValue = CSSPropertyParserHelpers::consumePercent(range, ValueRange::NonNegative);
     if (!parsedValue || !range.atEnd())
         return nullptr;
 
@@ -286,7 +286,7 @@ RefPtr<CSSValueList> consumeFontFaceSrc(CSSParserTokenRange& range, const CSSPar
         while (!range.atEnd() && range.peek().type() != CSSParserTokenType::CommaToken)
             range.consumeComponentValue();
         auto subrange = range.makeSubRange(begin, &range.peek());
-        if (auto parsedValue = consumeSrcListComponent(subrange))
+        if (RefPtr parsedValue = consumeSrcListComponent(subrange))
             values.append(parsedValue.releaseNonNull());
         if (!range.atEnd())
             range.consumeIncludingWhitespace();
@@ -301,7 +301,7 @@ RefPtr<CSSValueList> consumeFontFaceSrc(CSSParserTokenRange& range, const CSSPar
 static RefPtr<CSSPrimitiveValue> consumeFontStyleAngle(CSSParserTokenRange& range, CSSParserMode mode)
 {
     auto rangeAfterAngle = range;
-    auto angle = CSSPropertyParserHelpers::consumeAngle(rangeAfterAngle, mode);
+    RefPtr angle = CSSPropertyParserHelpers::consumeAngle(rangeAfterAngle, mode);
     if (!angle)
         return nullptr;
     if (!angle->isCalculated() && !CSSPropertyParserHelpers::isFontStyleAngleInRange(angle->doubleValue(CSSUnitType::CSS_DEG)))
@@ -312,7 +312,7 @@ static RefPtr<CSSPrimitiveValue> consumeFontStyleAngle(CSSParserTokenRange& rang
 
 RefPtr<CSSValue> consumeFontStyleRange(CSSParserTokenRange& range, CSSParserMode mode)
 {
-    auto keyword = CSSPropertyParserHelpers::consumeIdent<CSSValueNormal, CSSValueItalic, CSSValueOblique>(range);
+    RefPtr keyword = CSSPropertyParserHelpers::consumeIdent<CSSValueNormal, CSSValueItalic, CSSValueOblique>(range);
     if (!keyword)
         return nullptr;
 
@@ -328,7 +328,7 @@ RefPtr<CSSValue> consumeFontStyleRange(CSSParserTokenRange& range, CSSParserMode
     if (rangeAfterAngles.atEnd())
         angleList = CSSValueList::createSpaceSeparated(firstAngle.releaseNonNull());
     else {
-        auto secondAngle = consumeFontStyleAngle(rangeAfterAngles, mode);
+        RefPtr secondAngle = consumeFontStyleAngle(rangeAfterAngles, mode);
         if (!secondAngle)
             return nullptr;
         angleList = CSSValueList::createSpaceSeparated(firstAngle.releaseNonNull(), secondAngle.releaseNonNull());
@@ -342,7 +342,7 @@ RefPtr<CSSValue> consumeFontStyleRange(CSSParserTokenRange& range, CSSParserMode
 
 RefPtr<CSSValue> consumeFontStyle(CSSParserTokenRange& range, CSSParserMode mode)
 {
-    auto keyword = CSSPropertyParserHelpers::consumeIdent<CSSValueNormal, CSSValueItalic, CSSValueOblique>(range);
+    RefPtr keyword = CSSPropertyParserHelpers::consumeIdent<CSSValueNormal, CSSValueItalic, CSSValueOblique>(range);
     if (!keyword)
         return nullptr;
 
@@ -367,14 +367,14 @@ static RefPtr<CSSPrimitiveValue> consumeFontWeightAbsoluteKeywordValue(CSSParser
 
 RefPtr<CSSValue> consumeFontWeightAbsoluteRange(CSSParserTokenRange& range)
 {
-    if (auto result = consumeFontWeightAbsoluteKeywordValue(range))
+    if (RefPtr result = consumeFontWeightAbsoluteKeywordValue(range))
         return result;
-    auto firstNumber = CSSPropertyParserHelpers::consumeFontWeightNumber(range);
+    RefPtr firstNumber = CSSPropertyParserHelpers::consumeFontWeightNumber(range);
     if (!firstNumber)
         return nullptr;
     if (range.atEnd())
         return firstNumber;
-    auto secondNumber = CSSPropertyParserHelpers::consumeFontWeightNumber(range);
+    RefPtr secondNumber = CSSPropertyParserHelpers::consumeFontWeightNumber(range);
     if (!secondNumber)
         return nullptr;
     return CSSValueList::createSpaceSeparated(firstNumber.releaseNonNull(), secondNumber.releaseNonNull());
@@ -384,7 +384,7 @@ RefPtr<CSSValue> consumeFontWeightAbsoluteRange(CSSParserTokenRange& range)
 
 RefPtr<CSSPrimitiveValue> consumeFontWeightAbsolute(CSSParserTokenRange& range)
 {
-    if (auto result = consumeFontWeightAbsoluteKeywordValue(range))
+    if (RefPtr result = consumeFontWeightAbsoluteKeywordValue(range))
         return result;
     return CSSPropertyParserHelpers::consumeFontWeightNumber(range);
 }
@@ -400,10 +400,10 @@ RefPtr<CSSPrimitiveValue> consumeFontStretchKeywordValue(CSSParserTokenRange& ra
 
 RefPtr<CSSPrimitiveValue> consumeFontStretch(CSSParserTokenRange& range)
 {
-    if (auto result = consumeFontStretchKeywordValue(range))
+    if (RefPtr result = consumeFontStretchKeywordValue(range))
         return result;
 #if ENABLE(VARIATION_FONTS)
-    if (auto percent = CSSPropertyParserHelpers::consumePercent(range, ValueRange::NonNegative))
+    if (RefPtr percent = CSSPropertyParserHelpers::consumePercent(range, ValueRange::NonNegative))
         return percent;
 #endif
     return nullptr;
@@ -413,14 +413,14 @@ RefPtr<CSSPrimitiveValue> consumeFontStretch(CSSParserTokenRange& range)
 
 RefPtr<CSSValue> consumeFontStretchRange(CSSParserTokenRange& range)
 {
-    if (auto result = consumeFontStretchKeywordValue(range))
+    if (RefPtr result = consumeFontStretchKeywordValue(range))
         return result;
-    auto firstPercent = CSSPropertyParserHelpers::consumePercent(range, ValueRange::NonNegative);
+    RefPtr firstPercent = CSSPropertyParserHelpers::consumePercent(range, ValueRange::NonNegative);
     if (!firstPercent)
         return nullptr;
     if (range.atEnd())
         return firstPercent;
-    auto secondPercent = CSSPropertyParserHelpers::consumePercent(range, ValueRange::NonNegative);
+    RefPtr secondPercent = CSSPropertyParserHelpers::consumePercent(range, ValueRange::NonNegative);
     if (!secondPercent)
         return nullptr;
     return CSSValueList::createSpaceSeparated(firstPercent.releaseNonNull(), secondPercent.releaseNonNull());

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -138,7 +138,7 @@ void StyledElement::setInlineStyleFromString(const AtomString& newStyleString)
     if (RefPtr mutableStyleProperties = dynamicDowncast<MutableStyleProperties>(inlineStyle))
         mutableStyleProperties->parseDeclaration(newStyleString, protectedDocument().get());
     else
-        inlineStyle = CSSParser::parseInlineStyleDeclaration(newStyleString, this);
+        inlineStyle = CSSParser::parseInlineStyleDeclaration(newStyleString, *this);
 
     if (usesStyleBasedEditability(*inlineStyle))
         protectedDocument()->setHasElementUsingStyleBasedEditability();

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -1698,7 +1698,7 @@ bool InspectorStyleSheet::ensureSourceData()
         context.mode = UASheetMode;
     
     StyleSheetHandler handler(m_parsedStyleSheet->text(), m_pageStyleSheet->ownerDocument(), ruleSourceDataResult.get());
-    CSSParser::parseSheetForInspector(context, newStyleSheet.ptr(), m_parsedStyleSheet->text(), handler);
+    CSSParser::parseSheetForInspector(context, newStyleSheet, m_parsedStyleSheet->text(), handler);
     m_parsedStyleSheet->setSourceData(WTFMove(ruleSourceDataResult));
     return m_parsedStyleSheet->hasSourceData();
 }


### PR DESCRIPTION
#### a4a18ee4b8d7b456de7cd8f2bc6c4dc53826819e
<pre>
Use more smart pointers under WebCore/css/parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=267902">https://bugs.webkit.org/show_bug.cgi?id=267902</a>

Reviewed by Brent Fulgham.

* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleScope::setStyleSheetContents):
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::parseSheetForInspector):
(WebCore::CSSParser::parseKeyframeRule):
(WebCore::color):
(WebCore::CSSParser::parseSingleValue):
(WebCore::CSSParser::parseValue):
(WebCore::CSSParser::parseCustomPropertyValue):
(WebCore::CSSParser::parseInlineStyleDeclaration):
* Source/WebCore/css/parser/CSSParser.h:
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::parseSimpleTransformValue):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::parseValue):
(WebCore::CSSParserImpl::parseCustomPropertyValue):
(WebCore::createStyleProperties):
(WebCore::CSSParserImpl::parseInlineStyleDeclaration):
(WebCore::CSSParserImpl::parseStyleSheetForInspector):
(WebCore::CSSParserImpl::protectedStyleSheet const):
(WebCore::CSSParserImpl::consumeNestedGroupRules):
(WebCore::CSSParserImpl::consumeFontPaletteValuesRule):
(WebCore::CSSParserImpl::consumePageRule):
(WebCore::CSSParserImpl::consumeScopeRule):
(WebCore::CSSParserImpl::consumeStyleRule):
(WebCore::CSSParserImpl::consumeBlockContent):
* Source/WebCore/css/parser/CSSParserImpl.h:
(WebCore::CSSParserImpl::tokenizer const):
* Source/WebCore/css/parser/CSSParserObserverWrapper.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::parseSingleValue):
(WebCore::CSSPropertyParser::parseTypedCustomPropertyValue):
(WebCore::CSSPropertyParser::parseTypedCustomPropertyInitialValue):
(WebCore::CSSPropertyParser::parseValueStart):
(WebCore::CSSPropertyParser::consumeCSSWideKeyword):
(WebCore::CSSPropertyParser::consumeCustomPropertyValueWithSyntax):
(WebCore::CSSPropertyParser::parseCounterStyleDescriptor):
(WebCore::CSSPropertyParser::parseFontFaceDescriptor):
(WebCore::CSSPropertyParser::parsePropertyDescriptor):
(WebCore::CSSPropertyParser::parseFontPaletteValuesDescriptor):
(WebCore::CSSPropertyParser::consumeTextDecorationSkip):
(WebCore::CSSPropertyParser::consumeFontSynthesis):
(WebCore::CSSPropertyParser::consumeBorderSpacing):
(WebCore::CSSPropertyParser::consume2ValueShorthand):
(WebCore::CSSPropertyParser::consume4ValueShorthand):
(WebCore::CSSPropertyParser::consumeLegacyBreakProperty):
(WebCore::CSSPropertyParser::consumeGridItemPositionShorthand):
(WebCore::CSSPropertyParser::consumeGridAreaShorthand):
(WebCore::CSSPropertyParser::consumeGridTemplateRowsAndAreasAndColumns):
(WebCore::CSSPropertyParser::consumeGridTemplateShorthand):
(WebCore::CSSPropertyParser::consumePlaceContentShorthand):
(WebCore::CSSPropertyParser::consumePlaceItemsShorthand):
(WebCore::CSSPropertyParser::consumePlaceSelfShorthand):
(WebCore::CSSPropertyParser::consumeOverscrollBehaviorShorthand):
(WebCore::CSSPropertyParser::consumeContainerShorthand):
(WebCore::CSSPropertyParser::consumeContainIntrinsicSizeShorthand):
(WebCore::CSSPropertyParser::consumePrefixedPerspective):
(WebCore::CSSPropertyParser::consumeScrollTimelineShorthand):
(WebCore::CSSPropertyParser::consumeViewTimelineShorthand):
(WebCore::CSSPropertyParser::parseShorthand):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeCalcRawWithKnownTokenTypeFunction):
(WebCore::CSSPropertyParserHelpers::IntegerTypeRawKnownTokenTypeFunctionConsumer::consume):
(WebCore::CSSPropertyParserHelpers::NumberRawKnownTokenTypeFunctionConsumer::consume):
(WebCore::CSSPropertyParserHelpers::PercentRawKnownTokenTypeFunctionConsumer::consume):
(WebCore::CSSPropertyParserHelpers::LengthRawKnownTokenTypeFunctionConsumer::consume):
(WebCore::CSSPropertyParserHelpers::AngleRawKnownTokenTypeFunctionConsumer::consume):
(WebCore::CSSPropertyParserHelpers::ImageSetTypeCSSPrimitiveValueKnownTokenTypeFunctionConsumer::consume):
(WebCore::CSSPropertyParserHelpers::consumeNumberOrPercent):
* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserWorkerSafe::parseFontFaceSrc):
(WebCore::CSSPropertyParserWorkerSafe::parseFontFaceStyle):
(WebCore::CSSPropertyParserWorkerSafe::parseFontFaceWeight):
(WebCore::CSSPropertyParserWorkerSafe::parseFontFaceStretch):
(WebCore::CSSPropertyParserWorkerSafe::parseFontFaceUnicodeRange):
(WebCore::CSSPropertyParserWorkerSafe::parseFontFaceFeatureSettings):
(WebCore::CSSPropertyParserWorkerSafe::parseFontFaceDisplay):
(WebCore::CSSPropertyParserWorkerSafe::parseFontFaceSizeAdjust):
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrc):
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontStyleAngle):
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontStyleRange):
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontStyle):
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontWeightAbsoluteRange):
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontWeightAbsolute):
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontStretch):
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontStretchRange):
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::setInlineStyleFromString):
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::InspectorStyleSheet::ensureSourceData):

Canonical link: <a href="https://commits.webkit.org/273369@main">https://commits.webkit.org/273369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e40229bd1ed7471ea279b528be08c05f2cdbc8ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37963 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31778 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11208 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30677 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10486 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39211 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32022 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31834 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36531 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34542 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11195 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4545 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->