### PR TITLE
Restrict didFinishInsertingNode to connected nodes

### DIFF
--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -123,6 +123,8 @@ Node::InsertedIntoAncestorResult HTMLFormControlElement::insertedIntoAncestor(In
     HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     ValidatedFormListedElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
 
+    if (!insertionType.connectedToDocument)
+        return InsertedIntoAncestorResult::Done;
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
 

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1699,7 +1699,7 @@ void HTMLInputElement::didChangeForm()
 
 Node::InsertedIntoAncestorResult HTMLInputElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    HTMLTextFormControlElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = HTMLTextFormControlElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
 #if ENABLE(DATALIST_ELEMENT)
     resetListAttributeTargetObserver();
 #endif
@@ -1709,6 +1709,8 @@ Node::InsertedIntoAncestorResult HTMLInputElement::insertedIntoAncestor(Insertio
         document().addElementWithPendingUserAgentShadowTreeUpdate(*this);
         m_hasPendingUserAgentShadowTreeUpdate = true;
     }
+    if (!insertionType.connectedToDocument)
+        return result;
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
 

--- a/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.cpp
@@ -125,7 +125,8 @@ Node::InsertedIntoAncestorResult HTMLMaybeFormAssociatedCustomElement::insertedI
     HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     if (isFormAssociatedCustomElement())
         formAssociatedCustomElementUnsafe().insertedIntoAncestor(insertionType, parentOfInsertedTree);
-
+    if (!insertionType.connectedToDocument)
+        return InsertedIntoAncestorResult::Done;
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -886,6 +886,8 @@ Node::InsertedIntoAncestorResult HTMLMediaElement::insertedIntoAncestor(Insertio
     if (insertionType.connectedToDocument)
         setInActiveDocument(true);
 
+    if (!insertionType.connectedToDocument)
+        return InsertedIntoAncestorResult::Done;
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
 

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -239,6 +239,8 @@ Node::InsertedIntoAncestorResult HTMLObjectElement::insertedIntoAncestor(Inserti
 {
     HTMLPlugInImageElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     FormListedElement::elementInsertedIntoAncestor(*this, insertionType);
+    if (!insertionType.connectedToDocument)
+        return InsertedIntoAncestorResult::Done;
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
 

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -327,6 +327,11 @@ void ValidatedFormListedElement::insertedIntoAncestor(Node::InsertionType insert
     syncWithFieldsetAncestors(&parentOfInsertedTree);
 
     FormListedElement::elementInsertedIntoAncestor(asHTMLElement(), insertionType);
+
+    if (!insertionType.connectedToDocument)
+        resetFormOwner();
+    // Need to wait for didFinishInsertingNode to reset form when this element is inserted into a document
+    // because we rely on TreeScope::getElementById to return the right element.
 }
 
 void ValidatedFormListedElement::setDataListAncestorState(TriState isInsideDataList)

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -145,6 +145,8 @@ void SVGFEImageElement::svgAttributeChanged(const QualifiedName& attrName)
 Node::InsertedIntoAncestorResult SVGFEImageElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     SVGFilterPrimitiveStandardAttributes::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    if (!insertionType.connectedToDocument)
+        return InsertedIntoAncestorResult::Done;
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
 

--- a/Source/WebCore/svg/SVGTextPathElement.cpp
+++ b/Source/WebCore/svg/SVGTextPathElement.cpp
@@ -166,6 +166,8 @@ void SVGTextPathElement::buildPendingResource()
 Node::InsertedIntoAncestorResult SVGTextPathElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     SVGTextContentElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    if (!insertionType.connectedToDocument)
+        return InsertedIntoAncestorResult::Done;
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
 


### PR DESCRIPTION
#### 980a1d5fec289b479d5fd6f76bea60cdc8d8d25e
<pre>
Restrict didFinishInsertingNode to connected nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=268051">https://bugs.webkit.org/show_bug.cgi?id=268051</a>

Reviewed by Wenson Hsieh.

Don&apos;t call didFinishInsertingNode when a node is not connected to a document.

* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::notifyNodeInsertedIntoTree):
(WebCore::notifyChildNodeInserted):
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::insertedIntoAncestor):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::insertedIntoAncestor):
* Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.cpp:
(WebCore::HTMLMaybeFormAssociatedCustomElement::insertedIntoAncestor):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::insertedIntoAncestor):
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::insertedIntoAncestor):
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::insertedIntoAncestor): Call resetFormOwner when this insertion
didn&apos;t result in getting connected to a new document since didFinishInsertingNode won&apos;t be called in
such cases. It&apos;s okay to call this function synchronously in this case since we don&apos;t rely on
TreeScope::getElementById when the node is not connected to a a document in findAssociatedForm.
* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::insertedIntoAncestor):
* Source/WebCore/svg/SVGTextPathElement.cpp:
(WebCore::SVGTextPathElement::insertedIntoAncestor):

Canonical link: <a href="https://commits.webkit.org/273523@main">https://commits.webkit.org/273523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f88afcfa13f7ffea3575bc24f369798a8760541

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38289 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32041 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30853 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10747 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39534 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32304 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36730 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10953 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34785 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12669 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11468 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4622 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11732 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->