### PR TITLE
[git-webkit revert] Add relationships between issues when reverting

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
@@ -20,7 +20,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import logging
 import re
 import sys
 import os
@@ -33,7 +32,7 @@ from .commit import Commit as CommitProgram
 
 from webkitbugspy import Tracker, bugzilla, radar
 from webkitcorepy import arguments, run, Terminal, string_utils
-from webkitscmpy import local, log, remote
+from webkitscmpy import local, log
 from ..commit import Commit
 
 
@@ -69,21 +68,25 @@ class Revert(Command):
     @classmethod
     def get_commit_info(cls, args, repository, **kwargs):
         commit_objects = []
-        commits_to_revert = []
-        commit_bugs = set()
+        commit_issues = {}
+
         for c in args.commit:
             try:
                 commit = repository.find(c, include_log=True)
             except (local.Scm.Exception, ValueError) as exception:
                 sys.stderr.write('Could not find "{}"'.format(c) + '\n')
                 return None, None, None
+
             commit_objects.append(commit)
-            commits_to_revert.append(commit.hash)
-            commit_bugs.update({Tracker.from_string(i.link) for i in commit.issues if isinstance(Tracker.from_string(i.link).tracker, bugzilla.Tracker)})
-        return commit_objects, commits_to_revert, commit_bugs
+            for i in commit.issues:
+                if not commit_issues.get(i.tracker.NAME, None):
+                    commit_issues[i.tracker.NAME] = set()
+                commit_issues[i.tracker.NAME].add(i)
+
+        return commit_objects, commit_issues
 
     @classmethod
-    def get_issue_info(cls, args, repository, commit_objects, commit_bugs, **kwargs):
+    def get_issue_info(cls, args, repository, commit_objects, commit_issues, **kwargs):
         # Can give either a bug URL or a title of the new issue
         if not args.issue and not args.reason:
             print('This issue will track the revert and should not be the issue of the commit(s) to be reverted.')
@@ -93,25 +96,27 @@ class Revert(Command):
             args.issue = args.reason
 
         issue = Tracker.from_string(args.issue)
-        commit_bugs_list = list(commit_bugs)
+
         if not issue.title:
             sys.stderr.write('Could not fetch {} from link. Please verify that the issue exists.\n'.format(issue.tracker.NAME))
             return None
 
+        # Create a new bug if no issue exists
         if not issue and Tracker.instance() and getattr(args, 'update_issue', True):
             if getattr(Tracker.instance(), 'credentials', None):
                 Tracker.instance().credentials(required=True, validate=True)
 
             # Automatically set project, component, and version of new bug
             print('Setting bug properties...')
-            commit_bug = commit_bugs_list.pop()
+            commit_issues_list = list(commit_issues.get(Tracker.instance().NAME))
+            commit_bug = commit_issues_list.pop()
             project = commit_bug.project
             component = commit_bug.component
             version = commit_bug.version
 
             # Check whether properties are the same if multiple commits are reverted
-            while len(commit_bugs_list):
-                commit_bug = commit_bugs_list.pop()
+            while len(commit_issues_list):
+                commit_bug = commit_issues_list.pop()
                 # Setting properties to None will prompt for user input
                 if commit_bug.project != project:
                     project = None
@@ -193,7 +198,8 @@ class Revert(Command):
         return commit_identifiers, revert_reason
 
     @classmethod
-    def revert_commit(cls, args, repository, issue, commit_objects, commit_bugs, commits_to_revert, revert_reason, **kwargs):
+    def revert_commit(cls, args, repository, issue, commit_objects, **kwargs):
+        commits_to_revert = [c.hash for c in commit_objects]
         result = run([repository.executable(), 'revert', '--no-commit'] + commits_to_revert, cwd=repository.root_path, capture_output=True)
         if result.returncode:
             # git revert will output nothing if this commit is already reverted
@@ -219,11 +225,29 @@ class Revert(Command):
             return 1
         log.info('Reverted {}'.format(', '.join(commits)))
 
-        # This should occur only after a successful revert.
-        for c_bug in commit_bugs:
-            # TODO: relate revert bug
-            c_bug.open(why="{}, tracking revert in {}".format(revert_reason, issue.link))
+        return 0
 
+    @classmethod
+    def relate_issues(cls, args, repository, issue, commit_issues, revert_reason):
+        log.info("Automatically relating issues...")
+        rdar = Branch.cc_radar(args, repository, issue)
+        if rdar:
+            log.info("Created {}".format(rdar))
+
+        for r_link in CommitProgram.bug_urls(issue):
+            r_issue = Tracker.from_string(r_link)
+            for c_issue in commit_issues.get(r_issue.tracker.NAME, []):
+                c_issue.open(why="Reopened {}.\n{}, tracking revert in {}.".format(r_issue.tracker.NAME, revert_reason, r_issue.link))
+                # Revert tracking bug blocks commit bugs, revert tracking radar caused by commit radars
+                if isinstance(c_issue.tracker, bugzilla.Tracker):
+                    r = r_issue.relate(blocks=c_issue)
+                elif isinstance(c_issue.tracker, radar.Tracker):
+                    try:
+                        r = c_issue.relate(cause_of=r_issue)
+                    except c_issue.radarclient().exceptions.UnsuccessfulResponseException:
+                        r = None
+                if not r:
+                    sys.stderr.write('Failed to relate {} and {}.\n'.format(c_issue.link, r_issue.link))
         return 0
 
     @classmethod
@@ -239,11 +263,11 @@ class Revert(Command):
         if not PullRequest.check_pull_request_args(repository, args):
             return 1
 
-        commit_objects, commits_to_revert, commit_bugs = cls.get_commit_info(args, repository, **kwargs)
+        commit_objects, commit_issues = cls.get_commit_info(args, repository, **kwargs)
         if not commit_objects:
             return 1
 
-        issue = cls.get_issue_info(args, repository, commit_objects, commit_bugs, **kwargs)
+        issue = cls.get_issue_info(args, repository, commit_objects, commit_issues, **kwargs)
         if not issue:
             return 1
 
@@ -255,12 +279,13 @@ class Revert(Command):
         if not branch_point:
             return 1
 
-        result = cls.revert_commit(args, repository, issue, commit_objects, commit_bugs, commits_to_revert, revert_reason, **kwargs)
-        if result:
-            return result
+        if cls.revert_commit(args, repository, issue, commit_objects, **kwargs):
+            return 1
 
-        if not args.pr:
-            return result
+        if cls.relate_issues(args, repository, issue, commit_issues, revert_reason):
+            return 1
 
-        return PullRequest.create_pull_request(repository, args, branch_point)
+        if args.pr:
+            return PullRequest.create_pull_request(repository, args, branch_point)
 
+        return 0

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
@@ -76,6 +76,7 @@ class TestRevert(testing.PathTestCase):
             [line for line in log if 'Mock process' not in line], [
                 "Creating the local development branch 'eng/Example-feature-1'...",
                 'Reverted 5@main',
+                'Automatically relating issues...',
                 "Rebasing 'eng/Example-feature-1' on 'main'...",
                 "Rebased 'eng/Example-feature-1' on 'main!'",
                 'Running pre-PR checks...',
@@ -127,6 +128,7 @@ class TestRevert(testing.PathTestCase):
             [line for line in log if 'Mock process' not in line], [
                 "Creating the local development branch 'eng/Example-feature-1'...",
                 'Reverted 5@main',
+                'Automatically relating issues...',
                 'Using committed changes...',
                 "Rebasing 'eng/Example-feature-1' on 'main'...",
                 "Rebased 'eng/Example-feature-1' on 'main!'",
@@ -177,6 +179,7 @@ class TestRevert(testing.PathTestCase):
             [line for line in log if 'Mock process' not in line], [
                 "Creating the local development branch 'eng/Example-feature-1'...",
                 'Reverted 5@main',
+                'Automatically relating issues...',
                 'Using committed changes...',
                 "Rebasing 'eng/Example-feature-1' on 'main'...",
                 "Rebased 'eng/Example-feature-1' on 'main!'",
@@ -255,6 +258,7 @@ index 05e8751..0bf3c85 100644
             [line for line in log if 'Mock process' not in line], [
                 "Creating the local development branch 'eng/Example-feature-1'...",
                 'Reverted 5@main',
+                'Automatically relating issues...',
                 "Rebasing 'eng/Example-feature-1' on 'main'...",
                 "Rebased 'eng/Example-feature-1' on 'main!'",
                 'Running pre-PR checks...',


### PR DESCRIPTION
#### e177e893ff985e413c4991ebe1d79c2a4f704c5c
<pre>
[git-webkit revert] Add relationships between issues when reverting
<a href="https://bugs.webkit.org/show_bug.cgi?id=267276">https://bugs.webkit.org/show_bug.cgi?id=267276</a>
<a href="https://rdar.apple.com/120723182">rdar://120723182</a>

Reviewed by Jonathan Bedard.

Adds &apos;blocks&apos; relationship between bugs and &apos;cause of&apos; relationship between radars.
This happens after reverting so the issues are only changed with a successful revert.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py:
(Revert.get_commit_info):
(Revert.get_issue_info):
(Revert):
(Revert.relate_issues):
(Revert.main):

Canonical link: <a href="https://commits.webkit.org/275111@main">https://commits.webkit.org/275111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/846330929f067dfe320bcb6107bae6bfefc2afe6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43151 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36687 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16942 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33683 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34999 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14268 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/40468 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14343 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44424 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36812 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40039 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38370 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/40645 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17032 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9187 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17083 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16676 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->