### PR TITLE
[72857589b8bce60e] ASAN_ILL | WebCore::TreeScopeOrderedMap::getElementById; WebCore::TreeScope::getElementById; WebCore::SVGURIReference::targetElementFromIRIString.

### DIFF
--- a/LayoutTests/fast/shadow-dom/svg-mpath-removed-from-ancestor-crash-expected.txt
+++ b/LayoutTests/fast/shadow-dom/svg-mpath-removed-from-ancestor-crash-expected.txt
@@ -1,0 +1,3 @@
+Test passes if no crash.
+
+

--- a/LayoutTests/fast/shadow-dom/svg-mpath-removed-from-ancestor-crash.html
+++ b/LayoutTests/fast/shadow-dom/svg-mpath-removed-from-ancestor-crash.html
@@ -1,0 +1,41 @@
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    function main() {
+        try { v45 = x23.parentElement; } catch { }
+        try { v45.addEventListener("DOMNodeInserted", f2); } catch { }
+        try { x48.textContent = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"; } catch { }
+    }
+    function f1() {
+        try { v34 = x1.attachShadow({ mode: "closed", delegatesFocus: true }); } catch { }
+        try { v34.prepend(x27); } catch { }
+    }
+    function f2() {
+        var x27 = document.getElementById("x27");
+        try { v1 = document.createElement("thead"); } catch { }
+        try { v1.addEventListener("DOMSubtreeModified", f1); } catch { }
+        try { v1.setAttribute("lang", "id"); } catch { }
+        try { v84 = x33.farthestViewportElement; } catch { }
+        try { x27.insertBefore(x11, null); } catch { }
+        try { v84.replaceWith("AAAA"); } catch { }
+    }
+</script>
+<p>Test passes if no crash.</p>
+
+<body onload="main()">
+    <svg id="x11" meet">
+        <symbol id="x33" onclick="f3()">
+            <animateTransform id="x23" calcMode="paced">
+                <mpath id="x48" href="#x17" />
+                <polygon fill-rule="evenodd">
+                    <animateMotion id="x27" 0">
+                        <mpath href="#x17" />
+                    </animateMotion>
+                </polygon>
+                <path id="x17" stroke-width="0em">
+                    <div id="x1" slot="foo" />
+                </path>
+            </animateTransform>
+        </symbol>
+    </svg>
+</body>

--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -304,4 +304,23 @@ void SVGAnimateMotionElement::updateAnimationMode()
         SVGAnimationElement::updateAnimationMode();
 }
 
+void SVGAnimateMotionElement::childrenChanged(const ChildChange& change)
+{
+    SVGElement::childrenChanged(change);
+    switch (change.type) {
+    case ChildChange::Type::ElementRemoved:
+    case ChildChange::Type::AllChildrenRemoved:
+    case ChildChange::Type::AllChildrenReplaced:
+        updateAnimationPath();
+        break;
+    case ChildChange::Type::ElementInserted:
+    case ChildChange::Type::TextInserted:
+    case ChildChange::Type::TextRemoved:
+    case ChildChange::Type::TextChanged:
+    case ChildChange::Type::NonContentsChildInserted:
+    case ChildChange::Type::NonContentsChildRemoved:
+        break;
+    }
+}
+
 }

--- a/Source/WebCore/svg/SVGAnimateMotionElement.h
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.h
@@ -59,6 +59,7 @@ private:
     void buildTransformForProgress(AffineTransform*, float percentage);
 
     void updateAnimationMode() override;
+    void childrenChanged(const ChildChange&) final;
 
     // Note: we do not support percentage values for to/from coords as the spec implies we should (opera doesn't either)
     FloatPoint m_fromPoint;

--- a/Source/WebCore/svg/SVGMPathElement.cpp
+++ b/Source/WebCore/svg/SVGMPathElement.cpp
@@ -95,7 +95,6 @@ void SVGMPathElement::didFinishInsertingNode()
 void SVGMPathElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     SVGElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
-    notifyParentOfPathChange(&oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument)
         clearResourceReferences();
 }
@@ -125,11 +124,7 @@ RefPtr<SVGPathElement> SVGMPathElement::pathElement()
 
 void SVGMPathElement::targetPathChanged()
 {
-    notifyParentOfPathChange(parentNode());
-}
-
-void SVGMPathElement::notifyParentOfPathChange(ContainerNode* parent)
-{
+    auto* parent = parentNode();
     if (auto* animateMotionElement = dynamicDowncast<SVGAnimateMotionElement>(parent))
         animateMotionElement->updateAnimationPath();
 }

--- a/Source/WebCore/svg/SVGMPathElement.h
+++ b/Source/WebCore/svg/SVGMPathElement.h
@@ -54,8 +54,6 @@ private:
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
     void didFinishInsertingNode() final;
-
-    void notifyParentOfPathChange(ContainerNode*);
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 580e5844c227041f4e3dc3356948a9568a3b6d15
<pre>
[72857589b8bce60e] ASAN_ILL | WebCore::TreeScopeOrderedMap::getElementById; WebCore::TreeScope::getElementById; WebCore::SVGURIReference::targetElementFromIRIString.
<a href="https://bugs.webkit.org/show_bug.cgi?id=265562">https://bugs.webkit.org/show_bug.cgi?id=265562</a>
<a href="https://rdar.apple.com/118513775">rdar://118513775</a>

Reviewed by Chris Dumez.

updateAnimationPath should be done after treescope is fully updated.

* LayoutTests/fast/shadow-dom/svg-mpath-removed-from-ancestor-crash-expected.txt: Added.
* LayoutTests/fast/shadow-dom/svg-mpath-removed-from-ancestor-crash.html: Added.
* Source/WebCore/svg/SVGAnimateMotionElement.cpp:
(WebCore::SVGAnimateMotionElement::childrenChanged):
* Source/WebCore/svg/SVGAnimateMotionElement.h:
* Source/WebCore/svg/SVGMPathElement.cpp:
(WebCore::SVGMPathElement::removedFromAncestor):
(WebCore::SVGMPathElement::targetPathChanged):
(WebCore::SVGMPathElement::notifyParentOfPathChange): Deleted.
* Source/WebCore/svg/SVGMPathElement.h:

Originally-landed-as: 267815.611@safari-7617-branch (ca57f6a1de59). <a href="https://rdar.apple.com/121480927">rdar://121480927</a>
Canonical link: <a href="https://commits.webkit.org/273473@main">https://commits.webkit.org/273473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a000756552fa9b6224165e2f5706d8e7c07ec4af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38225 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31989 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30819 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10692 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10734 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39472 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32051 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36697 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10897 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34740 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12622 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31381 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11415 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4600 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11685 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->