### PR TITLE
VideoTrackGenerator muted should apply on the sink synchronously

### DIFF
--- a/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker-expected.txt
@@ -1,4 +1,5 @@
 
+PASS Tests that VideoTrackGenerator forwards frames only when unmuted
 PASS Frames get closed when written in a VideoTrackGenerator writable
 PASS Writable gets closed when writing a closed VideoFrame
 PASS Writable gets closed when writing something else than a VideoFrame

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
@@ -100,6 +100,8 @@ void VideoTrackGenerator::setMuted(ScriptExecutionContext& context, bool muted)
         return;
 
     m_muted = muted;
+    m_sink->setMuted(m_muted);
+
     if (m_hasMutedChanged)
         return;
 
@@ -107,7 +109,6 @@ void VideoTrackGenerator::setMuted(ScriptExecutionContext& context, bool muted)
     context.postTask([this, protectedThis = Ref { *this }] (auto&) {
         m_hasMutedChanged = false;
         m_track->privateTrack().setMuted(m_muted);
-        m_sink->setMuted(m_muted);
     });
 }
 


### PR DESCRIPTION
#### 3d9f01080b2343ad3a745b960335daf6556cb921
<pre>
VideoTrackGenerator muted should apply on the sink synchronously
<a href="https://bugs.webkit.org/show_bug.cgi?id=267931">https://bugs.webkit.org/show_bug.cgi?id=267931</a>
<a href="https://rdar.apple.com/121449466">rdar://121449466</a>

Reviewed by Eric Carlson.

We synchronously update the muted slot as defined by the spec.
Covered by added test.

* LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker-expected.txt:
* LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.js:
(makeOffscreenCanvasVideoFrame):
(promise_test.async t):
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp:
(WebCore::VideoTrackGenerator::setMuted):

Canonical link: <a href="https://commits.webkit.org/273398@main">https://commits.webkit.org/273398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e51f9bdd1a91431dfda6870854ad16f72ecea91

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37984 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31791 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30687 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35774 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31409 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10501 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10554 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39231 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31846 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36541 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34554 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12456 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8079 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11211 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11516 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->