### PR TITLE
[git-webkit] Automatically make merge-back tasks of umbrella radar

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
@@ -289,6 +289,24 @@ class RadarClient(object):
             return None
         return RadarModel(self, found)
 
+    def find_radars(self, query, return_find_results_directly=False):
+        result = []
+        for issue in self.parent.issues.values():
+            r = RadarModel(self, issue)
+
+            for key, value in query.items():
+                if key == 'state':
+                    if r.state != value:
+                        break
+                elif key == 'assignee':
+                    if r.assignee.dsid != value:
+                        break
+                elif issue.get(key, None) != value:
+                    break
+            else:
+                result.append(r)
+        return result
+
     def milestones_for_component(self, component, include_access_groups=False):
         return list(self.parent.milestones.values())
 

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
@@ -628,7 +628,6 @@ class Tracker(GenericTracker):
             result.assign(self.me())
         return result
 
-    # FIXME: This function is untested because it doesn't have a mock.
     def search(self, query):
         if not query or len(query) == 0:
             raise ValueError('Query must be provided')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py
@@ -21,6 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import time
 
 from mock import patch
 from webkitcorepy import OutputCapture, testing
@@ -141,9 +142,75 @@ class TestClone(testing.PathTestCase):
             'Moved clone to October and into Analyze: Prepare\n',
         )
 
+    def test_find_parent_none(self):
+        with mocks.local.Git(self.path), mocks.local.Svn(), Environment(RADAR_USERNAME='tcontributor'), bmocks.Radar(
+            issues=bmocks.ISSUES,
+            projects=bmocks.PROJECTS,
+            milestones=bmocks.MILESTONES,
+        ):
+            self.assertEqual(None, program.Clone.parent(radar.Tracker(), 'October'))
+
+    def test_find_parent(self):
+        issues = [issue.copy() for issue in bmocks.ISSUES]
+        issues.append(dict(
+            title=u'{} merge-back October release'.format(program.Clone.UMBRELLA),
+            timestamp=int(time.time()),
+            opened=True,
+            creator=bmocks.USERS['Tim Contributor'],
+            assignee=bmocks.USERS['Tim Contributor'],
+            description='Umbrella bug tracking October merge-back',
+            project='WebKit',
+            component='Text',
+            version='Other',
+            milestone='October',
+        ))
+
+        with mocks.local.Git(self.path), mocks.local.Svn(), Environment(RADAR_USERNAME='tcontributor'), bmocks.Radar(
+            issues=issues,
+            projects=bmocks.PROJECTS,
+            milestones=bmocks.MILESTONES,
+        ):
+            parent = program.Clone.parent(radar.Tracker(), 'October')
+            self.assertIsNotNone(parent)
+            self.assertEqual(parent.title, u'{} merge-back October release'.format(program.Clone.UMBRELLA))
+
+    def test_merge_back_no_parent(self):
+        issues = [issue.copy() for issue in bmocks.ISSUES]
+        issues[0]['category'] = 'Important'
+
+        with mocks.local.Git(self.path), mocks.local.Svn(), Environment(RADAR_USERNAME='tcontributor'), bmocks.Radar(
+            issues=issues,
+            projects=bmocks.PROJECTS,
+            milestones=bmocks.MILESTONES,
+        ), MockTerminal.input('1'), OutputCapture() as captured, patch('webkitbugspy.Tracker._trackers', [radar.Tracker()]):
+            self.assertEqual(255, program.main(
+                args=('clone', 'rdar://1', '--reason', 'Cloning for an October branch', '--milestone', 'October', '--merge-back'),
+                path=self.path,
+            ))
+
+        self.assertEqual(
+            captured.stderr.getvalue(),
+            'Failed to find existing Merge-Back umbrella\n'
+            u"Make sure you have a '{} Merge-Back' radar in October assigned to you\n".format(program.Clone.UMBRELLA),
+        )
+        self.assertEqual(captured.stdout.getvalue(), '')
+
     def test_merge_back(self):
         issues = [issue.copy() for issue in bmocks.ISSUES]
         issues[0]['category'] = 'Important'
+
+        issues.append(dict(
+            title=u'{} merge-back October release'.format(program.Clone.UMBRELLA),
+            timestamp=int(time.time()),
+            opened=True,
+            creator=bmocks.USERS['Tim Contributor'],
+            assignee=bmocks.USERS['Tim Contributor'],
+            description='Umbrella bug tracking October merge-back',
+            project='WebKit',
+            component='Text',
+            version='Other',
+            milestone='October',
+        ))
 
         with mocks.local.Git(self.path), mocks.local.Svn(), Environment(RADAR_USERNAME='tcontributor'), bmocks.Radar(
             issues=issues,
@@ -155,16 +222,20 @@ class TestClone(testing.PathTestCase):
                 path=self.path,
             ))
             tracker = radar.Tracker()
-            raw_issue = tracker.client.radar_for_id(4)
+            raw_issue = tracker.client.radar_for_id(5)
 
             self.assertEqual(raw_issue.milestone.name, 'Internal Tools - October')
             self.assertEqual(raw_issue.category.name, 'Important')
             self.assertIsNone(raw_issue.event)
             self.assertIsNone(raw_issue.tentpole)
 
+            parents = tracker.issue(5).related.get('subtask-of')
+            self.assertEqual(1, len(parents))
+            self.assertEqual(parents[0].title, u'{} merge-back October release'.format(program.Clone.UMBRELLA))
+
         self.assertEqual(captured.stderr.getvalue(), '')
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Created '[merge-back] rdar://4 Example issue 1'\n"
+            "Created '[merge-back] rdar://5 Example issue 1'\n"
             'Moved clone to Internal Tools - October and into Analyze: Prepare\n',
         )


### PR DESCRIPTION
#### fa283e1ae8bf83f6c4306344aac6def4fa5da24b
<pre>
[git-webkit] Automatically make merge-back tasks of umbrella radar
<a href="https://bugs.webkit.org/show_bug.cgi?id=267933">https://bugs.webkit.org/show_bug.cgi?id=267933</a>
<a href="https://rdar.apple.com/121450457">rdar://121450457</a>

Reviewed by Dewei Zhu.

Per policy, merge-back tasks should exist under an umbrella radar. We should
automatically create merge-back clones under this radar.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py:
(RadarClient.find_radars): Implement a basic mock of radarclient&apos;s find_radars query.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker): Remove comment on search function.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/clone.py:
(Clone.parent): Determine the umbrella merge-back radar for a specific milestone.
(Clone.main): Automatically mark merge-back clone as subtask of umbrella merge-back radar.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/clone_unittest.py:
(TestClone.test_find_parent_none):
(TestClone.test_find_parent):
(TestClone.test_merge_back_no_parent):
(TestClone.test_merge_back):

Canonical link: <a href="https://commits.webkit.org/273412@main">https://commits.webkit.org/273412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d0c9eff3429aa6439e4c0b5350058943a87e710

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37977 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30685 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31406 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10497 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/35647 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10567 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39225 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31842 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36538 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10681 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34550 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/35185 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12452 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11206 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4563 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->