### PR TITLE
Adopt more smart pointers in BasicShapeFunctions.cpp

### DIFF
--- a/Source/WebCore/css/BasicShapeFunctions.cpp
+++ b/Source/WebCore/css/BasicShapeFunctions.cpp
@@ -193,7 +193,7 @@ static LengthSize convertToLengthSize(const CSSToLengthConversionData& conversio
     if (!value)
         return { { 0, LengthType::Fixed }, { 0, LengthType::Fixed } };
 
-    return { convertToLength(conversionData, value->first()), convertToLength(conversionData, value->second()) };
+    return { convertToLength(conversionData, value->protectedFirst()), convertToLength(conversionData, value->protectedSecond()) };
 }
 
 static BasicShapeCenterCoordinate convertToCenterCoordinate(const CSSToLengthConversionData& conversionData, const CSSValue* value)
@@ -206,7 +206,7 @@ static BasicShapeCenterCoordinate convertToCenterCoordinate(const CSSToLengthCon
         keyword = value->valueID();
     else if (value->isPair()) {
         keyword = value->first().valueID();
-        offset = convertToLength(conversionData, value->second());
+        offset = convertToLength(conversionData, value->protectedSecond());
     } else
         offset = convertToLength(conversionData, *value);
 
@@ -257,18 +257,18 @@ Ref<BasicShape> basicShapeForValue(const CSSToLengthConversionData& conversionDa
 {
     if (auto* circleValue = dynamicDowncast<CSSCircleValue>(value)) {
         auto circle = BasicShapeCircle::create();
-        circle->setRadius(cssValueToBasicShapeRadius(conversionData, circleValue->radius()));
-        circle->setCenterX(convertToCenterCoordinate(conversionData, circleValue->centerX()));
-        circle->setCenterY(convertToCenterCoordinate(conversionData, circleValue->centerY()));
+        circle->setRadius(cssValueToBasicShapeRadius(conversionData, circleValue->protectedRadius().get()));
+        circle->setCenterX(convertToCenterCoordinate(conversionData, circleValue->protectedCenterX().get()));
+        circle->setCenterY(convertToCenterCoordinate(conversionData, circleValue->protectedCenterY().get()));
         circle->setPositionWasOmitted(!circleValue->centerX() && !circleValue->centerY());
         return circle;
     }
     if (auto* ellipseValue = dynamicDowncast<CSSEllipseValue>(value)) {
         auto ellipse = BasicShapeEllipse::create();
-        ellipse->setRadiusX(cssValueToBasicShapeRadius(conversionData, ellipseValue->radiusX()));
-        ellipse->setRadiusY(cssValueToBasicShapeRadius(conversionData, ellipseValue->radiusY()));
-        ellipse->setCenterX(convertToCenterCoordinate(conversionData, ellipseValue->centerX()));
-        ellipse->setCenterY(convertToCenterCoordinate(conversionData, ellipseValue->centerY()));
+        ellipse->setRadiusX(cssValueToBasicShapeRadius(conversionData, ellipseValue->protectedRadiusX().get()));
+        ellipse->setRadiusY(cssValueToBasicShapeRadius(conversionData, ellipseValue->protectedRadiusY().get()));
+        ellipse->setCenterX(convertToCenterCoordinate(conversionData, ellipseValue->protectedCenterX().get()));
+        ellipse->setCenterY(convertToCenterCoordinate(conversionData, ellipseValue->protectedCenterY().get()));
         ellipse->setPositionWasOmitted(!ellipseValue->centerX() && !ellipseValue->centerY());
         return ellipse;
     }
@@ -276,45 +276,45 @@ Ref<BasicShape> basicShapeForValue(const CSSToLengthConversionData& conversionDa
         auto polygon = BasicShapePolygon::create();
         polygon->setWindRule(polygonValue->windRule());
         for (unsigned i = 0; i < polygonValue->size(); i += 2)
-            polygon->appendPoint(convertToLength(conversionData, *polygonValue->item(i)), convertToLength(conversionData, *polygonValue->item(i + 1)));
+            polygon->appendPoint(convertToLength(conversionData, *polygonValue->protectedItem(i)), convertToLength(conversionData, *polygonValue->protectedItem(i + 1)));
         return polygon;
     }
     if (auto* rectValue = dynamicDowncast<CSSInsetShapeValue>(value)) {
         auto rect = BasicShapeInset::create();
-        rect->setTop(convertToLength(conversionData, rectValue->top()));
-        rect->setRight(convertToLength(conversionData, rectValue->right()));
-        rect->setBottom(convertToLength(conversionData, rectValue->bottom()));
-        rect->setLeft(convertToLength(conversionData, rectValue->left()));
-        rect->setTopLeftRadius(convertToLengthSize(conversionData, rectValue->topLeftRadius()));
-        rect->setTopRightRadius(convertToLengthSize(conversionData, rectValue->topRightRadius()));
-        rect->setBottomRightRadius(convertToLengthSize(conversionData, rectValue->bottomRightRadius()));
-        rect->setBottomLeftRadius(convertToLengthSize(conversionData, rectValue->bottomLeftRadius()));
+        rect->setTop(convertToLength(conversionData, rectValue->protectedTop()));
+        rect->setRight(convertToLength(conversionData, rectValue->protectedRight()));
+        rect->setBottom(convertToLength(conversionData, rectValue->protectedBottom()));
+        rect->setLeft(convertToLength(conversionData, rectValue->protectedLeft()));
+        rect->setTopLeftRadius(convertToLengthSize(conversionData, rectValue->protectedTopLeftRadius().get()));
+        rect->setTopRightRadius(convertToLengthSize(conversionData, rectValue->protectedTopRightRadius().get()));
+        rect->setBottomRightRadius(convertToLengthSize(conversionData, rectValue->protectedBottomRightRadius().get()));
+        rect->setBottomLeftRadius(convertToLengthSize(conversionData, rectValue->protectedBottomLeftRadius().get()));
         return rect;
     }
     if (auto* rectValue = dynamicDowncast<CSSXywhValue>(value)) {
         auto rect = BasicShapeXywh::create();
-        rect->setInsetX(convertToLength(conversionData, rectValue->insetX()));
-        rect->setInsetY(convertToLength(conversionData, rectValue->insetY()));
-        rect->setWidth(convertToLength(conversionData, rectValue->width()));
-        rect->setHeight(convertToLength(conversionData, rectValue->height()));
+        rect->setInsetX(convertToLength(conversionData, rectValue->protectedInsetX().get()));
+        rect->setInsetY(convertToLength(conversionData, rectValue->protectedInsetY().get()));
+        rect->setWidth(convertToLength(conversionData, rectValue->protectedWidth().get()));
+        rect->setHeight(convertToLength(conversionData, rectValue->protectedHeight().get()));
 
-        rect->setTopLeftRadius(convertToLengthSize(conversionData, rectValue->topLeftRadius()));
-        rect->setTopRightRadius(convertToLengthSize(conversionData, rectValue->topRightRadius()));
-        rect->setBottomRightRadius(convertToLengthSize(conversionData, rectValue->bottomRightRadius()));
-        rect->setBottomLeftRadius(convertToLengthSize(conversionData, rectValue->bottomLeftRadius()));
+        rect->setTopLeftRadius(convertToLengthSize(conversionData, rectValue->protectedTopLeftRadius().get()));
+        rect->setTopRightRadius(convertToLengthSize(conversionData, rectValue->protectedTopRightRadius().get()));
+        rect->setBottomRightRadius(convertToLengthSize(conversionData, rectValue->protectedBottomRightRadius().get()));
+        rect->setBottomLeftRadius(convertToLengthSize(conversionData, rectValue->protectedBottomLeftRadius().get()));
         return rect;
     }
     if (auto* rectValue = dynamicDowncast<CSSRectShapeValue>(value)) {
         auto rect = BasicShapeRect::create();
-        rect->setTop(convertToLengthOrAuto(conversionData, rectValue->top()));
-        rect->setRight(convertToLengthOrAuto(conversionData, rectValue->right()));
-        rect->setBottom(convertToLengthOrAuto(conversionData, rectValue->bottom()));
-        rect->setLeft(convertToLengthOrAuto(conversionData, rectValue->left()));
+        rect->setTop(convertToLengthOrAuto(conversionData, rectValue->protectedTop()));
+        rect->setRight(convertToLengthOrAuto(conversionData, rectValue->protectedRight()));
+        rect->setBottom(convertToLengthOrAuto(conversionData, rectValue->protectedBottom()));
+        rect->setLeft(convertToLengthOrAuto(conversionData, rectValue->protectedLeft()));
 
-        rect->setTopLeftRadius(convertToLengthSize(conversionData, rectValue->topLeftRadius()));
-        rect->setTopRightRadius(convertToLengthSize(conversionData, rectValue->topRightRadius()));
-        rect->setBottomRightRadius(convertToLengthSize(conversionData, rectValue->bottomRightRadius()));
-        rect->setBottomLeftRadius(convertToLengthSize(conversionData, rectValue->bottomLeftRadius()));
+        rect->setTopLeftRadius(convertToLengthSize(conversionData, rectValue->protectedTopLeftRadius().get()));
+        rect->setTopRightRadius(convertToLengthSize(conversionData, rectValue->protectedTopRightRadius().get()));
+        rect->setBottomRightRadius(convertToLengthSize(conversionData, rectValue->protectedBottomRightRadius().get()));
+        rect->setBottomLeftRadius(convertToLengthSize(conversionData, rectValue->protectedBottomLeftRadius().get()));
         return rect;
     }
     if (auto* pathValue = dynamicDowncast<CSSPathValue>(value)) {

--- a/Source/WebCore/css/CSSBasicShapes.h
+++ b/Source/WebCore/css/CSSBasicShapes.h
@@ -46,11 +46,19 @@ public:
     const CSSValue& right() const { return m_right; }
     const CSSValue& bottom() const { return m_bottom; }
     const CSSValue& left() const { return m_left; }
+    Ref<CSSValue> protectedTop() const { return m_top; }
+    Ref<CSSValue> protectedRight() const { return m_right; }
+    Ref<CSSValue> protectedBottom() const { return m_bottom; }
+    Ref<CSSValue> protectedLeft() const { return m_left; }
 
     const CSSValue* topLeftRadius() const { return m_topLeftRadius.get(); }
     const CSSValue* topRightRadius() const { return m_topRightRadius.get(); }
     const CSSValue* bottomRightRadius() const { return m_bottomRightRadius.get(); }
     const CSSValue* bottomLeftRadius() const { return m_bottomLeftRadius.get(); }
+    RefPtr<CSSValue> protectedTopLeftRadius() const { return m_topLeftRadius; }
+    RefPtr<CSSValue> protectedTopRightRadius() const { return m_topRightRadius; }
+    RefPtr<CSSValue> protectedBottomRightRadius() const { return m_bottomRightRadius; }
+    RefPtr<CSSValue> protectedBottomLeftRadius() const { return m_bottomLeftRadius; }
 
     String customCSSText() const;
     bool equals(const CSSInsetShapeValue&) const;
@@ -76,6 +84,9 @@ public:
     const CSSValue* radius() const { return m_radius.get(); }
     const CSSValue* centerX() const { return m_centerX.get(); }
     const CSSValue* centerY() const { return m_centerY.get(); }
+    RefPtr<CSSValue> protectedRadius() const { return m_radius; }
+    RefPtr<CSSValue> protectedCenterX() const { return m_centerX; }
+    RefPtr<CSSValue> protectedCenterY() const { return m_centerY; }
 
     String customCSSText() const;
     bool equals(const CSSCircleValue&) const;
@@ -96,6 +107,10 @@ public:
     const CSSValue* radiusY() const { return m_radiusY.get(); }
     const CSSValue* centerX() const { return m_centerX.get(); }
     const CSSValue* centerY() const { return m_centerY.get(); }
+    RefPtr<CSSValue> protectedRadiusX() const { return m_radiusX; }
+    RefPtr<CSSValue> protectedRadiusY() const { return m_radiusY; }
+    RefPtr<CSSValue> protectedCenterX() const { return m_centerX; }
+    RefPtr<CSSValue> protectedCenterY() const { return m_centerY; }
 
     String customCSSText() const;
     bool equals(const CSSEllipseValue&) const;
@@ -132,11 +147,19 @@ public:
     const CSSValue& right() const { return m_right; }
     const CSSValue& bottom() const { return m_bottom; }
     const CSSValue& left() const { return m_left; }
+    Ref<CSSValue> protectedTop() const { return m_top; }
+    Ref<CSSValue> protectedRight() const { return m_right; }
+    Ref<CSSValue> protectedBottom() const { return m_bottom; }
+    Ref<CSSValue> protectedLeft() const { return m_left; }
 
     const CSSValue* topLeftRadius() const { return m_topLeftRadius.get(); }
     const CSSValue* topRightRadius() const { return m_topRightRadius.get(); }
     const CSSValue* bottomRightRadius() const { return m_bottomRightRadius.get(); }
     const CSSValue* bottomLeftRadius() const { return m_bottomLeftRadius.get(); }
+    RefPtr<CSSValue> protectedTopLeftRadius() const { return m_topLeftRadius; }
+    RefPtr<CSSValue> protectedTopRightRadius() const { return m_topRightRadius; }
+    RefPtr<CSSValue> protectedBottomRightRadius() const { return m_bottomRightRadius; }
+    RefPtr<CSSValue> protectedBottomLeftRadius() const { return m_bottomLeftRadius; }
 
     String customCSSText() const;
     bool equals(const CSSRectShapeValue&) const;
@@ -163,11 +186,19 @@ public:
     const CSSValue& insetY() const { return m_insetY; }
     const CSSValue& width() const { return m_width; }
     const CSSValue& height() const { return m_height; }
+    Ref<CSSValue> protectedInsetX() const { return m_insetX; }
+    Ref<CSSValue> protectedInsetY() const { return m_insetY; }
+    Ref<CSSValue> protectedWidth() const { return m_width; }
+    Ref<CSSValue> protectedHeight() const { return m_height; }
 
     const CSSValue* topLeftRadius() const { return m_topLeftRadius.get(); }
     const CSSValue* topRightRadius() const { return m_topRightRadius.get(); }
     const CSSValue* bottomRightRadius() const { return m_bottomRightRadius.get(); }
     const CSSValue* bottomLeftRadius() const { return m_bottomLeftRadius.get(); }
+    RefPtr<CSSValue> protectedTopLeftRadius() const { return m_topLeftRadius; }
+    RefPtr<CSSValue> protectedTopRightRadius() const { return m_topRightRadius; }
+    RefPtr<CSSValue> protectedBottomRightRadius() const { return m_bottomRightRadius; }
+    RefPtr<CSSValue> protectedBottomLeftRadius() const { return m_bottomLeftRadius; }
 
     String customCSSText() const;
     bool equals(const CSSXywhValue&) const;

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -184,7 +184,9 @@ public:
     inline int integer() const;
 
     inline const CSSValue& first() const; // CSSValuePair
+    Ref<CSSValue> protectedFirst() const; // CSSValuePair
     inline const CSSValue& second() const; // CSSValuePair
+    Ref<CSSValue> protectedSecond() const; // CSSValuePair
     inline const Quad& quad() const; // CSSValueQuad
     inline const Rect& rect() const; // CSSSValueRect
 

--- a/Source/WebCore/css/CSSValueList.h
+++ b/Source/WebCore/css/CSSValueList.h
@@ -74,6 +74,7 @@ public:
     // Consider removing these functions and having callers use size() and operator[] instead.
     unsigned length() const { return size(); }
     const CSSValue* item(unsigned index) const { return index < size() ? &(*this)[index] : nullptr; }
+    RefPtr<const CSSValue> protectedItem(unsigned index) const { return item(index); }
     const CSSValue* itemWithoutBoundsCheck(unsigned index) const { return &(*this)[index]; }
 
 protected:

--- a/Source/WebCore/css/CSSValuePair.h
+++ b/Source/WebCore/css/CSSValuePair.h
@@ -37,6 +37,8 @@ public:
 
     const CSSValue& first() const { return m_first; }
     const CSSValue& second() const { return m_second; }
+    Ref<CSSValue> protectedFirst() const { return m_first; }
+    Ref<CSSValue> protectedSecond() const { return m_second; }
 
     String customCSSText() const;
     bool equals(const CSSValuePair&) const;
@@ -60,9 +62,19 @@ inline const CSSValue& CSSValue::first() const
     return downcast<CSSValuePair>(*this).first();
 }
 
+inline Ref<CSSValue> CSSValue::protectedFirst() const
+{
+    return downcast<CSSValuePair>(*this).protectedFirst();
+}
+
 inline const CSSValue& CSSValue::second() const
 {
     return downcast<CSSValuePair>(*this).second();
+}
+
+inline Ref<CSSValue> CSSValue::protectedSecond() const
+{
+    return downcast<CSSValuePair>(*this).protectedSecond();
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 70d8991806620901606a29d94c2c6e5f2e98a435
<pre>
Adopt more smart pointers in BasicShapeFunctions.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=268083">https://bugs.webkit.org/show_bug.cgi?id=268083</a>

Reviewed by Darin Adler.

* Source/WebCore/css/BasicShapeFunctions.cpp:
(WebCore::convertToLengthSize):
(WebCore::convertToCenterCoordinate):
(WebCore::basicShapeForValue):
* Source/WebCore/css/CSSBasicShapes.h:
(WebCore::CSSInsetShapeValue::protectedTop const):
(WebCore::CSSInsetShapeValue::protectedRight const):
(WebCore::CSSInsetShapeValue::protectedBottom const):
(WebCore::CSSInsetShapeValue::protectedLeft const):
(WebCore::CSSInsetShapeValue::protectedTopLeftRadius const):
(WebCore::CSSInsetShapeValue::protectedTopRightRadius const):
(WebCore::CSSInsetShapeValue::protectedBottomRightRadius const):
(WebCore::CSSInsetShapeValue::protectedBottomLeftRadius const):
(WebCore::CSSCircleValue::protectedRadius const):
(WebCore::CSSCircleValue::protectedCenterX const):
(WebCore::CSSCircleValue::protectedCenterY const):
(WebCore::CSSEllipseValue::protectedRadiusX const):
(WebCore::CSSEllipseValue::protectedRadiusY const):
(WebCore::CSSEllipseValue::protectedCenterX const):
(WebCore::CSSEllipseValue::protectedCenterY const):
(WebCore::CSSRectShapeValue::protectedTop const):
(WebCore::CSSRectShapeValue::protectedRight const):
(WebCore::CSSRectShapeValue::protectedBottom const):
(WebCore::CSSRectShapeValue::protectedLeft const):
(WebCore::CSSRectShapeValue::protectedTopLeftRadius const):
(WebCore::CSSRectShapeValue::protectedTopRightRadius const):
(WebCore::CSSRectShapeValue::protectedBottomRightRadius const):
(WebCore::CSSRectShapeValue::protectedBottomLeftRadius const):
(WebCore::CSSXywhValue::protectedInsetX const):
(WebCore::CSSXywhValue::protectedInsetY const):
(WebCore::CSSXywhValue::protectedWidth const):
(WebCore::CSSXywhValue::protectedHeight const):
(WebCore::CSSXywhValue::protectedTopLeftRadius const):
(WebCore::CSSXywhValue::protectedTopRightRadius const):
(WebCore::CSSXywhValue::protectedBottomRightRadius const):
(WebCore::CSSXywhValue::protectedBottomLeftRadius const):
* Source/WebCore/css/CSSValue.h:
* Source/WebCore/css/CSSValueList.h:
(WebCore::CSSValueContainingVector::protectedItem const):
* Source/WebCore/css/CSSValuePair.h:
(WebCore::CSSValuePair::protectedFirst const):
(WebCore::CSSValuePair::protectedSecond const):
(WebCore::CSSValue::protectedFirst const):
(WebCore::CSSValue::protectedSecond const):

Canonical link: <a href="https://commits.webkit.org/273527@main">https://commits.webkit.org/273527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b526f3be86016c2732a3ed7d2f4c5c25169cb16

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38381 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32109 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36839 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30893 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31722 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10832 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10836 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39626 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36791 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11028 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/8936 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34880 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12743 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11536 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4625 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11811 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->