### PR TITLE
[VisionOS] Twitter.com videos do not play

### DIFF
--- a/Source/WebCore/Modules/remoteplayback/HTMLMediaElement+RemotePlayback.idl
+++ b/Source/WebCore/Modules/remoteplayback/HTMLMediaElement+RemotePlayback.idl
@@ -25,9 +25,8 @@
 
 [
     Conditional=VIDEO&WIRELESS_PLAYBACK_TARGET,
-    EnabledBySetting=RemotePlaybackEnabled,
     ImplementedBy=HTMLMediaElementRemotePlayback
 ] partial interface HTMLMediaElement {
-    readonly attribute RemotePlayback remote;
+    [EnabledBySetting=RemotePlaybackEnabled] readonly attribute RemotePlayback remote;
     [Reflect] attribute boolean disableRemotePlayback;
 };


### PR DESCRIPTION
#### 277c42bdaccc434bff6fac4e45f23b7f31ca371b
<pre>
[VisionOS] Twitter.com videos do not play
<a href="https://bugs.webkit.org/show_bug.cgi?id=267938">https://bugs.webkit.org/show_bug.cgi?id=267938</a>
<a href="https://rdar.apple.com/121391975">rdar://121391975</a>

Reviewed by Tim Horton.

Twitter.com has adopted ManagedMediaSource, and disables airplay via
HTMLMediaElement.disableRemotePlayback. On other platforms, this allows
MMS to move to the &quot;open&quot; state, due to the managedMediaSourceNeedsAirPlay
setting. However, on VisionOS, the RemotePlaybackEnabled setting is off,
so the disableRemotePlayback property is not reflected into an attribute
on the HTMLMediaElement, and the check for isWirelessPlaybackTargetDisabled()
fails.

Selectively move portions of EnabledBySetting=RemotePlaybackEnabled from
the HTMLMediaElement+RemotePlayback.idl file sufficient for disableRemotePlayback
to be reflected, and to allow ManagedMediaSource to check for its presence.

* Source/WebCore/Modules/remoteplayback/HTMLMediaElement+RemotePlayback.idl:

Canonical link: <a href="https://commits.webkit.org/273434@main">https://commits.webkit.org/273434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/362df2cb840161396408bec1c7718075cffc9cd3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38169 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31949 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11404 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10643 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39417 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32201 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32005 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36647 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34694 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12591 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8097 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11372 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11651 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->