### PR TITLE
[JSC] Computed property keys of class fields should not be reparsed

### DIFF
--- a/JSTests/stress/class-fields-static-harmony.js
+++ b/JSTests/stress/class-fields-static-harmony.js
@@ -266,6 +266,20 @@ load("./resources/harmony-support.js");
   assertTrue(C.c instanceof C);
 }
 
+{
+  class C {
+    static c = new C();
+  }
+
+  assertTrue(C.c instanceof C);
+}
+
+assertThrows(() => {
+  eval(`class C {
+    static c = "foo", "bar";
+  }`);
+}, SyntaxError);
+
 (function test() {
   function makeC() {
     var x = 1;

--- a/JSTests/stress/regress-268019.js
+++ b/JSTests/stress/regress-268019.js
@@ -1,0 +1,35 @@
+function shouldBe(actual, expected) {
+  if (actual !== expected)
+    throw new Error(`Bad value: ${actual}!`);
+}
+
+async function instanceFieldTest() {
+  class C {
+    [await Promise.resolve(1)] = 1;
+  }
+
+  return (new C)[await Promise.resolve(1)];
+}
+
+async function* staticFieldTest() {
+  class C {
+    static [await Promise.resolve(2)] = 2;
+  }
+
+  return C[await Promise.resolve(2)];
+}
+
+let instanceFieldValue;
+instanceFieldTest().then(value => {
+  instanceFieldValue = value;
+});
+
+let staticFieldValue;
+staticFieldTest().next().then(({value}) => {
+  staticFieldValue = value;
+});
+
+drainMicrotasks();
+
+shouldBe(instanceFieldValue, 1);
+shouldBe(staticFieldValue, 2);

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -960,12 +960,6 @@ test/language/expressions/call/tco-non-eval-global.js:
   default: 'RangeError: Maximum call stack size exceeded.'
 test/language/expressions/call/tco-non-eval-with.js:
   default: 'RangeError: Maximum call stack size exceeded.'
-test/language/expressions/class/cpn-class-expr-fields-computed-property-name-from-yield-expression.js:
-  default: "SyntaxError: Unexpected keyword 'yield'. Cannot use yield expression out of generator."
-  strict mode: "SyntaxError: Unexpected keyword 'yield'. Cannot use yield expression out of generator."
-test/language/expressions/class/cpn-class-expr-fields-methods-computed-property-name-from-yield-expression.js:
-  default: "SyntaxError: Unexpected keyword 'yield'. Cannot use yield expression out of generator."
-  strict mode: "SyntaxError: Unexpected keyword 'yield'. Cannot use yield expression out of generator."
 test/language/expressions/class/elements/arrow-body-direct-eval-err-contains-arguments.js:
   default: 'Test262Error: Expected a SyntaxError but got a ReferenceError'
   strict mode: 'Test262Error: Expected a SyntaxError but got a ReferenceError'
@@ -1147,12 +1141,6 @@ test/language/statements/async-generator/yield-star-promise-not-unwrapped.js:
 test/language/statements/async-generator/yield-star-return-then-getter-ticks.js:
   default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected [start, tick 1, tick 2, get then, tick 3, get return, get then] and [start, tick 1, get then, tick 2, get return, get then, tick 3] to have the same contents. Ticks for return with thenable getter'
   strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected [start, tick 1, tick 2, get then, tick 3, get return, get then] and [start, tick 1, get then, tick 2, get return, get then, tick 3] to have the same contents. Ticks for return with thenable getter'
-test/language/statements/class/cpn-class-decl-fields-computed-property-name-from-yield-expression.js:
-  default: "SyntaxError: Unexpected keyword 'yield'. Cannot use yield expression out of generator."
-  strict mode: "SyntaxError: Unexpected keyword 'yield'. Cannot use yield expression out of generator."
-test/language/statements/class/cpn-class-decl-fields-methods-computed-property-name-from-yield-expression.js:
-  default: "SyntaxError: Unexpected keyword 'yield'. Cannot use yield expression out of generator."
-  strict mode: "SyntaxError: Unexpected keyword 'yield'. Cannot use yield expression out of generator."
 test/language/statements/class/definition/fn-length-static-precedence-order.js:
   default: 'Test262Error: Expected [name, prototype, method, length] and [length, name, prototype, method] to have the same contents. '
   strict mode: 'Test262Error: Expected [name, prototype, method, length] and [length, name, prototype, method] to have the same contents. '

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp
@@ -55,9 +55,9 @@ static UnlinkedFunctionCodeBlock* generateUnlinkedFunctionCodeBlock(
     JSParserStrictMode strictMode = executable->isInStrictContext() ? JSParserStrictMode::Strict : JSParserStrictMode::NotStrict;
     JSParserScriptMode scriptMode = executable->scriptMode();
     ASSERT(isFunctionParseMode(executable->parseMode()));
-    auto* classFieldLocations = executable->classFieldLocations();
+    auto* classElementDefinitions = executable->classElementDefinitions();
     std::unique_ptr<FunctionNode> function = parse<FunctionNode>(
-        vm, source, executable->name(), executable->implementationVisibility(), builtinMode, strictMode, scriptMode, executable->parseMode(), executable->functionMode(), executable->superBinding(), error, nullptr, ConstructorKind::None, DerivedContextType::None, EvalContextType::None, nullptr, nullptr, classFieldLocations);
+        vm, source, executable->name(), executable->implementationVisibility(), builtinMode, strictMode, scriptMode, executable->parseMode(), executable->functionMode(), executable->superBinding(), error, nullptr, ConstructorKind::None, DerivedContextType::None, EvalContextType::None, nullptr, nullptr, classElementDefinitions);
 
     if (!function) {
         ASSERT(error.isValid());

--- a/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h
@@ -224,6 +224,22 @@ public:
 
     void finalizeUnconditionally(VM&, CollectionScope);
 
+    struct ClassElementDefinition {
+        WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+        enum class Kind : uint8_t {
+            FieldWithLiteralPropertyKey = 0,
+            FieldWithComputedPropertyKey = 1,
+            FieldWithPrivatePropertyKey = 2,
+            StaticInitializationBlock = 3,
+        };
+
+        Identifier ident { };
+        JSTextPosition position { };
+        std::optional<JSTextPosition> initializerPosition { std::nullopt };
+        Kind kind { Kind::FieldWithLiteralPropertyKey };
+    };
+
     struct RareData {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
@@ -232,24 +248,24 @@ public:
         String m_sourceMappingURLDirective;
         RefPtr<TDZEnvironmentLink> m_parentScopeTDZVariables;
         FixedVector<Identifier> m_generatorOrAsyncWrapperFunctionParameterNames;
-        FixedVector<JSTextPosition> m_classFieldLocations;
+        FixedVector<ClassElementDefinition> m_classElementDefinitions;
         PrivateNameEnvironment m_parentPrivateNameEnvironment;
     };
 
     NeedsClassFieldInitializer needsClassFieldInitializer() const { return static_cast<NeedsClassFieldInitializer>(m_needsClassFieldInitializer); }
 
-    const FixedVector<JSTextPosition>* classFieldLocations() const
+    const FixedVector<ClassElementDefinition>* classElementDefinitions() const
     {
         if (m_rareData)
-            return &m_rareData->m_classFieldLocations;
+            return &m_rareData->m_classElementDefinitions;
         return nullptr;
     }
 
-    void setClassFieldLocations(Vector<JSTextPosition>&& classFieldLocations)
+    void setClassElementDefinitions(Vector<ClassElementDefinition>&& classElementDefinitions)
     {
-        if (classFieldLocations.isEmpty())
+        if (classElementDefinitions.isEmpty())
             return;
-        ensureRareData().m_classFieldLocations = FixedVector<JSTextPosition>(WTFMove(classFieldLocations));
+        ensureRareData().m_classElementDefinitions = FixedVector<ClassElementDefinition>(WTFMove(classElementDefinitions));
     }
 
 private:

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -3421,7 +3421,7 @@ RegisterID* BytecodeGenerator::emitNewDefaultConstructor(RegisterID* dst, Constr
     return dst;
 }
 
-RegisterID* BytecodeGenerator::emitNewClassFieldInitializerFunction(RegisterID* dst, Vector<JSTextPosition>&& classFieldLocations, bool isDerived)
+RegisterID* BytecodeGenerator::emitNewClassFieldInitializerFunction(RegisterID* dst, Vector<UnlinkedFunctionExecutable::ClassElementDefinition>&& classElementDefinitions, bool isDerived)
 {
     DerivedContextType newDerivedContextType;
     SuperBinding superBinding;
@@ -3441,7 +3441,7 @@ RegisterID* BytecodeGenerator::emitNewClassFieldInitializerFunction(RegisterID* 
     FunctionMetadataNode metadata(parserArena(), JSTokenLocation(), JSTokenLocation(), 0, 0, 0, 0, 0, ImplementationVisibility::Private, StrictModeLexicalFeature, ConstructorKind::None, superBinding, 0, parseMode, false);
     metadata.finishParsing(m_scopeNode->source(), Identifier(), FunctionMode::MethodDefinition);
     auto initializer = UnlinkedFunctionExecutable::create(m_vm, m_scopeNode->source(), &metadata, isBuiltinFunction() ? UnlinkedBuiltinFunction : UnlinkedNormalFunction, constructAbility, InlineAttribute::Always, scriptMode(), WTFMove(variablesUnderTDZ), { }, WTFMove(parentPrivateNameEnvironment), newDerivedContextType, NeedsClassFieldInitializer::No, PrivateBrandRequirement::None);
-    initializer->setClassFieldLocations(WTFMove(classFieldLocations));
+    initializer->setClassElementDefinitions(WTFMove(classElementDefinitions));
 
     unsigned index = m_codeBlock->addFunctionExpr(initializer);
     OpNewFuncExp::emit(this, dst, scopeRegister(), index);

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -548,14 +548,14 @@ namespace JSC {
             return emitNodeInTailPosition(nullptr, n);
         }
 
-        RegisterID* emitDefineClassElements(PropertyListNode* n, RegisterID* constructor, RegisterID* prototype, Vector<JSTextPosition>& instanceFieldLocations, Vector<JSTextPosition>& staticFieldLocations)
+        RegisterID* emitDefineClassElements(PropertyListNode* n, RegisterID* constructor, RegisterID* prototype, Vector<UnlinkedFunctionExecutable::ClassElementDefinition>& instanceElementDefinitions, Vector<UnlinkedFunctionExecutable::ClassElementDefinition>& staticElementDefinitions)
         {
             ASSERT(constructor->refCount() && prototype->refCount());
             if (UNLIKELY(!m_vm.isSafeToRecurse()))
                 return emitThrowExpressionTooDeepException();
             if (UNLIKELY(n->needsDebugHook()))
                 emitDebugHook(n);
-            return n->emitBytecode(*this, constructor, prototype, &instanceFieldLocations, &staticFieldLocations);
+            return n->emitBytecode(*this, constructor, prototype, &instanceElementDefinitions, &staticElementDefinitions);
         }
 
         RegisterID* emitNodeForProperty(RegisterID* dst, ExpressionNode* node)
@@ -730,7 +730,7 @@ namespace JSC {
         RegisterID* emitNewFunction(RegisterID* dst, FunctionMetadataNode*);
         RegisterID* emitNewFunctionExpression(RegisterID* dst, FuncExprNode*);
         RegisterID* emitNewDefaultConstructor(RegisterID* dst, ConstructorKind, const Identifier& name, const Identifier& ecmaName, const SourceCode& classSource, NeedsClassFieldInitializer, PrivateBrandRequirement);
-        RegisterID* emitNewClassFieldInitializerFunction(RegisterID* dst, Vector<JSTextPosition>&& classFieldLocations, bool isDerived);
+        RegisterID* emitNewClassFieldInitializerFunction(RegisterID* dst, Vector<UnlinkedFunctionExecutable::ClassElementDefinition>&&, bool isDerived);
         RegisterID* emitNewArrowFunctionExpression(RegisterID*, ArrowFuncExprNode*);
         RegisterID* emitNewMethodDefinition(RegisterID* dst, MethodDefinitionNode*);
         RegisterID* emitNewRegExp(RegisterID* dst, RegExp*);

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -414,7 +414,7 @@ public:
         return node;
     }
 
-    DefineFieldNode* createDefineField(const JSTokenLocation& location, const Identifier* ident, ExpressionNode* initializer, DefineFieldNode::Type type)
+    DefineFieldNode* createDefineField(const JSTokenLocation& location, const Identifier& ident, ExpressionNode* initializer, DefineFieldNode::Type type)
     {
         return new (m_parserArena) DefineFieldNode(location, ident, initializer, type);
     }

--- a/Source/JavaScriptCore/parser/NodeConstructors.h
+++ b/Source/JavaScriptCore/parser/NodeConstructors.h
@@ -1075,7 +1075,7 @@ namespace JSC {
     {
     }
 
-    inline DefineFieldNode::DefineFieldNode(const JSTokenLocation& location, const Identifier* ident, ExpressionNode* assign, Type type)
+    inline DefineFieldNode::DefineFieldNode(const JSTokenLocation& location, const Identifier& ident, ExpressionNode* assign, Type type)
         : StatementNode(location)
         , m_ident(ident)
         , m_assign(assign)

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -35,6 +35,7 @@
 #include "ResultType.h"
 #include "SourceCode.h"
 #include "SymbolTable.h"
+#include "UnlinkedFunctionExecutable.h"
 #include "VariableEnvironment.h"
 #include <wtf/MathExtras.h>
 #include <wtf/SmallSet.h>
@@ -832,7 +833,7 @@ namespace JSC {
 
         static bool shouldCreateLexicalScopeForClass(PropertyListNode*);
 
-        RegisterID* emitBytecode(BytecodeGenerator&, RegisterID*, RegisterID*, Vector<JSTextPosition>*, Vector<JSTextPosition>*);
+        RegisterID* emitBytecode(BytecodeGenerator&, RegisterID*, RegisterID*, Vector<UnlinkedFunctionExecutable::ClassElementDefinition>*, Vector<UnlinkedFunctionExecutable::ClassElementDefinition>*);
 
         void emitDeclarePrivateFieldNames(BytecodeGenerator&, RegisterID* scope);
 
@@ -2421,14 +2422,14 @@ namespace JSC {
     class DefineFieldNode final : public StatementNode {
     public:
         enum class Type { Name, PrivateName, ComputedName };
-        DefineFieldNode(const JSTokenLocation&, const Identifier*, ExpressionNode*, Type);
+        DefineFieldNode(const JSTokenLocation&, const Identifier&, ExpressionNode*, Type);
 
     private:
         void emitBytecode(BytecodeGenerator&, RegisterID* destination = nullptr) final;
 
         bool isDefineFieldNode() const final { return true; }
 
-        const Identifier* m_ident;
+        Identifier m_ident;
         ExpressionNode* m_assign;
         Type m_type;
     };

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -222,7 +222,7 @@ static ALWAYS_INLINE bool isPrivateFieldName(UniquedStringImpl* uid)
 }
 
 template <typename LexerType>
-Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>::parseInner(const Identifier& calleeName, ParsingContext parsingContext, std::optional<int> functionConstructorParametersEndPosition, const FixedVector<JSTextPosition>* classFieldLocations, const PrivateNameEnvironment* parentScopePrivateNames)
+Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>::parseInner(const Identifier& calleeName, ParsingContext parsingContext, std::optional<int> functionConstructorParametersEndPosition, const FixedVector<UnlinkedFunctionExecutable::ClassElementDefinition>* classElementDefinitions, const PrivateNameEnvironment* parentScopePrivateNames)
 {
     ASTBuilder context(const_cast<VM&>(m_vm), m_parserArena, const_cast<SourceCode*>(m_source));
     SourceParseMode parseMode = sourceParseMode();
@@ -288,8 +288,8 @@ Expected<typename Parser<LexerType>::ParseInnerResult, String> Parser<LexerType>
         else if (parsingContext == ParsingContext::FunctionConstructor)
             sourceElements = parseSingleFunction(context, functionConstructorParametersEndPosition);
         else if (parseMode == SourceParseMode::ClassFieldInitializerMode) {
-            ASSERT(classFieldLocations && !classFieldLocations->isEmpty());
-            sourceElements = parseClassFieldInitializerSourceElements(context, *classFieldLocations);
+            ASSERT(classElementDefinitions && !classElementDefinitions->isEmpty());
+            sourceElements = parseClassFieldInitializerSourceElements(context, *classElementDefinitions);
         } else
             sourceElements = parseSourceElements(context, CheckForStrictMode);
     }
@@ -3278,90 +3278,26 @@ parseMethod:
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseClassFieldInitializerSourceElements(TreeBuilder& context, const FixedVector<JSTextPosition>& classFieldLocations)
+template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseClassFieldInitializerSourceElements(TreeBuilder& context, const FixedVector<UnlinkedFunctionExecutable::ClassElementDefinition>& classElementDefinitions)
 {
+    using Kind = UnlinkedFunctionExecutable::ClassElementDefinition::Kind;
+
     TreeSourceElements sourceElements = context.createSourceElements();
     currentScope()->setIsClassScope();
 
-    unsigned numComputedFields = 0;
-    for (auto location : classFieldLocations) {
-        // This loop will either parse only static fields or only
-        // instance fields, but never a mix; we could make it slightly
-        // smarter about parsing given that fact, but it's probably
-        // not worth the hassle, so begin each iteration without
-        // knowing which kind the next field will be.
-        bool isStaticField = false;
-        // We don't need to worry about hasLineTerminatorBeforeToken
-        // on class fields, so we set this value to false.
-        LexerState lexerState { location.offset, static_cast<unsigned>(location.lineStartOffset), static_cast<unsigned>(location.line), static_cast<unsigned>(location.line), false };
-        restoreLexerState(lexerState);
-
-        JSTokenLocation fieldLocation = tokenLocation();
-        const Identifier* ident = nullptr;
-        DefineFieldNode::Type type = DefineFieldNode::Type::Name;
-
-        if (match(RESERVED_IF_STRICT) && *m_token.m_data.ident == m_vm.propertyNames->staticKeyword) {
-            auto* staticIdentifier = m_token.m_data.ident;
-            ASSERT(staticIdentifier);
-            next();
-            if (match(SEMICOLON) || match (EQUAL) || match(CLOSEBRACE) || m_lexer->hasLineTerminatorBeforeToken())
-                ident = staticIdentifier;
-            else
-                isStaticField = true;
-        }
-
-        if (!ident) {
-            switch (m_token.m_type) {
-            case PRIVATENAME:
-                type = DefineFieldNode::Type::PrivateName;
-                FALLTHROUGH;
-            case STRING:
-            case IDENT:
-            namedKeyword:
-                ident = m_token.m_data.ident;
-                ASSERT(ident);
-                next();
-                break;
-            case BIGINT:
-                ident = m_parserArena.identifierArena().makeBigIntDecimalIdentifier(const_cast<VM&>(m_vm), *m_token.m_data.bigIntString, m_token.m_data.radix);
-                failIfFalse(ident, "Cannot parse big int property name");
-                next();
-                break;
-            case DOUBLE:
-            case INTEGER:
-                ident = &m_parserArena.identifierArena().makeNumericIdentifier(const_cast<VM&>(m_vm), m_token.m_data.doubleValue);
-                ASSERT(ident);
-                next();
-                break;
-            case OPENBRACKET: {
-                next();
-                TreeExpression computedPropertyName = parseAssignmentExpression(context);
-                failIfFalse(computedPropertyName, "Cannot parse computed property name");
-                handleProductionOrFail(CLOSEBRACKET, "]", "end", "computed property name");
-                ident = &m_parserArena.identifierArena().makePrivateIdentifier(m_vm,
-                    isStaticField ? staticComputedNamePrefix : instanceComputedNamePrefix,
-                    numComputedFields++);
-                type = DefineFieldNode::Type::ComputedName;
-                break;
-            }
-            case OPENBRACE:
-                RELEASE_ASSERT(isStaticField);
-                break;
-            default:
-                if (m_token.m_type & KeywordTokenFlag)
-                    goto namedKeyword;
-                failDueToUnexpectedToken();
-            }
-        }
-
-        // Only valid class fields are handled in this function.
-        ASSERT(match(EQUAL) || match(SEMICOLON) || match(CLOSEBRACE) || match(OPENBRACE) || m_lexer->hasLineTerminatorBeforeToken());
+    for (auto definition : classElementDefinitions) {
+        auto position = definition.position;
+        bool hasLineTerminatorBeforeToken = false;
 
         TreeStatement statement;
-        if (match(OPENBRACE) && isStaticField) {
-            JSTextPosition startPosition = tokenStartPosition();
+        if (definition.kind == Kind::StaticInitializationBlock) {
+            restoreLexerState(LexerState { position.offset, static_cast<unsigned>(position.lineStartOffset), static_cast<unsigned>(position.line), static_cast<unsigned>(position.line), hasLineTerminatorBeforeToken });
             JSTokenLocation startLocation(tokenLocation());
+            JSTextPosition startPosition = tokenStartPosition();
             unsigned expressionStart = tokenStart();
+
+            ASSERT(match(RESERVED_IF_STRICT) && *m_token.m_data.ident == m_vm.propertyNames->staticKeyword);
+            next();
 
             ParserFunctionInfo<TreeBuilder> functionInfo;
             functionInfo.name = &m_vm.propertyNames->nullIdentifier;
@@ -3369,20 +3305,34 @@ template <class TreeBuilder> TreeSourceElements Parser<LexerType>::parseClassFie
             failIfFalse((parseFunctionInfo(context, FunctionNameRequirements::None, false, ConstructorKind::None, SuperBinding::Needed, expressionStart, functionInfo, FunctionDefinitionType::Expression)), "Cannot parse static block function");
             TreeExpression expression = context.createFunctionExpr(startLocation, functionInfo);
 
-            JSTextPosition endPosition = lastTokenEndPosition();
-            expression = context.makeStaticBlockFunctionCallNode(startLocation, expression, endPosition, startPosition, lastTokenEndPosition());
-
+            expression = context.makeStaticBlockFunctionCallNode(startLocation, expression, lastTokenEndPosition(), startPosition, lastTokenEndPosition());
             statement = context.createExprStatement(startLocation, expression, startPosition, m_lastTokenEndPosition.line);
         } else {
+            JSTokenLocation location;
+            location.line = position.line;
+            location.lineStartOffset = position.lineStartOffset;
+            location.startOffset = position.offset;
+
             TreeExpression initializer = 0;
-            if (consume(EQUAL))
-                initializer = parseAssignmentExpression(context);
+            if (auto initializerPosition = definition.initializerPosition) {
+                restoreLexerState(LexerState { initializerPosition->offset, static_cast<unsigned>(initializerPosition->lineStartOffset), static_cast<unsigned>(initializerPosition->line), static_cast<unsigned>(initializerPosition->line), hasLineTerminatorBeforeToken });
+                // parseExpression() is more permissive way to parse AssignmentExpression than parseAssignmentExpression() that is used in parseClass().
+                // This is very intentional: we need to fail for `foo = 1, 2` but support reparsing `foo = (1, 2)`, which is tricky because open paren
+                // is skipped (meaning start offset points to `1`) by parsePrimaryExpression().
+                initializer = parseExpression(context);
+            }
 
-            if (type == DefineFieldNode::Type::PrivateName)
-                currentScope()->useVariable(ident, false);
+            DefineFieldNode::Type type = DefineFieldNode::Type::Name;
+            if (definition.kind == Kind::FieldWithComputedPropertyKey)
+                type = DefineFieldNode::Type::ComputedName;
+            else if (definition.kind == Kind::FieldWithPrivatePropertyKey) {
+                type = DefineFieldNode::Type::PrivateName;
+                currentScope()->useVariable(definition.ident.impl(), false);
+            }
 
-            statement = context.createDefineField(fieldLocation, ident, initializer, type);
+            statement = context.createDefineField(location, definition.ident, initializer, type);
         }
+
         context.appendStatement(sourceElements, statement);
     }
 

--- a/Source/JavaScriptCore/parser/SyntaxChecker.h
+++ b/Source/JavaScriptCore/parser/SyntaxChecker.h
@@ -257,7 +257,7 @@ public:
     int createClauseList(int) { return ClauseListResult; }
     int createClauseList(int, int) { return ClauseListResult; }
     int createFuncDeclStatement(const JSTokenLocation&, const ParserFunctionInfo<SyntaxChecker>&) { return StatementResult; }
-    int createDefineField(const JSTokenLocation&, const Identifier*, int, DefineFieldNode::Type) { return 0; }
+    int createDefineField(const JSTokenLocation&, const Identifier&, int, DefineFieldNode::Type) { return 0; }
     int createClassDeclStatement(const JSTokenLocation&, ClassExpression,
         const JSTextPosition&, const JSTextPosition&, int, int) { return StatementResult; }
     int createBlockStatement(const JSTokenLocation&, int, int, int, VariableEnvironment&&, DeclarationStacks::FunctionStack&&) { return StatementResult; }

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -1768,6 +1768,51 @@ private:
     CachedRefPtr<CachedTDZEnvironmentLink> m_parent;
 };
 
+class CachedJSTextPosition : public CachedObject<JSTextPosition> {
+public:
+    void encode(Encoder&, const JSTextPosition& position)
+    {
+        m_line = position.line;
+        m_offset = position.offset;
+        m_lineStartOffset = position.lineStartOffset;
+    }
+
+    JSTextPosition decode(Decoder&) const
+    {
+        return JSTextPosition { m_line, m_offset, m_lineStartOffset };
+    }
+
+private:
+    int m_line;
+    int m_offset;
+    int m_lineStartOffset;
+};
+
+class CachedClassElementDefinition : public CachedObject<UnlinkedFunctionExecutable::ClassElementDefinition> {
+public:
+    void encode(Encoder& encoder, const UnlinkedFunctionExecutable::ClassElementDefinition& definition)
+    {
+        m_ident.encode(encoder, definition.ident);
+        m_position.encode(encoder, definition.position);
+        m_initializerPosition.encode(encoder, definition.initializerPosition);
+        m_kind = static_cast<uint8_t>(definition.kind);
+    }
+
+    void decode(Decoder& decoder, UnlinkedFunctionExecutable::ClassElementDefinition& definition) const
+    {
+        definition.ident = m_ident.decode(decoder);
+        definition.position = m_position.decode(decoder);
+        definition.initializerPosition = m_initializerPosition.decode(decoder);
+        definition.kind = static_cast<UnlinkedFunctionExecutable::ClassElementDefinition::Kind>(m_kind);
+    }
+
+private:
+    CachedIdentifier m_ident;
+    CachedJSTextPosition m_position;
+    CachedOptional<CachedJSTextPosition> m_initializerPosition;
+    uint8_t m_kind;
+};
+
 class CachedFunctionExecutableRareData : public CachedObject<UnlinkedFunctionExecutable::RareData> {
 public:
     void encode(Encoder& encoder, const UnlinkedFunctionExecutable::RareData& rareData)
@@ -1775,7 +1820,7 @@ public:
         m_classSource.encode(encoder, rareData.m_classSource);
         m_parentScopeTDZVariables.encode(encoder, rareData.m_parentScopeTDZVariables);
         m_generatorOrAsyncWrapperFunctionParameterNames.encode(encoder, rareData.m_generatorOrAsyncWrapperFunctionParameterNames);
-        m_classFieldLocations.encode(encoder, rareData.m_classFieldLocations);
+        m_classElementDefinitions.encode(encoder, rareData.m_classElementDefinitions);
         m_parentPrivateNameEnvironment.encode(encoder, rareData.m_parentPrivateNameEnvironment);
     }
 
@@ -1785,7 +1830,7 @@ public:
         m_classSource.decode(decoder, rareData->m_classSource);
         m_parentScopeTDZVariables.decode(decoder, rareData->m_parentScopeTDZVariables);
         m_generatorOrAsyncWrapperFunctionParameterNames.decode(decoder, rareData->m_generatorOrAsyncWrapperFunctionParameterNames);
-        m_classFieldLocations.decode(decoder, rareData->m_classFieldLocations);
+        m_classElementDefinitions.decode(decoder, rareData->m_classElementDefinitions);
         m_parentPrivateNameEnvironment.decode(decoder, rareData->m_parentPrivateNameEnvironment);
         return rareData;
     }
@@ -1794,7 +1839,7 @@ private:
     CachedSourceCodeWithoutProvider m_classSource;
     CachedRefPtr<CachedTDZEnvironmentLink> m_parentScopeTDZVariables;
     CachedVector<CachedIdentifier> m_generatorOrAsyncWrapperFunctionParameterNames;
-    CachedVector<JSTextPosition> m_classFieldLocations;
+    CachedVector<CachedClassElementDefinition> m_classElementDefinitions;
     CachedPrivateNameEnvironment m_parentPrivateNameEnvironment;
 };
 


### PR DESCRIPTION
#### 5553144b15b75352aa94ccf50c26b100bb4c2d10
<pre>
[JSC] Computed property keys of class fields should not be reparsed
<a href="https://bugs.webkit.org/show_bug.cgi?id=268019">https://bugs.webkit.org/show_bug.cgi?id=268019</a>
&lt;<a href="https://rdar.apple.com/121538219">rdar://121538219</a>&gt;

Reviewed by Justin Michaud.

Please consider the following code:

```
async function foo() {
    class C {
        [await &quot;foo&quot;] = 42;
    }
}
```

Before this change, we were remembering JSTextPosition of `[` and reparsing the whole line,
which led to SyntaxError since the context of having a parent async function scope was lost.
On top of that, reparsing identifier isn&apos;t very efficient and caused logic duplication.

With this change, we are remembering the identifier itself (in case of computed property key,
a private symbol with an ID: please see makePrivateIdentifier()) and JSTextPosition that comes
after `=`.

DefineFieldNode is tweaked to prevent identifier from being GCed.

* JSTests/stress/class-fields-static-harmony.js:
* JSTests/stress/regress-268019.js: Added.
* JSTests/test262/expectations.yaml: Mark 8 tests as passing.
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.cpp:
(JSC::generateUnlinkedFunctionCodeBlock):
* Source/JavaScriptCore/bytecode/UnlinkedFunctionExecutable.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitNewClassFieldInitializerFunction):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::BytecodeGenerator::emitDefineClassElements):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::PropertyListNode::emitBytecode):
(JSC::DefineFieldNode::emitBytecode):
(JSC::ClassExprNode::emitBytecode):
* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::createDefineField):
* Source/JavaScriptCore/parser/NodeConstructors.h:
(JSC::DefineFieldNode::DefineFieldNode):
* Source/JavaScriptCore/parser/Nodes.h:
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseInner):
(JSC::Parser&lt;LexerType&gt;::parseClass):
(JSC::Parser&lt;LexerType&gt;::parseClassFieldInitializerSourceElements):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Parser&lt;LexerType&gt;::parse):
(JSC::parse):
* Source/JavaScriptCore/parser/SyntaxChecker.h:
(JSC::SyntaxChecker::createDefineField):
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedJSTextPosition::encode):
(JSC::CachedJSTextPosition::decode const):
(JSC::CachedClassElementDefinition::encode):
(JSC::CachedClassElementDefinition::decode const):
(JSC::CachedFunctionExecutableRareData::encode):
(JSC::CachedFunctionExecutableRareData::decode const):

Canonical link: <a href="https://commits.webkit.org/273677@main">https://commits.webkit.org/273677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7883d2b43a80ae275d1854d79df3ded2275ecc7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38420 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32138 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30921 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31751 "Passed tests") | [💥 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10867 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10865 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39665 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/30212 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32427 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32229 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36826 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/35542 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34911 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12780 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/42238 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11565 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8763 "Found 39 new JSC stress test failures: microbenchmarks/array-from-derived-object-func.js.bytecode-cache, microbenchmarks/array-from-derived-object-func.js.default, microbenchmarks/array-from-derived-object-func.js.dfg-eager, microbenchmarks/array-from-derived-object-func.js.dfg-eager-no-cjit-validate, microbenchmarks/array-from-derived-object-func.js.eager-jettison-no-cjit, microbenchmarks/array-from-derived-object-func.js.no-cjit-collect-continuously, microbenchmarks/array-from-derived-object-func.js.no-cjit-validate-phases, microbenchmarks/array-from-derived-object-func.js.no-llint, microbenchmarks/array-from-object-func.js.bytecode-cache, microbenchmarks/array-from-object-func.js.default ... (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4705 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11848 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->