### PR TITLE
NativeImages shared to GPUP do not store GPUP-specific information

### DIFF
--- a/Source/WebCore/platform/graphics/NativeImage.cpp
+++ b/Source/WebCore/platform/graphics/NativeImage.cpp
@@ -28,7 +28,14 @@
 
 namespace WebCore {
 
+NativeImageBackend::NativeImageBackend() = default;
+
 NativeImageBackend::~NativeImageBackend() = default;
+
+bool NativeImageBackend::isRemoteNativeImageBackendProxy() const
+{
+    return false;
+}
 
 PlatformImageNativeImageBackend::~PlatformImageNativeImageBackend() = default;
 
@@ -83,9 +90,8 @@ DestinationColorSpace NativeImage::colorSpace() const
     return m_backend->colorSpace();
 }
 
-void NativeImage::replaceContents(PlatformImagePtr platformImage)
+void NativeImage::replaceBackend(UniqueRef<NativeImageBackend> backend)
 {
-    UniqueRef<PlatformImageNativeImageBackend> backend { *new PlatformImageNativeImageBackend(WTFMove(platformImage)) };
     m_backend = WTFMove(backend);
 }
 

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -57,7 +57,9 @@ public:
     void draw(GraphicsContext&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions);
     void clearSubimages();
 
-    WEBCORE_EXPORT void replaceContents(PlatformImagePtr);
+    WEBCORE_EXPORT void replaceBackend(UniqueRef<NativeImageBackend>);
+    NativeImageBackend& backend() { return m_backend.get(); }
+    const NativeImageBackend& backend() const { return m_backend.get(); }
 protected:
     NativeImage(UniqueRef<NativeImageBackend>, RenderingResourceIdentifier);
 
@@ -68,24 +70,25 @@ protected:
 
 class NativeImageBackend {
 public:
+    WEBCORE_EXPORT NativeImageBackend();
     WEBCORE_EXPORT virtual ~NativeImageBackend();
     virtual const PlatformImagePtr& platformImage() const = 0;
     virtual IntSize size() const = 0;
     virtual bool hasAlpha() const = 0;
     virtual DestinationColorSpace colorSpace() const = 0;
+    WEBCORE_EXPORT virtual bool isRemoteNativeImageBackendProxy() const;
 };
 
 class PlatformImageNativeImageBackend final : public NativeImageBackend {
 public:
+    WEBCORE_EXPORT PlatformImageNativeImageBackend(PlatformImagePtr);
     WEBCORE_EXPORT ~PlatformImageNativeImageBackend() final;
     WEBCORE_EXPORT const PlatformImagePtr& platformImage() const final;
     WEBCORE_EXPORT IntSize size() const final;
     WEBCORE_EXPORT bool hasAlpha() const final;
     WEBCORE_EXPORT DestinationColorSpace colorSpace() const final;
 private:
-    PlatformImageNativeImageBackend(PlatformImagePtr);
     PlatformImagePtr m_platformImage;
-    friend class NativeImage;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -717,6 +717,7 @@ WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
 WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
 WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
 WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.cpp
 WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
 WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
 WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6250,6 +6250,8 @@
 		7BCF70CC2614935F00E4FB70 /* ScopedWebGLRenderingResourcesRequest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ScopedWebGLRenderingResourcesRequest.cpp; sourceTree = "<group>"; };
 		7BCF70CD2614935F00E4FB70 /* ScopedRenderingResourcesRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScopedRenderingResourcesRequest.h; sourceTree = "<group>"; };
 		7BCF70CE2614935F00E4FB70 /* ScopedWebGLRenderingResourcesRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScopedWebGLRenderingResourcesRequest.h; sourceTree = "<group>"; };
+		7BDA50D42B5FF87F00B859E2 /* RemoteNativeImageBackendProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteNativeImageBackendProxy.h; sourceTree = "<group>"; };
+		7BDA50D52B5FF88000B859E2 /* RemoteNativeImageBackendProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteNativeImageBackendProxy.cpp; sourceTree = "<group>"; };
 		7BDD9DDA28D205C6004CDF48 /* MessageObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageObserver.h; sourceTree = "<group>"; };
 		7BDD9DDB28D205C6004CDF48 /* WorkQueueMessageReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WorkQueueMessageReceiver.h; sourceTree = "<group>"; };
 		7BDDA33F275652EA0038659E /* AuxiliaryProcessCreationParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AuxiliaryProcessCreationParameters.h; sourceTree = "<group>"; };
@@ -11952,6 +11954,8 @@
 				A78A5FE52B0EE4C3005036D3 /* RemoteImageBufferSetProxy.cpp */,
 				A78A5FE62B0EE4C3005036D3 /* RemoteImageBufferSetProxy.h */,
 				A7B94DE32B5D9DBB0058780B /* RemoteImageBufferSetProxy.messages.in */,
+				7BDA50D52B5FF88000B859E2 /* RemoteNativeImageBackendProxy.cpp */,
+				7BDA50D42B5FF87F00B859E2 /* RemoteNativeImageBackendProxy.h */,
 				5506409D2407160900AAE045 /* RemoteRenderingBackendProxy.cpp */,
 				5506409E2407160900AAE045 /* RemoteRenderingBackendProxy.h */,
 				550640A0240719E100AAE045 /* RemoteRenderingBackendProxy.messages.in */,

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(GPU_PROCESS)
+#include "RemoteNativeImageBackendProxy.h"
+
+#include "RemoteResourceCacheProxy.h"
+
+namespace WebKit {
+using namespace WebCore;
+
+std::unique_ptr<RemoteNativeImageBackendProxy> RemoteNativeImageBackendProxy::create(NativeImage& image)
+{
+    RefPtr<ShareableBitmap> bitmap;
+    PlatformImagePtr platformImage;
+#if USE(CG)
+    bitmap = ShareableBitmap::createFromImagePixels(image);
+    if (bitmap)
+        platformImage = bitmap->createPlatformImage(DontCopyBackingStore, ShouldInterpolate::Yes);
+#endif
+
+    // If we failed to create ShareableBitmap or PlatformImage, fall back to image-draw method.
+    if (!platformImage) {
+        bitmap = ShareableBitmap::createFromImageDraw(image);
+        if (bitmap)
+            platformImage = bitmap->createPlatformImage(DontCopyBackingStore, ShouldInterpolate::Yes);
+
+        // If createGraphicsContext() failed because the image colorSpace is not
+        // supported for output, fallback to SRGB.
+        if (!platformImage) {
+            bitmap = ShareableBitmap::createFromImageDraw(image, DestinationColorSpace::SRGB());
+            if (bitmap)
+                platformImage = bitmap->createPlatformImage(DontCopyBackingStore, ShouldInterpolate::Yes);
+        }
+    }
+    if (!platformImage)
+        return nullptr;
+    return std::unique_ptr<RemoteNativeImageBackendProxy> { new RemoteNativeImageBackendProxy(bitmap.releaseNonNull(), WTFMove(platformImage)) };
+}
+
+RemoteNativeImageBackendProxy::RemoteNativeImageBackendProxy(Ref<ShareableBitmap> bitmap, PlatformImagePtr platformImage)
+    : m_bitmap(WTFMove(bitmap))
+    , m_platformBackend(WTFMove(platformImage))
+{
+}
+
+RemoteNativeImageBackendProxy::~RemoteNativeImageBackendProxy() = default;
+
+const PlatformImagePtr& RemoteNativeImageBackendProxy::platformImage() const
+{
+    return m_platformBackend.platformImage();
+}
+
+IntSize RemoteNativeImageBackendProxy::size() const
+{
+    return m_platformBackend.size();
+}
+
+bool RemoteNativeImageBackendProxy::hasAlpha() const
+{
+    return m_platformBackend.hasAlpha();
+}
+
+DestinationColorSpace RemoteNativeImageBackendProxy::colorSpace() const
+{
+    return m_platformBackend.colorSpace();
+}
+
+bool RemoteNativeImageBackendProxy::isRemoteNativeImageBackendProxy() const
+{
+    return true;
+}
+
+std::optional<ShareableBitmap::Handle> RemoteNativeImageBackendProxy::createHandle()
+{
+    return m_bitmap->createHandle();
+}
+
+}
+
+#endif

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GPU_PROCESS)
+
+#include "ShareableBitmap.h"
+#include <WebCore/NativeImage.h>
+
+namespace WebKit {
+class RemoteResourceCacheProxy;
+
+class RemoteNativeImageBackendProxy final : public NativeImageBackend {
+public:
+    static std::unique_ptr<RemoteNativeImageBackendProxy> create(NativeImage&);
+    ~RemoteNativeImageBackendProxy() final;
+
+    const PlatformImagePtr& platformImage() const final;
+    IntSize size() const final;
+    bool hasAlpha() const final;
+    DestinationColorSpace colorSpace() const final;
+    bool isRemoteNativeImageBackendProxy() const final;
+
+    std::optional<ShareableBitmap::Handle> createHandle();
+private:
+    RemoteNativeImageBackendProxy(Ref<ShareableBitmap>, PlatformImagePtr);
+
+    Ref<ShareableBitmap> m_bitmap;
+    PlatformImageNativeImageBackend m_platformBackend;
+};
+
+}
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::RemoteNativeImageBackendProxy)
+    static bool isType(const WebCore::NativeImageBackend& backend) { return backend.isRemoteNativeImageBackendProxy(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+#endif


### PR DESCRIPTION
#### c59ecbabbca2f4c226d684a5b68432191294bf24
<pre>
NativeImages shared to GPUP do not store GPUP-specific information
<a href="https://bugs.webkit.org/show_bug.cgi?id=267998">https://bugs.webkit.org/show_bug.cgi?id=267998</a>
<a href="https://rdar.apple.com/121517135">rdar://121517135</a>

Reviewed by Matt Woodrow.

Modify current NativeImage behavior to use new
RemoteNativeImageBackendProxy.

RemoteNativeImageBackendProxy will be used to store GPUP specific
information. This is needed for cases where other engines, like
WebGL, WebGPU or such create NativeImages at GPUP side
and share them without waits to WP.

Store the shared memory to this class, so that when GPUP crashes, the
shared memory will not be recreated. This storage will be used in the
future to sink WP-only shareable ImageBuffer into shareable
NativeImages.

* Source/WebCore/platform/graphics/NativeImage.cpp:
(WebCore::NativeImageBackend::isRemoteNativeImageBackendProxy const):
(WebCore::NativeImage::replaceBackend):
(WebCore::NativeImage::replaceContents): Deleted.
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.cpp: Added.
(WebKit::RemoteNativeImageBackendProxy::create):
(WebKit::RemoteNativeImageBackendProxy::RemoteNativeImageBackendProxy):
(WebKit::RemoteNativeImageBackendProxy::platformImage const):
(WebKit::RemoteNativeImageBackendProxy::size const):
(WebKit::RemoteNativeImageBackendProxy::hasAlpha const):
(WebKit::RemoteNativeImageBackendProxy::colorSpace const):
(WebKit::RemoteNativeImageBackendProxy::isRemoteNativeImageBackendProxy const):
(WebKit::RemoteNativeImageBackendProxy::createHandle):
* Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.h: Added.
(isType):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordNativeImageUse):
(WebKit::createShareableBitmapFromNativeImage): Deleted.

Canonical link: <a href="https://commits.webkit.org/273739@main">https://commits.webkit.org/273739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea30e1aee397b545c7ef010f9182de1ce2bd1ec4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39204 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32773 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12561 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37102 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13048 "Found 1 new test failure: fast/events/ios/select-all-with-existing-selection.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11421 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40449 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33113 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37370 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35475 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13374 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8275 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12114 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12570 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->