### PR TITLE
Element::parserSetAttributes shouldn't trigger shadow tree construction in TextFieldInputType::attributeChanged

### DIFF
--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -547,6 +547,10 @@ void HTMLInputElement::updateType(const AtomString& typeAttributeValue)
     bool previouslySelectable = m_inputType->supportsSelectionAPI();
 
     m_inputType = WTFMove(newType);
+    if (!didStoreValue && willStoreValue)
+        m_valueIfDirty = sanitizeValue(attributeWithoutSynchronization(valueAttr));
+    else
+        updateValueIfNeeded();
     m_inputType->createShadowSubtreeIfNeeded();
 
     // https://html.spec.whatwg.org/multipage/dom.html#auto-directionality
@@ -559,11 +563,6 @@ void HTMLInputElement::updateType(const AtomString& typeAttributeValue)
     }
 
     updateWillValidateAndValidity();
-
-    if (!didStoreValue && willStoreValue)
-        m_valueIfDirty = sanitizeValue(attributeWithoutSynchronization(valueAttr));
-    else
-        updateValueIfNeeded();
 
     setFormControlValueMatchesRenderer(false);
     m_inputType->updateInnerTextValue();

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -310,12 +310,13 @@ bool HTMLTextFormControlElement::setSelectionRange(unsigned start, unsigned end,
     if (!isTextField())
         return false;
 
+    auto innerText = innerTextElementCreatingShadowSubtreeIfNeeded();
+
     // Clamps to the current value length.
     unsigned innerTextValueLength = innerTextValue().length();
     end = std::min(end, innerTextValueLength);
     start = std::min(start, end);
 
-    auto innerText = innerTextElementCreatingShadowSubtreeIfNeeded();
     bool hasFocus = document().focusedElement() == this;
 
     RefPtr frame = document().frame();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1531,6 +1531,8 @@ std::optional<Internals::EventThrottlingBehavior> Internals::eventThrottlingBeha
 
 String Internals::visiblePlaceholder(Element& element)
 {
+    element.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
+
     if (is<HTMLTextFormControlElement>(element)) {
         const HTMLTextFormControlElement& textFormControlElement = downcast<HTMLTextFormControlElement>(element);
         if (!textFormControlElement.isPlaceholderVisible())


### PR DESCRIPTION
#### 66bf68c9f4593eecb8dc370eb0761cb7a0e1ae77
<pre>
Element::parserSetAttributes shouldn&apos;t trigger shadow tree construction in TextFieldInputType::attributeChanged
<a href="https://bugs.webkit.org/show_bug.cgi?id=267936">https://bugs.webkit.org/show_bug.cgi?id=267936</a>

Reviewed by Aditya Keerthi and Yusuke Suzuki.

Don&apos;t construct shadow tree in TextFieldInputType::attributeChanged.

* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::updateType): Sanitize the value before calling createShadowSubtreeIfNeeded. Otherwise,
we can assert in NumberInputType::localizeValue for example.

* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::setSelectionRange):

* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::isEmptyValue const): Now checks visibleValue() when the shadow tree doesn&apos;t exist yet.
(WebCore::TextFieldInputType::createShadowSubtree): Update the inner text value after creating the shadow tree.
(WebCore::TextFieldInputType::attributeChanged): Fixed the code so that it no longer constructs the shadow tree.

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::visiblePlaceholder): Update the style / layout so that the shadow tree will get created.

Canonical link: <a href="https://commits.webkit.org/273461@main">https://commits.webkit.org/273461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe01960304564dae707db83d46a334fd32a4c3a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38230 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31994 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11466 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31604 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10706 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10737 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31728 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39477 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32257 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32060 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8803 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/34762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12628 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11420 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4592 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11690 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->