### PR TITLE
[Content-visibility] RenderTreeNeedsLayoutChecker asserts on fixed positioned box inside skipped subtree

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/scroll-skipped-content-fixed-container.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/scroll-skipped-content-fixed-container.html
@@ -1,0 +1,21 @@
+<style>
+.container {
+  content-visibility: hidden;
+  width: 50px;
+  height: 50px;
+  background-color: blue;
+}
+</style>
+<script>
+
+function runTest() {
+  document.offsetTop;
+  window.scrollTo(0, 2000);
+  location.reload();
+  window.scrollTo(0, 0);
+}
+</script>
+<body onload="runTest()">
+  <div class=container><div><div style="width: 20px; height: 20px; background-color: red; position: fixed; top: 0px; left: 0px;"></div></div></div>
+  <div style="width: 40px; height: 2000px; background-color: green"></div>
+</body>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -870,6 +870,10 @@ bool RenderBlock::simplifiedLayout()
     if (needsPositionedMovementLayout() && !tryLayoutDoingPositionedMovementOnly())
         return false;
 
+    bool canContainFixedPosObjects = canContainFixedPositionObjects();
+    if (isSkippedContentRoot() && (posChildNeedsLayout() || canContainFixedPosObjects))
+        return false;
+
     // Lay out positioned descendants or objects that just need to recompute overflow.
     if (needsSimplifiedNormalFlowLayout())
         simplifiedNormalFlowLayout();
@@ -884,7 +888,6 @@ bool RenderBlock::simplifiedLayout()
     // child, neither the fixed element nor its container learn of the movement since posChildNeedsLayout() is only marked as far as the 
     // relative positioned container. So if we can have fixed pos objects in our positioned objects list check if any of them
     // are statically positioned and thus need to move with their absolute ancestors.
-    bool canContainFixedPosObjects = canContainFixedPositionObjects();
     if (posChildNeedsLayout() || canContainFixedPosObjects)
         layoutPositionedObjects(false, !posChildNeedsLayout() && canContainFixedPosObjects);
 


### PR DESCRIPTION
#### 5e333884a680041a2415e7b64ba6c63e3f48522c
<pre>
[Content-visibility] RenderTreeNeedsLayoutChecker asserts on fixed positioned box inside skipped subtree
<a href="https://bugs.webkit.org/show_bug.cgi?id=264169">https://bugs.webkit.org/show_bug.cgi?id=264169</a>
<a href="https://rdar.apple.com/117914028">rdar://117914028</a>

Reviewed by Alan Baradlay.

Avoid simplified layout when laying out a content-visibility root with positioned children since
there is no guarentee the positioned children have been processed in a previous layout due to
lazy layout of skipped content.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/scroll-skipped-content-fixed-container.html: Added.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::simplifiedLayout):

Originally-landed-as: 270734.5@webkit-embargoed (bd192edd0348). <a href="https://rdar.apple.com/121480818">rdar://121480818</a>
Canonical link: <a href="https://commits.webkit.org/273504@main">https://commits.webkit.org/273504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f81e2cec9dccc7bf523ce3a44d0a79a171e26243

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38228 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/31992 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30823 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12251 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10697 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39475 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32315 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32053 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36706 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34754 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31383 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11418 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4610 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->