### PR TITLE
Adopt more smart pointers in HistoryController.cpp

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3060,7 +3060,7 @@ void FrameLoader::detachFromParent()
     Ref frame = m_frame.get();
 
     closeURL();
-    history().saveScrollPositionAndViewStateToItem(history().currentItem());
+    history().saveScrollPositionAndViewStateToItem(history().protectedCurrentItem().get());
     detachChildren();
     if (frame->document()->backForwardCacheState() != Document::InBackForwardCache) {
         // stopAllLoaders() needs to be called after detachChildren() if the document is not in the back/forward cache,
@@ -4097,6 +4097,11 @@ void FrameLoader::loadSameDocumentItem(HistoryItem& item)
 
     // Restore user view state from the current history item here since we don't do a normal load.
     history().restoreScrollPositionAndViewState();
+}
+
+CheckedRef<HistoryController> FrameLoader::checkedHistory() const
+{
+    return *m_history;
 }
 
 // FIXME: This function should really be split into a couple pieces, some of

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -117,6 +117,7 @@ public:
     PolicyChecker& policyChecker() const { return *m_policyChecker; }
 
     HistoryController& history() const { return *m_history; }
+    CheckedRef<HistoryController> checkedHistory() const;
     ResourceLoadNotifier& notifier() const { return m_notifier; }
 
     class SubframeLoader;

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -71,11 +71,11 @@ HistoryController::~HistoryController() = default;
 
 void HistoryController::saveScrollPositionAndViewStateToItem(HistoryItem* item)
 {
-    auto* frameView = m_frame.view();
+    RefPtr frameView = m_frame->view();
     if (!item || !frameView)
         return;
 
-    if (m_frame.document()->backForwardCacheState() != Document::NotInBackForwardCache) {
+    if (m_frame->document()->backForwardCacheState() != Document::NotInBackForwardCache) {
         item->setScrollPosition(frameView->cachedScrollPosition());
 #if PLATFORM(IOS_FAMILY)
         item->setUnobscuredContentRect(frameView->cachedUnobscuredContentRect());
@@ -89,8 +89,8 @@ void HistoryController::saveScrollPositionAndViewStateToItem(HistoryItem* item)
 #endif
     }
 
-    auto* page = m_frame.page();
-    if (page && m_frame.isMainFrame()) {
+    RefPtr page = m_frame->page();
+    if (page && m_frame->isMainFrame()) {
         item->setPageScaleFactor(page->pageScaleFactor() / page->viewScaleFactor());
 #if PLATFORM(IOS_FAMILY)
         item->setObscuredInsets(page->obscuredInsets());
@@ -98,19 +98,25 @@ void HistoryController::saveScrollPositionAndViewStateToItem(HistoryItem* item)
     }
 
     // FIXME: It would be great to work out a way to put this code in WebCore instead of calling through to the client.
-    m_frame.loader().client().saveViewStateToItem(*item);
+    protectedFrame()->checkedLoader()->client().saveViewStateToItem(*item);
 
     // Notify clients that the HistoryItem has changed.
     item->notifyChanged();
 }
 
+Ref<LocalFrame> HistoryController::protectedFrame() const
+{
+    return m_frame.get();
+}
+
 void HistoryController::clearScrollPositionAndViewState()
 {
-    if (!m_currentItem)
+    RefPtr currentItem = m_currentItem;
+    if (!currentItem)
         return;
 
-    m_currentItem->clearScrollPosition();
-    m_currentItem->setPageScaleFactor(0);
+    currentItem->clearScrollPosition();
+    currentItem->setPageScaleFactor(0);
 }
 
 /*
@@ -126,10 +132,12 @@ void HistoryController::clearScrollPositionAndViewState()
 */
 void HistoryController::restoreScrollPositionAndViewState()
 {
-    if (!m_currentItem || !m_frame.loader().stateMachine().committedFirstRealDocumentLoad())
+    RefPtr currentItem = m_currentItem;
+    Ref frame = m_frame.get();
+    if (!currentItem || !frame->loader().stateMachine().committedFirstRealDocumentLoad())
         return;
 
-    RefPtr view = m_frame.view();
+    RefPtr view = frame->view();
 
     // FIXME: There is some scrolling related work that needs to happen whenever a page goes into the
     // back/forward cache and similar work that needs to occur when it comes out. This is where we do the work
@@ -137,35 +145,35 @@ void HistoryController::restoreScrollPositionAndViewState()
     // Document::setIsInBackForwardCache(bool). It would be nice if there was more symmetry in these spots.
     // https://bugs.webkit.org/show_bug.cgi?id=98698
     if (view) {
-        Page* page = m_frame.page();
-        if (page && m_frame.isMainFrame()) {
-            if (ScrollingCoordinator* scrollingCoordinator = page->scrollingCoordinator())
+        RefPtr page = frame->page();
+        if (page && frame->isMainFrame()) {
+            if (RefPtr scrollingCoordinator = page->scrollingCoordinator())
                 scrollingCoordinator->frameViewRootLayerDidChange(*view);
         }
     }
 
     // FIXME: It would be great to work out a way to put this code in WebCore instead of calling
     // through to the client.
-    m_frame.loader().client().restoreViewState();
+    frame->checkedLoader()->client().restoreViewState();
 
 #if !PLATFORM(IOS_FAMILY)
     // Don't restore scroll point on iOS as LocalFrameLoaderClient::restoreViewState() does that.
     if (view && !view->wasScrolledByUser()) {
         view->scrollToFocusedElementImmediatelyIfNeeded();
 
-        Page* page = m_frame.page();
-        auto desiredScrollPosition = m_currentItem->shouldRestoreScrollPosition() ? m_currentItem->scrollPosition() : view->scrollPosition();
+        RefPtr page = frame->page();
+        auto desiredScrollPosition = currentItem->shouldRestoreScrollPosition() ? currentItem->scrollPosition() : view->scrollPosition();
         LOG(Scrolling, "HistoryController::restoreScrollPositionAndViewState scrolling to %d,%d", desiredScrollPosition.x(), desiredScrollPosition.y());
-        if (page && m_frame.isMainFrame() && m_currentItem->pageScaleFactor())
-            page->setPageScaleFactor(m_currentItem->pageScaleFactor() * page->viewScaleFactor(), desiredScrollPosition);
+        if (page && frame->isMainFrame() && currentItem->pageScaleFactor())
+            page->setPageScaleFactor(currentItem->pageScaleFactor() * page->viewScaleFactor(), desiredScrollPosition);
         else
             view->setScrollPosition(desiredScrollPosition);
 
         // If the scroll position doesn't have to be clamped, consider it successfully restored.
-        if (m_frame.isMainFrame()) {
+        if (frame->isMainFrame()) {
             auto adjustedDesiredScrollPosition = view->adjustScrollPositionWithinRange(desiredScrollPosition);
             if (desiredScrollPosition == adjustedDesiredScrollPosition)
-                m_frame.loader().client().didRestoreScrollPosition();
+                frame->checkedLoader()->client().didRestoreScrollPosition();
         }
 
     }
@@ -181,7 +189,7 @@ void HistoryController::saveDocumentState()
 {
     // FIXME: Reading this bit of FrameLoader state here is unfortunate.  I need to study
     // this more to see if we can remove this dependency.
-    if (m_frame.loader().stateMachine().creatingInitialEmptyDocument())
+    if (m_frame->checkedLoader()->stateMachine().creatingInitialEmptyDocument())
         return;
 
     // For a standard page load, we will have a previous item set, which will be used to
@@ -195,18 +203,18 @@ void HistoryController::saveDocumentState()
     // that we keep track of the end of a page transition with m_frameLoadComplete.  We
     // leverage the checkLoadComplete recursion to achieve this goal.
 
-    HistoryItem* item = m_frameLoadComplete ? m_currentItem.get() : m_previousItem.get();
+    RefPtr item = m_frameLoadComplete ? m_currentItem.get() : m_previousItem.get();
     if (!item)
         return;
 
-    ASSERT(m_frame.document());
-    Document& document = *m_frame.document();
-    if (item->isCurrentDocument(document) && document.hasLivingRenderTree()) {
-        if (DocumentLoader* documentLoader = document.loader())
+    ASSERT(m_frame->document());
+    Ref document = *m_frame->document();
+    if (item->isCurrentDocument(document) && document->hasLivingRenderTree()) {
+        if (RefPtr documentLoader = document->loader())
             item->setShouldOpenExternalURLsPolicy(documentLoader->shouldOpenExternalURLsPolicyToPropagate());
 
-        LOG(Loading, "WebCoreLoading frame %" PRIu64 ": saving form state to %p", m_frame.frameID().object().toUInt64(), item);
-        item->setDocumentState(document.formElementsState());
+        LOG(Loading, "WebCoreLoading frame %" PRIu64 ": saving form state to %p", m_frame->frameID().object().toUInt64(), item.get());
+        item->setDocumentState(document->formElementsState());
     }
 }
 
@@ -214,18 +222,19 @@ void HistoryController::saveDocumentState()
 // history item.
 void HistoryController::saveDocumentAndScrollState()
 {
-    for (Frame* frame = &m_frame; frame; frame = frame->tree().traverseNext(&m_frame)) {
-        auto* localFrame = dynamicDowncast<LocalFrame>(frame);
+    for (Frame* frame = m_frame.ptr(); frame; frame = frame->tree().traverseNext(m_frame.ptr())) {
+        RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;
-        localFrame->loader().history().saveDocumentState();
-        localFrame->loader().history().saveScrollPositionAndViewStateToItem(localFrame->loader().history().currentItem());
+        CheckedRef history = localFrame->loader().history();
+        history->saveDocumentState();
+        history->saveScrollPositionAndViewStateToItem(history->currentItem());
     }
 }
 
 void HistoryController::restoreDocumentState()
 {
-    switch (m_frame.loader().loadType()) {
+    switch (m_frame->loader().loadType()) {
     case FrameLoadType::Reload:
     case FrameLoadType::ReloadFromOrigin:
     case FrameLoadType::ReloadExpiredOnly:
@@ -241,26 +250,29 @@ void HistoryController::restoreDocumentState()
         break;
     }
     
-    if (!m_currentItem)
+    RefPtr currentItem = m_currentItem;
+    if (!currentItem)
         return;
-    if (m_frame.loader().requestedHistoryItem() != m_currentItem.get())
+    if (m_frame->loader().requestedHistoryItem() != currentItem.get())
         return;
-    if (m_frame.loader().documentLoader()->isClientRedirect())
+    RefPtr documentLoader = m_frame->loader().documentLoader();
+    if (documentLoader->isClientRedirect())
         return;
 
-    m_frame.loader().documentLoader()->setShouldOpenExternalURLsPolicy(m_currentItem->shouldOpenExternalURLsPolicy());
+    documentLoader->setShouldOpenExternalURLsPolicy(currentItem->shouldOpenExternalURLsPolicy());
 
-    LOG(Loading, "WebCoreLoading frame %" PRIu64 ": restoring form state from %p", m_frame.frameID().object().toUInt64(), m_currentItem.get());
-    m_frame.document()->setStateForNewFormElements(m_currentItem->documentState());
+    LOG(Loading, "WebCoreLoading frame %" PRIu64 ": restoring form state from %p", m_frame->frameID().object().toUInt64(), currentItem.get());
+    m_frame->protectedDocument()->setStateForNewFormElements(currentItem->documentState());
 }
 
 void HistoryController::invalidateCurrentItemCachedPage()
 {
-    if (!currentItem())
+    RefPtr currentItem = m_currentItem;
+    if (!currentItem)
         return;
 
     // When we are pre-commit, the currentItem is where any back/forward cache data resides.
-    std::unique_ptr<CachedPage> cachedPage = BackForwardCache::singleton().take(*currentItem(), m_frame.page());
+    auto cachedPage = BackForwardCache::singleton().take(*currentItem, m_frame->protectedPage().get());
     if (!cachedPage)
         return;
 
@@ -268,20 +280,22 @@ void HistoryController::invalidateCurrentItemCachedPage()
     // Somehow the PageState object is not properly updated, and is holding onto a stale document.
     // Both Xcode and FileMaker see this crash, Safari does not.
     
-    ASSERT(cachedPage->document() == m_frame.document());
-    if (cachedPage->document() == m_frame.document()) {
-        cachedPage->document()->setBackForwardCacheState(Document::NotInBackForwardCache);
+    RefPtr cachedPageDocument = cachedPage->document();
+    ASSERT(cachedPageDocument == m_frame->document());
+    if (cachedPageDocument == m_frame->document()) {
+        cachedPageDocument->setBackForwardCacheState(Document::NotInBackForwardCache);
         cachedPage->clear();
     }
 }
 
 bool HistoryController::shouldStopLoadingForHistoryItem(HistoryItem& targetItem) const
 {
-    if (!m_currentItem)
+    RefPtr currentItem = m_currentItem;
+    if (!currentItem)
         return false;
 
     // Don't abort the current load if we're navigating within the current document.
-    if (m_currentItem->shouldDoSameDocumentNavigationTo(targetItem))
+    if (currentItem->shouldDoSameDocumentNavigationTo(targetItem))
         return false;
 
     return true;
@@ -293,16 +307,17 @@ void HistoryController::goToItem(HistoryItem& targetItem, FrameLoadType type, Sh
 {
     LOG(History, "HistoryController %p goToItem %p type=%d", this, &targetItem, static_cast<int>(type));
 
-    ASSERT(!m_frame.tree().parent());
+    ASSERT(!m_frame->tree().parent());
     
     // shouldGoToHistoryItem is a private delegate method. This is needed to fix:
     // <rdar://problem/3951283> can view pages from the back/forward cache that should be disallowed by Parental Controls
     // Ultimately, history item navigations should go through the policy delegate. That's covered in:
     // <rdar://problem/3979539> back/forward cache navigations should consult policy delegate
-    Page* page = m_frame.page();
+    Ref frame = m_frame.get();
+    RefPtr page = frame->page();
     if (!page)
         return;
-    if (!m_frame.loader().client().shouldGoToHistoryItem(targetItem))
+    if (!frame->checkedLoader()->client().shouldGoToHistoryItem(targetItem))
         return;
     if (m_defersLoading) {
         m_deferredItem = &targetItem;
@@ -313,7 +328,7 @@ void HistoryController::goToItem(HistoryItem& targetItem, FrameLoadType type, Sh
     // Set the BF cursor before commit, which lets the user quickly click back/forward again.
     // - plus, it only makes sense for the top level of the operation through the frame tree,
     // as opposed to happening for some/one of the page commits that might happen soon
-    RefPtr<HistoryItem> currentItem = page->backForward().currentItem();
+    RefPtr currentItem = page->backForward().currentItem();
     page->backForward().setCurrentItem(targetItem);
 
     // First set the provisional item of any frames that are not actually navigating.
@@ -329,19 +344,22 @@ void HistoryController::goToItem(HistoryItem& targetItem, FrameLoadType type, Sh
 void HistoryController::setDefersLoading(bool defer)
 {
     m_defersLoading = defer;
-    if (!defer && m_deferredItem) {
-        goToItem(*m_deferredItem, m_deferredFrameLoadType, ShouldTreatAsContinuingLoad::No);
+    if (defer)
+        return;
+
+    if (RefPtr deferredItem = m_deferredItem) {
+        goToItem(*deferredItem, m_deferredFrameLoadType, ShouldTreatAsContinuingLoad::No);
         m_deferredItem = nullptr;
     }
 }
 
 void HistoryController::updateForBackForwardNavigation()
 {
-    LOG(History, "HistoryController %p updateForBackForwardNavigation: Updating History for back/forward navigation in frame %p (main frame %d) %s", this, &m_frame, m_frame.isMainFrame(), m_frame.loader().documentLoader() ? m_frame.loader().documentLoader()->url().string().utf8().data() : "");
+    LOG(History, "HistoryController %p updateForBackForwardNavigation: Updating History for back/forward navigation in frame %p (main frame %d) %s", this, &m_frame, m_frame->isMainFrame(), m_frame->loader().documentLoader() ? m_frame->loader().documentLoader()->url().string().utf8().data() : "");
 
     // Must grab the current scroll position before disturbing it
     if (!m_frameLoadComplete)
-        saveScrollPositionAndViewStateToItem(m_previousItem.get());
+        saveScrollPositionAndViewStateToItem(protectedPreviousItem().get());
 
     // When traversing history, we may end up redirecting to a different URL
     // this time (e.g., due to cookies).  See http://webkit.org/b/49654.
@@ -350,16 +368,16 @@ void HistoryController::updateForBackForwardNavigation()
 
 void HistoryController::updateForReload()
 {
-    LOG(History, "HistoryController %p updateForReload: Updating History for reload in frame %p (main frame %d) %s", this, &m_frame, m_frame.isMainFrame(), m_frame.loader().documentLoader() ? m_frame.loader().documentLoader()->url().string().utf8().data() : "");
+    LOG(History, "HistoryController %p updateForReload: Updating History for reload in frame %p (main frame %d) %s", this, &m_frame, m_frame->isMainFrame(), m_frame->loader().documentLoader() ? m_frame->loader().documentLoader()->url().string().utf8().data() : "");
 
-    if (m_currentItem) {
-        BackForwardCache::singleton().remove(*m_currentItem);
+    if (RefPtr currentItem = m_currentItem) {
+        BackForwardCache::singleton().remove(*currentItem);
     
-        if (m_frame.loader().loadType() == FrameLoadType::Reload || m_frame.loader().loadType() == FrameLoadType::ReloadFromOrigin)
-            saveScrollPositionAndViewStateToItem(m_currentItem.get());
+        if (m_frame->loader().loadType() == FrameLoadType::Reload || m_frame->loader().loadType() == FrameLoadType::ReloadFromOrigin)
+            saveScrollPositionAndViewStateToItem(currentItem.get());
 
         // Rebuild the history item tree when reloading as trying to re-associate everything is too error-prone.
-        m_currentItem->clearChildren();
+        currentItem->clearChildren();
     }
 
     // When reloading the page, we may end up redirecting to a different URL
@@ -375,22 +393,24 @@ void HistoryController::updateForReload()
 
 void HistoryController::updateForStandardLoad(HistoryUpdateType updateType)
 {
-    LOG(History, "HistoryController %p updateForStandardLoad: Updating History for standard load in frame %p (main frame %d) %s", this, &m_frame, m_frame.isMainFrame(), m_frame.loader().documentLoader()->url().string().ascii().data());
+    LOG(History, "HistoryController %p updateForStandardLoad: Updating History for standard load in frame %p (main frame %d) %s", this, &m_frame, m_frame->isMainFrame(), m_frame->loader().documentLoader()->url().string().ascii().data());
 
-    FrameLoader& frameLoader = m_frame.loader();
+    Ref frame = m_frame.get();
+    CheckedRef frameLoader = frame->loader();
 
-    bool usesEphemeralSession = m_frame.page() ? m_frame.page()->usesEphemeralSession() : true;
-    const URL& historyURL = frameLoader.documentLoader()->urlForHistory();
+    bool usesEphemeralSession = m_frame->page() ? m_frame->page()->usesEphemeralSession() : true;
+    const URL& historyURL = frameLoader->documentLoader()->urlForHistory();
 
-    if (!frameLoader.documentLoader()->isClientRedirect()) {
+    RefPtr documentLoader = frameLoader->documentLoader();
+    if (!frameLoader->documentLoader()->isClientRedirect()) {
         if (!historyURL.isEmpty()) {
             if (updateType != UpdateAllExceptBackForwardList)
                 updateBackForwardListClippedAtTarget(true);
             if (!usesEphemeralSession) {
-                frameLoader.client().updateGlobalHistory();
-                frameLoader.documentLoader()->setDidCreateGlobalHistoryEntry(true);
-                if (frameLoader.documentLoader()->unreachableURL().isEmpty())
-                    frameLoader.client().updateGlobalHistoryRedirectLinks();
+                frameLoader->client().updateGlobalHistory();
+                documentLoader->setDidCreateGlobalHistoryEntry(true);
+                if (documentLoader->unreachableURL().isEmpty())
+                    frameLoader->client().updateGlobalHistoryRedirectLinks();
             }
         }
     } else {
@@ -399,80 +419,86 @@ void HistoryController::updateForStandardLoad(HistoryUpdateType updateType)
     }
 
     if (!historyURL.isEmpty() && !usesEphemeralSession) {
-        if (Page* page = m_frame.page())
+        if (RefPtr page = m_frame->page())
             addVisitedLink(*page, historyURL);
 
-        if (!frameLoader.documentLoader()->didCreateGlobalHistoryEntry() && frameLoader.documentLoader()->unreachableURL().isEmpty() && !m_frame.document()->url().isEmpty())
-            frameLoader.client().updateGlobalHistoryRedirectLinks();
+        if (!documentLoader->didCreateGlobalHistoryEntry() && documentLoader->unreachableURL().isEmpty() && !m_frame->document()->url().isEmpty())
+            frameLoader->client().updateGlobalHistoryRedirectLinks();
     }
 }
 
 void HistoryController::updateForRedirectWithLockedBackForwardList()
 {
-    LOG(History, "HistoryController %p updateForRedirectWithLockedBackForwardList: Updating History for redirect load in frame %p (main frame %d) %s", this, &m_frame, m_frame.isMainFrame(), m_frame.loader().documentLoader() ? m_frame.loader().documentLoader()->url().string().utf8().data() : "");
+    LOG(History, "HistoryController %p updateForRedirectWithLockedBackForwardList: Updating History for redirect load in frame %p (main frame %d) %s", this, &m_frame, m_frame->isMainFrame(), m_frame->loader().documentLoader() ? m_frame->loader().documentLoader()->url().string().utf8().data() : "");
     
-    bool usesEphemeralSession = m_frame.page() ? m_frame.page()->usesEphemeralSession() : true;
-    auto historyURL = m_frame.loader().documentLoader() ? m_frame.loader().documentLoader()->urlForHistory() : URL { };
+    Ref frame = m_frame.get();
+    RefPtr documentLoader = frame->loader().documentLoader();
+    bool usesEphemeralSession = frame->page() ? frame->page()->usesEphemeralSession() : true;
+    auto historyURL = documentLoader ? documentLoader->urlForHistory() : URL { };
 
-    if (m_frame.loader().documentLoader() && m_frame.loader().documentLoader()->isClientRedirect()) {
-        if (!m_currentItem && !m_frame.tree().parent()) {
+    if (documentLoader && documentLoader->isClientRedirect()) {
+        if (!m_currentItem && !frame->tree().parent()) {
             if (!historyURL.isEmpty()) {
                 updateBackForwardListClippedAtTarget(true);
                 if (!usesEphemeralSession) {
-                    m_frame.loader().client().updateGlobalHistory();
-                    m_frame.loader().documentLoader()->setDidCreateGlobalHistoryEntry(true);
-                    if (m_frame.loader().documentLoader()->unreachableURL().isEmpty())
-                        m_frame.loader().client().updateGlobalHistoryRedirectLinks();
+                    CheckedRef frameLoader = frame->loader();
+                    frameLoader->client().updateGlobalHistory();
+                    documentLoader->setDidCreateGlobalHistoryEntry(true);
+                    if (documentLoader->unreachableURL().isEmpty())
+                        frameLoader->client().updateGlobalHistoryRedirectLinks();
                 }
             }
         }
         // The client redirect replaces the current history item.
         updateCurrentItem();
     } else {
-        auto* page = m_frame.page();
-        auto* parentFrame = dynamicDowncast<LocalFrame>(m_frame.tree().parent());
-        if (page && parentFrame && parentFrame->loader().history().currentItem())
-            parentFrame->loader().history().currentItem()->setChildItem(createItem(page->historyItemClient()));
+        RefPtr page = m_frame->page();
+        RefPtr parentFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent());
+        if (page && parentFrame) {
+            if (RefPtr parentCurrentItem = parentFrame->loader().history().currentItem())
+                parentCurrentItem->setChildItem(createItem(page->historyItemClient()));
+        }
     }
 
     if (!historyURL.isEmpty() && !usesEphemeralSession) {
-        if (Page* page = m_frame.page())
+        if (RefPtr page = m_frame->page())
             addVisitedLink(*page, historyURL);
 
-        if (!m_frame.loader().documentLoader()->didCreateGlobalHistoryEntry() && m_frame.loader().documentLoader()->unreachableURL().isEmpty())
-            m_frame.loader().client().updateGlobalHistoryRedirectLinks();
+        if (!documentLoader->didCreateGlobalHistoryEntry() && documentLoader->unreachableURL().isEmpty())
+            frame->checkedLoader()->client().updateGlobalHistoryRedirectLinks();
     }
 }
 
 void HistoryController::updateForClientRedirect()
 {
-    LOG(History, "HistoryController %p updateForClientRedirect: Updating History for client redirect in frame %p (main frame %d) %s", this, &m_frame, m_frame.isMainFrame(), m_frame.loader().documentLoader() ? m_frame.loader().documentLoader()->url().string().utf8().data() : "");
+    LOG(History, "HistoryController %p updateForClientRedirect: Updating History for client redirect in frame %p (main frame %d) %s", this, &m_frame, m_frame->isMainFrame(), m_frame->loader().documentLoader() ? m_frame->loader().documentLoader()->url().string().utf8().data() : "");
 
     // Clear out form data so we don't try to restore it into the incoming page.  Must happen after
     // webcore has closed the URL and saved away the form state.
-    if (m_currentItem) {
-        m_currentItem->clearDocumentState();
-        m_currentItem->clearScrollPosition();
+    if (RefPtr currentItem = m_currentItem) {
+        currentItem->clearDocumentState();
+        currentItem->clearScrollPosition();
     }
 
-    bool usesEphemeralSession = m_frame.page() ? m_frame.page()->usesEphemeralSession() : true;
-    const URL& historyURL = m_frame.loader().documentLoader()->urlForHistory();
+    bool usesEphemeralSession = m_frame->page() ? m_frame->page()->usesEphemeralSession() : true;
+    const URL& historyURL = m_frame->loader().documentLoader()->urlForHistory();
 
     if (!historyURL.isEmpty() && !usesEphemeralSession) {
-        if (Page* page = m_frame.page())
+        if (RefPtr page = m_frame->page())
             addVisitedLink(*page, historyURL);
     }
 }
 
 void HistoryController::updateForCommit()
 {
-    FrameLoader& frameLoader = m_frame.loader();
-    LOG(History, "HistoryController %p updateForCommit: Updating History for commit in frame %p (main frame %d) %s", this, &m_frame, m_frame.isMainFrame(), m_frame.loader().documentLoader() ? m_frame.loader().documentLoader()->url().string().utf8().data() : "");
+    Ref frame = m_frame.get();
+    CheckedRef frameLoader = frame->loader();
+    LOG(History, "HistoryController %p updateForCommit: Updating History for commit in frame %p (main frame %d) %s", this, &m_frame, m_frame->isMainFrame(), m_frame->loader().documentLoader() ? m_frame->loader().documentLoader()->url().string().utf8().data() : "");
 
-    FrameLoadType type = frameLoader.loadType();
+    FrameLoadType type = frameLoader->loadType();
     if (isBackForwardLoadType(type)
         || isReplaceLoadTypeWithProvisionalItem(type)
-        || (isReloadTypeWithProvisionalItem(type) && !frameLoader.provisionalDocumentLoader()->unreachableURL().isEmpty())) {
+        || (isReloadTypeWithProvisionalItem(type) && !frameLoader->provisionalDocumentLoader()->unreachableURL().isEmpty())) {
         // Once committed, we want to use current item for saving DocState, and
         // the provisional item for restoring state.
         // Note previousItem must be set before we close the URL, which will
@@ -483,15 +509,16 @@ void HistoryController::updateForCommit()
         // Not having one leads to us not having a m_currentItem later, which is also a terrible known issue.
         // We should get to the bottom of this.
         ASSERT(m_provisionalItem);
-        if (m_provisionalItem)
-            setCurrentItem(*m_provisionalItem.get());
-        m_provisionalItem = nullptr;
+        if (RefPtr provisionalItem = m_provisionalItem) {
+            setCurrentItem(provisionalItem.releaseNonNull());
+            m_provisionalItem = nullptr;
+        }
 
         // Tell all other frames in the tree to commit their provisional items and
         // restore their scroll position.  We'll avoid this frame (which has already
         // committed) and its children (which will be replaced).
-        if (auto* localFrame = dynamicDowncast<LocalFrame>(m_frame.mainFrame()))
-            localFrame->loader().history().recursiveUpdateForCommit();
+        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame()))
+            localFrame->loader().checkedHistory()->recursiveUpdateForCommit();
     }
 }
 
@@ -517,18 +544,19 @@ void HistoryController::recursiveUpdateForCommit()
     // For each frame that already had the content the item requested (based on
     // (a matching URL and frame tree snapshot), just restore the scroll position.
     // Save form state (works from currentItem, since m_frameLoadComplete is true)
-    if (m_currentItem && itemsAreClones(*m_currentItem, m_provisionalItem.get())) {
+    if (m_currentItem && itemsAreClones(*protectedCurrentItem(), protectedProvisionalItem().get())) {
         ASSERT(m_frameLoadComplete);
         saveDocumentState();
-        saveScrollPositionAndViewStateToItem(m_currentItem.get());
+        saveScrollPositionAndViewStateToItem(protectedCurrentItem().get());
 
-        if (auto* view = m_frame.view())
+        if (auto* view = m_frame->view())
             view->setWasScrolledByUser(false);
 
         // Now commit the provisional item
-        if (m_provisionalItem)
-            setCurrentItem(*m_provisionalItem.get());
-        m_provisionalItem = nullptr;
+        if (RefPtr provisionalItem = m_provisionalItem) {
+            setCurrentItem(provisionalItem.releaseNonNull());
+            m_provisionalItem = nullptr;
+        }
 
         // Restore form state (works from currentItem)
         restoreDocumentState();
@@ -538,34 +566,33 @@ void HistoryController::recursiveUpdateForCommit()
     }
 
     // Iterate over the rest of the tree
-    for (auto* child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
-        auto* localChild = dynamicDowncast<LocalFrame>(child);
-        if (!localChild)
-            continue;
-        localChild->loader().history().recursiveUpdateForCommit();
+    for (auto* child = m_frame->tree().firstChild(); child; child = child->tree().nextSibling()) {
+        if (RefPtr localChild = dynamicDowncast<LocalFrame>(child))
+            localChild->loader().checkedHistory()->recursiveUpdateForCommit();
     }
 }
 
 void HistoryController::updateForSameDocumentNavigation()
 {
-    if (m_frame.document()->url().isEmpty())
+    Ref frame = m_frame.get();
+    if (frame->document()->url().isEmpty())
         return;
 
-    Page* page = m_frame.page();
+    RefPtr page = frame->page();
     if (!page)
         return;
 
     bool usesEphemeralSession = page->usesEphemeralSession();
     if (!usesEphemeralSession)
-        addVisitedLink(*page, m_frame.document()->url());
+        addVisitedLink(*page, frame->document()->url());
 
-    if (auto *localFrame = dynamicDowncast<LocalFrame>(m_frame.mainFrame()))
-        localFrame->loader().history().recursiveUpdateForSameDocumentNavigation();
+    if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame()))
+        localFrame->loader().checkedHistory()->recursiveUpdateForSameDocumentNavigation();
 
-    if (m_currentItem) {
-        m_currentItem->setURL(m_frame.document()->url());
+    if (RefPtr currentItem = m_currentItem) {
+        currentItem->setURL(frame->document()->url());
         if (!usesEphemeralSession)
-            m_frame.loader().client().updateGlobalHistory();
+            frame->checkedLoader()->client().updateGlobalHistory();
     }
 }
 
@@ -578,20 +605,19 @@ void HistoryController::recursiveUpdateForSameDocumentNavigation()
 
     // The provisional item may represent a different pending navigation.
     // Don't commit it if it isn't a same document navigation.
-    if (m_currentItem && !m_currentItem->shouldDoSameDocumentNavigationTo(*m_provisionalItem))
+    if (m_currentItem && !protectedCurrentItem()->shouldDoSameDocumentNavigationTo(*protectedProvisionalItem()))
         return;
 
     // Commit the provisional item.
-    if (m_provisionalItem)
-        setCurrentItem(*m_provisionalItem.get());
-    m_provisionalItem = nullptr;
+    if (RefPtr provisionalItem = m_provisionalItem) {
+        setCurrentItem(provisionalItem.releaseNonNull());
+        m_provisionalItem = nullptr;
+    }
 
     // Iterate over the rest of the tree.
-    for (auto* child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
-        auto* localChild = dynamicDowncast<LocalFrame>(child);
-        if (!localChild)
-            continue;
-        localChild->loader().history().recursiveUpdateForSameDocumentNavigation();
+    for (auto* child = m_frame->tree().firstChild(); child; child = child->tree().nextSibling()) {
+        if (RefPtr localChild = dynamicDowncast<LocalFrame>(child))
+            localChild->loader().checkedHistory()->recursiveUpdateForSameDocumentNavigation();
     }
 }
 
@@ -603,18 +629,17 @@ void HistoryController::updateForFrameLoadCompleted()
     m_frameLoadComplete = true;
 }
 
-void HistoryController::setCurrentItem(HistoryItem& item)
+void HistoryController::setCurrentItem(Ref<HistoryItem>&& item)
 {
     m_frameLoadComplete = false;
-    m_previousItem = m_currentItem;
-    m_currentItem = &item;
+    m_previousItem = std::exchange(m_currentItem, WTFMove(item));
 }
 
 void HistoryController::setCurrentItemTitle(const StringWithDirection& title)
 {
     // FIXME: This ignores the title's direction.
-    if (m_currentItem)
-        m_currentItem->setTitle(title.string);
+    if (RefPtr currentItem = m_currentItem)
+        currentItem->setTitle(title.string);
 }
 
 bool HistoryController::currentItemShouldBeReplaced() const
@@ -629,22 +654,20 @@ bool HistoryController::currentItemShouldBeReplaced() const
 void HistoryController::clearPreviousItem()
 {
     m_previousItem = nullptr;
-    for (auto* child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
-        auto* localChild = dynamicDowncast<LocalFrame>(child);
-        if (!localChild)
-            continue;
-        localChild->loader().history().clearPreviousItem();
+    for (auto* child = m_frame->tree().firstChild(); child; child = child->tree().nextSibling()) {
+        if (RefPtr localChild = dynamicDowncast<LocalFrame>(child))
+            localChild->loader().checkedHistory()->clearPreviousItem();
     }
 }
 
-void HistoryController::setProvisionalItem(HistoryItem* item)
+void HistoryController::setProvisionalItem(RefPtr<HistoryItem>&& item)
 {
-    m_provisionalItem = item;
+    m_provisionalItem = WTFMove(item);
 }
 
 void HistoryController::initializeItem(HistoryItem& item)
 {
-    DocumentLoader* documentLoader = m_frame.loader().documentLoader();
+    RefPtr documentLoader = m_frame->loader().documentLoader();
     ASSERT(documentLoader);
 
     URL unreachableURL = documentLoader->unreachableURL();
@@ -673,7 +696,7 @@ void HistoryController::initializeItem(HistoryItem& item)
     StringWithDirection title = documentLoader->title();
 
     item.setURL(url);
-    item.setTarget(m_frame.tree().uniqueName());
+    item.setTarget(m_frame->tree().uniqueName());
     // FIXME: Should store the title direction as well.
     item.setTitle(title.string);
     item.setOriginalURLString(originalURL.string());
@@ -689,22 +712,22 @@ void HistoryController::initializeItem(HistoryItem& item)
 
 Ref<HistoryItem> HistoryController::createItem(HistoryItemClient& client)
 {
-    Ref<HistoryItem> item = HistoryItem::create(client);
+    Ref item = HistoryItem::create(client);
     initializeItem(item);
     
     // Set the item for which we will save document state
-    setCurrentItem(item);
+    setCurrentItem(item.copyRef());
     
     return item;
 }
 
 Ref<HistoryItem> HistoryController::createItemTree(HistoryItemClient& client, LocalFrame& targetFrame, bool clipAtTarget)
 {
-    Ref<HistoryItem> bfItem = createItem(client);
+    Ref item = createItem(client);
     if (!m_frameLoadComplete)
-        saveScrollPositionAndViewStateToItem(m_previousItem.get());
+        saveScrollPositionAndViewStateToItem(protectedPreviousItem().get());
 
-    if (!clipAtTarget || &m_frame != &targetFrame) {
+    if (!clipAtTarget || m_frame.ptr() != &targetFrame) {
         // save frame state for items that aren't loading (khtml doesn't save those)
         saveDocumentState();
 
@@ -712,31 +735,31 @@ Ref<HistoryItem> HistoryController::createItemTree(HistoryItemClient& client, Lo
         // we should copy the documentSequenceNumber over to the newly create
         // item.  Non-target items are just clones, and they should therefore
         // preserve the same itemSequenceNumber.
-        if (m_previousItem) {
-            if (&m_frame != &targetFrame)
-                bfItem->setItemSequenceNumber(m_previousItem->itemSequenceNumber());
-            bfItem->setDocumentSequenceNumber(m_previousItem->documentSequenceNumber());
+        if (RefPtr previousItem = m_previousItem) {
+            if (m_frame.ptr() != &targetFrame)
+                item->setItemSequenceNumber(previousItem->itemSequenceNumber());
+            item->setDocumentSequenceNumber(previousItem->documentSequenceNumber());
         }
 
-        for (auto* child = m_frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
-            auto* localChild = dynamicDowncast<LocalFrame>(child);
+        for (auto* child = m_frame->tree().firstChild(); child; child = child->tree().nextSibling()) {
+            RefPtr localChild = dynamicDowncast<LocalFrame>(child);
             if (!localChild)
                 continue;
-            FrameLoader& childLoader = localChild->loader();
-            bool hasChildLoaded = childLoader.frameHasLoaded();
+            CheckedRef childLoader = localChild->loader();
+            bool hasChildLoaded = childLoader->frameHasLoaded();
 
             // If the child is a frame corresponding to an <object> element that never loaded,
             // we don't want to create a history item, because that causes fallback content
             // to be ignored on reload.
             
             if (!(!hasChildLoaded && localChild->ownerElement() && is<HTMLObjectElement>(localChild->ownerElement())))
-                bfItem->addChildItem(childLoader.history().createItemTree(client, targetFrame, clipAtTarget));
+                item->addChildItem(childLoader->history().createItemTree(client, targetFrame, clipAtTarget));
         }
     }
     // FIXME: Eliminate the isTargetItem flag in favor of itemSequenceNumber.
-    if (&m_frame == &targetFrame)
-        bfItem->setIsTargetItem(true);
-    return bfItem;
+    if (m_frame.ptr() == &targetFrame)
+        item->setIsTargetItem(true);
+    return item;
 }
 
 // The general idea here is to traverse the frame tree and the item tree in parallel,
@@ -751,15 +774,15 @@ void HistoryController::recursiveSetProvisionalItem(HistoryItem& item, HistoryIt
     // Set provisional item, which will be committed in recursiveUpdateForCommit.
     m_provisionalItem = &item;
 
-    for (auto& childItem : item.children()) {
+    for (Ref childItem : item.children()) {
         auto& childFrameName = childItem->target();
 
-        auto* fromChildItem = fromItem->childItemWithTarget(childFrameName);
+        RefPtr fromChildItem = fromItem->childItemWithTarget(childFrameName);
         if (!fromChildItem)
             continue;
 
-        if (auto* childFrame = dynamicDowncast<LocalFrame>(m_frame.tree().childByUniqueName(childFrameName)))
-            childFrame->loader().history().recursiveSetProvisionalItem(childItem, fromChildItem);
+        if (RefPtr childFrame = dynamicDowncast<LocalFrame>(m_frame->tree().childByUniqueName(childFrameName)))
+            childFrame->loader().checkedHistory()->recursiveSetProvisionalItem(childItem, fromChildItem.get());
     }
 }
 
@@ -768,20 +791,20 @@ void HistoryController::recursiveSetProvisionalItem(HistoryItem& item, HistoryIt
 void HistoryController::recursiveGoToItem(HistoryItem& item, HistoryItem* fromItem, FrameLoadType type, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad)
 {
     if (!itemsAreClones(item, fromItem)) {
-        m_frame.loader().loadItem(item, fromItem, type, shouldTreatAsContinuingLoad);
+        protectedFrame()->checkedLoader()->loadItem(item, fromItem, type, shouldTreatAsContinuingLoad);
         return;
     }
 
     // Just iterate over the rest, looking for frames to navigate.
-    for (auto& childItem : item.children()) {
+    for (Ref childItem : item.children()) {
         auto& childFrameName = childItem->target();
 
-        auto* fromChildItem = fromItem->childItemWithTarget(childFrameName);
+        RefPtr fromChildItem = fromItem->childItemWithTarget(childFrameName);
         if (!fromChildItem)
             continue;
 
-        if (auto* childFrame = dynamicDowncast<LocalFrame>(m_frame.tree().childByUniqueName(childFrameName)))
-            childFrame->loader().history().recursiveGoToItem(childItem, fromChildItem, type, shouldTreatAsContinuingLoad);
+        if (RefPtr childFrame = dynamicDowncast<LocalFrame>(m_frame->tree().childByUniqueName(childFrameName)))
+            childFrame->loader().checkedHistory()->recursiveGoToItem(childItem, fromChildItem.get(), type, shouldTreatAsContinuingLoad);
     }
 }
 
@@ -803,15 +826,15 @@ bool HistoryController::itemsAreClones(HistoryItem& item1, HistoryItem* item2) c
 // Helper method that determines whether the current frame tree matches given history item's.
 bool HistoryController::currentFramesMatchItem(HistoryItem& item) const
 {
-    if ((!m_frame.tree().uniqueName().isEmpty() || !item.target().isEmpty()) && m_frame.tree().uniqueName() != item.target())
+    if ((!m_frame->tree().uniqueName().isEmpty() || !item.target().isEmpty()) && m_frame->tree().uniqueName() != item.target())
         return false;
 
     const auto& childItems = item.children();
-    if (childItems.size() != m_frame.tree().childCount())
+    if (childItems.size() != m_frame->tree().childCount())
         return false;
     
     for (auto& item : childItems) {
-        if (!m_frame.tree().childByUniqueName(item->target()))
+        if (!m_frame->tree().childByUniqueName(item->target()))
             return false;
     }
     
@@ -825,46 +848,47 @@ void HistoryController::updateBackForwardListClippedAtTarget(bool doClip)
     // When this function is called with doClip=true we're able to create the whole tree except for the target's children, 
     // which will be loaded in the future. That part of the tree will be filled out as the child loads are committed.
 
-    Page* page = m_frame.page();
+    RefPtr page = m_frame->page();
     if (!page)
         return;
 
-    if (m_frame.loader().documentLoader()->urlForHistory().isEmpty())
+    if (m_frame->loader().documentLoader()->urlForHistory().isEmpty())
         return;
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(m_frame.mainFrame());
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_frame->mainFrame());
     if (!localFrame)
         return;
 
-    FrameLoader& frameLoader = localFrame->loader();
+    CheckedRef frameLoader = localFrame->loader();
 
-    Ref<HistoryItem> topItem = frameLoader.history().createItemTree(page->historyItemClient(), m_frame, doClip);
-    LOG(History, "HistoryController %p updateBackForwardListClippedAtTarget: Adding backforward item %p in frame %p (main frame %d) %s", this, topItem.ptr(), &m_frame, m_frame.isMainFrame(), m_frame.loader().documentLoader()->url().string().utf8().data());
+    Ref topItem = frameLoader->checkedHistory()->createItemTree(page->historyItemClient(), protectedFrame(), doClip);
+    LOG(History, "HistoryController %p updateBackForwardListClippedAtTarget: Adding backforward item %p in frame %p (main frame %d) %s", this, topItem.ptr(), &m_frame, m_frame->isMainFrame(), m_frame->loader().documentLoader()->url().string().utf8().data());
 
     page->backForward().addItem(WTFMove(topItem));
 }
 
 void HistoryController::updateCurrentItem()
 {
-    if (!m_currentItem)
+    RefPtr currentItem = m_currentItem;
+    if (!currentItem)
         return;
 
-    DocumentLoader* documentLoader = m_frame.loader().documentLoader();
+    RefPtr documentLoader = m_frame->loader().documentLoader();
     if (!documentLoader || !documentLoader->unreachableURL().isEmpty())
         return;
 
-    if (m_currentItem->url() != documentLoader->url()) {
+    if (currentItem->url() != documentLoader->url()) {
         // We ended up on a completely different URL this time, so the HistoryItem
         // needs to be re-initialized.  Preserve the isTargetItem flag as it is a
         // property of how this HistoryItem was originally created and is not
         // dependent on the document.
-        bool isTargetItem = m_currentItem->isTargetItem();
-        m_currentItem->reset();
-        initializeItem(*m_currentItem);
-        m_currentItem->setIsTargetItem(isTargetItem);
+        bool isTargetItem = currentItem->isTargetItem();
+        currentItem->reset();
+        initializeItem(*currentItem);
+        currentItem->setIsTargetItem(isTargetItem);
     } else {
         // Even if the final URL didn't change, the form data may have changed.
-        m_currentItem->setFormInfoFromRequest(documentLoader->request());
+        currentItem->setFormInfoFromRequest(documentLoader->request());
     }
 }
 
@@ -873,7 +897,8 @@ void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, c
     if (!m_currentItem)
         return;
 
-    auto* page = m_frame.page();
+    Ref frame = m_frame.get();
+    RefPtr page = frame->page();
     if (!page) {
         ASSERT_NOT_REACHED();
         return;
@@ -882,71 +907,80 @@ void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, c
     bool shouldRestoreScrollPosition = m_currentItem->shouldRestoreScrollPosition();
 
     // Get a HistoryItem tree for the current frame tree.
-    auto* localFrame = dynamicDowncast<LocalFrame>(m_frame.mainFrame());
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
     if (!localFrame)
         return;
 
-    Ref<HistoryItem> topItem = localFrame->loader().history().createItemTree(page->historyItemClient(), m_frame, false);
+    Ref topItem = localFrame->loader().history().createItemTree(page->historyItemClient(), frame, false);
 
-    auto* document = m_frame.document();
+    RefPtr document = frame->document();
     if (document && !document->hasRecentUserInteractionForNavigationFromJS())
         topItem->setWasCreatedByJSWithoutUserInteraction(true);
 
     // Override data in the current item (created by createItemTree) to reflect
     // the pushState() arguments.
-    m_currentItem->setTitle(title);
-    m_currentItem->setStateObject(WTFMove(stateObject));
-    m_currentItem->setURLString(urlString);
-    m_currentItem->setShouldRestoreScrollPosition(shouldRestoreScrollPosition);
+    RefPtr currentItem = m_currentItem;
+    currentItem->setTitle(title);
+    currentItem->setStateObject(WTFMove(stateObject));
+    currentItem->setURLString(urlString);
+    currentItem->setShouldRestoreScrollPosition(shouldRestoreScrollPosition);
 
     LOG(History, "HistoryController %p pushState: Adding top item %p, setting url of current item %p to %s, scrollRestoration is %s", this, topItem.ptr(), m_currentItem.get(), urlString.ascii().data(), topItem->shouldRestoreScrollPosition() ? "auto" : "manual");
 
     page->backForward().addItem(WTFMove(topItem));
 
-    if (m_frame.page()->usesEphemeralSession())
+    if (page->usesEphemeralSession())
         return;
 
     addVisitedLink(*page, URL({ }, urlString));
-    m_frame.loader().client().updateGlobalHistory();
+    frame->checkedLoader()->client().updateGlobalHistory();
 }
 
 void HistoryController::replaceState(RefPtr<SerializedScriptValue>&& stateObject, const String& title, const String& urlString)
 {
-    if (!m_currentItem)
+    RefPtr currentItem = m_currentItem;
+    if (!currentItem)
         return;
 
-    LOG(History, "HistoryController %p replaceState: Setting url of current item %p to %s scrollRestoration %s", this, m_currentItem.get(), urlString.ascii().data(), m_currentItem->shouldRestoreScrollPosition() ? "auto" : "manual");
+    LOG(History, "HistoryController %p replaceState: Setting url of current item %p to %s scrollRestoration %s", this, currentItem.get(), urlString.ascii().data(), currentItem->shouldRestoreScrollPosition() ? "auto" : "manual");
 
     if (!urlString.isEmpty())
-        m_currentItem->setURLString(urlString);
-    m_currentItem->setTitle(title);
-    m_currentItem->setStateObject(WTFMove(stateObject));
-    m_currentItem->setFormData(nullptr);
-    m_currentItem->setFormContentType(String());
+        currentItem->setURLString(urlString);
+    currentItem->setTitle(title);
+    currentItem->setStateObject(WTFMove(stateObject));
+    currentItem->setFormData(nullptr);
+    currentItem->setFormContentType(String());
 
-    ASSERT(m_frame.page());
-    if (m_frame.page()->usesEphemeralSession())
+    Ref frame = m_frame.get();
+    RefPtr page = frame->page();
+    ASSERT(page);
+    if (page->usesEphemeralSession())
         return;
 
-    addVisitedLink(*m_frame.page(), URL({ }, urlString));
-    m_frame.loader().client().updateGlobalHistory();
+    addVisitedLink(*page, URL({ }, urlString));
+    frame->checkedLoader()->client().updateGlobalHistory();
 }
 
-void HistoryController::replaceCurrentItem(HistoryItem* item)
+void HistoryController::replaceCurrentItem(RefPtr<HistoryItem>&& item)
 {
     if (!item)
         return;
 
     m_previousItem = nullptr;
     if (m_provisionalItem)
-        m_provisionalItem = item;
+        m_provisionalItem = WTFMove(item);
     else
-        m_currentItem = item;
+        m_currentItem = WTFMove(item);
 }
 
 RefPtr<HistoryItem> HistoryController::protectedCurrentItem() const
 {
     return m_currentItem;
+}
+
+RefPtr<HistoryItem> HistoryController::protectedPreviousItem() const
+{
+    return m_previousItem;
 }
 
 RefPtr<HistoryItem> HistoryController::protectedProvisionalItem() const

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "FrameLoader.h"
+#include <wtf/CheckedPtr.h>
 
 namespace WebCore {
 
@@ -42,7 +43,7 @@ enum class ShouldTreatAsContinuingLoad : uint8_t;
 
 struct StringWithDirection;
 
-class HistoryController {
+class HistoryController : public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(HistoryController);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
@@ -74,17 +75,18 @@ public:
 
     HistoryItem* currentItem() const { return m_currentItem.get(); }
     RefPtr<HistoryItem> protectedCurrentItem() const;
-    WEBCORE_EXPORT void setCurrentItem(HistoryItem&);
+    WEBCORE_EXPORT void setCurrentItem(Ref<HistoryItem>&&);
     void setCurrentItemTitle(const StringWithDirection&);
     bool currentItemShouldBeReplaced() const;
-    WEBCORE_EXPORT void replaceCurrentItem(HistoryItem*);
+    WEBCORE_EXPORT void replaceCurrentItem(RefPtr<HistoryItem>&&);
 
     HistoryItem* previousItem() const { return m_previousItem.get(); }
+    RefPtr<HistoryItem> protectedPreviousItem() const;
     void clearPreviousItem();
 
     HistoryItem* provisionalItem() const { return m_provisionalItem.get(); }
     RefPtr<HistoryItem> protectedProvisionalItem() const;
-    void setProvisionalItem(HistoryItem*);
+    void setProvisionalItem(RefPtr<HistoryItem>&&);
 
     void pushState(RefPtr<SerializedScriptValue>&&, const String& title, const String& url);
     void replaceState(RefPtr<SerializedScriptValue>&&, const String& title, const String& url);
@@ -111,7 +113,9 @@ private:
     void updateBackForwardListClippedAtTarget(bool doClip);
     void updateCurrentItem();
 
-    LocalFrame& m_frame;
+    Ref<LocalFrame> protectedFrame() const;
+
+    WeakRef<LocalFrame> m_frame;
 
     RefPtr<HistoryItem> m_currentItem;
     RefPtr<HistoryItem> m_previousItem;


### PR DESCRIPTION
#### 8a2c5e5a36088bc357bac41acd8def29e3713bc1
<pre>
Adopt more smart pointers in HistoryController.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=267977">https://bugs.webkit.org/show_bug.cgi?id=267977</a>

Reviewed by Darin Adler.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::detachFromParent):
(WebCore::FrameLoader::checkedHistory const):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::saveScrollPositionAndViewStateToItem):
(WebCore::HistoryController::protectedFrame const):
(WebCore::HistoryController::clearScrollPositionAndViewState):
(WebCore::HistoryController::restoreScrollPositionAndViewState):
(WebCore::HistoryController::saveDocumentState):
(WebCore::HistoryController::saveDocumentAndScrollState):
(WebCore::HistoryController::restoreDocumentState):
(WebCore::HistoryController::invalidateCurrentItemCachedPage):
(WebCore::HistoryController::shouldStopLoadingForHistoryItem const):
(WebCore::HistoryController::goToItem):
(WebCore::HistoryController::setDefersLoading):
(WebCore::HistoryController::updateForBackForwardNavigation):
(WebCore::HistoryController::updateForReload):
(WebCore::HistoryController::updateForStandardLoad):
(WebCore::HistoryController::updateForRedirectWithLockedBackForwardList):
(WebCore::HistoryController::updateForClientRedirect):
(WebCore::HistoryController::updateForCommit):
(WebCore::HistoryController::recursiveUpdateForCommit):
(WebCore::HistoryController::updateForSameDocumentNavigation):
(WebCore::HistoryController::recursiveUpdateForSameDocumentNavigation):
(WebCore::HistoryController::setCurrentItem):
(WebCore::HistoryController::setCurrentItemTitle):
(WebCore::HistoryController::clearPreviousItem):
(WebCore::HistoryController::setProvisionalItem):
(WebCore::HistoryController::initializeItem):
(WebCore::HistoryController::createItem):
(WebCore::HistoryController::createItemTree):
(WebCore::HistoryController::recursiveSetProvisionalItem):
(WebCore::HistoryController::recursiveGoToItem):
(WebCore::HistoryController::currentFramesMatchItem const):
(WebCore::HistoryController::updateBackForwardListClippedAtTarget):
(WebCore::HistoryController::updateCurrentItem):
(WebCore::HistoryController::pushState):
(WebCore::HistoryController::replaceState):
(WebCore::HistoryController::replaceCurrentItem):
(WebCore::HistoryController::protectedPreviousItem const):
* Source/WebCore/loader/HistoryController.h:

Canonical link: <a href="https://commits.webkit.org/273449@main">https://commits.webkit.org/273449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d66d04c9d85458110a72ebfe95aced15b974cca6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38207 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31975 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11445 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10677 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10711 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39454 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36674 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10880 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8785 "Found 1 new test failure: http/tests/media/media-document-referer.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34728 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12611 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/8104 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11400 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4584 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11673 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->