### PR TITLE
[iOS] Time picker fails to dodge the software keyboard when presented below the element

### DIFF
--- a/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm
@@ -305,13 +305,15 @@
     auto distanceFromTop = CGRectGetMinY(rectInWindow) - CGRectGetMinY(windowBounds);
     auto distanceFromLeft = CGRectGetMinX(rectInWindow) - CGRectGetMinX(windowBounds);
     auto distanceFromRight = CGRectGetMaxX(windowBounds) - CGRectGetMaxX(rectInWindow);
-    auto distanceFromBottom = CGRectGetMaxY(windowBounds) - CGRectGetMaxY(rectInWindow);
     auto estimatedMaximumPopoverSize = [_contentView estimatedMaximumPopoverSize];
 
     auto canContainPopover = [&](CGFloat width, CGFloat height) {
         return estimatedMaximumPopoverSize.width < width && estimatedMaximumPopoverSize.height < height;
     };
 
+    // FIXME: We intentionally avoid presenting below the input element, since UIKit will prefer shrinking
+    // the popover instead of shifting it upwards in the case where the software keyboard is show.
+    // See also: <rdar://121571971>.
     auto presentationController = self.popoverPresentationController;
     UIPopoverArrowDirection permittedDirections = 0;
     if (canContainPopover(CGRectGetWidth(windowBounds), distanceFromTop))
@@ -320,8 +322,6 @@
         permittedDirections |= UIPopoverArrowDirectionRight;
     if (canContainPopover(distanceFromRight, CGRectGetHeight(windowBounds)))
         permittedDirections |= UIPopoverArrowDirectionLeft;
-    if (canContainPopover(CGRectGetWidth(windowBounds), distanceFromBottom))
-        permittedDirections |= UIPopoverArrowDirectionUp;
 
     presentationController.permittedArrowDirections = permittedDirections;
     presentationController.sourceView = view;


### PR DESCRIPTION
#### a011563227e99a7fb9f3d81a7ec7645d538b71ce
<pre>
[iOS] Time picker fails to dodge the software keyboard when presented below the element
<a href="https://bugs.webkit.org/show_bug.cgi?id=268056">https://bugs.webkit.org/show_bug.cgi?id=268056</a>
<a href="https://rdar.apple.com/120403319">rdar://120403319</a>

Reviewed by Aditya Keerthi.

When presented *below* the time input, it&apos;s possible for time pickers to shrink (and sometimes even
dismiss) when a software keyboard is shown, upon focusing either the hour or minute field. Avoid
this for now by not presenting below the input; I&apos;ve separately filed <a href="https://rdar.apple.com/121571971">rdar://121571971</a> for UIKit to
investigate moving the popover content in this case, instead of shrinking to fit.

* Source/WebKit/UIProcess/ios/forms/WKDatePickerPopoverController.mm:
(-[WKDatePickerPopoverController presentInView:sourceRect:completion:]):

Canonical link: <a href="https://commits.webkit.org/273480@main">https://commits.webkit.org/273480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b89c0040a29013e49d6a9c740761a26fb1880c97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38304 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32048 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11532 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31655 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10762 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39549 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32313 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32123 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10961 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/8855 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34798 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12676 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8119 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11475 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->