### PR TITLE
Add support for suppressing clang static analyzer issues with [[clang::suppress]]

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp
@@ -110,6 +110,7 @@ TEST(WTF_CheckedPtr, Basic)
         EXPECT_EQ(checkedObject.ptrCount(), 2u);
         EXPECT_EQ(ptr1.get(), &checkedObject);
         EXPECT_EQ(ptr2.get(), &checkedObject);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(ptr3.get(), nullptr);
     }
 }
@@ -260,6 +261,7 @@ TEST(WTF_CheckedPtr, DerivedClass)
         EXPECT_EQ(checkedObject.ptrCount(), 2u);
         EXPECT_EQ(ptr1.get(), nullptr);
         EXPECT_EQ(ptr2.get(), &checkedObject);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(ptr3.get(), nullptr);
         EXPECT_EQ(ptr4.get(), &checkedObject);
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/CompactPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompactPtr.cpp
@@ -74,6 +74,7 @@ TEST(WTF_CompactPtr, Basic)
     {
         CompactPtr<AlignedRefLogger> p1 = &a;
         CompactPtr<AlignedRefLogger> p2 = WTFMove(p1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -81,6 +82,7 @@ TEST(WTF_CompactPtr, Basic)
     {
         CompactPtr<AlignedRefLogger> p1 = &a;
         CompactPtr<AlignedRefLogger> p2(WTFMove(p1));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -95,6 +97,7 @@ TEST(WTF_CompactPtr, Basic)
     {
         CompactPtr<DerivedAlignedRefLogger> p1 = &a;
         CompactPtr<AlignedRefLogger> p2 = WTFMove(p1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -165,6 +168,7 @@ TEST(WTF_CompactPtr, Assignment)
         EXPECT_EQ(&b, p2.get());
         p1 = WTFMove(p2);
         EXPECT_EQ(&b, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
     }
 
@@ -185,6 +189,7 @@ TEST(WTF_CompactPtr, Assignment)
         EXPECT_EQ(&c, p2.get());
         p1 = WTFMove(p2);
         EXPECT_EQ(&c, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
     }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/CompactRefPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CompactRefPtr.cpp
@@ -77,6 +77,7 @@ TEST(WTF_CompactRefPtr, Basic)
     {
         CompactRefPtr<AlignedRefLogger> p1 = &a;
         CompactRefPtr<AlignedRefLogger> p2 = WTFMove(p1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -85,6 +86,7 @@ TEST(WTF_CompactRefPtr, Basic)
     {
         CompactRefPtr<AlignedRefLogger> p1 = &a;
         CompactRefPtr<AlignedRefLogger> p2(WTFMove(p1));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -101,6 +103,7 @@ TEST(WTF_CompactRefPtr, Basic)
     {
         CompactRefPtr<DerivedAlignedRefLogger> p1 = &a;
         CompactRefPtr<AlignedRefLogger> p2 = WTFMove(p1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -217,6 +220,7 @@ TEST(WTF_CompactRefPtr, Assignment)
         log() << "| ";
         p1 = WTFMove(p2);
         EXPECT_EQ(&b, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
     }
@@ -263,6 +267,7 @@ TEST(WTF_CompactRefPtr, Assignment)
         log() << "| ";
         p1 = WTFMove(p2);
         EXPECT_EQ(&c, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
     }
@@ -351,6 +356,7 @@ TEST(WTF_CompactRefPtr, Release)
     {
         CompactRefPtr<AlignedRefLogger> p1 = &a;
         CompactRefPtr<AlignedRefLogger> p2 = WTFMove(p1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -359,6 +365,7 @@ TEST(WTF_CompactRefPtr, Release)
     {
         CompactRefPtr<AlignedRefLogger> p1 = &a;
         CompactRefPtr<AlignedRefLogger> p2(WTFMove(p1));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -367,6 +374,7 @@ TEST(WTF_CompactRefPtr, Release)
     {
         CompactRefPtr<DerivedAlignedRefLogger> p1 = &a;
         CompactRefPtr<AlignedRefLogger> p2 = WTFMove(p1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -380,6 +388,7 @@ TEST(WTF_CompactRefPtr, Release)
         log() << "| ";
         p1 = WTFMove(p2);
         EXPECT_EQ(&b, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
     }
@@ -393,6 +402,7 @@ TEST(WTF_CompactRefPtr, Release)
         log() << "| ";
         p1 = WTFMove(p2);
         EXPECT_EQ(&c, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
     }
@@ -539,6 +549,7 @@ TEST(WTF_CompactRefPtr, AssignBeforeDeref)
         a.slotToCheck = nullptr;
         b.slotToCheck = nullptr;
         EXPECT_EQ(&b, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp
@@ -180,6 +180,7 @@ TEST(WTF_FixedVector, Move)
     vec1[2] = 2;
 
     FixedVector<unsigned> vec2(WTFMove(vec1));
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
     EXPECT_EQ(0U, vec1.size());
     EXPECT_EQ(3U, vec2.size());
     for (unsigned i = 0; i < vec2.size(); ++i)
@@ -195,6 +196,7 @@ TEST(WTF_FixedVector, MoveAssign)
 
     FixedVector<unsigned> vec2;
     vec2 = WTFMove(vec1);
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
     EXPECT_EQ(0U, vec1.size());
     EXPECT_EQ(3U, vec2.size());
     for (unsigned i = 0; i < vec2.size(); ++i)
@@ -206,6 +208,7 @@ TEST(WTF_FixedVector, MoveVector)
     auto vec1 = Vector<MoveOnly>::from(MoveOnly(0), MoveOnly(1), MoveOnly(2), MoveOnly(3));
     EXPECT_EQ(4U, vec1.size());
     FixedVector<MoveOnly> vec2(WTFMove(vec1));
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
     EXPECT_EQ(0U, vec1.size());
     EXPECT_EQ(4U, vec2.size());
     for (unsigned index = 0; index < vec2.size(); ++index)
@@ -219,6 +222,7 @@ TEST(WTF_FixedVector, MoveAssignVector)
         auto vec1 = Vector<MoveOnly>::from(MoveOnly(0), MoveOnly(1), MoveOnly(2), MoveOnly(3));
         EXPECT_EQ(4U, vec1.size());
         vec2 = WTFMove(vec1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(0U, vec1.size());
     }
     EXPECT_EQ(4U, vec2.size());

--- a/Tools/TestWebKitAPI/Tests/WTF/ListHashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/ListHashSet.cpp
@@ -338,6 +338,7 @@ TEST(WTF_ListHashSet, MoveConstructor)
     ASSERT_EQ(3, *iterator2);
     ++iterator2;
 
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
     ASSERT_EQ(0U, list.size());
     ASSERT_TRUE(list.begin() == list.end());
     list.add(4);
@@ -380,6 +381,7 @@ TEST(WTF_ListHashSet, MoveAssignment)
     ASSERT_EQ(3, *iterator2);
     ++iterator2;
 
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
     ASSERT_EQ(0U, list.size());
     ASSERT_TRUE(list.begin() == list.end());
     list.add(4);

--- a/Tools/TestWebKitAPI/Tests/WTF/NakedPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NakedPtr.cpp
@@ -69,6 +69,7 @@ TEST(WTF_NakedPtr, Basic)
     {
         NakedPtr<RefLogger> p1 = &a;
         NakedPtr<RefLogger> p2 = WTFMove(p1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         ASSERT_EQ(&a, p1.get());
         ASSERT_EQ(&a, p2.get());
     }
@@ -76,6 +77,7 @@ TEST(WTF_NakedPtr, Basic)
     {
         NakedPtr<RefLogger> p1 = &a;
         NakedPtr<RefLogger> p2(WTFMove(p1));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         ASSERT_EQ(&a, p1.get());
         ASSERT_EQ(&a, p2.get());
     }
@@ -90,6 +92,7 @@ TEST(WTF_NakedPtr, Basic)
     {
         NakedPtr<DerivedRefLogger> p1 = &a;
         NakedPtr<RefLogger> p2 = WTFMove(p1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         ASSERT_EQ(&a, p1.get());
         ASSERT_EQ(&a, p2.get());
     }
@@ -139,6 +142,7 @@ TEST(WTF_NakedPtr, Assignment)
         ASSERT_EQ(&b, p2.get());
         p1 = WTFMove(p2);
         ASSERT_EQ(&b, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         ASSERT_EQ(&b, p2.get());
     }
 
@@ -166,6 +170,7 @@ TEST(WTF_NakedPtr, Assignment)
         ASSERT_EQ(&c, p2.get());
         p1 = WTFMove(p2);
         ASSERT_EQ(&c, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         ASSERT_EQ(&c, p2.get());
     }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/PackedRefPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/PackedRefPtr.cpp
@@ -78,6 +78,7 @@ TEST(WTF_PackedRefPtr, Basic)
     {
         PackedRefPtr<RefLogger> p1 = &a;
         PackedRefPtr<RefLogger> p2 = WTFMove(p1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -86,6 +87,7 @@ TEST(WTF_PackedRefPtr, Basic)
     {
         PackedRefPtr<RefLogger> p1 = &a;
         PackedRefPtr<RefLogger> p2(WTFMove(p1));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -102,6 +104,7 @@ TEST(WTF_PackedRefPtr, Basic)
     {
         PackedRefPtr<DerivedRefLogger> p1 = &a;
         PackedRefPtr<RefLogger> p2 = WTFMove(p1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -204,6 +207,7 @@ TEST(WTF_PackedRefPtr, Assignment)
         log() << "| ";
         p1 = WTFMove(p2);
         EXPECT_EQ(&b, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
     }
@@ -250,6 +254,7 @@ TEST(WTF_PackedRefPtr, Assignment)
         log() << "| ";
         p1 = WTFMove(p2);
         EXPECT_EQ(&c, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
     }
@@ -280,6 +285,7 @@ TEST(WTF_PackedRefPtr, Assignment)
         IGNORE_WARNINGS_BEGIN("self-move")
         ptr = WTFMove(ptr);
         IGNORE_WARNINGS_END
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(&a, ptr.get());
     }
     EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
@@ -338,6 +344,7 @@ TEST(WTF_PackedRefPtr, Release)
     {
         PackedRefPtr<RefLogger> p1 = &a;
         PackedRefPtr<RefLogger> p2 = WTFMove(p1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -346,6 +353,7 @@ TEST(WTF_PackedRefPtr, Release)
     {
         PackedRefPtr<RefLogger> p1 = &a;
         PackedRefPtr<RefLogger> p2(WTFMove(p1));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -354,6 +362,7 @@ TEST(WTF_PackedRefPtr, Release)
     {
         PackedRefPtr<DerivedRefLogger> p1 = &a;
         PackedRefPtr<RefLogger> p2 = WTFMove(p1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -367,6 +376,7 @@ TEST(WTF_PackedRefPtr, Release)
         log() << "| ";
         p1 = WTFMove(p2);
         EXPECT_EQ(&b, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
     }
@@ -380,6 +390,7 @@ TEST(WTF_PackedRefPtr, Release)
         log() << "| ";
         p1 = WTFMove(p2);
         EXPECT_EQ(&c, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
     }
@@ -525,6 +536,7 @@ TEST(WTF_PackedRefPtr, AssignBeforeDeref)
         a.slotToCheck = nullptr;
         b.slotToCheck = nullptr;
         EXPECT_EQ(&b, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp
@@ -77,6 +77,7 @@ TEST(WTF_RefPtr, Basic)
     {
         RefPtr<RefLogger> p1 = &a;
         RefPtr<RefLogger> p2 = WTFMove(p1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -85,6 +86,7 @@ TEST(WTF_RefPtr, Basic)
     {
         RefPtr<RefLogger> p1 = &a;
         RefPtr<RefLogger> p2(WTFMove(p1));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -101,6 +103,7 @@ TEST(WTF_RefPtr, Basic)
     {
         RefPtr<DerivedRefLogger> p1 = &a;
         RefPtr<RefLogger> p2 = WTFMove(p1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -203,6 +206,7 @@ TEST(WTF_RefPtr, Assignment)
         log() << "| ";
         p1 = WTFMove(p2);
         EXPECT_EQ(&b, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
     }
@@ -249,6 +253,7 @@ TEST(WTF_RefPtr, Assignment)
         log() << "| ";
         p1 = WTFMove(p2);
         EXPECT_EQ(&c, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
     }
@@ -344,6 +349,7 @@ TEST(WTF_RefPtr, Release)
     {
         RefPtr<RefLogger> p1 = &a;
         RefPtr<RefLogger> p2 = WTFMove(p1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -352,6 +358,7 @@ TEST(WTF_RefPtr, Release)
     {
         RefPtr<RefLogger> p1 = &a;
         RefPtr<RefLogger> p2(WTFMove(p1));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -360,6 +367,7 @@ TEST(WTF_RefPtr, Release)
     {
         RefPtr<DerivedRefLogger> p1 = &a;
         RefPtr<RefLogger> p2 = WTFMove(p1);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p1.get());
         EXPECT_EQ(&a, p2.get());
     }
@@ -373,6 +381,7 @@ TEST(WTF_RefPtr, Release)
         log() << "| ";
         p1 = WTFMove(p2);
         EXPECT_EQ(&b, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
     }
@@ -386,6 +395,7 @@ TEST(WTF_RefPtr, Release)
         log() << "| ";
         p1 = WTFMove(p2);
         EXPECT_EQ(&c, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
     }
@@ -530,6 +540,7 @@ TEST(WTF_RefPtr, AssignBeforeDeref)
         a.slotToCheck = nullptr;
         b.slotToCheck = nullptr;
         EXPECT_EQ(&b, p1.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nullptr, p2.get());
         log() << "| ";
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
@@ -659,11 +659,13 @@ TEST_F(WTF_URL, MoveInvalidatesURL)
     EXPECT_TRUE(url1.isValid());
     URL url2 { WTFMove(url1) };
     EXPECT_TRUE(url2.isValid());
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
     EXPECT_FALSE(url1.isValid());
 
     URL url3 { "http://www.webkit.org"_str };
     url3 = WTFMove(url2);
     EXPECT_TRUE(url3.isValid());
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
     EXPECT_FALSE(url2.isValid());
 
     url3 = { };

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -126,6 +126,7 @@ TEST(WTF_Vector, ConstructWithFromString)
     EXPECT_TRUE(s1 == vector[0]);
     EXPECT_TRUE(s2 == vector[1]);
     EXPECT_TRUE(s1 == vector[2]);
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
     EXPECT_TRUE(s3.isNull());
 }
 
@@ -150,6 +151,7 @@ TEST(WTF_Vector, IsolatedCopy)
     EXPECT_FALSE(data2 == vector2[1].impl());
 
     auto vector3 = crossThreadCopy(WTFMove(vector1));
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
     EXPECT_EQ(0U, vector1.size());
 
     EXPECT_TRUE("s1"_s == vector3[0]);
@@ -431,6 +433,7 @@ TEST(WTF_Vector, MoveOnly_UncheckedAppend)
     for (size_t i = 0; i < 100; ++i) {
         MoveOnly moveOnly(i);
         vector.append(WTFMove(moveOnly));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(0U, moveOnly.value());
     }
 
@@ -445,6 +448,7 @@ TEST(WTF_Vector, MoveOnly_Append)
     for (size_t i = 0; i < 100; ++i) {
         MoveOnly moveOnly(i);
         vector.append(WTFMove(moveOnly));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(0U, moveOnly.value());
     }
 
@@ -460,6 +464,7 @@ TEST(WTF_Vector, MoveOnly_Append)
             vector.append(j);
         vector.append(WTFMove(vector[0]));
 
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(0U, vector[0].value());
 
         for (size_t j = 0; j < i; ++j)
@@ -475,6 +480,7 @@ TEST(WTF_Vector, MoveOnly_Insert)
     for (size_t i = 0; i < 100; ++i) {
         MoveOnly moveOnly(i);
         vector.insert(0, WTFMove(moveOnly));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(0U, moveOnly.value());
     }
 
@@ -485,6 +491,7 @@ TEST(WTF_Vector, MoveOnly_Insert)
     for (size_t i = 0; i < 200; i += 2) {
         MoveOnly moveOnly(1000 + i);
         vector.insert(i, WTFMove(moveOnly));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(0U, moveOnly.value());
     }
 
@@ -504,6 +511,7 @@ TEST(WTF_Vector, MoveOnly_TakeLast)
     for (size_t i = 0; i < 100; ++i) {
         MoveOnly moveOnly(i);
         vector.append(WTFMove(moveOnly));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(0U, moveOnly.value());
     }
 
@@ -1744,7 +1752,9 @@ TEST(WTF_Vector, MoveConstructor)
         Vector<String> strings({ "a"_str, "b"_str, "c"_str, "d"_str, "e"_str });
         EXPECT_EQ(strings.size(), 5U);
         Vector<String> strings2(WTFMove(strings));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.size(), 0U);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.capacity(), 0U);
         EXPECT_EQ(strings2.size(), 5U);
         EXPECT_EQ(strings2.capacity(), 5U);
@@ -1764,7 +1774,9 @@ TEST(WTF_Vector, MoveConstructor)
         EXPECT_EQ(strings.size(), 5U);
         EXPECT_EQ(strings.capacity(), 10U);
         Vector<String, 10> strings2(WTFMove(strings));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.size(), 0U);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.capacity(), 10U);
         EXPECT_EQ(strings2.size(), 5U);
         EXPECT_EQ(strings2.capacity(), 10U);
@@ -1784,7 +1796,9 @@ TEST(WTF_Vector, MoveConstructor)
         EXPECT_EQ(strings.size(), 5U);
         EXPECT_EQ(strings.capacity(), 5U);
         Vector<String, 2> strings2(WTFMove(strings));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.size(), 0U);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.capacity(), 2U);
         EXPECT_EQ(strings2.size(), 5U);
         EXPECT_EQ(strings2.capacity(), 5U);
@@ -1808,7 +1822,9 @@ TEST(WTF_Vector, MoveAssignmentOperator)
         EXPECT_EQ(strings.capacity(), 5U);
         Vector<String> strings2;
         strings2 = WTFMove(strings);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.size(), 0U);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.capacity(), 0U);
         EXPECT_EQ(strings2.size(), 5U);
         EXPECT_EQ(strings2.capacity(), 5U);
@@ -1828,7 +1844,9 @@ TEST(WTF_Vector, MoveAssignmentOperator)
         EXPECT_EQ(strings.size(), 5U);
         Vector<String> strings2({ "foo"_str, "bar"_str });
         strings2 = WTFMove(strings);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.size(), 0U);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.capacity(), 0U);
         EXPECT_EQ(strings2.size(), 5U);
         EXPECT_EQ(strings2.capacity(), 5U);
@@ -1849,7 +1867,9 @@ TEST(WTF_Vector, MoveAssignmentOperator)
         EXPECT_EQ(strings.capacity(), 10U);
         Vector<String, 10> strings2;
         strings2 = WTFMove(strings);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.size(), 0U);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.capacity(), 10U);
         EXPECT_EQ(strings2.size(), 5U);
         EXPECT_EQ(strings2.capacity(), 10U);
@@ -1870,7 +1890,9 @@ TEST(WTF_Vector, MoveAssignmentOperator)
         EXPECT_EQ(strings.capacity(), 10U);
         Vector<String, 10> strings2({ "foo"_str, "bar"_str });
         strings2 = WTFMove(strings);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.size(), 0U);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.capacity(), 10U);
         EXPECT_EQ(strings2.size(), 5U);
         EXPECT_EQ(strings2.capacity(), 10U);
@@ -1891,7 +1913,9 @@ TEST(WTF_Vector, MoveAssignmentOperator)
         EXPECT_EQ(strings.capacity(), 5U);
         Vector<String, 2> strings2;
         strings2 = WTFMove(strings);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.size(), 0U);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.capacity(), 2U);
         EXPECT_EQ(strings2.size(), 5U);
         EXPECT_EQ(strings2.capacity(), 5U);
@@ -1912,7 +1936,9 @@ TEST(WTF_Vector, MoveAssignmentOperator)
         EXPECT_EQ(strings.capacity(), 5U);
         Vector<String, 2> strings2({ "foo"_str, "bar"_str });
         strings2 = WTFMove(strings);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.size(), 0U);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.capacity(), 2U);
         EXPECT_EQ(strings2.size(), 5U);
         EXPECT_EQ(strings2.capacity(), 5U);
@@ -1933,7 +1959,9 @@ TEST(WTF_Vector, MoveAssignmentOperator)
         EXPECT_EQ(strings.capacity(), 5U);
         Vector<String, 2> strings2({ "foo"_str, "bar"_str, "baz"_str });
         strings2 = WTFMove(strings);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.size(), 0U);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.capacity(), 2U);
         EXPECT_EQ(strings2.size(), 5U);
         EXPECT_EQ(strings2.capacity(), 5U);
@@ -1954,7 +1982,9 @@ TEST(WTF_Vector, MoveAssignmentOperator)
         EXPECT_EQ(strings.capacity(), 2U);
         Vector<String, 2> strings2({ "foo"_str, "bar"_str, "baz"_str });
         strings2 = WTFMove(strings);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.size(), 0U);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(strings.capacity(), 2U);
         EXPECT_EQ(strings2.size(), 2U);
         EXPECT_EQ(strings2.capacity(), 2U);

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -228,6 +228,7 @@ TEST(WTF_WeakPtr, Operators)
 
     WeakPtr<Foo> weakPtr4 = WTFMove(weakPtr);
     EXPECT_EQ(weakPtr4.get(), &f);
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
     EXPECT_FALSE(weakPtr);
 }
 
@@ -333,6 +334,7 @@ TEST(WTF_WeakPtr, DerivedConstructAndAssign)
         WeakPtr<Derived> derivedWeakPtr = makeWeakPtr(derived);
         WeakPtr<Base> baseWeakPtr { WTFMove(derivedWeakPtr) };
         EXPECT_EQ(baseWeakPtr.get(), &derived);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_NULL(derivedWeakPtr.get());
     }
 
@@ -348,6 +350,7 @@ TEST(WTF_WeakPtr, DerivedConstructAndAssign)
         WeakPtr<Base> baseWeakPtr;
         baseWeakPtr = WTFMove(derivedWeakPtr);
         EXPECT_EQ(baseWeakPtr.get(), &derived);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_NULL(derivedWeakPtr.get());
     }
 
@@ -367,6 +370,7 @@ TEST(WTF_WeakPtr, DerivedConstructAndAssignConst)
         auto derivedWeakPtr = makeWeakPtr(derived);
         WeakPtr<const Base> baseWeakPtr { WTFMove(derivedWeakPtr) };
         EXPECT_EQ(baseWeakPtr.get(), &derived);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_NULL(derivedWeakPtr.get());
     }
 
@@ -382,6 +386,7 @@ TEST(WTF_WeakPtr, DerivedConstructAndAssignConst)
         WeakPtr<const Base> baseWeakPtr;
         baseWeakPtr = WTFMove(derivedWeakPtr);
         EXPECT_EQ(baseWeakPtr.get(), &derived);
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_NULL(derivedWeakPtr.get());
     }
 
@@ -2815,6 +2820,7 @@ TEST(WTF_ThreadSafeWeakPtr, UseAfterMoveResistance)
     auto counter = adoptRef(*new ThreadSafeInstanceCounter());
     auto weakPtr = ThreadSafeWeakPtr { counter.get() };
     auto movedTo = WTFMove(weakPtr);
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
     EXPECT_NULL(weakPtr.get());
     EXPECT_NOT_NULL(movedTo.get());
     ThreadSafeWeakPtr<ThreadSafeInstanceCounter> emptyConstructor;

--- a/Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtr.cpp
@@ -61,7 +61,8 @@ TEST(RetainPtr, ConstructionFromMutableCFType)
     RetainPtr<CFStringRef> ptr2(WTFMove(temp));
 
     EXPECT_EQ(string, ptr2);
-    EXPECT_EQ((CFStringRef)nullptr, temp);
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
+    EXPECT_EQ((CFStringRef)nullptr, temp.get());
 }
 
 TEST(RetainPtr, ConstructionFromSameCFType)
@@ -81,7 +82,8 @@ TEST(RetainPtr, ConstructionFromSameCFType)
     RetainPtr<CFStringRef> ptr2(WTFMove(temp));
 
     EXPECT_EQ(string, ptr2);
-    EXPECT_EQ((CFStringRef)nullptr, temp);
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
+    EXPECT_EQ((CFStringRef)nullptr, temp.get());
 }
 
 TEST(RetainPtr, MoveAssignmentFromMutableCFType)
@@ -103,7 +105,8 @@ TEST(RetainPtr, MoveAssignmentFromMutableCFType)
     ptr = WTFMove(temp);
 
     EXPECT_EQ(string, ptr);
-    EXPECT_EQ((CFStringRef)nullptr, temp);
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
+    EXPECT_EQ((CFStringRef)nullptr, temp.get());
 }
 
 TEST(RetainPtr, MoveAssignmentFromSameCFType)
@@ -125,7 +128,8 @@ TEST(RetainPtr, MoveAssignmentFromSameCFType)
     ptr = WTFMove(temp);
 
     EXPECT_EQ(string, ptr);
-    EXPECT_EQ((CFStringRef)nullptr, temp);
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
+    EXPECT_EQ((CFStringRef)nullptr, temp.get());
 }
 
 TEST(RetainPtr, OptionalRetainPtrCF)

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
@@ -66,12 +66,14 @@ TEST(TypeCastsCocoa, bridge_cast)
 
         auto objectCF = bridge_cast(WTFMove(objectNS));
         auto objectCFPtr = reinterpret_cast<uintptr_t>(objectCF.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nil, objectNS.get());
         EXPECT_EQ(objectNSPtr, objectCFPtr);
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCFPtr));
 
         objectNS = bridge_cast(WTFMove(objectCF));
         objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(NULL, objectCF.get());
         EXPECT_EQ(objectCFPtr, objectNSPtr);
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectNSPtr));
@@ -84,12 +86,14 @@ TEST(TypeCastsCocoa, bridge_cast)
 
         auto objectNS = bridge_cast(WTFMove(objectCF));
         auto objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(NULL, objectCF.get());
         EXPECT_EQ(objectCFPtr, objectNSPtr);
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectNSPtr));
 
         objectCF = bridge_cast(WTFMove(objectNS));
         objectCFPtr = reinterpret_cast<uintptr_t>(objectCF.get());
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nil, objectNS.get());
         EXPECT_EQ(objectNSPtr, objectCFPtr);
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCFPtr));
@@ -101,6 +105,7 @@ TEST(TypeCastsCocoa, bridge_id_cast)
     @autoreleasepool {
         RetainPtr<CFTypeRef> objectCF;
         auto objectID = bridge_id_cast(WTFMove(objectCF));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(NULL, objectCF.get());
         EXPECT_EQ(nil, objectID.get());
     }
@@ -115,6 +120,7 @@ TEST(TypeCastsCocoa, bridge_id_cast)
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
             objectIDPtr = reinterpret_cast<uintptr_t>(objectID.get());
         }
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(NULL, objectCF.get());
         EXPECT_EQ(objectCFPtr, objectIDPtr);
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectIDPtr));
@@ -225,6 +231,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
     @autoreleasepool {
         RetainPtr<NSString> object;
         auto objectCast = dynamic_objc_cast<NSString>(WTFMove(object));
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nil, object.get());
         EXPECT_EQ(nil, objectCast.get());
     }
@@ -243,6 +250,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
             objectCast = dynamic_objc_cast<NSString>(WTFMove(object));
             objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());
         }
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nil, object.get());
         EXPECT_EQ(objectPtr, objectCastPtr);
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCastPtr));
@@ -259,6 +267,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
             objectCast2 = dynamic_objc_cast<NSObject>(WTFMove(object));
             objectCastPtr2 = reinterpret_cast<uintptr_t>(objectCast2.get());
         }
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nil, object.get());
         EXPECT_EQ(objectPtr, objectCastPtr2);
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCastPtr2));
@@ -293,6 +302,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
         AUTORELEASEPOOL_FOR_ARC_DEBUG {
             objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());
         }
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nil, object.get());
         EXPECT_EQ(objectPtr, objectCastPtr);
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCastPtr));
@@ -313,6 +323,7 @@ TEST(TypeCastsCocoa, dynamic_objc_cast_RetainPtr)
             objectCast = dynamic_objc_cast<NSObject>(WTFMove(object));
             objectCastPtr = reinterpret_cast<uintptr_t>(objectCast.get());
         }
+        IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
         EXPECT_EQ(nil, object.get());
         EXPECT_EQ(objectPtr, objectCastPtr);
         EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCastPtr));

--- a/Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm
@@ -94,7 +94,8 @@ TEST(RETAIN_PTR_TEST_NAME, ConstructionFromMutableNSType)
     RetainPtr<NSString> ptr2(WTFMove(temp));
 
     EXPECT_EQ(string, ptr2);
-    EXPECT_EQ((NSString *)nil, temp);
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
+    EXPECT_EQ((NSString *)nil, temp.get());
 }
 
 TEST(RETAIN_PTR_TEST_NAME, ConstructionFromSameNSType)
@@ -114,7 +115,8 @@ TEST(RETAIN_PTR_TEST_NAME, ConstructionFromSameNSType)
     RetainPtr<NSString> ptr2(WTFMove(temp));
 
     EXPECT_EQ(string, ptr2);
-    EXPECT_EQ((NSString *)nil, temp);
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
+    EXPECT_EQ((NSString *)nil, temp.get());
 }
 
 TEST(RETAIN_PTR_TEST_NAME, ConstructionFromSimilarNSType)
@@ -134,7 +136,8 @@ TEST(RETAIN_PTR_TEST_NAME, ConstructionFromSimilarNSType)
     RetainPtr<NSString> ptr2(WTFMove(temp));
 
     EXPECT_EQ(string, ptr2);
-    EXPECT_EQ((NSString *)nil, temp);
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
+    EXPECT_EQ((NSString *)nil, temp.get());
 }
 
 TEST(RETAIN_PTR_TEST_NAME, ConstructionFromSimilarNSTypeReversed)
@@ -154,7 +157,8 @@ TEST(RETAIN_PTR_TEST_NAME, ConstructionFromSimilarNSTypeReversed)
     RetainPtr<NSString *> ptr2(WTFMove(temp));
 
     EXPECT_EQ(string, ptr2);
-    EXPECT_EQ((NSString *)nil, temp);
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
+    EXPECT_EQ((NSString *)nil, temp.get());
 }
 
 TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromMutableNSType)
@@ -176,7 +180,8 @@ TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromMutableNSType)
     ptr = WTFMove(temp);
 
     EXPECT_EQ(string, ptr);
-    EXPECT_EQ((NSString *)nil, temp);
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
+    EXPECT_EQ((NSString *)nil, temp.get());
 }
 
 TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromSameNSType)
@@ -198,7 +203,8 @@ TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromSameNSType)
     ptr = WTFMove(temp);
 
     EXPECT_EQ(string, ptr);
-    EXPECT_EQ((NSString *)nil, temp);
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
+    EXPECT_EQ((NSString *)nil, temp.get());
 }
 
 TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromSimilarNSType)
@@ -220,7 +226,8 @@ TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromSimilarNSType)
     ptr = WTFMove(temp);
 
     EXPECT_EQ(string, ptr);
-    EXPECT_EQ((NSString *)nil, temp);
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
+    EXPECT_EQ((NSString *)nil, temp.get());
 }
 
 TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromSimilarNSTypeReversed)
@@ -242,7 +249,8 @@ TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromSimilarNSTypeReversed)
     ptr = WTFMove(temp);
 
     EXPECT_EQ(string, ptr);
-    EXPECT_EQ((NSString *)nil, temp);
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
+    EXPECT_EQ((NSString *)nil, temp.get());
 }
 
 TEST(RETAIN_PTR_TEST_NAME, OptionalRetainPtrNS)

--- a/Tools/TestWebKitAPI/Tests/WebKit/cocoa/WeakObjCPtr.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/cocoa/WeakObjCPtr.mm
@@ -142,11 +142,13 @@ TEST(WebKit2_WeakObjCPtr, MoveConstructor)
     WeakObjCPtr<id> weak1(object);
     WeakObjCPtr<id> weak2(WTFMove(weak1));
 
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
     EXPECT_EQ(weak1.get(), (void*)nil);
     EXPECT_EQ(weak2.get(), object);
 
     [object release];
 
+    IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE
     EXPECT_EQ(weak1.get(), (void*)nil);
     EXPECT_EQ(weak2.get(), (void*)nil);
 }


### PR DESCRIPTION
#### 22343e69f00f3f26fc5df4016a301a654b1c0bc3
<pre>
Add support for suppressing clang static analyzer issues with [[clang::suppress]]
<a href="https://bugs.webkit.org/show_bug.cgi?id=267981">https://bugs.webkit.org/show_bug.cgi?id=267981</a>
&lt;<a href="https://rdar.apple.com/121489134">rdar://121489134</a>&gt;

Reviewed by Alex Christensen and Darin Adler.

This adds support for the `[[clang::suppress]]` attribute in clang-17.

Currently there is no way to ignore specific analyzer warnings, but the
macros add support for documenting the warning(s) in case support is
added later.

The `[[clang::suppress]]` attribute can be applied to a single line of
code or to a block of code.

* Source/WTF/wtf/Compiler.h:
(COMPILER_HAS_ATTRIBUTE): Add.
- Define helper macro since __has_attribute() is used more than once.
(COMPILER_HAS_CLANG_FEATURE):
- Update documentation link to https.
(FALLTHROUGH):
(NOT_TAIL_CALLED):
- Use COMPILER_HAS_ATTRIBUTE().
(IGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE): Add.
(IGNORE_CLANG_STATIC_ANALYZER_WARNINGS_BEGIN): Add.
(IGNORE_CLANG_STATIC_ANALYZER_WARNINGS_END): Add.
- Add support for the [[clang::suppress]] attribute.
(IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE): Add.
(TLS_MODEL_INITIAL_EXEC):
- Use COMPILER_HAS_ATTRIBUTE().

* Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp:
* Tools/TestWebKitAPI/Tests/WTF/CompactPtr.cpp:
* Tools/TestWebKitAPI/Tests/WTF/CompactRefPtr.cpp:
* Tools/TestWebKitAPI/Tests/WTF/FixedVector.cpp:
* Tools/TestWebKitAPI/Tests/WTF/ListHashSet.cpp:
* Tools/TestWebKitAPI/Tests/WTF/NakedPtr.cpp:
* Tools/TestWebKitAPI/Tests/WTF/PackedRefPtr.cpp:
* Tools/TestWebKitAPI/Tests/WTF/RefPtr.cpp:
* Tools/TestWebKitAPI/Tests/WTF/URL.cpp:
* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
* Tools/TestWebKitAPI/Tests/WTF/cf/RetainPtr.cpp:
* Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm:
* Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm:
* Tools/TestWebKitAPI/Tests/WebKit/cocoa/WeakObjCPtr.mm:
- Ignore expected cplusplus.Move warnings using
  IGNORE_CLANG_STATIC_ANALYZER_USE_AFTER_MOVE_ATTRIBUTE.

Canonical link: <a href="https://commits.webkit.org/273460@main">https://commits.webkit.org/273460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4bd35de58f17a0062ed0acce0b76d276867c827

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35506 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38248 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32015 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36704 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11485 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31618 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10711 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/31760 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39494 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/30106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32076 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/35389 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10920 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/8826 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34757 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/42063 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11437 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->