### PR TITLE
ShareableBitmap has redundant CG-specific create functions

### DIFF
--- a/Source/WebKit/Shared/ShareableBitmap.cpp
+++ b/Source/WebKit/Shared/ShareableBitmap.cpp
@@ -100,16 +100,22 @@ RefPtr<ShareableBitmap> ShareableBitmap::create(const ShareableBitmapConfigurati
     return adoptRef(new ShareableBitmap(configuration, WTFMove(sharedMemory)));
 }
 
-RefPtr<ShareableBitmap> ShareableBitmap::createFromImageDraw(NativeImage& image)
+RefPtr<ShareableBitmap> ShareableBitmap::create(NativeImage& image)
 {
-    return createFromImageDraw(image, image.colorSpace());
+    return create(image, image.colorSpace());
 }
 
-RefPtr<ShareableBitmap> ShareableBitmap::createFromImageDraw(NativeImage& image, const DestinationColorSpace& colorSpace)
+RefPtr<ShareableBitmap> ShareableBitmap::create(NativeImage& image, const DestinationColorSpace& colorSpace)
 {
+    RefPtr<ShareableBitmap> bitmap;
+#if USE(CG)
+    bitmap = createFromPixelsIfPossible(image, colorSpace);
+    if (bitmap)
+        return bitmap;
+#endif
     auto imageSize = image.size();
 
-    auto bitmap = ShareableBitmap::create({ imageSize, colorSpace });
+    bitmap = ShareableBitmap::create({ imageSize, colorSpace });
     if (!bitmap)
         return nullptr;
 

--- a/Source/WebKit/Shared/ShareableBitmap.h
+++ b/Source/WebKit/Shared/ShareableBitmap.h
@@ -55,7 +55,7 @@ public:
 #endif
     );
 #if USE(CG)
-    ShareableBitmapConfiguration(WebCore::NativeImage&);
+    ShareableBitmapConfiguration(const WebCore::NativeImage&);
 #endif
 
     WebCore::IntSize size() const { return m_size; }
@@ -127,12 +127,11 @@ public:
     // Create a shareable bitmap from an already existing shared memory block.
     static RefPtr<ShareableBitmap> create(const ShareableBitmapConfiguration&, Ref<SharedMemory>&&);
 
-    // Create a shareable bitmap from a NativeImage.
-#if USE(CG)
-    static RefPtr<ShareableBitmap> createFromImagePixels(WebCore::NativeImage&);
-#endif
-    static RefPtr<ShareableBitmap> createFromImageDraw(WebCore::NativeImage&);
-    static RefPtr<ShareableBitmap> createFromImageDraw(WebCore::NativeImage&, const WebCore::DestinationColorSpace&);
+    // Create a shareable bitmap with contents of NativeImage.
+    static RefPtr<ShareableBitmap> create(WebCore::NativeImage&);
+
+    // Create a shareable bitmap with contents of NativeImage in DestinationColorSpace.
+    static RefPtr<ShareableBitmap> create(WebCore::NativeImage&, const WebCore::DestinationColorSpace&);
 
     // Create a shareable bitmap from a handle.
     static RefPtr<ShareableBitmap> create(Handle&&, SharedMemory::Protection = SharedMemory::Protection::ReadWrite);
@@ -185,8 +184,8 @@ public:
 
 private:
     ShareableBitmap(ShareableBitmapConfiguration, Ref<SharedMemory>&&);
-
 #if USE(CG)
+    static RefPtr<ShareableBitmap> createFromPixelsIfPossible(const WebCore::NativeImage&, const WebCore::DestinationColorSpace&);
     RetainPtr<CGImageRef> createCGImage(CGDataProviderRef, WebCore::ShouldInterpolate) const;
     static void releaseBitmapContextData(void* typelessBitmap, void* typelessData);
 #endif


### PR DESCRIPTION
#### abe9a07b6891a4843cdd2ff6f552012c00f861fb
<pre>
ShareableBitmap has redundant CG-specific create functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=267920">https://bugs.webkit.org/show_bug.cgi?id=267920</a>
<a href="https://rdar.apple.com/121427528">rdar://121427528</a>

Reviewed by NOBODY (OOPS!).

Merge the ShareableBitmap::createFromImageDraw,
ShareableBitmap::createFromImagePixels to single client function
ShareableBitmap::create(NativeImage&amp;, ...)

Remove now unneccesary helper function
createShareableBitmapFromNativeImage. It was named misleadingly, as it
replaces the contents of the object it sources from.

Simplifies future work sharing NativeImages with other work queues than
RemoteRenderingBackend.

* Source/WebKit/Shared/ShareableBitmap.cpp:
(WebKit::ShareableBitmap::create):
(WebKit::ShareableBitmap::createFromImageDraw): Deleted.
* Source/WebKit/Shared/ShareableBitmap.h:
* Source/WebKit/Shared/cg/ShareableBitmapCG.mm:
(WebKit::ShareableBitmap::createFromPixelsIfPossible):
(WebKit::ShareableBitmap::createFromImagePixels): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordNativeImageUse):
(WebKit::createShareableBitmapFromNativeImage): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abe9a07b6891a4843cdd2ff6f552012c00f861fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38145 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31927 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11379 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30770 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10625 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10661 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-transforms/transform3d-image-scale-001.html (failure)") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39392 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32176 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31978 "Found 5 new test failures: imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-Blob.html, imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-cloned.html, imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-image.html, imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage.https.html, imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-pattern-image.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36636 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10826 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8735 "Found 22 new test failures: imported/w3c/web-platform-tests/content-security-policy/inheritance/iframe-all-local-schemes-inherit-self.sub.html, imported/w3c/web-platform-tests/css/css-transforms/transform3d-image-scale-001.html, imported/w3c/web-platform-tests/custom-elements/reactions/customized-builtins/HTMLInputElement.html, imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.pattern.paint.repeatx.coord1.html, imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.pattern.paint.repeatx.outside.html, imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.pattern.paint.repeaty.coord1.html, imported/w3c/web-platform-tests/html/canvas/element/fill-and-stroke-styles/2d.pattern.paint.repeaty.outside.html, imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-Blob.html, imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-ImageBitmap.html, imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-cloned.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34677 "Found 1 new API test failure: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12571 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11350 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11631 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->