### PR TITLE
[Gardening] `CSSStyleSheet-constructable-concat.html` is reftest and should not have '-expected.txt' file

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-concat-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-concat-expected.txt
@@ -1,4 +1,0 @@
-This should be green
-
-PASS adoptedStyleSheets should allow .concat on empty starting values
-


### PR DESCRIPTION
#### 0ae38a7f4c08fa8fbc9041e8cb52e5693eda0b1c
<pre>
[Gardening] `CSSStyleSheet-constructable-concat.html` is reftest and should not have &apos;-expected.txt&apos; file

<a href="https://bugs.webkit.org/show_bug.cgi?id=267997">https://bugs.webkit.org/show_bug.cgi?id=267997</a>

Reviewed by Anne van Kesteren.

The test is &apos;reftest&apos; and should not have `-expected.txt` file, this PR removes it.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-concat-expected.txt: Deleted

Canonical link: <a href="https://commits.webkit.org/273418@main">https://commits.webkit.org/273418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df4f87989af41d825affd2d3c68552ed38b59bc1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38179 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31956 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11414 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/35995 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/12145 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31561 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10651 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39427 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32206 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/32011 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36652 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34702 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11378 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4567 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->