### PR TITLE
upload-file-to-url should print information about retry attempts live while it is running

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -4928,7 +4928,7 @@ class UploadFileToS3(shell.ShellCommandNewStyle, AddToLogMixin):
     flunkOnFailure = False
 
     def __init__(self, **kwargs):
-        super().__init__(timeout=30 * 60, logEnviron=False, **kwargs)
+        super().__init__(timeout=31 * 60, logEnviron=False, **kwargs)
 
     @defer.inlineCallbacks
     def run(self):

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -4738,7 +4738,7 @@ class TestUploadFileToS3(BuildStepMixinAdditions, unittest.TestCase):
                         env=dict(UPLOAD_URL='https://test-s3-url'),
                         logEnviron=False,
                         command=['python3', 'Tools/Scripts/upload-file-to-url', '--filename', 'WebKitBuild/release.zip'],
-                        timeout=1800,
+                        timeout=1860,
                         )
             + 0,
         )
@@ -4753,7 +4753,7 @@ class TestUploadFileToS3(BuildStepMixinAdditions, unittest.TestCase):
                         env=dict(UPLOAD_URL='https://test-s3-url'),
                         logEnviron=False,
                         command=['python3', 'Tools/Scripts/upload-file-to-url', '--filename', 'WebKitBuild/release.zip'],
-                        timeout=1800,
+                        timeout=1860,
                         )
             + ExpectShell.log('stdio', stdout='''Uploading WebKitBuild/release.zip
 response: <Response [403]>, 403, Forbidden

--- a/Tools/Scripts/upload-file-to-url
+++ b/Tools/Scripts/upload-file-to-url
@@ -36,39 +36,39 @@ import requests
 
 def upload(filename, url, max_attempts=3):
     if not os.path.isfile(filename):
-        print(f'ERROR: File not found: {filename}')
+        sys.stderr.write(f'ERROR: File not found: {filename}\n')
         return -1
 
     if not url: 
-        print(f'Error: missing url, either pass --url or set UPLOAD_URL environment variable.')
+        sys.stderr.write(f'Error: missing url, either pass --url or set UPLOAD_URL environment variable.\n')
         return -1
 
     filesize = os.stat(filename).st_size / 1024 / 1024;
-    print(f'Uploading {filename}, size: {filesize:.2f} MB')
+    sys.stderr.write(f'Uploading {filename}, size: {filesize:.2f} MB\n')
 
     with open(filename, 'rb') as f:
         try:
             data = f.read()
         except Exception as e:
-            print(f'Exception: {e}')
+            sys.stderr.write(f'Exception: {e}\n')
             return -1
 
         for attempt in range(1, max_attempts + 1):
             try:
                 response = requests.put(url, data=data, timeout=10*60)
-                print(f'Response: {response}, status_code: {response.status_code}, {response.reason}')
+                sys.stderr.write(f'Response: {response}, status_code: {response.status_code}, {response.reason}\n')
                 if response and response.status_code // 100 == 2:
                     return 0
             except Exception as e:
-                print(f'Exception: {e}')
+                sys.stderr.write(f'Exception: {e}\n')
 
             if attempt < max_attempts:
-                print(f'Retrying, attempt {attempt + 1} of {max_attempts}')
+                sys.stderr.write(f'Retrying, attempt {attempt + 1} of {max_attempts}\n')
         return -1
 
 
 def main():
-    print(f'Starting to upload')
+    sys.stderr.write(f'Starting to upload\n')
     parser = argparse.ArgumentParser(add_help=True)
     parser.add_argument('--filename', action="store", required=True, help='Path to the file. [path/to/123456.zip]')
     parser.add_argument('--url', action="store", required=False, help='url to upload to')


### PR DESCRIPTION
#### 80d432578269e9734ce838b30d89f2b9308821c5
<pre>
upload-file-to-url should print information about retry attempts live while it is running
<a href="https://bugs.webkit.org/show_bug.cgi?id=268004">https://bugs.webkit.org/show_bug.cgi?id=268004</a>

Reviewed by Jonathan Bedard.

Replace print with sys.stderr.write.
Also, increase timeout for upload-file-to-s3 step from 30 to 31 minutes so as to
allow the script to finish by itself (it has 3 retries of 10 minutes each).

* Tools/Scripts/upload-file-to-url:
* Tools/CISupport/ews-build/steps.py:
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/273416@main">https://commits.webkit.org/273416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f92ab2976a770be1a9f66aa1d948e0d01d9b69b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38168 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31948 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11403 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31549 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10640 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39416 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/31999 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10847 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/8757 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34693 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/35397 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11371 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4566 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->