### PR TITLE
[GLib] Open test results in default browser if MiniBrowser fails

### DIFF
--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -31,10 +31,12 @@
 import os
 import logging
 import shlex
+import webbrowser
 
 import webkitpy
 from webkitpy.common.system import path
 from webkitpy.common.memoized import memoized
+from webkitpy.common.system.executive import ScriptError
 from webkitpy.layout_tests.models.test_configuration import TestConfiguration
 from webkitpy.port.glib import GLibPort
 from webkitpy.port.xvfbdriver import XvfbDriver
@@ -156,7 +158,12 @@ class GtkPort(GLibPort):
         self._leakdetector.parse_and_print_leaks_detail(leaks_files)
 
     def show_results_html_file(self, results_filename):
-        self.run_minibrowser([path.abspath_to_uri(self.host.platform, results_filename)])
+        uri = path.abspath_to_uri(self.host.platform, results_filename)
+        try:
+            self.run_minibrowser([uri, ])
+        except ScriptError:
+            print('Failed to run Minibrowser, falling back to default browser')
+            webbrowser.open_new(uri)
 
     def check_sys_deps(self):
         return super(GtkPort, self).check_sys_deps() and self._driver_class().check_driver(self)


### PR DESCRIPTION
#### 5a1edfb8f5d46eb96615619b789d6eaf7fdc9928
<pre>
[GLib] Open test results in default browser if MiniBrowser fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=268015">https://bugs.webkit.org/show_bug.cgi?id=268015</a>

Reviewed by Adrian Perez de Castro.

If something goes wrong, which happens during development, it is
useful to see results in a different browser rather than nothing.

* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort.show_results_html_file):

Canonical link: <a href="https://commits.webkit.org/273490@main">https://commits.webkit.org/273490@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c076b70aa7c41f30a2ba8225956fe72cb5e73b92

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38246 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31970 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30829 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31581 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10709 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/35681 "Found 1 webkitpy python2 test failure: webkitpy.port.server_process_unittest.TestServerProcess.serial_test_basic") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10705 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39447 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32230 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32035 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36666 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10875 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34719 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12608 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/8125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11395 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4605 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11670 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->