### PR TITLE
[WebDriver] Pytest errors running run-webdriver-tests on a clean environment

### DIFF
--- a/Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py
@@ -30,6 +30,8 @@ import tempfile
 from webkitpy.common.system.filesystem import FileSystem
 from webkitpy.common.webkit_finder import WebKitFinder
 import pytest
+import pytest_timeout
+import pytest_asyncio
 from _pytest.config import ExitCode
 
 

--- a/WebDriverTests/imported/w3c/config.json
+++ b/WebDriverTests/imported/w3c/config.json
@@ -7,7 +7,7 @@
           },
  "doc_root": "%DOC_ROOT%",
  "check_subdomains": false,
- "log_level":"debug",
+ "logging": { "level": "debug" },
  "bind_hostname": true,
  "ssl": {"type": "openssl",
          "encrypt_after_connect": false,


### PR DESCRIPTION
#### abe0591426767036fc01d5d86d8a158ddfb77457
<pre>
[WebDriver] Pytest errors running run-webdriver-tests on a clean environment
<a href="https://bugs.webkit.org/show_bug.cgi?id=265202">https://bugs.webkit.org/show_bug.cgi?id=265202</a>

Reviewed by Carlos Garcia Campos.

Import required pytest plugins to ensure Autoinstall installs them
before invoking pytest programatically in `pytest_runner.py`

pytest&apos;s lazy plugin loading wasn&apos;t installing either pytest-timeout nor
pytest-asyncio. The former added support for the `--timeout` parameter
that was being unrecognized in this bug original report.

This commit also includes a drive-by fix of WPT webdriver config.json,
updating a key in the same was as <a href="https://commits.webkit.org/272808@main">https://commits.webkit.org/272808@main</a>

* Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py:
* WebDriverTests/imported/w3c/config.json:

Canonical link: <a href="https://commits.webkit.org/273413@main">https://commits.webkit.org/273413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b9cc7abf3fbfa1c446331a42bc00134d9429f71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38094 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31886 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36554 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30747 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10583 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/35590 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10652 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-senderCaptureTimeOffset.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39340 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32156 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31927 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36605 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34631 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12542 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8089 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11310 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11599 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->