### PR TITLE
Refactor WCLayerUpdateInfo for serialization

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
@@ -144,7 +144,7 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
         if (layerUpdate.changes & WCLayerChange::MasksToBounds)
             layer->texmapLayer.setMasksToBounds(layerUpdate.masksToBounds);
         if (layerUpdate.changes & WCLayerChange::Background) {
-            if (layerUpdate.hasBackingStore) {
+            if (layerUpdate.background.hasBackingStore) {
                 if (!layer->backingStore) {
                     layer->backingStore = makeUnique<WebCore::TextureMapperSparseBackingStore>();
                     auto& backingStore = *layer->backingStore;
@@ -153,7 +153,7 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
                 }
                 auto& backingStore = *layer->backingStore;
                 backingStore.setSize(WebCore::IntSize(layer->texmapLayer.size()));
-                for (auto& tileUpdate : layerUpdate.tileUpdate) {
+                for (auto& tileUpdate : layerUpdate.background.tileUpdates) {
                     if (tileUpdate.willRemove)
                         backingStore.removeTile(tileUpdate.index);
                     else {
@@ -165,7 +165,7 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
                     }
                 }
             } else {
-                layer->texmapLayer.setBackgroundColor(layerUpdate.backgroundColor);
+                layer->texmapLayer.setBackgroundColor(layerUpdate.background.color);
                 layer->texmapLayer.setBackingStore(nullptr);
                 layer->backingStore = nullptr;
             }
@@ -212,7 +212,7 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
             layer->texmapLayer.setBackdropFiltersRect(layerUpdate.backdropFiltersRect);
         }
         if (layerUpdate.changes & WCLayerChange::PlatformLayer) {
-            if (!layerUpdate.hasPlatformLayer) {
+            if (!layerUpdate.platformLayer.hasLayer) {
                 if (layer->contentBuffer) {
                     layer->contentBuffer->setClient(nullptr);
                     layer->contentBuffer = nullptr;
@@ -220,7 +220,7 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
                 layer->texmapLayer.setContentsLayer(nullptr);
             } else {
                 WCContentBuffer* contentBuffer = nullptr;
-                for (auto identifier : layerUpdate.contentBufferIdentifiers)
+                for (auto identifier : layerUpdate.platformLayer.identifiers)
                     contentBuffer = WCContentBufferManager::singleton().releaseContentBufferIdentifier(m_webProcessIdentifier, identifier);
                 if (contentBuffer) {
                     if (layer->contentBuffer)

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -51,7 +51,7 @@ public:
             tileUpdate.index = entry.key;
             tileUpdate.willRemove = tile.willRemove();
             if (tileUpdate.willRemove) {
-                update.tileUpdate.append(WTFMove(tileUpdate));
+                update.background.tileUpdates.append(WTFMove(tileUpdate));
                 continue;
             }
             if (!tile.hasDirtyRect())
@@ -65,7 +65,7 @@ public:
             m_owner.paintGraphicsLayerContents(context, dirtyRect);
             image->flushDrawingContextAsync();
             tileUpdate.backingStore.setImageBuffer(WTFMove(image));
-            update.tileUpdate.append(WTFMove(tileUpdate));
+            update.background.tileUpdates.append(WTFMove(tileUpdate));
         }
         m_tileGrid.clearDirtyRects();
         return repainted;
@@ -576,15 +576,15 @@ void GraphicsLayerWC::flushCompositingStateForThisLayerOnly()
     if (update.changes & WCLayerChange::MasksToBounds)
         update.masksToBounds = masksToBounds();
     if (update.changes & WCLayerChange::Background) {
-        update.backgroundColor = backgroundColor();
+        update.background.color = backgroundColor();
         if (drawsContent() && contentsAreVisible()) {
-            update.hasBackingStore = true;
+            update.background.hasBackingStore = true;
             if (m_tiledBacking->paintAndFlush(update)) {
                 incrementRepaintCount();
                 update.changes.add(WCLayerChange::RepaintCount);
             }
         } else
-            update.hasBackingStore = false;
+            update.background.hasBackingStore = false;
     }
     if (update.changes & WCLayerChange::SolidColor)
         update.solidColor = m_solidColor;
@@ -611,10 +611,10 @@ void GraphicsLayerWC::flushCompositingStateForThisLayerOnly()
     if (update.changes & WCLayerChange::BackdropFiltersRect)
         update.backdropFiltersRect = backdropFiltersRect();
     if (update.changes & WCLayerChange::PlatformLayer) {
-        update.hasPlatformLayer = m_platformLayer;
+        update.platformLayer.hasLayer = m_platformLayer;
 #if ENABLE(WEBGL)
         if (m_platformLayer)
-            update.contentBufferIdentifiers = static_cast<WCPlatformLayerGCGL*>(m_platformLayer)->takeContentBufferIdentifiers();
+            update.platformLayer.identifiers = static_cast<WCPlatformLayerGCGL*>(m_platformLayer)->takeContentBufferIdentifiers();
 #endif
     }
     if (update.changes & WCLayerChange::RemoteFrame)

--- a/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.serialization.in
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.serialization.in
@@ -31,6 +31,17 @@ header: "WCUpdateInfo.h"
     WebCore::IntRect dirtyRect;
 }
 
+[Nested] struct WebKit::WCLayerUpdateInfo::BackgroundChanges {
+    WebCore::Color color;
+    bool hasBackingStore;
+    Vector<WebKit::WCTileUpdate> tileUpdates;
+}
+
+[Nested] struct WebKit::WCLayerUpdateInfo::PlatformLayerChanges {
+    bool hasLayer;
+    Vector<WebKit::WCContentBufferIdentifier> identifiers;
+}
+
 struct WebKit::WCUpdateInfo {
     Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostedIdentifier;
     WebCore::PlatformLayerIdentifier rootLayer;


### PR DESCRIPTION
#### e6e6c08dd097ff75e620ca93f357af5cabb65a8a
<pre>
Refactor WCLayerUpdateInfo for serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=267968">https://bugs.webkit.org/show_bug.cgi?id=267968</a>

Reviewed by Chris Dumez.

Modify `WCLayerUpdateInfo` so it&apos;s serialization can be generated. The
values to serialize in an instance are controlled by an `OptionSet`.
The generator supports this through `OptionalTupleBit` but it expects
one field per enumeration which is not the case for `WCLayerUpdateInfo`.
Group those fields together into nested structs and sort the fields by
the value of `WCLayerChange` they correspond to.

The actual serialization of `WCLayerUpdateInfo` will come in a separate
change.

* Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp:
(WebKit::WCScene::update):
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:
(WebKit::GraphicsLayerWC::flushCompositingStateForThisLayerOnly):
* Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h:
(WebKit::WCLayerUpdateInfo::encode const):
(WebKit::WCLayerUpdateInfo::decode):
* Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.serialization.in:

Canonical link: <a href="https://commits.webkit.org/273839@main">https://commits.webkit.org/273839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51ca6c338280321fbf9a1b902110481d78ace371

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39078 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32676 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12346 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31330 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11331 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11359 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40322 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32818 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37298 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35394 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13279 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12021 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4769 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12429 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->