### PR TITLE
[Glib] Getting stacktrace from systemd fails sometimes

### DIFF
--- a/Tools/Scripts/webkitpy/port/linux_get_crash_log.py
+++ b/Tools/Scripts/webkitpy/port/linux_get_crash_log.py
@@ -80,7 +80,7 @@ class GDBCrashLogGenerator(object):
                 time.sleep(1)
 
             try:
-                info = self._executive.run_command(coredumpctl + ['info', "--since=" + time.strftime("%a %Y-%m-%d %H:%M:%S %Z", time.localtime(self.newer_than))],
+                info = self._executive.run_command(coredumpctl + ['info', '--since=@%f' % self.newer_than],
                     return_stderr=True)
             except (ScriptError, OSError):
                 continue


### PR DESCRIPTION
#### a92146e5ba8f2bd1fcd843249aa9652e2852d922
<pre>
[Glib] Getting stacktrace from systemd fails sometimes
<a href="https://bugs.webkit.org/show_bug.cgi?id=267999">https://bugs.webkit.org/show_bug.cgi?id=267999</a>

Reviewed by Adrian Perez de Castro.

When `coredumpctl` is available, we use it to get the stacktrace.
The exact command executed is
`coredumpctl info --since=&quot;Wed 2024-01-24 14:48:45 CET&quot;`.

But sometimes it fails to parse the provided datetime:
```
$ coredumpctl info --since=&quot;Wed 2024-01-24 14:48:45 CET&quot;
Failed to parse timestamp &apos;Wed 2024-01-24 14:48:45 CET&apos;: Invalid argument
```

According to systemd documentation [1], we can pass the number of
seconds since the UNIX epoch prefixed with `@` instead.

[1] <a href="https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html">https://www.freedesktop.org/software/systemd/man/latest/systemd.time.html</a>

* Tools/Scripts/webkitpy/port/linux_get_crash_log.py:
(GDBCrashLogGenerator._get_trace_from_systemd):

Canonical link: <a href="https://commits.webkit.org/273408@main">https://commits.webkit.org/273408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb2fb4a3314ceeae5bf72521459eaec56585582d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38155 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31936 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11389 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12125 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31537 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10629 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/35645 "webkitpy-tests (failure)") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31655 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39402 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32186 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31986 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34683 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8085 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11359 "Built successfully") | | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/4562 "The change is no longer eligible for processing.") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->