### PR TITLE
Adopt more smart pointers in SubframeLoader.cpp

### DIFF
--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -79,6 +79,11 @@ FrameLoader::SubframeLoader::SubframeLoader(LocalFrame& frame)
 {
 }
 
+Ref<LocalFrame> FrameLoader::SubframeLoader::protectedFrame() const
+{
+    return m_frame.get();
+}
+
 void FrameLoader::SubframeLoader::clear()
 {
     m_containsPlugins = false;
@@ -88,11 +93,11 @@ void FrameLoader::SubframeLoader::createFrameIfNecessary(HTMLFrameOwnerElement& 
 {
     if (ownerElement.contentFrame())
         return;
-    m_frame.loader().client().createFrame(frameName, ownerElement);
+    protectedFrame()->checkedLoader()->client().createFrame(frameName, ownerElement);
     if (!ownerElement.contentFrame())
         return;
 
-    if (auto* contentDocument = downcast<LocalFrame>(ownerElement.contentFrame())->document())
+    if (RefPtr contentDocument = downcast<LocalFrame>(*ownerElement.contentFrame()).document())
         contentDocument->setReferrerPolicy(ownerElement.referrerPolicy());
 }
 
@@ -123,22 +128,22 @@ bool FrameLoader::SubframeLoader::resourceWillUsePlugin(const String& url, const
 
 bool FrameLoader::SubframeLoader::pluginIsLoadable(const URL& url)
 {
-    auto* document = m_frame.document();
-    if (document) {
+    if (RefPtr document = m_frame->document()) {
         if (document->isSandboxed(SandboxPlugins))
             return false;
 
-        if (!document->securityOrigin().canDisplay(url, OriginAccessPatternsForWebProcess::singleton())) {
-            FrameLoader::reportLocalLoadFailed(&m_frame, url.string());
+        Ref securityOrigin = document->securityOrigin();
+        if (!securityOrigin->canDisplay(url, OriginAccessPatternsForWebProcess::singleton())) {
+            FrameLoader::reportLocalLoadFailed(protectedFrame().ptr(), url.string());
             return false;
         }
 
         if (!portAllowed(url)) {
-            FrameLoader::reportBlockedLoadFailed(m_frame, url);
+            FrameLoader::reportBlockedLoadFailed(protectedFrame(), url);
             return false;
         }
 
-        if (!MixedContentChecker::frameAndAncestorsCanRunInsecureContent(m_frame, document->securityOrigin(), url))
+        if (!MixedContentChecker::frameAndAncestorsCanRunInsecureContent(protectedFrame(), securityOrigin, url))
             return false;
     }
 
@@ -168,14 +173,14 @@ bool FrameLoader::SubframeLoader::requestPlugin(HTMLPlugInImageElement& ownerEle
 {
     String mimeType = explicitMIMEType;
     if (mimeType.isEmpty()) {
-        if (auto page = ownerElement.document().page())
+        if (RefPtr page = ownerElement.document().page())
             mimeType = findPluginMIMETypeFromURL(*page, url);
     }
 
     // Application plug-ins are plug-ins implemented by the user agent, for example Qt plug-ins,
     // as opposed to third-party code such as Flash. The user agent decides whether or not they are
     // permitted, rather than WebKit.
-    if (!(m_frame.arePluginsEnabled() || MIMETypeRegistry::isApplicationPluginMIMEType(mimeType)))
+    if (!(m_frame->arePluginsEnabled() || MIMETypeRegistry::isApplicationPluginMIMEType(mimeType)))
         return false;
 
     if (!pluginIsLoadable(url))
@@ -261,9 +266,9 @@ LocalFrame* FrameLoader::SubframeLoader::loadOrRedirectSubframe(HTMLFrameOwnerEl
                 page->willChangeLocationInCompletelyLoadedSubframe();
         }
 
-        frame->navigationScheduler().scheduleLocationChange(initiatingDocument, initiatingDocument->securityOrigin(), upgradedRequestURL, m_frame.loader().outgoingReferrer(), lockHistory, lockBackForwardList, WTFMove(stopDelayingLoadEvent));
+        frame->checkedNavigationScheduler()->scheduleLocationChange(initiatingDocument, initiatingDocument->protectedSecurityOrigin(), upgradedRequestURL, m_frame->loader().outgoingReferrer(), lockHistory, lockBackForwardList, WTFMove(stopDelayingLoadEvent));
     } else
-        frame = loadSubframe(ownerElement, upgradedRequestURL, frameName, m_frame.loader().outgoingReferrer());
+        frame = loadSubframe(ownerElement, upgradedRequestURL, frameName, m_frame->loader().outgoingReferrer());
 
     if (!frame)
         return nullptr;
@@ -274,34 +279,34 @@ LocalFrame* FrameLoader::SubframeLoader::loadOrRedirectSubframe(HTMLFrameOwnerEl
 
 RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerElement& ownerElement, const URL& url, const AtomString& name, const String& referrer)
 {
-    Ref protectedFrame { m_frame };
+    Ref frame = m_frame.get();
     Ref document = ownerElement.document();
 
     if (!document->securityOrigin().canDisplay(url, OriginAccessPatternsForWebProcess::singleton())) {
-        FrameLoader::reportLocalLoadFailed(&m_frame, url.string());
+        FrameLoader::reportLocalLoadFailed(frame.ptr(), url.string());
         return nullptr;
     }
 
     if (!portAllowed(url)) {
-        FrameLoader::reportBlockedLoadFailed(m_frame, url);
+        FrameLoader::reportBlockedLoadFailed(frame, url);
         return nullptr;
     }
 
     if (!SubframeLoadingDisabler::canLoadFrame(ownerElement))
         return nullptr;
 
-    if (!m_frame.page() || m_frame.page()->subframeCount() >= Page::maxNumberOfFrames)
+    if (!frame->page() || frame->page()->subframeCount() >= Page::maxNumberOfFrames)
         return nullptr;
 
-    if (m_frame.tree().depth() >= Page::maxFrameDepth)
+    if (frame->tree().depth() >= Page::maxFrameDepth)
         return nullptr;
 
     // Prevent initial empty document load from triggering load events.
     document->incrementLoadEventDelayCount();
 
-    auto frame = m_frame.loader().client().createFrame(name, ownerElement);
-    if (!frame)  {
-        m_frame.loader().checkCallImplicitClose();
+    RefPtr subFrame = frame->loader().client().createFrame(name, ownerElement);
+    if (!subFrame)  {
+        frame->checkedLoader()->checkCallImplicitClose();
         document->decrementLoadEventDelayCount();
         return nullptr;
     }
@@ -310,13 +315,13 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
         policy = document->referrerPolicy();
     String referrerToUse = SecurityPolicy::generateReferrerHeader(policy, url, referrer, OriginAccessPatternsForWebProcess::singleton());
 
-    m_frame.loader().loadURLIntoChildFrame(url, referrerToUse, frame.get());
+    frame->checkedLoader()->loadURLIntoChildFrame(url, referrerToUse, subFrame.get());
 
     document->decrementLoadEventDelayCount();
 
     // The frame's onload handler may have removed it from the document.
-    if (!frame || !frame->tree().parent()) {
-        m_frame.loader().checkCallImplicitClose();
+    if (!subFrame || !subFrame->tree().parent()) {
+        frame->checkedLoader()->checkCallImplicitClose();
         return nullptr;
     }
 
@@ -326,16 +331,16 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
     // actually completed below. (Note that we set m_isComplete to false even for synchronous
     // loads, so that checkCompleted() below won't bail early.)
     // FIXME: Can we remove this entirely? m_isComplete normally gets set to false when a load is committed.
-    frame->loader().started();
+    subFrame->checkedLoader()->started();
    
     {
         CheckedPtr renderWidget = dynamicDowncast<RenderWidget>(ownerElement.renderer());
-        RefPtr view = frame->view();
+        RefPtr view = subFrame->view();
         if (renderWidget && view)
             renderWidget->setWidget(WTFMove(view));
     }
 
-    m_frame.loader().checkCallImplicitClose();
+    frame->checkedLoader()->checkCallImplicitClose();
 
     // Some loads are performed synchronously (e.g., about:blank and loads
     // cancelled by returning a null ResourceRequest from requestFromDelegate).
@@ -346,23 +351,24 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
     // FIXME: In this case the Frame will have finished loading before 
     // it's being added to the child list. It would be a good idea to
     // create the child first, then invoke the loader separately.
-    if (frame->loader().state() == FrameState::Complete && !frame->loader().policyDocumentLoader())
-        frame->loader().checkCompleted();
+    if (subFrame->loader().state() == FrameState::Complete && !subFrame->loader().policyDocumentLoader())
+        subFrame->checkedLoader()->checkCompleted();
 
-    if (!frame->tree().parent())
+    if (!subFrame->tree().parent())
         return nullptr;
 
-    return frame;
+    return subFrame;
 }
 
 bool FrameLoader::SubframeLoader::shouldUsePlugin(const URL& url, const String& mimeType, bool hasFallback, bool& useFallback)
 {
-    if (m_frame.loader().client().shouldAlwaysUsePluginDocument(mimeType)) {
+    Ref frame = m_frame.get();
+    if (frame->checkedLoader()->client().shouldAlwaysUsePluginDocument(mimeType)) {
         useFallback = false;
         return true;
     }
 
-    ObjectContentType objectType = m_frame.loader().client().objectContentType(url, mimeType);
+    ObjectContentType objectType = frame->checkedLoader()->client().objectContentType(url, mimeType);
     // If an object's content can't be handled and it has no fallback, let
     // it be handled as a plugin to show the broken plugin icon.
     useFallback = objectType == ObjectContentType::None && hasFallback;
@@ -375,47 +381,45 @@ bool FrameLoader::SubframeLoader::loadPlugin(HTMLPlugInImageElement& pluginEleme
     if (useFallback)
         return false;
 
-    auto& document = pluginElement.document();
-    auto* renderer = pluginElement.renderEmbeddedObject();
+    Ref document = pluginElement.document();
+    WeakPtr renderer = pluginElement.renderEmbeddedObject();
 
     // FIXME: This code should not depend on renderer!
     if (!renderer)
         return false;
 
-    auto* pluginDocument = dynamicDowncast<PluginDocument>(document);
+    RefPtr pluginDocument = dynamicDowncast<PluginDocument>(document);
     bool loadManually = pluginDocument && !m_containsPlugins && pluginDocument->shouldLoadPluginManually();
 
-    if (document.ownerElement() && document.settings().useImageDocumentForSubframePDF())
+    if (document->ownerElement() && document->settings().useImageDocumentForSubframePDF())
         loadManually = false;
 
-    WeakPtr weakRenderer { *renderer };
-
-    auto widget = m_frame.loader().client().createPlugin(pluginElement, url, paramNames, paramValues, mimeType, loadManually);
+    auto widget = m_frame->loader().client().createPlugin(pluginElement, url, paramNames, paramValues, mimeType, loadManually);
 
     // The call to createPlugin *may* cause this renderer to disappear from underneath.
-    if (!weakRenderer)
+    if (!renderer)
         return false;
 
     if (!widget) {
         if (!renderer->isPluginUnavailable())
-            renderer->setPluginUnavailabilityReason(RenderEmbeddedObject::PluginMissing);
+            CheckedRef { *renderer }->setPluginUnavailabilityReason(RenderEmbeddedObject::PluginMissing);
         return false;
     }
 
-    renderer->setWidget(WTFMove(widget));
+    CheckedRef { *renderer }->setWidget(WTFMove(widget));
     m_containsPlugins = true;
     return true;
 }
 
 URL FrameLoader::SubframeLoader::completeURL(const String& url) const
 {
-    ASSERT(m_frame.document());
-    return m_frame.document()->completeURL(url);
+    ASSERT(m_frame->document());
+    return m_frame->protectedDocument()->completeURL(url);
 }
 
 bool FrameLoader::SubframeLoader::shouldConvertInvalidURLsToBlank() const
 {
-    return m_frame.settings().shouldConvertInvalidURLsToBlank();
+    return m_frame->settings().shouldConvertInvalidURLsToBlank();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/SubframeLoader.h
+++ b/Source/WebCore/loader/SubframeLoader.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "FrameLoader.h"
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -71,9 +72,10 @@ private:
     URL completeURL(const String&) const;
 
     bool shouldConvertInvalidURLsToBlank() const;
+    Ref<LocalFrame> protectedFrame() const;
 
     bool m_containsPlugins { false };
-    LocalFrame& m_frame;
+    WeakRef<LocalFrame> m_frame;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 75d9af099b45c8a24199497f5a7ec24fccc11721
<pre>
Adopt more smart pointers in SubframeLoader.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=267980">https://bugs.webkit.org/show_bug.cgi?id=267980</a>

Reviewed by Darin Adler.

* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::protectedFrame const):
(WebCore::FrameLoader::SubframeLoader::createFrameIfNecessary):
(WebCore::FrameLoader::SubframeLoader::pluginIsLoadable):
(WebCore::FrameLoader::SubframeLoader::requestPlugin):
(WebCore::FrameLoader::SubframeLoader::loadOrRedirectSubframe):
(WebCore::FrameLoader::SubframeLoader::loadSubframe):
(WebCore::FrameLoader::SubframeLoader::shouldUsePlugin):
(WebCore::FrameLoader::SubframeLoader::loadPlugin):
(WebCore::FrameLoader::SubframeLoader::completeURL const):
(WebCore::FrameLoader::SubframeLoader::shouldConvertInvalidURLsToBlank const):
* Source/WebCore/loader/SubframeLoader.h:

Canonical link: <a href="https://commits.webkit.org/273425@main">https://commits.webkit.org/273425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4181c1657a9bdb5b4b7dacc2771e2f3b039af256

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38086 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31881 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30745 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10577 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10623 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39332 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32115 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31926 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36603 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34626 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12538 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11303 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4569 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11595 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->