### PR TITLE
[git-webkit revert] Update pr arguments and usability

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
@@ -66,10 +66,10 @@ class Revert(Command):
         )
 
         parser.add_argument(
-            '--pr',
-            default=False,
-            action='store_true',
-            help='Create a pull request at the same time'
+            '--pr', '--no-pr',
+            default=True,
+            action=arguments.NoAction,
+            help='Create a pull request (or do not) after reverting'
         )
 
     @classmethod
@@ -92,7 +92,8 @@ class Revert(Command):
     def get_issue_info(cls, args, repository, commit_objects, commit_bugs, **kwargs):
         # Can give either a bug URL or a title of the new issue
         if not args.issue and not args.reason:
-            prompt = 'Enter issue URL or reason for the revert: '
+            print('This issue will track the revert and should not be the issue of the commit(s) to be reverted.')
+            prompt = 'Enter issue URL or title of new issue (reason for the revert): '
             args.issue = Terminal.input(prompt, alert_after=2 * Terminal.RING_INTERVAL)
         elif args.reason:
             args.issue = args.reason
@@ -251,6 +252,6 @@ class Revert(Command):
 
         if not args.pr:
             return result
-        else:
-            return PullRequest.create_pull_request(repository, args, branch_point)
+
+        return PullRequest.create_pull_request(repository, args, branch_point)
 


### PR DESCRIPTION
#### a4de8ff7f69d29efcf0a414fb68af0db296bd630
<pre>
[git-webkit revert] Update pr arguments and usability
<a href="https://bugs.webkit.org/show_bug.cgi?id=267955">https://bugs.webkit.org/show_bug.cgi?id=267955</a>
<a href="https://rdar.apple.com/121379784">rdar://121379784</a>

Reviewed by Jonathan Bedard.

Set automatic PR creation to &apos;true&apos; in git-webkit revert. Added additional logging and clearer prompts.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py:
(Revert.parser): Added --pr and --no-pr options.
(Revert.get_issue_info):
(Revert.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py:
(TestRevert.test_github):
(TestRevert.test_github_two_step):
(TestRevert.test_args):
(test_update):
(test_pr):

Canonical link: <a href="https://commits.webkit.org/273569@main">https://commits.webkit.org/273569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/085c7200633bea2e7263a12400b4f7a032195a33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14803 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/38052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38584 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11829 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36415 "Failed to checkout and rebase branch from PR 23125") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/12518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/38052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/10993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/36056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/38052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/32582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/38052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/39834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/35838 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/38052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4645 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/12005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->