### PR TITLE
[CSS] Implement supports() after @import rule

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6885,7 +6885,6 @@ imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/custom-proper
 imported/w3c/web-platform-tests/scroll-animations/view-timelines/range-boundary.html [ ImageOnlyFailure ]
 
 # webkit.org/b/229520 CSS @scope unimplemented
-imported/w3c/web-platform-tests/css/css-cascade/import-conditional-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-cascade/scope-visited.html [ ImageOnlyFailure ]
 
 # :is(:host) https://bugs.webkit.org/show_bug.cgi?id=264628

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/import-conditions.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/import-conditions.html
@@ -48,6 +48,18 @@
       matches: false
     },
     {
+      importCondition: "supports(supports(display:block))",
+      matches: false
+    },
+    {
+      importCondition: "supports(())",
+      matches: false
+    },
+    {
+      importCondition: "supports()",
+      matches: false
+    },
+    {
       importCondition: "supports(display:block) (width >= 0px)",
       matches: true
     },

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssimportrule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssimportrule-expected.txt
@@ -8,6 +8,6 @@ PASS Values of CSSImportRule attributes
 PASS CSSImportRule : MediaList mediaText attribute should be updated due to [PutForwards]
 PASS CSSStyleDeclaration cssText attribute should be updated due to [PutForwards]
 PASS StyleSheet : MediaList mediaText attribute should be updated due to [PutForwards]
-FAIL Existence and writability of CSSImportRule supportsText attribute assert_idl_attribute: property "supportsText" not found in prototype chain
-FAIL Value of CSSImportRule supportsText attribute assert_equals: expected (string) "(display: flex) or (display: block)" but got (undefined) undefined
+PASS Existence and writability of CSSImportRule supportsText attribute
+PASS Value of CSSImportRule supportsText attribute
 

--- a/LayoutTests/platform/gtk-wk2/imported/w3c/web-platform-tests/css/css-cascade/import-conditions-expected.txt
+++ b/LayoutTests/platform/gtk-wk2/imported/w3c/web-platform-tests/css/css-cascade/import-conditions-expected.txt
@@ -18,7 +18,7 @@ PASS supports(selector(a)) is a valid import condition
 PASS supports(selector(p a)) is a valid import condition
 PASS supports(selector(p > a)) is a valid import condition
 PASS supports(selector(p + a)) is a valid import condition
-FAIL supports(font-tech(color-COLRv1)) is a valid import condition assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS supports(font-tech(color-COLRv1)) is a valid import condition
 PASS supports(font-tech(invalid)) is not a valid import condition
 PASS supports(font-format(opentype)) is a valid import condition
 PASS supports(font-format(woff)) is a valid import condition

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/import-conditions-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/import-conditions-expected.txt
@@ -18,7 +18,7 @@ PASS supports(selector(a)) is a valid import condition
 PASS supports(selector(p a)) is a valid import condition
 PASS supports(selector(p > a)) is a valid import condition
 PASS supports(selector(p + a)) is a valid import condition
-FAIL supports(font-tech(color-COLRv1)) is a valid import condition assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS supports(font-tech(color-COLRv1)) is a valid import condition
 PASS supports(font-tech(invalid)) is not a valid import condition
 PASS supports(font-format(opentype)) is a valid import condition
 PASS supports(font-format(woff)) is a valid import condition

--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -61,11 +61,16 @@ MediaList& CSSImportRule::media() const
 
 String CSSImportRule::layerName() const
 {
-    auto name = m_importRule.get().cascadeLayerName();
+    auto name = m_importRule->cascadeLayerName();
     if (!name)
         return { };
 
     return stringFromCascadeLayerName(*name);
+}
+
+String CSSImportRule::supportsText() const
+{
+    return m_importRule->supportsText();
 }
 
 String CSSImportRule::cssTextInternal(const String& urlString) const
@@ -79,6 +84,10 @@ String CSSImportRule::cssTextInternal(const String& urlString) const
         else
             builder.append(" layer(", layerName, ')');
     }
+
+    auto supports = supportsText();
+    if (!supports.isNull())
+        builder.append(" supports(", WTFMove(supports), ')');
 
     if (!mediaQueries().isEmpty()) {
         builder.append(' ');

--- a/Source/WebCore/css/CSSImportRule.h
+++ b/Source/WebCore/css/CSSImportRule.h
@@ -43,6 +43,7 @@ public:
     WEBCORE_EXPORT MediaList& media() const;
     WEBCORE_EXPORT CSSStyleSheet* styleSheet() const;
     String layerName() const;
+    String supportsText() const;
 
 private:
     friend class MediaList;

--- a/Source/WebCore/css/CSSImportRule.idl
+++ b/Source/WebCore/css/CSSImportRule.idl
@@ -27,5 +27,6 @@ typedef USVString CSSOMString;
     [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
     [SameObject] readonly attribute CSSStyleSheet styleSheet;
     readonly attribute CSSOMString? layerName;
+    readonly attribute CSSOMString? supportsText;
 };
 

--- a/Source/WebCore/css/StyleRuleImport.cpp
+++ b/Source/WebCore/css/StyleRuleImport.cpp
@@ -38,17 +38,18 @@
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRuleImport);
 
-Ref<StyleRuleImport> StyleRuleImport::create(const String& href, MQ::MediaQueryList&& mediaQueries, std::optional<CascadeLayerName>&& cascadeLayerName)
+Ref<StyleRuleImport> StyleRuleImport::create(const String& href, MQ::MediaQueryList&& mediaQueries, std::optional<CascadeLayerName>&& cascadeLayerName, SupportsCondition&& supportsCondition)
 {
-    return adoptRef(*new StyleRuleImport(href, WTFMove(mediaQueries), WTFMove(cascadeLayerName)));
+    return adoptRef(*new StyleRuleImport(href, WTFMove(mediaQueries), WTFMove(cascadeLayerName), WTFMove(supportsCondition)));
 }
 
-StyleRuleImport::StyleRuleImport(const String& href, MQ::MediaQueryList&& mediaQueries, std::optional<CascadeLayerName>&& cascadeLayerName)
+StyleRuleImport::StyleRuleImport(const String& href, MQ::MediaQueryList&& mediaQueries, std::optional<CascadeLayerName>&& cascadeLayerName, SupportsCondition&& supportsCondition)
     : StyleRuleBase(StyleRuleType::Import)
     , m_styleSheetClient(this)
     , m_strHref(href)
     , m_mediaQueries(WTFMove(mediaQueries))
     , m_cascadeLayerName(WTFMove(cascadeLayerName))
+    , m_supportsCondition(WTFMove(supportsCondition))
 {
 }
 

--- a/Source/WebCore/css/StyleRuleImport.h
+++ b/Source/WebCore/css/StyleRuleImport.h
@@ -36,7 +36,12 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StyleRuleImport);
 class StyleRuleImport final : public StyleRuleBase {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StyleRuleImport);
 public:
-    static Ref<StyleRuleImport> create(const String& href, MQ::MediaQueryList&&, std::optional<CascadeLayerName>&&);
+    struct SupportsCondition {
+        String text;
+        bool conditionMatches { true };
+    };
+
+    static Ref<StyleRuleImport> create(const String& href, MQ::MediaQueryList&&, std::optional<CascadeLayerName>&&, SupportsCondition&&);
     ~StyleRuleImport();
 
     Ref<StyleRuleImport> copy() const { RELEASE_ASSERT_NOT_REACHED(); }
@@ -58,6 +63,8 @@ public:
     const CachedCSSStyleSheet* cachedCSSStyleSheet() const { return m_cachedSheet.get(); }
 
     const std::optional<CascadeLayerName>& cascadeLayerName() const { return m_cascadeLayerName; }
+    const String& supportsText() const { return m_supportsCondition.text; }
+    bool supportsMatches() const { return m_supportsCondition.conditionMatches; }
 
 private:
     // NOTE: We put the CachedStyleSheetClient in a member instead of inheriting from it
@@ -77,7 +84,7 @@ private:
     void setCSSStyleSheet(const String& href, const URL& baseURL, const String& charset, const CachedCSSStyleSheet*);
     friend class ImportedStyleSheetClient;
 
-    StyleRuleImport(const String& href, MQ::MediaQueryList&&, std::optional<CascadeLayerName>&&);
+    StyleRuleImport(const String& href, MQ::MediaQueryList&&, std::optional<CascadeLayerName>&&, SupportsCondition&&);
 
     StyleSheetContents* m_parentStyleSheet { nullptr };
 
@@ -88,6 +95,7 @@ private:
     std::optional<CascadeLayerName> m_cascadeLayerName;
     CachedResourceHandle<CachedCSSStyleSheet> m_cachedSheet;
     bool m_loading { false };
+    SupportsCondition m_supportsCondition;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -87,7 +87,7 @@ bool CSSParser::parseSupportsCondition(const String& condition)
     CSSParserImpl parser(m_context, condition);
     if (!parser.tokenizer())
         return false;
-    return CSSSupportsParser::supportsCondition(parser.tokenizer()->tokenRange(), parser, CSSSupportsParser::ForWindowCSS, CSSParserEnum::IsNestedContext::No) == CSSSupportsParser::Supported;
+    return CSSSupportsParser::supportsCondition(parser.tokenizer()->tokenRange(), parser, CSSSupportsParser::ParsingMode::AllowBareDeclarationAndGeneralEnclosed, CSSParserEnum::IsNestedContext::No) == CSSSupportsParser::Supported;
 }
 
 static Color color(RefPtr<CSSValue>&& value)

--- a/Source/WebCore/css/parser/CSSSupportsParser.cpp
+++ b/Source/WebCore/css/parser/CSSSupportsParser.cpp
@@ -38,7 +38,7 @@
 
 namespace WebCore {
 
-CSSSupportsParser::SupportsResult CSSSupportsParser::supportsCondition(CSSParserTokenRange range, CSSParserImpl& parser, SupportsParsingMode mode, CSSParserEnum::IsNestedContext isNestedContext)
+CSSSupportsParser::SupportsResult CSSSupportsParser::supportsCondition(CSSParserTokenRange range, CSSParserImpl& parser, ParsingMode mode, CSSParserEnum::IsNestedContext isNestedContext)
 {
     // FIXME: The spec allows leading whitespace in @supports but not CSS.supports,
     // but major browser vendors allow it in CSS.supports also.
@@ -46,7 +46,7 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::supportsCondition(CSSParser
     CSSSupportsParser supportsParser(parser, isNestedContext);
 
     auto result = supportsParser.consumeCondition(range);
-    if (mode != ForWindowCSS || result != Invalid)
+    if (mode != ParsingMode::AllowBareDeclarationAndGeneralEnclosed || result != Invalid)
         return result;
 
     // window.CSS.supports requires parsing as-if the condition was wrapped in

--- a/Source/WebCore/css/parser/CSSSupportsParser.h
+++ b/Source/WebCore/css/parser/CSSSupportsParser.h
@@ -45,12 +45,12 @@ public:
         Invalid
     };
 
-    enum SupportsParsingMode {
-        ForAtRule,
-        ForWindowCSS,
+    enum class ParsingMode : bool {
+        ForAtRuleSupports,
+        AllowBareDeclarationAndGeneralEnclosed,
     };
 
-    static SupportsResult supportsCondition(CSSParserTokenRange, CSSParserImpl&, SupportsParsingMode, CSSParserEnum::IsNestedContext);
+    static SupportsResult supportsCondition(CSSParserTokenRange, CSSParserImpl&, ParsingMode, CSSParserEnum::IsNestedContext);
 
 private:
     CSSSupportsParser(CSSParserImpl& parser, CSSParserEnum::IsNestedContext isNestedContext = CSSParserEnum::IsNestedContext::No)

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -243,6 +243,9 @@ void RuleSetBuilder::addRulesFromSheetContents(const StyleSheetContents& sheet)
         if (!rule->styleSheet())
             continue;
 
+        if (!rule->supportsMatches())
+            continue;
+
         if (m_mediaQueryCollector.pushAndEvaluate(rule->mediaQueries())) {
             auto& cascadeLayerName = rule->cascadeLayerName();
             if (cascadeLayerName) {


### PR DESCRIPTION
#### 8338db44d91898abef308bf185572c5fd0fdfc69
<pre>
[CSS] Implement supports() after @import rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=256180">https://bugs.webkit.org/show_bug.cgi?id=256180</a>
<a href="https://rdar.apple.com/109060734">rdar://109060734</a>

Reviewed by Antti Koivisto.

<a href="https://drafts.csswg.org/css-cascade-5/#conditional-import">https://drafts.csswg.org/css-cascade-5/#conditional-import</a>
<a href="https://drafts.csswg.org/css-conditional-3/#typedef-supports-condition">https://drafts.csswg.org/css-conditional-3/#typedef-supports-condition</a>

The syntax is: [ supports( [ &lt;supports-condition&gt; | &lt;declaration&gt; ] ) ]?

Like for the CSS.window.supports API, the supports() after @import
allows bare declaration.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/import-conditions-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/import-conditions.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssimportrule-expected.txt:
* LayoutTests/platform/gtk-wk2/imported/w3c/web-platform-tests/css/css-cascade/import-conditions-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/import-conditions-expected.txt: Added.
* Source/WebCore/css/CSSImportRule.cpp:
(WebCore::CSSImportRule::layerName const):
(WebCore::CSSImportRule::supportsText const):
(WebCore::CSSImportRule::cssTextInternal const):
* Source/WebCore/css/CSSImportRule.h:
* Source/WebCore/css/CSSImportRule.idl:
* Source/WebCore/css/StyleRuleImport.cpp:
(WebCore::StyleRuleImport::create):
(WebCore::StyleRuleImport::StyleRuleImport):
* Source/WebCore/css/StyleRuleImport.h:
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::parseSupportsCondition):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeImportRule):
(WebCore::CSSParserImpl::consumeSupportsRule):
* Source/WebCore/css/parser/CSSSupportsParser.cpp:
(WebCore::CSSSupportsParser::supportsCondition):
* Source/WebCore/css/parser/CSSSupportsParser.h:
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addRulesFromSheetContents):

Canonical link: <a href="https://commits.webkit.org/273591@main">https://commits.webkit.org/273591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4405df0afde219c275e7a073373bd8a7f1e952d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38625 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32305 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11873 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11023 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/36089 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39874 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32621 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32394 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36989 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-cascade/import-conditions.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35066 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/35880 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31725 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/42455 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/8184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12040 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->