### PR TITLE
MediaStreamTrackProcessor should not be destroyed if its ReadableStream source is live

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchBodySource.h
+++ b/Source/WebCore/Modules/fetch/FetchBodySource.h
@@ -37,7 +37,7 @@ namespace WebCore {
 
 class FetchBodyOwner;
 
-class FetchBodySource final : public ReadableStreamSource {
+class FetchBodySource final : public RefCountedReadableStreamSource {
 public:
     FetchBodySource(FetchBodyOwner&);
 

--- a/Source/WebCore/Modules/streams/ReadableStreamSource.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamSource.h
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-class ReadableStreamSource : public RefCounted<ReadableStreamSource> {
+class ReadableStreamSource {
 public:
     WEBCORE_EXPORT ReadableStreamSource();
     WEBCORE_EXPORT virtual ~ReadableStreamSource();
@@ -44,6 +44,9 @@ public:
     void cancel(JSC::JSValue);
 
     bool isPulling() const { return !!m_promise; }
+
+    virtual void ref() = 0;
+    virtual void deref() = 0;
 
 protected:
     ReadableStreamDefaultController& controller() { return m_controller.value(); }
@@ -66,8 +69,16 @@ private:
     std::optional<ReadableStreamDefaultController> m_controller;
 };
 
-class SimpleReadableStreamSource
+class RefCountedReadableStreamSource
     : public ReadableStreamSource
+    , public RefCounted<RefCountedReadableStreamSource> {
+public:
+    void ref() final { RefCounted<RefCountedReadableStreamSource>::ref(); };
+    void deref() final { RefCounted<RefCountedReadableStreamSource>::deref(); };
+};
+
+class SimpleReadableStreamSource
+    : public RefCountedReadableStreamSource
     , public CanMakeWeakPtr<SimpleReadableStreamSource> {
 public:
     static Ref<SimpleReadableStreamSource> create() { return adoptRef(*new SimpleReadableStreamSource); }

--- a/Source/WebCore/Modules/webtransport/DatagramSource.h
+++ b/Source/WebCore/Modules/webtransport/DatagramSource.h
@@ -31,7 +31,7 @@ namespace WebCore {
 
 class WebTransport;
 
-class DatagramSource : public ReadableStreamSource {
+class DatagramSource : public RefCountedReadableStreamSource {
 public:
     static Ref<DatagramSource> create() { return adoptRef(*new DatagramSource()); }
     ~DatagramSource();

--- a/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamSource.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamSource.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-class WebTransportBidirectionalStreamSource : public ReadableStreamSource {
+class WebTransportBidirectionalStreamSource : public RefCountedReadableStreamSource {
 public:
     static Ref<WebTransportBidirectionalStreamSource> create() { return adoptRef(*new WebTransportBidirectionalStreamSource()); }
     void receiveIncomingStream();

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-class WebTransportReceiveStreamSource : public ReadableStreamSource {
+class WebTransportReceiveStreamSource : public RefCountedReadableStreamSource {
 public:
     static Ref<WebTransportReceiveStreamSource> create() { return adoptRef(*new WebTransportReceiveStreamSource()); }
     void receiveIncomingStream();

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -306,7 +306,7 @@ void Blob::arrayBuffer(Ref<DeferredPromise>&& promise)
 
 ExceptionOr<Ref<ReadableStream>> Blob::stream()
 {
-    class BlobStreamSource : public FileReaderLoaderClient, public ReadableStreamSource {
+    class BlobStreamSource : public FileReaderLoaderClient, public RefCountedReadableStreamSource {
     public:
         BlobStreamSource(ScriptExecutionContext& scriptExecutionContext, Blob& blob)
             : m_loader(makeUniqueRef<FileReaderLoader>(FileReaderLoader::ReadType::ReadAsBinaryChunks, this))

--- a/Source/WebKit/WebProcess/Network/WebTransportReceiveStreamSource.h
+++ b/Source/WebKit/WebProcess/Network/WebTransportReceiveStreamSource.h
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-class WebTransportReceiveStreamSource : public WebCore::ReadableStreamSource {
+class WebTransportReceiveStreamSource : public WebCore::RefCountedReadableStreamSource {
 public:
     static Ref<WebTransportReceiveStreamSource> create() { return adoptRef(*new WebTransportReceiveStreamSource()); }
 


### PR DESCRIPTION
#### 1dd42ba248d5a42d0142a2a0134b23ec189ff1cf
<pre>
MediaStreamTrackProcessor should not be destroyed if its ReadableStream source is live
<a href="https://bugs.webkit.org/show_bug.cgi?id=267932">https://bugs.webkit.org/show_bug.cgi?id=267932</a>
<a href="https://rdar.apple.com/121465569">rdar://121465569</a>

Reviewed by Eric Carlson.

We want to keep MediaStreamTrackProcessor alive if its ReadableStream source is alive, so that we can pipe the received video frames to the source.
To do this, MediaStreamTrackProcessor::Source is no longer RefCounted but will use its MediaStreamTrackProcessor ref count.

We make ReadableStreamSource no longer refcounted so that MediaStreamTrackProcessor::Source can do its own ref/deref.
We introduce RefCountedReadableStreamSource for other existing ReadableStream sources.

* Source/WebCore/Modules/fetch/FetchBodySource.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp:
(WebCore::MediaStreamTrackProcessor::readable):
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h:
* Source/WebCore/Modules/streams/ReadableStreamSource.h:
* Source/WebCore/Modules/webtransport/DatagramSource.h:
* Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamSource.h:
* Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.h:
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::Blob::stream):
* Source/WebKit/WebProcess/Network/WebTransportReceiveStreamSource.h:

Canonical link: <a href="https://commits.webkit.org/273400@main">https://commits.webkit.org/273400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1e6e85bcf0985da89cd636b106a6e05948ee194

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14204 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/37670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38023 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31827 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11266 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12012 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/37670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10530 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10583 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/37670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39269 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32074 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/37670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36561 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34576 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12487 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/37670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8081 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11244 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11544 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->