### PR TITLE
Adopt more smart pointers in ChildListMutationAccumulator

### DIFF
--- a/Source/WebCore/dom/ChildListMutationScope.h
+++ b/Source/WebCore/dom/ChildListMutationScope.h
@@ -36,13 +36,14 @@
 #include <memory>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class MutationObserverInterestGroup;
 
 // ChildListMutationAccumulator is not meant to be used directly; ChildListMutationScope is the public interface.
-class ChildListMutationAccumulator : public RefCounted<ChildListMutationAccumulator> {
+class ChildListMutationAccumulator : public RefCounted<ChildListMutationAccumulator>, public CanMakeSingleThreadWeakPtr<ChildListMutationAccumulator> {
 public:
     static Ref<ChildListMutationAccumulator> getOrCreate(ContainerNode&);
     ~ChildListMutationAccumulator();
@@ -68,7 +69,7 @@ private:
     Vector<Ref<Node>> m_addedNodes;
     RefPtr<Node> m_previousSibling;
     RefPtr<Node> m_nextSibling;
-    Node* m_lastAdded;
+    WeakPtr<Node, WeakPtrImplWithEventTargetData> m_lastAdded;
 
     std::unique_ptr<MutationObserverInterestGroup> m_observers;
 };


### PR DESCRIPTION
#### 6156d4819317b2d66450cc7b9e95abbd515cfa7e
<pre>
Adopt more smart pointers in ChildListMutationAccumulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=267925">https://bugs.webkit.org/show_bug.cgi?id=267925</a>

Reviewed by Darin Adler.

This tested as performance neutral on Speedometer 2 &amp; 3.

* Source/WebCore/dom/ChildListMutationScope.cpp:
(WebCore::ChildListMutationAccumulator::ChildListMutationAccumulator):
(WebCore::ChildListMutationAccumulator::~ChildListMutationAccumulator):
(WebCore::ChildListMutationAccumulator::getOrCreate):
(WebCore::ChildListMutationAccumulator::childAdded):
(WebCore::ChildListMutationAccumulator::willRemoveChild):
(WebCore::ChildListMutationAccumulator::enqueueMutationRecord):
* Source/WebCore/dom/ChildListMutationScope.h:

Canonical link: <a href="https://commits.webkit.org/273371@main">https://commits.webkit.org/273371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82453e6d9c5643f4f923ea728be0c6c6cacc2035

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38005 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31812 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16566 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11249 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11994 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10514 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10565 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39251 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31868 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36549 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10704 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/8629 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34564 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8065 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11229 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->