### PR TITLE
Implement event firing from the web process for webRequest events and add tests

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -69,6 +69,9 @@ NetworkResourceLoadParameters::NetworkResourceLoadParameters(
     , URL&& mainDocumentURL
     , std::optional<UserContentControllerIdentifier> userContentControllerIdentifier
 #endif
+#if ENABLE(WK_WEB_EXTENSIONS)
+    , bool pageHasExtensionController
+#endif
     , bool linkPreconnectEarlyHintsEnabled
     ) : NetworkLoadParameters(WTFMove(networkLoadParameters))
         , identifier(identifier)
@@ -103,6 +106,9 @@ NetworkResourceLoadParameters::NetworkResourceLoadParameters(
 #if ENABLE(CONTENT_EXTENSIONS)
         , mainDocumentURL(WTFMove(mainDocumentURL))
         , userContentControllerIdentifier(userContentControllerIdentifier)
+#endif
+#if ENABLE(WK_WEB_EXTENSIONS)
+        , pageHasExtensionController(pageHasExtensionController)
 #endif
         , linkPreconnectEarlyHintsEnabled(linkPreconnectEarlyHintsEnabled)
 {

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -86,6 +86,9 @@ public:
         , URL&& mainDocumentURL
         , std::optional<UserContentControllerIdentifier>
 #endif
+#if ENABLE(WK_WEB_EXTENSIONS)
+        , bool pageHasExtensionController
+#endif
         , bool linkPreconnectEarlyHintsEnabled
     );
     
@@ -131,6 +134,10 @@ public:
 #if ENABLE(CONTENT_EXTENSIONS)
     URL mainDocumentURL;
     std::optional<UserContentControllerIdentifier> userContentControllerIdentifier;
+#endif
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+    bool pageHasExtensionController { false };
 #endif
 
     bool linkPreconnectEarlyHintsEnabled { false };

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -106,5 +106,9 @@ class WebKit::NetworkResourceLoadParameters : WebKit::NetworkLoadParameters {
     std::optional<WebKit::UserContentControllerIdentifier> userContentControllerIdentifier;
 #endif
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+    bool pageHasExtensionController;
+#endif
+
     bool linkPreconnectEarlyHintsEnabled;
 };

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -273,6 +273,8 @@ private:
     void startRequest(const WebCore::ResourceRequest&);
     bool abortIfServiceWorkersOnly();
 
+    bool shouldSendResourceLoadMessages() const;
+
     NetworkResourceLoadParameters m_parameters;
 
     Ref<NetworkConnectionToWebProcess> m_connection;

--- a/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
@@ -98,6 +98,13 @@ inline bool matchesFrame(const WebExtensionFrameIdentifier& identifier, const We
     return frame.frameID().object().toUInt64() == identifier.toUInt64();
 }
 
+inline WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(WebCore::FrameIdentifier frameIdentifier)
+{
+    WebExtensionFrameIdentifier result { frameIdentifier.object().toUInt64() };
+    ASSERT(result.isValid());
+    return result;
+}
+
 inline WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(const WebFrame& frame)
 {
     if (auto* coreFrame = frame.coreFrame(); coreFrame->isMainFrame())
@@ -106,9 +113,7 @@ inline WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(const WebFrame&
     if (auto* page = frame.page(); &page->mainWebFrame() == &frame)
         return WebExtensionFrameConstants::MainFrameIdentifier;
 
-    WebExtensionFrameIdentifier result { frame.frameID().object().toUInt64() };
-    ASSERT(result.isValid());
-    return result;
+    return toWebExtensionFrameIdentifier(frame.frameID());
 }
 
 inline WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(const FrameInfoData& frameInfoData)
@@ -116,9 +121,7 @@ inline WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(const FrameInfo
     if (frameInfoData.isMainFrame)
         return WebExtensionFrameConstants::MainFrameIdentifier;
 
-    WebExtensionFrameIdentifier result { frameInfoData.frameID.object().toUInt64() };
-    ASSERT(result.isValid());
-    return result;
+    return toWebExtensionFrameIdentifier(frameInfoData.frameID);
 }
 
 #ifdef __OBJC__

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1918,10 +1918,10 @@ void WebExtensionContext::resourceLoadDidPerformHTTPRedirection(WebPageProxyIden
     if (!hasPermissionToSendWebRequestEvent(tab.get(), request.url(), loadInfo))
         return;
 
-    auto eventTypes = { WebExtensionEventListenerType::WebRequestOnHeadersReceived, WebExtensionEventListenerType::WebRequestOnBeforeRequest };
+    auto eventTypes = { WebExtensionEventListenerType::WebRequestOnHeadersReceived, WebExtensionEventListenerType::WebRequestOnBeforeRedirect };
     wakeUpBackgroundContentIfNecessaryToFireEvents(eventTypes, [&] {
         auto windowIdentifier = tab->window() ? tab->window()->identifier() : WebExtensionWindowConstants::NoneIdentifier;
-        sendToProcessesForEvents(eventTypes, Messages::WebExtensionContextProxy::ResourceLoadDidSendRequest(tab->identifier(), windowIdentifier, request, loadInfo));
+        sendToProcessesForEvents(eventTypes, Messages::WebExtensionContextProxy::ResourceLoadDidPerformHTTPRedirection(tab->identifier(), windowIdentifier, response, loadInfo, request));
     });
 
     // After dispatching the redirect events, also dispatch the `didSendRequest` events for the redirection.

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
@@ -54,6 +54,8 @@ public:
     void removeListener(WebPage*, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
+    void invokeListenersWithArgument(NSDictionary *argument, WebExtensionTabIdentifier, WebExtensionWindowIdentifier, const ResourceLoadInfo&);
+
     void removeAllListeners();
 
     virtual ~WebExtensionAPIWebRequestEvent()

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.h
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.h
@@ -25,9 +25,13 @@
 
 #import <WebKit/WKFoundation.h>
 
-NS_ASSUME_NONNULL_BEGIN
+#ifdef __cplusplus
+namespace WebKit {
+struct ResourceLoadInfo;
+}
+#endif
 
-@class _WKResourceLoadInfo;
+NS_ASSUME_NONNULL_BEGIN
 
 // https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType
 typedef NS_ENUM(NSInteger, _WKWebExtensionWebRequestResourceType) {
@@ -49,7 +53,9 @@ typedef NS_ENUM(NSInteger, _WKWebExtensionWebRequestResourceType) {
     _WKWebExtensionWebRequestResourceTypeOther,
 };
 
-WK_EXTERN _WKWebExtensionWebRequestResourceType _WKWebExtensionWebRequestResourceTypeFromWKResourceLoadInfo(_WKResourceLoadInfo *);
+#ifdef __cplusplus
+WK_EXTERN _WKWebExtensionWebRequestResourceType _WKWebExtensionWebRequestResourceTypeFromResourceLoadInfo(const WebKit::ResourceLoadInfo&);
+#endif
 
 // https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/RequestFilter
 WK_EXTERN

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm
@@ -33,6 +33,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "CocoaHelpers.h"
+#import "ResourceLoadInfo.h"
 #import "WebExtensionTabIdentifier.h"
 #import "WebExtensionUtilities.h"
 #import "WebExtensionWindowIdentifier.h"
@@ -47,37 +48,37 @@ static NSString *typesKey = @"types";
 static NSString *tabIdKey = @"tabId";
 static NSString *windowIdKey = @"windowId";
 
-_WKWebExtensionWebRequestResourceType _WKWebExtensionWebRequestResourceTypeFromWKResourceLoadInfo(_WKResourceLoadInfo *resourceLoadInfo)
+_WKWebExtensionWebRequestResourceType _WKWebExtensionWebRequestResourceTypeFromResourceLoadInfo(const ResourceLoadInfo& resourceLoadInfo)
 {
-    switch (resourceLoadInfo.resourceType) {
-    case _WKResourceLoadInfoResourceTypeDocument:
-        return resourceLoadInfo.parentFrame ? _WKWebExtensionWebRequestResourceTypeMainFrame : _WKWebExtensionWebRequestResourceTypeSubframe;
-    case _WKResourceLoadInfoResourceTypeStylesheet:
+    switch (resourceLoadInfo.type) {
+    case ResourceLoadInfo::Type::Document:
+        return resourceLoadInfo.parentFrameID ? _WKWebExtensionWebRequestResourceTypeMainFrame : _WKWebExtensionWebRequestResourceTypeSubframe;
+    case ResourceLoadInfo::Type::Stylesheet:
         return _WKWebExtensionWebRequestResourceTypeStylesheet;
-    case _WKResourceLoadInfoResourceTypeScript:
+    case ResourceLoadInfo::Type::Script:
         return _WKWebExtensionWebRequestResourceTypeScript;
-    case _WKResourceLoadInfoResourceTypeImage:
+    case ResourceLoadInfo::Type::Image:
         return _WKWebExtensionWebRequestResourceTypeImage;
-    case _WKResourceLoadInfoResourceTypeFont:
+    case ResourceLoadInfo::Type::Font:
         return _WKWebExtensionWebRequestResourceTypeFont;
-    case _WKResourceLoadInfoResourceTypeObject:
+    case ResourceLoadInfo::Type::Object:
         return _WKWebExtensionWebRequestResourceTypeObject;
-    case _WKResourceLoadInfoResourceTypeFetch:
-    case _WKResourceLoadInfoResourceTypeXMLHTTPRequest:
+    case ResourceLoadInfo::Type::Fetch:
+    case ResourceLoadInfo::Type::XMLHTTPRequest:
         return _WKWebExtensionWebRequestResourceTypeXMLHTTPRequest;
-    case _WKResourceLoadInfoResourceTypeCSPReport:
+    case ResourceLoadInfo::Type::CSPReport:
         return _WKWebExtensionWebRequestResourceTypeCSPReport;
-    case _WKResourceLoadInfoResourceTypeMedia:
+    case ResourceLoadInfo::Type::Media:
         return _WKWebExtensionWebRequestResourceTypeMedia;
-    case _WKResourceLoadInfoResourceTypeApplicationManifest:
+    case ResourceLoadInfo::Type::ApplicationManifest:
         return _WKWebExtensionWebRequestResourceTypeApplicationManifest;
-    case _WKResourceLoadInfoResourceTypeXSLT:
+    case ResourceLoadInfo::Type::XSLT:
         return _WKWebExtensionWebRequestResourceTypeXSLT;
-    case _WKResourceLoadInfoResourceTypePing:
+    case ResourceLoadInfo::Type::Ping:
         return _WKWebExtensionWebRequestResourceTypePing;
-    case _WKResourceLoadInfoResourceTypeBeacon:
+    case ResourceLoadInfo::Type::Beacon:
         return _WKWebExtensionWebRequestResourceTypeBeacon;
-    case _WKResourceLoadInfoResourceTypeOther:
+    case ResourceLoadInfo::Type::Other:
         return _WKWebExtensionWebRequestResourceTypeOther;
     }
 
@@ -262,7 +263,7 @@ static std::optional<WebExtensionWindowIdentifier> toWindowID(NSNumber *rawValue
     return NO;
 }
 
-_WKWebExtensionWebRequestResourceType _WKWebExtensionWebRequestResourceTypeFromWKResourceLoadInfo(_WKResourceLoadInfo *resourceLoadInfo)
+_WKWebExtensionWebRequestResourceType _WKWebExtensionWebRequestResourceTypeFromResourceLoadInfo(const WebKit::ResourceLoadInfo&)
 {
     return _WKWebExtensionWebRequestResourceTypeOther;
 }

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl
@@ -28,7 +28,7 @@
     MainWorldOnly,
 ] interface WebExtensionAPIWebRequestEvent {
 
-    [NeedsPage, RaisesException] void addListener([CallbackHandler] function listener, [NSDictionary, Optional] any filter, [Optional] any extraInfoSpec);
+    [NeedsPage, RaisesException] void addListener([CallbackHandler] function listener, [NSDictionary, Optional] any filter, [NSArray=NSString, Optional] array extraInfoSpec);
     [NeedsPage] void removeListener([CallbackHandler] function listener);
     boolean hasListener([CallbackHandler] function listener);
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -345,6 +345,11 @@ static void addParametersShared(const LocalFrame* frame, NetworkResourceLoadPara
         parameters.pageHasResourceLoadClient = page->hasResourceLoadClient();
         parameters.shouldRelaxThirdPartyCookieBlocking = page->shouldRelaxThirdPartyCookieBlocking();
         page->logMediaDiagnosticMessage(parameters.request.httpBody());
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+        if (auto* webPage = WebPage::fromCorePage(*page))
+            parameters.pageHasExtensionController = webPage->webExtensionControllerProxy();
+#endif
     }
 
     if (auto* ownerElement = frame->ownerElement()) {


### PR DESCRIPTION
#### 0c0655a175613f58168c7f30652e989cc0fe2736
<pre>
Implement event firing from the web process for webRequest events and add tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=267963">https://bugs.webkit.org/show_bug.cgi?id=267963</a>
<a href="https://rdar.apple.com/114823223">rdar://114823223</a>

Reviewed by Timothy Hatcher.

The tests exposed a few issues that were also fixed here:
1) The network process wasn&apos;t calling into WebPageProxy when running the tests because the
page didn&apos;t have a resource load delegate. To fix this, also call into the WebPageProxy when
the page has an extension controller.
2) There was a copy/paste-o in WebExtensionContext::resourceLoadDidPerformHTTPRedirection where
the wrong events were being sent.
3) When just a filter was being passed to webRequest.event.addListener, it was being treated as the extraInfoSpec because
we weren&apos;t being specific enough about the type.

This PR also changed _WKWebExtensionWebRequestFilter to deal with WebKit::ResourceLoadInfo instead of _WKResourceLoadInfo.

* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp:
(WebKit::NetworkResourceLoadParameters::NetworkResourceLoadParameters): Add a new pageHasExtensionController parameter.
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::shouldSendResourceLoadMessages const): Check both pageHasResourceLoadClient and pageHasExtensionController.
(WebKit::NetworkResourceLoader::startNetworkLoad): Adopt shouldSendResourceLoadMessages.
(WebKit::NetworkResourceLoader::didReceiveResponse): Ditto.
(WebKit::NetworkResourceLoader::didFinishLoading): Ditto.
(WebKit::NetworkResourceLoader::didFailLoading): Ditto.
(WebKit::NetworkResourceLoader::didReceiveChallenge): Ditto.
(WebKit::NetworkResourceLoader::continueWillSendRequest): Ditto.
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h:
(WebKit::toWebExtensionFrameIdentifier): Add a new flavor of this method.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::resourceLoadDidPerformHTTPRedirection): Make sure we are calling the correct events here.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm:
(WebKit::convertRequestBodyToWebExtensionFormat): Convert the request body to the format extensions expect.
(WebKit::webRequestDetailsForResourceLoad): Generate a dictionary of information about the resource load conforming to the webRequest spec.
(WebKit::convertHeaderFieldsToWebExtensionFormat): Convert the header fields to an array of dictionaries.
(WebKit::headersReceivedDetails): Convert the NSHTTPURLResponse information into a dictionary conforming to the webRequest spec.
(WebKit::WebExtensionContextProxy::resourceLoadDidSendRequest): Call the correct events.
(WebKit::WebExtensionContextProxy::resourceLoadDidPerformHTTPRedirection): Ditto.
(WebKit::WebExtensionContextProxy::resourceLoadDidReceiveChallenge): Ditto.
(WebKit::WebExtensionContextProxy::resourceLoadDidReceiveResponse): Ditto.
(WebKit::WebExtensionContextProxy::resourceLoadDidCompleteWithError): Ditto.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm:
(WebKit::WebExtensionAPIWebRequestEvent::invokeListenersWithArgument): Check the filter and invoke the correct listeners.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h:
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.h:
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm:
(_WKWebExtensionWebRequestResourceTypeFromResourceLoadInfo): Updated to deal with ResourceLoadInfo::Type.
(_WKWebExtensionWebRequestResourceTypeFromWKResourceLoadInfo): Deleted.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequestEvent.idl: Make sure extraInfoSpec is an array of strings.
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::addParametersShared): Set pageHasExtensionController.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWebRequest.mm:
(TestWebKitAPI::TEST): Add tests for various parts of webRequest functionality.

Canonical link: <a href="https://commits.webkit.org/273393@main">https://commits.webkit.org/273393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c652e1154d03937d21919e2ce96d58e47423ca5d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38100 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11334 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35912 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/12063 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10591 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39346 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32124 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31937 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34647 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8075 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11315 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->