### PR TITLE
Adopt more smart pointers in SubresourceLoader.cpp

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2623,6 +2623,11 @@ bool DocumentLoader::fingerprintingProtectionsEnabled() const
     return m_advancedPrivacyProtections.contains(AdvancedPrivacyProtections::FingerprintingProtections);
 }
 
+Ref<CachedResourceLoader> DocumentLoader::protectedCachedResourceLoader() const
+{
+    return m_cachedResourceLoader;
+}
+
 } // namespace WebCore
 
 #undef PAGE_ID

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -204,6 +204,7 @@ public:
     ResourceRequest& request();
 
     CachedResourceLoader& cachedResourceLoader() { return m_cachedResourceLoader; }
+    Ref<CachedResourceLoader> protectedCachedResourceLoader() const;
 
     const SubstituteData& substituteData() const { return m_substituteData; }
 

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -370,6 +370,11 @@ const FragmentedSharedBuffer* ResourceLoader::resourceData() const
     return m_resourceData.get().get();
 }
 
+RefPtr<const FragmentedSharedBuffer> ResourceLoader::protectedResourceData() const
+{
+    return resourceData();
+}
+
 void ResourceLoader::clearResourceData()
 {
     if (m_resourceData)
@@ -915,6 +920,11 @@ bool ResourceLoader::isPDFJSResourceLoad() const
 #else
     return false;
 #endif
+}
+
+RefPtr<LocalFrame> ResourceLoader::protectedFrame() const
+{
+    return m_frame;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -103,6 +103,7 @@ public:
     const ResourceResponse& response() const { return m_response; }
 
     const FragmentedSharedBuffer* resourceData() const;
+    RefPtr<const FragmentedSharedBuffer> protectedResourceData() const;
     void clearResourceData();
     
     virtual bool isSubresourceLoader() const;
@@ -156,7 +157,8 @@ public:
     void unschedule(WTF::SchedulePair&);
 #endif
 
-    const LocalFrame* frame() const { return m_frame.get(); }
+    LocalFrame* frame() const { return m_frame.get(); }
+    RefPtr<LocalFrame> protectedFrame() const;
 
     const ResourceLoaderOptions& options() const { return m_options; }
 

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -87,7 +87,7 @@ DEFINE_DEBUG_ONLY_GLOBAL(WTF::RefCountedLeakCounter, subresourceLoaderCounter, (
 
 SubresourceLoader::RequestCountTracker::RequestCountTracker(CachedResourceLoader& cachedResourceLoader, const CachedResource& resource)
     : m_cachedResourceLoader(&cachedResourceLoader)
-    , m_resource(&resource)
+    , m_resource(resource)
 {
     cachedResourceLoader.incrementRequestCount(resource);
 }
@@ -107,13 +107,15 @@ auto SubresourceLoader::RequestCountTracker::operator=(RequestCountTracker&& oth
 
 SubresourceLoader::RequestCountTracker::~RequestCountTracker()
 {
-    if (m_cachedResourceLoader && m_resource)
-        m_cachedResourceLoader->decrementRequestCount(*m_resource);
+    RefPtr cachedResourceLoader = m_cachedResourceLoader.get();
+    CachedResourceHandle resource = m_resource.get();
+    if (cachedResourceLoader && resource)
+        cachedResourceLoader->decrementRequestCount(*resource);
 }
 
 SubresourceLoader::SubresourceLoader(LocalFrame& frame, CachedResource& resource, const ResourceLoaderOptions& options)
     : ResourceLoader(frame, options)
-    , m_resource(&resource)
+    , m_resource(resource)
     , m_state(Uninitialized)
     , m_requestCountTracker(std::in_place, frame.document()->cachedResourceLoader(), resource)
 {
@@ -138,7 +140,7 @@ SubresourceLoader::~SubresourceLoader()
 
 void SubresourceLoader::create(LocalFrame& frame, CachedResource& resource, ResourceRequest&& request, const ResourceLoaderOptions& options, CompletionHandler<void(RefPtr<SubresourceLoader>&&)>&& completionHandler)
 {
-    auto subloader(adoptRef(*new SubresourceLoader(frame, resource, options)));
+    Ref subloader = adoptRef(*new SubresourceLoader(frame, resource, options));
 #if PLATFORM(IOS_FAMILY)
     if (!IOSApplication::isWebProcess()) {
         // On iOS, do not invoke synchronous resource load delegates while resource load scheduling
@@ -203,9 +205,7 @@ bool SubresourceLoader::isSubresourceLoader() const
 
 void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, const ResourceResponse& redirectResponse, CompletionHandler<void(ResourceRequest&&)>&& completionHandler)
 {
-    // Store the previous URL because the call to ResourceLoader::willSendRequest will modify it.
-    URL previousURL = request().url();
-    Ref<SubresourceLoader> protectedThis(*this);
+    Ref protectedThis { *this };
 
     if (!newRequest.url().isValid()) {
         SUBRESOURCELOADER_RELEASE_LOG("willSendRequestInternal: resource load canceled because new request is invalid");
@@ -214,7 +214,7 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
     }
 
     if (newRequest.requester() != ResourceRequestRequester::Main) {
-        ResourceLoadObserver::shared().logSubresourceLoading(m_frame.get(), newRequest, redirectResponse,
+        ResourceLoadObserver::shared().logSubresourceLoading(protectedFrame().get(), newRequest, redirectResponse,
             (isScriptLikeDestination(options().destination) ? ResourceLoadObserver::FetchDestinationIsScriptLike::Yes : ResourceLoadObserver::FetchDestinationIsScriptLike::No));
     }
 
@@ -256,7 +256,7 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
                 ResourceError error { errorDomainWebKitInternal, 0, request().url(), makeString("Not allowed to follow a redirection while loading ", request().url().string()), ResourceError::Type::AccessControl };
 
                 if (m_frame && m_frame->document())
-                    m_frame->document()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, error.localizedDescription());
+                    m_frame->protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, error.localizedDescription());
 
                 SUBRESOURCELOADER_RELEASE_LOG("willSendRequestInternal: resource load canceled because not allowed to follow a redirect");
 
@@ -290,16 +290,17 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
         // Doing so would have us reusing the resource from the first request if the second request's revalidation succeeds.
         if (newRequest.isConditional() && m_resource->resourceToRevalidate() && newRequest.url() != m_resource->resourceToRevalidate()->response().url()) {
             newRequest.makeUnconditional();
-            MemoryCache::singleton().revalidationFailed(*m_resource);
+            MemoryCache::singleton().revalidationFailed(*protectedCachedResource());
             if (m_frame && m_frame->page())
-                m_frame->page()->diagnosticLoggingClient().logDiagnosticMessageWithResult(DiagnosticLoggingKeys::cachedResourceRevalidationKey(), emptyString(), DiagnosticLoggingResultFail, ShouldSample::Yes);
+                m_frame->protectedPage()->diagnosticLoggingClient().logDiagnosticMessageWithResult(DiagnosticLoggingKeys::cachedResourceRevalidationKey(), emptyString(), DiagnosticLoggingResultFail, ShouldSample::Yes);
         }
 
         RefPtr documentLoader = this->documentLoader();
-        auto originalOrigin = SecurityOrigin::create(redirectResponse.url());
-        m_site = documentLoader->cachedResourceLoader().computeFetchMetadataSite(newRequest, m_resource->type(), options().mode, originalOrigin, m_site);
+        Ref originalOrigin = SecurityOrigin::create(redirectResponse.url());
+        Ref cachedResourceLoader = documentLoader->cachedResourceLoader();
+        m_site = cachedResourceLoader->computeFetchMetadataSite(newRequest, m_resource->type(), options().mode, originalOrigin, m_site);
 
-        if (!documentLoader->cachedResourceLoader().updateRequestAfterRedirection(m_resource->type(), newRequest, options(), m_site, originalRequest().url())) {
+        if (!cachedResourceLoader->updateRequestAfterRedirection(m_resource->type(), newRequest, options(), m_site, originalRequest().url())) {
             SUBRESOURCELOADER_RELEASE_LOG("willSendRequestInternal: resource load canceled because CachedResourceLoader::updateRequestAfterRedirection (really CachedResourceLoader::canRequestAfterRedirection) said no");
             cancel(ResourceError { String(), 0, request().url(), "Redirect was not allowed"_s, ResourceError::Type::AccessControl });
             return completionHandler(WTFMove(newRequest));
@@ -307,8 +308,8 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
 
         if (!portAllowed(newRequest.url())) {
             SUBRESOURCELOADER_RELEASE_LOG("willSendRequestInternal: resource load (redirect) canceled because it attempted to use a blocked port");
-            if (m_frame)
-                FrameLoader::reportBlockedLoadFailed(*m_frame, newRequest.url());
+            if (RefPtr frame = m_frame)
+                FrameLoader::reportBlockedLoadFailed(*frame, newRequest.url());
             cancel(frameLoader()->blockedError(newRequest));
             return completionHandler(WTFMove(newRequest));
         }
@@ -317,13 +318,13 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
         if (!accessControlCheckResult) {
             auto errorMessage = makeString("Cross-origin redirection to ", newRequest.url().string(), " denied by Cross-Origin Resource Sharing policy: ", accessControlCheckResult.error());
             if (m_frame && m_frame->document())
-                m_frame->document()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, errorMessage);
+                m_frame->protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, errorMessage);
             SUBRESOURCELOADER_RELEASE_LOG("willSendRequestInternal: resource load canceled because crosss-origin redirection denied by CORS policy");
             cancel(ResourceError(String(), 0, request().url(), errorMessage, ResourceError::Type::AccessControl));
             return completionHandler(WTFMove(newRequest));
         }
 
-        if (m_resource->isImage() && documentLoader->cachedResourceLoader().shouldDeferImageLoad(newRequest.url())) {
+        if (m_resource->isImage() && cachedResourceLoader->shouldDeferImageLoad(newRequest.url())) {
             SUBRESOURCELOADER_RELEASE_LOG("willSendRequestInternal: resource load canceled because it's an image that should be defered");
             cancel();
             return completionHandler(WTFMove(newRequest));
@@ -341,7 +342,7 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
 void SubresourceLoader::didSendData(unsigned long long bytesSent, unsigned long long totalBytesToBeSent)
 {
     ASSERT(m_state == Initialized);
-    Ref<SubresourceLoader> protectedThis(*this);
+    Ref protectedThis { *this };
     protectedCachedResource()->didSendData(bytesSent, totalBytesToBeSent);
 }
 
@@ -419,7 +420,7 @@ void SubresourceLoader::didReceiveResponse(const ResourceResponse& response, Com
 
     // Reference the object in this method since the additional processing can do
     // anything including removing the last reference to this object; one example of this is 3266216.
-    Ref<SubresourceLoader> protectedThis(*this);
+    Ref protectedThis { *this };
 
     if (shouldIncludeCertificateInfo())
         response.includeCertificateInfo();
@@ -437,23 +438,23 @@ void SubresourceLoader::didReceiveResponse(const ResourceResponse& response, Com
             ResourceResponse revalidationResponse = response;
             revalidationResponse.setSource(ResourceResponse::Source::MemoryCacheAfterValidation);
             resource->setResponse(revalidationResponse);
-            MemoryCache::singleton().revalidationSucceeded(*m_resource, revalidationResponse);
+            MemoryCache::singleton().revalidationSucceeded(*protectedCachedResource(), revalidationResponse);
             if (m_frame && m_frame->page())
-                m_frame->page()->diagnosticLoggingClient().logDiagnosticMessageWithResult(DiagnosticLoggingKeys::cachedResourceRevalidationKey(), emptyString(), DiagnosticLoggingResultPass, ShouldSample::Yes);
+                m_frame->protectedPage()->diagnosticLoggingClient().logDiagnosticMessageWithResult(DiagnosticLoggingKeys::cachedResourceRevalidationKey(), emptyString(), DiagnosticLoggingResultPass, ShouldSample::Yes);
             if (!reachedTerminalState())
                 ResourceLoader::didReceiveResponse(revalidationResponse, [completionHandlerCaller = WTFMove(completionHandlerCaller)] { });
             return;
         }
         // Did not get 304 response, continue as a regular resource load.
-        MemoryCache::singleton().revalidationFailed(*m_resource);
+        MemoryCache::singleton().revalidationFailed(*protectedCachedResource());
         if (m_frame && m_frame->page())
-            m_frame->page()->diagnosticLoggingClient().logDiagnosticMessageWithResult(DiagnosticLoggingKeys::cachedResourceRevalidationKey(), emptyString(), DiagnosticLoggingResultFail, ShouldSample::Yes);
+            m_frame->protectedPage()->diagnosticLoggingClient().logDiagnosticMessageWithResult(DiagnosticLoggingKeys::cachedResourceRevalidationKey(), emptyString(), DiagnosticLoggingResultFail, ShouldSample::Yes);
     }
 
     auto accessControlCheckResult = checkResponseCrossOriginAccessControl(response);
     if (!accessControlCheckResult) {
         if (m_frame && m_frame->document())
-            m_frame->document()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, accessControlCheckResult.error());
+            m_frame->protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, accessControlCheckResult.error());
         SUBRESOURCELOADER_RELEASE_LOG("didReceiveResponse: canceling load because of cross origin access control");
         cancel(ResourceError(String(), 0, request().url(), accessControlCheckResult.error(), ResourceError::Type::AccessControl));
         return;
@@ -490,7 +491,7 @@ void SubresourceLoader::didReceiveResponse(const ResourceResponse& response, Com
         // Since a subresource loader does not load multipart sections progressively, data was delivered to the loader all at once.
         // After the first multipart section is complete, signal to delegates that this load is "finished"
         NetworkLoadMetrics emptyMetrics;
-        m_documentLoader->subresourceLoaderFinishedLoadingOnePart(*this);
+        protectedDocumentLoader()->subresourceLoaderFinishedLoadingOnePart(*this);
         didFinishLoadingOnePart(emptyMetrics);
     } else {
         if (resource)
@@ -563,12 +564,12 @@ void SubresourceLoader::didReceiveBuffer(const FragmentedSharedBuffer& buffer, l
     ASSERT(m_state == Initialized);
     // Reference the object in this method since the additional processing can do
     // anything including removing the last reference to this object; one example of this is 3266216.
-    Ref<SubresourceLoader> protectedThis(*this);
+    Ref protectedThis { *this };
 
     ResourceLoader::didReceiveBuffer(buffer, encodedDataLength, dataPayloadType);
 
     if (!m_loadingMultipartContent) {
-        if (auto* resourceData = this->resourceData())
+        if (RefPtr resourceData = this->resourceData())
             resource->updateBuffer(*resourceData);
         else
             resource->updateData(buffer.makeContiguous());
@@ -633,7 +634,7 @@ static void logResourceLoaded(LocalFrame* frame, CachedResource::Type type)
         break;
     }
     
-    frame->page()->diagnosticLoggingClient().logDiagnosticMessage(DiagnosticLoggingKeys::resourceLoadedKey(), resourceType, ShouldSample::Yes);
+    frame->protectedPage()->diagnosticLoggingClient().logDiagnosticMessage(DiagnosticLoggingKeys::resourceLoadedKey(), resourceType, ShouldSample::Yes);
 }
 
 Expected<void, String> SubresourceLoader::checkResponseCrossOriginAccessControl(const ResourceResponse& response)
@@ -651,13 +652,18 @@ Expected<void, String> SubresourceLoader::checkResponseCrossOriginAccessControl(
 
     ASSERT(m_origin);
 
-    return passesAccessControlCheck(response, options().credentials == FetchOptions::Credentials::Include ? StoredCredentialsPolicy::Use : StoredCredentialsPolicy::DoNotUse, *m_origin, &CrossOriginAccessControlCheckDisabler::singleton());
+    return passesAccessControlCheck(response, options().credentials == FetchOptions::Credentials::Include ? StoredCredentialsPolicy::Use : StoredCredentialsPolicy::DoNotUse, *protectedOrigin(), &CrossOriginAccessControlCheckDisabler::singleton());
+}
+
+RefPtr<SecurityOrigin> SubresourceLoader::protectedOrigin() const
+{
+    return m_origin;
 }
 
 Expected<void, String> SubresourceLoader::checkRedirectionCrossOriginAccessControl(const ResourceRequest& previousRequest, const ResourceResponse& redirectResponse, ResourceRequest& newRequest)
 {
     bool crossOriginFlag = m_resource->isCrossOrigin();
-    bool isNextRequestCrossOrigin = m_origin && !m_origin->canRequest(newRequest.url(), OriginAccessPatternsForWebProcess::singleton());
+    bool isNextRequestCrossOrigin = m_origin && !protectedOrigin()->canRequest(newRequest.url(), OriginAccessPatternsForWebProcess::singleton());
 
     if (isNextRequestCrossOrigin)
         protectedCachedResource()->setCrossOrigin();
@@ -676,7 +682,7 @@ Expected<void, String> SubresourceLoader::checkRedirectionCrossOriginAccessContr
 
         ASSERT(m_origin);
         if (crossOriginFlag) {
-            auto accessControlCheckResult = passesAccessControlCheck(redirectResponse, options().storedCredentialsPolicy, *m_origin, &CrossOriginAccessControlCheckDisabler::singleton());
+            auto accessControlCheckResult = passesAccessControlCheck(redirectResponse, options().storedCredentialsPolicy, *protectedOrigin(), &CrossOriginAccessControlCheckDisabler::singleton());
             if (!accessControlCheckResult)
                 return accessControlCheckResult;
         }
@@ -701,12 +707,12 @@ Expected<void, String> SubresourceLoader::checkRedirectionCrossOriginAccessContr
 
     if (options().mode == FetchOptions::Mode::Cors && redirectingToNewOrigin) {
         cleanHTTPRequestHeadersForAccessControl(newRequest, options().httpHeadersToKeep);
-        updateRequestForAccessControl(newRequest, *m_origin, options().storedCredentialsPolicy);
+        updateRequestForAccessControl(newRequest, *protectedOrigin(), options().storedCredentialsPolicy);
     }
 
     updateRequestReferrer(newRequest, referrerPolicy(), previousRequest.httpReferrer(), OriginAccessPatternsForWebProcess::singleton());
 
-    FrameLoader::addHTTPOriginIfNeeded(newRequest, m_origin ? m_origin->toString() : String());
+    FrameLoader::addHTTPOriginIfNeeded(newRequest, m_origin ? protectedOrigin()->toString() : String());
 
     return { };
 }
@@ -744,7 +750,7 @@ void SubresourceLoader::didFinishLoading(const NetworkLoadMetrics& networkLoadMe
     // FIXME (129394): We should cancel the load when a decode error occurs instead of continuing the load to completion.
     ASSERT(!resource->errorOccurred() || resource->status() == CachedResource::DecodeError || !resource->isLoading());
     LOG(ResourceLoading, "Received '%s'.", resource->url().string().latin1().data());
-    logResourceLoaded(m_frame.get(), resource->type());
+    logResourceLoaded(protectedFrame().get(), resource->type());
 
     m_loadTiming.markEndTime();
 
@@ -764,7 +770,7 @@ void SubresourceLoader::didFinishLoading(const NetworkLoadMetrics& networkLoadMe
     m_state = Finishing;
     if (m_loadingMultipartContent && !m_previousPartResponse.isNull())
         resource->responseReceived(m_previousPartResponse);
-    resource->finishLoading(resourceData(), networkLoadMetrics);
+    resource->finishLoading(protectedResourceData().get(), networkLoadMetrics);
 
     if (wasCancelled()) {
         SUBRESOURCELOADER_RELEASE_LOG("didFinishLoading: was canceled");
@@ -803,7 +809,7 @@ void SubresourceLoader::didFail(const ResourceError& error)
     if (m_frame->document() && error.isAccessControl() && error.domain() != InspectorNetworkAgent::errorDomain() && resource->type() != CachedResource::Type::Ping)
         m_frame->protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, error.localizedDescription());
 
-    Ref<SubresourceLoader> protectedThis(*this);
+    Ref protectedThis { *this };
     m_state = Finishing;
 
     if (resource->type() != CachedResource::Type::MainResource)
@@ -839,7 +845,7 @@ void SubresourceLoader::willCancel(const ResourceError& error)
     ASSERT(!reachedTerminalState());
     LOG(ResourceLoading, "Cancelled load of '%s'.\n", m_resource->url().string().latin1().data());
 
-    Ref<SubresourceLoader> protectedThis(*this);
+    Ref protectedThis { *this };
     CachedResourceHandle resource = m_resource.get();
 #if PLATFORM(IOS_FAMILY)
     m_state = m_state == Uninitialized ? CancelledWhileInitializing : Finishing;
@@ -880,7 +886,7 @@ void SubresourceLoader::notifyDone(LoadCompletionType type)
         shouldPerformPostLoadActions = false;
 #endif
     if (RefPtr documentLoader = this->documentLoader())
-        documentLoader->cachedResourceLoader().loadDone(type, shouldPerformPostLoadActions);
+        documentLoader->protectedCachedResourceLoader()->loadDone(type, shouldPerformPostLoadActions);
     else
         SUBRESOURCELOADER_RELEASE_LOG_ERROR("notifyDone: document loader is null. Could not call loadDone()");
 
@@ -917,7 +923,7 @@ void SubresourceLoader::reportResourceTiming(const NetworkLoadMetrics& networkLo
     if (!document)
         return;
 
-    SecurityOrigin& origin = m_origin ? *m_origin : document->securityOrigin();
+    Ref origin = m_origin ? *m_origin : document->securityOrigin();
     auto resourceTiming = ResourceTiming::fromLoad(*resource, resource->resourceRequest().url(), resource->initiatorType(), m_loadTiming, networkLoadMetrics, origin);
 
     // Worker resources loaded here are all CachedRawResources loaded through WorkerThreadableLoader.
@@ -930,7 +936,7 @@ void SubresourceLoader::reportResourceTiming(const NetworkLoadMetrics& networkLo
     }
 
     ASSERT(options().initiatorContext == InitiatorContext::Document);
-    protectedDocumentLoader()->cachedResourceLoader().resourceTimingInformation().addResourceTiming(*protectedCachedResource(), *document, WTFMove(resourceTiming));
+    documentLoader()->protectedCachedResourceLoader()->resourceTimingInformation().addResourceTiming(*protectedCachedResource(), *document, WTFMove(resourceTiming));
 }
 
 const HTTPHeaderMap* SubresourceLoader::originalHeaders() const

--- a/Source/WebCore/loader/SubresourceLoader.h
+++ b/Source/WebCore/loader/SubresourceLoader.h
@@ -50,17 +50,18 @@ public:
     virtual ~SubresourceLoader();
 
     void cancelIfNotFinishing();
-    bool isSubresourceLoader() const override;
-    CachedResource* cachedResource() const override { return m_resource.get(); };
+    bool isSubresourceLoader() const final;
+    CachedResource* cachedResource() const final { return m_resource.get(); };
     WEBCORE_EXPORT const HTTPHeaderMap* originalHeaders() const;
 
     const SecurityOrigin* origin() const { return m_origin.get(); }
     SecurityOrigin* origin() { return m_origin.get(); }
+    RefPtr<SecurityOrigin> protectedOrigin() const;
 #if PLATFORM(IOS_FAMILY)
-    void startLoading() override;
+    void startLoading() final;
 
     // FIXME: What is an "iOS" original request? Why is it necessary?
-    const ResourceRequest& iOSOriginalRequest() const override { return m_iOSOriginalRequest; }
+    const ResourceRequest& iOSOriginalRequest() const final { return m_iOSOriginalRequest; }
 #endif
 
     unsigned redirectCount() const { return m_redirectCount; }
@@ -74,24 +75,24 @@ public:
 private:
     SubresourceLoader(LocalFrame&, CachedResource&, const ResourceLoaderOptions&);
 
-    void init(ResourceRequest&&, CompletionHandler<void(bool)>&&) override;
+    void init(ResourceRequest&&, CompletionHandler<void(bool)>&&) final;
 
-    void willSendRequestInternal(ResourceRequest&&, const ResourceResponse& redirectResponse, CompletionHandler<void(ResourceRequest&&)>&&) override;
-    void didSendData(unsigned long long bytesSent, unsigned long long totalBytesToBeSent) override;
-    void didReceiveResponse(const ResourceResponse&, CompletionHandler<void()>&& policyCompletionHandler) override;
-    void didReceiveBuffer(const FragmentedSharedBuffer&, long long encodedDataLength, DataPayloadType) override;
-    void didFinishLoading(const NetworkLoadMetrics&) override;
-    void didFail(const ResourceError&) override;
-    void willCancel(const ResourceError&) override;
-    void didCancel(const ResourceError&) override;
+    void willSendRequestInternal(ResourceRequest&&, const ResourceResponse& redirectResponse, CompletionHandler<void(ResourceRequest&&)>&&) final;
+    void didSendData(unsigned long long bytesSent, unsigned long long totalBytesToBeSent) final;
+    void didReceiveResponse(const ResourceResponse&, CompletionHandler<void()>&& policyCompletionHandler) final;
+    void didReceiveBuffer(const FragmentedSharedBuffer&, long long encodedDataLength, DataPayloadType) final;
+    void didFinishLoading(const NetworkLoadMetrics&) final;
+    void didFail(const ResourceError&) final;
+    void willCancel(const ResourceError&) final;
+    void didCancel(const ResourceError&) final;
     
     void updateReferrerPolicy(const String&);
 
 #if PLATFORM(COCOA)
-    void willCacheResponseAsync(ResourceHandle*, NSCachedURLResponse*, CompletionHandler<void(NSCachedURLResponse *)>&&) override;
+    void willCacheResponseAsync(ResourceHandle*, NSCachedURLResponse*, CompletionHandler<void(NSCachedURLResponse *)>&&) final;
 #endif
 
-    void releaseResources() override;
+    void releaseResources() final;
 
     bool responseHasHTTPStatusCodeError() const;
     Expected<void, String> checkResponseCrossOriginAccessControl(const ResourceResponse&);
@@ -105,7 +106,7 @@ private:
 
 #if USE(QUICK_LOOK)
     bool shouldCreatePreviewLoaderForResponse(const ResourceResponse&) const;
-    void didReceivePreviewResponse(const ResourceResponse&) override;
+    void didReceivePreviewResponse(const ResourceResponse&) final;
 #endif
 
     enum SubresourceLoaderState {
@@ -128,7 +129,7 @@ private:
         ~RequestCountTracker();
     private:
         WeakPtr<CachedResourceLoader> m_cachedResourceLoader;
-        WeakPtr<const CachedResource> m_resource;
+        WeakPtr<CachedResource> m_resource;
     };
 
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### ea3d99fe95daaa9b05825b685a41e86e866c69f5
<pre>
Adopt more smart pointers in SubresourceLoader.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=267982">https://bugs.webkit.org/show_bug.cgi?id=267982</a>

Reviewed by Darin Adler.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::protectedCachedResourceLoader const):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::protectedResourceData const):
(WebCore::ResourceLoader::protectedFrame const):
* Source/WebCore/loader/ResourceLoader.h:
(WebCore::ResourceLoader::frame const):
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::RequestCountTracker::RequestCountTracker):
(WebCore::SubresourceLoader::RequestCountTracker::~RequestCountTracker):
(WebCore::SubresourceLoader::SubresourceLoader):
(WebCore::SubresourceLoader::create):
(WebCore::SubresourceLoader::willSendRequestInternal):
(WebCore::SubresourceLoader::didSendData):
(WebCore::SubresourceLoader::didReceiveResponse):
(WebCore::SubresourceLoader::didReceiveBuffer):
(WebCore::logResourceLoaded):
(WebCore::SubresourceLoader::checkResponseCrossOriginAccessControl):
(WebCore::SubresourceLoader::protectedOrigin const):
(WebCore::SubresourceLoader::checkRedirectionCrossOriginAccessControl):
(WebCore::SubresourceLoader::didFinishLoading):
(WebCore::SubresourceLoader::didFail):
(WebCore::SubresourceLoader::willCancel):
(WebCore::SubresourceLoader::notifyDone):
(WebCore::SubresourceLoader::reportResourceTiming):
* Source/WebCore/loader/SubresourceLoader.h:

Canonical link: <a href="https://commits.webkit.org/273426@main">https://commits.webkit.org/273426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e2711f323b9b2daf22245eb4b2c31b586412afd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38098 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31890 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30750 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10590 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39344 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32127 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31932 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36608 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10790 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34640 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12546 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11314 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4570 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11603 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->