### PR TITLE
Migrate some WPT mediacapture-insertable-streams to latest API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-backpressure.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-backpressure.worker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Tests that backpressure forces MediaStreamTrackProcess to skip frames
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-backpressure.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-backpressure.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-backpressure.worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-backpressure.worker.js
@@ -1,0 +1,56 @@
+// META: title=MediaStreamTrackProcessor backpressure tests.
+
+importScripts("/resources/testharness.js");
+
+const height = 240;
+const width = 320;
+
+const inputCanvas = new OffscreenCanvas(width, height);
+const inputCtx = inputCanvas.getContext('2d', {alpha: false});
+inputCtx.fillStyle = 'black';
+inputCtx.fillRect(0, 0, width, height);
+
+const frameDuration = 40;
+
+function makeUniformVideoFrame(timestamp) {
+  return new VideoFrame(inputCanvas, {timestamp, alpha: 'discard'});
+}
+
+promise_test(async t => {
+  const generator = new VideoTrackGenerator();
+  t.add_cleanup(() => generator.track.stop());
+
+  // Write frames for the duration of the test.
+  const writer = generator.writable.getWriter();
+  let timestamp = 0;
+  const intervalId = setInterval(
+    t.step_func(async () => {
+      if (generator.readyState === 'live') {
+        timestamp++;
+        await writer.write(makeUniformVideoFrame(timestamp));
+      }
+    }),
+    frameDuration);
+  t.add_cleanup(() => clearInterval(intervalId));
+  t.step_timeout(function() {
+    clearInterval(intervalId);
+    generator.track.stop();
+  }, 2000);
+  const processor = new MediaStreamTrackProcessor(generator);
+  let ts = 1;
+  await processor.readable.pipeTo(new WritableStream({
+    async write(frame) {
+      if (ts === 1) {
+        assert_equals(frame.timestamp, ts, "Timestamp mismatch");
+      } else {
+        assert_greater_than_equal(frame.timestamp, ts, "Backpressure should have resulted in skipping at least 3 frames");
+      }
+      frame.close();
+      ts+=3;
+      // Wait the equivalent of 3 frames
+      return new Promise((res) => t.step_timeout(res, 3*frameDuration));
+    }
+  }));
+}, "Tests that backpressure forces MediaStreamTrackProcess to skip frames");
+
+done();

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-with-window-tracks.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-with-window-tracks.https-expected.txt
@@ -1,0 +1,9 @@
+When prompted, use the accept button to give permission to use your audio and video devices.
+
+Description
+
+This test checks that MediaStreamTrackProcessor works as expected on video MediaStreamTracks.
+
+
+PASS Tests that the reader of a video MediaStreamTrackProcessor produces VideoFrame objects and is closed on track stop while running on a worker
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-with-window-tracks.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-with-window-tracks.https.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html>
+<head>
+  <title>MediaStreamTrackProcessor</title>
+  <link rel="help" href="https://w3c.github.io/mediacapture-insertable-streams">
+</head>
+<body>
+<p class="instructions">When prompted, use the accept button to give permission to use your audio and video devices.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that MediaStreamTrackProcessor works as expected on video MediaStreamTracks.</p>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/testdriver.js></script>
+<script src=/resources/testdriver-vendor.js></script>
+<script src='/mediacapture-streams/permission-helper.js'></script>
+<script>
+async function createWorker(script) {
+  script = script + "self.postMessage('ready');";
+  const blob = new Blob([script], { type: 'text/javascript' });
+  const url = URL.createObjectURL(blob);
+  const worker = new Worker(url);
+  await new Promise(resolve => worker.onmessage = () => {
+      resolve();
+  });
+  URL.revokeObjectURL(url);
+  return worker;
+}
+
+promise_test(async t => {
+  const stream = await navigator.mediaDevices.getUserMedia({video: true});
+  const track = stream.getTracks()[0];
+  const worker = await createWorker(`
+    let track;
+    onmessage = async msg => {
+      if (msg.data.type === "stop") {
+        track.stop();
+        return;
+      }
+      track = msg.data.track;
+      const processor = new MediaStreamTrackProcessor({track});
+      const reader = processor.readable.getReader();
+      let readResult = await reader.read();
+      postMessage(readResult.value);
+      readResult.value.close();
+      // Continue reading until the stream is done due to a track.stop()
+      while (true) {
+        readResult = await reader.read();
+        if (readResult.done) {
+          break;
+        } else {
+          readResult.value.close();
+        }
+      }
+      await reader.closed;
+      postMessage('closed');
+    }
+  `);
+
+  worker.postMessage({ type: "start", track }, [track]);
+
+  return new Promise(resolve => {
+    worker.onmessage = t.step_func(msg => {
+      if (msg.data instanceof VideoFrame) {
+        msg.data.close();
+        worker.postMessage({ type: "stop" });
+      } else if (msg.data == 'closed') {
+        resolve();
+      } else {
+        assert_unreached();
+      }
+    })
+  });
+}, "Tests that the reader of a video MediaStreamTrackProcessor produces VideoFrame objects and is closed on track stop while running on a worker");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor.worker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Tests that multiple read requests are eventually settled
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor.worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor.worker.js
@@ -1,0 +1,47 @@
+// META: title=MediaStreamTrackProcessor tests.
+
+importScripts("/resources/testharness.js");
+
+function makeVideoFrame(timestamp) {
+  const canvas = new OffscreenCanvas(100, 100);
+  const ctx = canvas.getContext('2d');
+  return new VideoFrame(canvas, {timestamp});
+}
+
+promise_test(async t => {
+  // The generator will be used as the source for the processor to
+  // produce frames in a controlled manner.
+  const generator = new VideoTrackGenerator();
+  t.add_cleanup(() => generator.track.stop());
+  // Use a larger maxBufferSize than the default to ensure no frames
+  // will be dropped.
+  const processor = new MediaStreamTrackProcessor({track: generator.track, maxBufferSize:10});
+  const reader = processor.readable.getReader();
+  const writer = generator.writable.getWriter();
+
+  let numReads = 0;
+  let resolve = null;
+  const promise = new Promise(r => resolve = r);
+
+  const numOperations = 4;
+  // Issue reads without waiting for the frames to arrive.
+  for (let i = 0; i < numOperations; i++) {
+    reader.read().then(dv=> {
+      dv.value.close();
+      if (++numReads == numOperations)
+        resolve();
+    });
+  }
+
+  // Write video frames in different tasks to "slowly" settle the pending read
+  // requests.
+  for (let i = 0; i<numOperations; i++) {
+     await writer.write(makeVideoFrame(i));
+     await new Promise(r=>t.step_timeout(r,0));
+  }
+
+  return promise;
+
+}, "Tests that multiple read requests are eventually settled");
+
+done();

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator-with-window-tracks.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator-with-window-tracks.https-expected.txt
@@ -1,0 +1,9 @@
+Description
+
+This test checks that generating video MediaStreamTracks from VideoTrackGenerator works as expected.
+
+
+PASS Tests that frames are actually rendered correctly in a stream used for a video element.
+PASS Tests that frames are actually rendered correctly in a stream sent over a peer connection.
+PASS Tests that frames are sent correctly with RTCRtpEncodingParameters.scaleResolutionDownBy.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator-with-window-tracks.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator-with-window-tracks.https.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>MediaStream Insertable Streams - VideoTrackGenerator</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/webrtc/RTCPeerConnection-helper.js"></script>
+</head>
+<body>
+  <h1 class="instructions">Description</h1>
+  <p class="instructions">This test checks that generating video MediaStreamTracks from VideoTrackGenerator works as expected.</p>
+  <script id="scriptRoutines">
+    const pixelColour = [50, 100, 150, 255];
+    const height = 240;
+    const width = 320;
+    function makeVideoFrame(timestamp) {
+      const canvas = new OffscreenCanvas(width, height);
+
+      const ctx = canvas.getContext('2d', {alpha: false});
+      ctx.fillStyle = `rgba(${pixelColour.join()})`;
+      ctx.fillRect(0, 0, width, height);
+
+      return new VideoFrame(canvas, {timestamp, alpha: 'discard'});
+    }
+
+    async function getVideoFrame() {
+      const stream = await getNoiseStream({video: true});
+      const input_track = stream.getTracks()[0];
+      const processor = new MediaStreamTrackProcessor(input_track);
+      const reader = processor.readable.getReader();
+      const result = await reader.read();
+      input_track.stop();
+      return result.value;
+    }
+
+    function assertPixel(t, bytes, expected, epsilon = 5) {
+      for (let i = 0; i < bytes.length; i++) {
+        t.step(() => {
+          assert_less_than(Math.abs(bytes[i] - expected[i]),  epsilon, "Mismatched pixel");
+        });
+      }
+    }
+
+    async function initiateSingleTrackCall(t, track, output) {
+      const caller = new RTCPeerConnection();
+      t.add_cleanup(() => caller.close());
+      const callee = new RTCPeerConnection();
+      t.add_cleanup(() => callee.close());
+      caller.addTrack(track);
+      t.add_cleanup(() => track.stop());
+
+      exchangeIceCandidates(caller, callee);
+      // Wait for the first track.
+      const e = await exchangeOfferAndListenToOntrack(t, caller, callee);
+      output.srcObject = new MediaStream([e.track]);
+      // Exchange answer.
+      await exchangeAnswer(caller, callee);
+      await waitForConnectionStateChange(callee, ['connected']);
+    }
+  </script>
+  <script>
+    async function createWorker(script) {
+      script = scriptRoutines.text + script + "self.postMessage('ready');";
+      const blob = new Blob([script], { type: 'text/javascript' });
+      const url = URL.createObjectURL(blob);
+      const worker = new Worker(url);
+      await new Promise(resolve => worker.onmessage = () => {
+          resolve();
+      });
+      URL.revokeObjectURL(url);
+      return worker;
+    }
+
+   promise_test(async t => {
+     const worker = await createWorker(`
+         const generator = new VideoTrackGenerator();
+         const videoFrame = makeVideoFrame(1);
+         const originalWidth = videoFrame.displayWidth;
+         const originalHeight = videoFrame.displayHeight;
+         self.onmessage = async (event) => {
+           if (event.data == "transfer") {
+             self.postMessage({ track: generator.track, originalWidth, originalHeight }, [generator.track]);
+             return;
+           }
+           if (event.data == "write frame") {
+             generator.writable.getWriter().write(videoFrame)
+             return;
+           }
+           if (event.data == "cleanup") {
+             videoFrame.close();
+             return;
+           }
+         }
+     `);
+
+     t.add_cleanup(() => worker.postMessage("cleanup"));
+
+     worker.postMessage("transfer");
+     const { track, originalWidth, originalHeight } = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
+     t.add_cleanup(() => track.stop());
+
+     const video = document.createElement("video");
+     video.autoplay = true;
+     video.width = 320;
+     video.height = 240;
+     video.srcObject = new MediaStream([track]);
+     video.play();
+
+     // Wait for the video element to be connected to the generator and
+     // generate the frame.
+     video.onloadstart = () => worker.postMessage("write frame");
+
+     return new Promise((resolve)=> {
+       video.ontimeupdate = t.step_func(() => {
+         const canvas = document.createElement("canvas");
+         canvas.width = originalWidth;
+         canvas.height = originalHeight;
+         const context = canvas.getContext('2d');
+         context.drawImage(video, 0, 0);
+         // Pick a pixel in the centre of the video and check that it has the colour of the frame provided.
+         const pixel = context.getImageData(originalWidth/2, originalHeight/2, 1, 1);
+         assertPixel(t, pixel.data, pixelColour);
+         resolve();
+       });
+     });
+   }, 'Tests that frames are actually rendered correctly in a stream used for a video element.');
+
+   promise_test(async t => {
+     const worker = await createWorker(`
+         const generator = new VideoTrackGenerator();
+         const videoFrame = makeVideoFrame(1);
+         const originalWidth = videoFrame.displayWidth;
+         const originalHeight = videoFrame.displayHeight;
+         let intervalId;
+         self.onmessage = async (event) => {
+           if (event.data == "transfer") {
+             self.postMessage({ track: generator.track}, [generator.track]);
+             // Write frames for the duration of the test.
+             const writer = generator.writable.getWriter();
+             let timestamp = 0;
+             intervalId = setInterval(async () => {
+               timestamp++;
+               await writer.write(makeVideoFrame(timestamp));
+             }, 40);
+             return;
+           }
+         }
+     `);
+
+     worker.postMessage("transfer");
+     const { track } = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
+     t.add_cleanup(() => track.stop());
+
+     const video = document.createElement('video');
+     video.autoplay = true;
+     video.width = width;
+     video.height = height;
+     video.muted = true;
+
+     await initiateSingleTrackCall(t, track, video);
+     return new Promise(resolve => {
+       video.requestVideoFrameCallback(t.step_func(() => {
+         const canvas = document.createElement('canvas');
+         canvas.width = width;
+         canvas.height = height;
+         const context = canvas.getContext('2d');
+         context.drawImage(video, 0, 0);
+         // Pick a pixel in the centre of the video and check that it has the
+         // colour of the frame provided.
+         const pixel = context.getImageData(width / 2, height / 2, 1, 1);
+         // Encoding/decoding can add noise, so increase the threshhold to 8.
+         assertPixel(t, pixel.data, pixelColour, 8);
+         resolve();
+       }));
+     });
+   }, 'Tests that frames are actually rendered correctly in a stream sent over a peer connection.');
+
+    promise_test(async t => {
+      const colorUL = [255, 0, 0, 255];
+      const colorUR = [255, 255, 0, 255];
+      const colorLL = [0, 255, 0, 255];
+      const colorLR = [0, 255, 255, 255];
+      const worker = await createWorker(`
+          const generator = new VideoTrackGenerator();
+          const videoFrame = makeVideoFrame(1);
+          const originalWidth = videoFrame.displayWidth;
+          const originalHeight = videoFrame.displayHeight;
+          let intervalId;
+          self.onmessage = async (event) => {
+            if (event.data == "transfer") {
+              self.postMessage({ track: generator.track}, [generator.track]);
+              const inputCanvas = new OffscreenCanvas(width, height);
+              const inputContext = inputCanvas.getContext('2d', {alpha: false});
+              // draw four quadrants
+              inputContext.fillStyle = \`rgba(${colorUL.join()})\`;
+              inputContext.fillRect(0, 0, width / 2, height / 2);
+              inputContext.fillStyle = \`rgba(${colorUR.join()})\`;
+              inputContext.fillRect(width / 2, 0, width / 2, height / 2);
+              inputContext.fillStyle = \`rgba(${colorLL.join()})\`;
+              inputContext.fillRect(0, height / 2, width / 2, height / 2);
+              inputContext.fillStyle = \`rgba(${colorLR.join()})\`;
+              inputContext.fillRect(width / 2, height / 2, width / 2, height / 2);
+ 
+              // Write frames for the duration of the test.
+              const writer = generator.writable.getWriter();
+              let timestamp = 0;
+              const intervalId = setInterval(async () => {
+                timestamp++;
+                await writer.write(new VideoFrame(inputCanvas, {timestamp: timestamp, alpha: 'discard'}));
+              }, 40);
+              return;
+            }
+            if (event.data.type === "getVideoFrame") {
+              const processor = new MediaStreamTrackProcessor({ track: event.data.track });
+              const reader = processor.readable.getReader();
+              const frame = (await reader.read()).value;
+              self.postMessage({frame}, [frame])
+              event.data.track.stop();
+            }
+          }
+      `);
+
+      worker.postMessage("transfer");
+      const { track } = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
+      t.add_cleanup(() => track.stop());
+
+      const caller = new RTCPeerConnection();
+      t.add_cleanup(() => caller.close());
+      const callee = new RTCPeerConnection();
+      t.add_cleanup(() => callee.close());
+      const sender = caller.addTrack(track);
+
+      exchangeIceCandidates(caller, callee);
+      // Wait for the first track.
+      const e = await exchangeOfferAndListenToOntrack(t, caller, callee);
+
+      // Exchange answer.
+      await exchangeAnswer(caller, callee);
+      await waitForConnectionStateChange(callee, ['connected']);
+      const params = sender.getParameters();
+      params.encodings.forEach(e => e.scaleResolutionDownBy = 2);
+      sender.setParameters(params);
+
+      // The first frame may not have had scaleResolutionDownBy applied
+      const numTries = 5;
+      for (let i = 1; i <= numTries; i++) {
+        worker.postMessage({type:"getVideoFrame", track: e.track}, [e.track]);
+        const {frame: outputFrame} = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
+        if (outputFrame.displayWidth !== width / 2) {
+          assert_less_than(i, numTries, `First ${numTries} frames were the wrong size.`);
+          outputFrame.close();
+          continue;
+        }
+
+        assert_equals(outputFrame.displayWidth, width / 2);
+        assert_equals(outputFrame.displayHeight, height / 2);
+
+        const outputCanvas = new OffscreenCanvas(width / 2, height / 2);
+        const outputContext = outputCanvas.getContext('2d', {alpha: false});
+        outputContext.drawImage(outputFrame, 0, 0);
+        outputFrame.close();
+        // Check the four quadrants
+        const pixelUL = outputContext.getImageData(width / 8, height / 8, 1, 1);
+        assertPixel(t, pixelUL.data, colorUL);
+        const pixelUR =
+            outputContext.getImageData(width * 3 / 8, height / 8, 1, 1);
+        assertPixel(t, pixelUR.data, colorUR);
+        const pixelLL =
+            outputContext.getImageData(width / 8, height * 3 / 8, 1, 1);
+        assertPixel(t, pixelLL.data, colorLL);
+        const pixelLR =
+            outputContext.getImageData(width * 3 / 8, height * 3 / 8, 1, 1);
+        assertPixel(t, pixelLR.data, colorLR);
+        break;
+      }
+    }, 'Tests that frames are sent correctly with RTCRtpEncodingParameters.scaleResolutionDownBy.');
+
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.worker-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Tests that VideoTrackGenerator forwards frames to sink
+PASS Tests that creating a VideoTrackGenerator works as expected
+PASS Tests that VideoFrames are destroyed on write.
+PASS Mismatched frame and generator kind throws on write.
+PASS Tests that VideoTrackGenerator forwards frames only when unmuted
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.worker.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.worker.js
@@ -1,0 +1,120 @@
+// META: title=VideoTrackGenerator tests.
+
+importScripts("/resources/testharness.js");
+
+const pixelColour = [50, 100, 150, 255];
+const height = 240;
+const width = 320;
+function makeVideoFrame(timestamp) {
+  const canvas = new OffscreenCanvas(width, height);
+
+  const ctx = canvas.getContext('2d', {alpha: false});
+  ctx.fillStyle = `rgba(${pixelColour.join()})`;
+  ctx.fillRect(0, 0, width, height);
+
+  return new VideoFrame(canvas, {timestamp, alpha: 'discard'});
+}
+
+promise_test(async t => {
+  const videoFrame = makeVideoFrame(1);
+  const originalWidth = videoFrame.displayWidth;
+  const originalHeight = videoFrame.displayHeight;
+  const originalTimestamp = videoFrame.timestamp;
+  const generator = new VideoTrackGenerator();
+  t.add_cleanup(() => generator.track.stop());
+
+  // Use a MediaStreamTrackProcessor as a sink for |generator| to verify
+  // that |processor| actually forwards the frames written to its writable
+  // field.
+  const processor = new MediaStreamTrackProcessor(generator);
+  const reader = processor.readable.getReader();
+  const readerPromise = new Promise(async resolve => {
+    const result = await reader.read();
+    t.add_cleanup(() => result.value.close());
+    t.step_func(() => {
+      assert_equals(result.value.displayWidth, originalWidth);
+      assert_equals(result.value.displayHeight, originalHeight);
+      assert_equals(result.value.timestamp, originalTimestamp);
+    })();
+    resolve();
+  });
+
+  generator.writable.getWriter().write(videoFrame);
+  return readerPromise;
+}, 'Tests that VideoTrackGenerator forwards frames to sink');
+
+promise_test(async t => {
+  const generator = new VideoTrackGenerator();
+  t.add_cleanup(() => generator.track.stop());
+
+  const writer = generator.writable.getWriter();
+  const frame = makeVideoFrame(1);
+  await writer.write(frame);
+
+  assert_equals(generator.track.kind, "video");
+  assert_equals(generator.track.readyState, "live");
+}, "Tests that creating a VideoTrackGenerator works as expected");
+
+promise_test(async t => {
+  const generator = new VideoTrackGenerator();
+  t.add_cleanup(() => generator.track.stop());
+
+  const writer = generator.writable.getWriter();
+  const frame = makeVideoFrame(1);
+  await writer.write(frame);
+
+  assert_throws_dom("InvalidStateError", () => frame.clone(), "VideoFrame wasn't destroyed on write.");
+}, "Tests that VideoFrames are destroyed on write.");
+
+promise_test(async t => {
+  const generator = new VideoTrackGenerator();
+  t.add_cleanup(() => generator.track.stop());
+
+  const writer = generator.writable.getWriter();
+  const frame = makeVideoFrame(1);
+  t.add_cleanup(() => frame.close());
+  assert_throws_js(TypeError, writer.write(frame));
+}, "Mismatched frame and generator kind throws on write.");
+
+promise_test(async t => {
+  const generator = new VideoTrackGenerator();
+  t.add_cleanup(() => generator.track.stop());
+
+  // Use a MediaStreamTrackProcessor as a sink for |generator| to verify
+  // that |processor| actually forwards the frames written to its writable
+  // field.
+  const processor = new MediaStreamTrackProcessor(generator);
+  const reader = processor.readable.getReader();
+  const videoFrame = makeVideoFrame(1);
+
+  const writer = generator.writable.getWriter();
+  const videoFrame1 = makeVideoFrame(1);
+  writer.write(videoFrame1);
+  const result1 = await reader.read();
+  t.add_cleanup(() => result1.value.close());
+  assert_equals(result1.value.timestamp, 1);
+  generator.muted = true;
+
+  // This frame is expected to be discarded.
+  const videoFrame2 = makeVideoFrame(2);
+  writer.write(videoFrame2);
+  generator.muted = false;
+
+  const videoFrame3 = makeVideoFrame(3);
+  writer.write(videoFrame3);
+  const result3 = await reader.read();
+  t.add_cleanup(() => result3.value.close());
+  assert_equals(result3.value.timestamp, 3);
+
+  // Set up a read ahead of time, then mute, enqueue and unmute.
+  const promise5 = reader.read();
+  generator.muted = true;
+  writer.write(makeVideoFrame(4)); // Expected to be discarded.
+  generator.muted = false;
+  writer.write(makeVideoFrame(5));
+  const result5 = await promise5;
+  t.add_cleanup(() => result5.value.close());
+  assert_equals(result5.value.timestamp, 5);
+}, 'Tests that VideoTrackGenerator forwards frames only when unmuted');
+
+done();

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2039,6 +2039,8 @@ webkit.org/b/252878 webrtc/video-h264.html [ Pass Timeout ]
 imported/w3c/web-platform-tests/mediacapture-streams/GUM-required-constraint-with-ideal-value.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-MediaElement-preload-none.https.html [ Pass Failure ]
 
+imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator-with-window-tracks.https.html [ Skip ]
+
 # In these tests only one canvas frame is pushed towards the sender webrtcbin,
 # this is not enough for the receiver webrtcbin to create its video source pad,
 # because on sender side we need at least a complete GOP... So the tests time


### PR DESCRIPTION
#### 238433662c5ea887ab6b2e539012b6df98dcf29d
<pre>
Migrate some WPT mediacapture-insertable-streams to latest API
<a href="https://bugs.webkit.org/show_bug.cgi?id=267995">https://bugs.webkit.org/show_bug.cgi?id=267995</a>
<a href="https://rdar.apple.com/121512704">rdar://121512704</a>

Reviewed by Jean-Yves Avenard.

Some tests in the tenative folder were using the old API proposal.
We migrate them to the new API.
Skip one of the new test in Glib since it is timing out.

* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-backpressure.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-backpressure.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-backpressure.worker.js: Added.
(makeUniformVideoFrame):
(promise_test.async t.async t):
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-with-window-tracks.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor-with-window-tracks.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/MediaStreamTrackProcessor.worker.js: Added.
(makeVideoFrame):
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator-with-window-tracks.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator-with-window-tracks.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.worker.js: Added.
(makeVideoFrame):
(promise_test.async t):
* LayoutTests/platform/glib/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/273497@main">https://commits.webkit.org/273497@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e5a4a72d1ab2cba7c6c7f8fcd57803fd7fa4cd9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38356 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32086 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11584 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10807 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10814 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39601 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36769 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11005 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34847 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12719 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31494 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8131 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11513 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->