### PR TITLE
Add a hasUnreadBadgeText property to _WKWebExtensionAction.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h
@@ -89,8 +89,19 @@ NS_SWIFT_NAME(_WKWebExtension.Action)
 /*! @abstract The localized display label for the action. */
 @property (nonatomic, readonly, copy) NSString *label;
 
-/*! @abstract The badge text for the action. */
+/*!
+ @abstract The badge text for the action.
+ @discussion This property represents the text that appears on the badge for the action. An empty string signifies that no badge should be shown.
+ */
 @property (nonatomic, readonly, copy) NSString *badgeText;
+
+/*!
+ @abstract A Boolean value indicating whether the badge text is unread.
+ @discussion This property is automatically set to `YES` when `badgeText` changes and is not empty. If `badgeText` becomes empty or the
+ popup associated with the action is presented, this property is automatically set to `NO`. Additionally, it should be set to `NO` by the app when the badge
+ has been presented to the user. This property is useful for higher-level notification badges when extensions might be hidden behind an action sheet.
+ */
+@property (nonatomic) BOOL hasUnreadBadgeText;
 
 /*! @abstract A Boolean value indicating whether the action is enabled. */
 @property (nonatomic, readonly, getter=isEnabled) BOOL enabled;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm
@@ -99,6 +99,16 @@ using CocoaMenuItem = UIMenuElement;
     return _webExtensionAction->badgeText();
 }
 
+- (BOOL)hasUnreadBadgeText
+{
+    return _webExtensionAction->hasUnreadBadgeText();
+}
+
+- (void)setHasUnreadBadgeText:(BOOL)hasUnreadBadgeText
+{
+    return _webExtensionAction->setHasUnreadBadgeText(hasUnreadBadgeText);
+}
+
 - (BOOL)isEnabled
 {
     return _webExtensionAction->isEnabled();
@@ -161,6 +171,15 @@ using CocoaMenuItem = UIMenuElement;
 - (NSString *)badgeText
 {
     return nil;
+}
+
+- (BOOL)hasUnreadBadgeText
+{
+    return NO;
+}
+
+- (void)setHasUnreadBadgeText:(BOOL)hasUnreadBadgeText
+{
 }
 
 - (BOOL)isEnabled

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -83,6 +83,9 @@ public:
     String badgeText() const;
     void setBadgeText(String);
 
+    bool hasUnreadBadgeText() const;
+    void setHasUnreadBadgeText(bool);
+
     void incrementBlockedResourceCount(ssize_t amount);
 
     bool isEnabled() const;
@@ -121,8 +124,9 @@ private:
     String m_customBadgeText;
     ssize_t m_blockedResourceCount { 0 };
     std::optional<bool> m_customEnabled;
-    bool m_popupPresented { false };
-    bool m_respondsToPresentPopup { false };
+    std::optional<bool> m_hasUnreadBadgeText;
+    bool m_popupPresented : 1 { false };
+    bool m_respondsToPresentPopup : 1 { false };
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### eaff760b4a9ea37d5bbf33fd6d8f775b4c845135
<pre>
Add a hasUnreadBadgeText property to _WKWebExtensionAction.
<a href="https://webkit.org/b/268014">https://webkit.org/b/268014</a>
<a href="https://rdar.apple.com/problem/121536115">rdar://problem/121536115</a>

Reviewed by Brian Weinstein.

This property is automatically set to `YES` when `badgeText` changes and is not empty.
If `badgeText` becomes empty or the popup associated with the action is presented, this
property is automatically set to `NO`. Additionally, it should be set to `NO` by the app
when the badge has been presented to the user. This property is useful for higher-level
notification badges when extensions might be hidden behind an action sheet.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionAction.mm:
(-[_WKWebExtensionAction hasUnreadBadgeText]): Added.
(-[_WKWebExtensionAction setHasUnreadBadgeText:]): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::readyToPresentPopup):
(WebKit::WebExtensionAction::setBadgeText):
(WebKit::WebExtensionAction::hasUnreadBadgeText const): Added.
(WebKit::WebExtensionAction::setHasUnreadBadgeText): Added.
(WebKit::WebExtensionAction::incrementBlockedResourceCount):
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TestWebKitAPI::TEST): Added new tests.

Canonical link: <a href="https://commits.webkit.org/273458@main">https://commits.webkit.org/273458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f02a2fa490d1b2dbe818e4cf7da01ce4a2d23db6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38241 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11477 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10704 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39488 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32069 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36705 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8809 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/34763 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11431 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->