### PR TITLE
Create and adopt an SQLite store for web extension Storage API

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
@@ -62,6 +62,15 @@ NSString *toWebAPI(NSLocale *);
 /// This matches the maximum message length enforced by Chromium in its `MessageFromJSONString()` function.
 constexpr size_t webExtensionMaxMessageLength = 1024 * 1024 * 64;
 
+/// Returns the storage size of a string.
+size_t storageSizeOf(NSString *);
+
+/// Returns the storage size of all of the key value pairs in a dictionary.
+size_t storageSizeOf(NSDictionary<NSString *, NSString *> *);
+
+/// Returns true if the size of any item in the dictionary exceeds the given quota.
+bool anyItemsExceedQuota(NSDictionary *, size_t quota);
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
@@ -32,6 +32,7 @@
 
 #import "CocoaHelpers.h"
 #import "Logging.h"
+#import "WebExtensionConstants.h"
 #import "_WKWebExtensionSQLiteDatabase.h"
 #import "_WKWebExtensionSQLiteHelpers.h"
 #import "_WKWebExtensionSQLiteRow.h"

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.h
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import "_WKWebExtensionSQLiteStore.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+namespace WebKit {
+enum class WebExtensionStorageType : uint8_t;
+}
+
+@interface _WKWebExtensionStorageSQLiteStore : _WKWebExtensionSQLiteStore
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+- (instancetype)initWithUniqueIdentifier:(NSString *)uniqueIdentifier storageType:(WebKit::WebExtensionStorageType)storageType directory:(NSString *)directory usesInMemoryDatabase:(BOOL)useInMemoryDatabase;
+
+- (void)getValuesForKeys:(NSArray<NSString *> *)keys completionHandler:(void (^)(NSDictionary<NSString *, NSString *> *results, NSString * _Nullable errorMessage))completionHandler;
+- (void)getStorageSizeForKeys:(NSArray<NSString *> *)keys completionHandler:(void (^)(size_t storageSize, NSString * _Nullable errorMessage))completionHandler;
+- (void)getStorageSizeForAllKeysIncludingKeyedData:(NSDictionary<NSString *, NSString *> *)additionalKeyedData withCompletionHandler:(void (^)(size_t storageSize, NSUInteger numberOfKeysIncludingAdditionalKeyedData, NSDictionary<NSString *, NSString *> *existingKeysAndValues, NSString * _Nullable errorMessage))completionHandler;
+- (void)setKeyedData:(NSDictionary<NSString *, NSString *> *)keyedData completionHandler:(void (^)(NSArray<NSString *> * _Nullable keysSuccessfullySet, NSString * _Nullable errorMessage))completionHandler;
+- (void)deleteValuesForKeys:(NSArray<NSString *> *)keys completionHandler:(void (^)(NSString * _Nullable errorMessage))completionHandler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.mm
@@ -1,0 +1,371 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "_WKWebExtensionStorageSQLiteStore.h"
+
+#import "CocoaHelpers.h"
+#import "Logging.h"
+#import "WebExtensionStorageType.h"
+#import "WebExtensionUtilities.h"
+#import "_WKWebExtensionSQLiteDatabase.h"
+#import "_WKWebExtensionSQLiteHelpers.h"
+#import "_WKWebExtensionSQLiteRow.h"
+#import <wtf/WeakObjCPtr.h>
+
+using namespace WebKit;
+
+#if ENABLE(WK_WEB_EXTENSIONS)
+
+static const SchemaVersion currentDatabaseSchemaVersion = 1;
+
+static NSString *rowFilterStringFromRowKeys(NSArray<NSString *> *keys)
+{
+    auto *escapedAndQuotedKeys = [NSMutableArray arrayWithCapacity:keys.count];
+
+    for (NSString *key in keys) {
+        auto *keyWithSingleQuotesEscaped = [key stringByReplacingOccurrencesOfString:@"'" withString:@"''"];
+        [escapedAndQuotedKeys addObject:[NSString stringWithFormat:@"'%@'", keyWithSingleQuotesEscaped]];
+    }
+
+    return [escapedAndQuotedKeys componentsJoinedByString:@","];
+}
+
+@implementation _WKWebExtensionStorageSQLiteStore {
+    WebExtensionStorageType _storageType;
+}
+
+- (instancetype)initWithUniqueIdentifier:(NSString *)uniqueIdentifier storageType:(WebExtensionStorageType)storageType directory:(NSString *)directory usesInMemoryDatabase:(BOOL)useInMemoryDatabase
+{
+    if (!(self = [super initWithUniqueIdentifier:uniqueIdentifier directory:directory usesInMemoryDatabase:useInMemoryDatabase]))
+        return nil;
+
+    _storageType = storageType;
+
+    return self;
+}
+
+- (void)getValuesForKeys:(NSArray<NSString *> *)keys completionHandler:(void (^)(NSDictionary<NSString *, NSString *> *results, NSString *errorMessage))completionHandler
+{
+    auto weakSelf = WeakObjCPtr<_WKWebExtensionStorageSQLiteStore> { self };
+    dispatch_async(_databaseQueue, ^{
+        auto strongSelf = weakSelf.get();
+        if (!strongSelf) {
+            completionHandler(nil, [NSString stringWithFormat:@"Failed to retrieve keys %@", keys]);
+            return;
+        }
+
+        NSString *errorMessage;
+        auto *results = keys.count ? [self _getValuesForKeys:keys outErrorMessage:&errorMessage] : [self _getValuesForAllKeysReturningErrorMessage:&errorMessage];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completionHandler(results, errorMessage);
+        });
+    });
+}
+
+- (void)getStorageSizeForKeys:(NSArray<NSString *> *)keys completionHandler:(void (^)(size_t storageSize, NSString *errorMessage))completionHandler
+{
+    auto weakSelf = WeakObjCPtr<_WKWebExtensionStorageSQLiteStore> { self };
+    dispatch_async(_databaseQueue, ^{
+        auto strongSelf = weakSelf.get();
+        if (!strongSelf) {
+            completionHandler(0, [NSString stringWithFormat:@"Failed to caluclate storage size for keys: %@", keys]);
+            return;
+        }
+
+        NSString *errorMessage;
+
+        if (keys.count) {
+            auto *keysAndValues = [self _getValuesForKeys:keys outErrorMessage:&errorMessage];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completionHandler(storageSizeOf(keysAndValues), errorMessage);
+            });
+
+            return;
+        }
+
+        // Return storage size for all keys if no keys are specified.
+        if (![self _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage]) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completionHandler(0, errorMessage);
+            });
+            return;
+        }
+
+        int64_t result = 0;
+        NSError *error;
+        bool success = SQLiteDatabaseEnumerate(self->_database, &error, @"SELECT SUM(LENGTH(key) + LENGTH(value)) FROM extension_storage", std::tie(result));
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (success)
+                completionHandler(result, nil);
+            else
+                completionHandler(0, error.localizedDescription);
+        });
+    });
+}
+
+- (void)getStorageSizeForAllKeysIncludingKeyedData:(NSDictionary<NSString *, NSString *> *)additionalKeyedData withCompletionHandler:(void (^)(size_t storageSize, NSUInteger numberOfKeysIncludingAdditionalKeyedData, NSDictionary<NSString *, NSString *> *existingKeysAndValues, NSString *errorMessage))completionHandler
+{
+    [self getStorageSizeForKeys:@[] completionHandler:^(size_t storageSize, NSString *errorMessage) {
+        if (errorMessage.length) {
+            completionHandler(0.0, 0, @{ }, errorMessage);
+            return;
+        }
+
+        auto weakSelf = WeakObjCPtr<_WKWebExtensionStorageSQLiteStore> { self };
+        dispatch_async(self->_databaseQueue, ^{
+            auto strongSelf = weakSelf.get();
+            if (!strongSelf) {
+                completionHandler(0.0, 0, @{ }, @"Failed to calculate storage size");
+                return;
+            }
+
+            NSString *errorMessage;
+            auto *oldValuesForAdditionalKeys = [self _getValuesForKeys:additionalKeyedData.allKeys outErrorMessage:&errorMessage];
+            size_t oldStorageSizeForAdditionalKeys = storageSizeOf(oldValuesForAdditionalKeys);
+            size_t newStorageSizeForAdditionalKeys = storageSizeOf(additionalKeyedData);
+            size_t updatedStorageSize = storageSize - oldStorageSizeForAdditionalKeys + newStorageSizeForAdditionalKeys;
+
+            auto *existingAndAdditionalKeys = [NSMutableSet setWithSet:[self _getAllKeysReturningErrorMessage:&errorMessage]];
+            [existingAndAdditionalKeys unionSet:[NSSet setWithArray:additionalKeyedData.allKeys]];
+
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completionHandler(updatedStorageSize, existingAndAdditionalKeys.count, oldValuesForAdditionalKeys, errorMessage);
+            });
+        });
+    }];
+}
+
+- (void)setKeyedData:(NSDictionary<NSString *, NSString *> *)keyedData completionHandler:(void (^)(NSArray<NSString *> *keysSuccessfullySet, NSString *errorMessage))completionHandler
+{
+    auto weakSelf = WeakObjCPtr<_WKWebExtensionStorageSQLiteStore> { self };
+    dispatch_async(_databaseQueue, ^{
+        auto strongSelf = weakSelf.get();
+        if (!strongSelf) {
+            completionHandler(nil, [NSString stringWithFormat:@"Failed to set keys %@", keyedData.allKeys]);
+            return;
+        }
+
+        NSString *errorMessage;
+        if (![self _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage]) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completionHandler(nil, errorMessage);
+            });
+            return;
+        }
+
+        ASSERT(!errorMessage.length);
+
+        auto *keysSuccessfullySet = [NSMutableArray array];
+
+        for (NSString *key in keyedData) {
+            errorMessage = [self _insertOrUpdateValue:keyedData[key] forKey:key inDatabase:self->_database];
+            if (errorMessage.length)
+                break;
+
+            [keysSuccessfullySet addObject:key];
+        }
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completionHandler([keysSuccessfullySet copy], errorMessage);
+        });
+    });
+}
+
+- (void)deleteValuesForKeys:(NSArray<NSString *> *)keys completionHandler:(void (^)(NSString *errorMessage))completionHandler
+{
+    auto weakSelf = WeakObjCPtr<_WKWebExtensionStorageSQLiteStore> { self };
+    dispatch_async(_databaseQueue, ^{
+        auto strongSelf = weakSelf.get();
+        if (!strongSelf) {
+            completionHandler([NSString stringWithFormat:@"Failed to delete keys %@", keys]);
+            return;
+        }
+
+        NSString *errorMessage;
+        if (![self _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage]) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completionHandler(errorMessage);
+            });
+            return;
+        }
+
+        ASSERT(!errorMessage.length);
+
+        DatabaseResult result = SQLiteDatabaseExecute(self->_database, [NSString stringWithFormat:@"DELETE FROM extension_storage WHERE key in (%@)", rowFilterStringFromRowKeys(keys)]);
+        if (result != SQLITE_DONE) {
+            RELEASE_LOG_ERROR(Extensions, "Failed to delete keys %{private}@ for extension %{private}@.", keys, self->_uniqueIdentifier);
+            errorMessage = [NSString stringWithFormat:@"Failed to delete keys %@", keys];
+        }
+
+        NSString *deleteDatabaseErrorMessage = [self _deleteDatabaseIfEmpty];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            // Errors from opening the database or deleting keys take precedence over an error deleting the database.
+            completionHandler(errorMessage.length ? errorMessage : deleteDatabaseErrorMessage);
+        });
+    });
+}
+
+- (NSURL *)_databaseURL
+{
+    if (_useInMemoryDatabase)
+        return _WKWebExtensionSQLiteDatabase.inMemoryDatabaseURL;
+
+    NSString *databaseName;
+    switch (_storageType) {
+    case WebExtensionStorageType::Local:
+        databaseName = @"LocalStorage.db";
+        break;
+    case WebExtensionStorageType::Sync:
+        databaseName = @"SyncStorage.db";
+        break;
+    case WebExtensionStorageType::Session:
+        // Session storage is kept in memory only.
+        ASSERT_NOT_REACHED();
+    }
+
+    ASSERT(_directory);
+
+    return [_directory URLByAppendingPathComponent:databaseName isDirectory:NO];
+}
+
+- (NSString *)_insertOrUpdateValue:(NSString *)value forKey:(NSString *)key inDatabase:(_WKWebExtensionSQLiteDatabase *)database
+{
+    dispatch_assert_queue(_databaseQueue);
+    DatabaseResult result = SQLiteDatabaseExecute(database, @"INSERT OR REPLACE INTO extension_storage (key, value) VALUES (?, ?)", key, value);
+    if (result != SQLITE_DONE) {
+        RELEASE_LOG_ERROR(Extensions, "Failed to insert value %{private}@ for key %{private}@ for extension %{private}@.", value, key, _uniqueIdentifier);
+        return [NSString stringWithFormat:@"Failed to insert value %@ for key %@", value, key];
+    }
+
+    return nil;
+}
+
+- (NSDictionary<NSString *, NSString *> *)_getValuesForAllKeysReturningErrorMessage:(NSString **)outErrorMessage
+{
+    dispatch_assert_queue(_databaseQueue);
+
+    if (![self _openDatabaseIfNecessaryReturningErrorMessage:outErrorMessage])
+        return @{ };
+
+    ASSERT(!(*outErrorMessage).length);
+
+    _WKWebExtensionSQLiteRowEnumerator *rows = SQLiteDatabaseFetch(_database, @"SELECT * FROM extension_storage");
+    return [self _getKeysAndValuesFromRowEnumerator:rows];
+}
+
+- (NSDictionary<NSString *, NSString *> *)_getKeysAndValuesFromRowEnumerator:(_WKWebExtensionSQLiteRowEnumerator *)rows
+{
+    auto *results = [NSMutableDictionary dictionary];
+
+    for (_WKWebExtensionSQLiteRow *row in rows) {
+        auto *key = [row stringAtIndex:0];
+        auto *value = [row stringAtIndex:1];
+
+        results[key] = value;
+    }
+
+    return [results copy];
+}
+
+- (NSSet<NSString *> *)_getAllKeysReturningErrorMessage:(NSString **)outErrorMessage
+{
+    dispatch_assert_queue(_databaseQueue);
+
+    if (![self _openDatabaseIfNecessaryReturningErrorMessage:outErrorMessage])
+        return [NSSet set];
+
+    ASSERT(!(*outErrorMessage).length);
+
+    auto *keys = [NSMutableSet set];
+    _WKWebExtensionSQLiteRowEnumerator *rows = SQLiteDatabaseFetch(_database, @"SELECT key FROM extension_storage");
+    for (_WKWebExtensionSQLiteRow *row in rows)
+        [keys addObject:[row stringAtIndex:0]];
+
+    return keys;
+}
+
+- (NSDictionary<NSString *, NSString *> *)_getValuesForKeys:(NSArray<NSString *> *)keys outErrorMessage:(NSString **)outErrorMessage
+{
+    dispatch_assert_queue(_databaseQueue);
+    if (![self _openDatabaseIfNecessaryReturningErrorMessage:outErrorMessage])
+        return @{ };
+
+    ASSERT(!(*outErrorMessage).length);
+
+    _WKWebExtensionSQLiteRowEnumerator *rows = SQLiteDatabaseFetch(_database, [NSString stringWithFormat:@"SELECT * FROM extension_storage WHERE key in (%@)", rowFilterStringFromRowKeys(keys)]);
+    return [self _getKeysAndValuesFromRowEnumerator:rows];
+}
+
+// MARK: Database Schema
+
+- (SchemaVersion)_currentDatabaseSchemaVersion
+{
+    return currentDatabaseSchemaVersion;
+}
+
+- (DatabaseResult)_createFreshDatabaseSchema
+{
+    dispatch_assert_queue(_databaseQueue);
+    ASSERT(_database);
+
+    DatabaseResult result = SQLiteDatabaseExecute(_database, @"CREATE TABLE extension_storage (key TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL)");
+    if (result != SQLITE_DONE)
+        RELEASE_LOG_ERROR(Extensions, "Failed to create the extension_storage table for extension %{private}@: %{public}@ (%d)", _uniqueIdentifier, _database.lastErrorMessage, result);
+
+    return result;
+}
+
+- (DatabaseResult)_resetDatabaseSchema
+{
+    dispatch_assert_queue(_databaseQueue);
+    ASSERT(_database);
+
+    DatabaseResult result = SQLiteDatabaseExecute(_database, @"DROP TABLE IF EXISTS extension_storage");
+    if (result != SQLITE_DONE)
+        RELEASE_LOG_ERROR(Extensions, "Failed to reset database schema for extension %{private}@: %{public}@ (%d)", _uniqueIdentifier, _database.lastErrorMessage, result);
+
+    return result;
+}
+
+- (BOOL)_isDatabaseEmpty
+{
+    dispatch_assert_queue(_databaseQueue);
+    ASSERT(_database);
+
+    _WKWebExtensionSQLiteRowEnumerator *rows = SQLiteDatabaseFetch(_database, @"SELECT COUNT(*) FROM extension_storage");
+    return ![[rows nextObject] int64AtIndex:0];
+}
+
+@end
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -108,9 +108,9 @@ messages -> WebExtensionContext {
     ScriptingUnregisterContentScripts(Vector<String> scriptIDs) -> (WebKit::WebExtensionDynamicScripts::Error error);
 
     // Storage APIs
-    StorageGet(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionStorageType storageType, IPC::DataReference data) -> (std::optional<IPC::DataReference> data, WebKit::WebExtensionContext::ErrorString error);
+    StorageGet(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionStorageType storageType, Vector<String> keys) -> (std::optional<String> dataJSON, WebKit::WebExtensionContext::ErrorString error);
     StorageGetBytesInUse(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionStorageType storageType, Vector<String> keys) -> (std::optional<size_t> size, WebKit::WebExtensionContext::ErrorString error);
-    StorageSet(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionStorageType storageType, IPC::DataReference dataReference) -> (WebKit::WebExtensionContext::ErrorString error);
+    StorageSet(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionStorageType storageType, String dataJSON) -> (WebKit::WebExtensionContext::ErrorString error);
     StorageRemove(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionStorageType storageType, Vector<String> keys) -> (WebKit::WebExtensionContext::ErrorString error);
     StorageClear(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionStorageType storageType) -> (WebKit::WebExtensionContext::ErrorString error);
     StorageSetAccessLevel(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, WebKit::WebExtensionStorageType storageType, WebKit::WebExtensionStorageAccessLevel accessLevel) -> (WebKit::WebExtensionContext::ErrorString error);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1954,6 +1954,8 @@
 		B6B1565C2B5E177A004F9894 /* WebExtensionStorageType.h in Headers */ = {isa = PBXBuildFile; fileRef = B6B156582B5E1779004F9894 /* WebExtensionStorageType.h */; };
 		B6B1565E2B5E177A004F9894 /* WebExtensionStorageAccessLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = B6B1565A2B5E177A004F9894 /* WebExtensionStorageAccessLevel.h */; };
 		B6B156612B5E2618004F9894 /* WebExtensionContextAPIStorageCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6B156602B5E2618004F9894 /* WebExtensionContextAPIStorageCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		B6B156682B5E47A8004F9894 /* _WKWebExtensionStorageSQLiteStore.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6B156662B5E47A8004F9894 /* _WKWebExtensionStorageSQLiteStore.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		B6B156692B5E47A8004F9894 /* _WKWebExtensionStorageSQLiteStore.h in Headers */ = {isa = PBXBuildFile; fileRef = B6B156672B5E47A8004F9894 /* _WKWebExtensionStorageSQLiteStore.h */; };
 		B6BF18352B1A49EF00FA39D3 /* _WKWebExtensionSQLiteStatement.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6BF18332B1A49EE00FA39D3 /* _WKWebExtensionSQLiteStatement.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B6BF18362B1A49EF00FA39D3 /* _WKWebExtensionSQLiteStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = B6BF18342B1A49EE00FA39D3 /* _WKWebExtensionSQLiteStatement.h */; };
 		B6BF18392B1A510500FA39D3 /* _WKWebExtensionSQLiteRow.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6BF18372B1A510500FA39D3 /* _WKWebExtensionSQLiteRow.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -6927,6 +6929,8 @@
 		B6B1565A2B5E177A004F9894 /* WebExtensionStorageAccessLevel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionStorageAccessLevel.h; sourceTree = "<group>"; };
 		B6B1565B2B5E177A004F9894 /* WebExtensionContextParameters.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebExtensionContextParameters.serialization.in; sourceTree = "<group>"; };
 		B6B156602B5E2618004F9894 /* WebExtensionContextAPIStorageCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPIStorageCocoa.mm; sourceTree = "<group>"; };
+		B6B156662B5E47A8004F9894 /* _WKWebExtensionStorageSQLiteStore.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = _WKWebExtensionStorageSQLiteStore.mm; path = UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.mm; sourceTree = SOURCE_ROOT; };
+		B6B156672B5E47A8004F9894 /* _WKWebExtensionStorageSQLiteStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = _WKWebExtensionStorageSQLiteStore.h; path = UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.h; sourceTree = SOURCE_ROOT; };
 		B6BF18332B1A49EE00FA39D3 /* _WKWebExtensionSQLiteStatement.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionSQLiteStatement.mm; sourceTree = "<group>"; };
 		B6BF18342B1A49EE00FA39D3 /* _WKWebExtensionSQLiteStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionSQLiteStatement.h; sourceTree = "<group>"; };
 		B6BF18372B1A510500FA39D3 /* _WKWebExtensionSQLiteRow.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionSQLiteRow.mm; sourceTree = "<group>"; };
@@ -9391,6 +9395,8 @@
 				3343C3252B21140C00AD10A6 /* _WKWebExtensionDeclarativeNetRequestSQLiteStore.mm */,
 				3326F2632B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.h */,
 				3326F2642B06A1F4001A535F /* _WKWebExtensionDeclarativeNetRequestTranslator.mm */,
+				B6B156672B5E47A8004F9894 /* _WKWebExtensionStorageSQLiteStore.h */,
+				B6B156662B5E47A8004F9894 /* _WKWebExtensionStorageSQLiteStore.mm */,
 				1CF0C94F2AC380E900EC82F2 /* WebExtensionActionCocoa.mm */,
 				1C627477288A1DDE00CED3A2 /* WebExtensionCocoa.mm */,
 				1C8ECFD92AFC12CC007BAA62 /* WebExtensionCommandCocoa.mm */,
@@ -15275,6 +15281,7 @@
 				B6BF183A2B1A510500FA39D3 /* _WKWebExtensionSQLiteRow.h in Headers */,
 				B6BF18362B1A49EF00FA39D3 /* _WKWebExtensionSQLiteStatement.h in Headers */,
 				B6A292362B18FCF30061930E /* _WKWebExtensionSQLiteStore.h in Headers */,
+				B6B156692B5E47A8004F9894 /* _WKWebExtensionStorageSQLiteStore.h in Headers */,
 				1C049840289AFF9B0010308B /* _WKWebExtensionTab.h in Headers */,
 				1C5ACF912A955CB000C041C0 /* _WKWebExtensionTabCreationOptions.h in Headers */,
 				1C5ACF932A965C4000C041C0 /* _WKWebExtensionTabCreationOptionsInternal.h in Headers */,
@@ -18361,6 +18368,7 @@
 				B6BF18392B1A510500FA39D3 /* _WKWebExtensionSQLiteRow.mm in Sources */,
 				B6BF18352B1A49EF00FA39D3 /* _WKWebExtensionSQLiteStatement.mm in Sources */,
 				B6A292352B18FCF30061930E /* _WKWebExtensionSQLiteStore.mm in Sources */,
+				B6B156682B5E47A8004F9894 /* _WKWebExtensionStorageSQLiteStore.mm in Sources */,
 				1C5ACF902A955CB000C041C0 /* _WKWebExtensionTabCreationOptions.mm in Sources */,
 				337822432947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.mm in Sources */,
 				3370420A2B58A8390077FF78 /* _WKWebExtensionWebRequestFilter.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
@@ -57,7 +57,6 @@ static auto *storageManifest = @{
 TEST(WKWebExtensionAPIStorage, Errors)
 {
     auto *backgroundScript = Util::constructScript(@[
-        @"browser.test.assertThrows(() => browser?.storage?.local?.get({ 'key': () => { 'function' } }), /it is not JSON-serializable/i)",
         @"browser.test.assertThrows(() => browser?.storage?.local?.get(Date.now()), /'items' value is invalid, because an object or a string or an array of strings or null is expected, but a number was provided/i)",
 
         @"browser.test.assertThrows(() => browser?.storage?.local?.getBytesInUse({}), /'keys' value is invalid, because a string or an array of strings or null is expected, but an object was provided/i)",
@@ -70,6 +69,8 @@ TEST(WKWebExtensionAPIStorage, Errors)
         @"browser.test.assertThrows(() => browser?.storage?.local?.remove(), /A required argument is missing/i)",
         @"browser.test.assertThrows(() => browser?.storage?.local?.remove({}), /'keys' value is invalid, because a string or an array of strings is expected, but an object was provided/i)",
         @"browser.test.assertThrows(() => browser?.storage?.local?.remove([1]), /'keys' value is invalid, because a string or an array of strings is expected, but an array of other values was provided/i)",
+
+        @"browser.test.assertThrows(() => browser?.storage?.local?.clear('key'), /'callback' value is invalid, because a function is expected/i)",
 
         @"browser.test.assertThrows(() => browser?.storage?.session?.setAccessLevel('INVALID_ACCESS_LEVEL'), /'accessOptions' value is invalid, because an object is expected/i)",
         @"browser.test.assertThrows(() => browser?.storage?.session?.setAccessLevel({ 'accessLevel': 'INVALID_ACCESS_LEVEL' }), /'accessLevel' value is invalid, because it must specify either 'TRUSTED_CONTEXTS' or 'TRUSTED_AND_UNTRUSTED_CONTEXTS'/i)",
@@ -186,6 +187,134 @@ TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedAndUntrustedContexts)
     [manager.get().defaultTab.mainWebView loadRequest:urlRequest];
 
     [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIStorage, Set)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
+        @"await browser?.storage?.local?.set(data)",
+
+        @"var result = await browser?.storage?.local?.get()",
+        @"browser.test.assertDeepEq(data, result)",
+
+        @"const additionalData = { 'newItem' : 'item' }",
+        @"await browser?.storage?.local?.set(additionalData)",
+
+        @"result = await browser?.storage?.local?.get()",
+        @"browser.test.assertDeepEq({ ...data, ...additionalData }, result)",
+
+        @"await browser?.storage?.local?.set({ 'boolean': false })",
+        @"result = await browser?.storage?.local?.get('boolean')",
+        @"browser.test.assertFalse(result?.boolean)",
+
+        @"const updatedArray = [ 'new', 'values' ]",
+        @"await browser?.storage?.local?.set({ 'array': updatedArray })",
+
+        @"result = await browser?.storage?.local?.get('array')",
+        @"browser.test.assertDeepEq(updatedArray, result?.array)",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIStorage, Get)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
+        @"await browser?.storage?.local?.set(data)",
+
+        @"var result = await browser?.storage?.local?.get()",
+        @"browser.test.assertDeepEq(data, result)",
+
+        @"result = await browser?.storage?.local?.get('boolean')",
+        @"browser.test.assertTrue(result?.boolean)",
+
+        @"result = await browser?.storage?.local?.get([ 'string', 'number' ])",
+        @"browser.test.assertDeepEq({ 'string': 'string', 'number': 1 }, result)",
+
+        @"result = await browser?.storage?.local?.get({ 'boolean': false, 'unrecognized_key': 'default_value', 'array': [1, true, 'string'] })",
+        @"await browser.test.log(result)",
+        @"browser.test.assertDeepEq({ 'boolean': true, 'unrecognized_key': 'default_value', 'array': [1, true, 'string'] }, result)",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIStorage, GetBytesInUse)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
+        @"await browser?.storage?.local?.set(data)",
+
+        @"var result = await browser?.storage?.local?.getBytesInUse()",
+        @"browser.test.assertEq(result, 79)",
+
+        @"result = await browser?.storage?.local?.getBytesInUse('array')",
+        @"browser.test.assertEq(result, 22)",
+
+        @"result = await browser?.storage?.local?.getBytesInUse([ 'boolean', 'dictionary' ])",
+        @"browser.test.assertEq(result, 36)",
+
+        @"await browser?.storage?.local?.remove('array')",
+        @"result = await browser?.storage?.local?.getBytesInUse()",
+        @"browser.test.assertEq(result, 57)",
+
+        @"await browser?.storage?.local?.clear()",
+        @"result = await browser?.storage?.local?.getBytesInUse()",
+        @"browser.test.assertEq(result, 0)",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIStorage, Remove)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
+        @"await browser?.storage?.local?.set(data)",
+
+        @"await browser?.storage?.local?.remove('string')",
+        @"var result = await browser?.storage?.local?.get('string')",
+        @"browser.test.assertDeepEq(result, {})",
+
+        @"await browser?.storage?.local?.remove([ 'boolean', 'dictionary' ])",
+        @"result = await browser?.storage?.local?.get([ 'boolean', 'dictionary' ])",
+        @"browser.test.assertDeepEq(result, {})",
+
+        @"result = await browser?.storage?.local?.get()",
+        @"browser.test.assertDeepEq(result, { 'number': 1, 'array': [1, true, 'string'] })",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIStorage, Clear)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
+        @"await browser?.storage?.local?.set(data)",
+
+        @"var result = await browser?.storage?.local?.getBytesInUse()",
+        @"browser.test.assertEq(result, 79)",
+
+        @"await browser?.storage?.local?.clear()",
+
+        @"result = await browser?.storage?.local?.getBytesInUse()",
+        @"browser.test.assertEq(result, 0)",
+
+        @"browser.test.notifyPass()",
+    ]);
+
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### e1395e4dbba28625de13524fc5e94921c1eba60e
<pre>
Create and adopt an SQLite store for web extension Storage API
<a href="https://bugs.webkit.org/show_bug.cgi?id=267649">https://bugs.webkit.org/show_bug.cgi?id=267649</a>
<a href="https://rdar.apple.com/121143226">rdar://121143226</a>

Reviewed by Timothy Hatcher.

This patch creates and adopts a _WKWebExtensionStorageSQLiteStore which is used to manage storage
for web extensions. This patch also changes the way the data is sent over to the UI Proccess.
Instead of using a IPC::DataReference object, simply encode the data as a JSON string and send it
that way.

* Source/WebKit/Shared/Extensions/WebExtensionUtilities.h:
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm:
(WebKit::storageSizeOf):
(WebKit::anyItemsExceedQuota):

* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm:
* Source/WebKit/Shared/Extensions/_WKWebExtensionStorageSQLiteStore.h: Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm:
Utlize _WKWebExtensionStorageSQLiteStore to get/set/remove/clear data.
(WebKit::WebExtensionContext::storageGet):
(WebKit::WebExtensionContext::storageGetBytesInUse):
(WebKit::WebExtensionContext::storageSet):
(WebKit::WebExtensionContext::storageRemove):
(WebKit::WebExtensionContext::storageClear):

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::invalidateStorage):
(WebKit::WebExtensionContext::quoataForStorageType):
(WebKit::WebExtensionContext::localStorageStore):
(WebKit::WebExtensionContext::sessionStorageStore):
(WebKit::WebExtensionContext::syncStorageStore):
(WebKit::WebExtensionContext::storageForType):

* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.h: Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.mm: Added.
(rowFilterStringFromRowKeys):
(-[_WKWebExtensionStorageSQLiteStore initWithUniqueIdentifier:storageType:directory:usesInMemoryDatabase:]):
(-[_WKWebExtensionStorageSQLiteStore getValuesForKeys:completionHandler:]):
(-[_WKWebExtensionStorageSQLiteStore getStorageSizeForKeys:completionHandler:]):
(-[_WKWebExtensionStorageSQLiteStore getStorageSizeForAllKeysIncludingKeyedData:withCompletionHandler:]):
(-[_WKWebExtensionStorageSQLiteStore setKeyedData:completionHandler:]):
(-[_WKWebExtensionStorageSQLiteStore deleteValuesForKeys:completionHandler:]):
(-[_WKWebExtensionStorageSQLiteStore _databaseURL]):
(-[_WKWebExtensionStorageSQLiteStore _insertOrUpdateValue:forKey:inDatabase:]):
(-[_WKWebExtensionStorageSQLiteStore _getValuesForAllKeysReturningErrorMessage:]):
(-[_WKWebExtensionStorageSQLiteStore _getKeysAndValuesFromRowEnumerator:]):
(-[_WKWebExtensionStorageSQLiteStore _getAllKeysReturningErrorMessage:]):
(-[_WKWebExtensionStorageSQLiteStore _getValuesForKeys:outErrorMessage:]):
(-[_WKWebExtensionStorageSQLiteStore _currentDatabaseSchemaVersion]):
(-[_WKWebExtensionStorageSQLiteStore _createFreshDatabaseSchema]):
(-[_WKWebExtensionStorageSQLiteStore _resetDatabaseSchema]):
(-[_WKWebExtensionStorageSQLiteStore _isDatabaseEmpty]):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::get):
If &apos;items&apos; is a dictionary with keys and default values, only send the keys over to the UI process
since we can add the default values after we receive the data from storage.

(WebKit::WebExtensionAPIStorageArea::getBytesInUse):
(WebKit::WebExtensionAPIStorageArea::set):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl:
Needs JSContextRef so we can serialize and deserialize the data in &apos;storage.get()&apos; and &apos;storage.set()&apos;.

Canonical link: <a href="https://commits.webkit.org/273468@main">https://commits.webkit.org/273468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70def99d14d34fce050a01109a14506a7ccaec35

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35522 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38263 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32026 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11500 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31631 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10724 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39509 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32096 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34774 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12654 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11453 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4596 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->