### PR TITLE
WebCodecsVideoFrame should set its VideoFrame presentationTime at construction time

### DIFF
--- a/LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Check timestamp is preserved for camera video frames
+PASS Check timestamp is preserved for libwebrtc video frames
+

--- a/LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html
+++ b/LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Transfer MediaStreamTrack to dedicated worker</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<video id=video autplay playsinline></video>
+<script>
+
+async function createWorker(script)
+{
+    script += "self.postMessage('ready');";
+    const blob = new Blob([script], { type: 'text/javascript' });
+    const url = URL.createObjectURL(blob);
+    const worker = new Worker(url);
+    await new Promise(resolve => worker.onmessage = () => {
+        resolve();
+    });
+    URL.revokeObjectURL(url);
+    return worker;
+}
+
+async function pipeVideoFrameToMediaStreamTrackProcessor(videoFrame)
+{
+    const worker = await createWorker(`
+        self.onmessage = async (event) => {
+            const generator = new VideoTrackGenerator();
+            const processor = new MediaStreamTrackProcessor(generator);
+            generator.writable.getWriter().write(event.data);
+            const data = await processor.readable.getReader().read();
+            self.postMessage(data.value);
+            data.value.close();
+        }
+    `);
+    worker.postMessage(videoFrame, [videoFrame]);
+    return new Promise(resolve => worker.onmessage = e => resolve(e.data));
+}
+
+async function createConnections(test, firstConnectionCallback, secondConnectionCallback)
+{
+    const pc1 = new RTCPeerConnection();
+    const pc2 = new RTCPeerConnection();
+
+    test.add_cleanup(() => pc1.close());
+    test.add_cleanup(() => pc2.close());
+
+    pc1.onicecandidate = (e) => pc2.addIceCandidate(e.candidate);
+    pc2.onicecandidate = (e) => pc1.addIceCandidate(e.candidate);
+
+    firstConnectionCallback(pc1);
+
+    const offer = await pc1.createOffer();
+    await pc1.setLocalDescription(offer);
+    await pc2.setRemoteDescription(offer);
+
+    secondConnectionCallback(pc2);
+
+    const answer = await pc2.createAnswer();
+    await pc2.setLocalDescription(answer);
+    await pc1.setRemoteDescription(answer);
+}
+
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480 } });
+
+    video.srcObject = stream;
+    test.add_cleanup(async () => video.srcObject = null);
+    await new Promise(resolve => video.requestVideoFrameCallback(resolve));
+
+    const videoFrame1 = new VideoFrame(video, { timestamp: 10 });
+    const videoFrame2 = await pipeVideoFrameToMediaStreamTrackProcessor(videoFrame1);
+    test.add_cleanup(() => videoFrame2.close());
+    assert_equals(videoFrame1.timestamp, videoFrame2.timestamp);
+
+    const videoFrame3 = new VideoFrame(video);
+    const videoFrame4 = await pipeVideoFrameToMediaStreamTrackProcessor(videoFrame3);
+    test.add_cleanup(() => videoFrame4.close());
+    assert_equals(videoFrame3.timestamp, videoFrame4.timestamp);
+}, "Check timestamp is preserved for camera video frames");
+
+promise_test(async test => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480 } });
+
+    let pc2;
+    await createConnections(test, pc1 => {
+        pc1.addTrack(stream.getVideoTracks()[0], stream);
+        pc1.getTransceivers()[0].setCodecPreferences([{mimeType: "video/VP8", clockRate: 90000}]);
+    }, pc => {
+      pc2 = pc;
+    });
+
+    video.srcObject = new MediaStream([pc2.getReceivers()[0].track]);
+    test.add_cleanup(async () => video.srcObject = null);
+    await new Promise(resolve => video.requestVideoFrameCallback(resolve));
+
+    const videoFrame1 = new VideoFrame(video, { timestamp: 10 });
+    const videoFrame2 = await pipeVideoFrameToMediaStreamTrackProcessor(videoFrame1);
+    test.add_cleanup(() => videoFrame2.close());
+    assert_equals(videoFrame1.timestamp, videoFrame2.timestamp);
+
+    const videoFrame3 = new VideoFrame(video);
+    const videoFrame4 = await pipeVideoFrameToMediaStreamTrackProcessor(videoFrame3);
+    test.add_cleanup(() => videoFrame4.close());
+    assert_equals(videoFrame3.timestamp, videoFrame4.timestamp);
+}, "Check timestamp is preserved for libwebrtc video frames");
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1872,6 +1872,8 @@ webkit.org/b/187603 fast/mediastream/media-stream-track-source-failure.html [ Ti
 
 webkit.org/b/264803 fast/mediastream/mediastreamtrack-video-resize-event.html [ Failure ]
 
+http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html [ Failure ]
+
 # Adding transceivers without tracks is broken.
 webkit.org/b/265865 imported/w3c/web-platform-tests/webrtc-stats/rtp-stats-creation.html [ Skip ]
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -57,6 +57,16 @@
 
 namespace WebCore {
 
+static MediaTime timestampToMediaTime(int64_t timestamp)
+{
+    return MediaTime::createWithDouble(Seconds::fromMicroseconds(timestamp).value());
+}
+
+static int64_t mediaTimeToTimestamp(MediaTime mediaTime)
+{
+    return Seconds(mediaTime.toDouble()).microseconds();
+}
+
 WebCodecsVideoFrame::WebCodecsVideoFrame(ScriptExecutionContext& context)
     : ContextDestructionObserver(&context)
 {
@@ -192,7 +202,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
         RefPtr<VideoFrame> videoFrame = video->player() ? video->player()->videoFrameForCurrentTime() : nullptr;
         if (!videoFrame)
             return Exception { ExceptionCode::InvalidStateError,  "Video element has no video frame"_s };
-        return initializeFrameFromOtherFrame(context, videoFrame.releaseNonNull(), WTFMove(init), CanUpdateVideoFrameTimestamp::No);
+        return initializeFrameFromOtherFrame(context, videoFrame.releaseNonNull(), WTFMove(init), VideoFrame::ShouldCloneWithDifferentTimestamp::No);
     },
 #endif
     [&] (RefPtr<HTMLCanvasElement>& canvas) -> ExceptionOr<Ref<WebCodecsVideoFrame>> {
@@ -205,7 +215,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
         auto videoFrame = canvas->toVideoFrame();
         if (!videoFrame)
             return Exception { ExceptionCode::InvalidStateError,  "Canvas has no frame"_s };
-        return initializeFrameFromOtherFrame(context, videoFrame.releaseNonNull(), WTFMove(init), CanUpdateVideoFrameTimestamp::Yes);
+        return initializeFrameFromOtherFrame(context, videoFrame.releaseNonNull(), WTFMove(init), VideoFrame::ShouldCloneWithDifferentTimestamp::Yes);
     },
 #if ENABLE(OFFSCREEN_CANVAS)
     [&] (RefPtr<OffscreenCanvas>& canvas) -> ExceptionOr<Ref<WebCodecsVideoFrame>> {
@@ -252,14 +262,14 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
     if (!videoFrame)
         return Exception { ExceptionCode::InvalidStateError,  "Unable to create frame from buffer"_s };
 
-    return WebCodecsVideoFrame::initializeFrameFromOtherFrame(context, videoFrame.releaseNonNull(), WTFMove(init), CanUpdateVideoFrameTimestamp::Yes);
+    return WebCodecsVideoFrame::initializeFrameFromOtherFrame(context, videoFrame.releaseNonNull(), WTFMove(init), VideoFrame::ShouldCloneWithDifferentTimestamp::Yes);
 }
 
 ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutionContext& context, Ref<WebCodecsVideoFrame>&& initFrame, Init&& init)
 {
     if (initFrame->isDetached())
         return Exception { ExceptionCode::InvalidStateError,  "VideoFrame is detached"_s };
-    return initializeFrameFromOtherFrame(context, WTFMove(initFrame), WTFMove(init), CanUpdateVideoFrameTimestamp::No);
+    return initializeFrameFromOtherFrame(context, WTFMove(initFrame), WTFMove(init), VideoFrame::ShouldCloneWithDifferentTimestamp::No);
 }
 
 static std::optional<Exception> validateI420Sizes(const WebCodecsVideoFrame::BufferInit& init)
@@ -346,8 +356,8 @@ Ref<WebCodecsVideoFrame> WebCodecsVideoFrame::create(ScriptExecutionContext& con
     result->m_data.displayHeight = init.displayHeight.value_or(result->m_data.visibleHeight);
 
     result->m_data.duration = init.duration;
+    result->m_data.internalFrame = result->m_data.internalFrame->updateTimestamp(timestampToMediaTime(init.timestamp), VideoFrame::ShouldCloneWithDifferentTimestamp::No);
     result->m_data.timestamp = init.timestamp;
-    result->m_data.internalFrame->initializeCharacteristics(MediaTime::createWithDouble(Seconds::fromMicroseconds(init.timestamp).value()), false, VideoFrameRotation::None);
 
     return result;
 }
@@ -375,7 +385,7 @@ static VideoPixelFormat computeVideoPixelFormat(VideoPixelFormat baseFormat, boo
 }
 
 // https://w3c.github.io/webcodecs/#videoframe-initialize-frame-from-other-frame
-ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameFromOtherFrame(ScriptExecutionContext& context, Ref<WebCodecsVideoFrame>&& videoFrame, Init&& init, CanUpdateVideoFrameTimestamp canUpdateVideoFrameTimestamp)
+ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameFromOtherFrame(ScriptExecutionContext& context, Ref<WebCodecsVideoFrame>&& videoFrame, Init&& init, VideoFrame::ShouldCloneWithDifferentTimestamp shouldCloneWithDifferentTimestamp)
 {
     auto codedWidth = videoFrame->m_data.codedWidth;
     auto codedHeight = videoFrame->m_data.codedHeight;
@@ -394,15 +404,14 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameFromOt
     initializeVisibleRectAndDisplaySize(result.get(), init, DOMRectInit { static_cast<double>(videoFrame->m_data.visibleLeft), static_cast<double>(videoFrame->m_data.visibleTop), static_cast<double>(videoFrame->m_data.visibleWidth), static_cast<double>(videoFrame->m_data.visibleHeight) }, videoFrame->m_data.displayWidth, videoFrame->m_data.displayHeight);
 
     result->m_data.duration = init.duration ? init.duration : videoFrame->m_data.duration;
-    result->m_data.timestamp = init.timestamp.value_or(videoFrame->m_data.timestamp);
-    // FIXME: Handle CanUpdateVideoFrameTimestamp::No case.
-    if (canUpdateVideoFrameTimestamp == CanUpdateVideoFrameTimestamp::Yes && init.timestamp)
-        result->m_data.internalFrame->initializeCharacteristics(MediaTime::createWithDouble(Seconds::fromMicroseconds(*init.timestamp).value()), false, VideoFrameRotation::None);
+    if (init.timestamp)
+        result->m_data.internalFrame = result->m_data.internalFrame->updateTimestamp(timestampToMediaTime(*init.timestamp), shouldCloneWithDifferentTimestamp);
+    result->m_data.timestamp = mediaTimeToTimestamp(result->m_data.internalFrame->presentationTime());
 
     return result;
 }
 
-ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameFromOtherFrame(ScriptExecutionContext& context, Ref<VideoFrame>&& internalVideoFrame, Init&& init, CanUpdateVideoFrameTimestamp canUpdateVideoFrameTimestamp)
+ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameFromOtherFrame(ScriptExecutionContext& context, Ref<VideoFrame>&& internalVideoFrame, Init&& init, VideoFrame::ShouldCloneWithDifferentTimestamp shouldCloneWithDifferentTimestamp)
 {
     auto codedWidth = internalVideoFrame->presentationSize().width();
     auto codedHeight = internalVideoFrame->presentationSize().height();
@@ -419,11 +428,9 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameFromOt
     initializeVisibleRectAndDisplaySize(result.get(), init, DOMRectInit { 0, 0 , static_cast<double>(result->m_data.codedWidth), static_cast<double>(result->m_data.codedHeight) }, result->m_data.codedWidth, result->m_data.codedHeight);
 
     result->m_data.duration = init.duration;
-    // FIXME: Use internalVideoFrame timestamp if available and init has no timestamp.
-    result->m_data.timestamp = init.timestamp.value_or(0);
-    // FIXME: Handle CanUpdateVideoFrameTimestamp::No case.
-    if (canUpdateVideoFrameTimestamp == CanUpdateVideoFrameTimestamp::Yes && init.timestamp)
-        result->m_data.internalFrame->initializeCharacteristics(MediaTime::createWithDouble(Seconds::fromMicroseconds(*init.timestamp).value()), false, VideoFrameRotation::None);
+    if (init.timestamp)
+        result->m_data.internalFrame = result->m_data.internalFrame->updateTimestamp(timestampToMediaTime(*init.timestamp), shouldCloneWithDifferentTimestamp);
+    result->m_data.timestamp = mediaTimeToTimestamp(result->m_data.internalFrame->presentationTime());
 
     return result;
 }
@@ -450,7 +457,9 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameWithRe
     initializeVisibleRectAndDisplaySize(result.get(), init, DOMRectInit { 0, 0 , static_cast<double>(result->m_data.codedWidth), static_cast<double>(result->m_data.codedHeight) }, result->m_data.codedWidth, result->m_data.codedHeight);
 
     result->m_data.duration = init.duration;
-    result->m_data.timestamp = init.timestamp.value_or(0);
+    if (init.timestamp)
+        result->m_data.internalFrame = result->m_data.internalFrame->updateTimestamp(timestampToMediaTime(*init.timestamp), VideoFrame::ShouldCloneWithDifferentTimestamp::No);
+    result->m_data.timestamp = mediaTimeToTimestamp(result->m_data.internalFrame->presentationTime());
 
     return result;
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
@@ -143,9 +143,8 @@ private:
     explicit WebCodecsVideoFrame(ScriptExecutionContext&);
     WebCodecsVideoFrame(ScriptExecutionContext&, WebCodecsVideoFrameData&&);
 
-    enum class CanUpdateVideoFrameTimestamp : bool { No, Yes };
-    static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameFromOtherFrame(ScriptExecutionContext&, Ref<WebCodecsVideoFrame>&&, Init&&, CanUpdateVideoFrameTimestamp);
-    static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameFromOtherFrame(ScriptExecutionContext&, Ref<VideoFrame>&&, Init&&, CanUpdateVideoFrameTimestamp);
+    static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameFromOtherFrame(ScriptExecutionContext&, Ref<WebCodecsVideoFrame>&&, Init&&, VideoFrame::ShouldCloneWithDifferentTimestamp);
+    static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameFromOtherFrame(ScriptExecutionContext&, Ref<VideoFrame>&&, Init&&, VideoFrame::ShouldCloneWithDifferentTimestamp);
     static ExceptionOr<Ref<WebCodecsVideoFrame>> initializeFrameWithResourceAndSize(ScriptExecutionContext&, Ref<NativeImage>&&, Init&&);
 
     WebCodecsVideoFrameData m_data;

--- a/Source/WebCore/platform/VideoFrame.cpp
+++ b/Source/WebCore/platform/VideoFrame.cpp
@@ -49,6 +49,16 @@ void VideoFrame::initializeCharacteristics(MediaTime presentationTime, bool isMi
     const_cast<Rotation&>(m_rotation) = rotation;
 }
 
+Ref<VideoFrame> VideoFrame::updateTimestamp(MediaTime mediaTime, ShouldCloneWithDifferentTimestamp shouldCloneWithDifferentTimestamp)
+{
+    if (m_presentationTime == mediaTime)
+        return *this;
+
+    Ref updatedVideoFrame = shouldCloneWithDifferentTimestamp == ShouldCloneWithDifferentTimestamp::Yes ? clone() : Ref { *this };
+    const_cast<MediaTime&>(updatedVideoFrame->m_presentationTime) = mediaTime;
+    return updatedVideoFrame;
+}
+
 #if !PLATFORM(COCOA) && !USE(GSTREAMER)
 RefPtr<VideoFrame> VideoFrame::fromNativeImage(NativeImage&)
 {

--- a/Source/WebCore/platform/VideoFrame.h
+++ b/Source/WebCore/platform/VideoFrame.h
@@ -91,6 +91,9 @@ public:
     WEBCORE_EXPORT RefPtr<VideoFrameCV> asVideoFrameCV();
 #endif
 
+    enum class ShouldCloneWithDifferentTimestamp : bool { No, Yes };
+    Ref<VideoFrame> updateTimestamp(MediaTime, ShouldCloneWithDifferentTimestamp);
+
     using CopyCallback = CompletionHandler<void(std::optional<Vector<PlaneLayout>>&&)>;
     void copyTo(std::span<uint8_t>, VideoPixelFormat, Vector<ComputedPlaneLayout>&&, CopyCallback&&);
 
@@ -117,7 +120,11 @@ public:
 protected:
     WEBCORE_EXPORT VideoFrame(MediaTime presentationTime, bool isMirrored, Rotation, PlatformVideoColorSpace&& = { });
 
+    void initializePresentationTime(MediaTime);
+
 private:
+    virtual Ref<VideoFrame> clone() = 0;
+
     const MediaTime m_presentationTime;
     const bool m_isMirrored;
     const Rotation m_rotation;

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.h
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.h
@@ -56,6 +56,9 @@ public:
 private:
     friend struct IPC::ArgumentCoder<VideoFrameCV, void>;
     WEBCORE_EXPORT VideoFrameCV(MediaTime presentationTime, bool isMirrored, Rotation, RetainPtr<CVPixelBufferRef>&&, std::optional<PlatformVideoColorSpace>&&);
+    VideoFrameCV(MediaTime presentationTime, bool isMirrored, Rotation, RetainPtr<CVPixelBufferRef>&&, PlatformVideoColorSpace&&);
+
+    Ref<VideoFrame> clone() final;
 
     const RetainPtr<CVPixelBufferRef> m_pixelBuffer;
 };

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
@@ -575,6 +575,12 @@ VideoFrameCV::VideoFrameCV(MediaTime presentationTime, bool isMirrored, Rotation
 {
 }
 
+VideoFrameCV::VideoFrameCV(MediaTime presentationTime, bool isMirrored, Rotation rotation, RetainPtr<CVPixelBufferRef>&& pixelBuffer, PlatformVideoColorSpace&& colorSpace)
+    : VideoFrame(presentationTime, isMirrored, rotation, WTFMove(colorSpace))
+    , m_pixelBuffer(WTFMove(pixelBuffer))
+{
+}
+
 VideoFrameCV::~VideoFrameCV() = default;
 
 WebCore::FloatSize VideoFrameCV::presentationSize() const
@@ -608,6 +614,11 @@ ImageOrientation VideoFrameCV::orientation() const
     case VideoFrame::Rotation::Left:
         return isMirrored() ? ImageOrientation::Orientation::OriginLeftTop : ImageOrientation::Orientation::OriginLeftBottom;
     }
+}
+
+Ref<VideoFrame> VideoFrameCV::clone()
+{
+    return adoptRef(*new VideoFrameCV(presentationTime(), isMirrored(), rotation(), pixelBuffer(), PlatformVideoColorSpace { colorSpace() }));
 }
 
 }

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -514,6 +514,11 @@ RefPtr<ImageGStreamer> VideoFrameGStreamer::convertToImage()
     return convertSampleToImage(m_sample);
 }
 
+Ref<VideoFrame> VideoFrameGStreamer::clone()
+{
+    return createWrappedSample(m_sample, presentationTime());
+}
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -66,6 +66,7 @@ private:
     VideoFrameGStreamer(const GRefPtr<GstSample>&, const FloatSize& presentationSize, const MediaTime& presentationTime, Rotation = Rotation::None, PlatformVideoColorSpace&& = { });
 
     bool isGStreamer() const final { return true; }
+    Ref<VideoFrame> clone() final;
 
     GRefPtr<GstSample> convert(GstVideoFormat, const IntSize&);
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp
@@ -216,5 +216,10 @@ CVPixelBufferRef VideoFrameLibWebRTC::pixelBuffer() const
     return m_pixelBuffer.get();
 }
 
+Ref<VideoFrame> VideoFrameLibWebRTC::clone()
+{
+    return adoptRef(*new VideoFrameLibWebRTC(presentationTime(), isMirrored(), rotation(), PlatformVideoColorSpace { colorSpace() }, rtc::scoped_refptr<webrtc::VideoFrameBuffer> { m_buffer }, ConversionCallback { m_conversionCallback }));
+}
+
 }
 #endif // PLATFORM(COCOA) && USE(LIBWEBRTC)

--- a/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h
@@ -45,7 +45,7 @@ namespace WebCore {
 
 class VideoFrameLibWebRTC final : public VideoFrame {
 public:
-    using ConversionCallback = Function<RetainPtr<CVPixelBufferRef>(webrtc::VideoFrameBuffer&)>;
+    using ConversionCallback = std::function<RetainPtr<CVPixelBufferRef>(webrtc::VideoFrameBuffer&)>;
     static Ref<VideoFrameLibWebRTC> create(MediaTime, bool isMirrored, Rotation, std::optional<PlatformVideoColorSpace>&&, rtc::scoped_refptr<webrtc::VideoFrameBuffer>&&, ConversionCallback&&);
 
     rtc::scoped_refptr<webrtc::VideoFrameBuffer> buffer() const { return m_buffer; }
@@ -59,6 +59,8 @@ private:
     FloatSize presentationSize() const final { return m_size; }
     uint32_t pixelFormat() const final { return m_videoPixelFormat; }
     CVPixelBufferRef pixelBuffer() const final;
+
+    Ref<VideoFrame> clone() final;
 
     const rtc::scoped_refptr<webrtc::VideoFrameBuffer> m_buffer;
     FloatSize m_size;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
@@ -72,7 +72,7 @@ void RemoteVideoFrameProxy::releaseUnused(IPC::Connection& connection, Propertie
 
 RemoteVideoFrameProxy::RemoteVideoFrameProxy(IPC::Connection& connection, RemoteVideoFrameObjectHeapProxy& videoFrameObjectHeapProxy, Properties&& properties)
     : VideoFrame(properties.presentationTime, properties.isMirrored, properties.rotation, WTFMove(properties.colorSpace))
-    , m_connection(connection)
+    , m_connection(&connection)
     , m_referenceTracker(properties.reference)
     , m_size(properties.size)
     , m_pixelFormat(properties.pixelFormat)
@@ -80,19 +80,28 @@ RemoteVideoFrameProxy::RemoteVideoFrameProxy(IPC::Connection& connection, Remote
 {
 }
 
+RemoteVideoFrameProxy::RemoteVideoFrameProxy(CloneConstructor, RemoteVideoFrameProxy& baseVideoFrame)
+    : VideoFrame(baseVideoFrame.presentationTime(), baseVideoFrame.isMirrored(), baseVideoFrame.rotation(), PlatformVideoColorSpace { baseVideoFrame.colorSpace() })
+    , m_baseVideoFrame(&baseVideoFrame)
+    , m_size(baseVideoFrame.m_size)
+    , m_pixelFormat(baseVideoFrame.m_pixelFormat)
+{
+}
+
 RemoteVideoFrameProxy::~RemoteVideoFrameProxy()
 {
-    releaseRemoteVideoFrameProxy(m_connection, m_referenceTracker.write());
+    if (m_connection)
+        releaseRemoteVideoFrameProxy(*m_connection, m_referenceTracker->write());
 }
 
 RemoteVideoFrameIdentifier RemoteVideoFrameProxy::identifier() const
 {
-    return m_referenceTracker.identifier();
+    return m_baseVideoFrame ? m_baseVideoFrame->m_referenceTracker->identifier() : m_referenceTracker->identifier();
 }
 
 RemoteVideoFrameReadReference RemoteVideoFrameProxy::newReadReference() const
 {
-    return m_referenceTracker.read();
+    return m_baseVideoFrame ? m_baseVideoFrame->m_referenceTracker->read() : m_referenceTracker->read();
 }
 
 uint32_t RemoteVideoFrameProxy::pixelFormat() const
@@ -103,6 +112,9 @@ uint32_t RemoteVideoFrameProxy::pixelFormat() const
 #if PLATFORM(COCOA)
 CVPixelBufferRef RemoteVideoFrameProxy::pixelBuffer() const
 {
+    if (m_baseVideoFrame)
+        return m_baseVideoFrame->pixelBuffer();
+
     Locker lock(m_pixelBufferLock);
     if (!m_pixelBuffer && m_videoFrameObjectHeapProxy) {
         auto videoFrameObjectHeapProxy = std::exchange(m_videoFrameObjectHeapProxy, nullptr);
@@ -128,6 +140,11 @@ CVPixelBufferRef RemoteVideoFrameProxy::pixelBuffer() const
     return m_pixelBuffer.get();
 }
 #endif
+
+Ref<VideoFrame> RemoteVideoFrameProxy::clone()
+{
+    return adoptRef(*new RemoteVideoFrameProxy(cloneConstructor, *this));
+}
 
 TextStream& operator<<(TextStream& ts, const RemoteVideoFrameProxy::Properties& properties)
 {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
@@ -76,10 +76,17 @@ public:
 
 private:
     RemoteVideoFrameProxy(IPC::Connection&, RemoteVideoFrameObjectHeapProxy&, Properties&&);
+
+    enum CloneConstructor { cloneConstructor };
+    RemoteVideoFrameProxy(CloneConstructor, RemoteVideoFrameProxy&);
+
+    Ref<VideoFrame> clone() final;
+
     static inline Seconds defaultTimeout = 10_s;
 
-    const Ref<IPC::Connection> m_connection;
-    RemoteVideoFrameReferenceTracker m_referenceTracker;
+    const RefPtr<RemoteVideoFrameProxy> m_baseVideoFrame;
+    const RefPtr<IPC::Connection> m_connection;
+    std::optional<RemoteVideoFrameReferenceTracker> m_referenceTracker;
     const WebCore::IntSize m_size;
     uint32_t m_pixelFormat { 0 };
     // FIXME: Remove this.


### PR DESCRIPTION
#### c83c252e819519949155fd90995230fc40afd2a2
<pre>
WebCodecsVideoFrame should set its VideoFrame presentationTime at construction time
<a href="https://bugs.webkit.org/show_bug.cgi?id=267994">https://bugs.webkit.org/show_bug.cgi?id=267994</a>
<a href="https://rdar.apple.com/121512179">rdar://121512179</a>

Reviewed by Eric Carlson.

Consumers of WebCodecsVideoFrame like MediaStreamTrackProcessor use VideoFrame presentationTime instead of WebCodecsVideoFrame timestamp.
We need to keep them in sync and this patch does it at construction time.
We introduce a VideoFrame clone() method for the case where we cannot update the VideoFrame presentationTime directly.
We cannot remove WebCodecsVideoFrame timestamp since timestamp needs to stay even if WebCodecsVideoFrame is closed.

* LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp-expected.txt: Added.
* LayoutTests/http/wpt/mediastream/mediastreamtrackprocessor-videoframe-timestamp.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::timestampToMediaTime):
(WebCore::mediaTimeToTimestamp):
(WebCore::WebCodecsVideoFrame::create):
(WebCore::WebCodecsVideoFrame::initializeFrameFromOtherFrame):
(WebCore::WebCodecsVideoFrame::initializeFrameWithResourceAndSize):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h:
* Source/WebCore/platform/VideoFrame.cpp:
(WebCore::VideoFrame::updateTimestamp):
* Source/WebCore/platform/VideoFrame.h:
* Source/WebCore/platform/graphics/cv/VideoFrameCV.h:
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::VideoFrameCV::VideoFrameCV):
(WebCore::VideoFrameCV::clone):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrame::clone):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h:
* Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.cpp:
(WebCore::VideoFrameLibWebRTC::clone):
* Source/WebCore/platform/mediastream/libwebrtc/VideoFrameLibWebRTC.h:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp:
(WebKit::RemoteVideoFrameProxy::RemoteVideoFrameProxy):
(WebKit::m_pixelFormat):
(WebKit::RemoteVideoFrameProxy::~RemoteVideoFrameProxy):
(WebKit::RemoteVideoFrameProxy::identifier const):
(WebKit::RemoteVideoFrameProxy::newReadReference const):
(WebKit::RemoteVideoFrameProxy::pixelBuffer const):
(WebKit::RemoteVideoFrameProxy::clone):
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h:

Canonical link: <a href="https://commits.webkit.org/273496@main">https://commits.webkit.org/273496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61bd35dc586518ec979ad7b955008bf4bd3ba05f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35615 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38355 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32085 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11583 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31695 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10806 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39600 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32170 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36767 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11004 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34845 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31493 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8130 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->