### PR TITLE
[WGSL] Context should be a pointer into the vector buffer

### DIFF
--- a/Source/WebGPU/WGSL/ContextProvider.h
+++ b/Source/WebGPU/WGSL/ContextProvider.h
@@ -70,7 +70,7 @@ private:
     };
 
     Context* m_context;
-    Vector<Context> m_contexts;
+    Vector<std::unique_ptr<Context>> m_contexts;
     ContextScope m_globalScope;
 };
 

--- a/Source/WebGPU/WGSL/ContextProviderInlines.h
+++ b/Source/WebGPU/WGSL/ContextProviderInlines.h
@@ -61,8 +61,8 @@ ContextProvider<Value>::ContextScope::ContextScope(ContextProvider<Value>* provi
     : m_provider(*provider)
     , m_previousContext(provider->m_context)
 {
-    m_provider.m_contexts.append(Context { m_previousContext });
-    m_provider.m_context = &m_provider.m_contexts.last();
+    m_provider.m_contexts.append(std::unique_ptr<Context>(new Context { m_previousContext }));
+    m_provider.m_context = m_provider.m_contexts.last().get();
 }
 
 template<typename Value>


### PR DESCRIPTION
#### fd71e60136fe19a17c8cb10589afe14b6cdce089
<pre>
[WGSL] Context should be a pointer into the vector buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=268089">https://bugs.webkit.org/show_bug.cgi?id=268089</a>
<a href="https://rdar.apple.com/121447015">rdar://121447015</a>

Reviewed by Mike Wyrzykowski.

Pointing into the buffer directly can lead to a UAF if the vector gets resized, so
we store a unique_ptr in the vector and use that instead.

* Source/WebGPU/WGSL/ContextProvider.h:
* Source/WebGPU/WGSL/ContextProviderInlines.h:
(WGSL::ContextProvider&lt;Value&gt;::ContextScope::ContextScope):

Canonical link: <a href="https://commits.webkit.org/273561@main">https://commits.webkit.org/273561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1300559efaa4869024be29444298568850e900e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38391 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32115 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11618 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30899 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10838 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10863 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39636 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32423 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32200 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36797 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11034 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34877 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12752 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8165 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11542 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11820 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->