### PR TITLE
Timestamps should be preserved between VideoTrackGenerator and MediaStreamTrackProcessor

### DIFF
--- a/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.js
+++ b/LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.js
@@ -3,7 +3,7 @@ importScripts("/resources/testharness.js");
 
 function makeOffscreenCanvasVideoFrame(width, height, timestamp) {
     if (!timestamp)
-      timestamp = 1;
+        timestamp = 1;
     let canvas = new OffscreenCanvas(width, height);
     let ctx = canvas.getContext('2d');
     ctx.fillStyle = 'rgba(50, 100, 150, 255)';
@@ -162,10 +162,10 @@ promise_test(async (t) => {
 }, "Track gets muted based on VideoTrackGenerator.muted");
 
 promise_test(async (t) => {
-    const frame1 = makeOffscreenCanvasVideoFrame(100, 100);
+    const frame1 = makeOffscreenCanvasVideoFrame(100, 100, 1);
     t.add_cleanup(() => frame1.close());
 
-    const frame2 = makeOffscreenCanvasVideoFrame(200, 200);
+    const frame2 = makeOffscreenCanvasVideoFrame(200, 200, 2);
     t.add_cleanup(() => frame2.close());
 
     const generator = new VideoTrackGenerator();
@@ -176,13 +176,17 @@ promise_test(async (t) => {
 
     writer.write(frame1);
 
-    let chunk = await reader.read();
-    assert_equals(chunk.value.codedWidth, 100);
+    const chunk1 = await reader.read();
+    assert_equals(chunk1.value.codedWidth, 100);
+    assert_equals(chunk1.value.timestamp, 1);
+    t.add_cleanup(() => chunk1.value.close());
 
     writer.write(frame2);
 
-    chunk = await reader.read();
-    assert_equals(chunk.value.codedWidth, 200);
+    const chunk2 = await reader.read();
+    assert_equals(chunk2.value.codedWidth, 200);
+    assert_equals(chunk2.value.timestamp, 2);
+    t.add_cleanup(() => chunk2.value.close());
 
     const endedPromise = new Promise(resolve => generator.track.onended = resolve);
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
@@ -29,6 +29,7 @@
 
 #include "JSWebCodecsVideoFrame.h"
 #include "ReadableStream.h"
+#include <wtf/Seconds.h>
 
 namespace WebCore {
 
@@ -158,6 +159,7 @@ RefPtr<WebCodecsVideoFrame> MediaStreamTrackProcessor::VideoFrameObserver::takeV
     init.codedWidth = videoFrame->presentationSize().width();
     init.codedHeight = videoFrame->presentationSize().height();
     init.colorSpace = videoFrame->colorSpace();
+    init.timestamp = Seconds(videoFrame->presentationTime().toDouble()).microseconds();
 
     return WebCodecsVideoFrame::create(context, videoFrame.releaseNonNull(), WTFMove(init));
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
@@ -143,8 +143,9 @@ private:
     explicit WebCodecsVideoFrame(ScriptExecutionContext&);
     WebCodecsVideoFrame(ScriptExecutionContext&, WebCodecsVideoFrameData&&);
 
-    static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameFromOtherFrame(ScriptExecutionContext&, Ref<WebCodecsVideoFrame>&&, Init&&);
-    static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameFromOtherFrame(ScriptExecutionContext&, Ref<VideoFrame>&&, Init&&);
+    enum class CanUpdateVideoFrameTimestamp : bool { No, Yes };
+    static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameFromOtherFrame(ScriptExecutionContext&, Ref<WebCodecsVideoFrame>&&, Init&&, CanUpdateVideoFrameTimestamp);
+    static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameFromOtherFrame(ScriptExecutionContext&, Ref<VideoFrame>&&, Init&&, CanUpdateVideoFrameTimestamp);
     static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameWithResourceAndSize(ScriptExecutionContext&, Ref<NativeImage>&&, Init&&);
 
     WebCodecsVideoFrameData m_data;


### PR DESCRIPTION
#### 5eb8b5f9535303f4c25fbcaddcf718f0cf417ba1
<pre>
Timestamps should be preserved between VideoTrackGenerator and MediaStreamTrackProcessor
<a href="https://bugs.webkit.org/show_bug.cgi?id=267929">https://bugs.webkit.org/show_bug.cgi?id=267929</a>
<a href="https://rdar.apple.com/121462248">rdar://121462248</a>

Reviewed by Eric Carlson.

Add support for setting the VideoFrame presentationTime based on the WebCodecsVideoFrame timestamp.
In the future, the WebCodecsVideoFrame timestamp will be removed in favour of the VideoFrame presentationTime.

Make sure to have MediaStreamTrackProcessor correctly create the WebCodecsVideoFrame with the presentationTime.

* LayoutTests/http/wpt/mediastream/worker-mediastreamtrack.worker.js:
(makeOffscreenCanvasVideoFrame):
(promise_test.async t):
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp:
(WebCore::MediaStreamTrackProcessor::VideoFrameObserver::takeVideoFrame):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):
(WebCore::WebCodecsVideoFrame::initializeFrameFromOtherFrame):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h:

Canonical link: <a href="https://commits.webkit.org/273404@main">https://commits.webkit.org/273404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67f75e1d72b8f5255518340ded5e17ef3e646d3f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38114 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31899 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36572 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11346 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10609 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39360 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31948 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8707 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/34664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8082 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11326 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11612 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->