### PR TITLE
[masonry] Update to modern track sizing algorithm during accumulating track sizes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-001-expected.html
@@ -37,6 +37,4 @@ item {
   <item style="padding:0; place-self:start; min-width:0">2</item>
   <item>3</item>
   <item>4</item>
-  <item style="order:1; width:0; margin-right:-23px; margin-top:-37px; align-self:start">5</item>
-  <item>6</item>
 </grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-001-ref.html
@@ -15,7 +15,7 @@ html,body {
 grid {
   display: inline-grid;
   gap: 10px 20px;
-  grid-template-columns:  auto min-content repeat(2,auto);
+  grid-template-columns: auto min-content repeat(2,auto);
   color: #444;
   border: 1px solid;
   padding: 2px;
@@ -37,6 +37,4 @@ item {
   <item style="padding:0; place-self:start; min-width:0">2</item>
   <item>3</item>
   <item>4</item>
-  <item style="order:1; width:0; margin-right:-23px; margin-top:-37px; align-self:start">5</item>
-  <item>6</item>
 </grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-001.html
@@ -17,7 +17,7 @@ html,body {
 grid {
   display: inline-grid;
   gap: 10px 20px;
-  grid-template-columns:  repeat(4,auto);
+  grid-template-columns: repeat(4,auto);
   grid-template-rows: masonry;
   color: #444;
   border: 1px solid;
@@ -36,10 +36,8 @@ item {
 <body>
 
 <grid>
-  <item>1</item>
-  <item style="padding:0">2</item>
-  <item>3</item>
-  <item>4</item>
-  <item>5</item>
-  <item>6</item>
+  <item style="grid-column: 1;">1</item>
+  <item style="padding:0; grid-column: 2;">2</item>
+  <item style="grid-column: 3;">3</item>
+  <item style="grid-column: 4;">4</item>
 </grid>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-overflow-left-side-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-overflow-left-side-expected.html
@@ -12,7 +12,7 @@
 <style>
 grid {
   display: grid;
-  grid-template-columns: 50px 1fr;
+  grid-template-columns: 100px 1fr;
   grid-template-rows: 50px 250px;
   width: 300px;
   height: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-overflow-left-side-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-overflow-left-side-ref.html
@@ -12,7 +12,7 @@
 <style>
 grid {
   display: grid;
-  grid-template-columns: 50px 1fr;
+  grid-template-columns: 100px 1fr;
   grid-template-rows: 50px 250px;
   width: 300px;
   height: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-overflow-right-side-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-overflow-right-side-expected.html
@@ -12,7 +12,7 @@
 <style>
 grid {
   display: grid;
-  grid-template-columns: 1fr 50px;
+  grid-template-columns: 1fr 100px;
   grid-template-rows: 1fr 50px;
   width: 300px;
   height: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-overflow-right-side-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-overflow-right-side-ref.html
@@ -12,7 +12,7 @@
 <style>
 grid {
   display: grid;
-  grid-template-columns: 1fr 50px;
+  grid-template-columns: 1fr 100px;
   grid-template-rows: 1fr 50px;
   width: 300px;
   height: 100px;

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1363,28 +1363,22 @@ void GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack(GridTrack& track
         // https://drafts.csswg.org/css-grid-3/#track-sizing
         // We should only compute track sizes on a subset of items.
         //
-        // - Items placed at the first implicit line in the masonry axis.
-        // - Items that have a specified definite placement in the grid axis.
-        // - Items that span all grid axis tracks.
+        // - Items explicitly placed in that track contribute.
+        // - Items without an explicit placement contribute (regardless of whether they are ultimately placed in that track).
         if (m_renderGrid->isMasonry()) {
             bool skipTrackSizing = true;
 
             // m_direction shall always be the gridAxisDirection.
             ASSERT(!isDirectionInMasonryDirection());
             auto gridAxisDirection = m_direction;
-            auto masonryAxisDirection = m_renderGrid->areMasonryRows() ? GridTrackSizingDirection::ForRows : GridTrackSizingDirection::ForColumns;
             auto span = GridPositionsResolver::resolveGridPositionsFromStyle(*m_renderGrid, *gridItem, gridAxisDirection);
 
-            // Items placed at the first implicit line in the masonry axis.
-            if (!m_renderGrid->gridSpanForChild(*gridItem, masonryAxisDirection).startLine())
+            // Items specifically placed in this track.
+            if (m_renderGrid->gridSpanForChild(*gridItem, gridAxisDirection).startLine() == trackIndex)
                 skipTrackSizing = false;
 
-            // Items that have a specified definite placement in the grid axis.
-            if (!span.isIndefinite())
-                skipTrackSizing = false;
-
-            // Items that span all grid axis tracks.
-            if (m_renderGrid->gridSpanForChild(*gridItem, gridAxisDirection).integerSpan() == tracks(gridAxisDirection).size())
+            // Items that have an indefinite placement in the grid axis.
+            if (span.isIndefinite())
                 skipTrackSizing = false;
 
             if (skipTrackSizing)


### PR DESCRIPTION
#### 7719c4262533e0ce345feda9d30c9b399ec4efbd
<pre>
[masonry] Update to modern track sizing algorithm during accumulating track sizes
<a href="https://bugs.webkit.org/show_bug.cgi?id=268050">https://bugs.webkit.org/show_bug.cgi?id=268050</a>

Reviewed by Sammy Gill.

Update to the new track sizing algorithm. All elements participate that are definite inside the track,
and those that are indefinite.

This patch only handles the algorithm. Another patch will handle placing all indefinite items across
all intrinsic tracks.

Test Case Updates:

masonry-track-sizing-overflow-left/right-side:
These test cases were built off the idea of the old track sizing algorithm where only the first track determined the
column size. Under the new algorithm all items now contribute; therefore the bottom item extends the track an extra 50px.

masonry-gap-001:
Simplified test case to focus on the gap.
Updated the grid-columns for items to ensure that other tracks would not affect the 2nd column.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-001-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-001-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/gap/masonry-gap-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-overflow-left-side-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-overflow-left-side-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-overflow-right-side-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-overflow-right-side-ref.html:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack):

Canonical link: <a href="https://commits.webkit.org/273551@main">https://commits.webkit.org/273551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b4ee6d0b26873887c825d467ce5109257835513

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38465 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32168 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36953 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30940 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31784 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10901 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39713 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32463 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32274 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36850 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11088 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34934 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12822 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31604 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8153 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11593 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11894 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->