### PR TITLE
[Site Isolation] Begin implementing window.closed

### DIFF
--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -30,6 +30,7 @@
 #include "Frame.h"
 #include "HTTPParsers.h"
 #include "Location.h"
+#include "Page.h"
 #include "SecurityOrigin.h"
 #include "WebCoreOpaqueRoot.h"
 #include <wtf/IsoMallocInlines.h>
@@ -66,6 +67,16 @@ Location& DOMWindow::location()
     if (!m_location)
         m_location = Location::create(*this);
     return *m_location;
+}
+
+bool DOMWindow::closed() const
+{
+    RefPtr frame = this->frame();
+    if (!frame)
+        return true;
+
+    RefPtr page = frame->page();
+    return !page || page->isClosing();
 }
 
 RefPtr<Frame> DOMWindow::protectedFrame() const

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -59,6 +59,8 @@ public:
     WEBCORE_EXPORT Location& location();
     virtual void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, SetLocationLocking = SetLocationLocking::LockHistoryBasedOnGestureState) = 0;
 
+    bool closed() const;
+
 protected:
     explicit DOMWindow(GlobalWindowIdentifier&&);
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1468,16 +1468,6 @@ int LocalDOMWindow::scrollY() const
     return viewAfterLayout->mapFromLayoutToCSSUnits(viewAfterLayout->contentsScrollPosition().y());
 }
 
-bool LocalDOMWindow::closed() const
-{
-    RefPtr frame = this->frame();
-    if (!frame)
-        return true;
-
-    RefPtr page = frame->page();
-    return !page || page->isClosing();
-}
-
 unsigned LocalDOMWindow::length() const
 {
     if (!isCurrentlyDisplayedInFrame())

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -220,8 +220,6 @@ public:
     int scrollX() const;
     int scrollY() const;
 
-    bool closed() const;
-
     unsigned length() const;
 
     AtomString name() const;

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -31,6 +31,7 @@
 #include "LocalDOMWindow.h"
 #include "MessagePort.h"
 #include "NavigationScheduler.h"
+#include "Page.h"
 #include "RemoteFrame.h"
 #include "RemoteFrameClient.h"
 #include "SecurityOrigin.h"
@@ -62,14 +63,18 @@ void RemoteDOMWindow::close(Document&)
 {
     // FIXME: <rdar://117381050> Add security checks here equivalent to LocalDOMWindow::close (both with and without Document& parameter).
     // Or refactor to share code.
-    if (m_frame && m_frame->isMainFrame())
-        m_frame->client().close();
-}
+    if (!m_frame)
+        return;
 
-bool RemoteDOMWindow::closed() const
-{
-    // FIXME: This is probably not completely correct. <rdar://116203970>
-    return !m_frame;
+    if (!m_frame->isMainFrame())
+        return;
+
+    RefPtr page = m_frame->page();
+    if (!page)
+        return;
+
+    page->setIsClosing();
+    m_frame->client().close();
 }
 
 void RemoteDOMWindow::focus(LocalDOMWindow&)

--- a/Source/WebCore/page/RemoteDOMWindow.h
+++ b/Source/WebCore/page/RemoteDOMWindow.h
@@ -61,7 +61,6 @@ public:
     // DOM API exposed cross-origin.
     WindowProxy* self() const;
     void close(Document&);
-    bool closed() const;
     void focus(LocalDOMWindow& incumbentWindow);
     void blur();
     unsigned length() const;


### PR DESCRIPTION
#### 868b695ddf097c1c9acac9ed226adb66647ce36b
<pre>
[Site Isolation] Begin implementing window.closed
<a href="https://bugs.webkit.org/show_bug.cgi?id=268066">https://bugs.webkit.org/show_bug.cgi?id=268066</a>
<a href="https://rdar.apple.com/121583905">rdar://121583905</a>

Reviewed by Alex Christensen.

Move LocalDOMWindow::closed() to DOMWindow and call Page::setIsClosing() in RemoteDOMWindow::close().

* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::closed const):
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::closed const): Deleted.
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::close):
(WebCore::RemoteDOMWindow::closed const): Deleted.
* Source/WebCore/page/RemoteDOMWindow.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/273526@main">https://commits.webkit.org/273526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19b5361651449867c6454a617ab56c200f5acc26

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38334 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32070 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30869 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10786 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39580 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32344 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32149 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36752 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34819 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12700 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11497 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4624 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->