### PR TITLE
[macOS] WebContent crash in WTF::deallocateSendRightSafely under ~SharedVideoFrameWriter() (GUARD_TYPE_MACH_PORT :: INVALID_NAME)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7471,3 +7471,5 @@ webkit.org/b/266477 compositing/layer-creation/scale-rotation-transition-overlap
 
 # At the time of writing this test consumes all available IOSurfaces. If the next test is image-buffer-backend-variants.html, that will fail.
 fast/canvas/2d.context.many.small.html [ Slow Skip ]
+# rdar://120852401
+[ Debug ] ipc/media-player-invalid-test.html [ Skip ]

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7441,6 +7441,8 @@ imported/w3c/web-platform-tests/css/css-break/flexbox/flexbox-fragmentation-layo
 # css/css-break missing ref
 imported/w3c/web-platform-tests/css/css-break/chrome-bug-1289999-crash.https.html [ Skip ]
 
+webkit.org/b/264830 [ Debug ] fast/rendering/render-list-marker-select.html [ Skip ]
+
 # webkit.org/b/266168 Two wheel/mousewheel passive event listeners WPT test pass on macOS Sonoma and up
 imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-div.html [ Failure ]
 imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-div.html [ Failure ]

--- a/LayoutTests/fast/box-shadow/large-shadowblur-no-crash-expected.txt
+++ b/LayoutTests/fast/box-shadow/large-shadowblur-no-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if test doesn't crash.

--- a/LayoutTests/fast/box-shadow/large-shadowblur-no-crash.html
+++ b/LayoutTests/fast/box-shadow/large-shadowblur-no-crash.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        div {
+            box-shadow: blue 1.76px 0px 10px 24px inset;
+            width: 33554432px;
+            height: 33554432px;
+            border-radius: 5px;
+            filter: sepia(1);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('load', async () => {
+            await UIHelper.renderingUpdate();
+            testRunner.notifyDone();
+        }, false);
+    </script>
+</head>
+<body>
+    <div></div>
+    <p>This test passes if test doesn't crash.</p>
+</body>
+</html>

--- a/LayoutTests/fast/rendering/render-list-marker-select-expected.txt
+++ b/LayoutTests/fast/rendering/render-list-marker-select-expected.txt
@@ -1,0 +1,2 @@
+
+This test should not crash

--- a/LayoutTests/fast/rendering/render-list-marker-select.html
+++ b/LayoutTests/fast/rendering/render-list-marker-select.html
@@ -1,0 +1,17 @@
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+</script>
+<style>
+    ::before, html {
+        & body {
+            display: list-item;
+        }
+    }
+
+    select {
+        display: block;
+    }
+</style>
+<select></select>
+<div>This test should not crash</div>

--- a/LayoutTests/ipc/argumentParser.js
+++ b/LayoutTests/ipc/argumentParser.js
@@ -1,0 +1,196 @@
+let knownSizes = {
+    "unsigned": 4,
+    "int": 4,
+    "uint8_t": 1,
+    "int8_t": 1,
+    "uint64_t": 8,
+    "int64_t": 8,
+    "uint32_t": 4,
+    "int32_t": 4,
+    "uint16_t": 2,
+    "int16_t": 2,
+    "double": 8,
+    "float": 4,
+    "bool": 1,
+    "size_t": 8,
+    "unsigned short": 2,
+    "long long": 8,
+    "UUID": 16
+};
+
+
+// manual additions
+$F.fuzzerTypeInfo = {};
+$F.fuzzerTypeInfo['WebCore::DOMCacheEngine::CacheIdentifierOrError'] = [{'type': 'Expected<WebCore::DOMCacheEngine::CacheIdentifierOperationResult, Error>'}];
+
+let ArgumentParser = {};
+function align(pos, granularity) {
+    if(pos%granularity) {
+        pos = pos + granularity-(pos%granularity);
+    }
+    return pos;
+}
+
+ArgumentParser.parseMessage = function(msg, proc) {
+    let buffer = new Uint8Array(msg.buffer);
+    window.bada = buffer;
+    let name = msg.description;
+    let args = IPCmessages[name].arguments;
+    let results = {};
+    try {
+        ArgumentParser.parse(buffer, args, 0x10 /*skip message header*/, results);
+        if(proc) results[proc + "Connection"] = [ msg.destinationID ];
+        let clz = msg.description.substring(0, msg.description.indexOf("_"));
+        if(proc) results["clz_" + clz + "Connection"] = [ msg.destinationID ];
+        //$F.exec.log("//blam: " + msg.destinationID);
+        if($F.rand && $F.rand.chance(16)) {
+            //$F.exec.log("// focus on " + clz);
+            $F.focusClass = clz;
+        }
+    } catch (e) {
+        //$F.exec.log("//Bug: " + e);
+    }
+    return results;
+}
+
+ArgumentParser.parseMessageFromReply = function(args, buffer) {
+    buffer = new Uint8Array(buffer);
+    let results = {};
+    try {
+        ArgumentParser.parse(buffer, args, 0x10/*skip message header*/, results);
+    } catch (e) {
+        //$F.exec.log("//Bug: " + e);
+    }
+    return results;
+}
+
+function addResult(results, t, id) {
+    if(t in results) {
+        results[t].push(id);
+    } else {
+        results[t] = [ id ];
+    }
+}
+
+ArgumentParser.parse = function(buf, args, pos, results) {
+    if(args == null) return -1;
+    if(args.length == 0) return pos;
+    let arg = args.shift();
+    let t = arg['type'];
+    //$F.exec.log("// next " + t + " -> " + arg['optional']);
+    if(arg['optional']) {
+        let haz = !!buf[pos];
+        pos += 1
+        if(!haz) {
+            //$F.exec.log("// skipping optional argument")
+            return ArgumentParser.parse(buf, args, pos, results);
+        }
+    }
+    if (processQualified.includes(t)) {
+        pos = align(pos, 8);
+        if(pos + 16 > buf.length) {
+            //$F.exec.log("// Message too small to contain identifier")
+            return -1;
+        }
+        let view = new DataView(buf.buffer, pos);
+        let id1 = view.getBigUint64(0, true);
+        let id2 = view.getBigUint64(8, true);
+        addResult(results, t, id1);
+        addResult(results, "WebCore::ProcessIdentifier", id2);
+        return ArgumentParser.parse(buf, args, pos + 16, results);
+    } else if ( IPCobjectIdentifiers.includes(t) ) {
+        pos = align(pos, 8);
+        if(pos + 8 > buf.length) {
+            //$F.exec.log("// Message too small to contain identifier")
+            return -1;
+        }
+        let view = new DataView(buf.buffer, pos);
+        let id = view.getBigUint64(0, true);
+        //$F.exec.log("// Got Identifier '" + t + "': " + id);
+        //$F.objstore.addObj(t, id);
+        addResult(results, t, id);
+        return ArgumentParser.parse(buf, args, pos + 8, results);
+    } else if ( knownSizes[t] ) {
+        pos = align(pos, knownSizes[t]);
+        pos += knownSizes[t];
+        return ArgumentParser.parse(buf, args, pos, results);
+    } else if ( IPCserializedEnumInfo[t] ) {
+        let enumInfo = IPCserializedEnumInfo[t];
+        pos = align(pos, enumInfo.size);
+        pos += enumInfo.size;
+        return ArgumentParser.parse(buf, args, pos, results);
+    } else if ( $F.fuzzerTypeInfo[t] ) {
+        pos = ArgumentParser.parse(buf, $F.fuzzerTypeInfo[t], pos, results);
+        if(pos==-1) return -1;
+        return ArgumentParser.parse(buf, args, pos, results);
+    } else if ( IPCserializedTypeInfo[t] ) {
+        let typeInfo = IPCserializedTypeInfo[t];
+        let subArgs = [];
+        for (const element of typeInfo) {
+            subArgs.push(element);
+        }
+        pos = ArgumentParser.parse(buf, subArgs, pos, results);
+        if(pos==-1) return -1;
+        return ArgumentParser.parse(buf, args, pos, results);
+    } else if ( t == "String" || t == "URL" ) {
+        pos = align(pos, 4);
+        let view = new DataView(buf.buffer, pos);
+        let strLen = view.getUint32(0, true);
+        pos += 4;
+        if ( buf[pos++] == 0x01 ) {
+            let str = "";
+            for(let i=0; i<strLen; i++) {
+                str += String.fromCharCode(buf[pos++]);
+            }
+            return ArgumentParser.parse(buf, args, pos, results);
+        }  else {
+            // Other encodings are not supported
+            return -1;
+        }
+    } else if ( t.indexOf("std::pair<") == 0) {
+        let types = t.substr(10).split(", ");
+        for(const nextt of types) {
+            let contentArg = {'type': nextt};
+            pos = ArgumentParser.parse(buf, [ contentArg ], pos, results);
+            if(pos==-1) return -1;
+        }
+        return ArgumentParser.parse(buf, args, pos, results);
+    } else if ( t.indexOf("Expected<") == 0) {
+        let haz = !!buf[pos];
+        pos += 1
+        if(haz) {
+            let expected_type = t.substr(9).split(",")[0];
+            let contentArg = {'type': expected_type};
+            pos = ArgumentParser.parse(buf, [ contentArg ], pos, results);
+            if (pos == -1) {
+                return -1;
+            }
+            return ArgumentParser.parse(buf, args, pos, results);
+        } else {
+            return -1;
+        }
+    } else if ( t.indexOf("Vector<") == 0 ) {
+        pos = align(pos, 8);
+        if(pos + 8 > buf.length) {
+            //$F.exec.log("// Message too small to contain identifier")
+            return -1;
+        }
+        let view = new DataView(buf.buffer, pos);
+        let id = view.getBigUint64(0, true);
+        pos += 8;
+        if(id > 0x1000) {
+            return -1;
+        }
+        let contentArg = {'type': t.substring(7, t.length-1)};
+        for(let x = 0; x<id; x++) {
+            pos = ArgumentParser.parse(buf, [ contentArg ], pos, results);
+            if (pos == -1) {
+                return -1
+            }
+        }
+        return ArgumentParser.parse(buf, args, pos, results);
+    } else {
+        //$F.exec.log("//[x] could not parse '"+t+"'");
+    }
+    return -1;
+}

--- a/LayoutTests/ipc/fuzz_tools.js
+++ b/LayoutTests/ipc/fuzz_tools.js
@@ -1,0 +1,148 @@
+if(!window.$F) {
+    $F={};
+    $F.enableListener= true;
+}
+
+if(window.testRunner) {
+    testRunner.waitUntilDone();
+}
+
+if (window.IPC) {
+    // Cache to avoid context switches from JavaScript to Native
+    const IPCmessages = JSON.parse(JSON.stringify(IPC.messages));
+    const IPCobjectIdentifiers = JSON.parse(JSON.stringify(IPC.objectIdentifiers));
+    IPCobjectIdentifiers.push("PAL::SessionID");
+    IPCobjectIdentifiers.push("WebCore::ProcessIdentifier");
+    IPCobjectIdentifiers.push("WebKit::RemoteMediaSourceIdentifier");
+    IPCobjectIdentifiers.push("WebCore::MediaPlayerIdentifier");
+    IPCobjectIdentifiers.push("IPC::AsyncReplyID");
+    IPCobjectIdentifiers.push("ActivityStateChangeID");
+    IPCobjectIdentifiers.push("WebKit::EditorStateIdentifier");
+    IPCobjectIdentifiers.push("WebCore::PageOverlay::PageOverlayID");
+    IPCobjectIdentifiers.push("WebKit::DisplayLinkObserverID");
+    IPCobjectIdentifiers.push("WebKit::TextCheckerRequestID");
+    IPCobjectIdentifiers.push("WebKit::RemoteCDMIdentifier");
+    IPCobjectIdentifiers.push("WebKit::RemoteCDMInstanceIdentifier");
+    IPCobjectIdentifiers.push("WebKit::RemoteCDMInstanceSessionIdentifier");
+    IPCobjectIdentifiers.push("WebKit::RemoteSourceBufferIdentifier");
+    
+    const IPCserializedTypeInfo = JSON.parse(JSON.stringify(IPC.serializedTypeInfo));
+    const IPCserializedEnumInfo = JSON.parse(JSON.stringify(IPC.serializedEnumInfo));
+
+    const processQualified = ["WebCore::FrameIdentifier","WebCore::ScriptExecutionContextIdentifier","WebCore::PolicyCheckIdentifier","WebCore::WebLockIdentifier","WebCore::PlatformLayerIdentifier","WebCore::BackForwardItemIdentifier","WebCore::SharedWorkerObjectIdentifier"];
+
+    $F.GPUOutgoingHandler = {};
+    $F.UIOutgoingHandler = {};
+    $F.UIIncomingHandler = {};
+    $F.GPUIncomingHandler = {};
+    $F.NetworkingOutgoingHandler = {};
+    $F.NetworkingIncomingHandler = {};
+
+    function shouldDiscard(args) {
+        for(let a of args) {
+            if(Array.isArray(a)) {
+                if(shouldDiscard(a)) return true;
+            } else {
+                if(a['type']) {
+                    if(a['type'] == 'FrameID') {
+                        if(!Array.isArray(a['value'])) return true;
+                    } else if(a['type'] == 'Vector') {
+                        if(shouldDiscard(a['value'])) return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    $F.sendMessage = (process, connId, name, args) => {
+        if(shouldDiscard(args)) return;
+        if(window.$F) $F.enableListener = false;
+        try{
+            return IPC.sendMessage(process, connId, name, args);
+        }catch(e) {
+            $vm.print("[-] send exception: " + e);
+        }
+        finally {
+            $F.enableListener = true;
+        }
+    }
+    $F.sendSyncMessage = (process, connId, name, timeout, args) => {
+        if(shouldDiscard(args)) return;
+        if(window.$F) $F.enableListener = false;
+        try{
+            return IPC.sendSyncMessage(process, connId, name, timeout, args);
+        }catch(e) {
+            $vm.print("[-] sync send exception: " + e);
+        }
+        finally {
+            $F.enableListener = true;
+        }
+    }
+
+    IPC.addOutgoingMessageListener("GPU", (msg) => {
+        if(window.$F && $F.enableListener) {
+            let name = msg.name;
+            if (name in $F.GPUOutgoingHandler) {
+                let func = $F.GPUOutgoingHandler[name];
+                delete $F.GPUOutgoingHandler[name];
+                func(msg);
+            }
+        }
+    });
+
+    IPC.addOutgoingMessageListener("UI", (msg) => {
+        if(window.$F && $F.enableListener) {
+            let name = msg.name;
+            if (name in $F.UIOutgoingHandler) {
+                let func = $F.UIOutgoingHandler[name];
+                delete $F.UIOutgoingHandler[name];
+                func(msg);
+            }
+        }
+    });
+
+    IPC.addIncomingMessageListener("GPU", (msg) => {
+        if(window.$F && $F.enableListener) {
+            let name = msg.name;
+            if (name in $F.GPUIncomingHandler) {
+                let func = $F.GPUIncomingHandler[name];
+                delete $F.GPUIncomingHandler[name];
+                func(msg);
+            }
+        }
+    });
+
+    IPC.addIncomingMessageListener("UI", (msg) => {
+        if(window.$F && $F.enableListener) {
+            let name = msg.name;
+            if (name in $F.UIIncomingHandler) {
+                let func = $F.UIIncomingHandler[name];
+                delete $F.UIIncomingHandler[name];
+                func(msg);
+            }
+        }
+    });
+
+    IPC.addOutgoingMessageListener("Networking", (msg) => {
+        if(window.$F && $F.enableListener) {
+            let name = msg.name;
+            if (name in $F.NetworkingOutgoingHandler) {
+                let func = $F.NetworkingOutgoingHandler[name];
+                delete $F.NetworkingOutgoingHandler[name];
+                func(msg);
+            }
+        }
+    });
+
+    IPC.addIncomingMessageListener("Networking", (msg) => {
+        if(window.$F && $F.enableListener) {
+            let name = msg.name;
+            if (name in $F.NetworkingIncomingHandler) {
+                let func = $F.NetworkingIncomingHandler[name];
+                delete $F.NetworkingIncomingHandler[name];
+                func(msg);
+            }
+        }
+    });
+}

--- a/LayoutTests/ipc/media-player-invalid-test-expected.txt
+++ b/LayoutTests/ipc/media-player-invalid-test-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/media-player-invalid-test.html
+++ b/LayoutTests/ipc/media-player-invalid-test.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html><head>
+<script src="fuzz_tools.js"></script>
+<script src="argumentParser.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    setTimeout(() => {
+        testRunner.notifyDone();
+    }, 2000);
+    testRunner.dumpAsText();
+}
+
+function fuzz() {
+    if (window.IPC && IPC) {
+      $F.GPUOutgoingHandler[IPC.messages.RemoteMediaPlayerManagerProxy_CreateMediaPlayer.name]=parseMessage;
+      video=document.createElement('video');
+      video.src='abc';
+    }
+}
+function parseMessage(msg) {
+  let parseResults=ArgumentParser.parseMessage(msg,'GPU');
+  o17=parseResults['WebCore::MediaPlayerIdentifier'][0];
+  o19=parseResults['GPUConnection'][0];
+  o20=parseResults['clz_RemoteMediaPlayerManagerProxyConnection'][0];
+  IPC.sendMessage('GPU',o19,IPCmessages.GPUConnectionToWebProcess_EnableMockMediaSource.name,[]);
+  window.setTimeout(timeout_159,200);
+}
+function timeout_159() {
+  IPC.sendMessage('GPU',o20,IPCmessages.RemoteMediaPlayerManagerProxy_CreateMediaPlayer.name,[{type: 'uint64_t',value: o17},{type: 'uint8_t',value: 8},{type: 'String',value: ''},{type: 'String',value: ''},{type: 'String',value: ''},{type: 'String',value: ''},{type: 'Vector',value: [[{type: 'String',value: "pageUp:"}],[{type: 'String',value: ''}]]},{type: 'bool',value: 1},{type: 'Vector',value: [[{type: 'String',value: ''}],[{type: 'String',value: ''}],[{type: 'String',value: ''}],[{type: 'String',value: "video/mpeg"}],[{type: 'String',value: ''}],[{type: 'String',value: "http"}],[{type: 'String',value: "a"}],[{type: 'String',value: ''}],[{type: 'String',value: ''}]]},{type: 'bool',value: 0},{type: 'bool',value: 1},{type: 'Vector',value: []},{type: 'bool',value: 1},{type: 'Vector',value: [[{type: 'uint32_t',value: 476}],[{type: 'uint32_t',value: 555}]]},{type: 'bool',value: 0},{type: 'uint32_t',value: 697},{type: 'uint32_t',value: 644},{type: 'uint32_t',value: 543},{type: 'uint32_t',value: 460},{type: 'Vector',value: [[{type: 'String',value: "page-6"}],[{type: 'String',value: ''}]]},{type: 'Vector',value: []},{type: 'uint8_t',value: 0},{type: 'String',value: "file:///tmp/ipcfuzz"},{type: 'String',value: "file:///etc/passwd"},{type: 'bool',value: 1},{type: 'uint16_t',value: 47385},{type: 'uint32_t',value: 174},{type: 'uint32_t',value: 632},{type: 'float',value: 341},{type: 'float',value: 1316.9076250987036},{type: 'uint64_t',value: 1009},{type: 'bool',value: 1},{type: 'bool',value: 1},{type: 'bool',value: 0},{type: 'bool',value: 0},{type: 'bool',value: 1}]);
+  o112=2395;
+  IPC.sendMessage("GPU",o17,IPC.messages.RemoteMediaPlayerProxy_LoadMediaSource.name, [{type:"String", value: ''},{type:"String", value: ''},{type: "bool", value: 0},{type: "uint64_t", value: o112}]);
+  IPC.sendMessage('GPU',o20,IPC.messages.RemoteMediaPlayerManagerProxy_DeleteMediaPlayer.name,[{type: 'uint64_t',value: o17}]);
+  IPC.sendMessage('GPU',o112,IPCmessages.RemoteMediaSourceProxy_MarkEndOfStream.name,[{type: 'bool',value: 0}]);
+}
+</script></head>
+<body onload='fuzz()'>
+    This test passes if it does not crash.
+</body>
+</html>

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_vp9.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_vp9.cc
@@ -296,6 +296,10 @@ RTPVideoHeaderVP9 RemoveInactiveSpatialLayers(
   RTPVideoHeaderVP9 hdr(original_header);
   if (original_header.first_active_layer == 0)
     return hdr;
+#ifdef WEBRTC_WEBKIT_BUILD
+  if (hdr.num_spatial_layers < 1 || hdr.num_spatial_layers > kMaxVp9NumberOfSpatialLayers)
+    return hdr;
+#endif
   for (size_t i = hdr.first_active_layer; i < hdr.num_spatial_layers; ++i) {
     hdr.width[i - hdr.first_active_layer] = hdr.width[i];
     hdr.height[i - hdr.first_active_layer] = hdr.height[i];

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_vp9.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_vp9.cc
@@ -125,7 +125,12 @@ size_t SsDataLength(const RTPVideoHeaderVP9& hdr) {
 
   RTC_DCHECK_GT(hdr.num_spatial_layers, 0U);
   RTC_DCHECK_LE(hdr.num_spatial_layers, kMaxVp9NumberOfSpatialLayers);
+#ifdef WEBRTC_WEBKIT_BUILD
+  if (hdr.gof.num_frames_in_gof > kMaxVp9FramesInGof)
+    return 0;
+#else
   RTC_DCHECK_LE(hdr.gof.num_frames_in_gof, kMaxVp9FramesInGof);
+#endif
   size_t length = 1;  // V
   if (hdr.spatial_layer_resolution_present) {
     length += 4 * hdr.num_spatial_layers;  // Y

--- a/Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Out-of-bounds-crash-in-webrtc-anonymous_namespace-RemoveInactiveSpatialLayers.patch
+++ b/Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Out-of-bounds-crash-in-webrtc-anonymous_namespace-RemoveInactiveSpatialLayers.patch
@@ -1,0 +1,15 @@
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_vp9.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_vp9.cc
+index 15e059e85c89..bddb39f70c3e 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_vp9.cc
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_vp9.cc
+@@ -291,6 +291,10 @@ RTPVideoHeaderVP9 RemoveInactiveSpatialLayers(
+   RTPVideoHeaderVP9 hdr(original_header);
+   if (original_header.first_active_layer == 0)
+     return hdr;
++#ifdef WEBRTC_WEBKIT_BUILD
++  if (hdr.num_spatial_layers < 1 || hdr.num_spatial_layers > kMaxVp9NumberOfSpatialLayers)
++    return hdr;
++#endif
+   for (size_t i = hdr.first_active_layer; i < hdr.num_spatial_layers; ++i) {
+     hdr.width[i - hdr.first_active_layer] = hdr.width[i];
+     hdr.height[i - hdr.first_active_layer] = hdr.height[i];

--- a/Source/ThirdParty/libwebrtc/WebKit/01-WebRTC-Stack-buffer-overflow-in-webrtc-anonymous_namespace-SsDataLength.patch
+++ b/Source/ThirdParty/libwebrtc/WebKit/01-WebRTC-Stack-buffer-overflow-in-webrtc-anonymous_namespace-SsDataLength.patch
@@ -1,0 +1,17 @@
+diff --git a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_vp9.cc b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_vp9.cc
+index 15e059e85c89..60c18b807d74 100644
+--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_vp9.cc
++++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_vp9.cc
+@@ -125,7 +125,12 @@ size_t SsDataLength(const RTPVideoHeaderVP9& hdr) {
+ 
+   RTC_DCHECK_GT(hdr.num_spatial_layers, 0U);
+   RTC_DCHECK_LE(hdr.num_spatial_layers, kMaxVp9NumberOfSpatialLayers);
++#ifdef WEBRTC_WEBKIT_BUILD
++  if (hdr.gof.num_frames_in_gof > kMaxVp9FramesInGof)
++    return 0;
++#else
+   RTC_DCHECK_LE(hdr.gof.num_frames_in_gof, kMaxVp9FramesInGof);
++#endif
+   size_t length = 1;  // V
+   if (hdr.spatial_layer_resolution_present) {
+     length += 4 * hdr.num_spatial_layers;  // Y

--- a/Source/WebCore/platform/graphics/ShadowBlur.cpp
+++ b/Source/WebCore/platform/graphics/ShadowBlur.cpp
@@ -897,7 +897,7 @@ void ShadowBlur::blurShadowBuffer(ImageBuffer& layerImage, const IntSize& templa
     if (!layerData)
         return;
 
-    blurLayerImage(layerData->bytes(), blurRect.size(), blurRect.width() * 4);
+    blurLayerImage(layerData->bytes(), layerData->size(), layerData->size().width() * 4);
     layerImage.putPixelBuffer(*layerData, blurRect);
 }
 

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp
@@ -47,12 +47,12 @@ MockMediaSourcePrivate::MockMediaSourcePrivate(MockMediaPlayerMediaSource& paren
     : MediaSourcePrivate(client)
     , m_player(parent)
 #if !RELEASE_LOG_DISABLED
-    , m_logger(m_player.mediaPlayerLogger())
-    , m_logIdentifier(m_player.mediaPlayerLogIdentifier())
+    , m_logger(m_player->mediaPlayerLogger())
+    , m_logIdentifier(m_player->mediaPlayerLogIdentifier())
 #endif
 {
 #if !RELEASE_LOG_DISABLED
-    client.setLogIdentifier(m_player.mediaPlayerLogIdentifier());
+    client.setLogIdentifier(m_player->mediaPlayerLogIdentifier());
 #endif
 }
 
@@ -76,34 +76,41 @@ MediaSourcePrivate::AddStatus MockMediaSourcePrivate::addSourceBuffer(const Cont
 void MockMediaSourcePrivate::durationChanged(const MediaTime& duration)
 {
     MediaSourcePrivate::durationChanged(duration);
-    m_player.updateDuration(duration);
+    if (m_player)
+        m_player->updateDuration(duration);
 }
 
 void MockMediaSourcePrivate::markEndOfStream(EndOfStreamStatus status)
 {
-    if (status == EndOfStreamStatus::NoError)
-        m_player.setNetworkState(MediaPlayer::NetworkState::Loaded);
+    if (m_player && status == EndOfStreamStatus::NoError)
+        m_player->setNetworkState(MediaPlayer::NetworkState::Loaded);
     MediaSourcePrivate::markEndOfStream(status);
 }
 
 MediaPlayer::ReadyState MockMediaSourcePrivate::mediaPlayerReadyState() const
 {
-    return m_player.readyState();
+    if (m_player)
+        return m_player->readyState();
+    return MediaPlayer::ReadyState::HaveNothing;
 }
 
 void MockMediaSourcePrivate::setMediaPlayerReadyState(MediaPlayer::ReadyState readyState)
 {
-    m_player.setReadyState(readyState);
+    if (m_player)
+        m_player->setReadyState(readyState);
 }
 
 void MockMediaSourcePrivate::notifyActiveSourceBuffersChanged()
 {
-    m_player.notifyActiveSourceBuffersChanged();
+    if (m_player)
+        m_player->notifyActiveSourceBuffersChanged();
 }
 
 MediaTime MockMediaSourcePrivate::currentMediaTime() const
 {
-    return m_player.currentMediaTime();
+    if (m_player)
+        return m_player->currentMediaTime();
+    return MediaTime::invalidTime();
 }
 
 std::optional<VideoPlaybackQualityMetrics> MockMediaSourcePrivate::videoPlaybackQualityMetrics()

--- a/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h
@@ -48,7 +48,7 @@ public:
 
     constexpr MediaPlatformType platformType() const final { return MediaPlatformType::Mock; }
 
-    MockMediaPlayerMediaSource& player() const { return m_player; }
+    WeakPtr<MockMediaPlayerMediaSource> player() const { return m_player; }
 
     MediaTime currentMediaTime() const final;
 
@@ -83,7 +83,7 @@ private:
 
     friend class MockSourceBufferPrivate;
 
-    MockMediaPlayerMediaSource& m_player;
+    WeakPtr<MockMediaPlayerMediaSource> m_player;
 
     unsigned m_totalVideoFrames { 0 };
     unsigned m_droppedVideoFrames { 0 };

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -28,6 +28,7 @@
 #include "LineInlineHeaders.h"
 #include "RenderChildIterator.h"
 #include "RenderListMarker.h"
+#include "RenderMenuList.h"
 #include "RenderMultiColumnFlow.h"
 #include "RenderRuby.h"
 #include "RenderTable.h"
@@ -53,7 +54,7 @@ static RenderBlock* getParentOfFirstLineBox(RenderBlock& current, RenderObject& 
         if (child.isInline() && (!is<RenderInline>(child) || generatesLineBoxesForInlineChild(current, &child)))
             return &current;
 
-        if (child.isFloating() || child.isOutOfFlowPositioned())
+        if (child.isFloating() || child.isOutOfFlowPositioned() || is<RenderMenuList>(child))
             continue;
 
         if (!is<RenderBlock>(child) || is<RenderTable>(child) || is<RenderRubyAsBlock>(child))

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -153,16 +153,13 @@ private:
     RefPtr<WebCore::ImageBuffer> createAlignedImageBuffer(const WebCore::FloatSize&, const WebCore::DestinationColorSpace&, std::optional<WebCore::RenderingMethod>) const final;
     RefPtr<WebCore::ImageBuffer> createAlignedImageBuffer(const WebCore::FloatRect&, const WebCore::DestinationColorSpace&, std::optional<WebCore::RenderingMethod>) const final;
 
-#if PLATFORM(COCOA) && ENABLE(VIDEO)
-    SharedVideoFrameWriter& ensureSharedVideoFrameWriter();
-#endif
-
     WebCore::RenderingResourceIdentifier m_destinationBufferIdentifier;
     ThreadSafeWeakPtr<RemoteImageBufferProxy> m_imageBuffer;
     WeakPtr<RemoteRenderingBackendProxy> m_renderingBackend;
     WebCore::RenderingMode m_renderingMode;
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
-    std::unique_ptr<SharedVideoFrameWriter> m_sharedVideoFrameWriter;
+    Lock m_sharedVideoFrameWriterLock;
+    std::unique_ptr<SharedVideoFrameWriter> m_sharedVideoFrameWriter WTF_GUARDED_BY_LOCK(m_sharedVideoFrameWriterLock);
 #endif
 };
 


### PR DESCRIPTION
#### 0abac9dcb7e3639246a7c64b4b54a7b855ab5d26
<pre>
[macOS] WebContent crash in WTF::deallocateSendRightSafely under ~SharedVideoFrameWriter() (GUARD_TYPE_MACH_PORT :: INVALID_NAME)
<a href="https://rdar.apple.com/114943202">rdar://114943202</a>

Reviewed by Chris Dumez.

After <a href="https://bugs.webkit.org/show_bug.cgi?id=258379">https://bugs.webkit.org/show_bug.cgi?id=258379</a>, we were creating the writer lazily but the creation can be triggered from multiple threads at once.
Given SharedVideoFrameWriter is expected to be used on a single thread/queue, we now protect it in RemoteDisplayListRecorderProxy with a lock.

* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordPaintVideoFrame):
(WebKit::RemoteDisplayListRecorderProxy::disconnect):
(WebKit::RemoteDisplayListRecorderProxy::ensureSharedVideoFrameWriter): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:

Originally-landed-as: 267815.610@safari-7617-branch (8d4c34c20726). <a href="https://rdar.apple.com/121480967">rdar://121480967</a>
Canonical link: <a href="https://commits.webkit.org/273433@main">https://commits.webkit.org/273433@main</a>
</pre>
----------------------------------------------------------------------
#### 1e8c797c8799581ef47ad5a25f917064b1f40823
<pre>
heap-buffer-overflow: crash under WebCore::ShadowBlur::blurLayerImage().
<a href="https://bugs.webkit.org/show_bug.cgi?id=264978">https://bugs.webkit.org/show_bug.cgi?id=264978</a>
<a href="https://rdar.apple.com/118004762">rdar://118004762</a>.

Reviewed by Simon Fraser.

For very large box-shadow sizes due to floating point precision error,
ImageBuffer::getPixelBuffer returns &apos;PixelBuffer&apos; size which
is not same as passed size.This causes buffer overflow/underflow
issue for these large sizes. In order to fix it now we use same
size as allocated &apos;PixelBuffer&apos; size even though it could be slightly
different than original size.

* LayoutTests/fast/box-shadow/large-shadowblur-no-crash-expected.txt: Added test expected file.
* LayoutTests/fast/box-shadow/large-shadowblur-no-crash.html: Added test case.
* Source/WebCore/platform/graphics/ShadowBlur.cpp:
(WebCore::ShadowBlur::blurShadowBuffer): Using same size as allocated pixel buffer size.

Originally-landed-as: 267815.608@safari-7617-branch (e09e3cd2f3db). <a href="https://rdar.apple.com/121481090">rdar://121481090</a>
Canonical link: <a href="https://commits.webkit.org/273432@main">https://commits.webkit.org/273432@main</a>
</pre>
----------------------------------------------------------------------
#### bb644de42b02991f8e878e917b2df008a9a17a3e
<pre>
[WebRTC] Out-of-bounds crash in webrtc::anonymous_namespace::RemoveInactiveSpatialLayers() in vp9 packetizer
<a href="https://bugs.webkit.org/show_bug.cgi?id=265776">https://bugs.webkit.org/show_bug.cgi?id=265776</a>
&lt;<a href="https://rdar.apple.com/119112931">rdar://119112931</a>&gt;

Reviewed by Youenn Fablet.

* Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_vp9.cc:
(webrtc::anonymous_namespace::RemoveInactiveSpatialLayers):
- Add sanity check for RTPVideoHeaderVP9::num_spatial_layers.  This
  matches the check in SsDataLength(), but that&apos;s called later when
  initializing fields in RtpPacketizerVp9.

* Source/ThirdParty/libwebrtc/WebKit/0001-WebRTC-Out-of-bounds-crash-in-webrtc-anonymous_namespace-RemoveInactiveSpatialLayers.patch: Add.

Originally-landed-as: 267815.607@safari-7617-branch (7fa29f992225). <a href="https://rdar.apple.com/121481068">rdar://121481068</a>
Canonical link: <a href="https://commits.webkit.org/273431@main">https://commits.webkit.org/273431@main</a>
</pre>
----------------------------------------------------------------------
#### 15774fae27ec36386eddb171418ddcfe1c488c08
<pre>
[WebRTC] Stack-buffer-overflow in webrtc::anonymous_namespace::SsDataLength() in vp9 packetizer
<a href="https://bugs.webkit.org/show_bug.cgi?id=265727">https://bugs.webkit.org/show_bug.cgi?id=265727</a>
&lt;<a href="https://rdar.apple.com/119074872">rdar://119074872</a>&gt;

Reviewed by Youenn Fablet.

* Source/ThirdParty/libwebrtc/Source/webrtc/modules/rtp_rtcp/source/rtp_format_vp9.cc:
(webrtc::anonymous_namespace::SsDataLength):
- Change debug assertion into runtime check.

* Source/ThirdParty/libwebrtc/WebKit/01-WebRTC-Stack-buffer-overflow-in-webrtc-anonymous_namespace-SsDataLength.patch: Add.

Originally-landed-as: 267815.606@safari-7617-branch (f2ba7a5d0dd0). <a href="https://rdar.apple.com/121481147">rdar://121481147</a>
Canonical link: <a href="https://commits.webkit.org/273430@main">https://commits.webkit.org/273430@main</a>
</pre>
----------------------------------------------------------------------
#### 622f92afdb426af016db98987bbe36b87c9098f5
<pre>
jsc_fuz/wktr: null ptr deref in WebCore::RenderMenuList::computeIntrinsicLogicalWidths
<a href="https://bugs.webkit.org/show_bug.cgi?id=264830">https://bugs.webkit.org/show_bug.cgi?id=264830</a>
<a href="https://rdar.apple.com/115721454">rdar://115721454</a>

Reviewed by Alan Baradlay.

Null pointer dereference error caused by render tree being ordered incorrectly. RenderListMarker
was being placed inside RenderMenuList, where RenderListMarker and RenderMenuList should be on
the same level and in RenderListItem

* LayoutTests/fast/rendering/render-list-marker-select-expected.txt:
* LayoutTests/fast/rendering/render-list-marker-select.html:
* Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp:
(WebCore::getParentOfFirstLineBox): added check to ensure RenderListMarker isn&apos;t placed inside
RenderMenuList but can be placed at same level (ie, sibling)

Originally-landed-as: 267815.595@safari-7617-branch (2a1f2e7acfe2). <a href="https://rdar.apple.com/121481232">rdar://121481232</a>
Canonical link: <a href="https://commits.webkit.org/273429@main">https://commits.webkit.org/273429@main</a>
</pre>
----------------------------------------------------------------------
#### 4d861ff045d4ce0cc26414854fbb422b0299960f
<pre>
[CoreIPC] heap-use-after-free in WebCore::MockMediaSourcePrivate::markEndOfStream
<a href="https://rdar.apple.com/115982856">rdar://115982856</a>

Reviewed by Jean-Yves Avenard and Eric Carlson.

Error only hit in internal testing. Object was referenced after deletion. Updated `MockMediaPlayer` to use weak pointer for `m_player` instead of reference and added checks to methods to check that `m_player` exists before trying to read/write

* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.cpp: added check that `m_player` exists before accessing
* Source/WebCore/platform/mock/mediasource/MockMediaSourcePrivate.h: changed `m_player` to weak pointer instead of a reference
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp:
(WebCore::MockSourceBufferPrivate::readyState const):
(WebCore::MockSourceBufferPrivate::setReadyState):

Originally-landed-as: 267815.570@safari-7617-branch (fc6f62059d44). <a href="https://rdar.apple.com/121481507">rdar://121481507</a>
Canonical link: <a href="https://commits.webkit.org/273428@main">https://commits.webkit.org/273428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f9377e724be6ab33fcbbd93647f26e79731345c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38078 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31876 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36538 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30742 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10573 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10622 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39324 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32114 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31916 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36596 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8682 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34619 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/languages (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12533 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31240 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/8095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11297 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4571 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11590 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->