### PR TITLE
Add -Wno-elaborated-enum-base to WARNING_FLAGS when building with clang static analyzer

### DIFF
--- a/Configurations/CommonBase.xcconfig
+++ b/Configurations/CommonBase.xcconfig
@@ -56,7 +56,7 @@ WK_COMMON_OTHER_TAPI_FLAGS = -x objective-c++ -std=c++2a -fno-rtti $(WK_SANITIZE
 OTHER_TAPI_FLAGS = $(inherited) $(WK_COMMON_OTHER_TAPI_FLAGS);
 
 WK_COMMON_WARNING_CFLAGS = -Wall -Wc99-designator -Wconditional-uninitialized -Wextra -Wdeprecated-enum-enum-conversion -Wdeprecated-enum-float-conversion -Wenum-float-conversion -Wfinal-dtor-non-final-class -Wformat=2 -Wmisleading-indentation -Wreorder-init-list -Wundef;
-WARNING_CFLAGS = $(inherited) $(WK_COMMON_WARNING_CFLAGS);
+WARNING_CFLAGS = $(inherited) $(WK_COMMON_WARNING_CFLAGS) $(WK_SANITIZER_WARNING_CFLAGS);
 
 WK_LIBCPP_ASSERTIONS_CFLAGS = $(WK_LIBCPP_ASSERTIONS_CFLAGS_$(WK_PLATFORM_NAME));
 WK_LIBCPP_ASSERTIONS_CFLAGS_iphoneos = $(WK_LIBCPP_ASSERTIONS_CFLAGS$(WK_IOS_17));

--- a/Configurations/Sanitizers.xcconfig
+++ b/Configurations/Sanitizers.xcconfig
@@ -43,6 +43,8 @@ WK_SANITIZER_OTHER_TAPI_FLAGS_LIBFUZZER_YES = -Xparser -fsanitize=fuzzer;
 WK_SANITIZER_OTHER_TAPI_FLAGS_TSAN_YES = -Xparser -fsanitize=thread;
 WK_SANITIZER_OTHER_TAPI_FLAGS_UBSAN_YES = -Xparser -fsanitize=undefined;
 
+WK_SANITIZER_WARNING_CFLAGS = $(WK_STATIC_ANALYZER_WARNING_CFLAGS_$(RUN_CLANG_STATIC_ANALYZER));
+
 // All Sanitizers
 
 // FIXME: Tell Xcode not to compile host-side tools with sanitizers enabled (see <rdar://99386433>).
@@ -99,3 +101,8 @@ WK_LIBFUZZER_OTHER_LDFLAGS_YES = -fsanitize-coverage=$(WK_LIBFUZZER_COVERAGE);
 
 WK_FUZZILLI_OTHER_CFLAGS_YES = -fsanitize-coverage=trace-pc-guard -DENABLE_FUZZILLI=1;
 WK_FUZZILLI_OTHER_LDFLAGS_YES = -fsanitize-coverage=trace-pc-guard;
+
+// Clang Static Analyzer
+
+// FIXME: Remove -Wno-elaborated-enum-base once <rdar://121475724> is resolved.
+WK_STATIC_ANALYZER_WARNING_CFLAGS_YES = -Wno-elaborated-enum-base;


### PR DESCRIPTION
#### a4903bd869a66081c14a3d7b160bcce4868a0d85
<pre>
Add -Wno-elaborated-enum-base to WARNING_FLAGS when building with clang static analyzer
<a href="https://bugs.webkit.org/show_bug.cgi?id=267973">https://bugs.webkit.org/show_bug.cgi?id=267973</a>
&lt;<a href="https://rdar.apple.com/121479931">rdar://121479931</a>&gt;

Reviewed by Elliott Williams.

* Configurations/CommonBase.xcconfig:
(WARNING_CFLAGS):
- Add $(WK_SANITIZER_WARNING_CFLAGS) to the list of values.
* Configurations/Sanitizers.xcconfig:
(WK_SANITIZER_WARNING_CFLAGS): Add.
(WK_STATIC_ANALYZER_WARNING_CFLAGS_YES): Add.
- Include -Wno-elaborated-enum-base during build-and-analyze.

Canonical link: <a href="https://commits.webkit.org/273435@main">https://commits.webkit.org/273435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3a7277e397fd559608dcd20567ea13a551f9581

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38075 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31873 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30736 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10567 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10627 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39321 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32111 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31921 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36597 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34620 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12530 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11294 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4572 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->