### PR TITLE
Crash in SVGGeometryElement::isPointInFill

### DIFF
--- a/LayoutTests/fast/svg/isPointInFill-without-path-expected.txt
+++ b/LayoutTests/fast/svg/isPointInFill-without-path-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Error: Invalid value for <rect> attribute y="1 -1 62"
+CONSOLE MESSAGE: Error: Invalid negative value for <rect> attribute width="-1cm"
+ALERT: This test passes if it does not crash
+

--- a/LayoutTests/fast/svg/isPointInFill-without-path.html
+++ b/LayoutTests/fast/svg/isPointInFill-without-path.html
@@ -1,0 +1,10 @@
+<script>
+if (window.testRunner) { testRunner.dumpAsText() }
+function checkPointInFill() {
+    var result = rectElement.isPointInFill();
+    alert("This test passes if it does not crash");
+}
+</script>
+<body onload=checkPointInFill()>
+<svg id="svgElement" transform="skewY(0)" style="font-variant-caps: titling-case; rotation: 0deg; text-decoration-upright: all none; box-ordinal-group: 1; grid-template: none/-1px" xml:space="default" baseProfile="full" xml:space="preserve" preserveAlpha="true" points="1,1 12,0" x="1em" role="button" role="button">
+<rect id="rectElement" x="20em" y="1 -1 62" width="-1cm" height="1cm" font-size="4px" transform="skewX(-1) skewX(6)" fill="url(#doesnotexist) currentColor" clip-path="url(#svgElement)" repeatDur="4s" vert-origin-y="10" onclick="eventhandler4()" refX="56" fx="1" />

--- a/Source/WebCore/rendering/svg/RenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.cpp
@@ -190,6 +190,8 @@ bool RenderSVGRect::shapeDependentStrokeContains(const FloatPoint& point, PointC
 
 bool RenderSVGRect::shapeDependentFillContains(const FloatPoint& point, const WindRule fillRule) const
 {
+    if (m_shapeType == ShapeType::Empty)
+        return false;
     if (m_shapeType != ShapeType::Rectangle)
         return RenderSVGShape::shapeDependentFillContains(point, fillRule);
     return m_fillBoundingBox.contains(point.x(), point.y());

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
@@ -187,6 +187,8 @@ bool LegacyRenderSVGRect::shapeDependentStrokeContains(const FloatPoint& point, 
 
 bool LegacyRenderSVGRect::shapeDependentFillContains(const FloatPoint& point, const WindRule fillRule) const
 {
+    if (m_shapeType == ShapeType::Empty)
+        return false;
     if (m_shapeType != ShapeType::Rectangle)
         return LegacyRenderSVGShape::shapeDependentFillContains(point, fillRule);
     return m_fillBoundingBox.contains(point.x(), point.y());


### PR DESCRIPTION
#### 89b5637b58e30a61844041786aa09249b4e95d8f
<pre>
Crash in SVGGeometryElement::isPointInFill
<a href="https://bugs.webkit.org/show_bug.cgi?id=265802">https://bugs.webkit.org/show_bug.cgi?id=265802</a>
<a href="https://rdar.apple.com/119142303">rdar://119142303</a>

Reviewed by Ryosuke Niwa.

Check for empty objects.

* LayoutTests/fast/svg/isPointInFill-without-path-expected.txt: Added.
* LayoutTests/fast/svg/isPointInFill-without-path.html: Added.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::shapeDependentFillContains const):

Canonical link: <a href="https://commits.webkit.org/273494@main">https://commits.webkit.org/273494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89710cd5f4c908d5c772b406a917228df2666614

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35538 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38280 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32036 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30848 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10740 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10770 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32301 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32109 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36724 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34823 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31434 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8128 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11463 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->