### PR TITLE
Remove ENABLE_BADGING directive

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -482,7 +482,6 @@ AppBadgeEnabled:
   category: dom
   humanReadableName: "App Badge"
   humanReadableDescription: "Enable App Badge"
-  condition: ENABLE(BADGING)
   defaultValue:
     WebKitLegacy:
       default: false
@@ -1654,7 +1653,6 @@ ClientBadgeEnabled:
   category: dom
   humanReadableName: "Client Badge"
   humanReadableDescription: "Enable Client Badge"
-  condition: ENABLE(BADGING)
   defaultValue:
     WebKitLegacy:
       default: false

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -148,10 +148,6 @@
 #define ENABLE_AUTOCAPITALIZE 0
 #endif
 
-#if !defined(ENABLE_BADGING)
-#define ENABLE_BADGING 1
-#endif
-
 #if !defined(ENABLE_CONTENT_CHANGE_OBSERVER)
 #define ENABLE_CONTENT_CHANGE_OBSERVER 0
 #endif

--- a/Source/WebCore/Modules/badge/Navigator+Badge.idl
+++ b/Source/WebCore/Modules/badge/Navigator+Badge.idl
@@ -24,7 +24,6 @@
  */
 
 [
-    Conditional=BADGING,
     EnabledBySetting=ClientBadgeEnabled
 ] partial interface Navigator {
     [SecureContext] Promise<undefined> setClientBadge(optional [EnforceRange] unsigned long long contents);

--- a/Source/WebCore/Modules/badge/NavigatorBadge.idl
+++ b/Source/WebCore/Modules/badge/NavigatorBadge.idl
@@ -24,7 +24,6 @@
  */
 
 [
-    Conditional=BADGING,
     EnabledBySetting=AppBadgeEnabled
 ] interface mixin NavigatorBadge {
     [SecureContext] Promise<undefined> setAppBadge(optional [EnforceRange] unsigned long long contents);

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -393,8 +393,6 @@ Document* Navigator::document()
     return frame ? frame->document() : nullptr;
 }
 
-#if ENABLE(BADGING)
-
 void Navigator::setAppBadge(std::optional<unsigned long long> badge, Ref<DeferredPromise>&& promise)
 {
     auto* frame = this->frame();
@@ -446,8 +444,6 @@ void Navigator::clearClientBadge(Ref<DeferredPromise>&& promise)
 {
     setClientBadge(0, WTFMove(promise));
 }
-
-#endif // ENABLE(BADGING)
 
 #if ENABLE(DECLARATIVE_WEB_PUSH)
 PushManager& Navigator::pushManager()

--- a/Source/WebCore/page/Navigator.h
+++ b/Source/WebCore/page/Navigator.h
@@ -77,13 +77,11 @@ public:
 
     Document* document();
 
-#if ENABLE(BADGING)
     void setAppBadge(std::optional<unsigned long long>, Ref<DeferredPromise>&&);
     void clearAppBadge(Ref<DeferredPromise>&&);
 
     void setClientBadge(std::optional<unsigned long long>, Ref<DeferredPromise>&&);
     void clearClientBadge(Ref<DeferredPromise>&&);
-#endif
 
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     void ref() const final { RefCounted::ref(); }

--- a/Source/WebCore/page/WorkerNavigator.cpp
+++ b/Source/WebCore/page/WorkerNavigator.cpp
@@ -89,7 +89,6 @@ GPU* WorkerNavigator::gpu()
 #endif
 }
 
-#if ENABLE(BADGING)
 void WorkerNavigator::setAppBadge(std::optional<unsigned long long> badge, Ref<DeferredPromise>&& promise)
 {
 #if ENABLE(DECLARATIVE_WEB_PUSH)
@@ -116,7 +115,5 @@ void WorkerNavigator::clearAppBadge(Ref<DeferredPromise>&& promise)
 {
     setAppBadge(0, WTFMove(promise));
 }
-#endif
-
 
 } // namespace WebCore

--- a/Source/WebCore/page/WorkerNavigator.h
+++ b/Source/WebCore/page/WorkerNavigator.h
@@ -42,10 +42,8 @@ public:
     bool onLine() const final;
     void setIsOnline(bool isOnline) { m_isOnline = isOnline; }
 
-#if ENABLE(BADGING)
     void setAppBadge(std::optional<unsigned long long>, Ref<DeferredPromise>&&);
     void clearAppBadge(Ref<DeferredPromise>&&);
-#endif
 
     GPU* gpu();
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Badging.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Badging.mm
@@ -25,8 +25,6 @@
 
 #import "config.h"
 
-#if ENABLE(BADGING)
-
 #import "DeprecatedGlobalValues.h"
 #import "HTTPServer.h"
 #import "PlatformUtilities.h"
@@ -586,4 +584,3 @@ TEST(Badging, ServiceWorkerOverride)
     EXPECT_EQ(badgeDelegate.get().appBadgeIndex, 2);
     EXPECT_EQ(badgeDelegate.get().clientBadgeIndex, 0);
 }
-#endif // ENABLE(BADGING)


### PR DESCRIPTION
#### 5884ad3f8ba8967fe7f909bde32f4821cf68b845
<pre>
Remove ENABLE_BADGING directive
<a href="https://bugs.webkit.org/show_bug.cgi?id=268080">https://bugs.webkit.org/show_bug.cgi?id=268080</a>

Reviewed by Darin Adler.

A runtime preference is sufficient as this is always on.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WTF/wtf/PlatformEnable.h:
* Source/WebCore/Modules/badge/Navigator+Badge.idl:
* Source/WebCore/Modules/badge/NavigatorBadge.idl:
* Source/WebCore/page/Navigator.cpp:
* Source/WebCore/page/Navigator.h:
* Source/WebCore/page/WorkerNavigator.cpp:
(WebCore::WorkerNavigator::clearAppBadge):
* Source/WebCore/page/WorkerNavigator.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Badging.mm:

Canonical link: <a href="https://commits.webkit.org/273554@main">https://commits.webkit.org/273554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28fde6b81b3be1b92782effd0e05326b801f1297

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38378 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32106 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30891 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12326 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10830 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39623 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/30181 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32194 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36787 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/35500 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11025 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8916 "Found 1 new test failure: http/tests/inspector/dom/didFireEvent.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34865 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12740 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/42192 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8156 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11533 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8762 "Found 39 new JSC stress test failures: microbenchmarks/array-from-derived-object-func.js.bytecode-cache, microbenchmarks/array-from-derived-object-func.js.default, microbenchmarks/array-from-derived-object-func.js.dfg-eager, microbenchmarks/array-from-derived-object-func.js.dfg-eager-no-cjit-validate, microbenchmarks/array-from-derived-object-func.js.eager-jettison-no-cjit, microbenchmarks/array-from-derived-object-func.js.no-cjit-collect-continuously, microbenchmarks/array-from-derived-object-func.js.no-cjit-validate-phases, microbenchmarks/array-from-derived-object-func.js.no-llint, microbenchmarks/array-from-object-func.js.bytecode-cache, microbenchmarks/array-from-object-func.js.default ... (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11808 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->