### PR TITLE
[JSC] Add useCompilerSignpost option to emit signpost with compiled function information

### DIFF
--- a/Source/JavaScriptCore/jit/JITCompilationMode.cpp
+++ b/Source/JavaScriptCore/jit/JITCompilationMode.cpp
@@ -36,22 +36,22 @@ void printInternal(PrintStream& out, JITCompilationMode mode)
 {
     switch (mode) {
     case JITCompilationMode::InvalidCompilation:
-        out.print("InvalidCompilationMode");
+        out.print("InvalidCompilation");
         return;
     case JITCompilationMode::Baseline:
-        out.print("BaselineMode");
+        out.print("Baseline");
         return;
     case JITCompilationMode::DFG:
-        out.print("DFGMode");
+        out.print("DFG");
         return;
     case JITCompilationMode::UnlinkedDFG:
         out.print("UnlinkedDFG");
         return;
     case JITCompilationMode::FTL:
-        out.print("FTLMode");
+        out.print("FTL");
         return;
     case JITCompilationMode::FTLForOSREntry:
-        out.print("FTLForOSREntryMode");
+        out.print("FTLForOSREntry");
         return;
     }
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/jit/JITPlan.cpp
+++ b/Source/JavaScriptCore/jit/JITPlan.cpp
@@ -34,6 +34,8 @@
 #include "JSCellInlines.h"
 #include "VMInlines.h"
 #include <wtf/CompilationThread.h>
+#include <wtf/StringPrintStream.h>
+#include <wtf/SystemTracing.h>
 
 namespace JSC {
 
@@ -172,9 +174,21 @@ void JITPlan::compileInThread(JITWorklistThread* thread)
         dataLog("DFG(Plan) compiling ", *m_codeBlock, " with ", m_mode, ", instructions size = ", m_codeBlock->instructionsSize(), "\n");
 #endif // ENABLE(DFG_JIT)
 
+    CString signpostMessage;
+    UNUSED_VARIABLE(signpostMessage);
+    if (UNLIKELY(Options::useCompilerSignpost())) {
+        StringPrintStream stream;
+        stream.print(m_mode, " ", *m_codeBlock, " instructions size = ", m_codeBlock->instructionsSize());
+        signpostMessage = stream.toCString();
+        WTFBeginSignpost(this, JSCJITCompiler, "%" PUBLIC_LOG_STRING, signpostMessage.data());
+    }
+
     CompilationPath path = compileInThreadImpl();
 
     RELEASE_ASSERT((path == CancelPath) == (m_stage == JITPlanStage::Canceled));
+
+    if (UNLIKELY(Options::useCompilerSignpost()))
+        WTFEndSignpost(this, JSCJITCompiler, "%" PUBLIC_LOG_STRING, signpostMessage.data());
 
     if (LIKELY(!computeCompileTimes))
         return;

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -529,6 +529,7 @@ bool canUseHandlerIC();
     v(Bool, forcePolyProto, false, Normal, "If true, create_this will always create an object with a poly proto structure.") \
     v(Bool, forceMiniVMMode, false, Normal, "If true, it will force mini VM mode on.") \
     v(Bool, useTracePoints, false, Normal, nullptr) \
+    v(Bool, useCompilerSignpost, false, Normal, nullptr) \
     v(Bool, traceLLIntExecution, false, Configurable, nullptr) \
     v(Bool, traceLLIntSlowPath, false, Configurable, nullptr) \
     v(Bool, traceBaselineJITExecution, false, Normal, nullptr) \

--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -221,6 +221,7 @@ WTF_EXTERN_C_END
     M(NavigationAndPaintTiming) \
     M(ExecuteScriptElement) \
     M(RegisterImportMap) \
+    M(JSCJITCompiler) \
 
 #define DECLARE_WTF_SIGNPOST_NAME_ENUM(name) WTFOSSignpostName ## name,
 


### PR DESCRIPTION
#### d6c40e2a0098eab3db91270abcdeefe6059db682
<pre>
[JSC] Add useCompilerSignpost option to emit signpost with compiled function information
<a href="https://bugs.webkit.org/show_bug.cgi?id=268067">https://bugs.webkit.org/show_bug.cgi?id=268067</a>
<a href="https://rdar.apple.com/121584775">rdar://121584775</a>

Reviewed by Ryosuke Niwa.

This patch adds a JSC option, useCompilerSignpost, which can emit signpost for JSC JIT Compiler activities.
We record function name etc. as an interval signpost to investigate compiler activities in the complicated workload.
We also adjust JITCompilationMode&apos;s string to make it more modern and readable.

* Source/JavaScriptCore/jit/JITCompilationMode.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/jit/JITPlan.cpp:
(JSC::JITPlan::compileInThread):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/WTF/wtf/SystemTracing.h:

Canonical link: <a href="https://commits.webkit.org/273507@main">https://commits.webkit.org/273507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09a570ecec169c54bb0e94f83be4d3c849268e37

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38341 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32076 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30872 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10794 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10806 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39586 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/30160 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32352 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36754 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/35466 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/10994 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34835 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12706 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/42156 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11502 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4612 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11774 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->