### PR TITLE
Sync 'TouchEventInit' dictionary as per WebIDL Specification

### DIFF
--- a/Source/WebCore/dom/TouchEvent.idl
+++ b/Source/WebCore/dom/TouchEvent.idl
@@ -40,8 +40,10 @@
     readonly attribute boolean metaKey;
 };
 
-dictionary TouchEventInit : UIEventInit {
-    TouchList? touches = null;
-    TouchList? targetTouches = null;
-    TouchList? changedTouches = null;
+// https://w3c.github.io/touch-events/#dom-toucheventinit
+
+dictionary TouchEventInit : EventModifierInit {
+    sequence<Touch> touches = [];
+    sequence<Touch> targetTouches = [];
+    sequence<Touch> targetTouches = [];
 };


### PR DESCRIPTION
<pre>
Sync 'TouchEventInit' dictionary as per WebIDL Specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=267978">https://bugs.webkit.org/show_bug.cgi?id=267978</a>

Reviewed by NOBODY (OOPS!).

This patch is to align WebKit with Web Specification [1]:

[1] <a href="https://w3c.github.io/touch-events/#dom-toucheventinit">https://w3c.github.io/touch-events/#dom-toucheventinit</a>

As per web-specification, the interface is to use `sequence<>` so this updates it.

* Source/WebCore/dom/TouchEvent.idl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6aa2ee108809c99df98529a3d7478985694e045d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35347 "Failed to checkout and rebase branch from PR 23148") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37460 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38084 "Hash 6aa2ee10 for PR 23148 does not build (failure)") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/31879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36544 "Failed to checkout and rebase branch from PR 23148") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/16644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/11319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/38084 "Hash 6aa2ee10 for PR 23148 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35897 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/16644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/38084 "Hash 6aa2ee10 for PR 23148 does not build (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/16644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/31589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/16644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/31922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/39330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/10777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/11319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->