### PR TITLE
[WGSL] Should be able to parse hex and decimals when using 16-bit chars

### DIFF
--- a/Source/WebGPU/WGSL/tests/valid/constants-utf16.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/constants-utf16.wgsl
@@ -1,0 +1,109 @@
+// RUN: %wgslc
+
+// 🧪
+fn testU32ConstantsThatOverflowI32()
+{
+    let x1 = u32(4294967295);
+    let x2 = u32(3735928559);
+}
+
+fn testLiteralConstants()
+{
+    {
+        const x = 1;
+        _ = countOneBits(x);
+    }
+
+    {
+        const x = 1i;
+        _ = countOneBits(x);
+    }
+
+    {
+        const x = true;
+        if x {
+        }
+    }
+
+    {
+        const x = 3.0;
+        _ = sqrt(x);
+    }
+
+    {
+        const x = 3f;
+        _ = sqrt(x);
+    }
+}
+
+fn testArrayConstants() -> i32
+{
+    if (false) {
+        const a = array(0, 0, 0);
+        return a[0];
+    }
+    return 0;
+}
+
+fn testConstantMultiplication()
+{
+  const x1 = 2 * 2;
+  const x2 = 2 * 2.0;
+  const x3 = 2.0 * 2.0;
+  const x4 = 2.0 * vec2(2.0);
+  const x5 = vec2(2.0) * vec2(2.0);
+  const x6 = vec2(2.0) * 2.0;
+}
+
+fn testConstantAddition()
+{
+  const x1 = 2 + 2;
+  const x2 = 2 + 2.0;
+  const x3 = 2.0 + 2.0;
+  const x4 = 2.0 + vec2(2.0);
+  const x5 = vec2(2.0) + vec2(2.0);
+  const x6 = vec2(2.0) + 2.0;
+}
+
+
+@compute @workgroup_size(1)
+fn testVectorConstants() -> i32
+{
+    if (false) {
+        const a = vec3(0, 0, 0);
+        return a.x;
+    }
+    return 0;
+}
+
+fn testAbstractIntPromotion()
+{
+    const f = pow(vec2(0), vec2(0));
+}
+
+fn testMixedConstantValue()
+{
+    const x = 1 - 0.5;
+    _ = x;
+}
+
+fn testPrimitiveStructAccess()
+{
+  const f = frexp(1.25);
+  const fract = f.fract;
+  const exp = f.exp;
+}
+
+// Attribute constants
+const group = 0;
+const binding = 1;
+@group(group) @binding(binding) var<storage> w: i32;
+
+const x = 8;
+const y = 4;
+const z = 2;
+@compute @workgroup_size(x, y, z)
+fn main()
+{
+    _ = y;
+}


### PR DESCRIPTION
#### 04372fb7b43abb1dde761c9250e079ec47461801
<pre>
[WGSL] Should be able to parse hex and decimals when using 16-bit chars
<a href="https://bugs.webkit.org/show_bug.cgi?id=268087">https://bugs.webkit.org/show_bug.cgi?id=268087</a>
<a href="https://rdar.apple.com/121604575">rdar://121604575</a>

Reviewed by Mike Wyrzykowski.

We use `std::from_chars` to parse hex and decimals numbers, which only works with
char*. Since the digits should be ascii in either case, and the maximum length is
is only 19, we just copy it into a char[20] buffer and continue using `std::from_chars`.

* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lexNumber):
* Source/WebGPU/WGSL/tests/valid/constants-utf16.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/273564@main">https://commits.webkit.org/273564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23dedf091572bd53bac1ef9ecfde73752c469532

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38389 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32113 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30897 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10836 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10842 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39634 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32398 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36795 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34875 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12750 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8164 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11540 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->