### PR TITLE
Non-unified build fixes, late January 2024 edition

### DIFF
--- a/Source/JavaScriptCore/bytecode/ExpressionInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/ExpressionInfo.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "ExpressionInfo.h"
 
+#include "VM.h"
+#include <wtf/DataLog.h>
 #include <wtf/StringPrintStream.h>
 #include <wtf/UniqueRef.h>
 
@@ -1064,12 +1066,12 @@ void printInternal(PrintStream& out, JSC::ExpressionInfo::FieldID fieldID)
 {
     auto name = [] (auto fieldID) {
         switch (fieldID) {
-        case ExpressionInfo::FieldID::InstPC: return "Inst";
-        case ExpressionInfo::FieldID::Divot: return "Divot";
-        case ExpressionInfo::FieldID::Start: return "Start";
-        case ExpressionInfo::FieldID::End: return "End";
-        case ExpressionInfo::FieldID::Line: return "Line";
-        case ExpressionInfo::FieldID::Column: return "Column";
+        case JSC::ExpressionInfo::FieldID::InstPC: return "Inst";
+        case JSC::ExpressionInfo::FieldID::Divot: return "Divot";
+        case JSC::ExpressionInfo::FieldID::Start: return "Start";
+        case JSC::ExpressionInfo::FieldID::End: return "End";
+        case JSC::ExpressionInfo::FieldID::Line: return "Line";
+        case JSC::ExpressionInfo::FieldID::Column: return "Column";
         }
         return ""; // placate GCC.
     };

--- a/Source/JavaScriptCore/bytecode/ExpressionInfo.h
+++ b/Source/JavaScriptCore/bytecode/ExpressionInfo.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include "LineColumn.h"
+#include <wtf/HashMap.h>
+#include <wtf/HashTraits.h>
 #include <wtf/IterationStatus.h>
 #include <wtf/PrintStream.h>
 #include <wtf/StdLibExtras.h>

--- a/Source/JavaScriptCore/llint/LLIntThunks.cpp
+++ b/Source/JavaScriptCore/llint/LLIntThunks.cpp
@@ -32,6 +32,7 @@
 #include "LLIntCLoop.h"
 #include "LLIntData.h"
 #include "LinkBuffer.h"
+#include "MaxFrameExtentForSlowPathCall.h"
 #include "VMEntryRecord.h"
 #include "WasmCallingConvention.h"
 #include "WasmContext.h"

--- a/Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.h
+++ b/Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ExpressionInfo.h"
 #include "FuzzerAgent.h"
 #include "LineColumn.h"
 #include "Opcode.h"

--- a/Source/WebCore/Modules/WebGPU/GPUOutOfMemoryError.h
+++ b/Source/WebCore/Modules/WebGPU/GPUOutOfMemoryError.h
@@ -28,6 +28,7 @@
 #include "WebGPUOutOfMemoryError.h"
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassColorAttachment.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassColorAttachment.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "GPUColorDict.h"
+#include "GPUIntegralTypes.h"
 #include "GPULoadOp.h"
 #include "GPUStoreOp.h"
 #include "GPUTextureView.h"

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassColorAttachment.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassColorAttachment.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "WebGPUColor.h"
+#include "WebGPUIntegralTypes.h"
 #include "WebGPULoadOp.h"
 #include "WebGPUStoreOp.h"
 #include <variant>

--- a/Source/WebCore/css/calc/CSSCalcExpressionNodeParser.h
+++ b/Source/WebCore/css/calc/CSSCalcExpressionNodeParser.h
@@ -28,6 +28,7 @@
 #include "CSSValueKeywords.h"
 #include "CalcOperator.h"
 #include "CalculationCategory.h"
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -30,6 +30,7 @@
 #include "CachedPage.h"
 #include "Document.h"
 #include "KeyedCoding.h"
+#include "Page.h"
 #include "ResourceRequest.h"
 #include "SerializedScriptValue.h"
 #include "SharedBuffer.h"

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -35,6 +35,7 @@
 #include "HTMLObjectElement.h"
 #include "IdTargetObserver.h"
 #include "LocalFrame.h"
+#include "TreeScopeInlines.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp
@@ -28,7 +28,6 @@
 
 #include "InlineContentAligner.h"
 #include "InlineFormattingContext.h"
-#include "InlineLevelBox.h"
 #include "InlineLine.h"
 #include "RenderStyleInlines.h"
 

--- a/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.h
@@ -27,13 +27,13 @@
 
 #include "InlineContentBreaker.h"
 #include "InlineDisplayContent.h"
+#include "InlineLevelBox.h"
 #include <wtf/Range.h>
 
 namespace WebCore {
 namespace Layout {
 
 class InlineFormattingContext;
-class InlineLevelBox;
 class Line;
 class LineBox;
 class Rect;

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "RenderTreeUpdaterViewTransition.h"
 
+#include "ElementRuleCollector.h"
 #include "RenderDescendantIterator.h"
 #include "RenderElement.h"
 #include "RenderStyleInlines.h"

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.h
@@ -29,6 +29,7 @@
 
 #include "WebGPUColor.h"
 #include "WebGPUIdentifier.h"
+#include <WebCore/WebGPUIntegralTypes.h>
 #include <WebCore/WebGPULoadOp.h>
 #include <WebCore/WebGPUStoreOp.h>
 #include <optional>


### PR DESCRIPTION
#### 67943cb752bf84af9cdb249ad792f7369f9f0f96
<pre>
Non-unified build fixes, late January 2024 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=267954">https://bugs.webkit.org/show_bug.cgi?id=267954</a>

Reviewed by Ryosuke Niwa.

Unreviewed non-unified build fix.

* Source/JavaScriptCore/bytecode/ExpressionInfo.cpp:
* Source/JavaScriptCore/bytecode/ExpressionInfo.h:
* Source/JavaScriptCore/llint/LLIntThunks.cpp:
* Source/JavaScriptCore/runtime/FileBasedFuzzerAgentBase.h:
* Source/WebCore/Modules/WebGPU/GPUOutOfMemoryError.h:
* Source/WebCore/Modules/WebGPU/GPURenderPassColorAttachment.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassColorAttachment.h:
* Source/WebCore/css/calc/CSSCalcExpressionNodeParser.h:
* Source/WebCore/history/HistoryItem.cpp:
* Source/WebCore/html/FormListedElement.cpp:
* Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.cpp:
* Source/WebCore/layout/formattingContexts/inline/ruby/RubyFormattingContext.h:
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp:
* Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.h:

Canonical link: <a href="https://commits.webkit.org/273417@main">https://commits.webkit.org/273417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07612fb44d30c1aee51c4fa6e8502b5fed8a6273

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38053 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31853 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36507 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30729 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12073 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10558 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10637 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39299 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/29982 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32134 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36584 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/35202 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34605 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12510 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41848 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8092 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11274 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->