### PR TITLE
Port JavaScriptCore/parser enums to new serialization format

### DIFF
--- a/Source/JavaScriptCore/parser/SourceProvider.h
+++ b/Source/JavaScriptCore/parser/SourceProvider.h
@@ -221,17 +221,3 @@ class UnlinkedFunctionCodeBlock;
 #endif
 
 } // namespace JSC
-
-namespace WTF {
-
-template<> struct EnumTraits<JSC::SourceTaintedOrigin> {
-    using values = EnumValues<
-        JSC::SourceTaintedOrigin,
-        JSC::SourceTaintedOrigin::Untainted,
-        JSC::SourceTaintedOrigin::IndirectlyTaintedByHistory,
-        JSC::SourceTaintedOrigin::IndirectlyTainted,
-        JSC::SourceTaintedOrigin::KnownTainted
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebKit/Shared/JavaScriptCore.serialization.in
+++ b/Source/WebKit/Shared/JavaScriptCore.serialization.in
@@ -48,3 +48,11 @@ enum class JSC::MessageLevel : uint8_t {
     Debug,
     Info,
 };
+
+header: <JavaScriptCore/SourceTaintedOrigin.h>
+enum class JSC::SourceTaintedOrigin : uint8_t {
+    Untainted,
+    IndirectlyTaintedByHistory,
+    IndirectlyTainted,
+    KnownTainted
+};


### PR DESCRIPTION
#### 840e8f70706ef6076a82934d37857c04ff0b4b09
<pre>
Port JavaScriptCore/parser enums to new serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=268002">https://bugs.webkit.org/show_bug.cgi?id=268002</a>

Reviewed by Alex Christensen.

Port JavaScriptCore/parser enums to new serialization format

* Source/JavaScriptCore/parser/SourceProvider.h:
* Source/WebKit/Shared/JavaScriptCore.serialization.in:

Canonical link: <a href="https://commits.webkit.org/273445@main">https://commits.webkit.org/273445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cf7c00177c799eea8b8da95d2a3c61d5e78a2c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38159 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31939 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30780 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10639 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10673 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39407 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/30047 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32191 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36643 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/35301 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8747 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34690 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12582 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/41957 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11362 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4579 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11642 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->