### PR TITLE
More dynamicDowncast<Document> and adjacent dynamicDowncast<> adoption

### DIFF
--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -518,14 +518,11 @@ const char* CookieStore::activeDOMObjectName() const
 void CookieStore::stop()
 {
     // FIXME: This should work for service worker contexts as well.
-    if (!is<Document>(scriptExecutionContext()))
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
+    if (!document)
         return;
 
     if (!m_hasChangeEventListener)
-        return;
-
-    RefPtr document = downcast<Document>(scriptExecutionContext());
-    if (!document)
         return;
 
     WeakPtr page = document->page();

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -100,18 +100,16 @@ void InspectorInstrumentation::lastFrontendDeleted()
 
 static LocalFrame* frameForScriptExecutionContext(ScriptExecutionContext* context)
 {
-    LocalFrame* frame = nullptr;
-    if (is<Document>(*context))
-        frame = downcast<Document>(*context).frame();
-    return frame;
+    if (RefPtr document = dynamicDowncast<Document>(*context))
+        return document->frame();
+    return nullptr;
 }
 
 static LocalFrame* frameForScriptExecutionContext(ScriptExecutionContext& context)
 {
-    LocalFrame* frame = nullptr;
-    if (is<Document>(context))
-        frame = downcast<Document>(context).frame();
-    return frame;
+    if (RefPtr document = dynamicDowncast<Document>(context))
+        return document->frame();
+    return nullptr;
 }
 
 void InspectorInstrumentation::didClearWindowObjectInWorldImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame, DOMWrapperWorld& world)
@@ -1371,10 +1369,10 @@ InstrumentingAgents& InspectorInstrumentation::instrumentingAgents(Page& page)
 
 InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(ScriptExecutionContext& context)
 {
-    if (is<Document>(context))
-        return instrumentingAgents(downcast<Document>(context).page());
-    if (is<WorkerOrWorkletGlobalScope>(context))
-        return &instrumentingAgents(downcast<WorkerOrWorkletGlobalScope>(context));
+    if (RefPtr document = dynamicDowncast<Document>(context))
+        return instrumentingAgents(document->protectedPage().get());
+    if (RefPtr workerOrWorkletGlobal = dynamicDowncast<WorkerOrWorkletGlobalScope>(context))
+        return &instrumentingAgents(*workerOrWorkletGlobal);
     return nullptr;
 }
 

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -507,8 +507,8 @@ Protocol::ErrorStringOr<std::tuple<RefPtr<JSON::ArrayOf<Protocol::CSS::RuleMatch
                 auto entry = Protocol::CSS::InheritedStyleEntry::create()
                     .setMatchedCSSRules(buildArrayForMatchedRuleList(parentMatchedRules, styleResolver, ancestor, PseudoId::None))
                     .release();
-                if (is<StyledElement>(ancestor) && downcast<StyledElement>(ancestor).cssomStyle().length()) {
-                    auto& styleSheet = asInspectorStyleSheet(downcast<StyledElement>(ancestor));
+                if (RefPtr styledElement = dynamicDowncast<StyledElement>(ancestor); styledElement && styledElement->cssomStyle().length()) {
+                    auto& styleSheet = asInspectorStyleSheet(*styledElement);
                     entry->setInlineStyle(styleSheet.buildObjectForStyle(styleSheet.styleForId(InspectorCSSId(styleSheet.id(), 0))));
                 }
                 inherited->addItem(WTFMove(entry));
@@ -527,12 +527,12 @@ Protocol::ErrorStringOr<std::tuple<RefPtr<Protocol::CSS::CSSStyle> /* inlineStyl
     if (!element)
         return makeUnexpected(errorString);
 
-    if (!is<StyledElement>(element))
+    RefPtr styledElement = dynamicDowncast<StyledElement>(*element);
+    if (!styledElement)
         return { { nullptr, nullptr } };
 
-    auto& styledElement = downcast<StyledElement>(*element);
-    auto& styleSheet = asInspectorStyleSheet(styledElement);
-    return { { styleSheet.buildObjectForStyle(&styledElement.cssomStyle()), buildObjectForAttributesStyle(styledElement) } };
+    auto& styleSheet = asInspectorStyleSheet(*styledElement);
+    return { { styleSheet.buildObjectForStyle(&styledElement->cssomStyle()), buildObjectForAttributesStyle(*styledElement) } };
 }
 
 Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::CSS::CSSComputedStyleProperty>>> InspectorCSSAgent::getComputedStyleForNode(Protocol::DOM::NodeId nodeId)
@@ -1036,7 +1036,7 @@ OptionSet<InspectorCSSAgent::LayoutFlag> InspectorCSSAgent::layoutFlagsForNode(N
                 if (frameView->isScrollable())
                     layoutFlags.add(InspectorCSSAgent::LayoutFlag::Scrollable);
             }
-        } else if (is<RenderBox>(*renderer) && downcast<RenderBox>(*renderer).canBeScrolledAndHasScrollableArea())
+        } else if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(*renderer); renderBox && renderBox->canBeScrolledAndHasScrollableArea())
             layoutFlags.add(InspectorCSSAgent::LayoutFlag::Scrollable);
     }
 

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -284,8 +284,8 @@ std::optional<double> InspectorTimelineAgent::timestampFromMonotonicTime(Monoton
 
 static LocalFrame* frame(JSC::JSGlobalObject* globalObject)
 {
-    auto context = executionContext(globalObject);
-    return is<Document>(context) ? downcast<Document>(*context).frame() : nullptr;
+    RefPtr document = dynamicDowncast<Document>(executionContext(globalObject));
+    return document ? document->frame() : nullptr;
 }
 
 void InspectorTimelineAgent::startFromConsole(JSC::JSGlobalObject* globalObject, const String& title)

--- a/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp
@@ -85,11 +85,11 @@ Vector<WebSocket*> PageNetworkAgent::activeWebSockets()
         if (!channel->hasCreatedHandshake())
             continue;
 
-        if (!is<Document>(webSocket->scriptExecutionContext()))
+        RefPtr document = dynamicDowncast<Document>(webSocket->scriptExecutionContext());
+        if (!document)
             continue;
 
         // FIXME: <https://webkit.org/b/168475> Web Inspector: Correctly display iframe's WebSockets
-        auto* document = downcast<Document>(webSocket->scriptExecutionContext());
         if (document->page() != &m_inspectedPage)
             continue;
 


### PR DESCRIPTION
#### 10a815cfebf7c0bb1cbae781a57de67cd96edeee
<pre>
More dynamicDowncast&lt;Document&gt; and adjacent dynamicDowncast&lt;&gt; adoption
<a href="https://bugs.webkit.org/show_bug.cgi?id=268090">https://bugs.webkit.org/show_bug.cgi?id=268090</a>

Reviewed by Chris Dumez.

The result of grepping for is&lt;Document&gt; and then replacing downcast&lt;&gt;
calls in the returned files. Quite a bit of Web Inspector code this
time around.

Also increase RefPtr usage.

* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::stop):
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::frameForScriptExecutionContext):
(WebCore::InspectorInstrumentation::instrumentingAgents):
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::InspectorAnimationAgent::enable):
(WebCore::InspectorAnimationAgent::requestEffectTarget):
(WebCore::InspectorAnimationAgent::willApplyKeyframeEffect):
(WebCore::InspectorAnimationAgent::frameNavigated):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::getMatchedStylesForNode):
(WebCore::InspectorCSSAgent::getInlineStylesForNode):
(WebCore::InspectorCSSAgent::layoutFlagsForNode):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::unbind):
(WebCore::InspectorDOMAgent::assertDocument):
(WebCore::InspectorDOMAgent::assertElement):
(WebCore::InspectorDOMAgent::assertEditableNode):
(WebCore::InspectorDOMAgent::assertEditableElement):
(WebCore::InspectorDOMAgent::querySelector):
(WebCore::InspectorDOMAgent::querySelectorAll):
(WebCore::InspectorDOMAgent::insertAdjacentHTML):
(WebCore::InspectorDOMAgent::setNodeValue):
(WebCore::InspectorDOMAgent::highlightSelector):
(WebCore::InspectorDOMAgent::buildObjectForNode):
(WebCore::InspectorDOMAgent::buildObjectForEventListener):
(WebCore::InspectorDOMAgent::buildObjectForAccessibilityProperties):
(WebCore::containsOnlyASCIIWhitespace):
(WebCore::InspectorDOMAgent::innerParentNode):
(WebCore::InspectorDOMAgent::didAddEventListener):
(WebCore::InspectorDOMAgent::willRemoveEventListener):
(WebCore::InspectorDOMAgent::nodeForPath):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::didReceiveResponse):
(WebCore::InspectorNetworkAgent::enable):
(WebCore::InspectorNetworkAgent::resolveWebSocket):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::frame):
* Source/WebCore/inspector/agents/page/PageNetworkAgent.cpp:

Canonical link: <a href="https://commits.webkit.org/273601@main">https://commits.webkit.org/273601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37978cbd879569543288e24c2ef40f6f10ec7919

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38589 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32267 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37085 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31056 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12523 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11001 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10996 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39839 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32588 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32364 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36956 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35046 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12928 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8195 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11688 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12009 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->