### PR TITLE
Remove non-standard `KeyboardEvent.keyLocation`

### DIFF
--- a/LayoutTests/fast/events/constructors/keyboard-event-constructor-expected.txt
+++ b/LayoutTests/fast/events/constructors/keyboard-event-constructor-expected.txt
@@ -74,30 +74,6 @@ PASS new KeyboardEvent('eventType', { location: [12345, 67890] }).location is Ke
 PASS new KeyboardEvent('eventType', { location: {} }).location is KeyboardEvent.DOM_KEY_LOCATION_STANDARD
 PASS new KeyboardEvent('eventType', { location: {moemoe: 12345} }).location is KeyboardEvent.DOM_KEY_LOCATION_STANDARD
 PASS new KeyboardEvent('eventType', { location: {valueOf: function () { return 12345; }} }).location is 12345
-PASS new KeyboardEvent('eventType', { keyLocation: KeyboardEvent.DOM_KEY_LOCATION_STANDARD }).keyLocation is KeyboardEvent.DOM_KEY_LOCATION_STANDARD
-PASS new KeyboardEvent('eventType', { keyLocation: KeyboardEvent.DOM_KEY_LOCATION_LEFT }).keyLocation is KeyboardEvent.DOM_KEY_LOCATION_LEFT
-PASS new KeyboardEvent('eventType', { keyLocation: 4294967294 }).keyLocation is 4294967294
-PASS new KeyboardEvent('eventType', { keyLocation: 4294967295 }).keyLocation is 4294967295
-PASS new KeyboardEvent('eventType', { keyLocation: 9007199254740991 }).keyLocation is 4294967295
-PASS new KeyboardEvent('eventType', { keyLocation: 18446744073709551615 }).keyLocation is KeyboardEvent.DOM_KEY_LOCATION_STANDARD
-PASS new KeyboardEvent('eventType', { keyLocation: 12345678901234567890 }).keyLocation is 3944679424
-PASS new KeyboardEvent('eventType', { keyLocation: -1 }).keyLocation is 4294967295
-PASS new KeyboardEvent('eventType', { keyLocation: 123.45 }).keyLocation is 123
-PASS new KeyboardEvent('eventType', { keyLocation: NaN }).keyLocation is KeyboardEvent.DOM_KEY_LOCATION_STANDARD
-PASS new KeyboardEvent('eventType', { keyLocation: undefined }).keyLocation is KeyboardEvent.DOM_KEY_LOCATION_STANDARD
-PASS new KeyboardEvent('eventType', { keyLocation: null }).keyLocation is KeyboardEvent.DOM_KEY_LOCATION_STANDARD
-PASS new KeyboardEvent('eventType', { keyLocation: '' }).keyLocation is KeyboardEvent.DOM_KEY_LOCATION_STANDARD
-PASS new KeyboardEvent('eventType', { keyLocation: '12345' }).keyLocation is 12345
-PASS new KeyboardEvent('eventType', { keyLocation: '12345a' }).keyLocation is KeyboardEvent.DOM_KEY_LOCATION_STANDARD
-PASS new KeyboardEvent('eventType', { keyLocation: 'abc' }).keyLocation is KeyboardEvent.DOM_KEY_LOCATION_STANDARD
-PASS new KeyboardEvent('eventType', { keyLocation: [] }).keyLocation is KeyboardEvent.DOM_KEY_LOCATION_STANDARD
-PASS new KeyboardEvent('eventType', { keyLocation: [12345] }).keyLocation is 12345
-PASS new KeyboardEvent('eventType', { keyLocation: [12345, 67890] }).keyLocation is KeyboardEvent.DOM_KEY_LOCATION_STANDARD
-PASS new KeyboardEvent('eventType', { keyLocation: {} }).keyLocation is KeyboardEvent.DOM_KEY_LOCATION_STANDARD
-PASS new KeyboardEvent('eventType', { keyLocation: {moemoe: 12345} }).keyLocation is KeyboardEvent.DOM_KEY_LOCATION_STANDARD
-PASS new KeyboardEvent('eventType', { keyLocation: {valueOf: function () { return 12345; }} }).keyLocation is 12345
-PASS new KeyboardEvent('eventType', { keyLocation: KeyboardEvent.DOM_KEY_LOCATION_LEFT }).location is KeyboardEvent.DOM_KEY_LOCATION_LEFT
-PASS new KeyboardEvent('eventType', { location: KeyboardEvent.DOM_KEY_LOCATION_LEFT }).keyLocation is KeyboardEvent.DOM_KEY_LOCATION_LEFT
 PASS new KeyboardEvent('eventType', { ctrlKey: false }).ctrlKey is false
 PASS new KeyboardEvent('eventType', { ctrlKey: true }).ctrlKey is true
 PASS new KeyboardEvent('eventType', { altKey: false }).altKey is false

--- a/LayoutTests/fast/events/constructors/keyboard-event-constructor.html
+++ b/LayoutTests/fast/events/constructors/keyboard-event-constructor.html
@@ -80,40 +80,36 @@ shouldBeEqualToString("new KeyboardEvent('eventType', { keyIdentifier: [1, 2, 3]
 shouldBeEqualToString("new KeyboardEvent('eventType', { keyIdentifier: {koakuma: 12345} }).keyIdentifier", "[object Object]");
 shouldBeEqualToString("new KeyboardEvent('eventType', { keyIdentifier: {valueOf: function () { return 'koakuma'; } } }).keyIdentifier", "[object Object]");
 
-// location / keyLocation is passed.
-["location", "keyLocation"].forEach(function (propertyName) {
-    // numbers within the unsigned long range.
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": KeyboardEvent.DOM_KEY_LOCATION_STANDARD })." + propertyName, "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": KeyboardEvent.DOM_KEY_LOCATION_LEFT })." + propertyName, "KeyboardEvent.DOM_KEY_LOCATION_LEFT");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": 4294967294 })." + propertyName, "4294967294");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": 4294967295 })." + propertyName, "4294967295");
+// location is passed.
+// numbers within the unsigned long range.
+shouldBe("new KeyboardEvent('eventType', { location: KeyboardEvent.DOM_KEY_LOCATION_STANDARD }).location", "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
+shouldBe("new KeyboardEvent('eventType', { location: KeyboardEvent.DOM_KEY_LOCATION_LEFT }).location", "KeyboardEvent.DOM_KEY_LOCATION_LEFT");
+shouldBe("new KeyboardEvent('eventType', { location: 4294967294 }).location", "4294967294");
+shouldBe("new KeyboardEvent('eventType', { location: 4294967295 }).location", "4294967295");
 
-    // numbers out of the unsigned long range.
-    // 2^{53}-1, the largest number that can be exactly represented by double.
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": 9007199254740991 })." + propertyName, "4294967295");
-    // 2^{64}-1
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": 18446744073709551615 })." + propertyName, "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": 12345678901234567890 })." + propertyName, "3944679424");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": -1 })." + propertyName, "4294967295");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": 123.45 })." + propertyName, "123");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": NaN })." + propertyName, "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
+// numbers out of the unsigned long range.
+// 2^{53}-1, the largest number that can be exactly represented by double.
+shouldBe("new KeyboardEvent('eventType', { location: 9007199254740991 }).location", "4294967295");
+// 2^{64}-1
+shouldBe("new KeyboardEvent('eventType', { location: 18446744073709551615 }).location", "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
+shouldBe("new KeyboardEvent('eventType', { location: 12345678901234567890 }).location", "3944679424");
+shouldBe("new KeyboardEvent('eventType', { location: -1 }).location", "4294967295");
+shouldBe("new KeyboardEvent('eventType', { location: 123.45 }).location", "123");
+shouldBe("new KeyboardEvent('eventType', { location: NaN }).location", "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
 
-    // Non-numeric values.
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": undefined })." + propertyName, "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": null })." + propertyName, "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": '' })." + propertyName, "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": '12345' })." + propertyName, "12345");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": '12345a' })." + propertyName, "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": 'abc' })." + propertyName, "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": [] })." + propertyName, "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": [12345] })." + propertyName, "12345");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": [12345, 67890] })." + propertyName, "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": {} })." + propertyName, "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": {moemoe: 12345} })." + propertyName, "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
-    shouldBe("new KeyboardEvent('eventType', { " + propertyName + ": {valueOf: function () { return 12345; }} })." + propertyName, "12345");
-});
-shouldBe("new KeyboardEvent('eventType', { keyLocation: KeyboardEvent.DOM_KEY_LOCATION_LEFT }).location", "KeyboardEvent.DOM_KEY_LOCATION_LEFT");
-shouldBe("new KeyboardEvent('eventType', { location: KeyboardEvent.DOM_KEY_LOCATION_LEFT }).keyLocation", "KeyboardEvent.DOM_KEY_LOCATION_LEFT");
+// Non-numeric values.
+shouldBe("new KeyboardEvent('eventType', { location: undefined }).location", "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
+shouldBe("new KeyboardEvent('eventType', { location: null }).location", "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
+shouldBe("new KeyboardEvent('eventType', { location: '' }).location", "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
+shouldBe("new KeyboardEvent('eventType', { location: '12345' }).location", "12345");
+shouldBe("new KeyboardEvent('eventType', { location: '12345a' }).location", "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
+shouldBe("new KeyboardEvent('eventType', { location: 'abc' }).location", "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
+shouldBe("new KeyboardEvent('eventType', { location: [] }).location", "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
+shouldBe("new KeyboardEvent('eventType', { location: [12345] }).location", "12345");
+shouldBe("new KeyboardEvent('eventType', { location: [12345, 67890] }).location", "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
+shouldBe("new KeyboardEvent('eventType', { location: {} }).location", "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
+shouldBe("new KeyboardEvent('eventType', { location: {moemoe: 12345} }).location", "KeyboardEvent.DOM_KEY_LOCATION_STANDARD");
+shouldBe("new KeyboardEvent('eventType', { location: {valueOf: function () { return 12345; }} }).location", "12345");
 
 // ctrlKey, altKey, shiftKey and metaKey are passed.
 ["ctrlKey", "altKey", "shiftKey", "metaKey"].forEach(function (attr) {

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-control-expected.txt
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-control-expected.txt
@@ -2,289 +2,289 @@ This logs DOM keydown, keyup, keypress events that are dispatched when pressing 
 
 
 Test Control + a:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: a, code: KeyA, keyIdentifier: , keyCode: 1, charCode: 1, keyCode: 1, which: 1, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: a, code: KeyA, keyIdentifier: , keyCode: 1, charCode: 1, keyCode: 1, which: 1, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + b:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: b, code: KeyB, keyIdentifier: , keyCode: 2, charCode: 2, keyCode: 2, which: 2, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: b, code: KeyB, keyIdentifier: , keyCode: 2, charCode: 2, keyCode: 2, which: 2, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + c:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: c, code: KeyC, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: c, code: KeyC, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + d:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: d, code: KeyD, keyIdentifier: , keyCode: 4, charCode: 4, keyCode: 4, which: 4, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: d, code: KeyD, keyIdentifier: , keyCode: 4, charCode: 4, keyCode: 4, which: 4, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + f:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: f, code: KeyF, keyIdentifier: , keyCode: 6, charCode: 6, keyCode: 6, which: 6, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: f, code: KeyF, keyIdentifier: , keyCode: 6, charCode: 6, keyCode: 6, which: 6, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + g:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: g, code: KeyG, keyIdentifier: , keyCode: 7, charCode: 7, keyCode: 7, which: 7, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: g, code: KeyG, keyIdentifier: , keyCode: 7, charCode: 7, keyCode: 7, which: 7, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + h:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: h, code: KeyH, keyIdentifier: , keyCode: 8, charCode: 8, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: h, code: KeyH, keyIdentifier: , keyCode: 8, charCode: 8, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + j:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: j, code: KeyJ, keyIdentifier: , keyCode: 10, charCode: 10, keyCode: 10, which: 10, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: j, code: KeyJ, keyIdentifier: , keyCode: 10, charCode: 10, keyCode: 10, which: 10, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + k:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: k, code: KeyK, keyIdentifier: , keyCode: 11, charCode: 11, keyCode: 11, which: 11, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: k, code: KeyK, keyIdentifier: , keyCode: 11, charCode: 11, keyCode: 11, which: 11, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + l:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: l, code: KeyL, keyIdentifier: , keyCode: 12, charCode: 12, keyCode: 12, which: 12, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: l, code: KeyL, keyIdentifier: , keyCode: 12, charCode: 12, keyCode: 12, which: 12, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + m:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: m, code: KeyM, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: m, code: KeyM, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + o:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: o, code: KeyO, keyIdentifier: , keyCode: 15, charCode: 15, keyCode: 15, which: 15, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: o, code: KeyO, keyIdentifier: , keyCode: 15, charCode: 15, keyCode: 15, which: 15, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + p:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: p, code: KeyP, keyIdentifier: , keyCode: 16, charCode: 16, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: p, code: KeyP, keyIdentifier: , keyCode: 16, charCode: 16, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + q:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: q, code: KeyQ, keyIdentifier: , keyCode: 17, charCode: 17, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: q, code: KeyQ, keyIdentifier: , keyCode: 17, charCode: 17, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + r:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: r, code: KeyR, keyIdentifier: , keyCode: 18, charCode: 18, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: r, code: KeyR, keyIdentifier: , keyCode: 18, charCode: 18, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + s:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: s, code: KeyS, keyIdentifier: , keyCode: 19, charCode: 19, keyCode: 19, which: 19, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: s, code: KeyS, keyIdentifier: , keyCode: 19, charCode: 19, keyCode: 19, which: 19, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + t:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: t, code: KeyT, keyIdentifier: , keyCode: 20, charCode: 20, keyCode: 20, which: 20, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: t, code: KeyT, keyIdentifier: , keyCode: 20, charCode: 20, keyCode: 20, which: 20, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + v:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: v, code: KeyV, keyIdentifier: , keyCode: 22, charCode: 22, keyCode: 22, which: 22, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: v, code: KeyV, keyIdentifier: , keyCode: 22, charCode: 22, keyCode: 22, which: 22, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + w:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: w, code: KeyW, keyIdentifier: , keyCode: 23, charCode: 23, keyCode: 23, which: 23, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: w, code: KeyW, keyIdentifier: , keyCode: 23, charCode: 23, keyCode: 23, which: 23, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + x:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: x, code: KeyX, keyIdentifier: , keyCode: 24, charCode: 24, keyCode: 24, which: 24, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: x, code: KeyX, keyIdentifier: , keyCode: 24, charCode: 24, keyCode: 24, which: 24, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + y:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: y, code: KeyY, keyIdentifier: , keyCode: 25, charCode: 25, keyCode: 25, which: 25, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: y, code: KeyY, keyIdentifier: , keyCode: 25, charCode: 25, keyCode: 25, which: 25, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + z:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: z, code: KeyZ, keyIdentifier: , keyCode: 26, charCode: 26, keyCode: 26, which: 26, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: z, code: KeyZ, keyIdentifier: , keyCode: 26, charCode: 26, keyCode: 26, which: 26, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 0:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 0, code: Digit0, keyIdentifier: , keyCode: 48, charCode: 48, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 0, code: Digit0, keyIdentifier: , keyCode: 48, charCode: 48, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 1:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 1, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 1, code: Digit1, keyIdentifier: , keyCode: 49, charCode: 49, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 1, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 1, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 1, code: Digit1, keyIdentifier: , keyCode: 49, charCode: 49, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 1, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 2:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 2, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 2, code: Digit2, keyIdentifier: , keyCode: 50, charCode: 50, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 2, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 2, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 2, code: Digit2, keyIdentifier: , keyCode: 50, charCode: 50, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 2, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 3:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 3, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 3, code: Digit3, keyIdentifier: , keyCode: 51, charCode: 51, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 3, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 3, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 3, code: Digit3, keyIdentifier: , keyCode: 51, charCode: 51, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 3, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 4:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 4, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 4, code: Digit4, keyIdentifier: , keyCode: 52, charCode: 52, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 4, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 4, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 4, code: Digit4, keyIdentifier: , keyCode: 52, charCode: 52, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 4, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 5:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 5, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 5, code: Digit5, keyIdentifier: , keyCode: 53, charCode: 53, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 5, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 5, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 5, code: Digit5, keyIdentifier: , keyCode: 53, charCode: 53, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 5, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 6:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 6, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 6, code: Digit6, keyIdentifier: , keyCode: 54, charCode: 54, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 6, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 6, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 6, code: Digit6, keyIdentifier: , keyCode: 54, charCode: 54, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 6, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 7:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 7, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 7, code: Digit7, keyIdentifier: , keyCode: 55, charCode: 55, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 7, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 7, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 7, code: Digit7, keyIdentifier: , keyCode: 55, charCode: 55, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 7, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 8:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 8, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 8, code: Digit8, keyIdentifier: , keyCode: 56, charCode: 56, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 8, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 8, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 8, code: Digit8, keyIdentifier: , keyCode: 56, charCode: 56, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 8, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 9:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 9, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 9, code: Digit9, keyIdentifier: , keyCode: 57, charCode: 57, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 9, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 9, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 9, code: Digit9, keyIdentifier: , keyCode: 57, charCode: 57, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 9, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + -:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: -, code: Minus, keyIdentifier: , keyCode: 31, charCode: 31, keyCode: 31, which: 31, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: -, code: Minus, keyIdentifier: , keyCode: 31, charCode: 31, keyCode: 31, which: 31, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + =:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: =, code: Equal, keyIdentifier: , keyCode: 61, charCode: 61, keyCode: 61, which: 61, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: =, code: Equal, keyIdentifier: , keyCode: 61, charCode: 61, keyCode: 61, which: 61, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + [:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: [, code: BracketLeft, keyIdentifier: U+005B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: [, code: BracketLeft, keyIdentifier: , keyCode: 27, charCode: 27, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: [, code: BracketLeft, keyIdentifier: U+005B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: [, code: BracketLeft, keyIdentifier: U+005B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: [, code: BracketLeft, keyIdentifier: , keyCode: 27, charCode: 27, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: [, code: BracketLeft, keyIdentifier: U+005B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + ]:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ], code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ], code: BracketRight, keyIdentifier: , keyCode: 29, charCode: 29, keyCode: 29, which: 29, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ], code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ], code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ], code: BracketRight, keyIdentifier: , keyCode: 29, charCode: 29, keyCode: 29, which: 29, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ], code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + ;:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ;, code: Semicolon, keyIdentifier: , keyCode: 59, charCode: 59, keyCode: 59, which: 59, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ;, code: Semicolon, keyIdentifier: , keyCode: 59, charCode: 59, keyCode: 59, which: 59, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + ':
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ', code: Quote, keyIdentifier: , keyCode: 39, charCode: 39, keyCode: 39, which: 39, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ', code: Quote, keyIdentifier: , keyCode: 39, charCode: 39, keyCode: 39, which: 39, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + ,:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ,, code: Comma, keyIdentifier: , keyCode: 44, charCode: 44, keyCode: 44, which: 44, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ,, code: Comma, keyIdentifier: , keyCode: 44, charCode: 44, keyCode: 44, which: 44, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + .:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ., code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ., code: Period, keyIdentifier: , keyCode: 46, charCode: 46, keyCode: 46, which: 46, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ., code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ., code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ., code: Period, keyIdentifier: , keyCode: 46, charCode: 46, keyCode: 46, which: 46, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ., code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + /:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: /, code: Slash, keyIdentifier: , keyCode: 47, charCode: 47, keyCode: 47, which: 47, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: /, code: Slash, keyIdentifier: , keyCode: 47, charCode: 47, keyCode: 47, which: 47, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-control-option-expected.txt
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-control-option-expected.txt
@@ -2,371 +2,371 @@ This logs DOM keydown, keyup, keypress events that are dispatched when pressing 
 
 
 Test Control + Option + a:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: a, code: KeyA, keyIdentifier: , keyCode: 1, charCode: 1, keyCode: 1, which: 1, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: a, code: KeyA, keyIdentifier: , keyCode: 1, charCode: 1, keyCode: 1, which: 1, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + b:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: b, code: KeyB, keyIdentifier: , keyCode: 2, charCode: 2, keyCode: 2, which: 2, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: b, code: KeyB, keyIdentifier: , keyCode: 2, charCode: 2, keyCode: 2, which: 2, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + c:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: c, code: KeyC, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: c, code: KeyC, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + d:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: d, code: KeyD, keyIdentifier: , keyCode: 4, charCode: 4, keyCode: 4, which: 4, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: d, code: KeyD, keyIdentifier: , keyCode: 4, charCode: 4, keyCode: 4, which: 4, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + f:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: f, code: KeyF, keyIdentifier: , keyCode: 6, charCode: 6, keyCode: 6, which: 6, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: f, code: KeyF, keyIdentifier: , keyCode: 6, charCode: 6, keyCode: 6, which: 6, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + g:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: g, code: KeyG, keyIdentifier: , keyCode: 7, charCode: 7, keyCode: 7, which: 7, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: g, code: KeyG, keyIdentifier: , keyCode: 7, charCode: 7, keyCode: 7, which: 7, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + h:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: h, code: KeyH, keyIdentifier: , keyCode: 8, charCode: 8, keyCode: 8, which: 8, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: h, code: KeyH, keyIdentifier: , keyCode: 8, charCode: 8, keyCode: 8, which: 8, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + j:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: j, code: KeyJ, keyIdentifier: , keyCode: 10, charCode: 10, keyCode: 10, which: 10, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: j, code: KeyJ, keyIdentifier: , keyCode: 10, charCode: 10, keyCode: 10, which: 10, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + k:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: k, code: KeyK, keyIdentifier: , keyCode: 11, charCode: 11, keyCode: 11, which: 11, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: k, code: KeyK, keyIdentifier: , keyCode: 11, charCode: 11, keyCode: 11, which: 11, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + l:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: l, code: KeyL, keyIdentifier: , keyCode: 12, charCode: 12, keyCode: 12, which: 12, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: l, code: KeyL, keyIdentifier: , keyCode: 12, charCode: 12, keyCode: 12, which: 12, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + m:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: m, code: KeyM, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: m, code: KeyM, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + o:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: o, code: KeyO, keyIdentifier: , keyCode: 15, charCode: 15, keyCode: 15, which: 15, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: o, code: KeyO, keyIdentifier: , keyCode: 15, charCode: 15, keyCode: 15, which: 15, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + p:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: p, code: KeyP, keyIdentifier: , keyCode: 16, charCode: 16, keyCode: 16, which: 16, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: p, code: KeyP, keyIdentifier: , keyCode: 16, charCode: 16, keyCode: 16, which: 16, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + q:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: q, code: KeyQ, keyIdentifier: , keyCode: 17, charCode: 17, keyCode: 17, which: 17, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: q, code: KeyQ, keyIdentifier: , keyCode: 17, charCode: 17, keyCode: 17, which: 17, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + r:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: r, code: KeyR, keyIdentifier: , keyCode: 18, charCode: 18, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: r, code: KeyR, keyIdentifier: , keyCode: 18, charCode: 18, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + s:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: s, code: KeyS, keyIdentifier: , keyCode: 19, charCode: 19, keyCode: 19, which: 19, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: s, code: KeyS, keyIdentifier: , keyCode: 19, charCode: 19, keyCode: 19, which: 19, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + t:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: t, code: KeyT, keyIdentifier: , keyCode: 20, charCode: 20, keyCode: 20, which: 20, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: t, code: KeyT, keyIdentifier: , keyCode: 20, charCode: 20, keyCode: 20, which: 20, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + v:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: v, code: KeyV, keyIdentifier: , keyCode: 22, charCode: 22, keyCode: 22, which: 22, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: v, code: KeyV, keyIdentifier: , keyCode: 22, charCode: 22, keyCode: 22, which: 22, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + w:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: w, code: KeyW, keyIdentifier: , keyCode: 23, charCode: 23, keyCode: 23, which: 23, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: w, code: KeyW, keyIdentifier: , keyCode: 23, charCode: 23, keyCode: 23, which: 23, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + x:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: x, code: KeyX, keyIdentifier: , keyCode: 24, charCode: 24, keyCode: 24, which: 24, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: x, code: KeyX, keyIdentifier: , keyCode: 24, charCode: 24, keyCode: 24, which: 24, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + y:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: y, code: KeyY, keyIdentifier: , keyCode: 25, charCode: 25, keyCode: 25, which: 25, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: y, code: KeyY, keyIdentifier: , keyCode: 25, charCode: 25, keyCode: 25, which: 25, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + z:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: z, code: KeyZ, keyIdentifier: , keyCode: 26, charCode: 26, keyCode: 26, which: 26, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: z, code: KeyZ, keyIdentifier: , keyCode: 26, charCode: 26, keyCode: 26, which: 26, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + 0:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 0, code: Digit0, keyIdentifier: , keyCode: 48, charCode: 48, keyCode: 48, which: 48, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 0, code: Digit0, keyIdentifier: , keyCode: 48, charCode: 48, keyCode: 48, which: 48, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + 1:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 1, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 1, code: Digit1, keyIdentifier: , keyCode: 49, charCode: 49, keyCode: 49, which: 49, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 1, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 1, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 1, code: Digit1, keyIdentifier: , keyCode: 49, charCode: 49, keyCode: 49, which: 49, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 1, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + 2:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 2, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 2, code: Digit2, keyIdentifier: , keyCode: 50, charCode: 50, keyCode: 50, which: 50, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 2, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 2, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 2, code: Digit2, keyIdentifier: , keyCode: 50, charCode: 50, keyCode: 50, which: 50, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 2, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + 3:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 3, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 3, code: Digit3, keyIdentifier: , keyCode: 51, charCode: 51, keyCode: 51, which: 51, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 3, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 3, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 3, code: Digit3, keyIdentifier: , keyCode: 51, charCode: 51, keyCode: 51, which: 51, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 3, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + 4:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 4, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 4, code: Digit4, keyIdentifier: , keyCode: 52, charCode: 52, keyCode: 52, which: 52, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 4, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 4, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 4, code: Digit4, keyIdentifier: , keyCode: 52, charCode: 52, keyCode: 52, which: 52, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 4, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + 5:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 5, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 5, code: Digit5, keyIdentifier: , keyCode: 53, charCode: 53, keyCode: 53, which: 53, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 5, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 5, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 5, code: Digit5, keyIdentifier: , keyCode: 53, charCode: 53, keyCode: 53, which: 53, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 5, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + 6:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 6, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 6, code: Digit6, keyIdentifier: , keyCode: 54, charCode: 54, keyCode: 54, which: 54, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 6, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 6, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 6, code: Digit6, keyIdentifier: , keyCode: 54, charCode: 54, keyCode: 54, which: 54, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 6, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + 7:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 7, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 7, code: Digit7, keyIdentifier: , keyCode: 55, charCode: 55, keyCode: 55, which: 55, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 7, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 7, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 7, code: Digit7, keyIdentifier: , keyCode: 55, charCode: 55, keyCode: 55, which: 55, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 7, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + 8:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 8, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 8, code: Digit8, keyIdentifier: , keyCode: 56, charCode: 56, keyCode: 56, which: 56, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 8, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 8, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 8, code: Digit8, keyIdentifier: , keyCode: 56, charCode: 56, keyCode: 56, which: 56, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 8, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + 9:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 9, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 9, code: Digit9, keyIdentifier: , keyCode: 57, charCode: 57, keyCode: 57, which: 57, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: 9, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 9, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 9, code: Digit9, keyIdentifier: , keyCode: 57, charCode: 57, keyCode: 57, which: 57, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: 9, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + -:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: -, code: Minus, keyIdentifier: , keyCode: 31, charCode: 31, keyCode: 31, which: 31, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: -, code: Minus, keyIdentifier: , keyCode: 31, charCode: 31, keyCode: 31, which: 31, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + =:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: =, code: Equal, keyIdentifier: , keyCode: 61, charCode: 61, keyCode: 61, which: 61, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: =, code: Equal, keyIdentifier: , keyCode: 61, charCode: 61, keyCode: 61, which: 61, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + [:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: [, code: BracketLeft, keyIdentifier: U+005B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: [, code: BracketLeft, keyIdentifier: , keyCode: 27, charCode: 27, keyCode: 27, which: 27, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: [, code: BracketLeft, keyIdentifier: U+005B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: [, code: BracketLeft, keyIdentifier: U+005B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: [, code: BracketLeft, keyIdentifier: , keyCode: 27, charCode: 27, keyCode: 27, which: 27, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: [, code: BracketLeft, keyIdentifier: U+005B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + ]:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ], code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ], code: BracketRight, keyIdentifier: , keyCode: 29, charCode: 29, keyCode: 29, which: 29, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ], code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ], code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ], code: BracketRight, keyIdentifier: , keyCode: 29, charCode: 29, keyCode: 29, which: 29, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ], code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + ;:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ;, code: Semicolon, keyIdentifier: , keyCode: 59, charCode: 59, keyCode: 59, which: 59, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ;, code: Semicolon, keyIdentifier: , keyCode: 59, charCode: 59, keyCode: 59, which: 59, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + ':
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ', code: Quote, keyIdentifier: , keyCode: 39, charCode: 39, keyCode: 39, which: 39, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ', code: Quote, keyIdentifier: , keyCode: 39, charCode: 39, keyCode: 39, which: 39, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + ,:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ,, code: Comma, keyIdentifier: , keyCode: 44, charCode: 44, keyCode: 44, which: 44, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ,, code: Comma, keyIdentifier: , keyCode: 44, charCode: 44, keyCode: 44, which: 44, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + .:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ., code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ., code: Period, keyIdentifier: , keyCode: 46, charCode: 46, keyCode: 46, which: 46, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ., code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ., code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ., code: Period, keyIdentifier: , keyCode: 46, charCode: 46, keyCode: 46, which: 46, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ., code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Option + /:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: /, code: Slash, keyIdentifier: , keyCode: 47, charCode: 47, keyCode: 47, which: 47, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: /, code: Slash, keyIdentifier: , keyCode: 47, charCode: 47, keyCode: 47, which: 47, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: true, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-control-shift-expected.txt
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-control-shift-expected.txt
@@ -2,371 +2,371 @@ This logs DOM keydown, keyup, keypress events that are dispatched when pressing 
 
 
 Test Control + Shift + a:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: A, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: A, code: KeyA, keyIdentifier: , keyCode: 1, charCode: 1, keyCode: 1, which: 1, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: A, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: A, code: KeyA, keyIdentifier: , keyCode: 1, charCode: 1, keyCode: 1, which: 1, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + b:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: B, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: B, code: KeyB, keyIdentifier: , keyCode: 2, charCode: 2, keyCode: 2, which: 2, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: B, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: B, code: KeyB, keyIdentifier: , keyCode: 2, charCode: 2, keyCode: 2, which: 2, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + c:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: C, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: C, code: KeyC, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: C, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: C, code: KeyC, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + d:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: D, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: D, code: KeyD, keyIdentifier: , keyCode: 4, charCode: 4, keyCode: 4, which: 4, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: D, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: D, code: KeyD, keyIdentifier: , keyCode: 4, charCode: 4, keyCode: 4, which: 4, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + f:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: F, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: F, code: KeyF, keyIdentifier: , keyCode: 6, charCode: 6, keyCode: 6, which: 6, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: F, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: F, code: KeyF, keyIdentifier: , keyCode: 6, charCode: 6, keyCode: 6, which: 6, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + g:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: G, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: G, code: KeyG, keyIdentifier: , keyCode: 7, charCode: 7, keyCode: 7, which: 7, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: G, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: G, code: KeyG, keyIdentifier: , keyCode: 7, charCode: 7, keyCode: 7, which: 7, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + h:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: H, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: H, code: KeyH, keyIdentifier: , keyCode: 8, charCode: 8, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: H, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: H, code: KeyH, keyIdentifier: , keyCode: 8, charCode: 8, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + j:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: J, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: J, code: KeyJ, keyIdentifier: , keyCode: 10, charCode: 10, keyCode: 10, which: 10, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: J, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: J, code: KeyJ, keyIdentifier: , keyCode: 10, charCode: 10, keyCode: 10, which: 10, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + k:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: K, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: K, code: KeyK, keyIdentifier: , keyCode: 11, charCode: 11, keyCode: 11, which: 11, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: K, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: K, code: KeyK, keyIdentifier: , keyCode: 11, charCode: 11, keyCode: 11, which: 11, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + l:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: L, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: L, code: KeyL, keyIdentifier: , keyCode: 12, charCode: 12, keyCode: 12, which: 12, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: L, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: L, code: KeyL, keyIdentifier: , keyCode: 12, charCode: 12, keyCode: 12, which: 12, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + m:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: M, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: M, code: KeyM, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: M, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: M, code: KeyM, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + o:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: O, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: O, code: KeyO, keyIdentifier: , keyCode: 15, charCode: 15, keyCode: 15, which: 15, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: O, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: O, code: KeyO, keyIdentifier: , keyCode: 15, charCode: 15, keyCode: 15, which: 15, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + p:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: P, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: P, code: KeyP, keyIdentifier: , keyCode: 16, charCode: 16, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: P, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: P, code: KeyP, keyIdentifier: , keyCode: 16, charCode: 16, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + q:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Q, code: KeyQ, keyIdentifier: , keyCode: 17, charCode: 17, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Q, code: KeyQ, keyIdentifier: , keyCode: 17, charCode: 17, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + r:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: R, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: R, code: KeyR, keyIdentifier: , keyCode: 18, charCode: 18, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: R, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: R, code: KeyR, keyIdentifier: , keyCode: 18, charCode: 18, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + s:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: S, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: S, code: KeyS, keyIdentifier: , keyCode: 19, charCode: 19, keyCode: 19, which: 19, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: S, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: S, code: KeyS, keyIdentifier: , keyCode: 19, charCode: 19, keyCode: 19, which: 19, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + t:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: T, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: T, code: KeyT, keyIdentifier: , keyCode: 20, charCode: 20, keyCode: 20, which: 20, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: T, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: T, code: KeyT, keyIdentifier: , keyCode: 20, charCode: 20, keyCode: 20, which: 20, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + v:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: V, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: V, code: KeyV, keyIdentifier: , keyCode: 22, charCode: 22, keyCode: 22, which: 22, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: V, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: V, code: KeyV, keyIdentifier: , keyCode: 22, charCode: 22, keyCode: 22, which: 22, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + w:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: W, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: W, code: KeyW, keyIdentifier: , keyCode: 23, charCode: 23, keyCode: 23, which: 23, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: W, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: W, code: KeyW, keyIdentifier: , keyCode: 23, charCode: 23, keyCode: 23, which: 23, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + x:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: X, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: X, code: KeyX, keyIdentifier: , keyCode: 24, charCode: 24, keyCode: 24, which: 24, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: X, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: X, code: KeyX, keyIdentifier: , keyCode: 24, charCode: 24, keyCode: 24, which: 24, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + y:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Y, code: KeyY, keyIdentifier: , keyCode: 25, charCode: 25, keyCode: 25, which: 25, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Y, code: KeyY, keyIdentifier: , keyCode: 25, charCode: 25, keyCode: 25, which: 25, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + z:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Z, code: KeyZ, keyIdentifier: , keyCode: 26, charCode: 26, keyCode: 26, which: 26, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Z, code: KeyZ, keyIdentifier: , keyCode: 26, charCode: 26, keyCode: 26, which: 26, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + 0:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ), code: Digit0, keyIdentifier: U+0029, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ), code: Digit0, keyIdentifier: , keyCode: 48, charCode: 48, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ), code: Digit0, keyIdentifier: U+0029, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ), code: Digit0, keyIdentifier: , keyCode: 48, charCode: 48, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + 1:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: !, code: Digit1, keyIdentifier: U+0021, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: !, code: Digit1, keyIdentifier: , keyCode: 49, charCode: 49, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: 1, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: !, code: Digit1, keyIdentifier: U+0021, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: !, code: Digit1, keyIdentifier: , keyCode: 49, charCode: 49, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: 1, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + 2:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: @, code: Digit2, keyIdentifier: U+0040, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: @, code: Digit2, keyIdentifier: , keyCode: 50, charCode: 50, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: 2, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: @, code: Digit2, keyIdentifier: U+0040, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: @, code: Digit2, keyIdentifier: , keyCode: 50, charCode: 50, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: 2, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + 3:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: #, code: Digit3, keyIdentifier: U+0023, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: #, code: Digit3, keyIdentifier: , keyCode: 51, charCode: 51, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: 3, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: #, code: Digit3, keyIdentifier: U+0023, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: #, code: Digit3, keyIdentifier: , keyCode: 51, charCode: 51, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: 3, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + 4:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: $, code: Digit4, keyIdentifier: U+0024, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: $, code: Digit4, keyIdentifier: , keyCode: 52, charCode: 52, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: 4, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: $, code: Digit4, keyIdentifier: U+0024, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: $, code: Digit4, keyIdentifier: , keyCode: 52, charCode: 52, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: 4, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + 5:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: %, code: Digit5, keyIdentifier: U+0025, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: %, code: Digit5, keyIdentifier: , keyCode: 53, charCode: 53, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: 5, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: %, code: Digit5, keyIdentifier: U+0025, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: %, code: Digit5, keyIdentifier: , keyCode: 53, charCode: 53, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: 5, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + 6:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ^, code: Digit6, keyIdentifier: U+005E, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ^, code: Digit6, keyIdentifier: , keyCode: 54, charCode: 54, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: 6, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ^, code: Digit6, keyIdentifier: U+005E, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ^, code: Digit6, keyIdentifier: , keyCode: 54, charCode: 54, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: 6, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + 7:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: &, code: Digit7, keyIdentifier: U+0026, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: &, code: Digit7, keyIdentifier: , keyCode: 55, charCode: 55, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: 7, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: &, code: Digit7, keyIdentifier: U+0026, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: &, code: Digit7, keyIdentifier: , keyCode: 55, charCode: 55, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: 7, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + 8:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: *, code: Digit8, keyIdentifier: U+002A, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: *, code: Digit8, keyIdentifier: , keyCode: 56, charCode: 56, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: 8, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: *, code: Digit8, keyIdentifier: U+002A, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: *, code: Digit8, keyIdentifier: , keyCode: 56, charCode: 56, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: 8, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + 9:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: (, code: Digit9, keyIdentifier: U+0028, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: (, code: Digit9, keyIdentifier: , keyCode: 57, charCode: 57, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: 9, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: (, code: Digit9, keyIdentifier: U+0028, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: (, code: Digit9, keyIdentifier: , keyCode: 57, charCode: 57, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: 9, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + -:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: _, code: Minus, keyIdentifier: U+005F, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: _, code: Minus, keyIdentifier: , keyCode: 31, charCode: 31, keyCode: 31, which: 31, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: _, code: Minus, keyIdentifier: U+005F, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: _, code: Minus, keyIdentifier: , keyCode: 31, charCode: 31, keyCode: 31, which: 31, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + =:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: +, code: Equal, keyIdentifier: U+002B, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: +, code: Equal, keyIdentifier: , keyCode: 61, charCode: 61, keyCode: 61, which: 61, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: +, code: Equal, keyIdentifier: U+002B, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: +, code: Equal, keyIdentifier: , keyCode: 61, charCode: 61, keyCode: 61, which: 61, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + [:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: {, code: BracketLeft, keyIdentifier: U+007B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: {, code: BracketLeft, keyIdentifier: , keyCode: 27, charCode: 27, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: [, code: BracketLeft, keyIdentifier: U+005B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: {, code: BracketLeft, keyIdentifier: U+007B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: {, code: BracketLeft, keyIdentifier: , keyCode: 27, charCode: 27, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: [, code: BracketLeft, keyIdentifier: U+005B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + ]:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: }, code: BracketRight, keyIdentifier: U+007D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: }, code: BracketRight, keyIdentifier: , keyCode: 29, charCode: 29, keyCode: 29, which: 29, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ], code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: }, code: BracketRight, keyIdentifier: U+007D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: }, code: BracketRight, keyIdentifier: , keyCode: 29, charCode: 29, keyCode: 29, which: 29, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ], code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + ;:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: :, code: Semicolon, keyIdentifier: U+003A, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: :, code: Semicolon, keyIdentifier: , keyCode: 59, charCode: 59, keyCode: 59, which: 59, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: :, code: Semicolon, keyIdentifier: U+003A, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: :, code: Semicolon, keyIdentifier: , keyCode: 59, charCode: 59, keyCode: 59, which: 59, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + ':
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ", code: Quote, keyIdentifier: U+0022, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ", code: Quote, keyIdentifier: , keyCode: 39, charCode: 39, keyCode: 39, which: 39, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ", code: Quote, keyIdentifier: U+0022, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ", code: Quote, keyIdentifier: , keyCode: 39, charCode: 39, keyCode: 39, which: 39, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + ,:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: <, code: Comma, keyIdentifier: U+003C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: <, code: Comma, keyIdentifier: , keyCode: 44, charCode: 44, keyCode: 44, which: 44, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: <, code: Comma, keyIdentifier: U+003C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: <, code: Comma, keyIdentifier: , keyCode: 44, charCode: 44, keyCode: 44, which: 44, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + .:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: >, code: Period, keyIdentifier: U+003E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: >, code: Period, keyIdentifier: , keyCode: 46, charCode: 46, keyCode: 46, which: 46, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ., code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: >, code: Period, keyIdentifier: U+003E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: >, code: Period, keyIdentifier: , keyCode: 46, charCode: 46, keyCode: 46, which: 46, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ., code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + Shift + /:
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ?, code: Slash, keyIdentifier: U+003F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ?, code: Slash, keyIdentifier: , keyCode: 47, charCode: 47, keyCode: 47, which: 47, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ?, code: Slash, keyIdentifier: U+003F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ?, code: Slash, keyIdentifier: , keyCode: 47, charCode: 47, keyCode: 47, which: 47, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: true, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-control-expected.txt
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-control-expected.txt
@@ -2,330 +2,330 @@ This logs DOM keydown, keyup, keypress events that are dispatched when pressing 
 
 
 Test Command + Control + a:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: a, code: KeyA, keyIdentifier: , keyCode: 1, charCode: 1, keyCode: 1, which: 1, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: a, code: KeyA, keyIdentifier: , keyCode: 1, charCode: 1, keyCode: 1, which: 1, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + b:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: b, code: KeyB, keyIdentifier: , keyCode: 2, charCode: 2, keyCode: 2, which: 2, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: b, code: KeyB, keyIdentifier: , keyCode: 2, charCode: 2, keyCode: 2, which: 2, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + c:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: c, code: KeyC, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: c, code: KeyC, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + d:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: d, code: KeyD, keyIdentifier: , keyCode: 4, charCode: 4, keyCode: 4, which: 4, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: d, code: KeyD, keyIdentifier: , keyCode: 4, charCode: 4, keyCode: 4, which: 4, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + f:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: f, code: KeyF, keyIdentifier: , keyCode: 6, charCode: 6, keyCode: 6, which: 6, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: f, code: KeyF, keyIdentifier: , keyCode: 6, charCode: 6, keyCode: 6, which: 6, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + g:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: g, code: KeyG, keyIdentifier: , keyCode: 7, charCode: 7, keyCode: 7, which: 7, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: g, code: KeyG, keyIdentifier: , keyCode: 7, charCode: 7, keyCode: 7, which: 7, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + h:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: h, code: KeyH, keyIdentifier: , keyCode: 8, charCode: 8, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: h, code: KeyH, keyIdentifier: , keyCode: 8, charCode: 8, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + j:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: j, code: KeyJ, keyIdentifier: , keyCode: 10, charCode: 10, keyCode: 10, which: 10, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: j, code: KeyJ, keyIdentifier: , keyCode: 10, charCode: 10, keyCode: 10, which: 10, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + k:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: k, code: KeyK, keyIdentifier: , keyCode: 11, charCode: 11, keyCode: 11, which: 11, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: k, code: KeyK, keyIdentifier: , keyCode: 11, charCode: 11, keyCode: 11, which: 11, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + l:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: l, code: KeyL, keyIdentifier: , keyCode: 12, charCode: 12, keyCode: 12, which: 12, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: l, code: KeyL, keyIdentifier: , keyCode: 12, charCode: 12, keyCode: 12, which: 12, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + m:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: m, code: KeyM, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: m, code: KeyM, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + o:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: o, code: KeyO, keyIdentifier: , keyCode: 15, charCode: 15, keyCode: 15, which: 15, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: o, code: KeyO, keyIdentifier: , keyCode: 15, charCode: 15, keyCode: 15, which: 15, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + p:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: p, code: KeyP, keyIdentifier: , keyCode: 16, charCode: 16, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: p, code: KeyP, keyIdentifier: , keyCode: 16, charCode: 16, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + q:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: q, code: KeyQ, keyIdentifier: , keyCode: 17, charCode: 17, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: q, code: KeyQ, keyIdentifier: , keyCode: 17, charCode: 17, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + r:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: r, code: KeyR, keyIdentifier: , keyCode: 18, charCode: 18, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: r, code: KeyR, keyIdentifier: , keyCode: 18, charCode: 18, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + s:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: s, code: KeyS, keyIdentifier: , keyCode: 19, charCode: 19, keyCode: 19, which: 19, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: s, code: KeyS, keyIdentifier: , keyCode: 19, charCode: 19, keyCode: 19, which: 19, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + t:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: t, code: KeyT, keyIdentifier: , keyCode: 20, charCode: 20, keyCode: 20, which: 20, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: t, code: KeyT, keyIdentifier: , keyCode: 20, charCode: 20, keyCode: 20, which: 20, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + v:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: v, code: KeyV, keyIdentifier: , keyCode: 22, charCode: 22, keyCode: 22, which: 22, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: v, code: KeyV, keyIdentifier: , keyCode: 22, charCode: 22, keyCode: 22, which: 22, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + w:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: w, code: KeyW, keyIdentifier: , keyCode: 23, charCode: 23, keyCode: 23, which: 23, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: w, code: KeyW, keyIdentifier: , keyCode: 23, charCode: 23, keyCode: 23, which: 23, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + x:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: x, code: KeyX, keyIdentifier: , keyCode: 24, charCode: 24, keyCode: 24, which: 24, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: x, code: KeyX, keyIdentifier: , keyCode: 24, charCode: 24, keyCode: 24, which: 24, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + y:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: y, code: KeyY, keyIdentifier: , keyCode: 25, charCode: 25, keyCode: 25, which: 25, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: y, code: KeyY, keyIdentifier: , keyCode: 25, charCode: 25, keyCode: 25, which: 25, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + z:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: z, code: KeyZ, keyIdentifier: , keyCode: 26, charCode: 26, keyCode: 26, which: 26, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: z, code: KeyZ, keyIdentifier: , keyCode: 26, charCode: 26, keyCode: 26, which: 26, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + 0:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 0, code: Digit0, keyIdentifier: , keyCode: 48, charCode: 48, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 0, code: Digit0, keyIdentifier: , keyCode: 48, charCode: 48, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + 1:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 1, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 1, code: Digit1, keyIdentifier: , keyCode: 49, charCode: 49, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 1, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 1, code: Digit1, keyIdentifier: , keyCode: 49, charCode: 49, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + 2:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 2, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 2, code: Digit2, keyIdentifier: , keyCode: 50, charCode: 50, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 2, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 2, code: Digit2, keyIdentifier: , keyCode: 50, charCode: 50, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + 3:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 3, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 3, code: Digit3, keyIdentifier: , keyCode: 51, charCode: 51, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 3, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 3, code: Digit3, keyIdentifier: , keyCode: 51, charCode: 51, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + 4:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 4, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 4, code: Digit4, keyIdentifier: , keyCode: 52, charCode: 52, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 4, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 4, code: Digit4, keyIdentifier: , keyCode: 52, charCode: 52, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + 5:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 5, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 5, code: Digit5, keyIdentifier: , keyCode: 53, charCode: 53, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 5, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 5, code: Digit5, keyIdentifier: , keyCode: 53, charCode: 53, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + 6:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 6, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 6, code: Digit6, keyIdentifier: , keyCode: 54, charCode: 54, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 6, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 6, code: Digit6, keyIdentifier: , keyCode: 54, charCode: 54, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + 7:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 7, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 7, code: Digit7, keyIdentifier: , keyCode: 55, charCode: 55, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 7, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 7, code: Digit7, keyIdentifier: , keyCode: 55, charCode: 55, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + 8:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 8, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 8, code: Digit8, keyIdentifier: , keyCode: 56, charCode: 56, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 8, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 8, code: Digit8, keyIdentifier: , keyCode: 56, charCode: 56, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + 9:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 9, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 9, code: Digit9, keyIdentifier: , keyCode: 57, charCode: 57, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 9, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 9, code: Digit9, keyIdentifier: , keyCode: 57, charCode: 57, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + -:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: -, code: Minus, keyIdentifier: , keyCode: 31, charCode: 31, keyCode: 31, which: 31, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: -, code: Minus, keyIdentifier: , keyCode: 31, charCode: 31, keyCode: 31, which: 31, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + =:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: =, code: Equal, keyIdentifier: , keyCode: 61, charCode: 61, keyCode: 61, which: 61, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: =, code: Equal, keyIdentifier: , keyCode: 61, charCode: 61, keyCode: 61, which: 61, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + [:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: [, code: BracketLeft, keyIdentifier: U+005B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: [, code: BracketLeft, keyIdentifier: , keyCode: 27, charCode: 27, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: [, code: BracketLeft, keyIdentifier: U+005B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: [, code: BracketLeft, keyIdentifier: , keyCode: 27, charCode: 27, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + ]:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ], code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ], code: BracketRight, keyIdentifier: , keyCode: 29, charCode: 29, keyCode: 29, which: 29, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ], code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ], code: BracketRight, keyIdentifier: , keyCode: 29, charCode: 29, keyCode: 29, which: 29, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + ;:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ;, code: Semicolon, keyIdentifier: , keyCode: 59, charCode: 59, keyCode: 59, which: 59, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ;, code: Semicolon, keyIdentifier: , keyCode: 59, charCode: 59, keyCode: 59, which: 59, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + ':
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ', code: Quote, keyIdentifier: , keyCode: 39, charCode: 39, keyCode: 39, which: 39, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ', code: Quote, keyIdentifier: , keyCode: 39, charCode: 39, keyCode: 39, which: 39, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + ,:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ,, code: Comma, keyIdentifier: , keyCode: 44, charCode: 44, keyCode: 44, which: 44, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ,, code: Comma, keyIdentifier: , keyCode: 44, charCode: 44, keyCode: 44, which: 44, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + .:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: UIKeyInputEscape, code: Period, keyIdentifier: Unidentified, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: UIKeyInputEscape, code: Period, keyIdentifier: , keyCode: 46, charCode: 46, keyCode: 46, which: 46, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: UIKeyInputEscape, code: Period, keyIdentifier: Unidentified, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: UIKeyInputEscape, code: Period, keyIdentifier: , keyCode: 46, charCode: 46, keyCode: 46, which: 46, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Control + /:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: /, code: Slash, keyIdentifier: , keyCode: 47, charCode: 47, keyCode: 47, which: 47, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: /, code: Slash, keyIdentifier: , keyCode: 47, charCode: 47, keyCode: 47, which: 47, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-expected.txt
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-expected.txt
@@ -2,151 +2,151 @@ This logs DOM keydown, keyup, keypress events that are dispatched when pressing 
 
 
 Test Command + b:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: b, code: KeyB, keyIdentifier: , keyCode: 98, charCode: 98, keyCode: 98, which: 98, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: b, code: KeyB, keyIdentifier: , keyCode: 98, charCode: 98, keyCode: 98, which: 98, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + c:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: c, code: KeyC, keyIdentifier: , keyCode: 99, charCode: 99, keyCode: 99, which: 99, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: c, code: KeyC, keyIdentifier: , keyCode: 99, charCode: 99, keyCode: 99, which: 99, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + d:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: d, code: KeyD, keyIdentifier: , keyCode: 100, charCode: 100, keyCode: 100, which: 100, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: d, code: KeyD, keyIdentifier: , keyCode: 100, charCode: 100, keyCode: 100, which: 100, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + f:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: f, code: KeyF, keyIdentifier: , keyCode: 102, charCode: 102, keyCode: 102, which: 102, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: f, code: KeyF, keyIdentifier: , keyCode: 102, charCode: 102, keyCode: 102, which: 102, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + g:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: g, code: KeyG, keyIdentifier: , keyCode: 103, charCode: 103, keyCode: 103, which: 103, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: g, code: KeyG, keyIdentifier: , keyCode: 103, charCode: 103, keyCode: 103, which: 103, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + h:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: h, code: KeyH, keyIdentifier: , keyCode: 104, charCode: 104, keyCode: 104, which: 104, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: h, code: KeyH, keyIdentifier: , keyCode: 104, charCode: 104, keyCode: 104, which: 104, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + j:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: j, code: KeyJ, keyIdentifier: , keyCode: 106, charCode: 106, keyCode: 106, which: 106, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: j, code: KeyJ, keyIdentifier: , keyCode: 106, charCode: 106, keyCode: 106, which: 106, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + k:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: k, code: KeyK, keyIdentifier: , keyCode: 107, charCode: 107, keyCode: 107, which: 107, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: k, code: KeyK, keyIdentifier: , keyCode: 107, charCode: 107, keyCode: 107, which: 107, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + m:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: m, code: KeyM, keyIdentifier: , keyCode: 109, charCode: 109, keyCode: 109, which: 109, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: m, code: KeyM, keyIdentifier: , keyCode: 109, charCode: 109, keyCode: 109, which: 109, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + o:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: o, code: KeyO, keyIdentifier: , keyCode: 111, charCode: 111, keyCode: 111, which: 111, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: o, code: KeyO, keyIdentifier: , keyCode: 111, charCode: 111, keyCode: 111, which: 111, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + p:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: p, code: KeyP, keyIdentifier: , keyCode: 112, charCode: 112, keyCode: 112, which: 112, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: p, code: KeyP, keyIdentifier: , keyCode: 112, charCode: 112, keyCode: 112, which: 112, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + q:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: q, code: KeyQ, keyIdentifier: , keyCode: 113, charCode: 113, keyCode: 113, which: 113, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: q, code: KeyQ, keyIdentifier: , keyCode: 113, charCode: 113, keyCode: 113, which: 113, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + s:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: s, code: KeyS, keyIdentifier: , keyCode: 115, charCode: 115, keyCode: 115, which: 115, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: s, code: KeyS, keyIdentifier: , keyCode: 115, charCode: 115, keyCode: 115, which: 115, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + v:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: v, code: KeyV, keyIdentifier: , keyCode: 118, charCode: 118, keyCode: 118, which: 118, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: v, code: KeyV, keyIdentifier: , keyCode: 118, charCode: 118, keyCode: 118, which: 118, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + x:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: x, code: KeyX, keyIdentifier: , keyCode: 120, charCode: 120, keyCode: 120, which: 120, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: x, code: KeyX, keyIdentifier: , keyCode: 120, charCode: 120, keyCode: 120, which: 120, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + y:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: y, code: KeyY, keyIdentifier: , keyCode: 121, charCode: 121, keyCode: 121, which: 121, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: y, code: KeyY, keyIdentifier: , keyCode: 121, charCode: 121, keyCode: 121, which: 121, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + z:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + 0:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: 0, code: Digit0, keyIdentifier: , keyCode: 48, charCode: 48, keyCode: 48, which: 48, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: 0, code: Digit0, keyIdentifier: , keyCode: 48, charCode: 48, keyCode: 48, which: 48, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + -:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: -, code: Minus, keyIdentifier: , keyCode: 45, charCode: 45, keyCode: 45, which: 45, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: -, code: Minus, keyIdentifier: , keyCode: 45, charCode: 45, keyCode: 45, which: 45, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + =:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: =, code: Equal, keyIdentifier: , keyCode: 61, charCode: 61, keyCode: 61, which: 61, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: =, code: Equal, keyIdentifier: , keyCode: 61, charCode: 61, keyCode: 61, which: 61, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + ;:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ;, code: Semicolon, keyIdentifier: , keyCode: 59, charCode: 59, keyCode: 59, which: 59, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ;, code: Semicolon, keyIdentifier: , keyCode: 59, charCode: 59, keyCode: 59, which: 59, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + ':
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ', code: Quote, keyIdentifier: , keyCode: 39, charCode: 39, keyCode: 39, which: 39, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ', code: Quote, keyIdentifier: , keyCode: 39, charCode: 39, keyCode: 39, which: 39, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + ,:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ,, code: Comma, keyIdentifier: , keyCode: 44, charCode: 44, keyCode: 44, which: 44, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ,, code: Comma, keyIdentifier: , keyCode: 44, charCode: 44, keyCode: 44, which: 44, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + .:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Escape, code: Escape, keyIdentifier: U+001B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: Escape, code: Escape, keyIdentifier: , keyCode: 27, charCode: 27, keyCode: 27, which: 27, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Escape, code: Escape, keyIdentifier: U+001B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: Escape, code: Escape, keyIdentifier: , keyCode: 27, charCode: 27, keyCode: 27, which: 27, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + /:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: /, code: Slash, keyIdentifier: , keyCode: 47, charCode: 47, keyCode: 47, which: 47, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: /, code: Slash, keyIdentifier: , keyCode: 47, charCode: 47, keyCode: 47, which: 47, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-option-expected.txt
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-option-expected.txt
@@ -2,306 +2,306 @@ This logs DOM keydown, keyup, keypress events that are dispatched when pressing 
 
 
 Test Command + Option + a:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: å, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: å, code: KeyA, keyIdentifier: , keyCode: 229, charCode: 229, keyCode: 229, which: 229, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: å, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: å, code: KeyA, keyIdentifier: , keyCode: 229, charCode: 229, keyCode: 229, which: 229, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + b:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ∫, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ∫, code: KeyB, keyIdentifier: , keyCode: 8747, charCode: 8747, keyCode: 8747, which: 8747, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ∫, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ∫, code: KeyB, keyIdentifier: , keyCode: 8747, charCode: 8747, keyCode: 8747, which: 8747, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + c:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ç, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ç, code: KeyC, keyIdentifier: , keyCode: 231, charCode: 231, keyCode: 231, which: 231, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ç, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ç, code: KeyC, keyIdentifier: , keyCode: 231, charCode: 231, keyCode: 231, which: 231, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + d:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ∂, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ∂, code: KeyD, keyIdentifier: , keyCode: 8706, charCode: 8706, keyCode: 8706, which: 8706, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ∂, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ∂, code: KeyD, keyIdentifier: , keyCode: 8706, charCode: 8706, keyCode: 8706, which: 8706, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + g:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ©, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ©, code: KeyG, keyIdentifier: , keyCode: 169, charCode: 169, keyCode: 169, which: 169, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ©, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ©, code: KeyG, keyIdentifier: , keyCode: 169, charCode: 169, keyCode: 169, which: 169, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + h:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ˙, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ˙, code: KeyH, keyIdentifier: , keyCode: 729, charCode: 729, keyCode: 729, which: 729, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ˙, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ˙, code: KeyH, keyIdentifier: , keyCode: 729, charCode: 729, keyCode: 729, which: 729, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + j:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ∆, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ∆, code: KeyJ, keyIdentifier: , keyCode: 8710, charCode: 8710, keyCode: 8710, which: 8710, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ∆, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ∆, code: KeyJ, keyIdentifier: , keyCode: 8710, charCode: 8710, keyCode: 8710, which: 8710, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + k:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ˚, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ˚, code: KeyK, keyIdentifier: , keyCode: 730, charCode: 730, keyCode: 730, which: 730, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ˚, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ˚, code: KeyK, keyIdentifier: , keyCode: 730, charCode: 730, keyCode: 730, which: 730, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + l:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ¬, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ¬, code: KeyL, keyIdentifier: , keyCode: 172, charCode: 172, keyCode: 172, which: 172, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ¬, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ¬, code: KeyL, keyIdentifier: , keyCode: 172, charCode: 172, keyCode: 172, which: 172, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + m:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: µ, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: µ, code: KeyM, keyIdentifier: , keyCode: 181, charCode: 181, keyCode: 181, which: 181, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: µ, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: µ, code: KeyM, keyIdentifier: , keyCode: 181, charCode: 181, keyCode: 181, which: 181, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + o:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ø, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ø, code: KeyO, keyIdentifier: , keyCode: 248, charCode: 248, keyCode: 248, which: 248, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ø, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ø, code: KeyO, keyIdentifier: , keyCode: 248, charCode: 248, keyCode: 248, which: 248, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + p:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: π, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: π, code: KeyP, keyIdentifier: , keyCode: 960, charCode: 960, keyCode: 960, which: 960, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: π, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: π, code: KeyP, keyIdentifier: , keyCode: 960, charCode: 960, keyCode: 960, which: 960, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + q:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: œ, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: œ, code: KeyQ, keyIdentifier: , keyCode: 339, charCode: 339, keyCode: 339, which: 339, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: œ, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: œ, code: KeyQ, keyIdentifier: , keyCode: 339, charCode: 339, keyCode: 339, which: 339, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + s:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ß, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ß, code: KeyS, keyIdentifier: , keyCode: 223, charCode: 223, keyCode: 223, which: 223, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ß, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ß, code: KeyS, keyIdentifier: , keyCode: 223, charCode: 223, keyCode: 223, which: 223, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + t:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: †, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: †, code: KeyT, keyIdentifier: , keyCode: 8224, charCode: 8224, keyCode: 8224, which: 8224, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: †, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: †, code: KeyT, keyIdentifier: , keyCode: 8224, charCode: 8224, keyCode: 8224, which: 8224, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + v:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: √, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: √, code: KeyV, keyIdentifier: , keyCode: 8730, charCode: 8730, keyCode: 8730, which: 8730, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: √, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: √, code: KeyV, keyIdentifier: , keyCode: 8730, charCode: 8730, keyCode: 8730, which: 8730, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + x:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ≈, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ≈, code: KeyX, keyIdentifier: , keyCode: 8776, charCode: 8776, keyCode: 8776, which: 8776, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ≈, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ≈, code: KeyX, keyIdentifier: , keyCode: 8776, charCode: 8776, keyCode: 8776, which: 8776, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + y:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ¥, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ¥, code: KeyY, keyIdentifier: , keyCode: 165, charCode: 165, keyCode: 165, which: 165, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ¥, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ¥, code: KeyY, keyIdentifier: , keyCode: 165, charCode: 165, keyCode: 165, which: 165, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + z:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Ω, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: Ω, code: KeyZ, keyIdentifier: , keyCode: 937, charCode: 937, keyCode: 937, which: 937, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Ω, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: Ω, code: KeyZ, keyIdentifier: , keyCode: 937, charCode: 937, keyCode: 937, which: 937, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + 0:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: º, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: º, code: Digit0, keyIdentifier: , keyCode: 186, charCode: 186, keyCode: 186, which: 186, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: º, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: º, code: Digit0, keyIdentifier: , keyCode: 186, charCode: 186, keyCode: 186, which: 186, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + 1:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ¡, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ¡, code: Digit1, keyIdentifier: , keyCode: 161, charCode: 161, keyCode: 161, which: 161, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ¡, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ¡, code: Digit1, keyIdentifier: , keyCode: 161, charCode: 161, keyCode: 161, which: 161, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + 2:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ™, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ™, code: Digit2, keyIdentifier: , keyCode: 8482, charCode: 8482, keyCode: 8482, which: 8482, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ™, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ™, code: Digit2, keyIdentifier: , keyCode: 8482, charCode: 8482, keyCode: 8482, which: 8482, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + 3:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: £, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: £, code: Digit3, keyIdentifier: , keyCode: 163, charCode: 163, keyCode: 163, which: 163, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: £, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: £, code: Digit3, keyIdentifier: , keyCode: 163, charCode: 163, keyCode: 163, which: 163, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + 4:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ¢, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ¢, code: Digit4, keyIdentifier: , keyCode: 162, charCode: 162, keyCode: 162, which: 162, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ¢, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ¢, code: Digit4, keyIdentifier: , keyCode: 162, charCode: 162, keyCode: 162, which: 162, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + 5:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ∞, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ∞, code: Digit5, keyIdentifier: , keyCode: 8734, charCode: 8734, keyCode: 8734, which: 8734, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ∞, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ∞, code: Digit5, keyIdentifier: , keyCode: 8734, charCode: 8734, keyCode: 8734, which: 8734, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + 6:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: §, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: §, code: Digit6, keyIdentifier: , keyCode: 167, charCode: 167, keyCode: 167, which: 167, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: §, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: §, code: Digit6, keyIdentifier: , keyCode: 167, charCode: 167, keyCode: 167, which: 167, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + 7:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ¶, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ¶, code: Digit7, keyIdentifier: , keyCode: 182, charCode: 182, keyCode: 182, which: 182, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ¶, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ¶, code: Digit7, keyIdentifier: , keyCode: 182, charCode: 182, keyCode: 182, which: 182, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + 8:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: •, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: •, code: Digit8, keyIdentifier: , keyCode: 8226, charCode: 8226, keyCode: 8226, which: 8226, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: •, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: •, code: Digit8, keyIdentifier: , keyCode: 8226, charCode: 8226, keyCode: 8226, which: 8226, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + 9:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ª, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ª, code: Digit9, keyIdentifier: , keyCode: 170, charCode: 170, keyCode: 170, which: 170, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ª, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ª, code: Digit9, keyIdentifier: , keyCode: 170, charCode: 170, keyCode: 170, which: 170, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + -:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: –, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: –, code: Minus, keyIdentifier: , keyCode: 8211, charCode: 8211, keyCode: 8211, which: 8211, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: –, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: –, code: Minus, keyIdentifier: , keyCode: 8211, charCode: 8211, keyCode: 8211, which: 8211, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + =:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ≠, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ≠, code: Equal, keyIdentifier: , keyCode: 8800, charCode: 8800, keyCode: 8800, which: 8800, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ≠, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ≠, code: Equal, keyIdentifier: , keyCode: 8800, charCode: 8800, keyCode: 8800, which: 8800, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + [:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: “, code: BracketLeft, keyIdentifier: U+005B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: “, code: BracketLeft, keyIdentifier: , keyCode: 8220, charCode: 8220, keyCode: 8220, which: 8220, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: “, code: BracketLeft, keyIdentifier: U+005B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: “, code: BracketLeft, keyIdentifier: , keyCode: 8220, charCode: 8220, keyCode: 8220, which: 8220, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + ]:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ‘, code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ‘, code: BracketRight, keyIdentifier: , keyCode: 8216, charCode: 8216, keyCode: 8216, which: 8216, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ‘, code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ‘, code: BracketRight, keyIdentifier: , keyCode: 8216, charCode: 8216, keyCode: 8216, which: 8216, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + ;:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: …, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: …, code: Semicolon, keyIdentifier: , keyCode: 8230, charCode: 8230, keyCode: 8230, which: 8230, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: …, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: …, code: Semicolon, keyIdentifier: , keyCode: 8230, charCode: 8230, keyCode: 8230, which: 8230, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + ':
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: æ, code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: æ, code: Quote, keyIdentifier: , keyCode: 230, charCode: 230, keyCode: 230, which: 230, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: æ, code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: æ, code: Quote, keyIdentifier: , keyCode: 230, charCode: 230, keyCode: 230, which: 230, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + ,:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ≤, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ≤, code: Comma, keyIdentifier: , keyCode: 8804, charCode: 8804, keyCode: 8804, which: 8804, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ≤, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ≤, code: Comma, keyIdentifier: , keyCode: 8804, charCode: 8804, keyCode: 8804, which: 8804, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + .:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ≥, code: Period, keyIdentifier: Unidentified, keyCode: 85, charCode: 0, keyCode: 85, which: 85, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ≥, code: Period, keyIdentifier: , keyCode: 8805, charCode: 8805, keyCode: 8805, which: 8805, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ≥, code: Period, keyIdentifier: Unidentified, keyCode: 85, charCode: 0, keyCode: 85, which: 85, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ≥, code: Period, keyIdentifier: , keyCode: 8805, charCode: 8805, keyCode: 8805, which: 8805, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Option + /:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ÷, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ÷, code: Slash, keyIdentifier: , keyCode: 247, charCode: 247, keyCode: 247, which: 247, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ÷, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ÷, code: Slash, keyIdentifier: , keyCode: 247, charCode: 247, keyCode: 247, which: 247, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-shift-expected.txt
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-shift-expected.txt
@@ -2,321 +2,321 @@ This logs DOM keydown, keyup, keypress events that are dispatched when pressing 
 
 
 Test Command + Shift + a:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: a, code: KeyA, keyIdentifier: , keyCode: 97, charCode: 97, keyCode: 97, which: 97, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: a, code: KeyA, keyIdentifier: , keyCode: 97, charCode: 97, keyCode: 97, which: 97, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + b:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: b, code: KeyB, keyIdentifier: , keyCode: 98, charCode: 98, keyCode: 98, which: 98, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: b, code: KeyB, keyIdentifier: , keyCode: 98, charCode: 98, keyCode: 98, which: 98, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + c:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: c, code: KeyC, keyIdentifier: , keyCode: 99, charCode: 99, keyCode: 99, which: 99, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: c, code: KeyC, keyIdentifier: , keyCode: 99, charCode: 99, keyCode: 99, which: 99, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + d:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: d, code: KeyD, keyIdentifier: , keyCode: 100, charCode: 100, keyCode: 100, which: 100, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: d, code: KeyD, keyIdentifier: , keyCode: 100, charCode: 100, keyCode: 100, which: 100, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + f:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: f, code: KeyF, keyIdentifier: , keyCode: 102, charCode: 102, keyCode: 102, which: 102, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: f, code: KeyF, keyIdentifier: , keyCode: 102, charCode: 102, keyCode: 102, which: 102, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + g:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: g, code: KeyG, keyIdentifier: , keyCode: 103, charCode: 103, keyCode: 103, which: 103, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: g, code: KeyG, keyIdentifier: , keyCode: 103, charCode: 103, keyCode: 103, which: 103, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + h:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: h, code: KeyH, keyIdentifier: , keyCode: 104, charCode: 104, keyCode: 104, which: 104, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: h, code: KeyH, keyIdentifier: , keyCode: 104, charCode: 104, keyCode: 104, which: 104, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + j:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: j, code: KeyJ, keyIdentifier: , keyCode: 106, charCode: 106, keyCode: 106, which: 106, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: j, code: KeyJ, keyIdentifier: , keyCode: 106, charCode: 106, keyCode: 106, which: 106, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + k:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: k, code: KeyK, keyIdentifier: , keyCode: 107, charCode: 107, keyCode: 107, which: 107, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: k, code: KeyK, keyIdentifier: , keyCode: 107, charCode: 107, keyCode: 107, which: 107, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + l:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: l, code: KeyL, keyIdentifier: , keyCode: 108, charCode: 108, keyCode: 108, which: 108, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: l, code: KeyL, keyIdentifier: , keyCode: 108, charCode: 108, keyCode: 108, which: 108, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + m:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: m, code: KeyM, keyIdentifier: , keyCode: 109, charCode: 109, keyCode: 109, which: 109, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: m, code: KeyM, keyIdentifier: , keyCode: 109, charCode: 109, keyCode: 109, which: 109, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + o:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: o, code: KeyO, keyIdentifier: , keyCode: 111, charCode: 111, keyCode: 111, which: 111, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: o, code: KeyO, keyIdentifier: , keyCode: 111, charCode: 111, keyCode: 111, which: 111, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + p:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: p, code: KeyP, keyIdentifier: , keyCode: 112, charCode: 112, keyCode: 112, which: 112, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: p, code: KeyP, keyIdentifier: , keyCode: 112, charCode: 112, keyCode: 112, which: 112, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + q:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: q, code: KeyQ, keyIdentifier: , keyCode: 113, charCode: 113, keyCode: 113, which: 113, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: q, code: KeyQ, keyIdentifier: , keyCode: 113, charCode: 113, keyCode: 113, which: 113, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + r:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: r, code: KeyR, keyIdentifier: , keyCode: 114, charCode: 114, keyCode: 114, which: 114, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: r, code: KeyR, keyIdentifier: , keyCode: 114, charCode: 114, keyCode: 114, which: 114, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + s:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: s, code: KeyS, keyIdentifier: , keyCode: 115, charCode: 115, keyCode: 115, which: 115, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: s, code: KeyS, keyIdentifier: , keyCode: 115, charCode: 115, keyCode: 115, which: 115, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + t:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: t, code: KeyT, keyIdentifier: , keyCode: 116, charCode: 116, keyCode: 116, which: 116, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: t, code: KeyT, keyIdentifier: , keyCode: 116, charCode: 116, keyCode: 116, which: 116, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + v:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: v, code: KeyV, keyIdentifier: , keyCode: 118, charCode: 118, keyCode: 118, which: 118, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: v, code: KeyV, keyIdentifier: , keyCode: 118, charCode: 118, keyCode: 118, which: 118, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + w:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: w, code: KeyW, keyIdentifier: , keyCode: 119, charCode: 119, keyCode: 119, which: 119, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: w, code: KeyW, keyIdentifier: , keyCode: 119, charCode: 119, keyCode: 119, which: 119, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + x:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: x, code: KeyX, keyIdentifier: , keyCode: 120, charCode: 120, keyCode: 120, which: 120, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: x, code: KeyX, keyIdentifier: , keyCode: 120, charCode: 120, keyCode: 120, which: 120, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + y:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: y, code: KeyY, keyIdentifier: , keyCode: 121, charCode: 121, keyCode: 121, which: 121, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: y, code: KeyY, keyIdentifier: , keyCode: 121, charCode: 121, keyCode: 121, which: 121, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + z:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + 0:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: 0, code: Digit0, keyIdentifier: U+0029, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: 0, code: Digit0, keyIdentifier: , keyCode: 48, charCode: 48, keyCode: 48, which: 48, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: 0, code: Digit0, keyIdentifier: U+0029, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: 0, code: Digit0, keyIdentifier: , keyCode: 48, charCode: 48, keyCode: 48, which: 48, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + 1:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: 1, code: Digit1, keyIdentifier: U+0021, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: 1, code: Digit1, keyIdentifier: , keyCode: 49, charCode: 49, keyCode: 49, which: 49, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: 1, code: Digit1, keyIdentifier: U+0021, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: 1, code: Digit1, keyIdentifier: , keyCode: 49, charCode: 49, keyCode: 49, which: 49, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + 2:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: 2, code: Digit2, keyIdentifier: U+0040, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: 2, code: Digit2, keyIdentifier: , keyCode: 50, charCode: 50, keyCode: 50, which: 50, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: 2, code: Digit2, keyIdentifier: U+0040, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: 2, code: Digit2, keyIdentifier: , keyCode: 50, charCode: 50, keyCode: 50, which: 50, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + 3:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: 3, code: Digit3, keyIdentifier: U+0023, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: 3, code: Digit3, keyIdentifier: , keyCode: 51, charCode: 51, keyCode: 51, which: 51, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: 3, code: Digit3, keyIdentifier: U+0023, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: 3, code: Digit3, keyIdentifier: , keyCode: 51, charCode: 51, keyCode: 51, which: 51, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + 4:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: 4, code: Digit4, keyIdentifier: U+0024, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: 4, code: Digit4, keyIdentifier: , keyCode: 52, charCode: 52, keyCode: 52, which: 52, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: 4, code: Digit4, keyIdentifier: U+0024, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: 4, code: Digit4, keyIdentifier: , keyCode: 52, charCode: 52, keyCode: 52, which: 52, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + 5:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: 5, code: Digit5, keyIdentifier: U+0025, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: 5, code: Digit5, keyIdentifier: , keyCode: 53, charCode: 53, keyCode: 53, which: 53, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: 5, code: Digit5, keyIdentifier: U+0025, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: 5, code: Digit5, keyIdentifier: , keyCode: 53, charCode: 53, keyCode: 53, which: 53, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + 6:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: 6, code: Digit6, keyIdentifier: U+005E, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: 6, code: Digit6, keyIdentifier: , keyCode: 54, charCode: 54, keyCode: 54, which: 54, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: 6, code: Digit6, keyIdentifier: U+005E, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: 6, code: Digit6, keyIdentifier: , keyCode: 54, charCode: 54, keyCode: 54, which: 54, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + 7:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: 7, code: Digit7, keyIdentifier: U+0026, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: 7, code: Digit7, keyIdentifier: , keyCode: 55, charCode: 55, keyCode: 55, which: 55, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: 7, code: Digit7, keyIdentifier: U+0026, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: 7, code: Digit7, keyIdentifier: , keyCode: 55, charCode: 55, keyCode: 55, which: 55, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + 8:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: 8, code: Digit8, keyIdentifier: U+002A, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: 8, code: Digit8, keyIdentifier: , keyCode: 56, charCode: 56, keyCode: 56, which: 56, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: 8, code: Digit8, keyIdentifier: U+002A, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: 8, code: Digit8, keyIdentifier: , keyCode: 56, charCode: 56, keyCode: 56, which: 56, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + 9:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: 9, code: Digit9, keyIdentifier: U+0028, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: 9, code: Digit9, keyIdentifier: , keyCode: 57, charCode: 57, keyCode: 57, which: 57, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: 9, code: Digit9, keyIdentifier: U+0028, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: 9, code: Digit9, keyIdentifier: , keyCode: 57, charCode: 57, keyCode: 57, which: 57, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + -:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: -, code: Minus, keyIdentifier: U+005F, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: -, code: Minus, keyIdentifier: , keyCode: 45, charCode: 45, keyCode: 45, which: 45, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: -, code: Minus, keyIdentifier: U+005F, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: -, code: Minus, keyIdentifier: , keyCode: 45, charCode: 45, keyCode: 45, which: 45, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + =:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: =, code: Equal, keyIdentifier: U+002B, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: =, code: Equal, keyIdentifier: , keyCode: 61, charCode: 61, keyCode: 61, which: 61, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: =, code: Equal, keyIdentifier: U+002B, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: =, code: Equal, keyIdentifier: , keyCode: 61, charCode: 61, keyCode: 61, which: 61, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + [:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: [, code: BracketLeft, keyIdentifier: U+007B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: [, code: BracketLeft, keyIdentifier: , keyCode: 91, charCode: 91, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: [, code: BracketLeft, keyIdentifier: U+007B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: [, code: BracketLeft, keyIdentifier: , keyCode: 91, charCode: 91, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + ]:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ], code: BracketRight, keyIdentifier: U+007D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ], code: BracketRight, keyIdentifier: , keyCode: 93, charCode: 93, keyCode: 93, which: 93, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ], code: BracketRight, keyIdentifier: U+007D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ], code: BracketRight, keyIdentifier: , keyCode: 93, charCode: 93, keyCode: 93, which: 93, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + ;:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ;, code: Semicolon, keyIdentifier: U+003A, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ;, code: Semicolon, keyIdentifier: , keyCode: 59, charCode: 59, keyCode: 59, which: 59, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ;, code: Semicolon, keyIdentifier: U+003A, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ;, code: Semicolon, keyIdentifier: , keyCode: 59, charCode: 59, keyCode: 59, which: 59, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + ':
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ', code: Quote, keyIdentifier: U+0022, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ', code: Quote, keyIdentifier: , keyCode: 39, charCode: 39, keyCode: 39, which: 39, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ', code: Quote, keyIdentifier: U+0022, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ', code: Quote, keyIdentifier: , keyCode: 39, charCode: 39, keyCode: 39, which: 39, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + ,:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ,, code: Comma, keyIdentifier: U+003C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ,, code: Comma, keyIdentifier: , keyCode: 44, charCode: 44, keyCode: 44, which: 44, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ,, code: Comma, keyIdentifier: U+003C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ,, code: Comma, keyIdentifier: , keyCode: 44, charCode: 44, keyCode: 44, which: 44, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + Shift + .:
-type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ., code: Period, keyIdentifier: U+003E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ., code: Period, keyIdentifier: , keyCode: 46, charCode: 46, keyCode: 46, which: 46, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ., code: Period, keyIdentifier: U+003E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ., code: Period, keyIdentifier: , keyCode: 46, charCode: 46, keyCode: 46, which: 46, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-option-expected.txt
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-option-expected.txt
@@ -2,289 +2,289 @@ This logs DOM keydown, keyup, keypress events that are dispatched when pressing 
 
 
 Test Option + a:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: å, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: å, code: KeyA, keyIdentifier: , keyCode: 229, charCode: 229, keyCode: 229, which: 229, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: å, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: å, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: å, code: KeyA, keyIdentifier: , keyCode: 229, charCode: 229, keyCode: 229, which: 229, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: å, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + b:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ∫, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ∫, code: KeyB, keyIdentifier: , keyCode: 8747, charCode: 8747, keyCode: 8747, which: 8747, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ∫, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ∫, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ∫, code: KeyB, keyIdentifier: , keyCode: 8747, charCode: 8747, keyCode: 8747, which: 8747, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ∫, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + c:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ç, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ç, code: KeyC, keyIdentifier: , keyCode: 231, charCode: 231, keyCode: 231, which: 231, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ç, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ç, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ç, code: KeyC, keyIdentifier: , keyCode: 231, charCode: 231, keyCode: 231, which: 231, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ç, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + d:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ∂, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ∂, code: KeyD, keyIdentifier: , keyCode: 8706, charCode: 8706, keyCode: 8706, which: 8706, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ∂, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ∂, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ∂, code: KeyD, keyIdentifier: , keyCode: 8706, charCode: 8706, keyCode: 8706, which: 8706, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ∂, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + f:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ƒ, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ƒ, code: KeyF, keyIdentifier: , keyCode: 402, charCode: 402, keyCode: 402, which: 402, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ƒ, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ƒ, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ƒ, code: KeyF, keyIdentifier: , keyCode: 402, charCode: 402, keyCode: 402, which: 402, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ƒ, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + g:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ©, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ©, code: KeyG, keyIdentifier: , keyCode: 169, charCode: 169, keyCode: 169, which: 169, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ©, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ©, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ©, code: KeyG, keyIdentifier: , keyCode: 169, charCode: 169, keyCode: 169, which: 169, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ©, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + h:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ˙, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ˙, code: KeyH, keyIdentifier: , keyCode: 729, charCode: 729, keyCode: 729, which: 729, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ˙, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ˙, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ˙, code: KeyH, keyIdentifier: , keyCode: 729, charCode: 729, keyCode: 729, which: 729, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ˙, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + j:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ∆, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ∆, code: KeyJ, keyIdentifier: , keyCode: 8710, charCode: 8710, keyCode: 8710, which: 8710, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ∆, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ∆, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ∆, code: KeyJ, keyIdentifier: , keyCode: 8710, charCode: 8710, keyCode: 8710, which: 8710, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ∆, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + k:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ˚, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ˚, code: KeyK, keyIdentifier: , keyCode: 730, charCode: 730, keyCode: 730, which: 730, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ˚, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ˚, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ˚, code: KeyK, keyIdentifier: , keyCode: 730, charCode: 730, keyCode: 730, which: 730, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ˚, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + l:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ¬, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ¬, code: KeyL, keyIdentifier: , keyCode: 172, charCode: 172, keyCode: 172, which: 172, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ¬, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ¬, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ¬, code: KeyL, keyIdentifier: , keyCode: 172, charCode: 172, keyCode: 172, which: 172, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ¬, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + m:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: µ, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: µ, code: KeyM, keyIdentifier: , keyCode: 181, charCode: 181, keyCode: 181, which: 181, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: µ, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: µ, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: µ, code: KeyM, keyIdentifier: , keyCode: 181, charCode: 181, keyCode: 181, which: 181, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: µ, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + o:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ø, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ø, code: KeyO, keyIdentifier: , keyCode: 248, charCode: 248, keyCode: 248, which: 248, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ø, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ø, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ø, code: KeyO, keyIdentifier: , keyCode: 248, charCode: 248, keyCode: 248, which: 248, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ø, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + p:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: π, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: π, code: KeyP, keyIdentifier: , keyCode: 960, charCode: 960, keyCode: 960, which: 960, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: π, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: π, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: π, code: KeyP, keyIdentifier: , keyCode: 960, charCode: 960, keyCode: 960, which: 960, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: π, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + q:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: œ, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: œ, code: KeyQ, keyIdentifier: , keyCode: 339, charCode: 339, keyCode: 339, which: 339, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: œ, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: œ, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: œ, code: KeyQ, keyIdentifier: , keyCode: 339, charCode: 339, keyCode: 339, which: 339, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: œ, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + r:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ®, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ®, code: KeyR, keyIdentifier: , keyCode: 174, charCode: 174, keyCode: 174, which: 174, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ®, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ®, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ®, code: KeyR, keyIdentifier: , keyCode: 174, charCode: 174, keyCode: 174, which: 174, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ®, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + s:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ß, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ß, code: KeyS, keyIdentifier: , keyCode: 223, charCode: 223, keyCode: 223, which: 223, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ß, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ß, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ß, code: KeyS, keyIdentifier: , keyCode: 223, charCode: 223, keyCode: 223, which: 223, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ß, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + t:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: †, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: †, code: KeyT, keyIdentifier: , keyCode: 8224, charCode: 8224, keyCode: 8224, which: 8224, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: †, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: †, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: †, code: KeyT, keyIdentifier: , keyCode: 8224, charCode: 8224, keyCode: 8224, which: 8224, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: †, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + v:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: √, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: √, code: KeyV, keyIdentifier: , keyCode: 8730, charCode: 8730, keyCode: 8730, which: 8730, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: √, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: √, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: √, code: KeyV, keyIdentifier: , keyCode: 8730, charCode: 8730, keyCode: 8730, which: 8730, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: √, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + w:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ∑, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ∑, code: KeyW, keyIdentifier: , keyCode: 8721, charCode: 8721, keyCode: 8721, which: 8721, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ∑, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ∑, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ∑, code: KeyW, keyIdentifier: , keyCode: 8721, charCode: 8721, keyCode: 8721, which: 8721, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ∑, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + x:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ≈, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ≈, code: KeyX, keyIdentifier: , keyCode: 8776, charCode: 8776, keyCode: 8776, which: 8776, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ≈, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ≈, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ≈, code: KeyX, keyIdentifier: , keyCode: 8776, charCode: 8776, keyCode: 8776, which: 8776, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ≈, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + y:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ¥, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ¥, code: KeyY, keyIdentifier: , keyCode: 165, charCode: 165, keyCode: 165, which: 165, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ¥, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ¥, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ¥, code: KeyY, keyIdentifier: , keyCode: 165, charCode: 165, keyCode: 165, which: 165, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ¥, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + z:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Ω, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: Ω, code: KeyZ, keyIdentifier: , keyCode: 937, charCode: 937, keyCode: 937, which: 937, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Ω, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Ω, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: Ω, code: KeyZ, keyIdentifier: , keyCode: 937, charCode: 937, keyCode: 937, which: 937, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Ω, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + 0:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: º, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: º, code: Digit0, keyIdentifier: , keyCode: 186, charCode: 186, keyCode: 186, which: 186, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: º, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: º, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: º, code: Digit0, keyIdentifier: , keyCode: 186, charCode: 186, keyCode: 186, which: 186, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: º, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + 1:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ¡, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ¡, code: Digit1, keyIdentifier: , keyCode: 161, charCode: 161, keyCode: 161, which: 161, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ¡, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ¡, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ¡, code: Digit1, keyIdentifier: , keyCode: 161, charCode: 161, keyCode: 161, which: 161, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ¡, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + 2:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ™, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ™, code: Digit2, keyIdentifier: , keyCode: 8482, charCode: 8482, keyCode: 8482, which: 8482, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ™, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ™, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ™, code: Digit2, keyIdentifier: , keyCode: 8482, charCode: 8482, keyCode: 8482, which: 8482, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ™, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + 3:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: £, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: £, code: Digit3, keyIdentifier: , keyCode: 163, charCode: 163, keyCode: 163, which: 163, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: £, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: £, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: £, code: Digit3, keyIdentifier: , keyCode: 163, charCode: 163, keyCode: 163, which: 163, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: £, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + 4:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ¢, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ¢, code: Digit4, keyIdentifier: , keyCode: 162, charCode: 162, keyCode: 162, which: 162, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ¢, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ¢, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ¢, code: Digit4, keyIdentifier: , keyCode: 162, charCode: 162, keyCode: 162, which: 162, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ¢, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + 5:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ∞, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ∞, code: Digit5, keyIdentifier: , keyCode: 8734, charCode: 8734, keyCode: 8734, which: 8734, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ∞, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ∞, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ∞, code: Digit5, keyIdentifier: , keyCode: 8734, charCode: 8734, keyCode: 8734, which: 8734, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ∞, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + 6:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: §, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: §, code: Digit6, keyIdentifier: , keyCode: 167, charCode: 167, keyCode: 167, which: 167, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: §, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: §, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: §, code: Digit6, keyIdentifier: , keyCode: 167, charCode: 167, keyCode: 167, which: 167, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: §, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + 7:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ¶, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ¶, code: Digit7, keyIdentifier: , keyCode: 182, charCode: 182, keyCode: 182, which: 182, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ¶, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ¶, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ¶, code: Digit7, keyIdentifier: , keyCode: 182, charCode: 182, keyCode: 182, which: 182, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ¶, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + 8:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: •, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: •, code: Digit8, keyIdentifier: , keyCode: 8226, charCode: 8226, keyCode: 8226, which: 8226, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: •, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: •, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: •, code: Digit8, keyIdentifier: , keyCode: 8226, charCode: 8226, keyCode: 8226, which: 8226, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: •, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + 9:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ª, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ª, code: Digit9, keyIdentifier: , keyCode: 170, charCode: 170, keyCode: 170, which: 170, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ª, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ª, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ª, code: Digit9, keyIdentifier: , keyCode: 170, charCode: 170, keyCode: 170, which: 170, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ª, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + -:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: –, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: –, code: Minus, keyIdentifier: , keyCode: 8211, charCode: 8211, keyCode: 8211, which: 8211, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: –, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: –, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: –, code: Minus, keyIdentifier: , keyCode: 8211, charCode: 8211, keyCode: 8211, which: 8211, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: –, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + =:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ≠, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ≠, code: Equal, keyIdentifier: , keyCode: 8800, charCode: 8800, keyCode: 8800, which: 8800, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ≠, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ≠, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ≠, code: Equal, keyIdentifier: , keyCode: 8800, charCode: 8800, keyCode: 8800, which: 8800, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ≠, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + [:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: “, code: BracketLeft, keyIdentifier: U+005B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: “, code: BracketLeft, keyIdentifier: , keyCode: 8220, charCode: 8220, keyCode: 8220, which: 8220, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: “, code: BracketLeft, keyIdentifier: U+005B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: “, code: BracketLeft, keyIdentifier: U+005B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: “, code: BracketLeft, keyIdentifier: , keyCode: 8220, charCode: 8220, keyCode: 8220, which: 8220, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: “, code: BracketLeft, keyIdentifier: U+005B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + ]:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ‘, code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ‘, code: BracketRight, keyIdentifier: , keyCode: 8216, charCode: 8216, keyCode: 8216, which: 8216, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ‘, code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ‘, code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ‘, code: BracketRight, keyIdentifier: , keyCode: 8216, charCode: 8216, keyCode: 8216, which: 8216, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ‘, code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + ;:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: …, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: …, code: Semicolon, keyIdentifier: , keyCode: 8230, charCode: 8230, keyCode: 8230, which: 8230, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: …, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: …, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: …, code: Semicolon, keyIdentifier: , keyCode: 8230, charCode: 8230, keyCode: 8230, which: 8230, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: …, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + ':
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: æ, code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: æ, code: Quote, keyIdentifier: , keyCode: 230, charCode: 230, keyCode: 230, which: 230, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: æ, code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: æ, code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: æ, code: Quote, keyIdentifier: , keyCode: 230, charCode: 230, keyCode: 230, which: 230, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: æ, code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + ,:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ≤, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ≤, code: Comma, keyIdentifier: , keyCode: 8804, charCode: 8804, keyCode: 8804, which: 8804, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ≤, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ≤, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ≤, code: Comma, keyIdentifier: , keyCode: 8804, charCode: 8804, keyCode: 8804, which: 8804, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ≤, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + .:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ≥, code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ≥, code: Period, keyIdentifier: , keyCode: 8805, charCode: 8805, keyCode: 8805, which: 8805, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ≥, code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ≥, code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ≥, code: Period, keyIdentifier: , keyCode: 8805, charCode: 8805, keyCode: 8805, which: 8805, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ≥, code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + /:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: ÷, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keypress, key: ÷, code: Slash, keyIdentifier: , keyCode: 247, charCode: 247, keyCode: 247, which: 247, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: ÷, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: 0
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: ÷, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keypress, key: ÷, code: Slash, keyIdentifier: , keyCode: 247, charCode: 247, keyCode: 247, which: 247, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: ÷, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-option-shift-expected.txt
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-option-shift-expected.txt
@@ -2,371 +2,371 @@ This logs DOM keydown, keyup, keypress events that are dispatched when pressing 
 
 
 Test Option + Shift + a:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Å, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Å, code: KeyA, keyIdentifier: , keyCode: 197, charCode: 197, keyCode: 197, which: 197, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Å, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Å, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Å, code: KeyA, keyIdentifier: , keyCode: 197, charCode: 197, keyCode: 197, which: 197, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Å, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + b:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ı, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ı, code: KeyB, keyIdentifier: , keyCode: 305, charCode: 305, keyCode: 305, which: 305, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ı, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ı, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ı, code: KeyB, keyIdentifier: , keyCode: 305, charCode: 305, keyCode: 305, which: 305, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ı, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + c:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Ç, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Ç, code: KeyC, keyIdentifier: , keyCode: 199, charCode: 199, keyCode: 199, which: 199, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Ç, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Ç, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Ç, code: KeyC, keyIdentifier: , keyCode: 199, charCode: 199, keyCode: 199, which: 199, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Ç, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + d:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Î, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Î, code: KeyD, keyIdentifier: , keyCode: 206, charCode: 206, keyCode: 206, which: 206, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Î, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Î, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Î, code: KeyD, keyIdentifier: , keyCode: 206, charCode: 206, keyCode: 206, which: 206, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Î, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + f:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Ï, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Ï, code: KeyF, keyIdentifier: , keyCode: 207, charCode: 207, keyCode: 207, which: 207, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Ï, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Ï, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Ï, code: KeyF, keyIdentifier: , keyCode: 207, charCode: 207, keyCode: 207, which: 207, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Ï, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + g:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ˝, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ˝, code: KeyG, keyIdentifier: , keyCode: 733, charCode: 733, keyCode: 733, which: 733, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ˝, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ˝, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ˝, code: KeyG, keyIdentifier: , keyCode: 733, charCode: 733, keyCode: 733, which: 733, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ˝, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + h:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Ó, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Ó, code: KeyH, keyIdentifier: , keyCode: 211, charCode: 211, keyCode: 211, which: 211, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Ó, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Ó, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Ó, code: KeyH, keyIdentifier: , keyCode: 211, charCode: 211, keyCode: 211, which: 211, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Ó, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + j:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Ô, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Ô, code: KeyJ, keyIdentifier: , keyCode: 212, charCode: 212, keyCode: 212, which: 212, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Ô, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Ô, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Ô, code: KeyJ, keyIdentifier: , keyCode: 212, charCode: 212, keyCode: 212, which: 212, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Ô, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + k:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: , code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: , code: KeyK, keyIdentifier: , keyCode: 63743, charCode: 63743, keyCode: 63743, which: 63743, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: , code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: , code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: , code: KeyK, keyIdentifier: , keyCode: 63743, charCode: 63743, keyCode: 63743, which: 63743, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: , code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + l:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Ò, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Ò, code: KeyL, keyIdentifier: , keyCode: 210, charCode: 210, keyCode: 210, which: 210, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Ò, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Ò, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Ò, code: KeyL, keyIdentifier: , keyCode: 210, charCode: 210, keyCode: 210, which: 210, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Ò, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + m:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Â, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Â, code: KeyM, keyIdentifier: , keyCode: 194, charCode: 194, keyCode: 194, which: 194, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Â, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Â, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Â, code: KeyM, keyIdentifier: , keyCode: 194, charCode: 194, keyCode: 194, which: 194, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Â, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + o:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Ø, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Ø, code: KeyO, keyIdentifier: , keyCode: 216, charCode: 216, keyCode: 216, which: 216, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Ø, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Ø, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Ø, code: KeyO, keyIdentifier: , keyCode: 216, charCode: 216, keyCode: 216, which: 216, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Ø, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + p:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ∏, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ∏, code: KeyP, keyIdentifier: , keyCode: 8719, charCode: 8719, keyCode: 8719, which: 8719, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ∏, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ∏, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ∏, code: KeyP, keyIdentifier: , keyCode: 8719, charCode: 8719, keyCode: 8719, which: 8719, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ∏, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + q:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Œ, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Œ, code: KeyQ, keyIdentifier: , keyCode: 338, charCode: 338, keyCode: 338, which: 338, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Œ, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Œ, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Œ, code: KeyQ, keyIdentifier: , keyCode: 338, charCode: 338, keyCode: 338, which: 338, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Œ, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + r:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ‰, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ‰, code: KeyR, keyIdentifier: , keyCode: 8240, charCode: 8240, keyCode: 8240, which: 8240, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ‰, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ‰, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ‰, code: KeyR, keyIdentifier: , keyCode: 8240, charCode: 8240, keyCode: 8240, which: 8240, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ‰, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + s:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Í, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Í, code: KeyS, keyIdentifier: , keyCode: 205, charCode: 205, keyCode: 205, which: 205, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Í, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Í, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Í, code: KeyS, keyIdentifier: , keyCode: 205, charCode: 205, keyCode: 205, which: 205, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Í, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + t:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ˇ, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ˇ, code: KeyT, keyIdentifier: , keyCode: 711, charCode: 711, keyCode: 711, which: 711, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ˇ, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ˇ, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ˇ, code: KeyT, keyIdentifier: , keyCode: 711, charCode: 711, keyCode: 711, which: 711, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ˇ, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + v:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ◊, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ◊, code: KeyV, keyIdentifier: , keyCode: 9674, charCode: 9674, keyCode: 9674, which: 9674, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ◊, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ◊, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ◊, code: KeyV, keyIdentifier: , keyCode: 9674, charCode: 9674, keyCode: 9674, which: 9674, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ◊, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + w:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: „, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: „, code: KeyW, keyIdentifier: , keyCode: 8222, charCode: 8222, keyCode: 8222, which: 8222, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: „, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: „, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: „, code: KeyW, keyIdentifier: , keyCode: 8222, charCode: 8222, keyCode: 8222, which: 8222, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: „, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + x:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ˛, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ˛, code: KeyX, keyIdentifier: , keyCode: 731, charCode: 731, keyCode: 731, which: 731, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ˛, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ˛, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ˛, code: KeyX, keyIdentifier: , keyCode: 731, charCode: 731, keyCode: 731, which: 731, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ˛, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + y:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Á, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Á, code: KeyY, keyIdentifier: , keyCode: 193, charCode: 193, keyCode: 193, which: 193, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Á, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Á, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Á, code: KeyY, keyIdentifier: , keyCode: 193, charCode: 193, keyCode: 193, which: 193, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Á, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + z:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ¸, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ¸, code: KeyZ, keyIdentifier: , keyCode: 184, charCode: 184, keyCode: 184, which: 184, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ¸, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ¸, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ¸, code: KeyZ, keyIdentifier: , keyCode: 184, charCode: 184, keyCode: 184, which: 184, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ¸, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + 0:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ‚, code: Digit0, keyIdentifier: U+0029, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ‚, code: Digit0, keyIdentifier: , keyCode: 8218, charCode: 8218, keyCode: 8218, which: 8218, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ‚, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ‚, code: Digit0, keyIdentifier: U+0029, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ‚, code: Digit0, keyIdentifier: , keyCode: 8218, charCode: 8218, keyCode: 8218, which: 8218, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ‚, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + 1:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ⁄, code: Digit1, keyIdentifier: U+0021, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ⁄, code: Digit1, keyIdentifier: , keyCode: 8260, charCode: 8260, keyCode: 8260, which: 8260, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ⁄, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ⁄, code: Digit1, keyIdentifier: U+0021, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ⁄, code: Digit1, keyIdentifier: , keyCode: 8260, charCode: 8260, keyCode: 8260, which: 8260, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ⁄, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + 2:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: €, code: Digit2, keyIdentifier: U+0040, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: €, code: Digit2, keyIdentifier: , keyCode: 8364, charCode: 8364, keyCode: 8364, which: 8364, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: €, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: €, code: Digit2, keyIdentifier: U+0040, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: €, code: Digit2, keyIdentifier: , keyCode: 8364, charCode: 8364, keyCode: 8364, which: 8364, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: €, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + 3:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ‹, code: Digit3, keyIdentifier: U+0023, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ‹, code: Digit3, keyIdentifier: , keyCode: 8249, charCode: 8249, keyCode: 8249, which: 8249, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ‹, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ‹, code: Digit3, keyIdentifier: U+0023, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ‹, code: Digit3, keyIdentifier: , keyCode: 8249, charCode: 8249, keyCode: 8249, which: 8249, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ‹, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + 4:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ›, code: Digit4, keyIdentifier: U+0024, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ›, code: Digit4, keyIdentifier: , keyCode: 8250, charCode: 8250, keyCode: 8250, which: 8250, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ›, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ›, code: Digit4, keyIdentifier: U+0024, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ›, code: Digit4, keyIdentifier: , keyCode: 8250, charCode: 8250, keyCode: 8250, which: 8250, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ›, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + 5:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ﬁ, code: Digit5, keyIdentifier: U+0025, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ﬁ, code: Digit5, keyIdentifier: , keyCode: 64257, charCode: 64257, keyCode: 64257, which: 64257, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ﬁ, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ﬁ, code: Digit5, keyIdentifier: U+0025, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ﬁ, code: Digit5, keyIdentifier: , keyCode: 64257, charCode: 64257, keyCode: 64257, which: 64257, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ﬁ, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + 6:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ﬂ, code: Digit6, keyIdentifier: U+005E, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ﬂ, code: Digit6, keyIdentifier: , keyCode: 64258, charCode: 64258, keyCode: 64258, which: 64258, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ﬂ, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ﬂ, code: Digit6, keyIdentifier: U+005E, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ﬂ, code: Digit6, keyIdentifier: , keyCode: 64258, charCode: 64258, keyCode: 64258, which: 64258, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ﬂ, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + 7:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ‡, code: Digit7, keyIdentifier: U+0026, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ‡, code: Digit7, keyIdentifier: , keyCode: 8225, charCode: 8225, keyCode: 8225, which: 8225, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ‡, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ‡, code: Digit7, keyIdentifier: U+0026, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ‡, code: Digit7, keyIdentifier: , keyCode: 8225, charCode: 8225, keyCode: 8225, which: 8225, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ‡, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + 8:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: °, code: Digit8, keyIdentifier: U+002A, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: °, code: Digit8, keyIdentifier: , keyCode: 176, charCode: 176, keyCode: 176, which: 176, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: °, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: °, code: Digit8, keyIdentifier: U+002A, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: °, code: Digit8, keyIdentifier: , keyCode: 176, charCode: 176, keyCode: 176, which: 176, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: °, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + 9:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ·, code: Digit9, keyIdentifier: U+0028, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ·, code: Digit9, keyIdentifier: , keyCode: 183, charCode: 183, keyCode: 183, which: 183, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ·, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ·, code: Digit9, keyIdentifier: U+0028, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ·, code: Digit9, keyIdentifier: , keyCode: 183, charCode: 183, keyCode: 183, which: 183, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ·, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + -:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: —, code: Minus, keyIdentifier: U+005F, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: —, code: Minus, keyIdentifier: , keyCode: 8212, charCode: 8212, keyCode: 8212, which: 8212, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: —, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: —, code: Minus, keyIdentifier: U+005F, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: —, code: Minus, keyIdentifier: , keyCode: 8212, charCode: 8212, keyCode: 8212, which: 8212, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: —, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + =:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ±, code: Equal, keyIdentifier: U+002B, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ±, code: Equal, keyIdentifier: , keyCode: 177, charCode: 177, keyCode: 177, which: 177, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ±, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ±, code: Equal, keyIdentifier: U+002B, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ±, code: Equal, keyIdentifier: , keyCode: 177, charCode: 177, keyCode: 177, which: 177, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ±, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + [:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ”, code: BracketLeft, keyIdentifier: U+007B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ”, code: BracketLeft, keyIdentifier: , keyCode: 8221, charCode: 8221, keyCode: 8221, which: 8221, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ”, code: BracketLeft, keyIdentifier: U+005B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ”, code: BracketLeft, keyIdentifier: U+007B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ”, code: BracketLeft, keyIdentifier: , keyCode: 8221, charCode: 8221, keyCode: 8221, which: 8221, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ”, code: BracketLeft, keyIdentifier: U+005B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + ]:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ’, code: BracketRight, keyIdentifier: U+007D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ’, code: BracketRight, keyIdentifier: , keyCode: 8217, charCode: 8217, keyCode: 8217, which: 8217, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ’, code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ’, code: BracketRight, keyIdentifier: U+007D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ’, code: BracketRight, keyIdentifier: , keyCode: 8217, charCode: 8217, keyCode: 8217, which: 8217, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ’, code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + ;:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Ú, code: Semicolon, keyIdentifier: U+003A, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Ú, code: Semicolon, keyIdentifier: , keyCode: 218, charCode: 218, keyCode: 218, which: 218, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Ú, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Ú, code: Semicolon, keyIdentifier: U+003A, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Ú, code: Semicolon, keyIdentifier: , keyCode: 218, charCode: 218, keyCode: 218, which: 218, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Ú, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + ':
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Æ, code: Quote, keyIdentifier: U+0022, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Æ, code: Quote, keyIdentifier: , keyCode: 198, charCode: 198, keyCode: 198, which: 198, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Æ, code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Æ, code: Quote, keyIdentifier: U+0022, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Æ, code: Quote, keyIdentifier: , keyCode: 198, charCode: 198, keyCode: 198, which: 198, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Æ, code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + ,:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ¯, code: Comma, keyIdentifier: U+003C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ¯, code: Comma, keyIdentifier: , keyCode: 175, charCode: 175, keyCode: 175, which: 175, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ¯, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ¯, code: Comma, keyIdentifier: U+003C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ¯, code: Comma, keyIdentifier: , keyCode: 175, charCode: 175, keyCode: 175, which: 175, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ¯, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + .:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ˘, code: Period, keyIdentifier: U+003E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ˘, code: Period, keyIdentifier: , keyCode: 728, charCode: 728, keyCode: 728, which: 728, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ˘, code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ˘, code: Period, keyIdentifier: U+003E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ˘, code: Period, keyIdentifier: , keyCode: 728, charCode: 728, keyCode: 728, which: 728, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ˘, code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Option + Shift + /:
-type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ¿, code: Slash, keyIdentifier: U+003F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ¿, code: Slash, keyIdentifier: , keyCode: 191, charCode: 191, keyCode: 191, which: 191, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ¿, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
-type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ¿, code: Slash, keyIdentifier: U+003F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ¿, code: Slash, keyIdentifier: , keyCode: 191, charCode: 191, keyCode: 191, which: 191, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ¿, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: true, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: true, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
+type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-shift-expected.txt
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-shift-expected.txt
@@ -2,289 +2,289 @@ This logs DOM keydown, keyup, keypress events that are dispatched when pressing 
 
 
 Test Shift + a:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: A, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: A, code: KeyA, keyIdentifier: , keyCode: 65, charCode: 65, keyCode: 65, which: 65, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: A, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: A, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: A, code: KeyA, keyIdentifier: , keyCode: 65, charCode: 65, keyCode: 65, which: 65, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: A, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + b:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: B, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: B, code: KeyB, keyIdentifier: , keyCode: 66, charCode: 66, keyCode: 66, which: 66, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: B, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: B, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: B, code: KeyB, keyIdentifier: , keyCode: 66, charCode: 66, keyCode: 66, which: 66, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: B, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + c:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: C, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: C, code: KeyC, keyIdentifier: , keyCode: 67, charCode: 67, keyCode: 67, which: 67, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: C, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: C, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: C, code: KeyC, keyIdentifier: , keyCode: 67, charCode: 67, keyCode: 67, which: 67, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: C, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + d:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: D, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: D, code: KeyD, keyIdentifier: , keyCode: 68, charCode: 68, keyCode: 68, which: 68, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: D, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: D, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: D, code: KeyD, keyIdentifier: , keyCode: 68, charCode: 68, keyCode: 68, which: 68, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: D, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + f:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: F, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: F, code: KeyF, keyIdentifier: , keyCode: 70, charCode: 70, keyCode: 70, which: 70, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: F, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: F, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: F, code: KeyF, keyIdentifier: , keyCode: 70, charCode: 70, keyCode: 70, which: 70, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: F, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + g:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: G, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: G, code: KeyG, keyIdentifier: , keyCode: 71, charCode: 71, keyCode: 71, which: 71, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: G, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: G, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: G, code: KeyG, keyIdentifier: , keyCode: 71, charCode: 71, keyCode: 71, which: 71, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: G, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + h:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: H, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: H, code: KeyH, keyIdentifier: , keyCode: 72, charCode: 72, keyCode: 72, which: 72, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: H, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: H, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: H, code: KeyH, keyIdentifier: , keyCode: 72, charCode: 72, keyCode: 72, which: 72, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: H, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + j:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: J, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: J, code: KeyJ, keyIdentifier: , keyCode: 74, charCode: 74, keyCode: 74, which: 74, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: J, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: J, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: J, code: KeyJ, keyIdentifier: , keyCode: 74, charCode: 74, keyCode: 74, which: 74, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: J, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + k:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: K, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: K, code: KeyK, keyIdentifier: , keyCode: 75, charCode: 75, keyCode: 75, which: 75, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: K, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: K, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: K, code: KeyK, keyIdentifier: , keyCode: 75, charCode: 75, keyCode: 75, which: 75, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: K, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + l:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: L, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: L, code: KeyL, keyIdentifier: , keyCode: 76, charCode: 76, keyCode: 76, which: 76, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: L, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: L, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: L, code: KeyL, keyIdentifier: , keyCode: 76, charCode: 76, keyCode: 76, which: 76, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: L, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + m:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: M, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: M, code: KeyM, keyIdentifier: , keyCode: 77, charCode: 77, keyCode: 77, which: 77, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: M, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: M, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: M, code: KeyM, keyIdentifier: , keyCode: 77, charCode: 77, keyCode: 77, which: 77, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: M, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + o:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: O, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: O, code: KeyO, keyIdentifier: , keyCode: 79, charCode: 79, keyCode: 79, which: 79, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: O, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: O, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: O, code: KeyO, keyIdentifier: , keyCode: 79, charCode: 79, keyCode: 79, which: 79, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: O, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + p:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: P, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: P, code: KeyP, keyIdentifier: , keyCode: 80, charCode: 80, keyCode: 80, which: 80, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: P, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: P, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: P, code: KeyP, keyIdentifier: , keyCode: 80, charCode: 80, keyCode: 80, which: 80, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: P, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + q:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Q, code: KeyQ, keyIdentifier: , keyCode: 81, charCode: 81, keyCode: 81, which: 81, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Q, code: KeyQ, keyIdentifier: , keyCode: 81, charCode: 81, keyCode: 81, which: 81, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + r:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: R, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: R, code: KeyR, keyIdentifier: , keyCode: 82, charCode: 82, keyCode: 82, which: 82, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: R, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: R, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: R, code: KeyR, keyIdentifier: , keyCode: 82, charCode: 82, keyCode: 82, which: 82, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: R, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + s:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: S, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: S, code: KeyS, keyIdentifier: , keyCode: 83, charCode: 83, keyCode: 83, which: 83, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: S, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: S, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: S, code: KeyS, keyIdentifier: , keyCode: 83, charCode: 83, keyCode: 83, which: 83, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: S, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + t:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: T, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: T, code: KeyT, keyIdentifier: , keyCode: 84, charCode: 84, keyCode: 84, which: 84, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: T, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: T, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: T, code: KeyT, keyIdentifier: , keyCode: 84, charCode: 84, keyCode: 84, which: 84, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: T, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + v:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: V, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: V, code: KeyV, keyIdentifier: , keyCode: 86, charCode: 86, keyCode: 86, which: 86, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: V, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: V, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: V, code: KeyV, keyIdentifier: , keyCode: 86, charCode: 86, keyCode: 86, which: 86, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: V, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + w:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: W, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: W, code: KeyW, keyIdentifier: , keyCode: 87, charCode: 87, keyCode: 87, which: 87, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: W, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: W, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: W, code: KeyW, keyIdentifier: , keyCode: 87, charCode: 87, keyCode: 87, which: 87, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: W, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + x:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: X, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: X, code: KeyX, keyIdentifier: , keyCode: 88, charCode: 88, keyCode: 88, which: 88, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: X, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: X, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: X, code: KeyX, keyIdentifier: , keyCode: 88, charCode: 88, keyCode: 88, which: 88, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: X, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + y:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Y, code: KeyY, keyIdentifier: , keyCode: 89, charCode: 89, keyCode: 89, which: 89, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Y, code: KeyY, keyIdentifier: , keyCode: 89, charCode: 89, keyCode: 89, which: 89, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + z:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: Z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: Z, code: KeyZ, keyIdentifier: , keyCode: 90, charCode: 90, keyCode: 90, which: 90, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: Z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: Z, code: KeyZ, keyIdentifier: , keyCode: 90, charCode: 90, keyCode: 90, which: 90, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + 0:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ), code: Digit0, keyIdentifier: U+0029, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ), code: Digit0, keyIdentifier: , keyCode: 41, charCode: 41, keyCode: 41, which: 41, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ), code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ), code: Digit0, keyIdentifier: U+0029, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ), code: Digit0, keyIdentifier: , keyCode: 41, charCode: 41, keyCode: 41, which: 41, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ), code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + 1:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: !, code: Digit1, keyIdentifier: U+0021, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: !, code: Digit1, keyIdentifier: , keyCode: 33, charCode: 33, keyCode: 33, which: 33, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: !, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: !, code: Digit1, keyIdentifier: U+0021, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: !, code: Digit1, keyIdentifier: , keyCode: 33, charCode: 33, keyCode: 33, which: 33, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: !, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + 2:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: @, code: Digit2, keyIdentifier: U+0040, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: @, code: Digit2, keyIdentifier: , keyCode: 64, charCode: 64, keyCode: 64, which: 64, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: @, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: @, code: Digit2, keyIdentifier: U+0040, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: @, code: Digit2, keyIdentifier: , keyCode: 64, charCode: 64, keyCode: 64, which: 64, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: @, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + 3:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: #, code: Digit3, keyIdentifier: U+0023, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: #, code: Digit3, keyIdentifier: , keyCode: 35, charCode: 35, keyCode: 35, which: 35, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: #, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: #, code: Digit3, keyIdentifier: U+0023, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: #, code: Digit3, keyIdentifier: , keyCode: 35, charCode: 35, keyCode: 35, which: 35, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: #, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + 4:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: $, code: Digit4, keyIdentifier: U+0024, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: $, code: Digit4, keyIdentifier: , keyCode: 36, charCode: 36, keyCode: 36, which: 36, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: $, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: $, code: Digit4, keyIdentifier: U+0024, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: $, code: Digit4, keyIdentifier: , keyCode: 36, charCode: 36, keyCode: 36, which: 36, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: $, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + 5:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: %, code: Digit5, keyIdentifier: U+0025, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: %, code: Digit5, keyIdentifier: , keyCode: 37, charCode: 37, keyCode: 37, which: 37, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: %, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: %, code: Digit5, keyIdentifier: U+0025, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: %, code: Digit5, keyIdentifier: , keyCode: 37, charCode: 37, keyCode: 37, which: 37, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: %, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + 6:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ^, code: Digit6, keyIdentifier: U+005E, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ^, code: Digit6, keyIdentifier: , keyCode: 94, charCode: 94, keyCode: 94, which: 94, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ^, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ^, code: Digit6, keyIdentifier: U+005E, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ^, code: Digit6, keyIdentifier: , keyCode: 94, charCode: 94, keyCode: 94, which: 94, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ^, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + 7:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: &, code: Digit7, keyIdentifier: U+0026, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: &, code: Digit7, keyIdentifier: , keyCode: 38, charCode: 38, keyCode: 38, which: 38, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: &, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: &, code: Digit7, keyIdentifier: U+0026, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: &, code: Digit7, keyIdentifier: , keyCode: 38, charCode: 38, keyCode: 38, which: 38, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: &, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + 8:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: *, code: Digit8, keyIdentifier: U+002A, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: *, code: Digit8, keyIdentifier: , keyCode: 42, charCode: 42, keyCode: 42, which: 42, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: *, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: *, code: Digit8, keyIdentifier: U+002A, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: *, code: Digit8, keyIdentifier: , keyCode: 42, charCode: 42, keyCode: 42, which: 42, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: *, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + 9:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: (, code: Digit9, keyIdentifier: U+0028, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: (, code: Digit9, keyIdentifier: , keyCode: 40, charCode: 40, keyCode: 40, which: 40, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: (, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: (, code: Digit9, keyIdentifier: U+0028, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: (, code: Digit9, keyIdentifier: , keyCode: 40, charCode: 40, keyCode: 40, which: 40, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: (, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + -:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: _, code: Minus, keyIdentifier: U+005F, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: _, code: Minus, keyIdentifier: , keyCode: 95, charCode: 95, keyCode: 95, which: 95, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: _, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: _, code: Minus, keyIdentifier: U+005F, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: _, code: Minus, keyIdentifier: , keyCode: 95, charCode: 95, keyCode: 95, which: 95, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: _, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + =:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: +, code: Equal, keyIdentifier: U+002B, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: +, code: Equal, keyIdentifier: , keyCode: 43, charCode: 43, keyCode: 43, which: 43, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: +, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: +, code: Equal, keyIdentifier: U+002B, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: +, code: Equal, keyIdentifier: , keyCode: 43, charCode: 43, keyCode: 43, which: 43, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: +, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + [:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: {, code: BracketLeft, keyIdentifier: U+007B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: {, code: BracketLeft, keyIdentifier: , keyCode: 123, charCode: 123, keyCode: 123, which: 123, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: {, code: BracketLeft, keyIdentifier: U+005B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: {, code: BracketLeft, keyIdentifier: U+007B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: {, code: BracketLeft, keyIdentifier: , keyCode: 123, charCode: 123, keyCode: 123, which: 123, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: {, code: BracketLeft, keyIdentifier: U+005B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + ]:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: }, code: BracketRight, keyIdentifier: U+007D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: }, code: BracketRight, keyIdentifier: , keyCode: 125, charCode: 125, keyCode: 125, which: 125, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: }, code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: }, code: BracketRight, keyIdentifier: U+007D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: }, code: BracketRight, keyIdentifier: , keyCode: 125, charCode: 125, keyCode: 125, which: 125, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: }, code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + ;:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: :, code: Semicolon, keyIdentifier: U+003A, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: :, code: Semicolon, keyIdentifier: , keyCode: 58, charCode: 58, keyCode: 58, which: 58, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: :, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: :, code: Semicolon, keyIdentifier: U+003A, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: :, code: Semicolon, keyIdentifier: , keyCode: 58, charCode: 58, keyCode: 58, which: 58, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: :, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + ':
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ", code: Quote, keyIdentifier: U+0022, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ", code: Quote, keyIdentifier: , keyCode: 34, charCode: 34, keyCode: 34, which: 34, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ", code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ", code: Quote, keyIdentifier: U+0022, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ", code: Quote, keyIdentifier: , keyCode: 34, charCode: 34, keyCode: 34, which: 34, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ", code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + ,:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: <, code: Comma, keyIdentifier: U+003C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: <, code: Comma, keyIdentifier: , keyCode: 60, charCode: 60, keyCode: 60, which: 60, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: <, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: <, code: Comma, keyIdentifier: U+003C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: <, code: Comma, keyIdentifier: , keyCode: 60, charCode: 60, keyCode: 60, which: 60, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: <, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + .:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: >, code: Period, keyIdentifier: U+003E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: >, code: Period, keyIdentifier: , keyCode: 62, charCode: 62, keyCode: 62, which: 62, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: >, code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: >, code: Period, keyIdentifier: U+003E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: >, code: Period, keyIdentifier: , keyCode: 62, charCode: 62, keyCode: 62, which: 62, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: >, code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Shift + /:
-type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: 1
-type: keydown, key: ?, code: Slash, keyIdentifier: U+003F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keypress, key: ?, code: Slash, keyIdentifier: , keyCode: 63, charCode: 63, keyCode: 63, which: 63, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: ?, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: 0
-type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: 1
+type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 1, keyLocation: undefined
+type: keydown, key: ?, code: Slash, keyIdentifier: U+003F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keypress, key: ?, code: Slash, keyIdentifier: , keyCode: 63, charCode: 63, keyCode: 63, which: 63, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: ?, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: false, metaKey: false, shiftKey: true, location: 0, keyLocation: undefined
+type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 

--- a/Source/WebCore/dom/KeyboardEvent.cpp
+++ b/Source/WebCore/dom/KeyboardEvent.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2001 Peter Kelly (pmk@post.com)
  * Copyright (C) 2001 Tobias Anton (anton@stud.fbi.fh-darmstadt.de)
  * Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
- * Copyright (C) 2003-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -134,7 +134,7 @@ inline KeyboardEvent::KeyboardEvent(const AtomString& eventType, const Init& ini
     , m_key(initializer.key)
     , m_code(initializer.code)
     , m_keyIdentifier(initializer.keyIdentifier)
-    , m_location(initializer.keyLocation ? *initializer.keyLocation : initializer.location)
+    , m_location(initializer.location)
     , m_repeat(initializer.repeat)
     , m_isComposing(initializer.isComposing)
     , m_charCode(initializer.charCode)

--- a/Source/WebCore/dom/KeyboardEvent.h
+++ b/Source/WebCore/dom/KeyboardEvent.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2001 Peter Kelly (pmk@post.com)
  * Copyright (C) 2001 Tobias Anton (anton@stud.fbi.fh-darmstadt.de)
  * Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
- * Copyright (C) 2003-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -56,7 +56,6 @@ public:
 
         // Legacy.
         AtomString keyIdentifier;
-        std::optional<unsigned> keyLocation;
         unsigned charCode;
         unsigned keyCode;
         unsigned which;

--- a/Source/WebCore/dom/KeyboardEvent.idl
+++ b/Source/WebCore/dom/KeyboardEvent.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006 Apple Inc.
+ * Copyright (C) 2006-2024 Apple Inc.
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -17,6 +17,8 @@
  * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA 02110-1301, USA.
  */
+
+// https://w3c.github.io/uievents/#idl-keyboardevent
 
 [
     Exposed=Window
@@ -44,7 +46,6 @@
 
     // Everything below is legacy.
     readonly attribute [AtomString] DOMString keyIdentifier;
-    [ImplementedAs=location] readonly attribute unsigned long keyLocation;
     readonly attribute unsigned long charCode;
     readonly attribute unsigned long keyCode;
     readonly attribute unsigned long which;
@@ -54,6 +55,8 @@
         optional WindowProxy? view = null, optional [AtomString] DOMString keyIdentifier = "undefined", optional unsigned long location = 0,
         optional boolean ctrlKey = false, optional boolean altKey = false, optional boolean shiftKey = false, optional boolean metaKey = false);
 };
+
+// https://w3c.github.io/uievents/#idl-keyboardeventinit
 
 dictionary KeyboardEventInit : EventModifierInit {
     DOMString key = "";
@@ -65,7 +68,6 @@ dictionary KeyboardEventInit : EventModifierInit {
     // This members are not in the specification but are needed to initialize the corresponding legacy
     // attributes we still support on KeyboardEvent for backward compatibility.
     [AtomString] DOMString keyIdentifier = "";
-    unsigned long keyLocation;
     unsigned long charCode = 0;
     unsigned long keyCode = 0;
     unsigned long which = 0;


### PR DESCRIPTION
#### bba680e17fee76325be7facc38899eda3f43d419
<pre>
Remove non-standard `KeyboardEvent.keyLocation`

<a href="https://bugs.webkit.org/show_bug.cgi?id=267819">https://bugs.webkit.org/show_bug.cgi?id=267819</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium
by removing non-standard KeyboardEvent.keyLocation (alias of &apos;location&apos;).

It is not in web-specification [1].

[1] <a href="https://w3c.github.io/uievents/#events-keyboardevents">https://w3c.github.io/uievents/#events-keyboardevents</a>

It was never shipped in Gecko / Firefox while removed in Blink
in 2016 and with commit [2]:

[2] <a href="https://chromium.googlesource.com/chromium/src.git/+/263d94f9b2dc4a0a3cf5b3124c1cc8d2163a4410">https://chromium.googlesource.com/chromium/src.git/+/263d94f9b2dc4a0a3cf5b3124c1cc8d2163a4410</a>

* Source/WebCore/dom/KeyboardEvent.cpp:
(KeyboardEvent::KeyboardEvent):
* Source/WebCore/dom/KeyboardEvent.h:
* Source/WebCore/dom/KeyboardEvent.idl:
* LayoutTests/fast/events/constructors/keyboard-event-constructor.html: Rebaselined
* LayoutTests/fast/events/constructors/keyboard-event-constructor-expected.txt: Rebaselined
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-control-expected.txt: Rebaselined
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-control-option-expected.txt: Ditto
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-control-shift-expected.txt: Ditto
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-control-expected.txt: Ditto
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-expected.txt: Ditto
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-option-expected.txt: Ditto
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-shift-expected.txt: Ditto
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-option-expected.txt: Ditto
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-option-shift-expected.txt: Ditto
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-shift-expected.txt: Ditto

Canonical link: <a href="https://commits.webkit.org/273457@main">https://commits.webkit.org/273457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccfe6cc83a9f45b44594648632966b5d61404e5b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38171 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31951 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36630 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30785 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10648 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10712 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39419 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32240 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36649 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10849 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34697 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31339 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8108 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11652 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->