### PR TITLE
Use std::variant and std::optional as storage for WTF::Expected

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -169,15 +169,6 @@ template<typename T> struct ConnectionSendSyncResult {
     bool succeeded() const { return value.has_value(); }
     Error error() const { return value.has_value() ? Error::NoError : value.error(); }
 
-    // FIXME: Remove this when we start using c++23 and std::expected.
-#if OS(WINDOWS) // Expected isn't move-constuctible
-    ConnectionSendSyncResult(ConnectionSendSyncResult&& other)
-        : value(makeUnexpected(Error::NoError))
-    {
-        value.swap(other.value);
-    }
-#endif
-
     typename T::ReplyArguments& reply()
     {
         return value.value();


### PR DESCRIPTION
#### 23402d69a57f55e6a557868d128bc4a6b5c75068
<pre>
Use std::variant and std::optional as storage for WTF::Expected
<a href="https://bugs.webkit.org/show_bug.cgi?id=267956">https://bugs.webkit.org/show_bug.cgi?id=267956</a>
<a href="https://rdar.apple.com/121471408">rdar://121471408</a>

Reviewed by Fujii Hironori.

Our Expected interface is 7 paper revisions behind <a href="https://wg21.link/P0323R11">https://wg21.link/P0323R11</a>
It has all kinds of issues with trivially copyable and trivially destructable types
that have been solved since <a href="https://wg21.link/P0323R4">https://wg21.link/P0323R4</a> and it&apos;s in C++23 which we
can&apos;t use for another few months.  Until then, just use std::optional and std::variant
as the storage, where these problems have also already been solved.

* Source/WTF/wtf/Expected.h:
(std::experimental::fundamentals_v3::__expected_detail::base::base):
(std::experimental::fundamentals_v3::__expected_detail::voidbase::voidbase):
(std::experimental::fundamentals_v3::expected::expected):
(std::experimental::fundamentals_v3::expected::swap):
(std::experimental::fundamentals_v3::expected::operator-&gt; const):
(std::experimental::fundamentals_v3::expected::operator-&gt;):
(std::experimental::fundamentals_v3::expected::operator* const):
(std::experimental::fundamentals_v3::expected::operator*):
(std::experimental::fundamentals_v3::expected::operator bool const):
(std::experimental::fundamentals_v3::expected::has_value const):
(std::experimental::fundamentals_v3::expected::value const):
(std::experimental::fundamentals_v3::expected::value):
(std::experimental::fundamentals_v3::expected::error const):
(std::experimental::fundamentals_v3::expected::error):
(std::experimental::fundamentals_v3::expected::value_or const):
(std::experimental::fundamentals_v3::expected::value_or):
(std::experimental::fundamentals_v3::__expected_detail::destroy): Deleted.
(std::experimental::fundamentals_v3::__expected_detail::std::is_trivially_destructible&lt;T&gt;::value): Deleted.
(std::experimental::fundamentals_v3::__expected_detail::constexpr_base::constexpr_base): Deleted.
(std::experimental::fundamentals_v3::__expected_detail::base::~base): Deleted.
* Source/WebKit/Platform/IPC/Connection.h:

Canonical link: <a href="https://commits.webkit.org/273395@main">https://commits.webkit.org/273395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f4d729a81ed36736f3097cfdaf505d01b602d88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38037 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31840 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11279 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30718 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10543 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10590 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39283 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/29970 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32081 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36574 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/35186 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10734 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34593 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12500 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41828 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8076 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11258 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11557 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->