### PR TITLE
ASSERT when calling browser.storageArea.get()

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm
@@ -43,9 +43,8 @@ void WebExtensionContext::storageGet(WebPageProxyIdentifier webPageProxyIdentifi
 {
     static NSString * const callingAPIName = [NSString stringWithFormat:@"%@.get()", (NSString *)toAPIPrefixString(storageType)];
 
-    String errorString;
-    if (!extensionCanAccessWebPage(webPageProxyIdentifier, errorString)) {
-        completionHandler(std::nullopt, toErrorString(callingAPIName, nil, errorString));
+    if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
+        completionHandler(std::nullopt, toErrorString(callingAPIName, nil, @"access not allowed"));
         return;
     }
 
@@ -57,9 +56,8 @@ void WebExtensionContext::storageGetBytesInUse(WebPageProxyIdentifier webPagePro
 {
     static NSString * const callingAPIName = [NSString stringWithFormat:@"%@.getBytesInUse()", (NSString *)toAPIPrefixString(storageType)];
 
-    String errorString;
-    if (!extensionCanAccessWebPage(webPageProxyIdentifier, errorString)) {
-        completionHandler(std::nullopt, toErrorString(callingAPIName, nil, errorString));
+    if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
+        completionHandler(std::nullopt, toErrorString(callingAPIName, nil, @"access not allowed"));
         return;
     }
 
@@ -71,9 +69,8 @@ void WebExtensionContext::storageSet(WebPageProxyIdentifier webPageProxyIdentifi
 {
     static NSString * const callingAPIName = [NSString stringWithFormat:@"%@.set()", (NSString *)toAPIPrefixString(storageType)];
 
-    String errorString;
-    if (!extensionCanAccessWebPage(webPageProxyIdentifier, errorString)) {
-        completionHandler(toErrorString(callingAPIName, nil, errorString));
+    if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
+        completionHandler(toErrorString(callingAPIName, nil, @"access not allowed"));
         return;
     }
 
@@ -85,9 +82,8 @@ void WebExtensionContext::storageRemove(WebPageProxyIdentifier webPageProxyIdent
 {
     static NSString * const callingAPIName = [NSString stringWithFormat:@"%@.remove()", (NSString *)toAPIPrefixString(storageType)];
 
-    String errorString;
-    if (!extensionCanAccessWebPage(webPageProxyIdentifier, errorString)) {
-        completionHandler(toErrorString(callingAPIName, nil, errorString));
+    if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
+        completionHandler(toErrorString(callingAPIName, nil, @"access not allowed"));
         return;
     }
 
@@ -99,9 +95,8 @@ void WebExtensionContext::storageClear(WebPageProxyIdentifier webPageProxyIdenti
 {
     static NSString * const callingAPIName = [NSString stringWithFormat:@"%@.clear()", (NSString *)toAPIPrefixString(storageType)];
 
-    String errorString;
-    if (!extensionCanAccessWebPage(webPageProxyIdentifier, errorString)) {
-        completionHandler(toErrorString(callingAPIName, nil, errorString));
+    if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
+        completionHandler(toErrorString(callingAPIName, nil, @"access not allowed"));
         return;
     }
 
@@ -113,9 +108,8 @@ void WebExtensionContext::storageSetAccessLevel(WebPageProxyIdentifier webPagePr
 {
     static NSString * const callingAPIName = @"browser.session.setAccessLevel()";
 
-    String errorString;
-    if (!extensionCanAccessWebPage(webPageProxyIdentifier, errorString)) {
-        completionHandler(toErrorString(callingAPIName, nil, errorString));
+    if (!extensionCanAccessWebPage(webPageProxyIdentifier)) {
+        completionHandler(toErrorString(callingAPIName, nil, @"access not allowed"));
         return;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -237,7 +237,7 @@ public:
     void setBaseURL(URL&&);
 
     bool isURLForThisExtension(const URL&) const;
-    bool extensionCanAccessWebPage(WebPageProxyIdentifier, ErrorString);
+    bool extensionCanAccessWebPage(WebPageProxyIdentifier);
 
     bool hasCustomUniqueIdentifier() const { return m_customUniqueIdentifier; }
 


### PR DESCRIPTION
#### 4522d41c15c5272d1a47017cd6c5fd1bb1dcf0a8
<pre>
ASSERT when calling browser.storageArea.get()
<a href="https://bugs.webkit.org/show_bug.cgi?id=268020">https://bugs.webkit.org/show_bug.cgi?id=268020</a>
<a href="https://rdar.apple.com/121538792">rdar://121538792</a>

Reviewed by Timothy Hatcher.

Issues with how ErrorString was being used in WebKit::WebExtensionContext::extensionCanAccessWebPage
caused the crash. However, since a failure in this method would indicate a security issue, we should
remove this error message and instead add a RELEASE_ASSERT_NOT_REACHED().

The reason why we&apos;re hitting this failure currently is because we return false when the tab
for the web page is not found. This is an internal bug and is being tracked in
<a href="https://bugs.webkit.org/show_bug.cgi?id=268030">https://bugs.webkit.org/show_bug.cgi?id=268030</a>, <a href="https://rdar.apple.com/121550605">rdar://121550605</a>.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm:
(WebKit::WebExtensionContext::storageGet):
(WebKit::WebExtensionContext::storageGetBytesInUse):
(WebKit::WebExtensionContext::storageSet):
(WebKit::WebExtensionContext::storageRemove):
(WebKit::WebExtensionContext::storageClear):
(WebKit::WebExtensionContext::storageSetAccessLevel):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::extensionCanAccessWebPage):
A failure in this function would indicate a security bug as this case should never be hit.
Add a RELEASE_ASSERT_NOT_REACHED() for this.

* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:

Canonical link: <a href="https://commits.webkit.org/273448@main">https://commits.webkit.org/273448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75091aaabd6c33ec41780ca0d771dd6bc25b8fcf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37631 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/38238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11474 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/38238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36047 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/12204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/38238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/32266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/32065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/39485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10910 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/8807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4583 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->