### PR TITLE
Adopt more smart pointers in ResourceLoader.cpp

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4423,6 +4423,11 @@ NetworkingContext* FrameLoader::networkingContext() const
     return m_networkingContext.get();
 }
 
+RefPtr<NetworkingContext> FrameLoader::protectedNetworkingContext() const
+{
+    return m_networkingContext;
+}
+
 void FrameLoader::loadProgressingStatusChanged()
 {
     if (RefPtr localFrame = dynamicDowncast<LocalFrame>(m_frame->mainFrame())) {

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -310,6 +310,7 @@ public:
     PageDismissalType pageDismissalEventBeingDispatched() const { return m_pageDismissalEventBeingDispatched; }
 
     WEBCORE_EXPORT NetworkingContext* networkingContext() const;
+    WEBCORE_EXPORT RefPtr<NetworkingContext> protectedNetworkingContext() const;
 
     void loadProgressingStatusChanged();
 

--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -80,6 +80,7 @@ public:
 #endif
 
     WEBCORE_EXPORT FrameLoader* frameLoader() const;
+    WEBCORE_EXPORT CheckedPtr<FrameLoader> checkedFrameLoader() const;
     DocumentLoader* documentLoader() const { return m_documentLoader.get(); }
     RefPtr<DocumentLoader> protectedDocumentLoader() const;
     const ResourceRequest& originalRequest() const { return m_originalRequest; }


### PR DESCRIPTION
#### 578277aa333935292b2c672558d6e45bfe14d7e4
<pre>
Adopt more smart pointers in ResourceLoader.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=268054">https://bugs.webkit.org/show_bug.cgi?id=268054</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::protectedNetworkingContext const):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::finishNetworkLoad):
(WebCore::ResourceLoader::releaseResources):
(WebCore::ResourceLoader::init):
(WebCore::ResourceLoader::start):
(WebCore::ResourceLoader::setDefersLoading):
(WebCore::ResourceLoader::loadDataURL):
(WebCore::ResourceLoader::willSwitchToSubstituteResource):
(WebCore::ResourceLoader::checkedFrameLoader const):
(WebCore::ResourceLoader::willSendRequestInternal):
(WebCore::logResourceResponseSource):
(WebCore::ResourceLoader::shouldAllowResourceToAskForCredentials const):
(WebCore::ResourceLoader::didBlockAuthenticationChallenge):
(WebCore::ResourceLoader::didReceiveResponse):
(WebCore::ResourceLoader::didReceiveBuffer):
(WebCore::ResourceLoader::didFinishLoadingOnePart):
(WebCore::ResourceLoader::didFail):
(WebCore::ResourceLoader::cleanupForError):
(WebCore::ResourceLoader::cancel):
(WebCore::ResourceLoader::cancelledError):
(WebCore::ResourceLoader::blockedError):
(WebCore::ResourceLoader::blockedByContentBlockerError):
(WebCore::ResourceLoader::cannotShowURLError):
(WebCore::ResourceLoader::httpsUpgradeRedirectLoopError):
(WebCore::ResourceLoader::willSendRequestAsync):
(WebCore::ResourceLoader::didReceiveResponseAsync):
(WebCore::ResourceLoader::shouldUseCredentialStorage):
(WebCore::ResourceLoader::didReceiveAuthenticationChallenge):
(WebCore::ResourceLoader::canAuthenticateAgainstProtectionSpace):
(WebCore::ResourceLoader::connectionProperties):
(WebCore::ResourceLoader::schedule):
(WebCore::ResourceLoader::unschedule):
(WebCore::ResourceLoader::isPDFJSResourceLoad const):
* Source/WebCore/loader/ResourceLoader.h:

Canonical link: <a href="https://commits.webkit.org/273478@main">https://commits.webkit.org/273478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d99400f10ab09d1f0c33f17dc5bab6fcb23e309

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38296 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32044 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11524 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36108 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31649 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10753 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39541 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32307 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32115 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36733 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10956 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/8858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34789 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12672 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11471 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4601 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11735 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->