### PR TITLE
[Site Isolation] Make `findString:` correctly cycle through matches and update selection

### DIFF
--- a/LayoutTests/platform/ios/fast/scrolling/find-text-in-overflow-node.html
+++ b/LayoutTests/platform/ios/fast/scrolling/find-text-in-overflow-node.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width">
     <script src="../../../../resources/testharness.js"></script>
     <script src="../../../../resources/testharnessreport.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
     <script type="text/javascript">
       setup({ "explicit_done": true });
       function height(id) {
@@ -32,7 +33,8 @@
           testRunner.runUIScript(`
             uiController.findString("match", ${findOptions}, ${maxCount}); // match 4
             uiController.uiScriptComplete("Done");
-          `, afterMatch4.step_func_done(function() {
+          `, afterMatch4.step_func_done(async function() {
+              await UIHelper.ensurePresentationUpdate();
               assert_greater_than(node.scrollTop, 0);
               var expectedScrollTop = height("divBefore") + height("match4") / 2 - height("scrollable") / 2;
               assert_approx_equals(node.scrollTop, expectedScrollTop, 2);

--- a/LayoutTests/platform/ios/fast/scrolling/find-text-in-subframe.html
+++ b/LayoutTests/platform/ios/fast/scrolling/find-text-in-subframe.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width">
     <script src="../../../../resources/testharness.js"></script>
     <script src="../../../../resources/testharnessreport.js"></script>
+    <script src="../../../../resources/ui-helper.js"></script>
     <script type="text/javascript">
       if (window.internals)
         window.internals.settings.setAsyncFrameScrollingEnabled(true);
@@ -34,7 +35,8 @@
           testRunner.runUIScript(`
             uiController.findString("match", ${findOptions}, ${maxCount}); // match 4
             uiController.uiScriptComplete("Done");
-          `, afterMatch4.step_func_done(function() {
+          `, afterMatch4.step_func_done(async function() {
+              await UIHelper.ensurePresentationUpdate();
               assert_greater_than(node.scrollY, 0);
               var expectedScrollY = height(node, "divBefore") + height(node, "match4") / 2 - height(window, "scrollable") / 2;
               assert_approx_equals(node.scrollY, expectedScrollY, 2);

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -3694,7 +3694,8 @@ bool Editor::findString(const String& target, FindOptions options)
     if (!resultRange)
         return false;
 
-    document->selection().setSelection(VisibleSelection(*resultRange));
+    if (!options.contains(DoNotSetSelection))
+        document->selection().setSelection(VisibleSelection(*resultRange));
 
     if (!(options.contains(DoNotRevealSelection)))
         document->selection().revealSelection();

--- a/Source/WebCore/editing/FindOptions.h
+++ b/Source/WebCore/editing/FindOptions.h
@@ -41,6 +41,7 @@ enum FindOptionFlag {
     DoNotRevealSelection = 1 << 6,
     AtWordEnds = 1 << 7,
     DoNotTraverseFlatTree = 1 << 8,
+    DoNotSetSelection = 1 << 9,
 };
 
 using FindOptions = OptionSet<FindOptionFlag>;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -423,7 +423,7 @@ public:
     void setTabKeyCyclesThroughElements(bool b) { m_tabKeyCyclesThroughElements = b; }
     bool tabKeyCyclesThroughElements() const { return m_tabKeyCyclesThroughElements; }
 
-    WEBCORE_EXPORT bool findString(const String&, FindOptions, DidWrap* = nullptr);
+    WEBCORE_EXPORT std::optional<FrameIdentifier> findString(const String&, FindOptions, DidWrap* = nullptr);
     WEBCORE_EXPORT uint32_t replaceRangesWithText(const Vector<SimpleRange>& rangesToReplace, const String& replacementText, bool selectionOnly);
     WEBCORE_EXPORT uint32_t replaceSelectionWithText(const String& replacementText);
 

--- a/Source/WebKit/Shared/WebFindOptions.h
+++ b/Source/WebKit/Shared/WebFindOptions.h
@@ -41,6 +41,7 @@ enum class FindOptions : uint16_t {
     DetermineMatchIndex = 1 << 8,
     NoIndexChange = 1 << 9,
     AtWordEnds = 1 << 10,
+    DoNotSetSelection = 1 << 11,
 };
 
 enum class FindDecorationStyle : uint8_t {

--- a/Source/WebKit/Shared/WebFindOptions.serialization.in
+++ b/Source/WebKit/Shared/WebFindOptions.serialization.in
@@ -35,6 +35,7 @@ header: "WebFindOptions.h"
     DetermineMatchIndex,
     NoIndexChange,
     AtWordEnds,
+    DoNotSetSelection,
 };
 
 enum class WebKit::FindDecorationStyle : uint8_t {

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -380,6 +380,7 @@ UIProcess/DeviceIdHashSaltStorage.cpp
 UIProcess/DisplayLink.cpp
 UIProcess/DisplayLinkProcessProxyClient.cpp
 UIProcess/DrawingAreaProxy.cpp
+UIProcess/FindStringCallbackAggregator.cpp
 UIProcess/FrameLoadState.cpp
 UIProcess/GeolocationPermissionRequestManagerProxy.cpp
 UIProcess/GeolocationPermissionRequestProxy.cpp

--- a/Source/WebKit/UIProcess/FindStringCallbackAggregator.cpp
+++ b/Source/WebKit/UIProcess/FindStringCallbackAggregator.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FindStringCallbackAggregator.h"
+
+#include "WebFrameProxy.h"
+#include "WebPageMessages.h"
+#include "WebPageProxy.h"
+
+namespace WebKit {
+
+using namespace WebCore;
+
+Ref<FindStringCallbackAggregator> FindStringCallbackAggregator::create(WebPageProxy& page, const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount, CompletionHandler<void(bool)>&& completionHandler)
+{
+    return adoptRef(*new FindStringCallbackAggregator(page, string, options, maxMatchCount, WTFMove(completionHandler)));
+}
+
+void FindStringCallbackAggregator::foundString(std::optional<FrameIdentifier> frameID, bool didWrap)
+{
+    if (!frameID)
+        return;
+
+    m_matches.set(*frameID, didWrap);
+}
+
+static inline bool shouldTargetFrame(const WebFrameProxy& frame, const WebFrameProxy& focusedFrame, bool didWrap)
+{
+    if (!didWrap)
+        return true;
+
+    if (frame.process() != focusedFrame.process())
+        return true;
+
+    RefPtr nextFrameInProcess = focusedFrame.traverseNext(CanWrap::Yes).frame;
+    while (nextFrameInProcess && nextFrameInProcess != &focusedFrame && nextFrameInProcess->process() == focusedFrame.process()) {
+        if (nextFrameInProcess == &frame)
+            return true;
+        nextFrameInProcess = nextFrameInProcess->traverseNext(CanWrap::Yes).frame;
+    }
+    return false;
+}
+
+FindStringCallbackAggregator::~FindStringCallbackAggregator()
+{
+    RefPtr protectedPage = m_page.get();
+    if (!protectedPage) {
+        m_completionHandler(false);
+        return;
+    }
+
+    RefPtr focusedFrame = protectedPage->focusedOrMainFrame();
+    if (!focusedFrame) {
+        m_completionHandler(false);
+        return;
+    }
+
+    RefPtr targetFrame = focusedFrame.get();
+    do {
+        auto it = m_matches.find(targetFrame->frameID());
+        if (it != m_matches.end()) {
+            if (shouldTargetFrame(*targetFrame, *focusedFrame, it->value))
+                break;
+        }
+        // FIXME(267905): This should have support for backwards traversal.
+        // FIXME(267904): This probably shouldn't always wrap if FindOptions::WrapAround is not in m_options.
+        targetFrame = targetFrame->traverseNext(CanWrap::Yes).frame;
+    } while (targetFrame && targetFrame != focusedFrame);
+
+    if (!targetFrame) {
+        m_completionHandler(false);
+        return;
+    }
+
+    targetFrame->process().sendWithAsyncReply(Messages::WebPage::FindString(m_string, m_options, m_maxMatchCount), [completionHandler = WTFMove(m_completionHandler)](std::optional<FrameIdentifier> frameID, bool) mutable {
+        completionHandler(frameID.has_value());
+    }, protectedPage->webPageID());
+
+    if (focusedFrame && focusedFrame->process() != targetFrame->process())
+        focusedFrame->process().send(Messages::WebPage::ClearSelection(), protectedPage->webPageID());
+}
+
+FindStringCallbackAggregator::FindStringCallbackAggregator(WebPageProxy& page, const String& string, OptionSet<FindOptions> options, unsigned maxMatchCount, CompletionHandler<void(bool)>&& completionHandler)
+    : m_page(page)
+    , m_string(string)
+    , m_options(options)
+    , m_maxMatchCount(maxMatchCount)
+    , m_completionHandler(WTFMove(completionHandler))
+{
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/FindStringCallbackAggregator.h
+++ b/Source/WebKit/UIProcess/FindStringCallbackAggregator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,29 +23,32 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "WebFindOptions.h"
+#pragma once
+
+#include <WebCore/FrameIdentifier.h>
+#include <wtf/CompletionHandler.h>
 
 namespace WebKit {
 
-WebCore::FindOptions core(OptionSet<FindOptions> options)
-{
-    WebCore::FindOptions result;
-    if (options.contains(FindOptions::CaseInsensitive))
-        result.add(WebCore::CaseInsensitive);
-    if (options.contains(FindOptions::AtWordStarts))
-        result.add(WebCore::AtWordStarts);
-    if (options.contains(FindOptions::TreatMedialCapitalAsWordStart))
-        result.add(WebCore::TreatMedialCapitalAsWordStart);
-    if (options.contains(FindOptions::Backwards))
-        result.add(WebCore::Backwards);
-    if (options.contains(FindOptions::WrapAround))
-        result.add(WebCore::WrapAround);
-    if (options.contains(FindOptions::AtWordEnds))
-        result.add(WebCore::AtWordEnds);
-    if (options.contains(FindOptions::DoNotSetSelection))
-        result.add(WebCore::DoNotSetSelection);
-    return result;
-}
+class WebPageProxy;
+
+enum class FindOptions : uint16_t;
+
+class FindStringCallbackAggregator : public RefCounted<FindStringCallbackAggregator> {
+public:
+    static Ref<FindStringCallbackAggregator> create(WebPageProxy&, const String&, OptionSet<FindOptions>, unsigned maxMatchCount, CompletionHandler<void(bool)>&&);
+    void foundString(std::optional<WebCore::FrameIdentifier>, bool didWrap);
+    ~FindStringCallbackAggregator();
+
+private:
+    FindStringCallbackAggregator(WebPageProxy&, const String&, OptionSet<FindOptions>, unsigned maxMatchCount, CompletionHandler<void(bool)>&&);
+
+    WeakPtr<WebPageProxy> m_page;
+    String m_string;
+    OptionSet<FindOptions> m_options;
+    unsigned m_maxMatchCount;
+    CompletionHandler<void(bool)> m_completionHandler;
+    HashMap<WebCore::FrameIdentifier, bool> m_matches;
+};
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -63,6 +63,8 @@ class WebPageProxy;
 class WebProcessProxy;
 class WebsiteDataStore;
 
+enum class CanWrap : bool { No, Yes };
+enum class DidWrap : bool { No, Yes };
 enum class ShouldExpectSafeBrowsingResult : bool;
 enum class ProcessSwapRequestedByClient : bool;
 
@@ -158,7 +160,7 @@ public:
     void getFrameInfo(CompletionHandler<void(FrameTreeNodeData&&)>&&);
     FrameTreeCreationParameters frameTreeCreationParameters() const;
 
-    WebFrameProxy* parentFrame() { return m_parentFrame.get(); }
+    WebFrameProxy* parentFrame() const { return m_parentFrame.get(); }
     WebProcessProxy& process() const { return m_process.get(); }
     Ref<WebProcessProxy> protectedProcess() const { return process(); }
     void setProcess(WebProcessProxy& process) { m_process = process; }
@@ -171,10 +173,24 @@ public:
 
     bool isFocused() const;
 
+    struct TraversalResult {
+        RefPtr<WebFrameProxy> frame;
+        DidWrap didWrap { DidWrap::No };
+    };
+    TraversalResult traverseNext() const;
+    TraversalResult traverseNext(CanWrap) const;
+    TraversalResult traversePrevious(CanWrap);
+
 private:
     WebFrameProxy(WebPageProxy&, WebProcessProxy&, WebCore::FrameIdentifier);
 
     std::optional<WebCore::PageIdentifier> pageIdentifier() const;
+
+    RefPtr<WebFrameProxy> deepLastChild();
+    RefPtr<WebFrameProxy> firstChild() const;
+    RefPtr<WebFrameProxy> lastChild() const;
+    RefPtr<WebFrameProxy> nextSibling() const;
+    RefPtr<WebFrameProxy> previousSibling() const;
 
     WeakPtr<WebPageProxy> m_page;
     Ref<WebProcessProxy> m_process;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -544,6 +544,7 @@ public:
     WebFrameProxy* mainFrame() const { return m_mainFrame.get(); }
     WebFrameProxy* openerFrame() const { return m_openerFrame.get(); }
     WebFrameProxy* focusedFrame() const { return m_focusedFrame.get(); }
+    WebFrameProxy* focusedOrMainFrame() const { return m_focusedFrame ? m_focusedFrame.get() : m_mainFrame.get(); }
 
     DrawingAreaProxy* drawingArea() const { return m_drawingArea.get(); }
     DrawingAreaProxy* provisionalDrawingArea() const;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -167,8 +167,6 @@ constexpr Seconds resetGPUProcessCrashCountDelay { 30_s };
 constexpr unsigned maximumGPUProcessRelaunchAttemptsBeforeKillingWebProcesses { 2 };
 #endif
 
-static constexpr Seconds audibleActivityClearDelay = 5_s;
-
 Ref<WebProcessPool> WebProcessPool::create(API::ProcessPoolConfiguration& configuration)
 {
     InitializeWebKit2();

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -569,6 +569,7 @@ private:
 #endif
 
     void updateProcessAssertions();
+    static constexpr Seconds audibleActivityClearDelay = 5_s;
     void updateAudibleMediaAssertions();
     void updateMediaStreamingActivity();
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		005D158F18E4C4EB00734619 /* _WKFindDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 005D158E18E4C4EB00734619 /* _WKFindDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		00B9661618E24CBA00CE1F88 /* APIFindClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B9661518E24CBA00CE1F88 /* APIFindClient.h */; };
 		00B9661A18E25AE100CE1F88 /* FindClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B9661818E25AE100CE1F88 /* FindClient.h */; };
+		0250C2512B5DCB2000D05C0B /* FindStringCallbackAggregator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0250C24F2B5DCB0100D05C0B /* FindStringCallbackAggregator.h */; };
 		0701789E23BE9CFC005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0701789B23BAE261005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp */; };
 		0712654928EE06F800AE69D7 /* WebChromeClientCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0712654728EE06F800AE69D7 /* WebChromeClientCocoa.mm */; };
 		071BC58F23CE1EAA00680D7C /* RemoteMediaPlayerProxyMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 071BC58C23CE1EA900680D7C /* RemoteMediaPlayerProxyMessageReceiver.cpp */; };
@@ -2996,6 +2997,8 @@
 		0214701A2995D2FE0077AFD6 /* DrawingAreaCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DrawingAreaCocoa.mm; sourceTree = "<group>"; };
 		0214701B2995D3860077AFD6 /* DrawingArea.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DrawingArea.cpp; sourceTree = "<group>"; };
 		0237C21428C168D10018A851 /* WebGPUSupportedFeatures.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUSupportedFeatures.serialization.in; sourceTree = "<group>"; };
+		0250C24E2B5DCAFB00D05C0B /* FindStringCallbackAggregator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FindStringCallbackAggregator.cpp; sourceTree = "<group>"; };
+		0250C24F2B5DCB0100D05C0B /* FindStringCallbackAggregator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FindStringCallbackAggregator.h; sourceTree = "<group>"; };
 		02789EF628D3FC3200F77E40 /* WebGPUBufferBindingLayout.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUBufferBindingLayout.serialization.in; sourceTree = "<group>"; };
 		02789EF728D3FF4800F77E40 /* WebGPUCanvasConfiguration.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUCanvasConfiguration.serialization.in; sourceTree = "<group>"; };
 		02789EF828D4026000F77E40 /* WebGPUColor.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebGPUColor.serialization.in; sourceTree = "<group>"; };
@@ -13238,6 +13241,8 @@
 				BC2652121182608100243E12 /* DrawingAreaProxy.cpp */,
 				BC2652131182608100243E12 /* DrawingAreaProxy.h */,
 				1A6422FC12DD08FE00CAAE2C /* DrawingAreaProxy.messages.in */,
+				0250C24E2B5DCAFB00D05C0B /* FindStringCallbackAggregator.cpp */,
+				0250C24F2B5DCB0100D05C0B /* FindStringCallbackAggregator.h */,
 				1AE00D5E1831792100087DD7 /* FrameLoadState.cpp */,
 				1AE00D5F1831792100087DD7 /* FrameLoadState.h */,
 				9EC532A22447FBAD00215216 /* GeolocationIdentifier.h */,
@@ -15540,6 +15545,7 @@
 				00B9661A18E25AE100CE1F88 /* FindClient.h in Headers */,
 				1A90C1F41264FD71003E44D4 /* FindController.h in Headers */,
 				DD4DB789280F9471001700D4 /* FindNodes.js in Headers */,
+				0250C2512B5DCB2000D05C0B /* FindStringCallbackAggregator.h in Headers */,
 				C59C4A5918B81174007BDCB6 /* FocusedElementInformation.h in Headers */,
 				BCE81D8D1319F7EF00241910 /* FontInfo.h in Headers */,
 				DD4DB78A280F9471001700D4 /* FormElementClear.js in Headers */,

--- a/Source/WebKit/WebProcess/WebPage/FindController.h
+++ b/Source/WebKit/WebProcess/WebPage/FindController.h
@@ -28,6 +28,7 @@
 #include "ShareableBitmap.h"
 #include "WebFindOptions.h"
 #include <WebCore/FindOptions.h>
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/PageOverlay.h>
 #include <WebCore/SimpleRange.h>
@@ -62,7 +63,7 @@ public:
     explicit FindController(WebPage*);
     virtual ~FindController();
 
-    void findString(const String&, OptionSet<FindOptions>, unsigned maxMatchCount, TriggerImageAnalysis, CompletionHandler<void(bool)>&& = { });
+    void findString(const String&, OptionSet<FindOptions>, unsigned maxMatchCount, TriggerImageAnalysis, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>, bool)>&& = { });
     void findStringMatches(const String&, OptionSet<FindOptions>, unsigned maxMatchCount);
     void findRectsForStringMatches(const String&, OptionSet<WebKit::FindOptions>, unsigned maxMatchCount, CompletionHandler<void(Vector<WebCore::FloatRect>&&)>&&);
     void getImageForFindMatch(uint32_t matchIndex);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5320,7 +5320,7 @@ void WebPage::setTextIndicator(const WebCore::TextIndicatorData& indicatorData)
 
 bool WebPage::findStringFromInjectedBundle(const String& target, OptionSet<FindOptions> options)
 {
-    return m_page->findString(target, core(options));
+    return m_page->findString(target, core(options)).has_value();
 }
 
 void WebPage::findStringMatchesFromInjectedBundle(const String& target, OptionSet<FindOptions> options)
@@ -5333,7 +5333,7 @@ void WebPage::replaceStringMatchesFromInjectedBundle(const Vector<uint32_t>& mat
     findController().replaceMatches(matchIndices, replacementText, selectionOnly);
 }
 
-void WebPage::findString(const String& string, OptionSet<FindOptions> options, uint32_t maxMatchCount, CompletionHandler<void(bool)>&& completionHandler)
+void WebPage::findString(const String& string, OptionSet<FindOptions> options, uint32_t maxMatchCount, CompletionHandler<void(std::optional<FrameIdentifier>, bool)>&& completionHandler)
 {
     findController().findString(string, options, maxMatchCount, FindController::TriggerImageAnalysis::Yes, WTFMove(completionHandler));
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1953,7 +1953,7 @@ private:
     void reapplyEditCommand(WebUndoStepID commandID);
     void didRemoveEditCommand(WebUndoStepID commandID);
 
-    void findString(const String&, OptionSet<FindOptions>, uint32_t maxMatchCount, CompletionHandler<void(bool)>&&);
+    void findString(const String&, OptionSet<FindOptions>, uint32_t maxMatchCount, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>, bool)>&&);
     void findStringMatches(const String&, OptionSet<FindOptions>, uint32_t maxMatchCount);
     void getImageForFindMatch(uint32_t matchIndex);
     void selectFindMatch(uint32_t matchIndex);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -328,7 +328,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     PostInjectedBundleMessage(String messageName, WebKit::UserData messageBody)
 
     # Find.
-    FindString(String string, OptionSet<WebKit::FindOptions> findOptions, unsigned maxMatchCount) -> (bool found)
+    FindString(String string, OptionSet<WebKit::FindOptions> findOptions, unsigned maxMatchCount) -> (std::optional<WebCore::FrameIdentifier> frameContainingString, bool didWrap)
     FindStringMatches(String string, OptionSet<WebKit::FindOptions> findOptions, unsigned maxMatchCount)
     GetImageForFindMatch(uint32_t matchIndex)
     SelectFindMatch(uint32_t matchIndex)

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -146,6 +146,7 @@ struct AutocorrectionContext {
 - (void)collapseToEnd;
 - (void)addToTestWindow;
 - (BOOL)selectionRangeHasStartOffset:(int)start endOffset:(int)end;
+- (BOOL)selectionRangeHasStartOffset:(int)start endOffset:(int)end inFrame:(WKFrameInfo *)frameInfo;
 - (void)clickOnElementID:(NSString *)elementID;
 - (void)waitForPendingMouseEvents;
 - (void)focus;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -1008,6 +1008,24 @@ static InputSessionChangeCount nextInputSessionChangeCount()
     return matches;
 }
 
+- (BOOL)selectionRangeHasStartOffset:(int)start endOffset:(int)end inFrame:(WKFrameInfo *)frameInfo
+{
+    __block bool isDone = false;
+    __block bool matches = true;
+    [self evaluateJavaScript:@"window.getSelection().getRangeAt(0).startOffset" inFrame:frameInfo inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
+        if ([(NSNumber *)result intValue] != start)
+            matches = false;
+    }];
+    [self evaluateJavaScript:@"window.getSelection().getRangeAt(0).endOffset" inFrame:frameInfo inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
+        if ([(NSNumber *)result intValue] != end)
+            matches = false;
+        isDone = true;
+    }];
+    TestWebKitAPI::Util::run(&isDone);
+
+    return matches;
+}
+
 - (void)clickOnElementID:(NSString *)elementID
 {
     [self evaluateJavaScript:[NSString stringWithFormat:@"document.getElementById('%@').click();", elementID] completionHandler:nil];


### PR DESCRIPTION
#### bf1345fe689b99d16d63b52702777db6c79e1717
<pre>
[Site Isolation] Make `findString:` correctly cycle through matches and update selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=267908">https://bugs.webkit.org/show_bug.cgi?id=267908</a>
<a href="https://rdar.apple.com/121411740">rdar://121411740</a>

Reviewed by Alex Christensen.

This patch adds initial support for the UI process to coordinate `findString:` across multiple web
processes.

To make this work with site isolation, I needed to:
- Search all web processes without setting selection and have them reply with the identifier of the frame
  containing the string and if the last match was cycled.
- Traverse the frame tree in the UI process to determine which frame is closest to the focused frame.
- Consider when all matches have been cycled in a process and when all matches have been cycled in the
  page.
- Change logic in the web process to consider an out-of-process focused or main frame during frame
  traversal.

This assumes that all web processes will respond. There still needs to be work to make this robust
against unresponsive web processes. More details below.

* LayoutTests/platform/ios/fast/scrolling/find-text-in-overflow-node.html:
* LayoutTests/platform/ios/fast/scrolling/find-text-in-subframe.html:
Wait for a presentation update on some layout tests using findString.

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::findString):
* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::executeFindString):
* Source/WebCore/editing/FindOptions.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::find const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::findString):
* Source/WebCore/page/Page.h:
`FocusController::focusedOrMainFrame()` will return the root frame if the focused and main frame are both
remote. This means that if there is a local frame containing a match between the root frame and the
out-of-process focused frame, any local frame following the focused remote frame will not be searched. To
fix this, we should always begin the frame traversal at the focused or main frame, even if they are
out-of-process.

We should only update the focused frame if selection is being set.

Also return the identifier of the frame containing the match. std::nullopt indicates no match.

* Source/WebKit/Shared/WebFindOptions.cpp:
(WebKit::core):
* Source/WebKit/Shared/WebFindOptions.h:
* Source/WebKit/Shared/WebFindOptions.serialization.in:
Add a `SetSelection` value to `FindOptions` to indicate when we only want to search the frame.

* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/FindStringCallbackAggregator.cpp: Added.
(WebKit::FindStringCallbackAggregator::create):
(WebKit::FindStringCallbackAggregator::foundString):
This function is called in response to each FindString IPC message that does not set selection.

(WebKit::FindStringCallbackAggregator::~FindStringCallbackAggregator):
Traverse the frame tree to find the frame closest to the focused frame containing a match. If findString
has cycled through all matches in the process but not the page the frame should not be considered. If the
frame is in a different process than the frame which previously had focus, send an IPC message to clear
selection from the previously focused frame.

(WebKit::FindStringCallbackAggregator::FindStringCallbackAggregator):

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::didCreateSubframe):
(WebKit::WebFrameProxy::traverseNext const):
(WebKit::WebFrameProxy::traversePrevious):
(WebKit::WebFrameProxy::isDescendantOf const):
(WebKit::WebFrameProxy::deepLastChild):
(WebKit::WebFrameProxy::firstChild const):
(WebKit::WebFrameProxy::lastChild const):
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::parentFrame const):
(WebKit::WebFrameProxy::nextSibling const):
(WebKit::WebFrameProxy::previousSibling const):
(WebKit::WebFrameProxy::parentFrame): Deleted.
Added member variables and functions for traversing the frame tree, designed to behave similarly to the
frame traversal functions in `FrameTree`.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::findString):
* Source/WebKit/UIProcess/WebPageProxy.h:

* Source/WebKit/UIProcess/WebProcessPool.cpp:
* Source/WebKit/UIProcess/WebProcessPool.h:
There were two `audibleActivityClearDelay`` variables that started conflicting due to the unified sources
shift. I moved this one to fix it.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

* Source/WebKit/WebProcess/WebPage/FindController.cpp:
* Source/WebKit/WebProcess/WebPage/FindController.h:
(WebKit::FindController::updateFindUIAfterPageScroll):
Selection should not be cleared on searches where selection cannot be set.

(WebKit::FindController::findString):
Pass the frame identifier and didWrap to the completion handler instead of whether a match was found.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::findStringFromInjectedBundle):
(WebKit::WebPage::findString):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::siteIsolatedViewAndDelegate):
(TestWebKitAPI::TEST):
Add tests to verify `findString:` correctly updates selection on pages with various frame orderings.

* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView selectionRangeHasStartOffset:endOffset:inFrame:])
Add a function similar to the existing `selectionRangeHasStartOffset:endOffset:`, used to check selection
within a frame.

Canonical link: <a href="https://commits.webkit.org/273517@main">https://commits.webkit.org/273517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd6c405a02e7200d9e8b23bf852a078f51dc2342

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38326 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32062 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30867 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10780 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10796 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39571 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32336 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36750 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34815 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12692 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31466 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/8141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11489 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4620 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11760 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->