### PR TITLE
Adopt more smart pointers under WebCore/css/query

### DIFF
--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -45,7 +45,7 @@ struct SizeFeatureSchema : public FeatureSchema {
         // or the query container does not support container size queries on the relevant axes, then the result of
         // evaluating the size feature is unknown."
         // https://drafts.csswg.org/css-contain-3/#size-container
-        CheckedPtr renderer = dynamicDowncast<RenderBox>(context.renderer);
+        CheckedPtr renderer = dynamicDowncast<RenderBox>(context.renderer.get());
         if (!renderer)
             return MQ::EvaluationResult::Unknown;
 

--- a/Source/WebCore/css/query/GenericMediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/GenericMediaQueryEvaluator.cpp
@@ -73,7 +73,7 @@ static EvaluationResult evaluateLengthComparison(LayoutUnit size, const std::opt
     if (!comparison)
         return EvaluationResult::True;
 
-    auto expressionSize = computeLength(comparison->value.get(), conversionData);
+    auto expressionSize = computeLength(RefPtr { comparison->value }.get(), conversionData);
     if (!expressionSize)
         return EvaluationResult::Unknown;
 
@@ -88,7 +88,7 @@ static EvaluationResult evaluateNumberComparison(double number, const std::optio
     if (!comparison)
         return EvaluationResult::True;
 
-    auto expressionNumber = dynamicDowncast<CSSPrimitiveValue>(comparison->value.get())->doubleValue();
+    auto expressionNumber = Ref { downcast<CSSPrimitiveValue>(*comparison->value) }->doubleValue();
 
     auto left = side == Side::Left ? expressionNumber : number;
     auto right = side == Side::Left ? number : expressionNumber;
@@ -101,7 +101,7 @@ static EvaluationResult evaluateIntegerComparison(int number, const std::optiona
     if (!comparison)
         return EvaluationResult::True;
 
-    auto expressionNumber = dynamicDowncast<CSSPrimitiveValue>(comparison->value.get())->intValue();
+    auto expressionNumber = Ref { downcast<CSSPrimitiveValue>(*comparison->value) }->intValue();
 
     auto left = side == Side::Left ? expressionNumber : number;
     auto right = side == Side::Left ? number : expressionNumber;
@@ -114,7 +114,7 @@ static EvaluationResult evaluateResolutionComparison(float resolution, const std
     if (!comparison)
         return EvaluationResult::True;
 
-    auto expressionResolution = dynamicDowncast<CSSPrimitiveValue>(comparison->value.get())->floatValue(CSSUnitType::CSS_DPPX);
+    auto expressionResolution = Ref { downcast<CSSPrimitiveValue>(*comparison->value) }->floatValue(CSSUnitType::CSS_DPPX);
 
     auto left = side == Side::Left ? expressionResolution : resolution;
     auto right = side == Side::Left ? resolution : expressionResolution;
@@ -138,7 +138,7 @@ static EvaluationResult evaluateRatioComparison(FloatSize size, const std::optio
     if (!comparison)
         return EvaluationResult::True;
 
-    auto* ratioValue = dynamicDowncast<CSSAspectRatioValue>(comparison->value.get());
+    RefPtr ratioValue = dynamicDowncast<CSSAspectRatioValue>(comparison->value);
     if (!ratioValue)
         return EvaluationResult::Unknown;
 
@@ -170,8 +170,8 @@ EvaluationResult evaluateBooleanFeature(const Feature& feature, bool currentValu
     if (!feature.rightComparison)
         return toEvaluationResult(currentValue);
 
-    auto& value = downcast<CSSPrimitiveValue>(*feature.rightComparison->value);
-    auto expectedValue = value.intValue();
+    Ref value = downcast<CSSPrimitiveValue>(*feature.rightComparison->value);
+    auto expectedValue = value->intValue();
 
     if (expectedValue && expectedValue != 1)
         return EvaluationResult::Unknown;

--- a/Source/WebCore/css/query/GenericMediaQueryParser.cpp
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.cpp
@@ -88,7 +88,7 @@ std::optional<Feature> GenericMediaQueryParserBase::consumeBooleanOrPlainFeature
     if (range.atEnd())
         return { };
 
-    auto value = consumeValue(range);
+    RefPtr value = consumeValue(range);
     if (!value)
         return { };
 
@@ -135,7 +135,7 @@ std::optional<Feature> GenericMediaQueryParserBase::consumeRangeFeature(CSSParse
     auto consumeLeftComparison = [&]() -> std::optional<Comparison> {
         if (range.peek().type() == IdentToken)
             return { };
-        auto value = consumeValue(range);
+        RefPtr value = consumeValue(range);
         if (!value)
             return { };
         auto op = consumeRangeOperator();
@@ -151,7 +151,7 @@ std::optional<Feature> GenericMediaQueryParserBase::consumeRangeFeature(CSSParse
         auto op = consumeRangeOperator();
         if (!op)
             return { };
-        auto value = consumeValue(range);
+        RefPtr value = consumeValue(range);
         if (!value) {
             didFailParsing = true;
             return { };
@@ -192,14 +192,14 @@ std::optional<Feature> GenericMediaQueryParserBase::consumeRangeFeature(CSSParse
 
 static RefPtr<CSSValue> consumeRatioWithSlash(CSSParserTokenRange& range)
 {
-    auto leftValue = CSSPropertyParserHelpers::consumeNumber(range, ValueRange::NonNegative);
+    RefPtr leftValue = CSSPropertyParserHelpers::consumeNumber(range, ValueRange::NonNegative);
     if (!leftValue)
         return nullptr;
 
     if (!CSSPropertyParserHelpers::consumeSlashIncludingWhitespace(range))
         return nullptr;
 
-    auto rightValue = CSSPropertyParserHelpers::consumeNumber(range, ValueRange::NonNegative);
+    RefPtr rightValue = CSSPropertyParserHelpers::consumeNumber(range, ValueRange::NonNegative);
     if (!rightValue)
         return nullptr;
 
@@ -211,21 +211,21 @@ RefPtr<CSSValue> GenericMediaQueryParserBase::consumeValue(CSSParserTokenRange& 
     if (range.atEnd())
         return nullptr;
 
-    if (auto value = CSSPropertyParserHelpers::consumeIdent(range))
+    if (RefPtr value = CSSPropertyParserHelpers::consumeIdent(range))
         return value;
 
     auto rangeCopy = range;
-    if (auto value = consumeRatioWithSlash(range))
+    if (RefPtr value = consumeRatioWithSlash(range))
         return value;
     range = rangeCopy;
 
-    if (auto value = CSSPropertyParserHelpers::consumeInteger(range))
+    if (RefPtr value = CSSPropertyParserHelpers::consumeInteger(range))
         return value;
-    if (auto value = CSSPropertyParserHelpers::consumeNumber(range, ValueRange::All))
+    if (RefPtr value = CSSPropertyParserHelpers::consumeNumber(range, ValueRange::All))
         return value;
-    if (auto value = CSSPropertyParserHelpers::consumeLength(range, HTMLStandardMode, ValueRange::All))
+    if (RefPtr value = CSSPropertyParserHelpers::consumeLength(range, HTMLStandardMode, ValueRange::All))
         return value;
-    if (auto value = CSSPropertyParserHelpers::consumeResolution(range))
+    if (RefPtr value = CSSPropertyParserHelpers::consumeResolution(range))
         return value;
 
     return nullptr;
@@ -234,7 +234,7 @@ RefPtr<CSSValue> GenericMediaQueryParserBase::consumeValue(CSSParserTokenRange& 
 bool GenericMediaQueryParserBase::validateFeatureAgainstSchema(Feature& feature, const FeatureSchema& schema)
 {
     auto validateValue = [&](auto& value) {
-        auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value.get());
+        RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value);
         switch (schema.valueType) {
         case FeatureSchema::ValueType::Integer:
             return primitiveValue && primitiveValue->isInteger();

--- a/Source/WebCore/css/query/GenericMediaQueryTypes.h
+++ b/Source/WebCore/css/query/GenericMediaQueryTypes.h
@@ -27,6 +27,7 @@
 #include "CSSToLengthConversionData.h"
 #include "CSSValue.h"
 #include "CSSValueKeywords.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/OptionSet.h>
 #include <wtf/text/AtomString.h>
 
@@ -72,9 +73,9 @@ struct Condition {
 enum class EvaluationResult : uint8_t { False, True, Unknown };
 
 struct FeatureEvaluationContext {
-    const Document& document;
+    CheckedRef<const Document> document;
     CSSToLengthConversionData conversionData { };
-    const RenderElement* renderer { nullptr };
+    CheckedPtr<const RenderElement> renderer { };
 };
 
 struct FeatureSchema {

--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -38,7 +38,7 @@ namespace MQ {
 MediaQueryEvaluator::MediaQueryEvaluator(const AtomString& mediaType, const Document& document, const RenderStyle* rootElementStyle)
     : GenericMediaQueryEvaluator()
     , m_mediaType(mediaType)
-    , m_document(&document)
+    , m_document(document)
     , m_rootElementStyle(rootElementStyle)
 {
 }
@@ -73,21 +73,22 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
         if (!query.condition)
             return EvaluationResult::True;
 
-        if (!m_document || !m_rootElementStyle)
+        RefPtr document = m_document.get();
+        if (!document || !m_rootElementStyle)
             return m_staticMediaConditionResult;
 
-        if (!m_document->view() || !m_document->documentElement())
+        if (!document->view() || !document->documentElement())
             return EvaluationResult::Unknown;
 
         auto defaultStyle = RenderStyle::create();
         auto fontDescription = defaultStyle.fontDescription();
-        auto size = Style::fontSizeForKeyword(CSSValueMedium, false, *m_document);
+        auto size = Style::fontSizeForKeyword(CSSValueMedium, false, *document);
         fontDescription.setComputedSize(size);
         fontDescription.setSpecifiedSize(size);
         defaultStyle.setFontDescription(WTFMove(fontDescription));
         defaultStyle.fontCascade().update();
 
-        FeatureEvaluationContext context { *m_document, { *m_rootElementStyle, &defaultStyle, nullptr, m_document->renderView() }, nullptr };
+        FeatureEvaluationContext context { *document, { *m_rootElementStyle, &defaultStyle, nullptr, document->renderView() }, nullptr };
         return evaluateCondition(*query.condition, context);
     }();
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.h
@@ -50,8 +50,8 @@ public:
 
 private:
     AtomString m_mediaType;
-    const Document* m_document { nullptr };
-    const RenderStyle* m_rootElementStyle { nullptr };
+    WeakPtr<const Document, WeakPtrImplWithEventTargetData> m_document;
+    const RenderStyle* m_rootElementStyle { nullptr }; // FIXME: Switch to a smart pointer.
     EvaluationResult m_staticMediaConditionResult { EvaluationResult::Unknown };
 };
 

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -174,7 +174,7 @@ private:
 
 static float deviceScaleFactor(const FeatureEvaluationContext& context)
 {
-    auto& frame = *context.document.frame();
+    auto& frame = *context.document->frame();
     auto mediaType = frame.view()->mediaType();
     
     if (mediaType == screenAtom())
@@ -204,7 +204,7 @@ const FeatureSchema& anyHover()
         "any-hover"_s,
         FixedVector { CSSValueNone, CSSValueHover },
         [](auto& context) {
-            auto* page = context.document.frame()->page();
+            RefPtr page = context.document->frame()->page();
             bool isSupported = page && page->chrome().client().hoverSupportedByAnyAvailablePointingDevice();
             return MatchingIdentifiers { isSupported ? CSSValueHover : CSSValueNone };
         }
@@ -218,7 +218,7 @@ const FeatureSchema& anyPointer()
         "any-pointer"_s,
         FixedVector { CSSValueNone, CSSValueFine, CSSValueCoarse },
         [](auto& context) {
-            auto* page = context.document.frame()->page();
+            RefPtr page = context.document->frame()->page();
             auto pointerCharacteristics = page ? page->chrome().client().pointerCharacteristicsOfAllAvailablePointingDevices() : OptionSet<PointerCharacteristics>();
 
             MatchingIdentifiers identifiers;
@@ -240,7 +240,7 @@ const FeatureSchema& aspectRatio()
     static MainThreadNeverDestroyed<RatioSchema> schema {
         "aspect-ratio"_s,
         [](auto& context) {
-            auto& view = *context.document.view();
+            auto& view = *context.document->view();
             return FloatSize(view.layoutWidth(), view.layoutHeight());
         }
     };
@@ -252,7 +252,7 @@ const FeatureSchema& color()
     static MainThreadNeverDestroyed<IntegerSchema> schema {
         "color"_s,
         [](auto& context) {
-            return screenDepthPerComponent(context.document.frame()->mainFrame().virtualView());
+            return screenDepthPerComponent(context.document->frame()->mainFrame().protectedVirtualView().get());
         }
     };
     return schema;
@@ -264,12 +264,12 @@ const FeatureSchema& colorGamut()
         "color-gamut"_s,
         FixedVector { CSSValueSRGB, CSSValueP3, CSSValueRec2020 },
         [](auto& context) {
-            auto& frame = *context.document.frame();
+            Ref frame = *context.document->frame();
 
             // FIXME: At some point we should start detecting displays that support more colors.
             MatchingIdentifiers identifiers { CSSValueSRGB };
-            if (auto* localFrame = dynamicDowncast<LocalFrame>(frame.mainFrame())) {
-                if (screenSupportsExtendedColor(localFrame->view()))
+            if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame())) {
+                if (screenSupportsExtendedColor(localFrame->protectedView().get()))
                     identifiers.append(CSSValueP3);
             }
             return identifiers;
@@ -292,7 +292,7 @@ const FeatureSchema& deviceAspectRatio()
     static MainThreadNeverDestroyed<RatioSchema> schema {
         "device-aspect-ratio"_s,
         [](auto& context) {
-            if (auto* localFrame = dynamicDowncast<LocalFrame>(context.document.frame()->mainFrame())) {
+            if (RefPtr localFrame = dynamicDowncast<LocalFrame>(context.document->frame()->mainFrame())) {
                 auto screenSize = localFrame->screenSize();
                 return FloatSize { screenSize.width(), screenSize.height() };
             }
@@ -307,7 +307,7 @@ const FeatureSchema& deviceHeight()
     static MainThreadNeverDestroyed<LengthSchema> schema {
         "device-height"_s,
         [](auto& context) {
-            if (auto* localFrame = dynamicDowncast<LocalFrame>(context.document.frame()->mainFrame()))
+            if (RefPtr localFrame = dynamicDowncast<LocalFrame>(context.document->frame()->mainFrame()))
                 return LayoutUnit { localFrame->screenSize().height() };
             return LayoutUnit { 0.0f };
         }
@@ -331,7 +331,7 @@ const FeatureSchema& deviceWidth()
     static MainThreadNeverDestroyed<LengthSchema> schema {
         "device-width"_s,
         [](auto& context) {
-            if (auto* localFrame = dynamicDowncast<LocalFrame>(context.document.frame()->mainFrame()))
+            if (RefPtr localFrame = dynamicDowncast<LocalFrame>(context.document->frame()->mainFrame()))
                 return LayoutUnit { localFrame->screenSize().width() };
             return LayoutUnit { 0.0f };
         }
@@ -346,12 +346,12 @@ const FeatureSchema& dynamicRange()
         FixedVector { CSSValueStandard, CSSValueHigh },
         [](auto& context) {
             bool supportsHighDynamicRange = [&] {
-                auto& frame = *context.document.frame();
-                if (frame.settings().forcedSupportsHighDynamicRangeValue() == ForcedAccessibilityValue::On)
+                Ref frame = *context.document->frame();
+                if (frame->settings().forcedSupportsHighDynamicRangeValue() == ForcedAccessibilityValue::On)
                     return true;
-                if (frame.settings().forcedSupportsHighDynamicRangeValue() == ForcedAccessibilityValue::Off)
+                if (frame->settings().forcedSupportsHighDynamicRangeValue() == ForcedAccessibilityValue::Off)
                     return false;
-                return screenSupportsHighDynamicRange(frame.mainFrame().virtualView());
+                return screenSupportsHighDynamicRange(frame->mainFrame().protectedVirtualView().get());
             }();
 
             MatchingIdentifiers identifiers { CSSValueStandard };
@@ -389,8 +389,8 @@ const FeatureSchema& height()
     static MainThreadNeverDestroyed<LengthSchema> schema {
         "height"_s,
         [](auto& context) {
-            auto height = context.document.view()->layoutHeight();
-            if (auto* renderView = context.document.renderView())
+            auto height = context.document->protectedView()->layoutHeight();
+            if (CheckedPtr renderView = context.document->renderView())
                 height = adjustForAbsoluteZoom(height, *renderView);
             return height;
         }
@@ -404,7 +404,7 @@ const FeatureSchema& hover()
         "hover"_s,
         FixedVector { CSSValueNone, CSSValueHover },
         [](auto& context) {
-            auto* page = context.document.frame()->page();
+            RefPtr page = context.document->frame()->page();
             bool isSupported =  page && page->chrome().client().hoverSupportedByPrimaryPointingDevice();
             return MatchingIdentifiers { isSupported ? CSSValueHover : CSSValueNone };
         }
@@ -419,10 +419,10 @@ const FeatureSchema& invertedColors()
         FixedVector { CSSValueNone, CSSValueInverted },
         [](auto& context) {
             bool isInverted = [&] {
-                auto& frame = *context.document.frame();
-                if (frame.settings().forcedColorsAreInvertedAccessibilityValue() == ForcedAccessibilityValue::On)
+                Ref frame = *context.document->frame();
+                if (frame->settings().forcedColorsAreInvertedAccessibilityValue() == ForcedAccessibilityValue::On)
                     return true;
-                if (frame.settings().forcedColorsAreInvertedAccessibilityValue() == ForcedAccessibilityValue::Off)
+                if (frame->settings().forcedColorsAreInvertedAccessibilityValue() == ForcedAccessibilityValue::Off)
                     return false;
                 return screenHasInvertedColors();
             }();
@@ -438,19 +438,19 @@ const FeatureSchema& monochrome()
     static MainThreadNeverDestroyed<IntegerSchema> schema {
         "monochrome"_s,
         [](auto& context) {
-            auto& frame = *context.document.frame();
-            auto* localFrame = dynamicDowncast<LocalFrame>(frame.mainFrame());
+            Ref frame = *context.document->frame();
+            RefPtr localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
             bool isMonochrome = [&] {
-                if (frame.settings().forcedDisplayIsMonochromeAccessibilityValue() == ForcedAccessibilityValue::On)
+                if (frame->settings().forcedDisplayIsMonochromeAccessibilityValue() == ForcedAccessibilityValue::On)
                     return true;
-                if (frame.settings().forcedDisplayIsMonochromeAccessibilityValue() == ForcedAccessibilityValue::Off)
+                if (frame->settings().forcedDisplayIsMonochromeAccessibilityValue() == ForcedAccessibilityValue::Off)
                     return false;
                 if (localFrame)
-                    return screenIsMonochrome(localFrame->view());
+                    return screenIsMonochrome(localFrame->protectedView().get());
                 return false;
             }();
 
-            return isMonochrome && localFrame ? screenDepthPerComponent(localFrame->view()) : 0;
+            return isMonochrome && localFrame ? screenDepthPerComponent(localFrame->protectedView().get()) : 0;
         }
     };
     return schema;
@@ -462,9 +462,9 @@ const FeatureSchema& orientation()
         "orientation"_s,
         FixedVector { CSSValueLandscape, CSSValuePortrait },
         [](auto& context) {
-            auto& view = *context.document.view();
+            Ref view = *context.document->view();
             // Square viewport is portrait.
-            bool isPortrait = view.layoutHeight() >= view.layoutWidth();
+            bool isPortrait = view->layoutHeight() >= view->layoutWidth();
             return MatchingIdentifiers { isPortrait ? CSSValuePortrait : CSSValueLandscape };
         }
     };
@@ -477,11 +477,11 @@ const FeatureSchema& pointer()
         "pointer"_s,
         FixedVector { CSSValueNone, CSSValueFine, CSSValueCoarse },
         [](auto& context) {
-            auto* page = context.document.frame()->page();
+            RefPtr page = context.document->frame()->page();
             auto pointerCharacteristics = page ? page->chrome().client().pointerCharacteristicsOfPrimaryPointingDevice() : OptionSet<PointerCharacteristics>();
 #if ENABLE(TOUCH_EVENTS)
             if (pointerCharacteristics.contains(PointerCharacteristics::Coarse)) {
-                if (context.document.quirks().shouldPreventPointerMediaQueryFromEvaluatingToCoarse())
+                if (context.document->quirks().shouldPreventPointerMediaQueryFromEvaluatingToCoarse())
                     pointerCharacteristics = PointerCharacteristics::Fine;
             }
 #endif
@@ -506,8 +506,8 @@ const FeatureSchema& prefersContrast()
         FixedVector { CSSValueNoPreference, CSSValueMore, CSSValueLess },
         [](auto& context) {
             bool userPrefersContrast = [&] {
-                auto& frame = *context.document.frame();
-                switch (frame.settings().forcedPrefersContrastAccessibilityValue()) {
+                Ref frame = *context.document->frame();
+                switch (frame->settings().forcedPrefersContrastAccessibilityValue()) {
                 case ForcedAccessibilityValue::On:
                     return true;
                 case ForcedAccessibilityValue::Off:
@@ -530,8 +530,8 @@ const FeatureSchema& prefersDarkInterface()
         "prefers-dark-interface"_s,
         FixedVector { CSSValueNoPreference, CSSValuePrefers },
         [](auto& context) {
-            auto& frame = *context.document.frame();
-            bool prefersDarkInterface = frame.page()->useSystemAppearance() && frame.page()->useDarkAppearance();
+            Ref page = *context.document->frame()->page();
+            bool prefersDarkInterface = page->useSystemAppearance() && page->useDarkAppearance();
 
             return MatchingIdentifiers { prefersDarkInterface ? CSSValuePrefers : CSSValueNoPreference };
         }
@@ -546,8 +546,8 @@ const FeatureSchema& prefersReducedMotion()
         FixedVector { CSSValueNoPreference, CSSValueReduce },
         [](auto& context) {
             bool userPrefersReducedMotion = [&] {
-                auto& frame = *context.document.frame();
-                switch (frame.settings().forcedPrefersReducedMotionAccessibilityValue()) {
+                Ref frame = *context.document->frame();
+                switch (frame->settings().forcedPrefersReducedMotionAccessibilityValue()) {
                 case ForcedAccessibilityValue::On:
                     return true;
                 case ForcedAccessibilityValue::Off:
@@ -593,9 +593,8 @@ const FeatureSchema& scripting()
         "scripting"_s,
         FixedVector { CSSValueNone, CSSValueInitialOnly, CSSValueEnabled },
         [](auto& context) {
-            auto& frame = *context.document.frame();
-
-            if (!frame.script().canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
+            Ref frame = *context.document->frame();
+            if (!frame->checkedScript()->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
                 return MatchingIdentifiers { CSSValueNone };
             return MatchingIdentifiers { CSSValueEnabled };
         }
@@ -618,7 +617,7 @@ const FeatureSchema& transform3d()
         "-webkit-transform-3d"_s,
         [](auto& context) {
 #if ENABLE(3D_TRANSFORMS)
-            auto* view = context.document.renderView();
+            CheckedPtr view = context.document->renderView();
             return view && view->compositor().canRender3DTransforms();
 #else
             UNUSED_PARAM(context);
@@ -644,9 +643,7 @@ const FeatureSchema& update()
         "update"_s,
         FixedVector { CSSValueNone, CSSValueSlow, CSSValueFast },
         [](auto& context) {
-            auto& frame = *context.document.frame();
-            auto* frameView = frame.view();
-
+            RefPtr frameView = context.document->frame()->view();
             if (frameView && frameView->mediaType() == printAtom())
                 return MatchingIdentifiers { CSSValueNone };
 
@@ -662,7 +659,7 @@ const FeatureSchema& videoPlayableInline()
     static MainThreadNeverDestroyed<BooleanSchema> schema {
         "-webkit-video-playable-inline"_s,
         [](auto& context) {
-            return context.document.frame()->settings().allowsInlineMediaPlayback();
+            return context.document->frame()->settings().allowsInlineMediaPlayback();
         }
     };
     return schema;
@@ -673,8 +670,8 @@ const FeatureSchema& width()
     static MainThreadNeverDestroyed<LengthSchema> schema {
         "width"_s,
         [](auto& context) {
-            auto width = context.document.view()->layoutWidth();
-            if (auto* renderView = context.document.renderView())
+            auto width = context.document->protectedView()->layoutWidth();
+            if (CheckedPtr renderView = context.document->renderView())
                 width = adjustForAbsoluteZoom(width, *renderView);
             return width;
         }
@@ -690,8 +687,8 @@ const FeatureSchema& displayMode()
         FixedVector { CSSValueFullscreen, CSSValueStandalone, CSSValueMinimalUi, CSSValueBrowser },
         [](auto& context) {
             auto identifier = [&] {
-                auto& frame = *context.document.frame();
-                auto manifest = frame.page() ? frame.page()->applicationManifest() : std::nullopt;
+                Ref frame = *context.document->frame();
+                auto manifest = frame->page() ? frame->page()->applicationManifest() : std::nullopt;
                 if (!manifest)
                     return CSSValueBrowser;
 
@@ -724,8 +721,7 @@ const FeatureSchema& overflowBlock()
         [](auto& context) {
             // FIXME: Match none when scrollEnabled is set to false by UIKit.
             bool matchesPaged = [&] {
-                auto& frame = *context.document.frame();
-                auto* frameView = frame.view();
+                RefPtr frameView = context.document->frame()->view();
                 if (!frameView)
                     return false;
                 return frameView->mediaType() == printAtom() || frameView->pagination().mode != PaginationMode::Unpaginated;
@@ -756,8 +752,8 @@ const FeatureSchema& prefersColorScheme()
         "prefers-color-scheme"_s,
         FixedVector { CSSValueLight, CSSValueDark },
         [](auto& context) {
-            auto& frame = *context.document.frame();
-            bool useDarkAppearance = frame.page()->useDarkAppearance();
+            Ref page = *context.document->frame()->page();
+            bool useDarkAppearance = page->useDarkAppearance();
 
             return MatchingIdentifiers { useDarkAppearance ? CSSValueDark : CSSValueLight };
         }

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -126,4 +126,9 @@ bool Frame::arePluginsEnabled()
     return settings().arePluginsEnabled();
 }
 
+RefPtr<FrameView> Frame::protectedVirtualView() const
+{
+    return virtualView();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -86,6 +86,7 @@ public:
     virtual void didFinishLoadInAnotherProcess() = 0;
 
     virtual FrameView* virtualView() const = 0;
+    RefPtr<FrameView> protectedVirtualView() const;
     virtual void disconnectView() = 0;
     virtual void setOpener(Frame*) = 0;
     virtual const Frame* opener() const = 0;


### PR DESCRIPTION
#### 1c3b20fe345a6729f1b2569f72b6cf5889a43233
<pre>
Adopt more smart pointers under WebCore/css/query
<a href="https://bugs.webkit.org/show_bug.cgi?id=267966">https://bugs.webkit.org/show_bug.cgi?id=267966</a>

Reviewed by Darin Adler.

* Source/WebCore/css/query/ContainerQueryFeatures.cpp:
* Source/WebCore/css/query/GenericMediaQueryEvaluator.cpp:
(WebCore::MQ::evaluateLengthComparison):
(WebCore::MQ::evaluateNumberComparison):
(WebCore::MQ::evaluateIntegerComparison):
(WebCore::MQ::evaluateResolutionComparison):
(WebCore::MQ::evaluateRatioComparison):
(WebCore::MQ::evaluateBooleanFeature):
* Source/WebCore/css/query/GenericMediaQueryParser.cpp:
(WebCore::MQ::GenericMediaQueryParserBase::consumeBooleanOrPlainFeature):
(WebCore::MQ::GenericMediaQueryParserBase::consumeRangeFeature):
(WebCore::MQ::consumeRatioWithSlash):
(WebCore::MQ::GenericMediaQueryParserBase::consumeValue):
(WebCore::MQ::GenericMediaQueryParserBase::validateFeatureAgainstSchema):
* Source/WebCore/css/query/GenericMediaQueryTypes.h:
* Source/WebCore/css/query/MediaQueryEvaluator.cpp:
(WebCore::MQ::MediaQueryEvaluator::MediaQueryEvaluator):
(WebCore::MQ::MediaQueryEvaluator::evaluate const):
* Source/WebCore/css/query/MediaQueryEvaluator.h:
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::deviceScaleFactor):
(WebCore::MQ::Features::anyHover):
(WebCore::MQ::Features::anyPointer):
(WebCore::MQ::Features::aspectRatio):
(WebCore::MQ::Features::color):
(WebCore::MQ::Features::colorGamut):
(WebCore::MQ::Features::deviceAspectRatio):
(WebCore::MQ::Features::deviceHeight):
(WebCore::MQ::Features::deviceWidth):
(WebCore::MQ::Features::dynamicRange):
(WebCore::MQ::Features::height):
(WebCore::MQ::Features::hover):
(WebCore::MQ::Features::invertedColors):
(WebCore::MQ::Features::monochrome):
(WebCore::MQ::Features::orientation):
(WebCore::MQ::Features::pointer):
(WebCore::MQ::Features::prefersContrast):
(WebCore::MQ::Features::prefersDarkInterface):
(WebCore::MQ::Features::prefersReducedMotion):
(WebCore::MQ::Features::scripting):
(WebCore::MQ::Features::transform3d):
(WebCore::MQ::Features::update):
(WebCore::MQ::Features::videoPlayableInline):
(WebCore::MQ::Features::width):
(WebCore::MQ::Features::displayMode):
(WebCore::MQ::Features::overflowBlock):
(WebCore::MQ::Features::prefersColorScheme):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::protectedVirtualView const):
* Source/WebCore/page/Frame.h:

Canonical link: <a href="https://commits.webkit.org/273447@main">https://commits.webkit.org/273447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f0264c354fc813e7a6bebbab22c75479ef88af6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38088 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31882 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11322 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30748 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10584 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10624 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39334 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32117 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36606 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10780 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34632 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12539 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11304 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4580 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11596 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->