### PR TITLE
Update MediaStreamTrack contentHint and kind implementation to handle tracks living in workers

### DIFF
--- a/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker-expected.txt
@@ -5,4 +5,5 @@ PASS Writable gets closed when writing something else than a VideoFrame
 PASS Track settings are updated according enqueued video frames
 PASS Track gets muted based on VideoTrackGenerator.muted
 PASS VideoTrackGenerator to MediaStreamTrackProcessor
+PASS kind and content hint tests
 

--- a/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.js
+++ b/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.js
@@ -109,7 +109,6 @@ promise_test(async (t) => {
     assert_equals(capabilities.height.max, 200, "max height 4");
 }, "Track settings are updated according enqueued video frames");
 
-
 promise_test(async (t) => {
     const generator = new VideoTrackGenerator();
     generator.muted = true;
@@ -151,5 +150,22 @@ promise_test(async (t) => {
 
     await endedPromise;
 }, "VideoTrackGenerator to MediaStreamTrackProcessor");
+
+promise_test(async (t) => {
+    const generator = new VideoTrackGenerator();
+    const track = generator.track;
+
+    assert_equals(track.kind, "video");
+
+    for (let hint of ["motion", "detail", "text", ""]) {
+        track.contentHint = hint;
+        assert_equals(track.contentHint, hint);
+    }
+
+    for (let hint of ["speech", "music", "funky"]) {
+        track.contentHint = hint;
+        assert_equals(track.contentHint, "");
+    }
+}, "kind and content hint tests");
 
 done();

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -230,6 +230,8 @@ private:
     bool m_isInterrupted { false };
     bool m_shouldFireMuteEventImmediately { false };
     bool m_isDetached { false };
+    mutable AtomString m_kind;
+    mutable AtomString m_contentHint;
 };
 
 typedef Vector<Ref<MediaStreamTrack>> MediaStreamTrackVector;


### PR DESCRIPTION
#### 4d979907052d94f13720d299fccfe1fe47175216
<pre>
Update MediaStreamTrack contentHint and kind implementation to handle tracks living in workers
<a href="https://bugs.webkit.org/show_bug.cgi?id=267930">https://bugs.webkit.org/show_bug.cgi?id=267930</a>
<a href="https://rdar.apple.com/121448238">rdar://121448238</a>

Reviewed by Eric Carlson.

Now that tracks can live in workers, we cannot use main thread only atom strings.
Update implementation accordingly.

* LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker-expected.txt:
* LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.js:
(promise_test.async t):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::kind const):
(WebCore::contentHintToAtomString):
(WebCore::MediaStreamTrack::contentHint const):
(WebCore::MediaStreamTrack::setContentHint):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:

Canonical link: <a href="https://commits.webkit.org/273397@main">https://commits.webkit.org/273397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50c7b072f6105817fa086e799fe170b011fbc74a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35219 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37974 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31786 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11219 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30684 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10495 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10575 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39222 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32066 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36535 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34547 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12451 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8078 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11203 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11512 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->