### PR TITLE
Make sure simulators have correct bundle ID

### DIFF
--- a/Source/WebKit/Configurations/GPUService.xcconfig
+++ b/Source/WebKit/Configurations/GPUService.xcconfig
@@ -31,6 +31,9 @@ PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator17.1*] = $(PRODUCT_NAME);
 PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator17.2*] = $(PRODUCT_NAME);
 PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator17.3*] = $(PRODUCT_NAME);
 PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator18.0*] = $(PRODUCT_NAME);
+PRODUCT_BUNDLE_IDENTIFIER[sdk=watchsimulator*] = $(PRODUCT_NAME);
+PRODUCT_BUNDLE_IDENTIFIER[sdk=appletvsimulator*] = $(PRODUCT_NAME);
+PRODUCT_BUNDLE_IDENTIFIER[sdk=xrsimulator*] = $(PRODUCT_NAME);
 
 INFOPLIST_FILE[sdk=embedded*] = GPUProcess/EntryPoint/Cocoa/XPCService/GPUService/Info-iOS.plist;
 INFOPLIST_FILE[sdk=macosx*] = GPUProcess/EntryPoint/Cocoa/XPCService/GPUService/Info-OSX.plist;

--- a/Source/WebKit/Configurations/NetworkService.xcconfig
+++ b/Source/WebKit/Configurations/NetworkService.xcconfig
@@ -31,6 +31,9 @@ PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator17.1*] = $(PRODUCT_NAME);
 PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator17.2*] = $(PRODUCT_NAME);
 PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator17.3*] = $(PRODUCT_NAME);
 PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator18.0*] = $(PRODUCT_NAME);
+PRODUCT_BUNDLE_IDENTIFIER[sdk=watchsimulator*] = $(PRODUCT_NAME);
+PRODUCT_BUNDLE_IDENTIFIER[sdk=appletvsimulator*] = $(PRODUCT_NAME);
+PRODUCT_BUNDLE_IDENTIFIER[sdk=xrsimulator*] = $(PRODUCT_NAME);
 
 INFOPLIST_FILE[sdk=embedded*] = NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkService/Info-iOS.plist;
 INFOPLIST_FILE[sdk=macosx*] = NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkService/Info-OSX.plist;

--- a/Source/WebKit/Configurations/WebContentService.xcconfig
+++ b/Source/WebKit/Configurations/WebContentService.xcconfig
@@ -36,6 +36,9 @@ PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator17.1*] = $(PRODUCT_NAME);
 PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator17.2*] = $(PRODUCT_NAME);
 PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator17.3*] = $(PRODUCT_NAME);
 PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator18.0*] = $(PRODUCT_NAME);
+PRODUCT_BUNDLE_IDENTIFIER[sdk=watchsimulator*] = $(PRODUCT_NAME);
+PRODUCT_BUNDLE_IDENTIFIER[sdk=appletvsimulator*] = $(PRODUCT_NAME);
+PRODUCT_BUNDLE_IDENTIFIER[sdk=xrsimulator*] = $(PRODUCT_NAME);
 
 INFOPLIST_FILE[sdk=embedded*] = WebProcess/EntryPoint/Cocoa/XPCService/WebContentService/Info-iOS.plist;
 INFOPLIST_FILE[sdk=macosx*] = WebProcess/EntryPoint/Cocoa/XPCService/WebContentService/Info-OSX.plist;


### PR DESCRIPTION
#### 9a9aef3921444c4ae209f0b75e9acbda461ec83a
<pre>
Make sure simulators have correct bundle ID
<a href="https://bugs.webkit.org/show_bug.cgi?id=267964">https://bugs.webkit.org/show_bug.cgi?id=267964</a>
<a href="https://rdar.apple.com/121474403">rdar://121474403</a>

Reviewed by Brent Fulgham.

Make sure simulators have correct bundle ID for all platforms.

* Source/WebKit/Configurations/GPUService.xcconfig:
* Source/WebKit/Configurations/NetworkService.xcconfig:
* Source/WebKit/Configurations/WebContentService.xcconfig:

Canonical link: <a href="https://commits.webkit.org/273388@main">https://commits.webkit.org/273388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00bb5bdc17cfa78812d1a6c5211d2d7f0ae09e73

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38047 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31847 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11286 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10548 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10594 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39293 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36578 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34598 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8072 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11268 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->