### PR TITLE
[WGSL] Validate variable declarations

### DIFF
--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -975,6 +975,9 @@ Result<AST::VariableQualifier::Ref> Parser<Lexer>::parseVariableQualifier()
 
     AccessMode accessMode;
     if (current().type == TokenType::Comma) {
+        if (addressSpace != AddressSpace::Storage)
+            FAIL("only variables in the <storage> address space may specify an access mode"_s);
+
         consume();
         PARSE(actualAccessMode, AccessMode);
         accessMode = actualAccessMode;

--- a/Source/WebGPU/WGSL/tests/valid/attributes.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/attributes.wgsl
@@ -6,9 +6,9 @@ struct S {
     @size(4) z: i32,
 }
 
-@group(0) @binding(0) var x : i32;
+@group(0) @binding(0) var<storage> x : i32;
 
-@group(0) @binding(0) var y : i32;
+@group(0) @binding(0) var<storage> y : i32;
 
 // FIXME: we don't yet parse @id
 // @id(0) override z : i32;

--- a/Source/WebGPU/WGSL/tests/valid/constants.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/constants.wgsl
@@ -96,7 +96,7 @@ fn testPrimitiveStructAccess()
 // Attribute constants
 const group = 0;
 const binding = 1;
-@group(group) @binding(binding) var w: i32;
+@group(group) @binding(binding) var<storage> w: i32;
 
 const x = 8;
 const y = 4;


### PR DESCRIPTION
#### bbf7224ca0edd26f16133946978a64999c99cbfc
<pre>
[WGSL] Validate variable declarations
<a href="https://bugs.webkit.org/show_bug.cgi?id=268013">https://bugs.webkit.org/show_bug.cgi?id=268013</a>
<a href="https://rdar.apple.com/121435952">rdar://121435952</a>

Reviewed by Mike Wyrzykowski.

Add validation for variable declaration according to the spec [1]. This checks
that varibles have the correct attributes, variable initialization, etc.

[1]: <a href="https://www.w3.org/TR/WGSL/#var-and-value">https://www.w3.org/TR/WGSL/#var-and-value</a>

* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseVariableQualifier):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitVariable):

Canonical link: <a href="https://commits.webkit.org/273514@main">https://commits.webkit.org/273514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49d668ae932851dd544a81706d137b82ed0aa111

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38382 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11609 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31721 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10831 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39627 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32394 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/32197 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36790 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8920 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/34869 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12744 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8135 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->