### PR TITLE
Perform media networking operations off the main thread

### DIFF
--- a/Source/WebCore/loader/MediaResourceLoader.h
+++ b/Source/WebCore/loader/MediaResourceLoader.h
@@ -33,6 +33,7 @@
 #include "FetchOptions.h"
 #include "PlatformMediaResourceLoader.h"
 #include "ResourceResponse.h"
+#include <wtf/Atomics.h>
 #include <wtf/HashSet.h>
 #include <wtf/Ref.h>
 #include <wtf/WeakPtr.h>
@@ -55,22 +56,22 @@ public:
     void sendH2Ping(const URL&, CompletionHandler<void(Expected<Seconds, ResourceError>&&)>&&) final;
     void removeResource(MediaResource&);
 
-    Document* document() { return m_document.get(); }
-    const String& crossOriginMode() const { return m_crossOriginMode; }
+    Document* document();
+    const String& crossOriginMode() const;
 
     WEBCORE_EXPORT static void recordResponsesForTesting();
-    Vector<ResourceResponse> responsesForTesting() const { return m_responsesForTesting; }
+    WEBCORE_EXPORT Vector<ResourceResponse> responsesForTesting() const;
     void addResponseForTesting(const ResourceResponse&);
 
 private:
     void contextDestroyed() override;
 
-    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
-    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_element;
-    String m_crossOriginMode;
-    HashSet<MediaResource*> m_resources;
-    Vector<ResourceResponse> m_responsesForTesting;
-    FetchOptions::Destination m_destination;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document WTF_GUARDED_BY_CAPABILITY(mainThread);
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_element WTF_GUARDED_BY_CAPABILITY(mainThread);
+    String m_crossOriginMode WTF_GUARDED_BY_CAPABILITY(mainThread);
+    HashSet<MediaResource*> m_resources WTF_GUARDED_BY_CAPABILITY(mainThread);
+    Vector<ResourceResponse> m_responsesForTesting WTF_GUARDED_BY_CAPABILITY(mainThread);
+    FetchOptions::Destination m_destination WTF_GUARDED_BY_CAPABILITY(mainThread);
 };
 
 class MediaResource : public PlatformMediaResource, CachedRawResourceClient {
@@ -79,8 +80,8 @@ public:
     virtual ~MediaResource();
 
     // PlatformMediaResource
-    void stop() override;
-    bool didPassAccessControlCheck() const override { return m_didPassAccessControlCheck; }
+    void shutdown() override;
+    bool didPassAccessControlCheck() const override { return m_didPassAccessControlCheck.load(); }
 
     // CachedRawResourceClient
     void responseReceived(CachedResource&, const ResourceResponse&, CompletionHandler<void()>&&) override;
@@ -92,8 +93,9 @@ public:
 
 private:
     MediaResource(MediaResourceLoader&, CachedResourceHandle<CachedRawResource>);
-    Ref<MediaResourceLoader> m_loader;
-    bool m_didPassAccessControlCheck { false };
+    void ensureShutdown();
+    const Ref<MediaResourceLoader> m_loader;
+    Atomic<bool> m_didPassAccessControlCheck { false };
     CachedResourceHandle<CachedRawResource> m_resource;
 };
 

--- a/Source/WebCore/loader/cache/CachedRawResourceClient.h
+++ b/Source/WebCore/loader/cache/CachedRawResourceClient.h
@@ -35,7 +35,6 @@ class SharedBuffer;
 
 class CachedRawResourceClient : public CachedResourceClient {
 public:
-    virtual ~CachedRawResourceClient() = default;
     static CachedResourceClientType expectedType() { return RawResourceType; }
     CachedResourceClientType resourceClientType() const override { return expectedType(); }
 

--- a/Source/WebCore/platform/graphics/WebMResourceClient.cpp
+++ b/Source/WebCore/platform/graphics/WebMResourceClient.cpp
@@ -57,32 +57,25 @@ void WebMResourceClient::stop()
         return;
 
     auto resource = WTFMove(m_resource);
-    resource->stop();
-    resource->setClient(nullptr);
+    resource->shutdown();
 }
 
 void WebMResourceClient::dataReceived(PlatformMediaResource&, const SharedBuffer& buffer)
 {
-    if (!m_parent)
-        return;
-    
-    m_parent->dataReceived(buffer);
+    if (RefPtr parent = m_parent.get())
+        parent->dataReceived(buffer);
 }
 
 void WebMResourceClient::loadFailed(PlatformMediaResource&, const ResourceError& error)
 {
-    if (!m_parent)
-        return;
-    
-    m_parent->loadFailed(error);
+    if (RefPtr parent = m_parent.get())
+        parent->loadFailed(error);
 }
 
 void WebMResourceClient::loadFinished(PlatformMediaResource&, const NetworkLoadMetrics&)
 {
-    if (!m_parent)
-        return;
-    
-    m_parent->loadFinished();
+    if (RefPtr parent = m_parent.get())
+        parent->loadFinished();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/WebMResourceClient.h
+++ b/Source/WebCore/platform/graphics/WebMResourceClient.h
@@ -28,11 +28,12 @@
 #if ENABLE(ALTERNATE_WEBM_PLAYER)
 
 #include "PlatformMediaResourceLoader.h"
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
-class WebMResourceClientParent : public CanMakeWeakPtr<WebMResourceClientParent> {
+class WebMResourceClientParent : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebMResourceClientParent, WTF::DestructionThread::Main> {
 public:
     virtual ~WebMResourceClientParent() = default;
 
@@ -42,8 +43,7 @@ public:
 };
 
 class WebMResourceClient final
-    : public PlatformMediaResourceClient
-    , public CanMakeWeakPtr<WebMResourceClient> {
+    : public PlatformMediaResourceClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static RefPtr<WebMResourceClient> create(WebMResourceClientParent&, PlatformMediaResourceLoader&, ResourceRequest&&);
@@ -58,7 +58,7 @@ private:
     void loadFailed(PlatformMediaResource&, const ResourceError&) final;
     void loadFinished(PlatformMediaResource&, const NetworkLoadMetrics&) final;
 
-    WeakPtr<WebMResourceClientParent> m_parent;
+    ThreadSafeWeakPtr<WebMResourceClientParent> m_parent;
     RefPtr<PlatformMediaResource> m_resource;
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -34,6 +34,7 @@
 #include <wtf/Function.h>
 #include <wtf/Observer.h>
 #include <wtf/RobinHoodHashMap.h>
+#include <wtf/WorkQueue.h>
 
 OBJC_CLASS AVAssetImageGenerator;
 OBJC_CLASS AVAssetTrack;
@@ -493,6 +494,7 @@ private:
     ProcessIdentity m_resourceOwner;
     PlatformTimeRanges m_buffered;
     TrackID m_currentTextTrackID { 0 };
+    Ref<WorkQueue> m_targetQueue { WorkQueue::main() };
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -453,8 +453,11 @@ MediaPlayerPrivateAVFoundationObjC::~MediaPlayerPrivateAVFoundationObjC()
 {
     [[m_avAsset resourceLoader] setDelegate:nil queue:0];
 
-    for (auto& pair : m_resourceLoaderMap)
-        pair.value->invalidate();
+    for (auto& pair : m_resourceLoaderMap) {
+        m_targetQueue->dispatch([loader = pair.value] () mutable {
+            loader->stopLoading();
+        });
+    }
 
     if (m_videoOutput)
         m_videoOutput->invalidate();
@@ -1035,11 +1038,13 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
         }
     }
 
-    AVAssetResourceLoader *resourceLoader = m_avAsset.get().resourceLoader;
+    AVAssetResourceLoader *resourceLoader = [m_avAsset resourceLoader];
     [resourceLoader setDelegate:m_loaderDelegate.get() queue:globalLoaderDelegateQueue()];
 
-    if (auto mediaResourceLoader = player->createResourceLoader())
+    if (auto mediaResourceLoader = player->createResourceLoader()) {
+        m_targetQueue = mediaResourceLoader->targetQueue();
         resourceLoader.URLSession = (NSURLSession *)adoptNS([[WebCoreNSURLSession alloc] initWithResourceLoader:*mediaResourceLoader delegate:resourceLoader.URLSessionDataDelegate delegateQueue:resourceLoader.URLSessionDataDelegateQueue]).get();
+    }
 
     [[NSNotificationCenter defaultCenter] addObserver:m_objcObserver.get() selector:@selector(chapterMetadataDidChange:) name:AVAssetChapterMetadataGroupsDidChangeNotification object:m_avAsset.get()];
 
@@ -2190,25 +2195,27 @@ bool MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource(AVAssetR
 #endif
 #endif
 
-    auto resourceLoader = WebCoreAVFResourceLoader::create(this, avRequest);
+    auto resourceLoader = WebCoreAVFResourceLoader::create(this, avRequest, m_targetQueue);
     m_resourceLoaderMap.add((__bridge CFTypeRef)avRequest, resourceLoader.copyRef());
     resourceLoader->startLoading();
+
     return true;
 }
 
 void MediaPlayerPrivateAVFoundationObjC::didCancelLoadingRequest(AVAssetResourceLoadingRequest* avRequest)
 {
-    String scheme = [[[avRequest request] URL] scheme];
-
-    WebCoreAVFResourceLoader* resourceLoader = m_resourceLoaderMap.get((__bridge CFTypeRef)avRequest);
-
-    if (resourceLoader)
-        resourceLoader->stopLoading();
+    ASSERT(isMainThread());
+    if (RefPtr resourceLoader = m_resourceLoaderMap.get((__bridge CFTypeRef)avRequest)) {
+        m_targetQueue->dispatch([resourceLoader = WTFMove(resourceLoader)] { resourceLoader->stopLoading();
+        });
+    }
 }
 
 void MediaPlayerPrivateAVFoundationObjC::didStopLoadingRequest(AVAssetResourceLoadingRequest *avRequest)
 {
-    m_resourceLoaderMap.remove((__bridge CFTypeRef)avRequest);
+    ASSERT(isMainThread());
+    if (RefPtr resourceLoader = m_resourceLoaderMap.take((__bridge CFTypeRef)avRequest))
+        m_targetQueue->dispatch([resourceLoader = WTFMove(resourceLoader)] { });
 }
 
 bool MediaPlayerPrivateAVFoundationObjC::isAvailable()
@@ -2622,7 +2629,7 @@ void MediaPlayerPrivateAVFoundationObjC::resolvedURLChanged()
 
 bool MediaPlayerPrivateAVFoundationObjC::didPassCORSAccessCheck() const
 {
-    AVAssetResourceLoader *resourceLoader = m_avAsset.get().resourceLoader;
+    AVAssetResourceLoader *resourceLoader = [m_avAsset resourceLoader];
     WebCoreNSURLSession *session = (WebCoreNSURLSession *)resourceLoader.URLSession;
     if ([session isKindOfClass:[WebCoreNSURLSession class]])
         return session.didPassCORSAccessChecks;
@@ -2632,7 +2639,9 @@ bool MediaPlayerPrivateAVFoundationObjC::didPassCORSAccessCheck() const
 
 std::optional<bool> MediaPlayerPrivateAVFoundationObjC::isCrossOrigin(const SecurityOrigin& origin) const
 {
-    AVAssetResourceLoader *resourceLoader = m_avAsset.get().resourceLoader;
+    assertIsMainThread();
+
+    AVAssetResourceLoader *resourceLoader = [m_avAsset resourceLoader];
     WebCoreNSURLSession *session = (WebCoreNSURLSession *)resourceLoader.URLSession;
     if ([session isKindOfClass:[WebCoreNSURLSession class]])
         return [session isCrossOrigin:origin];

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -40,7 +40,9 @@
 #import <AVFoundation/AVAssetResourceLoader.h>
 #import <objc/runtime.h>
 #import <wtf/BlockObjCExceptions.h>
+#import <wtf/Scope.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/WorkQueue.h>
 #import <wtf/text/CString.h>
 
 @interface AVAssetResourceLoadingContentInformationRequest (WebKitExtensions)
@@ -119,7 +121,7 @@ void CachedResourceMediaLoader::responseReceived(CachedResource& resource, const
     ASSERT_UNUSED(resource, &resource == m_resource);
     CompletionHandlerCallingScope completionHandlerCaller(WTFMove(completionHandler));
 
-    m_parent.responseReceived(response);
+    m_parent.responseReceived(response.mimeType(), response.httpStatusCode(), response.contentRange(), response.expectedContentLength());
 }
 
 void CachedResourceMediaLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
@@ -138,11 +140,11 @@ void CachedResourceMediaLoader::dataReceived(CachedResource& resource, const Sha
         m_parent.newDataStoredInSharedBuffer(*data);
 }
 
-class PlatformResourceMediaLoader final : public PlatformMediaResourceClient, public CanMakeWeakPtr<PlatformResourceMediaLoader> {
+class PlatformResourceMediaLoader final : public PlatformMediaResourceClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static WeakPtr<PlatformResourceMediaLoader> create(WebCoreAVFResourceLoader&, PlatformMediaResourceLoader&, ResourceRequest&&);
-    ~PlatformResourceMediaLoader() { stop(); }
+    static RefPtr<PlatformResourceMediaLoader> create(WebCoreAVFResourceLoader&, PlatformMediaResourceLoader&, ResourceRequest&&);
+    ~PlatformResourceMediaLoader() = default;
 
     void stop();
 
@@ -163,122 +165,137 @@ private:
     void loadFinished(PlatformMediaResource&, const NetworkLoadMetrics&) final { loadFinished(); }
 
     WebCoreAVFResourceLoader& m_parent;
-    RefPtr<PlatformMediaResource> m_resource;
-    SharedBufferBuilder m_buffer;
+    const WorkQueue& m_targetQueue;
+    RefPtr<PlatformMediaResource> m_resource WTF_GUARDED_BY_CAPABILITY(m_targetQueue);
+    SharedBufferBuilder m_buffer WTF_GUARDED_BY_CAPABILITY(m_targetQueue);
 };
 
-WeakPtr<PlatformResourceMediaLoader> PlatformResourceMediaLoader::create(WebCoreAVFResourceLoader& parent, PlatformMediaResourceLoader& loader, ResourceRequest&& request)
+RefPtr<PlatformResourceMediaLoader> PlatformResourceMediaLoader::create(WebCoreAVFResourceLoader& parent, PlatformMediaResourceLoader& loader, ResourceRequest&& request)
 {
     auto resource = loader.requestResource(WTFMove(request), PlatformMediaResourceLoader::LoadOption::DisallowCaching);
     if (!resource)
         return nullptr;
-    auto client = adoptRef(*new PlatformResourceMediaLoader { parent, Ref { *resource } });
-    WeakPtr result = client;
-
-    resource->setClient(WTFMove(client));
-    return result;
+    auto* resourcePointer = resource.get();
+    auto client = adoptRef(*new PlatformResourceMediaLoader { parent, resource.releaseNonNull() });
+    resourcePointer->setClient(client.copyRef());
+    return client;
 }
 
 PlatformResourceMediaLoader::PlatformResourceMediaLoader(WebCoreAVFResourceLoader& parent, Ref<PlatformMediaResource>&& resource)
     : m_parent(parent)
+    , m_targetQueue(parent.m_targetQueue)
     , m_resource(WTFMove(resource))
 {
 }
 
 void PlatformResourceMediaLoader::stop()
 {
+    assertIsCurrent(m_targetQueue);
+
     if (!m_resource)
         return;
 
-    auto resource = WTFMove(m_resource);
-    resource->stop();
-    resource->setClient(nullptr);
+    m_resource->shutdown();
+    m_resource = nullptr;
 }
 
 void PlatformResourceMediaLoader::responseReceived(PlatformMediaResource&, const ResourceResponse& response, CompletionHandler<void(ShouldContinuePolicyCheck)>&& completionHandler)
 {
-    m_parent.responseReceived(response);
+    assertIsCurrent(m_targetQueue);
+
+    m_parent.responseReceived(response.mimeType(), response.httpStatusCode(), response.contentRange(), response.expectedContentLength());
     completionHandler(ShouldContinuePolicyCheck::Yes);
 }
 
 void PlatformResourceMediaLoader::loadFailed(const ResourceError& error)
 {
+    assertIsCurrent(m_targetQueue);
+
     m_parent.loadFailed(error);
 }
 
 void PlatformResourceMediaLoader::loadFinished()
 {
+    assertIsCurrent(m_targetQueue);
+
     m_parent.loadFinished();
 }
 
 void PlatformResourceMediaLoader::dataReceived(PlatformMediaResource&, const SharedBuffer& buffer)
 {
+    assertIsCurrent(m_targetQueue);
+
     m_buffer.append(buffer);
     m_parent.newDataStoredInSharedBuffer(*m_buffer.get());
 }
 
-class DataURLResourceMediaLoader : public CanMakeWeakPtr<DataURLResourceMediaLoader> {
+class DataURLResourceMediaLoader {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     DataURLResourceMediaLoader(WebCoreAVFResourceLoader&, ResourceRequest&&);
 
 private:
     WebCoreAVFResourceLoader& m_parent;
-    ResourceResponse m_response;
-    RefPtr<SharedBuffer> m_buffer;
 };
 
 DataURLResourceMediaLoader::DataURLResourceMediaLoader(WebCoreAVFResourceLoader& parent, ResourceRequest&& request)
     : m_parent(parent)
 {
     RELEASE_ASSERT(request.url().protocolIsData());
+    ASSERT(isMainThread());
 
     if (auto result = DataURLDecoder::decode(request.url())) {
-        m_response = ResourceResponse::dataURLResponse(request.url(), *result);
-        m_buffer = SharedBuffer::create(WTFMove(result->data));
-    }
+        // data URLs can end up being unreasonably big so we want to avoid having to call isolatedCopy() here when passing the URL String to the loading thread.
+        auto response = ResourceResponse::dataURLResponse(request.url(), *result);
+        auto buffer = SharedBuffer::create(WTFMove(result->data));
+        m_parent.m_targetQueue->dispatch([this, parent = Ref { m_parent }, buffer = WTFMove(buffer), mimeType = response.mimeType().isolatedCopy(), status =  response.httpStatusCode(), contentRange = response.contentRange()] {
 
-    callOnMainThread([this, weakThis = WeakPtr { *this }] {
-        if (!weakThis)
-            return;
+            if (m_parent.m_dataURLMediaLoader.get() != this)
+                return;
 
-        if (!m_buffer || m_response.isNull()) {
+            if (m_parent.responseReceived(mimeType, status, contentRange, buffer->size()))
+                return;
+
+            if (m_parent.newDataStoredInSharedBuffer(buffer))
+                return;
+
+            m_parent.loadFinished();
+        });
+    } else {
+        m_parent.m_targetQueue->dispatch([this, parent = Ref { m_parent }] {
+            if (m_parent.m_dataURLMediaLoader.get() != this)
+                return;
             m_parent.loadFailed(ResourceError(ResourceError::Type::General));
-            return;
-        }
-        m_parent.responseReceived(m_response);
-        if (!weakThis)
-            return;
-
-        m_parent.newDataStoredInSharedBuffer(*m_buffer);
-        if (!weakThis)
-            return;
-
-        m_parent.loadFinished();
-    });
+        });
+    }
 }
 
-Ref<WebCoreAVFResourceLoader> WebCoreAVFResourceLoader::create(MediaPlayerPrivateAVFoundationObjC* parent, AVAssetResourceLoadingRequest *avRequest)
+Ref<WebCoreAVFResourceLoader> WebCoreAVFResourceLoader::create(MediaPlayerPrivateAVFoundationObjC* parent, AVAssetResourceLoadingRequest *avRequest, WorkQueue& targetQueue)
 {
     ASSERT(avRequest);
     ASSERT(parent);
-    return adoptRef(*new WebCoreAVFResourceLoader(parent, avRequest));
+    return adoptRef(*new WebCoreAVFResourceLoader(parent, avRequest, targetQueue));
 }
 
-WebCoreAVFResourceLoader::WebCoreAVFResourceLoader(MediaPlayerPrivateAVFoundationObjC* parent, AVAssetResourceLoadingRequest *avRequest)
+WebCoreAVFResourceLoader::WebCoreAVFResourceLoader(MediaPlayerPrivateAVFoundationObjC* parent, AVAssetResourceLoadingRequest *avRequest, WorkQueue& targetQueue)
     : m_parent(parent)
     , m_avRequest(avRequest)
+    , m_targetQueue(targetQueue)
 {
 }
 
 WebCoreAVFResourceLoader::~WebCoreAVFResourceLoader()
 {
-    stopLoading();
 }
 
 void WebCoreAVFResourceLoader::startLoading()
 {
-    if (m_dataURLMediaLoader || m_resourceMediaLoader || m_platformMediaLoader || !m_parent)
+    // Called from the main thread, before any loaders are created.
+    assertIsMainThread();
+
+    RefPtr parent = m_parent.get();
+
+    if (m_dataURLMediaLoader || m_resourceMediaLoader || m_platformMediaLoader || !parent)
         return;
 
     NSURLRequest *nsRequest = [m_avRequest request];
@@ -286,10 +303,14 @@ void WebCoreAVFResourceLoader::startLoading()
     ResourceRequest request(nsRequest);
     request.setPriority(ResourceLoadPriority::Low);
 
-    if (AVAssetResourceLoadingDataRequest *dataRequest = [m_avRequest dataRequest]; dataRequest.requestedLength
+    AVAssetResourceLoadingDataRequest* dataRequest = [m_avRequest dataRequest];
+    m_currentOffset = m_requestedOffset = dataRequest ? [dataRequest requestedOffset] : -1;
+    m_requestedLength = dataRequest ? [dataRequest requestedLength] : -1;
+
+    if (dataRequest && m_requestedLength > 0
         && !request.hasHTTPHeaderField(HTTPHeaderName::Range)) {
-        String rangeEnd = dataRequest.requestsAllDataToEndOfResource ? emptyString() : makeString(dataRequest.requestedOffset + dataRequest.requestedLength - 1);
-        request.addHTTPHeaderField(HTTPHeaderName::Range, makeString("bytes=", dataRequest.requestedOffset, '-', rangeEnd));
+        String rangeEnd = dataRequest.requestsAllDataToEndOfResource ? emptyString() : makeString(m_requestedOffset + m_requestedLength - 1);
+        request.addHTTPHeaderField(HTTPHeaderName::Range, makeString("bytes=", m_requestedOffset, '-', rangeEnd));
     }
 
     if (request.url().protocolIsData()) {
@@ -297,13 +318,13 @@ void WebCoreAVFResourceLoader::startLoading()
         return;
     }
 
-    if (auto* loader = m_parent->player()->cachedResourceLoader()) {
+    if (auto* loader = parent->player()->cachedResourceLoader()) {
         m_resourceMediaLoader = CachedResourceMediaLoader::create(*this, *loader, ResourceRequest(request));
         if (m_resourceMediaLoader)
             return;
     }
 
-    if (auto loader = m_parent->player()->createResourceLoader()) {
+    if (auto loader = parent->player()->createResourceLoader()) {
         m_platformMediaLoader = PlatformResourceMediaLoader::create(*this, *loader, WTFMove(request));
         if (m_platformMediaLoader)
             return;
@@ -313,49 +334,43 @@ void WebCoreAVFResourceLoader::startLoading()
     [m_avRequest finishLoadingWithError:0];
 }
 
+// No code accessing `this` should ever be used after calling stopLoading().
 void WebCoreAVFResourceLoader::stopLoading()
 {
+    assertIsCurrent(m_targetQueue);
+
     m_dataURLMediaLoader = nullptr;
     m_resourceMediaLoader = nullptr;
 
-    if (m_platformMediaLoader) {
+    if (m_platformMediaLoader)
         m_platformMediaLoader->stop();
-        m_platformMediaLoader = nullptr;
-    }
-    if (m_parent && m_avRequest)
-        m_parent->didStopLoadingRequest(m_avRequest.get());
-}
 
-void WebCoreAVFResourceLoader::invalidate()
-{
-    if (!m_parent)
-        return;
-
-    m_parent = nullptr;
-
-    callOnMainThread([protectedThis = Ref { *this }] () mutable {
-        protectedThis->stopLoading();
+    callOnMainThread([m_parent = WTFMove(m_parent), loader = WTFMove(m_platformMediaLoader), avRequest = WTFMove(m_avRequest)] {
+        if (RefPtr parent = m_parent.get(); parent && avRequest)
+            parent->didStopLoadingRequest(avRequest.get());
     });
+
+    ASSERT(!m_platformMediaLoader && !m_avRequest);
 }
 
-void WebCoreAVFResourceLoader::responseReceived(const ResourceResponse& response)
+bool WebCoreAVFResourceLoader::responseReceived(const String& mimeType, int status, const ParsedContentRange& contentRange, size_t expectedContentLength)
 {
-    int status = response.httpStatusCode();
+    assertIsCurrent(m_targetQueue);
+
     if (status && (status < 200 || status > 299)) {
         [m_avRequest finishLoadingWithError:0];
-        return;
+        return true;
     }
 
-    auto& contentRange = response.contentRange();
     if (contentRange.isValid())
         m_responseOffset = static_cast<NSUInteger>(contentRange.firstBytePosition());
 
     if (AVAssetResourceLoadingContentInformationRequest* contentInfo = [m_avRequest contentInformationRequest]) {
-        String uti = UTIFromMIMEType(response.mimeType());
+        String uti = UTIFromMIMEType(mimeType);
 
         [contentInfo setContentType:uti];
 
-        [contentInfo setContentLength:contentRange.isValid() ? contentRange.instanceLength() : response.expectedContentLength()];
+        [contentInfo setContentLength:contentRange.isValid() ? contentRange.instanceLength() : expectedContentLength];
         [contentInfo setByteRangeAccessSupported:YES];
 
         // Do not set "EntireLengthAvailableOnDemand" to YES when the loader is DataURLResourceMediaLoader.
@@ -370,12 +385,16 @@ void WebCoreAVFResourceLoader::responseReceived(const ResourceResponse& response
             [m_avRequest finishLoading];
             END_BLOCK_OBJC_EXCEPTIONS
             stopLoading();
+            return true;
         }
     }
+    return false;
 }
 
 void WebCoreAVFResourceLoader::loadFailed(const ResourceError& error)
 {
+    assertIsCurrent(m_targetQueue);
+
     // <rdar://problem/13987417> Set the contentType of the contentInformationRequest to an empty
     // string to trigger AVAsset's playable value to complete loading.
     if ([m_avRequest contentInformationRequest] && ![[m_avRequest contentInformationRequest] contentType])
@@ -387,58 +406,67 @@ void WebCoreAVFResourceLoader::loadFailed(const ResourceError& error)
 
 void WebCoreAVFResourceLoader::loadFinished()
 {
+    assertIsCurrent(m_targetQueue);
+
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     [m_avRequest finishLoading];
     END_BLOCK_OBJC_EXCEPTIONS
     stopLoading();
 }
 
-void WebCoreAVFResourceLoader::newDataStoredInSharedBuffer(const FragmentedSharedBuffer& data)
+bool WebCoreAVFResourceLoader::newDataStoredInSharedBuffer(const FragmentedSharedBuffer& data)
 {
+    assertIsCurrent(m_targetQueue);
+
     AVAssetResourceLoadingDataRequest* dataRequest = [m_avRequest dataRequest];
     if (!dataRequest)
-        return;
+        return true;
 
     // Check for possible unsigned overflow.
-    ASSERT(dataRequest.currentOffset >= dataRequest.requestedOffset);
-    ASSERT(dataRequest.requestedLength >= (dataRequest.currentOffset - dataRequest.requestedOffset));
+    ASSERT(m_currentOffset >= m_requestedOffset);
+    ASSERT(m_requestedLength >= m_currentOffset - m_requestedOffset);
 
-    NSUInteger remainingLength = dataRequest.requestedLength - static_cast<NSUInteger>(dataRequest.currentOffset - dataRequest.requestedOffset);
+    NSUInteger remainingLength = m_requestedLength - (m_currentOffset - m_requestedOffset);
 
-    auto bytesToSkip = dataRequest.currentOffset - m_responseOffset;
+    auto bytesToSkip = m_currentOffset - m_responseOffset;
     auto array = data.createNSDataArray();
-    for (NSData *segment in array.get()) {
+    for (NSData* segment in array.get()) {
         if (bytesToSkip) {
             if (bytesToSkip > segment.length) {
                 bytesToSkip -= segment.length;
                 continue;
             }
             auto bytesToUse = segment.length - bytesToSkip;
-            [dataRequest respondWithData:[segment subdataWithRange:NSMakeRange(static_cast<NSUInteger>(bytesToSkip), static_cast<NSUInteger>(segment.length - bytesToSkip))]];
+            [dataRequest respondWithData:[segment subdataWithRange:NSMakeRange(static_cast<NSUInteger>(bytesToSkip), static_cast<NSUInteger>(bytesToUse))]];
             bytesToSkip = 0;
             remainingLength -= bytesToUse;
+            m_currentOffset += bytesToUse;
             continue;
         }
         if (segment.length <= remainingLength) {
             [dataRequest respondWithData:segment];
             remainingLength -= segment.length;
+            m_currentOffset += segment.length;
             continue;
         }
         [dataRequest respondWithData:[segment subdataWithRange:NSMakeRange(0, remainingLength)]];
+        m_currentOffset += remainingLength;
         remainingLength = 0;
         break;
     }
 
     // There was not enough data in the buffer to satisfy the data request.
     if (remainingLength)
-        return;
+        return false;
 
-    if (dataRequest.currentOffset + dataRequest.requestedLength >= dataRequest.requestedOffset) {
+    if (m_currentOffset >= m_requestedOffset + m_requestedLength) {
         BEGIN_BLOCK_OBJC_EXCEPTIONS
         [m_avRequest finishLoading];
         END_BLOCK_OBJC_EXCEPTIONS
         stopLoading();
+        return true;
     }
+    return false;
 }
 
 }

--- a/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
+++ b/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
@@ -35,14 +35,17 @@
 #import "WebCoreNSURLSession.h"
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <wtf/FastMalloc.h>
+#import <wtf/WorkQueue.h>
 #import <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
 struct RangeResponseGenerator::Data {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
+    // The RangeResponseGenerator is used with a WorkQueue which can do thread hoping over time.
+    // The ResourceResponse contains WTF::Strings which must first be copied via isolatedCopy().
     Data(const ResourceResponse& response, PlatformMediaResource& resource)
-        : originalResponse(response)
+        : originalResponse(ResourceResponse::fromCrossThreadData(response.crossThreadData()))
         , resource(&resource) { }
 
     struct TaskData : public CanMakeWeakPtr<TaskData> {
@@ -56,6 +59,18 @@ struct RangeResponseGenerator::Data {
         enum class ResponseState : uint8_t { NotSynthesizedYet, WaitingForSession, SessionCalledCompletionHandler } responseState { ResponseState::NotSynthesizedYet };
     };
 
+    virtual ~Data()
+    {
+        shutdownResource();
+    }
+
+    void shutdownResource()
+    {
+        if (resource) {
+            resource->shutdown();
+            resource = nullptr;
+        }
+    }
     HashMap<RetainPtr<WebCoreNSURLSessionDataTask>, std::unique_ptr<TaskData>> taskData;
     SharedBufferBuilder buffer;
     ResourceResponse originalResponse;
@@ -63,19 +78,21 @@ struct RangeResponseGenerator::Data {
     RefPtr<PlatformMediaResource> resource;
 };
 
-RangeResponseGenerator::RangeResponseGenerator()
+RangeResponseGenerator::RangeResponseGenerator(WorkQueue& targetQueue)
+    : m_targetQueue(targetQueue)
 {
-    ASSERT(isMainThread());
 }
 
-RangeResponseGenerator::~RangeResponseGenerator()
+RangeResponseGenerator::~RangeResponseGenerator() = default;
+
+HashMap<String, std::unique_ptr<RangeResponseGenerator::Data>>& RangeResponseGenerator::map()
 {
-    ASSERT(isMainThread());
+    assertIsCurrent(m_targetQueue.get());
+    return m_map;
 }
 
 static ResourceResponse synthesizedResponseForRange(const ResourceResponse& originalResponse, const ParsedRequestRange& parsedRequestRange, std::optional<size_t> totalContentLength)
 {
-    ASSERT(isMainThread());
     auto begin = parsedRequestRange.begin;
     auto end = parsedRequestRange.end;
 
@@ -95,12 +112,11 @@ static ResourceResponse synthesizedResponseForRange(const ResourceResponse& orig
 
 void RangeResponseGenerator::removeTask(WebCoreNSURLSessionDataTask *task)
 {
-    ASSERT(isMainThread());
     auto url = task.originalRequest.URL;
     // HashMap::get() crashes if a null String is passed.
     if (!url)
         return;
-    auto* data = m_map.get(url.absoluteString);
+    auto* data = map().get(url.absoluteString);
     if (!data)
         return;
     data->taskData.remove(task);
@@ -108,8 +124,7 @@ void RangeResponseGenerator::removeTask(WebCoreNSURLSessionDataTask *task)
 
 void RangeResponseGenerator::giveResponseToTaskIfBytesInRangeReceived(WebCoreNSURLSessionDataTask *task, const ParsedRequestRange& range, std::optional<size_t> expectedContentLength, const Data& data)
 {
-    ASSERT(isMainThread());
-
+    assertIsCurrent(m_targetQueue);
     auto bufferSize = data.buffer.size();
     if (bufferSize < range.begin)
         return;
@@ -119,8 +134,8 @@ void RangeResponseGenerator::giveResponseToTaskIfBytesInRangeReceived(WebCoreNSU
     if (!taskData)
         return;
 
-    auto giveBytesToTask = [task = retainPtr(task), buffer, bufferSize, taskData = WeakPtr { *taskData }, weakGenerator = ThreadSafeWeakPtr { *this }] {
-        ASSERT(isMainThread());
+    auto giveBytesToTask = [task = retainPtr(task), buffer, bufferSize, taskData = WeakPtr { *taskData }, weakGenerator = ThreadSafeWeakPtr { *this }, targetQueue = m_targetQueue] {
+        assertIsCurrent(targetQueue);
         if ([task state] != NSURLSessionTaskStateRunning)
             return;
         if (!taskData)
@@ -140,17 +155,15 @@ void RangeResponseGenerator::giveResponseToTaskIfBytesInRangeReceived(WebCoreNSU
         }
         if (byteIndex >= range.end) {
             [task resourceFinished:nullptr metrics:NetworkLoadMetrics { }];
-            callOnMainThread([weakGenerator, task] {
-                if (RefPtr strongGenerator = weakGenerator.get())
-                    strongGenerator->removeTask(task.get());
-            });
+            if (RefPtr strongGenerator = weakGenerator.get())
+                strongGenerator->removeTask(task.get());
         }
     };
 
     switch (taskData->responseState) {
     case Data::TaskData::ResponseState::NotSynthesizedYet: {
         auto response = synthesizedResponseForRange(data.originalResponse, range, expectedContentLength);
-        [task resource:nullptr receivedResponse:response completionHandler:[giveBytesToTask = WTFMove(giveBytesToTask), taskData = WeakPtr { taskData }, task = retainPtr(task)] (WebCore::ShouldContinuePolicyCheck shouldContinue) {
+        [task resource:nullptr receivedResponse:response completionHandler:[giveBytesToTask = WTFMove(giveBytesToTask), taskData = WeakPtr { taskData }, task = retainPtr(task)] (WebCore::ShouldContinuePolicyCheck shouldContinue) mutable {
             if (taskData)
                 taskData->responseState = Data::TaskData::ResponseState::SessionCalledCompletionHandler;
             if (shouldContinue == ShouldContinuePolicyCheck::Yes)
@@ -171,7 +184,6 @@ void RangeResponseGenerator::giveResponseToTaskIfBytesInRangeReceived(WebCoreNSU
 
 std::optional<size_t> RangeResponseGenerator::expectedContentLengthFromData(const Data& data)
 {
-    ASSERT(isMainThread());
     if (data.successfullyFinishedLoading == Data::SuccessfullyFinishedLoading::Yes)
         return data.buffer.size();
 
@@ -184,7 +196,7 @@ std::optional<size_t> RangeResponseGenerator::expectedContentLengthFromData(cons
 
 void RangeResponseGenerator::giveResponseToTasksWithFinishedRanges(Data& data)
 {
-    ASSERT(isMainThread());
+    assertIsCurrent(m_targetQueue);
     auto expectedContentLength = expectedContentLengthFromData(data);
 
     for (auto& pair : data.taskData)
@@ -193,10 +205,11 @@ void RangeResponseGenerator::giveResponseToTasksWithFinishedRanges(Data& data)
 
 bool RangeResponseGenerator::willHandleRequest(WebCoreNSURLSessionDataTask *task, NSURLRequest *request)
 {
-    ASSERT(isMainThread());
+    assertIsCurrent(m_targetQueue);
+
     if (!request.URL)
         return false;
-    auto* data = m_map.get(request.URL.absoluteString);
+    auto* data = map().get(request.URL.absoluteString);
     if (!data)
         return false;
 
@@ -240,17 +253,15 @@ private:
 
     bool shouldCacheResponse(PlatformMediaResource&, const ResourceResponse&) final
     {
-        ASSERT(isMainThread());
         return false;
     }
 
     void dataReceived(PlatformMediaResource&, const SharedBuffer& buffer) final
     {
-        ASSERT(isMainThread());
         RefPtr generator = m_generator.get();
         if (!generator)
             return;
-        auto* data = generator->m_map.get(m_urlString);
+        auto* data = generator->map().get(m_urlString);
         if (!data)
             return;
         data->buffer.append(buffer);
@@ -259,11 +270,10 @@ private:
 
     void loadFailed(PlatformMediaResource&, const ResourceError& error) final
     {
-        ASSERT(isMainThread());
         RefPtr generator = m_generator.get();
         if (!generator)
             return;
-        auto data = generator->m_map.take(m_urlString);
+        auto data = generator->map().take(m_urlString);
         if (!data)
             return;
         for (auto& task : data->taskData.keys())
@@ -272,15 +282,14 @@ private:
 
     void loadFinished(PlatformMediaResource&, const NetworkLoadMetrics&) final
     {
-        ASSERT(isMainThread());
         RefPtr generator = m_generator.get();
         if (!generator)
             return;
-        auto* data = generator->m_map.get(m_urlString);
+        auto* data = generator->map().get(m_urlString);
         if (!data)
             return;
         data->successfullyFinishedLoading = Data::SuccessfullyFinishedLoading::Yes;
-        data->resource = nullptr; // This line can delete this MediaResourceClient.
+        data->shutdownResource();
         generator->giveResponseToTasksWithFinishedRanges(*data);
     }
 
@@ -290,7 +299,7 @@ private:
 
 bool RangeResponseGenerator::willSynthesizeRangeResponses(WebCoreNSURLSessionDataTask *task, PlatformMediaResource& resource, const ResourceResponse& response)
 {
-    ASSERT(isMainThread());
+    assertIsCurrent(m_targetQueue.get());
     NSURLRequest *originalRequest = task.originalRequest;
     if (!originalRequest.URL)
         return false;

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
@@ -56,6 +56,10 @@ class WebCoreNSURLSessionDataTaskClient;
 enum class ShouldContinuePolicyCheck : bool;
 }
 
+namespace WTF {
+class WorkQueue;
+}
+
 enum class WebCoreNSURLSessionCORSAccessCheckResults : uint8_t {
     Unknown,
     Pass,
@@ -64,20 +68,22 @@ enum class WebCoreNSURLSessionCORSAccessCheckResults : uint8_t {
 
 NS_ASSUME_NONNULL_BEGIN
 
+// Created on the main thread; used on targetQueue.
 WEBCORE_EXPORT @interface WebCoreNSURLSession : NSObject {
 @private
     RefPtr<WebCore::PlatformMediaResourceLoader> _loader;
+    RefPtr<WTF::WorkQueue> _targetQueue;
     WeakObjCPtr<id<NSURLSessionDelegate>> _delegate;
     RetainPtr<NSOperationQueue> _queue;
     RetainPtr<NSString> _sessionDescription;
     Lock _dataTasksLock;
     HashSet<RetainPtr<WebCoreNSURLSessionDataTask>> _dataTasks WTF_GUARDED_BY_LOCK(_dataTasksLock);
-    HashSet<RefPtr<WebCore::SecurityOrigin>> _origins;
-    BOOL _invalidated;
-    std::atomic<uint64_t> _nextTaskIdentifier;
-    OSObjectPtr<dispatch_queue_t> _internalQueue;
+    HashSet<RefPtr<WebCore::SecurityOrigin>> _origins WTF_GUARDED_BY_LOCK(_dataTasksLock);
+    BOOL _invalidated; // Access on multiple thread, must be accessed via ObjC property.
+    NSUInteger _nextTaskIdentifier;
+    RefPtr<WTF::WorkQueue> _internalQueue;
     WebCoreNSURLSessionCORSAccessCheckResults _corsResults;
-    RefPtr<WebCore::RangeResponseGenerator> _rangeResponseGenerator;
+    RefPtr<WebCore::RangeResponseGenerator> _rangeResponseGenerator; // Only created/accessed on _targetQueue
 }
 - (id)initWithResourceLoader:(WebCore::PlatformMediaResourceLoader&)loader delegate:(id<NSURLSessionTaskDelegate>)delegate delegateQueue:(NSOperationQueue*)queue;
 @property (readonly, retain) NSOperationQueue *delegateQueue;
@@ -85,6 +91,8 @@ WEBCORE_EXPORT @interface WebCoreNSURLSession : NSObject {
 @property (readonly, copy) NSURLSessionConfiguration *configuration;
 @property (copy) NSString *sessionDescription;
 @property (readonly) BOOL didPassCORSAccessChecks;
+@property (assign, atomic) WebCoreNSURLSessionCORSAccessCheckResults corsResults;
+@property (assign, atomic) BOOL invalidated;
 - (void)finishTasksAndInvalidate;
 - (void)invalidateAndCancel;
 - (BOOL)isCrossOrigin:(const WebCore::SecurityOrigin&)origin;
@@ -120,20 +128,22 @@ WEBCORE_EXPORT @interface WebCoreNSURLSession : NSObject {
 - (void)sendH2Ping:(NSURL *)url pongHandler:(void (^)(NSError * _Nullable error, NSTimeInterval interval))pongHandler;
 @end
 
+// Created on com.apple.avfoundation.customurl.nsurlsession
 @interface WebCoreNSURLSessionDataTask : NSObject {
-    WeakObjCPtr<WebCoreNSURLSession> _session;
-    RefPtr<WebCore::PlatformMediaResource> _resource;
-    RetainPtr<NSURLResponse> _response;
+    WeakObjCPtr<WebCoreNSURLSession> _session; // Accesssed from operation queue, main and loader thread. Must be accessed through Obj-C property.
+    RefPtr<WTF::WorkQueue> _targetQueue;
+    RefPtr<WebCore::PlatformMediaResource> _resource; // Accesssed from main and loader thread. Must be accessed through Obj-C property.
+    RetainPtr<NSURLResponse> _response; // Set on operation queue.
     NSUInteger _taskIdentifier;
-    RetainPtr<NSURLRequest> _originalRequest;
-    RetainPtr<NSURLRequest> _currentRequest;
+    RetainPtr<NSURLRequest> _originalRequest; // Set on construction, never modified.
+    RetainPtr<NSURLRequest> _currentRequest; // Set on construction, never modified.
     int64_t _countOfBytesReceived;
     int64_t _countOfBytesSent;
     int64_t _countOfBytesExpectedToSend;
     int64_t _countOfBytesExpectedToReceive;
     std::atomic<NSURLSessionTaskState> _state;
-    RetainPtr<NSError> _error;
-    RetainPtr<NSString> _taskDescription;
+    RetainPtr<NSError> _error; // Unused, always nil.
+    RetainPtr<NSString> _taskDescription; // Only set / read on the user's thread.
     float _priority;
 }
 

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -347,7 +347,7 @@ private:
     std::unique_ptr<RemoteAudioDestinationManager> m_remoteAudioDestinationManager;
 #endif
 #if ENABLE(VIDEO)
-    std::unique_ptr<RemoteMediaResourceManager> m_remoteMediaResourceManager;
+    RefPtr<RemoteMediaResourceManager> m_remoteMediaResourceManager WTF_GUARDED_BY_CAPABILITY(mainThread);
     UniqueRef<RemoteMediaPlayerManagerProxy> m_remoteMediaPlayerManagerProxy;
 #endif
     PAL::SessionID m_sessionID;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -325,6 +325,8 @@ void RemoteMediaPlayerProxy::setPresentationSize(const WebCore::IntSize& size)
 
 RefPtr<PlatformMediaResource> RemoteMediaPlayerProxy::requestResource(ResourceRequest&& request, PlatformMediaResourceLoader::LoadOptions options)
 {
+    ASSERT(isMainRunLoop());
+
     ASSERT(m_manager && m_manager->gpuConnectionToWebProcess());
     if (!m_manager || !m_manager->gpuConnectionToWebProcess())
         return nullptr;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.cpp
@@ -38,6 +38,7 @@ using namespace WebCore;
 RemoteMediaResourceLoader::RemoteMediaResourceLoader(RemoteMediaPlayerProxy& remoteMediaPlayerProxy)
     : m_remoteMediaPlayerProxy(remoteMediaPlayerProxy)
 {
+    ASSERT(isMainRunLoop());
 }
 
 RemoteMediaResourceLoader::~RemoteMediaResourceLoader()
@@ -46,6 +47,7 @@ RemoteMediaResourceLoader::~RemoteMediaResourceLoader()
 
 RefPtr<PlatformMediaResource> RemoteMediaResourceLoader::requestResource(ResourceRequest&& request, LoadOptions options)
 {
+    ASSERT(isMainRunLoop());
     if (!m_remoteMediaPlayerProxy)
         return nullptr;
 
@@ -54,6 +56,7 @@ RefPtr<PlatformMediaResource> RemoteMediaResourceLoader::requestResource(Resourc
 
 void RemoteMediaResourceLoader::sendH2Ping(const URL& url, CompletionHandler<void(Expected<Seconds, ResourceError>&&)>&& completionHandler)
 {
+    ASSERT(isMainRunLoop());
     if (!m_remoteMediaPlayerProxy)
         return completionHandler(makeUnexpected(internalError(url)));
     

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.h
@@ -30,6 +30,7 @@
 #include <WebCore/PlatformMediaResourceLoader.h>
 #include <WebCore/ResourceRequest.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/WorkQueue.h>
 
 namespace WebKit {
 
@@ -41,9 +42,20 @@ public:
     explicit RemoteMediaResourceLoader(RemoteMediaPlayerProxy&);
     ~RemoteMediaResourceLoader();
 
+    static Ref<WorkQueue> defaultQueue()
+    {
+        static std::once_flag onceKey;
+        static LazyNeverDestroyed<Ref<WorkQueue>> messageQueue;
+        std::call_once(onceKey, [] {
+            messageQueue.construct(WorkQueue::create("PlatformMediaResourceLoader", WorkQueue::QOS::Background));
+        });
+        return messageQueue.get();
+    }
+
 private:
     RefPtr<WebCore::PlatformMediaResource> requestResource(WebCore::ResourceRequest&&, LoadOptions) final;
     void sendH2Ping(const URL&, CompletionHandler<void(Expected<WTF::Seconds, WebCore::ResourceError>&&)>&&) final;
+    Ref<WorkQueue> targetQueue() final { return defaultQueue(); }
 
     WeakPtr<RemoteMediaPlayerProxy> m_remoteMediaPlayerProxy;
 };

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
@@ -31,8 +31,11 @@
 #include "Connection.h"
 #include "RemoteMediaResource.h"
 #include "RemoteMediaResourceIdentifier.h"
+#include "RemoteMediaResourceLoader.h"
+#include "RemoteMediaResourceManagerMessages.h"
 #include "SharedBufferReference.h"
 #include "WebCoreArgumentCoders.h"
+#include <WebCore/PlatformMediaResourceLoader.h>
 #include <WebCore/ResourceRequest.h>
 #include <wtf/Scope.h>
 
@@ -46,54 +49,89 @@ RemoteMediaResourceManager::RemoteMediaResourceManager()
 
 RemoteMediaResourceManager::~RemoteMediaResourceManager()
 {
+    assertIsMainThread();
+    Locker locker { m_lock };
+    // Shutdown any stale RemoteMediaResources. We must complete this step in a follow-up task to prevent re-entry in RemoteMediaResourceManager.
+    callOnMainRunLoop([resources = WTFMove(m_remoteMediaResources)] {
+        for (auto&& resource : resources) {
+            if (RefPtr protectedResource = resource.value.get())
+                protectedResource->shutdown();
+        }
+    });
+}
+
+void RemoteMediaResourceManager::stopListeningForIPC()
+{
+    assertIsMainThread();
+    initializeConnection(nullptr);
+}
+
+void RemoteMediaResourceManager::initializeConnection(IPC::Connection* connection)
+{
+    assertIsMainThread();
+    if (m_connection == connection)
+        return;
+
+    if (m_connection)
+        m_connection->removeWorkQueueMessageReceiver(Messages::RemoteMediaResourceManager::messageReceiverName());
+
+    m_connection = connection;
+
+    if (m_connection)
+        m_connection->addWorkQueueMessageReceiver(Messages::RemoteMediaResourceManager::messageReceiverName(), RemoteMediaResourceLoader::defaultQueue(), *this);
 }
 
 void RemoteMediaResourceManager::addMediaResource(RemoteMediaResourceIdentifier remoteMediaResourceIdentifier, RemoteMediaResource& remoteMediaResource)
 {
+    Locker locker { m_lock };
     ASSERT(!m_remoteMediaResources.contains(remoteMediaResourceIdentifier));
     m_remoteMediaResources.add(remoteMediaResourceIdentifier, ThreadSafeWeakPtr { remoteMediaResource });
 }
 
 void RemoteMediaResourceManager::removeMediaResource(RemoteMediaResourceIdentifier remoteMediaResourceIdentifier)
 {
+    Locker locker { m_lock };
     ASSERT(m_remoteMediaResources.contains(remoteMediaResourceIdentifier));
     m_remoteMediaResources.remove(remoteMediaResourceIdentifier);
 }
 
+RefPtr<RemoteMediaResource> RemoteMediaResourceManager::resourceForId(RemoteMediaResourceIdentifier identifier)
+{
+    Locker locker { m_lock };
+    return m_remoteMediaResources.get(identifier).get();
+}
+
 void RemoteMediaResourceManager::responseReceived(RemoteMediaResourceIdentifier identifier, const ResourceResponse& response, bool didPassAccessControlCheck, CompletionHandler<void(ShouldContinuePolicyCheck)>&& completionHandler)
 {
-    auto resource = m_remoteMediaResources.get(identifier).get();
-    if (!resource) {
-        completionHandler(ShouldContinuePolicyCheck::No);
-        return;
-    }
+    assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
 
-    resource->responseReceived(response, didPassAccessControlCheck, WTFMove(completionHandler));
+    if (auto resource = resourceForId(identifier))
+        resource->responseReceived(response, didPassAccessControlCheck, WTFMove(completionHandler));
+    else
+        completionHandler(ShouldContinuePolicyCheck::No);
 }
 
 void RemoteMediaResourceManager::redirectReceived(RemoteMediaResourceIdentifier identifier, ResourceRequest&& request, const ResourceResponse& response, CompletionHandler<void(WebCore::ResourceRequest&&)>&& completionHandler)
 {
-    auto resource = m_remoteMediaResources.get(identifier).get();
-    if (!resource) {
-        completionHandler({ });
-        return;
-    }
+    assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
 
-    resource->redirectReceived(WTFMove(request), response, WTFMove(completionHandler));
+    if (auto resource = resourceForId(identifier))
+        resource->redirectReceived(WTFMove(request), response, WTFMove(completionHandler));
+    else
+        completionHandler({ });
 }
 
 void RemoteMediaResourceManager::dataSent(RemoteMediaResourceIdentifier identifier, uint64_t bytesSent, uint64_t totalBytesToBeSent)
 {
-    auto resource = m_remoteMediaResources.get(identifier).get();
-    if (!resource)
-        return;
+    assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
 
-    resource->dataSent(bytesSent, totalBytesToBeSent);
+    if (auto resource = resourceForId(identifier))
+        resource->dataSent(bytesSent, totalBytesToBeSent);
 }
 
 void RemoteMediaResourceManager::dataReceived(RemoteMediaResourceIdentifier identifier, IPC::SharedBufferReference&& buffer, CompletionHandler<void(std::optional<SharedMemory::Handle>&&)>&& completionHandler)
 {
-    auto resource = m_remoteMediaResources.get(identifier).get();
+    auto resource = resourceForId(identifier);
     if (!resource)
         return completionHandler(std::nullopt);
 
@@ -111,29 +149,26 @@ void RemoteMediaResourceManager::dataReceived(RemoteMediaResourceIdentifier iden
 
 void RemoteMediaResourceManager::accessControlCheckFailed(RemoteMediaResourceIdentifier identifier, const ResourceError& error)
 {
-    auto resource = m_remoteMediaResources.get(identifier).get();
-    if (!resource)
-        return;
+    assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
 
-    resource->accessControlCheckFailed(error);
+    if (auto resource = resourceForId(identifier))
+        resource->accessControlCheckFailed(error);
 }
 
 void RemoteMediaResourceManager::loadFailed(RemoteMediaResourceIdentifier identifier, const ResourceError& error)
 {
-    auto resource = m_remoteMediaResources.get(identifier).get();
-    if (!resource)
-        return;
+    assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
 
-    resource->loadFailed(error);
+    if (auto resource = resourceForId(identifier))
+        resource->loadFailed(error);
 }
 
 void RemoteMediaResourceManager::loadFinished(RemoteMediaResourceIdentifier identifier, const NetworkLoadMetrics& metrics)
 {
-    auto resource = m_remoteMediaResources.get(identifier).get();
-    if (!resource)
-        return;
+    assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());
 
-    resource->loadFinished(metrics);
+    if (auto resource = resourceForId(identifier))
+        resource->loadFinished(metrics);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h
@@ -27,12 +27,14 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
 
+#include "Connection.h"
 #include "DataReference.h"
-#include "MessageReceiver.h"
 #include "RemoteMediaResourceIdentifier.h"
 #include "SharedMemory.h"
+#include "WorkQueueMessageReceiver.h"
 #include <WebCore/PolicyChecker.h>
 #include <wtf/HashMap.h>
+#include <wtf/Lock.h>
 #include <wtf/WeakPtr.h>
 
 namespace IPC {
@@ -51,19 +53,23 @@ namespace WebKit {
 class RemoteMediaResource;
 
 class RemoteMediaResourceManager
-    : public IPC::MessageReceiver {
+    : public IPC::WorkQueueMessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    RemoteMediaResourceManager();
+    static Ref<RemoteMediaResourceManager> create() { return adoptRef(*new RemoteMediaResourceManager()); }
     ~RemoteMediaResourceManager();
+
+    void initializeConnection(IPC::Connection*);
+    void stopListeningForIPC();
 
     void addMediaResource(RemoteMediaResourceIdentifier, RemoteMediaResource&);
     void removeMediaResource(RemoteMediaResourceIdentifier);
 
-    // IPC::MessageReceiver
+    // IPC::Connection::WorkQueueMessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
 private:
+    RemoteMediaResourceManager();
     void responseReceived(RemoteMediaResourceIdentifier, const WebCore::ResourceResponse&, bool, CompletionHandler<void(WebCore::ShouldContinuePolicyCheck)>&&);
     void redirectReceived(RemoteMediaResourceIdentifier, WebCore::ResourceRequest&&, const WebCore::ResourceResponse&, CompletionHandler<void(WebCore::ResourceRequest&&)>&&);
     void dataSent(RemoteMediaResourceIdentifier, uint64_t, uint64_t);
@@ -72,7 +78,12 @@ private:
     void loadFailed(RemoteMediaResourceIdentifier, const WebCore::ResourceError&);
     void loadFinished(RemoteMediaResourceIdentifier, const WebCore::NetworkLoadMetrics&);
 
-    HashMap<RemoteMediaResourceIdentifier, ThreadSafeWeakPtr<RemoteMediaResource>> m_remoteMediaResources;
+    RefPtr<RemoteMediaResource> resourceForId(RemoteMediaResourceIdentifier);
+
+    Lock m_lock;
+    HashMap<RemoteMediaResourceIdentifier, ThreadSafeWeakPtr<RemoteMediaResource>> m_remoteMediaResources WTF_GUARDED_BY_LOCK(m_lock);
+
+    RefPtr<IPC::Connection> m_connection;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 75bfd79c190e9b11ce6e4677f6321d5d6432663a
<pre>
Perform media networking operations off the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=235353">https://bugs.webkit.org/show_bug.cgi?id=235353</a>
<a href="https://rdar.apple.com/84517825">rdar://84517825</a>

Reviewed by Eric Carlson.

We run the media&apos;s networking operation and IPC service into a new dedicated WorkQueue.
A MediaResource still need to be created on the main thread due to the current architecture
but all other operations will now run on a WorkQueue when the GPU Process is enabled.
For WK1 or if no GPU process is in use, we continue to use the main thread.

We use the IPC::Connection::WorkQueueMessageReceiver characteristics to proxy the network operations from the content process main thread to the GPU Process MediaResourceLoader&apos;s WorkQueue.

Side-by fixes: various thread-safety fixes in WebCoreNSURLSession, access to some members weren&apos;t thread-safe.

To make the code flow easier to follow, we use the new assertIsCurrent(WorkQueue&amp;) extensively. Most methods will now assert that it runs on the thread it&apos;s supposed to.

* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::MediaResourceLoader::MediaResourceLoader):
(WebCore::MediaResourceLoader::~MediaResourceLoader):
(WebCore::MediaResourceLoader::contextDestroyed):
(WebCore::MediaResourceLoader::sendH2Ping):
(WebCore::MediaResourceLoader::requestResource):
(WebCore::MediaResourceLoader::removeResource):
(WebCore::MediaResourceLoader::addResponseForTesting):
(WebCore::MediaResourceLoader::document):
(WebCore::MediaResourceLoader::crossOriginMode const):
(WebCore::MediaResourceLoader::responsesForTesting const):
(WebCore::MediaResource::MediaResource):
(WebCore::MediaResource::~MediaResource):
(WebCore::MediaResource::shutdown):
(WebCore::MediaResource::responseReceived):
(WebCore::MediaResource::shouldCacheResponse):
(WebCore::MediaResource::redirectReceived):
(WebCore::MediaResource::dataSent):
(WebCore::MediaResource::dataReceived):
(WebCore::MediaResource::notifyFinished):
(WebCore::MediaResource::ensureShutdown):
(WebCore::MediaResource::stop): Deleted.
* Source/WebCore/loader/MediaResourceLoader.h:
* Source/WebCore/loader/cache/CachedRawResourceClient.h:
* Source/WebCore/platform/graphics/PlatformMediaResourceLoader.h:
(WebCore::PlatformMediaResourceLoader::targetQueue):
(WebCore::PlatformMediaResource::didPassAccessControlCheck const):
(WebCore::PlatformMediaResource::shutdown):
(WebCore::PlatformMediaResource::setClient):
(WebCore::PlatformMediaResource::client const):
(WebCore::PlatformMediaResource::stop): Deleted.
(WebCore::PlatformMediaResource::client): Deleted.
* Source/WebCore/platform/graphics/WebMResourceClient.cpp:
(WebCore::WebMResourceClient::stop):
(WebCore::WebMResourceClient::dataReceived):
(WebCore::WebMResourceClient::loadFailed):
(WebCore::WebMResourceClient::loadFinished):
* Source/WebCore/platform/graphics/WebMResourceClient.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::~MediaPlayerPrivateAVFoundationObjC):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL):
(WebCore::MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource):
(WebCore::MediaPlayerPrivateAVFoundationObjC::didCancelLoadingRequest):
(WebCore::MediaPlayerPrivateAVFoundationObjC::didStopLoadingRequest):
(WebCore::MediaPlayerPrivateAVFoundationObjC::didPassCORSAccessCheck const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::isCrossOrigin const):
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.h:
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
(WebCore::CachedResourceMediaLoader::responseReceived):
(WebCore::PlatformResourceMediaLoader::create):
(WebCore::PlatformResourceMediaLoader::PlatformResourceMediaLoader):
(WebCore::PlatformResourceMediaLoader::stop):
(WebCore::PlatformResourceMediaLoader::responseReceived):
(WebCore::PlatformResourceMediaLoader::loadFailed):
(WebCore::PlatformResourceMediaLoader::loadFinished):
(WebCore::PlatformResourceMediaLoader::dataReceived):
(WebCore::DataURLResourceMediaLoader::DataURLResourceMediaLoader):
(WebCore::WebCoreAVFResourceLoader::create):
(WebCore::WebCoreAVFResourceLoader::WebCoreAVFResourceLoader):
(WebCore::WebCoreAVFResourceLoader::~WebCoreAVFResourceLoader):
(WebCore::WebCoreAVFResourceLoader::startLoading):
(WebCore::WebCoreAVFResourceLoader::stopLoading):
(WebCore::WebCoreAVFResourceLoader::responseReceived):
(WebCore::WebCoreAVFResourceLoader::loadFailed):
(WebCore::WebCoreAVFResourceLoader::loadFinished):
(WebCore::WebCoreAVFResourceLoader::newDataStoredInSharedBuffer):
(WebCore::WebCoreAVFResourceLoader::invalidate): Deleted.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::dataReceived):
(WebCore::MediaPlayerPrivateWebM::loadFailed):
(WebCore::MediaPlayerPrivateWebM::loadFinished):
(WebCore::MediaPlayerPrivateWebM::setDuration):
(WebCore::MediaPlayerPrivateWebM::enqueueSample):
(WebCore::MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::appendCompleted):
(WebCore::MediaPlayerPrivateWebM::maybeFinishLoading):
(WebCore::MediaPlayerPrivateWebM::trackDidChangeSelected):
(WebCore::MediaPlayerPrivateWebM::didParseInitializationData):
(WebCore::MediaPlayerPrivateWebM::append): Deleted.
* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp: Initialise members with default values. Some can be read before a response is received.
(stopLoaderIfNeeded):
(webKitWebSrcUnLock):
(CachedResourceStreamingClient::responseReceived): Store origins into WebKitWebSrcPrivate as it may need to be retrieved after the PlatformMediaResourceClient got deleted.
(CachedResourceStreamingClient::redirectReceived): same.
(webKitSrcIsCrossOrigin):
* Source/WebCore/platform/network/cocoa/RangeResponseGenerator.h:
* Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm:
(WebCore::RangeResponseGenerator::Data::Data):
(WebCore::RangeResponseGenerator::Data::~Data):
(WebCore::RangeResponseGenerator::Data::shutdownResource):
(WebCore::RangeResponseGenerator::RangeResponseGenerator):
(WebCore::RangeResponseGenerator::map):
(WebCore::synthesizedResponseForRange):
(WebCore::RangeResponseGenerator::removeTask):
(WebCore::RangeResponseGenerator::giveResponseToTaskIfBytesInRangeReceived):
(WebCore::RangeResponseGenerator::expectedContentLengthFromData):
(WebCore::RangeResponseGenerator::giveResponseToTasksWithFinishedRanges):
(WebCore::RangeResponseGenerator::willHandleRequest):
(WebCore::RangeResponseGenerator::willSynthesizeRangeResponses):
(WebCore::RangeResponseGenerator::~RangeResponseGenerator): Deleted.
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h:
* Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm:
(-[WebCoreNSURLSessionTaskTransactionMetrics _initWithMetrics:onTarget:]):
(-[WebCoreNSURLSessionTaskTransactionMetrics dealloc]):
(-[WebCoreNSURLSessionTaskMetrics _initWithMetrics:onTarget:]):
(-[WebCoreNSURLSessionTaskMetrics dealloc]):
(-[WebCoreNSURLSessionTaskMetrics transactionMetrics]):
(-[WebCoreNSURLSession initWithResourceLoader:delegate:delegateQueue:]):
(-[WebCoreNSURLSession dealloc]):
(-[WebCoreNSURLSession taskCompleted:]):
(-[WebCoreNSURLSession addDelegateOperation:]):
(-[WebCoreNSURLSession task:didReceiveCORSAccessCheckResult:]):
(-[WebCoreNSURLSession task:addSecurityOrigin:]):
(-[WebCoreNSURLSession rangeResponseGenerator]):
(-[WebCoreNSURLSession didPassCORSAccessChecks]):
(-[WebCoreNSURLSession isCrossOrigin:]):
(-[WebCoreNSURLSession finishTasksAndInvalidate]):
(-[WebCoreNSURLSession dataTaskWithRequest:]):
(-[WebCoreNSURLSession sendH2Ping:pongHandler:]):
(WebCore::WebCoreNSURLSessionDataTaskClient::WebCoreNSURLSessionDataTaskClient):
(WebCore::WebCoreNSURLSessionDataTaskClient::clearTask):
(WebCore::WebCoreNSURLSessionDataTaskClient::dataSent):
(WebCore::WebCoreNSURLSessionDataTaskClient::responseReceived):
(WebCore::WebCoreNSURLSessionDataTaskClient::shouldCacheResponse):
(WebCore::WebCoreNSURLSessionDataTaskClient::dataReceived):
(WebCore::WebCoreNSURLSessionDataTaskClient::redirectReceived):
(WebCore::WebCoreNSURLSessionDataTaskClient::accessControlCheckFailed):
(WebCore::WebCoreNSURLSessionDataTaskClient::loadFailed):
(WebCore::WebCoreNSURLSessionDataTaskClient::loadFinished):
(-[WebCoreNSURLSessionDataTask initWithSession:identifier:request:targetQueue:]):
(-[WebCoreNSURLSessionDataTask _cancel]):
(-[WebCoreNSURLSessionDataTask error]):
(-[WebCoreNSURLSessionDataTask session]):
(-[WebCoreNSURLSessionDataTask setSession:]):
(-[WebCoreNSURLSessionDataTask resource]):
(-[WebCoreNSURLSessionDataTask setResource:]):
(-[WebCoreNSURLSessionDataTask cancel]):
(-[WebCoreNSURLSessionDataTask suspend]):
(-[WebCoreNSURLSessionDataTask resume]):
(-[WebCoreNSURLSessionDataTask dealloc]):
(-[WebCoreNSURLSessionDataTask resource:sentBytes:totalBytesToBeSent:]):
(-[WebCoreNSURLSessionDataTask resource:receivedResponse:completionHandler:]):
(-[WebCoreNSURLSessionDataTask resource:shouldCacheResponse:]):
(-[WebCoreNSURLSessionDataTask resource:receivedData:]):
(-[WebCoreNSURLSessionDataTask resource:receivedRedirect:request:completionHandler:]):
(-[WebCoreNSURLSessionDataTask _resource:loadFinishedWithError:metrics:]):
(-[WebCoreNSURLSessionDataTask resource:accessControlCheckFailedWithError:]):
(-[WebCoreNSURLSessionDataTask resource:loadFailedWithError:]):
(-[WebCoreNSURLSessionDataTask resourceFinished:metrics:]):
(-[WebCoreNSURLSessionTaskTransactionMetrics _initWithMetrics:]): Deleted.
(-[WebCoreNSURLSessionTaskMetrics _initWithMetrics:]): Deleted.
(-[WebCoreNSURLSessionDataTask initWithSession:identifier:request:]): Deleted.
(-[WebCoreNSURLSessionDataTask _restart]): Deleted.
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::didClose):
(WebKit::GPUConnectionToWebProcess::remoteMediaResourceManager):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::requestResource):
* Source/WebKit/GPUProcess/media/RemoteMediaResource.cpp:
(WebKit::RemoteMediaResource::RemoteMediaResource):
(WebKit::RemoteMediaResource::~RemoteMediaResource):
(WebKit::RemoteMediaResource::shutdown):
(WebKit::RemoteMediaResource::responseReceived):
(WebKit::RemoteMediaResource::redirectReceived):
(WebKit::RemoteMediaResource::dataSent):
(WebKit::RemoteMediaResource::dataReceived):
(WebKit::RemoteMediaResource::accessControlCheckFailed):
(WebKit::RemoteMediaResource::loadFailed):
(WebKit::RemoteMediaResource::loadFinished):
(WebKit::RemoteMediaResource::stop): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaResource.h:
* Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.cpp:
(WebKit::RemoteMediaResourceLoader::RemoteMediaResourceLoader):
(WebKit::RemoteMediaResourceLoader::requestResource):
(WebKit::RemoteMediaResourceLoader::sendH2Ping):
* Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.h:
* Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp:
(WebKit::RemoteMediaResourceManager::~RemoteMediaResourceManager):
(WebKit::RemoteMediaResourceManager::stopListeningForIPC):
(WebKit::RemoteMediaResourceManager::initializeConnection):
(WebKit::RemoteMediaResourceManager::addMediaResource):
(WebKit::RemoteMediaResourceManager::removeMediaResource):
(WebKit::RemoteMediaResourceManager::resourceForId):
(WebKit::RemoteMediaResourceManager::responseReceived):
(WebKit::RemoteMediaResourceManager::redirectReceived):
(WebKit::RemoteMediaResourceManager::dataSent):
(WebKit::RemoteMediaResourceManager::dataReceived):
(WebKit::RemoteMediaResourceManager::accessControlCheckFailed):
(WebKit::RemoteMediaResourceManager::loadFailed):
(WebKit::RemoteMediaResourceManager::loadFinished):
* Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h:
(WebKit::RemoteMediaResourceManager::create):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::~MediaPlayerPrivateRemote):
(WebKit::MediaPlayerPrivateRemote::removeResource):

Canonical link: <a href="https://commits.webkit.org/273804@main">https://commits.webkit.org/273804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6c2791c282bb31bcbd601a33648b1ff2d288e74

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39340 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12743 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11528 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40587 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33234 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33051 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37468 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11813 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35588 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8323 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12700 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->