### PR TITLE
[UnifiedPDF] Start handling text widget annotations.

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -114,36 +114,6 @@
 @end
 #endif
 
-// Set overflow: hidden on the annotation container so <input> elements scrolled out of view don't show
-// scrollbars on the body. We can't add annotations directly to the body, because overflow: hidden on the body
-// will break rubber-banding.
-static constexpr auto annotationStyle =
-"#annotationContainer {"
-"    overflow: hidden; "
-"    position: absolute; "
-"    pointer-events: none; "
-"    top: 0; "
-"    left: 0; "
-"    right: 0; "
-"    bottom: 0; "
-"    display: -webkit-box; "
-"    -webkit-box-align: center; "
-"    -webkit-box-pack: center; "
-"} "
-".annotation { "
-"    position: absolute; "
-"    pointer-events: auto; "
-"} "
-"textarea.annotation { "
-"    resize: none; "
-"} "
-"input.annotation[type='password'] { "
-"    position: static; "
-"    width: 238px; "
-"    height: 20px; "
-"    margin-top: 110px; "
-"    font-size: 15px; "
-"} "_s;
 
 // In non-continuous modes, a single scroll event with a magnitude of >= 20px
 // will jump to the next or previous page, to match PDFKit behavior.
@@ -2106,7 +2076,10 @@ bool PDFPlugin::performDictionaryLookupAtLocation(const WebCore::FloatPoint& poi
 
 CGRect PDFPlugin::boundsForAnnotation(RetainPtr<PDFAnnotation>& annotation) const
 {
-    return [m_pdfLayerController boundsForAnnotation:annotation.get()];
+    auto documentSize = contentSizeRespectingZoom();
+    auto annotationBounds = [m_pdfLayerController boundsForAnnotation:annotation.get()];
+    annotationBounds.origin.y = documentSize.height - annotationBounds.origin.y - annotationBounds.size.height;
+    return annotationBounds;
 }
 
 void PDFPlugin::focusNextAnnotation()

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
@@ -104,7 +104,6 @@ PDFPluginAnnotation::~PDFPluginAnnotation()
 
 void PDFPluginAnnotation::updateGeometry()
 {
-    IntSize documentSize(m_plugin->contentSizeRespectingZoom());
     NSRect annotationRect = NSRectFromCGRect(m_plugin->boundsForAnnotation(m_annotation));
 
     StyledElement* styledElement = static_cast<StyledElement*>(element());
@@ -112,7 +111,7 @@ void PDFPluginAnnotation::updateGeometry()
     styledElement->setInlineStyleProperty(CSSPropertyHeight, annotationRect.size.height, CSSUnitType::CSS_PX);
     IntPoint scrollPosition(m_plugin->scrollPosition());
     styledElement->setInlineStyleProperty(CSSPropertyLeft, annotationRect.origin.x - scrollPosition.x(), CSSUnitType::CSS_PX);
-    styledElement->setInlineStyleProperty(CSSPropertyTop, documentSize.height() - annotationRect.origin.y - annotationRect.size.height - scrollPosition.y(), CSSUnitType::CSS_PX);
+    styledElement->setInlineStyleProperty(CSSPropertyTop, annotationRect.origin.y - scrollPosition.y(), CSSUnitType::CSS_PX);
 }
 
 bool PDFPluginAnnotation::handleEvent(Event& event)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -296,6 +296,37 @@ protected:
     RefPtr<WebCore::Element> m_annotationContainer;
     bool m_pdfDocumentWasMutated { false };
 
+    // Set overflow: hidden on the annotation container so <input> elements scrolled out of view don't show
+    // scrollbars on the body. We can't add annotations directly to the body, because overflow: hidden on the body
+    // will break rubber-banding.
+    static constexpr auto annotationStyle =
+    "#annotationContainer {"
+    "    overflow: hidden; "
+    "    position: absolute; "
+    "    pointer-events: none; "
+    "    top: 0; "
+    "    left: 0; "
+    "    right: 0; "
+    "    bottom: 0; "
+    "    display: -webkit-box; "
+    "    -webkit-box-align: center; "
+    "    -webkit-box-pack: center; "
+    "} "
+    ".annotation { "
+    "    position: absolute; "
+    "    pointer-events: auto; "
+    "} "
+    "textarea.annotation { "
+    "    resize: none; "
+    "} "
+    "input.annotation[type='password'] { "
+    "    position: static; "
+    "    width: 238px; "
+    "    height: 20px; "
+    "    margin-top: 110px; "
+    "    font-size: 15px; "
+    "} "_s;
+
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -63,6 +63,7 @@ public:
     static constexpr WebCore::FloatSize pageMargin { 4, 6 };
 
     RetainPtr<PDFPage> pageAtIndex(PageIndex) const;
+    std::optional<unsigned> indexForPage(RetainPtr<PDFPage>) const;
     WebCore::FloatRect boundsForPageAtIndex(PageIndex) const;
     // Returns 0, 90, 180, 270.
     WebCore::IntDegrees rotationForPageAtIndex(PageIndex) const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -46,6 +46,15 @@ RetainPtr<PDFPage> PDFDocumentLayout::pageAtIndex(PageIndex index) const
     return [m_pdfDocument pageAtIndex:index];
 }
 
+std::optional<unsigned> PDFDocumentLayout::indexForPage(RetainPtr<PDFPage> page) const
+{
+    for (unsigned pageIndex = 0; pageIndex < [m_pdfDocument pageCount]; ++pageIndex) {
+        if (page == [m_pdfDocument pageAtIndex:pageIndex])
+            return pageIndex;
+    }
+    return std::nullopt;
+}
+
 void PDFDocumentLayout::updateLayout(IntSize pluginSize)
 {
     auto pageCount = this->pageCount();

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -215,6 +215,7 @@ private:
     WebCore::IntPoint convertFromPluginToDocument(const WebCore::IntPoint&) const;
     std::optional<PDFDocumentLayout::PageIndex> nearestPageIndexForDocumentPoint(const WebCore::IntPoint&) const;
     WebCore::IntPoint convertFromDocumentToPage(const WebCore::IntPoint&, PDFDocumentLayout::PageIndex) const;
+    WebCore::IntPoint convertFromPageToDocument(const WebCore::IntPoint&, PDFDocumentLayout::PageIndex) const;
     PDFElementTypes pdfElementTypesForPluginPoint(const WebCore::IntPoint&) const;
 
     bool isTaggedPDF() const;


### PR DESCRIPTION
#### e0038b5b7ace4173ca4547fbbf9f4e124dec0675
<pre>
[UnifiedPDF] Start handling text widget annotations.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267967">https://bugs.webkit.org/show_bug.cgi?id=267967</a>
<a href="https://rdar.apple.com/problem/121474907">rdar://problem/121474907</a>

Reviewed by Simon Fraser.

To start handling text annotations, we start by handling mouse left
clicks. When doing this we check to see if there is an annotation under
the left click event and if is a text annotation widget. If this is the
case then we will set the active annotation to this one (making sure
to commit any other previously active annotation).

The PDFPluginAnnotation that is created will need the bounds for the
underlying annotation to properly style the HTML input element that is
used. This is a matter of getting the bounds from the annotation, which
is in page space, and then converting it into document space. Before
this patch the PDFPluginAnnotation was performing this conversion, but
I moved this responsibility to the PDFPlugins instead so that the
annotations can just do everything in document space.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::boundsForAnnotation const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm:
(WebKit::PDFPluginAnnotation::updateGeometry):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::indexForPage const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::UnifiedPDFPlugin):
(WebKit::documentSpaceToPageSpaceTransform):
(WebKit::UnifiedPDFPlugin::convertFromDocumentToPage const):
(WebKit::UnifiedPDFPlugin::convertFromPageToDocument const):
(WebKit::UnifiedPDFPlugin::handleMouseEvent):
(WebKit::UnifiedPDFPlugin::boundsForAnnotation const):
(WebKit::UnifiedPDFPlugin::setActiveAnnotation):

Canonical link: <a href="https://commits.webkit.org/273456@main">https://commits.webkit.org/273456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5132612777a78943a4f70ee01269d03686e9fe8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35319 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38062 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31860 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30733 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12034 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10562 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10604 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39308 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32096 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31907 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36600 "Found 1 new test failure: fast/repaint/animation-after-layer-scroll.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34623 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12517 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8109 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11281 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->