### PR TITLE
Rename VideoFullscreenInterface to VideoPresentationInterface

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -551,7 +551,7 @@ platform/ios/UIFoundationSoftLink.mm
 platform/ios/UIViewControllerUtilities.mm
 platform/ios/UserAgentIOS.mm
 platform/ios/ValidationBubbleIOS.mm
-platform/ios/VideoFullscreenInterfaceIOS.mm @no-unify
+platform/ios/VideoPresentationInterfaceIOS.mm @no-unify
 platform/ios/WebAVPlayerController.mm
 platform/ios/WebBackgroundTaskController.mm
 platform/ios/WebCoreMotionManager.mm
@@ -604,7 +604,7 @@ platform/mac/ThreadCheck.mm @no-unify
 platform/mac/UserActivityMac.mm
 platform/mac/UserAgentMac.mm
 platform/mac/ValidationBubbleMac.mm
-platform/mac/VideoFullscreenInterfaceMac.mm
+platform/mac/VideoPresentationInterfaceMac.mm
 platform/mac/WebCoreFullScreenPlaceholderView.mm
 platform/mac/WebCoreFullScreenWarningView.mm
 platform/mac/WebCoreFullScreenWindow.mm

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -150,7 +150,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 #include "RuntimeApplicationChecks.h"
-#include "VideoFullscreenInterfaceIOS.h"
+#include "VideoPresentationInterfaceIOS.h"
 #endif
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Source/WebCore/platform/graphics/PlatformVideoPresentationInterface.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoPresentationInterface.h
@@ -27,16 +27,16 @@
 
 namespace WebCore {
 
-class NullVideoFullscreenInterface;
-class VideoFullscreenInterfaceIOS;
-class VideoFullscreenInterfaceMac;
+class NullVideoPresentationInterface;
+class VideoPresentationInterfaceIOS;
+class VideoPresentationInterfaceMac;
 
 #if PLATFORM(WATCHOS)
-using PlatformVideoFullscreenInterface = NullVideoFullscreenInterface;
+using PlatformVideoPresentationInterface = NullVideoPresentationInterface;
 #elif PLATFORM(IOS_FAMILY)
-using PlatformVideoFullscreenInterface = VideoFullscreenInterfaceIOS;
+using PlatformVideoPresentationInterface = VideoPresentationInterfaceIOS;
 #elif PLATFORM(MAC)
-using PlatformVideoFullscreenInterface = VideoFullscreenInterfaceMac;
+using PlatformVideoPresentationInterface = VideoPresentationInterfaceMac;
 #endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
@@ -33,18 +33,18 @@
 
 namespace WebCore {
 
-class NullVideoFullscreenInterface final
+class NullVideoPresentationInterface final
     : public VideoPresentationModelClient
     , public PlaybackSessionModelClient
     , public VideoFullscreenCaptions
-    , public RefCounted<NullVideoFullscreenInterface> {
+    , public RefCounted<NullVideoPresentationInterface> {
 public:
-    static Ref<NullVideoFullscreenInterface> create(NullPlaybackSessionInterface& playbackSessionInterface)
+    static Ref<NullVideoPresentationInterface> create(NullPlaybackSessionInterface& playbackSessionInterface)
     {
-        return adoptRef(*new NullVideoFullscreenInterface(playbackSessionInterface));
+        return adoptRef(*new NullVideoPresentationInterface(playbackSessionInterface));
     }
 
-    virtual ~NullVideoFullscreenInterface() = default;
+    virtual ~NullVideoPresentationInterface() = default;
     NullPlaybackSessionInterface& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
 
@@ -82,7 +82,7 @@ public:
     void externalPlaybackChanged(bool, PlaybackSessionModel::ExternalPlaybackTargetType, const String&) final { }
 
 private:
-    NullVideoFullscreenInterface(NullPlaybackSessionInterface& playbackSessionInterface)
+    NullVideoPresentationInterface(NullPlaybackSessionInterface& playbackSessionInterface)
         : m_playbackSessionInterface(playbackSessionInterface)
     {
     }

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -61,14 +61,14 @@ namespace WebCore {
 class FloatRect;
 class FloatSize;
 
-class VideoFullscreenInterfaceIOS final
+class VideoPresentationInterfaceIOS final
     : public VideoPresentationModelClient
     , public PlaybackSessionModelClient
     , public VideoFullscreenCaptions
-    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoFullscreenInterfaceIOS, WTF::DestructionThread::MainRunLoop> {
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoPresentationInterfaceIOS, WTF::DestructionThread::MainRunLoop> {
 public:
-    WEBCORE_EXPORT static Ref<VideoFullscreenInterfaceIOS> create(PlaybackSessionInterfaceAVKit&);
-    WEBCORE_EXPORT virtual ~VideoFullscreenInterfaceIOS();
+    WEBCORE_EXPORT static Ref<VideoPresentationInterfaceIOS> create(PlaybackSessionInterfaceAVKit&);
+    WEBCORE_EXPORT virtual ~VideoPresentationInterfaceIOS();
     WEBCORE_EXPORT void setVideoPresentationModel(VideoPresentationModel*);
     PlaybackSessionInterfaceAVKit& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
@@ -166,12 +166,12 @@ public:
 #if !RELEASE_LOG_DISABLED
     const void* logIdentifier() const;
     const Logger* loggerPtr() const;
-    const char* logClassName() const { return "VideoFullscreenInterfaceIOS"; };
+    const char* logClassName() const { return "VideoPresentationInterfaceIOS"; };
     WTFLogChannel& logChannel() const;
 #endif
 
 private:
-    WEBCORE_EXPORT VideoFullscreenInterfaceIOS(PlaybackSessionInterfaceAVKit&);
+    WEBCORE_EXPORT VideoPresentationInterfaceIOS(PlaybackSessionInterfaceAVKit&);
 
     void doSetup();
     void finalizeSetup();

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -36,7 +36,7 @@
 #import "PlaybackSessionModelMediaElement.h"
 #import "RenderVideo.h"
 #import "TimeRanges.h"
-#import "VideoFullscreenInterfaceIOS.h"
+#import "VideoPresentationInterfaceIOS.h"
 #import "VideoPresentationModelVideoElement.h"
 #import "WebCoreThreadRun.h"
 #import <QuartzCore/CoreAnimation.h>
@@ -212,7 +212,7 @@ private:
 
     HashSet<CheckedPtr<PlaybackSessionModelClient>> m_playbackClients;
     HashSet<CheckedPtr<VideoPresentationModelClient>> m_presentationClients;
-    RefPtr<VideoFullscreenInterfaceIOS> m_interface;
+    RefPtr<VideoPresentationInterfaceIOS> m_interface;
     RefPtr<VideoPresentationModelVideoElement> m_presentationModel;
     RefPtr<PlaybackSessionModelMediaElement> m_playbackModel;
     RefPtr<HTMLVideoElement> m_videoElement;
@@ -1009,7 +1009,7 @@ void VideoFullscreenControllerContext::setUpFullscreen(HTMLVideoElement& videoEl
         WebThreadLock();
 
         Ref<PlaybackSessionInterfaceAVKit> sessionInterface = PlaybackSessionInterfaceAVKit::create(*this);
-        m_interface = VideoFullscreenInterfaceIOS::create(sessionInterface.get());
+        m_interface = VideoPresentationInterfaceIOS::create(sessionInterface.get());
         m_interface->setVideoPresentationModel(this);
 
         m_videoFullscreenView = adoptNS([PAL::allocUIViewInstance() init]);

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -39,7 +39,7 @@
 #include <wtf/text/WTFString.h>
 
 OBJC_CLASS NSWindow;
-OBJC_CLASS WebVideoFullscreenInterfaceMacObjC;
+OBJC_CLASS WebVideoPresentationInterfaceMacObjC;
 
 namespace WebCore {
 
@@ -47,18 +47,18 @@ class IntRect;
 class FloatSize;
 class PlaybackSessionInterfaceMac;
 
-class VideoFullscreenInterfaceMac
+class VideoPresentationInterfaceMac
     : public VideoPresentationModelClient
     , private PlaybackSessionModelClient
     , public VideoFullscreenCaptions
-    , public RefCounted<VideoFullscreenInterfaceMac> {
+    , public RefCounted<VideoPresentationInterfaceMac> {
 
 public:
-    static Ref<VideoFullscreenInterfaceMac> create(PlaybackSessionInterfaceMac& playbackSessionInterface)
+    static Ref<VideoPresentationInterfaceMac> create(PlaybackSessionInterfaceMac& playbackSessionInterface)
     {
-        return adoptRef(*new VideoFullscreenInterfaceMac(playbackSessionInterface));
+        return adoptRef(*new VideoPresentationInterfaceMac(playbackSessionInterface));
     }
-    virtual ~VideoFullscreenInterfaceMac();
+    virtual ~VideoPresentationInterfaceMac();
     PlaybackSessionInterfaceMac& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
     RefPtr<VideoPresentationModel> videoPresentationModel() const { return m_videoPresentationModel.get(); }
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
@@ -95,7 +95,7 @@ public:
     bool mayAutomaticallyShowVideoPictureInPicture() const { return false; }
     void applicationDidBecomeActive() { }
 
-    WEBCORE_EXPORT WebVideoFullscreenInterfaceMacObjC *videoFullscreenInterfaceObjC();
+    WEBCORE_EXPORT WebVideoPresentationInterfaceMacObjC *videoPresentationInterfaceObjC();
 
     WEBCORE_EXPORT void requestHideAndExitPiP();
 
@@ -104,17 +104,17 @@ public:
 #if !RELEASE_LOG_DISABLED
     const void* logIdentifier() const;
     const Logger* loggerPtr() const;
-    const char* logClassName() const { return "VideoFullscreenInterfaceMac"; };
+    const char* logClassName() const { return "VideoPresentationInterfaceMac"; };
     WTFLogChannel& logChannel() const;
 #endif
 
 private:
-    WEBCORE_EXPORT VideoFullscreenInterfaceMac(PlaybackSessionInterfaceMac&);
+    WEBCORE_EXPORT VideoPresentationInterfaceMac(PlaybackSessionInterfaceMac&);
     Ref<PlaybackSessionInterfaceMac> m_playbackSessionInterface;
     std::optional<MediaPlayerIdentifier> m_playerIdentifier;
     ThreadSafeWeakPtr<VideoPresentationModel> m_videoPresentationModel;
     HTMLMediaElementEnums::VideoFullscreenMode m_mode { HTMLMediaElementEnums::VideoFullscreenModeNone };
-    RetainPtr<WebVideoFullscreenInterfaceMacObjC> m_webVideoFullscreenInterfaceObjC;
+    RetainPtr<WebVideoPresentationInterfaceMacObjC> m_webVideoPresentationInterfaceObjC;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -34,7 +34,7 @@
 #include <WebCore/AudioSession.h>
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/PlatformLayer.h>
-#include <WebCore/PlatformVideoFullscreenInterface.h>
+#include <WebCore/PlatformVideoPresentationInterface.h>
 #include <WebCore/PlatformView.h>
 #include <WebCore/VideoPresentationModel.h>
 #include <wtf/HashMap.h>
@@ -177,16 +177,16 @@ public:
 
     bool isPlayingVideoInEnhancedFullscreen() const;
 
-    WebCore::PlatformVideoFullscreenInterface* controlsManagerInterface();
+    WebCore::PlatformVideoPresentationInterface* controlsManagerInterface();
     using VideoInPictureInPictureDidChangeObserver = WTF::Observer<void(bool)>;
     void addVideoInPictureInPictureDidChangeObserver(const VideoInPictureInPictureDidChangeObserver&);
 
-    void forEachSession(Function<void(VideoPresentationModelContext&, WebCore::PlatformVideoFullscreenInterface&)>&&);
+    void forEachSession(Function<void(VideoPresentationModelContext&, WebCore::PlatformVideoPresentationInterface&)>&&);
 
     void requestBitmapImageForCurrentTime(PlaybackSessionContextIdentifier, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&)>&&);
 
 #if PLATFORM(IOS_FAMILY)
-    WebCore::PlatformVideoFullscreenInterface* returningToStandbyInterface() const;
+    WebCore::PlatformVideoPresentationInterface* returningToStandbyInterface() const;
     AVPlayerViewController *playerViewController(PlaybackSessionContextIdentifier) const;
     RetainPtr<WKVideoView> createViewWithID(PlaybackSessionContextIdentifier, WebKit::LayerHostingContextID videoLayerID, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& nativeSize, float hostingScaleFactor);
 #endif
@@ -201,12 +201,12 @@ private:
     explicit VideoPresentationManagerProxy(WebPageProxy&, PlaybackSessionManagerProxy&);
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    typedef std::tuple<RefPtr<VideoPresentationModelContext>, RefPtr<WebCore::PlatformVideoFullscreenInterface>> ModelInterfaceTuple;
+    typedef std::tuple<RefPtr<VideoPresentationModelContext>, RefPtr<WebCore::PlatformVideoPresentationInterface>> ModelInterfaceTuple;
     ModelInterfaceTuple createModelAndInterface(PlaybackSessionContextIdentifier);
     ModelInterfaceTuple& ensureModelAndInterface(PlaybackSessionContextIdentifier);
     VideoPresentationModelContext& ensureModel(PlaybackSessionContextIdentifier);
-    WebCore::PlatformVideoFullscreenInterface& ensureInterface(PlaybackSessionContextIdentifier);
-    WebCore::PlatformVideoFullscreenInterface* findInterface(PlaybackSessionContextIdentifier) const;
+    WebCore::PlatformVideoPresentationInterface& ensureInterface(PlaybackSessionContextIdentifier);
+    WebCore::PlatformVideoPresentationInterface* findInterface(PlaybackSessionContextIdentifier) const;
     void ensureClientForContext(PlaybackSessionContextIdentifier);
     void addClientForContext(PlaybackSessionContextIdentifier);
     void removeClientForContext(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -41,10 +41,10 @@
 #import "WebProcessProxy.h"
 #import <QuartzCore/CoreAnimation.h>
 #import <WebCore/MediaPlayerEnums.h>
-#import <WebCore/NullVideoFullscreenInterface.h>
+#import <WebCore/NullVideoPresentationInterface.h>
 #import <WebCore/TimeRanges.h>
-#import <WebCore/VideoFullscreenInterfaceIOS.h>
-#import <WebCore/VideoFullscreenInterfaceMac.h>
+#import <WebCore/VideoPresentationInterfaceIOS.h>
+#import <WebCore/VideoPresentationInterfaceMac.h>
 #import <WebCore/WebAVPlayerLayer.h>
 #import <WebCore/WebAVPlayerLayerView.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
@@ -520,7 +520,7 @@ bool VideoPresentationManagerProxy::isPlayingVideoInEnhancedFullscreen() const
 }
 #endif
 
-PlatformVideoFullscreenInterface* VideoPresentationManagerProxy::controlsManagerInterface()
+PlatformVideoPresentationInterface* VideoPresentationManagerProxy::controlsManagerInterface()
 {
     if (auto contextId = m_playbackSessionManagerProxy->controlsManagerContextId())
         return &ensureInterface(contextId);
@@ -545,7 +545,7 @@ VideoPresentationManagerProxy::ModelInterfaceTuple VideoPresentationManagerProxy
     Ref playbackSessionModel = m_playbackSessionManagerProxy->ensureModel(contextId);
     auto model = VideoPresentationModelContext::create(*this, playbackSessionModel, contextId);
     Ref playbackSessionInterface = m_playbackSessionManagerProxy->ensureInterface(contextId);
-    Ref<PlatformVideoFullscreenInterface> interface = PlatformVideoFullscreenInterface::create(playbackSessionInterface);
+    Ref<PlatformVideoPresentationInterface> interface = PlatformVideoPresentationInterface::create(playbackSessionInterface);
     m_playbackSessionManagerProxy->addClientForContext(contextId);
 
     interface->setVideoPresentationModel(model.ptr());
@@ -566,12 +566,12 @@ VideoPresentationModelContext& VideoPresentationManagerProxy::ensureModel(Playba
     return *std::get<0>(ensureModelAndInterface(contextId));
 }
 
-PlatformVideoFullscreenInterface& VideoPresentationManagerProxy::ensureInterface(PlaybackSessionContextIdentifier contextId)
+PlatformVideoPresentationInterface& VideoPresentationManagerProxy::ensureInterface(PlaybackSessionContextIdentifier contextId)
 {
     return *std::get<1>(ensureModelAndInterface(contextId));
 }
 
-PlatformVideoFullscreenInterface* VideoPresentationManagerProxy::findInterface(PlaybackSessionContextIdentifier contextId) const
+PlatformVideoPresentationInterface* VideoPresentationManagerProxy::findInterface(PlaybackSessionContextIdentifier contextId) const
 {
     auto it = m_contextMap.find(contextId);
     if (it == m_contextMap.end())
@@ -614,14 +614,14 @@ void VideoPresentationManagerProxy::removeClientForContext(PlaybackSessionContex
     m_clientCounts.set(contextId, clientCount);
 }
 
-void VideoPresentationManagerProxy::forEachSession(Function<void(VideoPresentationModelContext&, PlatformVideoFullscreenInterface&)>&& callback)
+void VideoPresentationManagerProxy::forEachSession(Function<void(VideoPresentationModelContext&, PlatformVideoPresentationInterface&)>&& callback)
 {
     if (m_contextMap.isEmpty())
         return;
 
     for (auto& value : copyToVector(m_contextMap.values())) {
         RefPtr<VideoPresentationModelContext> model;
-        RefPtr<PlatformVideoFullscreenInterface> interface;
+        RefPtr<PlatformVideoPresentationInterface> interface;
         std::tie(model, interface) = value;
 
         ASSERT(model);
@@ -751,7 +751,7 @@ RetainPtr<WKLayerHostView> VideoPresentationManagerProxy::createLayerHostViewWit
 }
 
 #if PLATFORM(IOS_FAMILY)
-PlatformVideoFullscreenInterface* VideoPresentationManagerProxy::returningToStandbyInterface() const
+PlatformVideoPresentationInterface* VideoPresentationManagerProxy::returningToStandbyInterface() const
 {
     if (m_contextMap.isEmpty())
         return nullptr;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -39,7 +39,7 @@
 #import "WebPageProxy.h"
 #import "WebPreferences.h"
 #import <WebCore/LocalizedStrings.h>
-#import <WebCore/VideoFullscreenInterfaceIOS.h>
+#import <WebCore/VideoPresentationInterfaceIOS.h>
 #import <pal/spi/cocoa/AVKitSPI.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakObjCPtr.h>
@@ -333,8 +333,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     ASSERT(_valid);
     auto page = [self._webView _page];
     auto* videoPresentationManager = page ? page->videoPresentationManager() : nullptr;
-    auto* videoFullscreenInterface = videoPresentationManager ? videoPresentationManager->controlsManagerInterface() : nullptr;
-    auto* playbackSessionInterface = videoFullscreenInterface ? &videoFullscreenInterface->playbackSessionInterface() : nullptr;
+    auto* videoPresentationInterface = videoPresentationManager ? videoPresentationManager->controlsManagerInterface() : nullptr;
+    auto* playbackSessionInterface = videoPresentationInterface ? &videoPresentationInterface->playbackSessionInterface() : nullptr;
 
     _playbackClient.setInterface(playbackSessionInterface);
 

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -47,7 +47,7 @@
 #import <WebCore/GeometryUtilities.h>
 #import <WebCore/IntRect.h>
 #import <WebCore/LocalizedStrings.h>
-#import <WebCore/VideoFullscreenInterfaceIOS.h>
+#import <WebCore/VideoPresentationInterfaceIOS.h>
 #import <WebCore/VideoPresentationModel.h>
 #import <WebCore/ViewportArguments.h>
 #import <objc/runtime.h>
@@ -1081,11 +1081,11 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
                     });
                     videoPresentationManager->addVideoInPictureInPictureDidChangeObserver(*_pipObserver);
                 }
-                if (auto* videoFullscreenInterface = videoPresentationManager ? videoPresentationManager->returningToStandbyInterface() : nullptr) {
+                if (auto* videoPresentationInterface = videoPresentationManager ? videoPresentationManager->returningToStandbyInterface() : nullptr) {
                     if (_returnToFullscreenFromPictureInPicture)
-                        videoFullscreenInterface->preparedToReturnToStandby();
-                    else if (videoFullscreenInterface->inPictureInPicture()) {
-                        if (auto model = videoFullscreenInterface->videoPresentationModel()) {
+                        videoPresentationInterface->preparedToReturnToStandby();
+                    else if (videoPresentationInterface->inPictureInPicture()) {
+                        if (auto model = videoPresentationInterface->videoPresentationModel()) {
                             _enterFullscreenNeedsExitPictureInPicture = YES;
                             model->requestFullscreenMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModeNone);
                         }
@@ -1254,8 +1254,8 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
         manager->didExitFullScreen();
     }
 
-    auto* videoFullscreenInterface = self._videoPresentationManager ? self._videoPresentationManager->controlsManagerInterface() : nullptr;
-    _shouldReturnToFullscreenFromPictureInPicture = videoFullscreenInterface && videoFullscreenInterface->inPictureInPicture();
+    auto* videoPresentationInterface = self._videoPresentationManager ? self._videoPresentationManager->controlsManagerInterface() : nullptr;
+    _shouldReturnToFullscreenFromPictureInPicture = videoPresentationInterface && videoPresentationInterface->inPictureInPicture();
 
     [_window setHidden:YES];
     _window = nil;
@@ -1338,12 +1338,12 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 - (void)didExitPictureInPicture
 {
     if (!_enterFullscreenNeedsExitPictureInPicture && _shouldReturnToFullscreenFromPictureInPicture) {
-        auto* videoFullscreenInterface = self._videoPresentationManager ? self._videoPresentationManager->returningToStandbyInterface() : nullptr;
-        if (videoFullscreenInterface && videoFullscreenInterface->returningToStandby()) {
+        auto* videoPresentationInterface = self._videoPresentationManager ? self._videoPresentationManager->returningToStandbyInterface() : nullptr;
+        if (videoPresentationInterface && videoPresentationInterface->returningToStandby()) {
             OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, "returning to standby");
             if (!_exitingFullScreen) {
                 if (_fullScreenState == WebKit::InFullScreen)
-                    videoFullscreenInterface->preparedToReturnToStandby();
+                    videoPresentationInterface->preparedToReturnToStandby();
                 else
                     [self requestRestoreFullScreen];
             } else

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -43,7 +43,7 @@
 #import <WebCore/IntRect.h>
 #import <WebCore/LocalizedStrings.h>
 #import <WebCore/PlatformScreen.h>
-#import <WebCore/VideoFullscreenInterfaceMac.h>
+#import <WebCore/VideoPresentationInterfaceMac.h>
 #import <WebCore/VideoPresentationModel.h>
 #import <WebCore/WebCoreFullScreenPlaceholderView.h>
 #import <WebCore/WebCoreFullScreenWindow.h>


### PR DESCRIPTION
#### 482e2b0ed7b166adfb9073f78d9a7a12560d9957
<pre>
Rename VideoFullscreenInterface to VideoPresentationInterface
<a href="https://bugs.webkit.org/show_bug.cgi?id=267937">https://bugs.webkit.org/show_bug.cgi?id=267937</a>
<a href="https://rdar.apple.com/121457364">rdar://121457364</a>

Reviewed by Andy Estes.

VideoFullscreenInterface* is used for presentation modes other than Fullscreen,
Therefore naming more appropriately to VideoPresentationInterface*.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h: Renamed from Source/WebCore/platform/ios/VideoFullscreenInterfaceIOS.h.
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm: Renamed from Source/WebCore/platform/ios/VideoFullscreenInterfaceIOS.mm.
(clearUIColor):
(boolString):
(-[WebAVPlayerViewControllerDelegate fullscreenInterface]):
(-[WebAVPlayerViewControllerDelegate setFullscreenInterface:]):
(-[WebAVPlayerViewControllerDelegate playerViewControllerWillStartPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate playerViewControllerDidStartPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate playerViewController:failedToStartPictureInPictureWithError:]):
(-[WebAVPlayerViewControllerDelegate playerViewControllerWillStopPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate playerViewControllerDidStopPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate playerViewControllerShouldAutomaticallyDismissAtPictureInPictureStart:]):
(convertToExitFullScreenReason):
(-[WebAVPlayerViewControllerDelegate playerViewController:shouldExitFullScreenWithReason:]):
(-[WebAVPlayerViewControllerDelegate playerViewController:restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:]):
(-[WebAVPlayerViewControllerDelegate playerViewControllerShouldStartPictureInPictureFromInlineWhenEnteringBackground:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureControllerWillStartPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureControllerDidStartPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureController:failedToStartPictureInPictureWithError:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureControllerWillStopPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureControllerDidStopPictureInPicture:]):
(-[WebAVPlayerViewControllerDelegate pictureInPictureController:restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:]):
(WebAVPictureInPictureContentViewController_initWithController):
(WebAVPictureInPictureContentViewController_controller):
(WebAVPictureInPictureContentViewController_playerLayer):
(WebAVPictureInPictureContentViewController_setPlayerLayer):
(WebAVPictureInPictureContentViewController_viewWillLayoutSubviews):
(WebAVPictureInPictureContentViewController_dealloc):
(allocWebAVPictureInPictureContentViewControllerInstance):
(-[WebAVPlayerViewController initWithFullscreenInterface:]):
(-[WebAVPlayerViewController configurePlayerViewControllerWithFullscreenInterface:]):
(-[WebAVPlayerViewController dealloc]):
(-[WebAVPlayerViewController playerViewControllerShouldHandleDoneButtonTap:]):
(-[WebAVPlayerViewController setWebKitOverrideRouteSharingPolicy:routingContextUID:]):
(-[WebAVPlayerViewController enterFullScreenAnimated:completionHandler:]):
(-[WebAVPlayerViewController exitFullScreenAnimated:completionHandler:]):
(-[WebAVPlayerViewController observeValueForKeyPath:ofObject:change:context:]):
(-[WebAVPlayerViewController initObserver]):
(-[WebAVPlayerViewController removeObserver]):
(-[WebAVPlayerViewController MY_NO_RETURN]):
(-[WebAVPlayerViewController isPictureInPicturePossible]):
(-[WebAVPlayerViewController isPictureInPictureActive]):
(-[WebAVPlayerViewController pictureInPictureActive]):
(-[WebAVPlayerViewController pictureInPictureWasStartedWhenEnteringBackground]):
(-[WebAVPlayerViewController view]):
(-[WebAVPlayerViewController flashPlaybackControlsWithDuration:]):
(-[WebAVPlayerViewController showsPlaybackControls]):
(-[WebAVPlayerViewController setShowsPlaybackControls:]):
(-[WebAVPlayerViewController setAllowsPictureInPicturePlayback:]):
(-[WebAVPlayerViewController setDelegate:]):
(-[WebAVPlayerViewController setPlayerController:]):
(-[WebAVPlayerViewController avPlayerViewController]):
(-[WebAVPlayerViewController removeFromParentViewController]):
(-[WebAVPlayerViewController logIdentifier]):
(-[WebAVPlayerViewController loggerPtr]):
(-[WebAVPlayerViewController logChannel]):
(VideoFullscreenInterfaceIOS::create):
(VideoFullscreenInterfaceIOS::VideoFullscreenInterfaceIOS):
(VideoFullscreenInterfaceIOS::~VideoFullscreenInterfaceIOS):
(VideoFullscreenInterfaceIOS::playerController const):
(VideoFullscreenInterfaceIOS::avPlayerViewController const):
(VideoFullscreenInterfaceIOS::setVideoPresentationModel):
(VideoFullscreenInterfaceIOS::hasVideoChanged):
(VideoFullscreenInterfaceIOS::videoDimensionsChanged):
(VideoFullscreenInterfaceIOS::externalPlaybackChanged):
(VideoFullscreenInterfaceIOS::pictureInPictureWasStartedWhenEnteringBackground const):
(fallbackViewController):
(VideoFullscreenInterfaceIOS::presentingViewController):
(VideoFullscreenInterfaceIOS::applicationDidBecomeActive):
(VideoFullscreenInterfaceIOS::setupFullscreen):
(VideoFullscreenInterfaceIOS::enterFullscreen):
(VideoFullscreenInterfaceIOS::exitFullscreen):
(VideoFullscreenInterfaceIOS::exitFullscreenWithoutAnimationToMode):
(VideoFullscreenInterfaceIOS::cleanupFullscreen):
(VideoFullscreenInterfaceIOS::invalidate):
(VideoFullscreenInterfaceIOS::setPlayerIdentifier):
(VideoFullscreenInterfaceIOS::requestHideAndExitFullscreen):
(VideoFullscreenInterfaceIOS::preparedToReturnToInline):
(VideoFullscreenInterfaceIOS::preparedToExitFullscreen):
(VideoFullscreenInterfaceIOS::mayAutomaticallyShowVideoPictureInPicture const):
(VideoFullscreenInterfaceIOS::prepareForPictureInPictureStop):
(VideoFullscreenInterfaceIOS::willStartPictureInPicture):
(VideoFullscreenInterfaceIOS::didStartPictureInPicture):
(VideoFullscreenInterfaceIOS::failedToStartPictureInPicture):
(VideoFullscreenInterfaceIOS::willStopPictureInPicture):
(VideoFullscreenInterfaceIOS::didStopPictureInPicture):
(VideoFullscreenInterfaceIOS::prepareForPictureInPictureStopWithCompletionHandler):
(VideoFullscreenInterfaceIOS::shouldExitFullscreenWithReason):
(VideoFullscreenInterfaceIOS::setHasVideoContentLayer):
(VideoFullscreenInterfaceIOS::setInlineRect):
(VideoFullscreenInterfaceIOS::doSetup):
(VideoFullscreenInterfaceIOS::preparedToReturnToStandby):
(VideoFullscreenInterfaceIOS::finalizeSetup):
(VideoFullscreenInterfaceIOS::doEnterFullscreen):
(VideoFullscreenInterfaceIOS::doExitFullscreen):
(VideoFullscreenInterfaceIOS::exitFullscreenHandler):
(VideoFullscreenInterfaceIOS::enterFullscreenHandler):
(VideoFullscreenInterfaceIOS::returnToStandby):
(VideoFullscreenInterfaceIOS::watchdogTimerFired):
(VideoFullscreenInterfaceIOS::setMode):
(VideoFullscreenInterfaceIOS::clearMode):
(VideoFullscreenInterfaceIOS::isPlayingVideoInEnhancedFullscreen const):
(VideoFullscreenInterfaceIOS::logIdentifier const):
(VideoFullscreenInterfaceIOS::loggerPtr const):
(VideoFullscreenInterfaceIOS::logChannel const):
(WebCore::setSupportsPictureInPicture):
(WebCore::supportsPictureInPicture):

Canonical link: <a href="https://commits.webkit.org/273521@main">https://commits.webkit.org/273521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e5802aeacd21c0d7ff115e82f9fba2984ddd39e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35242 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/37999 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31806 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36405 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30693 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/11986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10512 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10560 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39245 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31858 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36547 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34562 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12466 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8142 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11223 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11526 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->