### PR TITLE
[upload-file-to-url] Bump S3 upload timeout to 15 minutes

### DIFF
--- a/Tools/Scripts/upload-file-to-url
+++ b/Tools/Scripts/upload-file-to-url
@@ -34,7 +34,7 @@ import os
 import requests
 
 
-def upload(filename, url, max_attempts=3):
+def upload(filename, url, max_attempts=2):
     if not os.path.isfile(filename):
         sys.stderr.write(f'ERROR: File not found: {filename}\n')
         return -1
@@ -55,7 +55,7 @@ def upload(filename, url, max_attempts=3):
 
         for attempt in range(1, max_attempts + 1):
             try:
-                response = requests.put(url, data=data, timeout=10*60)
+                response = requests.put(url, data=data, timeout=15*60)
                 sys.stderr.write(f'Response: {response}, status_code: {response.status_code}, {response.reason}\n')
                 if response and response.status_code // 100 == 2:
                     return 0


### PR DESCRIPTION
#### 2a66dadaf2d756b702a1db90f45af3a65158b7a5
<pre>
[upload-file-to-url] Bump S3 upload timeout to 15 minutes
<a href="https://bugs.webkit.org/show_bug.cgi?id=268076">https://bugs.webkit.org/show_bug.cgi?id=268076</a>

Reviewed by Jonathan Bedard.

Recently added logging in 273416@main indicates that we are occasionally hitting the 10 minute timeout.
Also, when the retry helps, the retry is also taking near about 10 minutes.
Let&apos;s bump S3 upload timeout to 15 minutes, and reduce the number of retries from 3 to 2,
effectively still maintaining the overall time of 30 minutes.

* Tools/Scripts/upload-file-to-url:
(upload):

Canonical link: <a href="https://commits.webkit.org/273499@main">https://commits.webkit.org/273499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf5e7a6593d593a6f3341ddcc1e42d17c939d99c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35623 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38363 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32093 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36822 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11591 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36176 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/12312 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31703 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/10813 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10821 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/31841 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39613 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/32375 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/32179 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/39613 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11012 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/8902 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39613 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12726 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11520 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4607 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11794 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->