### PR TITLE
rdar://115106974 (SEGV in -[NSView resizeSubviewsWithOldSize:])

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5407,6 +5407,9 @@ webkit.org/b/239959 ipc/stream-sync-crash-no-timeout.html [ Skip ]
 # The test invokes random messages, potentially produces random results.
 ipc/start-message-testing.html [ Skip ]
 
+# Test is slow
+ipc/invalid-fullscreen-enum.html [ Pass Timeout ]
+
 # Test is crashing in Debug builds since import.
 webkit.org/b/234977 [ Debug ] imported/w3c/web-platform-tests/dom/events/focus-event-document-move.html [ Skip ]
 

--- a/LayoutTests/ipc/invalid-fullscreen-enum-expected.txt
+++ b/LayoutTests/ipc/invalid-fullscreen-enum-expected.txt
@@ -1,0 +1,2 @@
+This test should not crash
+

--- a/LayoutTests/ipc/invalid-fullscreen-enum.html
+++ b/LayoutTests/ipc/invalid-fullscreen-enum.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+function test() {
+  if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+  }
+
+  if (window.IPC) {
+    IPC.addOutgoingMessageListener("UI", (msg) => {
+      if (msg.name == IPC.messages.VideoPresentationManagerProxy_SetHasVideo.name) {
+        parseSetHasVideo(msg);
+      }
+    });
+
+    o8=document.createElement('video');
+    o8.src='resources/1080i60_SMPTE_8CH_audible.mov';
+    document.body.appendChild(o8);
+    o9=document.createElement('canvas');
+  } else {
+    console.log("Can't run test");
+  }
+}
+function parseSetHasVideo(msg) {
+  destinationId=msg['destinationID'];
+  contextId=msg['arguments'][0]['value'];
+  window.setTimeout(timeout1,200);
+}
+function timeout1() {
+  o39=document.createElement('iframe');
+  document.body.appendChild(o39);
+  IPC.sendMessage('UI',destinationId,IPC.messages.VideoPresentationManagerProxy_SetupFullscreenWithID.name,
+                  [{type: 'uint64_t',value: contextId},                                                                             // PlaybackSessionContextIdentifier contextId
+                   {type: 'uint32_t',value: 8},                                                                                     // WebKit::LayerHostingContextID videoLayerID
+                   {type: 'float',value: 338},{type: 'float',value: -429},{type: 'float',value: 117},{type: 'float',value: 1411},   // WebCore::FloatRect& screenRect
+                   {type: 'float',value: 557},{type: 'float',value: 885},                                                           // WebCore::FloatSize& initialSize
+                   {type: 'float',value: 215},{type: 'float',value: 537},                                                           // WebCore::FloatSize& videoDimensions
+                   {type: 'float',value: 299},                                                                                      // float hostingDeviceScaleFactor
+                   {type: 'uint32_t',value: 2n},                                                                                    // HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode
+                   {type: 'bool',value: 0},                                                                                         // bool allowsPictureInPicture
+                   {type: 'bool',value: 1},                                                                                         // bool standby
+                   {type: 'bool',value: 1}                                                                                          // bool blocksReturnToFullscreenFromPictureInPicture
+                 ]);
+  window.setTimeout(timeout2,200);
+}
+function timeout2() {
+  window.open('empty.html',"InsertTab",'heigth=100,width=200');
+  IPC.sendMessage('UI',destinationId,IPC.messages.VideoPresentationManagerProxy_SetupFullscreenWithID.name,
+                  [{type: 'uint64_t',value: contextId},                                                                             // PlaybackSessionContextIdentifier contextId
+                   {type: 'uint32_t',value: 8},                                                                                     // WebKit::LayerHostingContextID videoLayerID
+                   {type: 'float',value: 2659},{type: 'float',value: 2032},{type: 'float',value: 69},{type: 'float',value: 713},    // WebCore::FloatRect& screenRect
+                   {type: 'float',value: 3444},{type: 'float',value: 23},                                                           // WebCore::FloatSize& initialSize
+                   {type: 'float',value: 463},{type: 'float',value: 938},                                                           // WebCore::FloatSize& videoDimensions
+                   {type: 'float',value: 950},                                                                                      // float hostingDeviceScaleFactor
+                   {type: 'uint32_t',value: 68n},                                                                                   // HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode
+                   {type: 'bool',value: 1},                                                                                         // bool allowsPictureInPicture
+                   {type: 'bool',value: 0},                                                                                         // bool standby
+                   {type: 'bool',value: 0}]);                                                                                       // bool blocksReturnToFullscreenFromPictureInPicture
+  o70=document.createElement('iframe');
+  document.body.appendChild(o70);
+  o8.srcObject=o9.captureStream();
+  window.setTimeout(timeout3,200);
+}
+function timeout3() {
+  IPC.sendMessage('UI',IPC.webPageProxyID,IPC.messages.WebPageProxy_SetWindowFrame.name,[{type: 'float',value: 1142},{type: 'float',value: 1330},{type: 'float',value: 168},{type: 'float',value: 1869}]);
+  window.setTimeout(timeout4,500);
+}
+function timeout4() {
+  if (window.testRunner)
+    testRunner.notifyDone();
+}
+</script>
+<body onload='test()'>
+<div>This test should not crash</div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/MediaPlayerEnums.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerEnums.h
@@ -122,6 +122,7 @@ public:
         VideoFullscreenModeNone = 0,
         VideoFullscreenModeStandard = 1 << 0,
         VideoFullscreenModePictureInPicture = 1 << 1,
+        VideoFullscreenModeAllValidBitsMask = (VideoFullscreenModeStandard | VideoFullscreenModePictureInPicture)
     };
     typedef uint32_t VideoFullscreenMode;
 };


### PR DESCRIPTION
#### 235ea5801184534cc4fe85b818c642eeea8849c3
<pre>
<a href="https://rdar.apple.com/115106974">rdar://115106974</a> (SEGV in -[NSView resizeSubviewsWithOldSize:])

Checks that the VideoFullscreenMode argument for two IPC calls is valid and invalidates the IPC message if not.

Reviewed by Alex Christensen (achristensen07).

If the VideoFullscreenMode value is not as expected it IPC message will be marked as invalid, which is supposed
to crash the content process thereby thwarting any attempted attack through this mechanism.

* LayoutTests/TestExpectations:
* LayoutTests/ipc/invalid-fullscreen-enum-expected.txt: Added.
* LayoutTests/ipc/invalid-fullscreen-enum.html: Added.
* LayoutTests/ipc/resources/1080i60_SMPTE_8CH_audible.mov: Added.
* Source/WebCore/platform/graphics/MediaPlayerEnums.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
(WebKit::VideoPresentationManagerProxy::exitFullscreenWithoutAnimationToMode):

Originally-landed-as: 267815.636@safari-7617-branch (cc4e54ad41c9). <a href="https://rdar.apple.com/121480101">rdar://121480101</a>
Canonical link: <a href="https://commits.webkit.org/273472@main">https://commits.webkit.org/273472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6277cc068cbb648bcb0d6572464ec2080bd14b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38247 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32009 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11483 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31616 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10714 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10747 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39493 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36710 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34759 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12640 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31405 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11436 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4599 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->