### PR TITLE
[Site Isolation] Get basic UI side scrolling working

### DIFF
--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -564,7 +564,7 @@ bool isTopTargetFrameName(StringView name)
 
 } // namespace WebCore
 
-#ifndef NDEBUG
+//#ifndef NDEBUG
 
 static void printIndent(int indent)
 {
@@ -589,7 +589,7 @@ static void printFrames(const WebCore::Frame& frame, const WebCore::Frame* targe
         printIndent(indent);
         printf("  ownerElement=%p\n", localFrame->ownerElement());
         printIndent(indent);
-        printf("  frameView=%p (needs layout %d)\n", view, view ? view->needsLayout() : false);
+        printf("  frameView=%p (nodeID (%llu,%llu))\n", view, view ? view->scrollingNodeID().object() : 0,view ? view->scrollingNodeID().processIdentifier().toUInt64() : 0 );
         printIndent(indent);
         printf("  renderView=%p\n", view ? view->renderView() : nullptr);
         printIndent(indent);
@@ -613,4 +613,4 @@ void showFrameTree(const WebCore::Frame* frame)
     printFrames(frame->tree().top(), frame, 0);
 }
 
-#endif
+//#endif

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -125,7 +125,7 @@ bool isTopTargetFrameName(StringView);
 
 } // namespace WebCore
 
-#if ENABLE(TREE_DEBUGGING)
+//#if ENABLE(TREE_DEBUGGING)
 // Outside the WebCore namespace for ease of invocation from the debugger.
 WEBCORE_EXPORT void showFrameTree(const WebCore::Frame*);
-#endif
+//#endif

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -97,9 +97,9 @@ public:
     IntPoint convertToContainingView(const IntPoint&) const final;
     FloatPoint convertToContainingView(const FloatPoint&) const final;
     IntPoint convertFromContainingView(const IntPoint&) const final;
+    ScrollableArea* enclosingScrollableArea() const final;
 
 private:
-    ScrollableArea* enclosingScrollableArea() const final;
 
     bool scrollAnimatorEnabled() const final;
 };

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -62,6 +62,7 @@ public:
     Markable<LayerHostingContextIdentifier> layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
 
     String renderTreeAsText(size_t baseIndent, OptionSet<RenderAsTextFlag>);
+//    ScrollableArea* enclosingScrollableArea(Node* node);
 
 private:
     WEBCORE_EXPORT explicit RemoteFrame(Page&, UniqueRef<RemoteFrameClient>&&, FrameIdentifier, HTMLFrameOwnerElement*, Frame* parent, Markable<LayerHostingContextIdentifier>, Frame* opener = nullptr);

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -75,6 +75,8 @@ public:
     
     WEBCORE_EXPORT void setMouseIsOverContentArea(ScrollableArea&, bool) override;
     WEBCORE_EXPORT void setMouseMovedInContentArea(ScrollableArea&) override;
+    WEBCORE_EXPORT void setLayerHostingContextIdentifier(ScrollableArea&, Markable<LayerHostingContextIdentifier>) override;
+
 
 protected:
     WEBCORE_EXPORT AsyncScrollingCoordinator(Page*);

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -368,7 +368,9 @@ bool ScrollingCoordinator::shouldUpdateScrollLayerPositionSynchronously(const Lo
 ScrollingNodeID ScrollingCoordinator::uniqueScrollingNodeID()
 {
     static ScrollingNodeID uniqueScrollingNodeID = 1;
-    return uniqueScrollingNodeID++;
+    auto returnID = uniqueScrollingNodeID;
+    uniqueScrollingNodeID = ProcessQualified(returnID.object() + 1);
+    return returnID;
 }
 
 void ScrollingCoordinator::receivedWheelEventWithPhases(PlatformWheelEventPhase phase, PlatformWheelEventPhase momentumPhase)
@@ -388,7 +390,7 @@ void ScrollingCoordinator::deferWheelEventTestCompletionForReason(ScrollingNodeI
         return;
 
     if (auto monitor = m_page->wheelEventTestMonitor())
-        monitor->deferForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID), reason);
+        monitor->deferForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID.object()), reason);
 }
 
 void ScrollingCoordinator::removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
@@ -398,7 +400,7 @@ void ScrollingCoordinator::removeWheelEventTestCompletionDeferralForReason(Scrol
         return;
 
     if (auto monitor = m_page->wheelEventTestMonitor())
-        monitor->removeDeferralForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID), reason);
+        monitor->removeDeferralForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID.object()), reason);
 }
 
 String ScrollingCoordinator::scrollingStateTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior>) const

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -37,6 +37,7 @@
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Threading.h>
 #include <wtf/TypeCasts.h>
+#include "LayerHostingContextIdentifier.h"
 
 namespace WTF {
 class TextStream;
@@ -209,7 +210,9 @@ public:
     WEBCORE_EXPORT virtual void setMouseMovedInContentArea(ScrollableArea&) { }
     WEBCORE_EXPORT virtual void setMouseIsOverScrollbar(Scrollbar*, bool) { }
     WEBCORE_EXPORT virtual void setScrollbarEnabled(Scrollbar&) { }
-
+    
+    WEBCORE_EXPORT virtual bool isSiteIsolatedTree() { return false; }
+    WEBCORE_EXPORT virtual void setLayerHostingContextIdentifier(ScrollableArea&, Markable<LayerHostingContextIdentifier>) { }
 protected:
     explicit ScrollingCoordinator(Page*);
 

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
@@ -61,6 +61,7 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(
     MouseLocationState&& mouseLocationState,
     ScrollbarHoverState&& scrollbarHoverState,
     ScrollbarEnabledState&& scrollbarEnabledState,
+    Markable<LayerHostingContextIdentifier> identifier,
     RequestedKeyboardScrollData&& keyboardScrollData,
     float frameScaleFactor,
     EventTrackingRegions&& eventTrackingRegions,
@@ -110,6 +111,7 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(
     WTFMove(mouseLocationState),
     WTFMove(scrollbarHoverState),
     WTFMove(scrollbarEnabledState),
+    WTFMove(identifier),
     WTFMove(keyboardScrollData))
     , m_rootContentsLayer(rootContentsLayer.value_or(PlatformLayerIdentifier()))
     , m_counterScrollingLayer(counterScrollingLayer.value_or(PlatformLayerIdentifier()))

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
@@ -153,6 +153,7 @@ private:
         MouseLocationState&&,
         ScrollbarHoverState&&,
         ScrollbarEnabledState&&,
+        Markable<LayerHostingContextIdentifier> identifier,
         RequestedKeyboardScrollData&&,
         float frameScaleFactor,
         EventTrackingRegions&&,

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.cpp
@@ -37,6 +37,18 @@
 
 namespace WebCore {
 
+TextStream& operator<<(TextStream& ts, LayerRepresentation::Type scrollType)
+{
+    switch (scrollType) {
+        case LayerRepresentation::EmptyRepresentation: ts << "EmptyRepresentation"; break;
+        case LayerRepresentation::GraphicsLayerRepresentation: ts << "GraphicsLayerRepresentation"; break;
+        case LayerRepresentation::PlatformLayerRepresentation: ts << "PlatformLayerRepresentation"; break;
+        case LayerRepresentation::PlatformLayerIDRepresentation: ts << "PlatformLayerIDRepresentation"; break;
+    }
+    return ts;
+}
+
+
 ScrollingStateNode::ScrollingStateNode(ScrollingNodeType nodeType, ScrollingStateTree& scrollingStateTree, ScrollingNodeID nodeID)
     : m_nodeType(nodeType)
     , m_nodeID(nodeID)
@@ -199,6 +211,7 @@ void ScrollingStateNode::setLayer(const LayerRepresentation& layerRepresentation
         return;
 
     m_layer = layerRepresentation;
+    ALWAYS_LOG_WITH_STREAM(stream << "ScrollingStateNode::setLayer: node ID:" << scrollingNodeID() << " layer: " << layerRepresentation.layerID() << " type: " << layerRepresentation.representation() << " ");
 
     setPropertyChanged(Property::Layer);
 }

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -103,7 +103,7 @@ public:
 
     explicit operator PlatformLayer*() const
     {
-        ASSERT(m_representation == PlatformLayerRepresentation);
+//        ASSERT(m_representation == PlatformLayerRepresentation);
         return makePlatformLayerTyped(m_typelessPlatformLayer);
     }
     
@@ -174,6 +174,7 @@ public:
     
     LayerRepresentation toRepresentation(Type representation) const
     {
+        ALWAYS_LOG_WITH_STREAM(stream << "toRepresentation: " << representation);
         switch (representation) {
         case EmptyRepresentation:
             return LayerRepresentation();
@@ -188,9 +189,10 @@ public:
         ASSERT_NOT_REACHED();
         return LayerRepresentation();
     }
-
+    
     bool representsGraphicsLayer() const { return m_representation == GraphicsLayerRepresentation; }
     bool representsPlatformLayerID() const { return m_representation == PlatformLayerIDRepresentation; }
+    Type representation() const { return m_representation; }
     
 private:
     WEBCORE_EXPORT static void retainPlatformLayer(void* typelessPlatformLayer);
@@ -203,6 +205,9 @@ private:
     PlatformLayerIdentifier m_layerID;
     Type m_representation { EmptyRepresentation };
 };
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, LayerRepresentation::Type);
+
 
 enum class ScrollingStateNodeProperty : uint64_t {
     // ScrollingStateNode
@@ -234,8 +239,9 @@ enum class ScrollingStateNodeProperty : uint64_t {
     MouseActivityState                          = ContentAreaHoverState << 1,
     ScrollbarHoverState                         = MouseActivityState << 1,
     ScrollbarEnabledState                       = ScrollbarHoverState << 1,
+    LayerHostingContextIdentifier               = ScrollbarEnabledState << 1,
     // ScrollingStateFrameScrollingNode
-    KeyboardScrollData                          = ScrollbarEnabledState << 1,
+    KeyboardScrollData                          = LayerHostingContextIdentifier << 1,
     FrameScaleFactor                            = KeyboardScrollData << 1,
     EventTrackingRegion                         = FrameScaleFactor << 1,
     RootContentsLayer                           = EventTrackingRegion << 1,

--- a/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp
@@ -60,6 +60,7 @@ ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode(
     MouseLocationState&& mouseLocationState,
     ScrollbarHoverState&& scrollbarHoverState,
     ScrollbarEnabledState&& scrollbarEnabledState,
+    Markable<LayerHostingContextIdentifier> identifier,
     RequestedKeyboardScrollData&& scrollData
 ) : ScrollingStateScrollingNode(
     ScrollingNodeType::Overflow,
@@ -89,6 +90,7 @@ ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode(
     WTFMove(mouseLocationState),
     WTFMove(scrollbarHoverState),
     WTFMove(scrollbarEnabledState),
+    WTFMove(identifier),
     WTFMove(scrollData)
 ) { }
 

--- a/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h
@@ -69,6 +69,7 @@ private:
         MouseLocationState&&,
         ScrollbarHoverState&&,
         ScrollbarEnabledState&&,
+        Markable<LayerHostingContextIdentifier> identifier,
         RequestedKeyboardScrollData&&
     );
     ScrollingStateOverflowScrollingNode(ScrollingStateTree&, ScrollingNodeID);

--- a/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp
@@ -60,6 +60,7 @@ ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode(
     MouseLocationState&& mouseLocationState,
     ScrollbarHoverState&& scrollbarHoverState,
     ScrollbarEnabledState&& scrollbarEnabledState,
+    Markable<LayerHostingContextIdentifier> identifier,
     RequestedKeyboardScrollData&& scrollData
 ) : ScrollingStateScrollingNode(
     ScrollingNodeType::PluginScrolling,
@@ -89,6 +90,7 @@ ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode(
     WTFMove(mouseLocationState),
     WTFMove(scrollbarHoverState),
     WTFMove(scrollbarEnabledState),
+    WTFMove(identifier),
     WTFMove(scrollData)
 )
 {

--- a/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h
@@ -75,6 +75,7 @@ private:
         MouseLocationState&&,
         ScrollbarHoverState&&,
         ScrollbarEnabledState&&,
+        Markable<LayerHostingContextIdentifier> identifier,
         RequestedKeyboardScrollData&&
     );
 

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp
@@ -67,6 +67,7 @@ ScrollingStateScrollingNode::ScrollingStateScrollingNode(
     MouseLocationState&& mouseLocationState,
     ScrollbarHoverState&& scrollbarHoverState,
     ScrollbarEnabledState&& scrollbarEnabledState,
+    Markable<LayerHostingContextIdentifier> identifier,
     RequestedKeyboardScrollData&& keyboardScrollData
 ) : ScrollingStateNode(nodeType, nodeID, WTFMove(children), changedProperties, layerID)
     , m_scrollableAreaSize(scrollableAreaSize)
@@ -84,6 +85,7 @@ ScrollingStateScrollingNode::ScrollingStateScrollingNode(
     , m_scrollbarHoverState(WTFMove(scrollbarHoverState))
     , m_mouseLocationState(WTFMove(mouseLocationState))
     , m_scrollbarEnabledState(WTFMove(scrollbarEnabledState))
+    , m_remoteContextHostedIdentifier(identifier)
     , m_scrollableAreaParameters(WTFMove(scrollableAreaParameters))
     , m_requestedScrollData(WTFMove(requestedScrollData))
     , m_keyboardScrollData(WTFMove(keyboardScrollData))
@@ -111,6 +113,7 @@ ScrollingStateScrollingNode::ScrollingStateScrollingNode(const ScrollingStateScr
     , m_verticalScrollerImp(stateNode.verticalScrollerImp())
     , m_horizontalScrollerImp(stateNode.horizontalScrollerImp())
 #endif
+    , m_remoteContextHostedIdentifier(stateNode.layerHostingContextIdentifier())
     , m_scrollableAreaParameters(stateNode.scrollableAreaParameters())
     , m_requestedScrollData(stateNode.requestedScrollData())
     , m_keyboardScrollData(stateNode.keyboardScrollData())
@@ -374,6 +377,14 @@ void ScrollingStateScrollingNode::setScrollbarEnabledState(ScrollbarOrientation 
     setPropertyChanged(Property::ScrollbarEnabledState);
 }
 
+void ScrollingStateScrollingNode::setLayerHostingContextIdentifier(const Markable<LayerHostingContextIdentifier> identifier)
+{
+    if (identifier == m_remoteContextHostedIdentifier)
+        return;
+    m_remoteContextHostedIdentifier = identifier;
+    setPropertyChanged(Property::LayerHostingContextIdentifier);
+}
+
 void ScrollingStateScrollingNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
 {
     ScrollingStateNode::dumpProperties(ts, behavior);
@@ -460,6 +471,7 @@ void ScrollingStateScrollingNode::dumpProperties(TextStream& ts, OptionSet<Scrol
         if (m_scrolledContentsLayer.layerID())
             ts.dumpProperty("scrolled contents layer", m_scrolledContentsLayer.layerID());
     }
+    ts.dumpProperty("remote context hosted identifier", m_remoteContextHostedIdentifier);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
@@ -136,6 +136,9 @@ public:
     WEBCORE_EXPORT void setMouseMovedInContentArea(const MouseLocationState&);
     const MouseLocationState& mouseLocationState() const { return m_mouseLocationState; }
 
+    WEBCORE_EXPORT void setLayerHostingContextIdentifier(const Markable<LayerHostingContextIdentifier>);
+    const Markable<LayerHostingContextIdentifier> layerHostingContextIdentifier() const { return m_remoteContextHostedIdentifier; }
+
 protected:
     ScrollingStateScrollingNode(
         ScrollingNodeType,
@@ -165,6 +168,7 @@ protected:
         MouseLocationState&&,
         ScrollbarHoverState&&,
         ScrollbarEnabledState&&,
+        Markable<LayerHostingContextIdentifier> identifier,
         RequestedKeyboardScrollData&&
     );
     ScrollingStateScrollingNode(ScrollingStateTree&, ScrollingNodeType, ScrollingNodeID);
@@ -198,6 +202,7 @@ private:
     RetainPtr<NSScrollerImp> m_horizontalScrollerImp;
 #endif
 
+    Markable<LayerHostingContextIdentifier> m_remoteContextHostedIdentifier;
     ScrollableAreaParameters m_scrollableAreaParameters;
     RequestedScrollData m_requestedScrollData;
     RequestedKeyboardScrollData m_keyboardScrollData;

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
@@ -153,7 +153,7 @@ Ref<ScrollingStateNode> ScrollingStateTree::createNode(ScrollingNodeType nodeTyp
 
 ScrollingNodeID ScrollingStateTree::createUnparentedNode(ScrollingNodeType nodeType, ScrollingNodeID newNodeID)
 {
-    LOG_WITH_STREAM(ScrollingTree, stream << "ScrollingStateTree " << this << " createUnparentedNode " << newNodeID);
+//    ALWAYS_LOG_WITH_STREAM(stream << "ScrollingStateTree " << this << " createUnparentedNode " << newNodeID);
 
     if (auto node = stateNodeForID(newNodeID)) {
         if (node->nodeType() == nodeType) {
@@ -177,12 +177,17 @@ ScrollingNodeID ScrollingStateTree::createUnparentedNode(ScrollingNodeType nodeT
     auto stateNode = createNode(nodeType, newNodeID);
     addNode(stateNode);
     m_unparentedNodes.add(newNodeID, WTFMove(stateNode));
+//    ALWAYS_LOG_WITH_STREAM(stream << "ScrollingStateTree asdfasfsdfa " << newNodeID);
+//    showScrollingStateTree(*this);
+//    ALWAYS_LOG_WITH_STREAM(stream << "ScrollingStateTree asdfasfsdfa " << newNodeID);
+
     return newNodeID;
 }
 
 ScrollingNodeID ScrollingStateTree::insertNode(ScrollingNodeType nodeType, ScrollingNodeID newNodeID, ScrollingNodeID parentID, size_t childIndex)
 {
-    LOG_WITH_STREAM(ScrollingTree, stream << "ScrollingStateTree " << this << " insertNode " << newNodeID << " in parent " << parentID << " at " << childIndex);
+//    ALWAYS_LOG_WITH_STREAM(stream << "ScrollingStateTree " << this << " insertNode " << newNodeID << " in parent " << parentID << " at " << childIndex);
+
     ASSERT(newNodeID);
 
     if (auto node = stateNodeForID(newNodeID)) {
@@ -220,12 +225,12 @@ ScrollingNodeID ScrollingStateTree::insertNode(ScrollingNodeType nodeType, Scrol
 
     RefPtr<ScrollingStateNode> newNode;
     if (!parentID) {
-        RELEASE_ASSERT(nodeType == ScrollingNodeType::MainFrame);
         ASSERT(!childIndex || childIndex == notFound);
         // If we're resetting the root node, we should clear the HashMap and destroy the current children.
         clear();
+//        ALWAYS_LOG_WITH_STREAM(stream << "ScrollingStateTree " << this << " creating root state node " << newNodeID << " in parent " << parentID << " at " << childIndex);
 
-        setRootStateNode(ScrollingStateFrameScrollingNode::create(*this, ScrollingNodeType::MainFrame, newNodeID));
+        setRootStateNode(ScrollingStateFrameScrollingNode::create(*this, nodeType, newNodeID));
         newNode = rootStateNode();
         m_hasNewRootStateNode = true;
     } else {
@@ -258,6 +263,11 @@ ScrollingNodeID ScrollingStateTree::insertNode(ScrollingNodeType nodeType, Scrol
     }
 
     addNode(*newNode);
+//    ALWAYS_LOG_WITH_STREAM(stream << "ScrollingStateTree asdfasfsdfa " << newNodeID);
+//
+//    showScrollingStateTree(*this);
+//    ALWAYS_LOG_WITH_STREAM(stream << "ScrollingStateTree asdfasfsdfa " << newNodeID);
+
     return newNodeID;
 }
 
@@ -496,7 +506,7 @@ String ScrollingStateTree::scrollingStateTreeAsText(OptionSet<ScrollingStateTree
 
 } // namespace WebCore
 
-#ifndef NDEBUG
+//#ifndef NDEBUG
 void showScrollingStateTree(const WebCore::ScrollingStateTree& tree)
 {
     auto rootNode = tree.rootStateNode();
@@ -508,12 +518,12 @@ void showScrollingStateTree(const WebCore::ScrollingStateTree& tree)
     String output = rootNode->scrollingStateTreeAsText(WebCore::debugScrollingStateTreeAsTextBehaviors);
     WTFLogAlways("%s\n", output.utf8().data());
 }
+//
+//void showScrollingStateTree(const WebCore::ScrollingStateNode& node)
+//{
+//    showScrollingStateTree(node.scrollingStateTree());
+//}
 
-void showScrollingStateTree(const WebCore::ScrollingStateNode& node)
-{
-    showScrollingStateTree(node.scrollingStateTree());
-}
-
-#endif
+//#endif
 
 #endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -125,9 +125,7 @@ private:
 
 } // namespace WebCore
 
-#ifndef NDEBUG
 void showScrollingStateTree(const WebCore::ScrollingStateTree&);
-void showScrollingStateTree(const WebCore::ScrollingStateNode&);
-#endif
+//void showScrollingStateTree(const WebCore::ScrollingStateNode&);
 
 #endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -192,7 +192,7 @@ WheelEventHandlingResult ScrollingTree::handleWheelEvent(const PlatformWheelEven
         }
         auto node = scrollingNodeForPoint(position);
 
-        LOG_WITH_STREAM(Scrolling, stream << "ScrollingTree::handleWheelEvent found node " << (node ? node->scrollingNodeID() : 0) << " for point " << position);
+        LOG_WITH_STREAM(Scrolling, stream << "ScrollingTree::handleWheelEvent found node " << (node ? node->scrollingNodeID() : ProcessQualified(0, Process::identifier())) << " for point " << position);
 
         return handleWheelEventWithNode(wheelEvent, processingSteps, node.get());
     }();

--- a/Source/WebCore/page/scrolling/ScrollingTreeGestureState.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeGestureState.cpp
@@ -105,8 +105,8 @@ void ScrollingTreeGestureState::nodeDidHandleEvent(ScrollingNodeID nodeID, const
 
 void ScrollingTreeGestureState::clearAllNodes()
 {
-    m_mayBeginNodeID = 0;
-    m_activeNodeID = 0;
+    m_mayBeginNodeID = std::nullopt;
+    m_activeNodeID = std::nullopt;
 }
 
 };

--- a/Source/WebCore/page/scrolling/ScrollingTreeGestureState.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeGestureState.h
@@ -51,8 +51,8 @@ private:
     void clearAllNodes();
 
     ScrollingTree& m_scrollingTree;
-    Markable<ScrollingNodeID, IntegralMarkableTraits<ScrollingNodeID, 0>> m_mayBeginNodeID;
-    Markable<ScrollingNodeID, IntegralMarkableTraits<ScrollingNodeID, 0>> m_activeNodeID;
+    Markable<ScrollingNodeID> m_mayBeginNodeID;
+    Markable<ScrollingNodeID> m_activeNodeID;
 };
 
 }

--- a/Source/WebCore/page/scrolling/ScrollingTreeNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeNode.cpp
@@ -72,11 +72,11 @@ void ScrollingTreeNode::removeChild(ScrollingTreeNode& node)
         child->removeChild(node);
 }
 
-void ScrollingTreeNode::removeAllChildren()
+void ScrollingTreeNode::removeAllChildren(bool isHostedCommit)
 {
     RELEASE_ASSERT(m_scrollingTree.inCommitTreeState());
-
-    m_children.clear();
+    
+    m_children.removeAllMatching([isHostedCommit](Ref<ScrollingTreeNode> x) { return x->isHostedSubtree() == isHostedCommit; });
 }
 
 bool ScrollingTreeNode::isRootNode() const

--- a/Source/WebCore/page/scrolling/ScrollingTreeNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeNode.h
@@ -84,15 +84,19 @@ public:
     WEBCORE_EXPORT bool isRootNode() const;
 
     const Vector<Ref<ScrollingTreeNode>>& children() const { return m_children; }
-
+    void setIsHostedSubtree(bool flag) { m_isHostedSubtree = flag; }
+    bool isHostedSubtree() const { return m_isHostedSubtree;}
+    
     void appendChild(Ref<ScrollingTreeNode>&&);
     void removeChild(ScrollingTreeNode&);
-    void removeAllChildren();
+    void removeAllChildren(bool isHostedCommit=false);
 
     WEBCORE_EXPORT RefPtr<ScrollingTreeFrameScrollingNode> enclosingFrameNodeIncludingSelf();
     WEBCORE_EXPORT RefPtr<ScrollingTreeScrollingNode> enclosingScrollingNodeIncludingSelf();
 
     WEBCORE_EXPORT void dump(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const;
+    std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() { return m_hostingContext; }
+    void setlayerHostingContextIdentifier(LayerHostingContextIdentifier identifier) { m_hostingContext = identifier; }
 
 protected:
     ScrollingTreeNode(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);
@@ -109,6 +113,9 @@ private:
 
     const ScrollingNodeType m_nodeType;
     const ScrollingNodeID m_nodeID;
+    bool m_isHostedSubtree { false };
+    std::optional<LayerHostingContextIdentifier> m_hostingContext;
+
 
     ThreadSafeWeakPtr<ScrollingTreeNode> m_parent;
 };

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -102,6 +102,16 @@ bool ScrollingTreeScrollingNode::commitStateBeforeChildren(const ScrollingStateN
     if (state.hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))
         m_scrolledContentsLayer = state.scrolledContentsLayer();
 
+    if (state.hasChangedProperty(ScrollingStateNode::Property::LayerHostingContextIdentifier)) {
+        if (state.layerHostingContextIdentifier()) {
+            scrollingTree().addScrollingNodeToHostedSubtreeMap(*state.layerHostingContextIdentifier(), this);
+            setlayerHostingContextIdentifier(*state.layerHostingContextIdentifier());
+            // TODO: look to see if there is an untached subtree waiting in m_hostedSubtreesNeedingPairing
+        } else {
+            // TODO: need some logic to remove subtree if we are no longer hosting
+        }
+    }
+    
     return true;
 }
 
@@ -419,7 +429,11 @@ void ScrollingTreeScrollingNode::dumpProperties(TextStream& ts, OptionSet<Scroll
     if (m_reachableContentsSize != m_totalContentsSize)
         ts.dumpProperty("reachable content size", m_reachableContentsSize);
     ts.dumpProperty("last committed scroll position", m_lastCommittedScrollPosition);
-
+    
+    ts.dumpProperty("scroll container layer", m_scrollContainerLayer.layerID());
+    ts.dumpProperty("scroll m_scrollContentsLayer", m_scrolledContentsLayer.layerID());
+    ts.dumpProperty("is hosted subtree", isHostedSubtree());
+//    LayerRepresentation m_scrolledContentsLayer
     if (!m_currentScrollPosition.isZero())
         ts.dumpProperty("scroll position", m_currentScrollPosition);
 

--- a/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
@@ -79,7 +79,7 @@ WheelEventHandlingResult ThreadedScrollingCoordinator::handleWheelEventForScroll
 
     LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingCoordinator::handleWheelEventForScrolling " << wheelEvent << " - sending event to scrolling thread, node " << targetNodeID << " gestureState " << gestureState);
 
-    auto deferrer = WheelEventTestMonitorCompletionDeferrer { m_page->wheelEventTestMonitor().get(), reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(targetNodeID), WheelEventTestMonitor::DeferReason::PostMainThreadWheelEventHandling };
+    auto deferrer = WheelEventTestMonitorCompletionDeferrer { m_page->wheelEventTestMonitor().get(), reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(targetNodeID.object()), WheelEventTestMonitor::DeferReason::PostMainThreadWheelEventHandling };
 
     RefPtr<ThreadedScrollingTree> threadedScrollingTree = downcast<ThreadedScrollingTree>(scrollingTree());
     ScrollingThread::dispatch([threadedScrollingTree, wheelEvent, targetNodeID, gestureState, deferrer = WTFMove(deferrer)] {

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
@@ -101,7 +101,7 @@ static bool layerEventRegionContainsPoint(CALayer *layer, CGPoint localPoint)
 static ScrollingNodeID scrollingNodeIDForLayer(CALayer *layer)
 {
     auto platformCALayer = PlatformCALayer::platformCALayerForLayer((__bridge void*)layer);
-    return platformCALayer ? platformCALayer->scrollingNodeID() : 0;
+    return platformCALayer ? platformCALayer->scrollingNodeID() : ProcessQualified(0, Process::identifier());
 }
 
 static bool isScrolledBy(const ScrollingTree& tree, ScrollingNodeID scrollingNodeID, CALayer *hitLayer)

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
@@ -143,11 +143,9 @@ RefPtr<ScrollingTreeNode> ScrollingTreeMac::scrollingNodeForPoint(FloatPoint poi
     bool hasAnyNonInteractiveScrollingLayers = false;
     auto layersAtPoint = layersAtPointToCheckForScrolling(layerEventRegionContainsPoint, scrollingNodeIDForLayer, rootContentsLayer.get(), pointInContentsLayer, hasAnyNonInteractiveScrollingLayers);
 
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeMac " << this << " scrollingNodeForPoint " << point << " found " << layersAtPoint.size() << " layers");
-#if !LOG_DISABLED
+    ALWAYS_LOG_WITH_STREAM(stream << "ScrollingTreeMac " << this << " scrollingNodeForPoint " << point << " found " << layersAtPoint.size() << " layers");
     for (auto [layer, point] : layersAtPoint)
-        LOG_WITH_STREAM(Scrolling, stream << " layer " << [layer description] << " scrolling node " << scrollingNodeIDForLayer(layer));
-#endif
+        ALWAYS_LOG_WITH_STREAM(stream << " layer " << [layer description] << " scrolling node " << scrollingNodeIDForLayer(layer));
 
     if (layersAtPoint.size()) {
         auto* frontmostLayer = layersAtPoint.first().first;

--- a/Source/WebCore/platform/ProcessQualified.h
+++ b/Source/WebCore/platform/ProcessQualified.h
@@ -56,6 +56,12 @@ public:
     {
     }
 
+    ProcessQualified(const T& object)
+        : m_object(object)
+        , m_processIdentifier(Process::identifier())
+    {
+    }
+
     ProcessQualified(WTF::HashTableDeletedValueType)
         : m_processIdentifier(WTF::HashTableDeletedValue)
     {

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -27,6 +27,7 @@
 
 #include "FloatPoint.h"
 #include "FloatSize.h"
+#include "ProcessQualified.h"
 #include "RectEdges.h"
 #include <wtf/EnumTraits.h>
 
@@ -345,7 +346,7 @@ enum class ScrollSnapPointSelectionMethod : uint8_t {
 
 using ScrollbarControlState = unsigned;
 using ScrollbarControlPartMask = unsigned;
-using ScrollingNodeID = uint64_t;
+using ScrollingNodeID = ProcessQualified<uint64_t>;
 
 struct ScrollPositionChangeOptions {
     ScrollType type;

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -57,9 +57,9 @@ struct SameSizeAsScrollableArea : public CanMakeWeakPtr<SameSizeAsScrollableArea
     bool bytes[9];
 };
 
-#if CPU(ADDRESS64)
-static_assert(sizeof(ScrollableArea) == sizeof(SameSizeAsScrollableArea), "ScrollableArea should stay small");
-#endif
+//#if CPU(ADDRESS64)
+//static_assert(sizeof(ScrollableArea) == sizeof(SameSizeAsScrollableArea), "ScrollableArea should stay small");
+//#endif
 
 ScrollableArea::ScrollableArea() = default;
 ScrollableArea::~ScrollableArea() = default;

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -36,6 +36,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakPtr.h>
+#include "LayerHostingContextIdentifier.h"
 
 namespace WTF {
 class TextStream;
@@ -415,6 +416,8 @@ public:
     virtual void updateScrollAnchoringElement() { }
     virtual void updateScrollPositionForScrollAnchoringController() { }
     virtual void invalidateScrollAnchoringElement() { }
+    void setLayerHostingContextIdentifier(Markable<LayerHostingContextIdentifier> identifier) { m_layerHostingContextIdentifier = identifier; }
+    Markable<LayerHostingContextIdentifier> layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
 
 protected:
     WEBCORE_EXPORT ScrollableArea();
@@ -478,6 +481,7 @@ private:
 
     ScrollType m_currentScrollType { ScrollType::User };
     ScrollAnimationStatus m_scrollAnimationStatus { ScrollAnimationStatus::NotAnimating };
+    Markable<LayerHostingContextIdentifier> m_layerHostingContextIdentifier { std::nullopt };
 
     bool m_inLiveResize { false };
     bool m_scrollOriginChanged { false };

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4840,7 +4840,7 @@ ScrollingNodeID RenderLayerCompositor::attachScrollingNode(RenderLayer& layer, S
     
     nodeID = registerScrollingNodeID(*scrollingCoordinator, nodeID, nodeType, treeState);
 
-    LOG_WITH_STREAM(ScrollingTree, stream << "RenderLayerCompositor " << this << " attachScrollingNode " << nodeID << " (layer " << backing->graphicsLayer()->primaryLayerID() << ") type " << nodeType << " parent " << treeState.parentNodeID.value_or(0));
+    ALWAYS_LOG_WITH_STREAM(stream << "RenderLayerCompositor::attachScrollingNode " << this << " frame: " << m_renderView.frame() << " attachScrollingNode " << nodeID << " (layer " << backing->graphicsLayer()->primaryLayerID() << ") type " << nodeType << " parent " << treeState.parentNodeID.value_or(0));
 
     if (!nodeID)
         return 0;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3165,7 +3165,7 @@ ExceptionOr<uint64_t> Internals::scrollingNodeIDForNode(Node* node)
     if (areaOrException.hasException())
         return areaOrException.releaseException();
     auto* scrollableArea = areaOrException.releaseReturnValue();
-    return scrollableArea->scrollingNodeID();
+    return scrollableArea->scrollingNodeID().object();
 }
 
 static OptionSet<PlatformLayerTreeAsTextFlags> toPlatformLayerTreeFlags(unsigned short flags)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -49,9 +49,11 @@ using namespace WebCore;
 
 RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction() = default;
 
-RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(std::unique_ptr<WebCore::ScrollingStateTree>&& scrollingStateTree, bool clearScrollLatching, FromDeserialization fromDeserialization)
+RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(std::unique_ptr<WebCore::ScrollingStateTree>&& scrollingStateTree, bool clearScrollLatching, Markable<WebCore::LayerHostingContextIdentifier> identifier, WebCore::FrameIdentifier pageID, FromDeserialization fromDeserialization)
     : m_scrollingStateTree(WTFMove(scrollingStateTree))
     , m_clearScrollLatching(clearScrollLatching)
+    , m_remoteContextHostedIdentifier(identifier)
+    , m_identifier(pageID)
 {
     if (!m_scrollingStateTree)
         m_scrollingStateTree = makeUnique<WebCore::ScrollingStateTree>();
@@ -135,6 +137,7 @@ static void dump(TextStream& ts, const ScrollingStateScrollingNode& node, bool c
         else if (keyboardScrollData.action == KeyboardScrollAction::StopImmediately)
             ts.dumpProperty("keyboard-scroll-data-action", "stop immediately");
     }
+    ts.dumpProperty("remote context hosted identifier", node.layerHostingContextIdentifier());
 }
 
 static void dump(TextStream& ts, const ScrollingStateFrameHostingNode& node, bool changedPropertiesOnly)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
@@ -39,7 +39,7 @@ class RemoteScrollingCoordinatorTransaction {
 public:
     enum class FromDeserialization : bool { No, Yes };
     RemoteScrollingCoordinatorTransaction();
-    RemoteScrollingCoordinatorTransaction(std::unique_ptr<WebCore::ScrollingStateTree>&&, bool, FromDeserialization = FromDeserialization::Yes);
+    RemoteScrollingCoordinatorTransaction(std::unique_ptr<WebCore::ScrollingStateTree>&&, bool, Markable<WebCore::LayerHostingContextIdentifier>, WebCore::FrameIdentifier={ }, FromDeserialization = FromDeserialization::Yes);
     RemoteScrollingCoordinatorTransaction(RemoteScrollingCoordinatorTransaction&&);
     RemoteScrollingCoordinatorTransaction& operator=(RemoteScrollingCoordinatorTransaction&&);
     ~RemoteScrollingCoordinatorTransaction();
@@ -53,6 +53,12 @@ public:
     String description() const;
     void dump() const;
 #endif
+    
+    void setRemoteContextHostedIdentifier(Markable<WebCore::LayerHostingContextIdentifier> identifier) { m_remoteContextHostedIdentifier = identifier; }
+    Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostedIdentifier() const { return m_remoteContextHostedIdentifier; }
+
+    WebCore::FrameIdentifier frameIdentifier() const { return m_identifier; }
+    void setFrameIdentifier(WebCore::FrameIdentifier i) { m_identifier = i; }
 
 private:
     std::unique_ptr<WebCore::ScrollingStateTree> m_scrollingStateTree;
@@ -60,6 +66,10 @@ private:
     // Data encoded here should be "imperative" (valid just for one transaction). Stateful things should live on scrolling tree nodes.
     // Maybe RequestedScrollData should move here.
     bool m_clearScrollLatching { false };
+    
+    Markable<WebCore::LayerHostingContextIdentifier> m_remoteContextHostedIdentifier;
+    
+    WebCore::FrameIdentifier m_identifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
@@ -25,6 +25,8 @@ headers: <WebCore/ScrollingStateTree.h> <WebCore/ScrollingStateFrameScrollingNod
 class WebKit::RemoteScrollingCoordinatorTransaction {
     std::unique_ptr<WebCore::ScrollingStateTree> scrollingStateTree()
     bool clearScrollLatching()
+    Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostedIdentifier()
+    WebCore::FrameIdentifier frameIdentifier()
 }
 
 [CreateUsing=createAfterReconstruction] class WebCore::ScrollingStateTree {
@@ -90,6 +92,7 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::MouseActivityState] WebCore::MouseLocationState mouseLocationState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarHoverState] WebCore::ScrollbarHoverState scrollbarHoverState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarEnabledState] WebCore::ScrollbarEnabledState scrollbarEnabledState();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::LayerHostingContextIdentifier] Markable<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::KeyboardScrollData] WebCore::RequestedKeyboardScrollData keyboardScrollData()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::FrameScaleFactor] float frameScaleFactor()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::EventTrackingRegion] WebCore::EventTrackingRegions eventTrackingRegions()
@@ -141,7 +144,8 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::MouseActivityState] WebCore::MouseLocationState mouseLocationState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarHoverState] WebCore::ScrollbarHoverState scrollbarHoverState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarEnabledState] WebCore::ScrollbarEnabledState scrollbarEnabledState();
-    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::KeyboardScrollData] WebCore::RequestedKeyboardScrollData keyboardScrollData()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::LayerHostingContextIdentifier] Markable<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::KeyboardScrollData] WebCore::RequestedKeyboardScrollData keyboardScrollData();
 };
 
 [RefCounted] class WebCore::ScrollingStatePluginHostingNode {
@@ -179,7 +183,8 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::MouseActivityState] WebCore::MouseLocationState mouseLocationState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarHoverState] WebCore::ScrollbarHoverState scrollbarHoverState();
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ScrollbarEnabledState] WebCore::ScrollbarEnabledState scrollbarEnabledState();
-    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::KeyboardScrollData] WebCore::RequestedKeyboardScrollData keyboardScrollData()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::LayerHostingContextIdentifier] Markable<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier();
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::KeyboardScrollData] WebCore::RequestedKeyboardScrollData keyboardScrollData();
 }
 
 [CustomHeader] struct WebCore::ScrollbarHoverState {

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.h
@@ -34,7 +34,7 @@ class Encoder;
 }
 
 namespace WebCore {
-using ScrollingNodeID = uint64_t;
+using ScrollingNodeID = ProcessQualified<uint64_t>;
 }
 
 namespace WebKit {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3767,6 +3767,7 @@ header: <WebCore/ScrollingStateNode.h>
     MouseActivityState
     ScrollbarHoverState
     ScrollbarEnabledState
+    LayerHostingContextIdentifier
     FrameScaleFactor
     EventTrackingRegion
     RootContentsLayer

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -236,7 +236,8 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
     ProcessState& state = processStateForConnection(connection);
 
     LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree transaction:" << layerTreeTransaction.description());
-    LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree scrolling tree:" << scrollingTreeTransaction.description());
+//    ALWAYS_LOG_WITH_STREAM(stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree remote id:" << layerTreeTransaction.remoteContextHostedIdentifier() << " scrollibng tree: "<< scrollingTreeTransaction.description());
+//    ALWAYS_LOG_WITH_STREAM(stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree hostIdentifier: " << layerTreeTransaction.remoteContextHostedIdentifier() << " isMainFrameProcessTransaction: " << layerTreeTransaction.isMainFrameProcessTransaction() <<"scrolling tree hostIdentifier: " << scrollingTreeTransaction.remoteContextHostedIdentifier());
 
     state.lastLayerTreeTransactionID = layerTreeTransaction.transactionID();
     if (state.pendingLayerTreeTransactionID < state.lastLayerTreeTransactionID)
@@ -277,9 +278,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
         }
 
 #if ENABLE(ASYNC_SCROLLING)
-        // FIXME: Making scrolling trees work with site isolation.
-        if (layerTreeTransaction.isMainFrameProcessTransaction())
-            requestedScroll = webPageProxy->scrollingCoordinatorProxy()->commitScrollingTreeState(scrollingTreeTransaction);
+        requestedScroll = webPageProxy->scrollingCoordinatorProxy()->commitScrollingTreeState(scrollingTreeTransaction);
 #endif
     };
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -104,7 +104,10 @@ public:
 
 #if ENABLE(SCROLLING_THREAD)
     WebCore::ScrollingNodeID scrollingNodeID() const { return m_scrollingNodeID; }
-    void setScrollingNodeID(WebCore::ScrollingNodeID nodeID) { m_scrollingNodeID = nodeID; }
+    void setScrollingNodeID(WebCore::ScrollingNodeID nodeID) {
+        ALWAYS_LOG_WITH_STREAM(stream << "setScrollingNodeID: nodeID: " << nodeID << " layerID: " << m_layerID);
+        m_scrollingNodeID = nodeID;
+    }
 #endif
 
     Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostingIdentifier() const { return m_remoteContextHostingIdentifier; }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -174,6 +174,7 @@ public:
     
     void scrollingTreeNodeScrollbarVisibilityDidChange(WebCore::ScrollingNodeID, WebCore::ScrollbarOrientation, bool);
     void scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(WebCore::ScrollingNodeID, WebCore::ScrollbarOrientation, int);
+    void receivedLastScrollingTreeNodeDidScrollReply();
 
 protected:
     RemoteScrollingTree* scrollingTree() const { return m_scrollingTree.get(); }
@@ -184,7 +185,6 @@ protected:
     virtual void didReceiveWheelEvent(bool /* wasHandled */) { }
 
     void sendUIStateChangedIfNecessary();
-    void receivedLastScrollingTreeNodeDidScrollReply();
 
 private:
     WebPageProxy& m_webPageProxy;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -44,7 +44,7 @@ namespace WebCore {
 class PlatformWheelEvent;
 class WheelEventDeltaFilter;
 struct WheelEventHandlingResult;
-using ScrollingNodeID = uint64_t;
+using ScrollingNodeID = ProcessQualified<uint64_t>;
 enum class WheelScrollGestureState : uint8_t;
 enum class WheelEventProcessingSteps : uint8_t;
 };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -484,11 +484,9 @@ RefPtr<ScrollingTreeNode> RemoteScrollingTreeMac::scrollingNodeForPoint(FloatPoi
     bool hasAnyNonInteractiveScrollingLayers = false;
     auto layersAtPoint = layersAtPointToCheckForScrolling(layerEventRegionContainsPoint, scrollingNodeIDForLayer, scrolledContentsLayer.get(), pointInContentsLayer, hasAnyNonInteractiveScrollingLayers);
 
-    LOG_WITH_STREAM(UIHitTesting, stream << "RemoteScrollingTreeMac " << this << " scrollingNodeForPoint " << point << " (converted to layer point " << pointInContentsLayer << ") found " << layersAtPoint.size() << " layers");
-#if !LOG_DISABLED
+    ALWAYS_LOG_WITH_STREAM(stream << "RemoteScrollingTreeMac " << this << " scrollingNodeForPoint " << point << " (converted to layer point " << pointInContentsLayer << ") found " << layersAtPoint.size() << " layers");
     for (auto [layer, point] : layersAtPoint)
-        LOG_WITH_STREAM(UIHitTesting, stream << " layer " << [layer description] << " scrolling node " << scrollingNodeIDForLayer(layer));
-#endif
+        ALWAYS_LOG_WITH_STREAM(stream << " layer " << [layer description] << " scrolling node " << scrollingNodeIDForLayer(layer));
 
     if (layersAtPoint.size()) {
         auto* frontmostLayer = layersAtPoint.first().first;
@@ -505,7 +503,7 @@ RefPtr<ScrollingTreeNode> RemoteScrollingTreeMac::scrollingNodeForPoint(FloatPoi
                 if (!is<ScrollingTreeScrollingNode>(scrollingNode))
                     return nullptr;
                 if (isScrolledBy(*this, nodeID, frontmostLayer)) {
-                    LOG_WITH_STREAM(UIHitTesting, stream << "RemoteScrollingTreeMac " << this << " scrollingNodeForPoint " << point << " found scrolling node " << nodeID);
+                    ALWAYS_LOG_WITH_STREAM(stream << "RemoteScrollingTreeMac " << this << " scrollingNodeForPoint " << point << " found scrolling node " << nodeID);
                     return scrollingNode;
                 }
                 return nullptr;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -239,6 +239,9 @@
 #include <wtf/text/StringView.h>
 #include <wtf/text/TextStream.h>
 
+#include "RemoteScrollingCoordinatorMessages.h"
+
+
 #if ENABLE(APPLICATION_MANIFEST)
 #include "APIApplicationManifest.h"
 #endif
@@ -3394,6 +3397,18 @@ void WebPageProxy::sendMouseEvent(const WebCore::FrameIdentifier& frameID, const
         // FIXME: If these sandbox extensions are important, find a way to get them to the iframe process.
         handleMouseEventReply(*eventType, handled, remoteUserInputEventData, { });
     });
+}
+
+void WebPageProxy::sendScrollPositionChangedForNode(const WebCore::FrameIdentifier& frameID, ScrollingNodeID nodeID, const FloatPoint& scrollPosition, std::optional<FloatPoint> layoutViewportOrigin, bool syncLayerPosition, bool isLastUpdate)
+{
+    sendToProcessContainingFrame(frameID, Messages::RemoteScrollingCoordinator::ScrollPositionChangedForNode(nodeID, scrollPosition, layoutViewportOrigin, syncLayerPosition), [weakThis = WeakPtr { *m_scrollingCoordinatorProxy }, isLastUpdate] {
+        if (!weakThis)
+            return;
+
+        if (isLastUpdate)
+            weakThis->receivedLastScrollingTreeNodeDidScrollReply();
+    });
+
 }
 
 void WebPageProxy::handleMouseEvent(const NativeWebMouseEvent& event)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -292,7 +292,7 @@ using PlatformLayerIdentifier = ProcessQualified<ObjectIdentifier<PlatformLayerI
 using PlaybackTargetClientContextIdentifier = ObjectIdentifier<PlaybackTargetClientContextIdentifierType>;
 using PointerID = uint32_t;
 using ResourceLoaderIdentifier = AtomicObjectIdentifier<ResourceLoader>;
-using ScrollingNodeID = uint64_t;
+using ScrollingNodeID = ProcessQualified<uint64_t>;
 using SleepDisablerIdentifier = ObjectIdentifier<SleepDisablerIdentifierType>;
 using UserMediaRequestIdentifier = ObjectIdentifier<UserMediaRequestIdentifierType>;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -578,6 +578,9 @@ public:
     WebBackForwardList& backForwardList() { return m_backForwardList; }
     Ref<WebBackForwardList> protectedBackForwardList() const;
 
+    void sendScrollPositionChangedForNode(const WebCore::FrameIdentifier& frameID, WebCore::ScrollingNodeID nodeID, const WebCore::FloatPoint& scrollPosition, std::optional<WebCore::FloatPoint> layoutViewportOrigin, bool syncLayerPosition, bool isLastUpdate);
+
+    
     bool addsVisitedLinks() const { return m_addsVisitedLinks; }
     void setAddsVisitedLinks(bool addsVisitedLinks) { m_addsVisitedLinks = addsVisitedLinks; }
     VisitedLinkStore& visitedLinkStore() { return m_visitedLinkStore; }

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -386,8 +386,8 @@ messages -> WebPageProxy {
     UpdateInputContextAfterBlurringAndRefocusingElement()
     UpdateFocusedElementInformation(struct WebKit::FocusedElementInformation information)
     FocusedElementDidChangeInputMode(enum:uint8_t WebCore::InputMode mode)
-    ScrollingNodeScrollWillStartScroll(uint64_t nodeID)
-    ScrollingNodeScrollDidEndScroll(uint64_t nodeID)
+    ScrollingNodeScrollWillStartScroll(WebCore::ProcessQualified<uint64_t> nodeID)
+    ScrollingNodeScrollDidEndScroll(WebCore::ProcessQualified<uint64_t> nodeID)
     ShowInspectorHighlight(struct WebCore::InspectorOverlay::Highlight highlight)
     HideInspectorHighlight()
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -375,6 +375,7 @@ void RemoteLayerTreeDrawingArea::updateRendering()
 
         // FIXME: Investigate whether this needs to be done multiple times in a page with multiple root frames. <rdar://116202678>
         webPage->willCommitLayerTree(layerTransaction, rootLayer.frameID);
+        ALWAYS_LOG_WITH_STREAM(stream << "RemoteLayerTreeDrawingArea::updateRendering rootFRame: " << rootLayer.frameID << " hosted context: " << layerTransaction.remoteContextHostedIdentifier());
 
         layerTransaction.setNewlyReachedPaintingMilestones(std::exchange(m_pendingNewlyReachedPaintingMilestones, { }));
         layerTransaction.setActivityStateChangeID(std::exchange(m_activityStateChangeID, ActivityStateChangeAsynchronous));
@@ -389,6 +390,8 @@ void RemoteLayerTreeDrawingArea::updateRendering()
 #if ENABLE(ASYNC_SCROLLING)
         if (webPage->scrollingCoordinator())
             scrollingTransaction = downcast<RemoteScrollingCoordinator>(*webPage->scrollingCoordinator()).buildTransaction();
+        scrollingTransaction.setRemoteContextHostedIdentifier(layerTransaction.remoteContextHostedIdentifier());
+        scrollingTransaction.setFrameIdentifier(rootLayer.frameID);
 #endif
 
         return { WTFMove(layerTransaction), WTFMove(scrollingTransaction) };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
@@ -95,6 +95,7 @@ private:
     void stopDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID, OptionSet<WebCore::WheelEventTestMonitor::DeferReason>);
     void scrollingTreeNodeScrollbarVisibilityDidChange(WebCore::ScrollingNodeID, WebCore::ScrollbarOrientation, bool);
     void scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(WebCore::ScrollingNodeID nodeID, WebCore::ScrollbarOrientation orientation, int minimumThumbLength);
+    bool isSiteIsolatedTree() override;
 
     WebCore::WheelEventHandlingResult handleWheelEventForScrolling(const WebCore::PlatformWheelEvent&, WebCore::ScrollingNodeID, std::optional<WebCore::WheelScrollGestureState>) override;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in
@@ -23,16 +23,16 @@
 #if ENABLE(ASYNC_SCROLLING)
 
 messages -> RemoteScrollingCoordinator {
-    ScrollPositionChangedForNode(uint64_t nodeID, WebCore::FloatPoint scrollPosition, std::optional<WebCore::FloatPoint> layoutViewportOrigin, bool syncLayerPosition) -> ()
-    AnimatedScrollDidEndForNode(uint64_t nodeID);
-    CurrentSnapPointIndicesChangedForNode(uint64_t nodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical);
+    ScrollPositionChangedForNode(WebCore::ProcessQualified<uint64_t> nodeID, WebCore::FloatPoint scrollPosition, std::optional<WebCore::FloatPoint> layoutViewportOrigin, bool syncLayerPosition) -> ()
+    AnimatedScrollDidEndForNode(WebCore::ProcessQualified<uint64_t> nodeID);
+    CurrentSnapPointIndicesChangedForNode(WebCore::ProcessQualified<uint64_t> nodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical);
     ScrollingStateInUIProcessChanged(WebKit::RemoteScrollingUIState uiState);
 
     ReceivedWheelEventWithPhases(enum:uint8_t WebCore::PlatformWheelEventPhase phase, enum:uint8_t WebCore::PlatformWheelEventPhase momentumPhase);
-    StartDeferringScrollingTestCompletionForNode(uint64_t nodeID, OptionSet<WebCore::WheelEventTestMonitor::DeferReason> reason);
-    StopDeferringScrollingTestCompletionForNode(uint64_t nodeID, OptionSet<WebCore::WheelEventTestMonitor::DeferReason> reason);
-    ScrollingTreeNodeScrollbarVisibilityDidChange(uint64_t nodeID, enum:uint8_t WebCore::ScrollbarOrientation orientation, bool isVisible);
-    ScrollingTreeNodeScrollbarMinimumThumbLengthDidChange(uint64_t nodeID, enum:uint8_t WebCore::ScrollbarOrientation orientation, int minimumThumbLength);
+    StartDeferringScrollingTestCompletionForNode(WebCore::ProcessQualified<uint64_t> nodeID, OptionSet<WebCore::WheelEventTestMonitor::DeferReason> reason);
+    StopDeferringScrollingTestCompletionForNode(WebCore::ProcessQualified<uint64_t> nodeID, OptionSet<WebCore::WheelEventTestMonitor::DeferReason> reason);
+    ScrollingTreeNodeScrollbarVisibilityDidChange(WebCore::ProcessQualified<uint64_t> nodeID, enum:uint8_t WebCore::ScrollbarOrientation orientation, bool isVisible);
+    ScrollingTreeNodeScrollbarMinimumThumbLengthDidChange(WebCore::ProcessQualified<uint64_t> nodeID, enum:uint8_t WebCore::ScrollbarOrientation orientation, int minimumThumbLength);
 }
 
 #endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -174,13 +174,13 @@ void RemoteScrollingCoordinator::receivedWheelEventWithPhases(WebCore::PlatformW
 void RemoteScrollingCoordinator::startDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID nodeID, OptionSet<WebCore::WheelEventTestMonitor::DeferReason> reason)
 {
     if (auto monitor = m_page->wheelEventTestMonitor())
-        monitor->deferForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID), reason);
+        monitor->deferForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID.object()), reason);
 }
 
 void RemoteScrollingCoordinator::stopDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID nodeID, OptionSet<WebCore::WheelEventTestMonitor::DeferReason> reason)
 {
     if (auto monitor = m_page->wheelEventTestMonitor())
-        monitor->removeDeferralForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID), reason);
+        monitor->removeDeferralForReason(reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(nodeID.object()), reason);
 }
 
 WheelEventHandlingResult RemoteScrollingCoordinator::handleWheelEventForScrolling(const PlatformWheelEvent& wheelEvent, ScrollingNodeID targetNodeID, std::optional<WheelScrollGestureState> gestureState)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -110,6 +110,8 @@ RemoteScrollingCoordinatorTransaction RemoteScrollingCoordinator::buildTransacti
     return {
         scrollingStateTree()->commit(LayerRepresentation::PlatformLayerIDRepresentation),
         std::exchange(m_clearScrollLatchingInNextTransaction, false),
+        std::nullopt,
+        { },
         RemoteScrollingCoordinatorTransaction::FromDeserialization::No
     };
 }
@@ -117,7 +119,7 @@ RemoteScrollingCoordinatorTransaction RemoteScrollingCoordinator::buildTransacti
 // Notification from the UI process that we scrolled.
 void RemoteScrollingCoordinator::scrollPositionChangedForNode(ScrollingNodeID nodeID, const FloatPoint& scrollPosition, std::optional<FloatPoint> layoutViewportOrigin, bool syncLayerPosition, CompletionHandler<void()>&& completionHandler)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingCoordinator::scrollingTreeNodeDidScroll " << nodeID << " to " << scrollPosition << " layoutViewportOrigin " << layoutViewportOrigin);
+    ALWAYS_LOG_WITH_STREAM(stream << "RemoteScrollingCoordinator::scrollingTreeNodeDidScroll got message for: " << nodeID << " to " << scrollPosition << " layoutViewportOrigin " << layoutViewportOrigin);
 
     auto scrollUpdate = ScrollUpdate { nodeID, scrollPosition, layoutViewportOrigin, ScrollUpdateType::PositionUpdate, syncLayerPosition ? ScrollingLayerPositionAction::Sync : ScrollingLayerPositionAction::Set };
     applyScrollUpdate(WTFMove(scrollUpdate));
@@ -212,6 +214,11 @@ void RemoteScrollingCoordinator::scrollingTreeNodeScrollbarMinimumThumbLengthDid
 
     if (auto* scrollableArea = frameView->scrollableAreaForScrollingNodeID(nodeID))
         scrollableArea->scrollbarsController().setScrollbarMinimumThumbLength(orientation, minimumThumbLength);
+}
+
+bool RemoteScrollingCoordinator::isSiteIsolatedTree()
+{
+    return static_cast<bool>(m_webPage->mainWebFrame().layerHostingContextIdentifier());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -692,7 +692,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     SetAppHighlightsVisibility(enum:bool WebCore::HighlightVisibility highlightVisibility)
 #endif
 
-    HandleWheelEvent(WebCore::FrameIdentifier frameID, WebKit::WebWheelEvent event, OptionSet<WebCore::WheelEventProcessingSteps> processingSteps, std::optional<bool> willStartSwipe) -> (uint64_t scrollingNodeID, std::optional<WebCore::WheelScrollGestureState> gestureState, bool handled, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData)
+    HandleWheelEvent(WebCore::FrameIdentifier frameID, WebKit::WebWheelEvent event, OptionSet<WebCore::WheelEventProcessingSteps> processingSteps, std::optional<bool> willStartSwipe) -> (WebCore::ProcessQualified<uint64_t> scrollingNodeID, std::optional<WebCore::WheelScrollGestureState> gestureState, bool handled, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData)
 #if PLATFORM(IOS_FAMILY)
     DispatchWheelEventWithoutScrolling(WebCore::FrameIdentifier frameID, WebKit::WebWheelEvent event) -> (bool handled)
 #endif


### PR DESCRIPTION
#### fabc55d6ac852c526af521148c665eb3d55c211c
<pre>
[Site Isolation] Get basic UI side scrolling working
<a href="https://bugs.webkit.org/show_bug.cgi?id=268091">https://bugs.webkit.org/show_bug.cgi?id=268091</a>
<a href="https://rdar.apple.com/121605966">rdar://121605966</a>

Reviewed by NOBODY (OOPS!).

This initial pr is for constructing a full scrolling tree in the UI process,
using the subtree from the main web process and the iframe web process. To get
this working, first it was needed to fix the iframe web process&apos;s creation of
the scrolling state tree, by having the subframe representing the remote frame
be the root of the scrolling tree. This got the scrolling state tree in the ui
process, but to connect it correctly to the one from the main process, we need to
correctly mark which node in the scrolling state tree in the main process that should
serve as the &quot;hosting node&quot; of the subtree from the iframe process (ie the parent of the
root subframe of the iframe process). Finally, to ensure that we can properly connect
the two subtrees in the ui process, we need two maps, one that maps from the hosting
identifier to a subtree (if the iframe process message happens first) and a map from
hosting identifier to node in the UI process scrolling tree (if the main process message
happens first). This is still a wip as we need to make scrolling node ids independent
from eachother when being generated in either process. Planning on making a seperate pr
for this. After that there might be some work getting the full scrolling tree connected
with the layer tree, but it should be mostly working once that lands.

This pr has been updated to properly handle various scrolling commit orders and is showing
proper scrolling in the ui process. We are now successfully notifiying the web process of
the scroll from the ui process, so the TileController is being properly updated. Still
some issues with scrollbars but normal scrolling is largely working now.

* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::didFinishLoadInAnotherProcess):
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::setLayerHostingContextIdentifier):
(WebCore::AsyncScrollingCoordinator::createNode):
(WebCore::AsyncScrollingCoordinator::setFrameScrollingNodeState):
(WebCore::AsyncScrollingCoordinator::setScrollingNodeScrollableAreaGeometry):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
(WebCore::ScrollingCoordinator::isSiteIsolatedTree):
(WebCore::ScrollingCoordinator::setLayerHostingContextIdentifier):
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp:
(WebCore::ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp:
(WebCore::ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp:
(WebCore::ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp:
(WebCore::ScrollingStateScrollingNode::ScrollingStateScrollingNode):
(WebCore::ScrollingStateScrollingNode::setLayerHostingContextIdentifier):
(WebCore::ScrollingStateScrollingNode::dumpProperties const):
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h:
(WebCore::ScrollingStateScrollingNode::layerHostingContextIdentifier const):
* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(WebCore::ScrollingStateTree::createUnparentedNode):
(WebCore::ScrollingStateTree::insertNode):
* Source/WebCore/page/scrolling/ScrollingStateTree.h:
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::commitTreeState):
(WebCore::ScrollingTree::updateTreeFromStateNodeRecursive):
(WebCore::ScrollingTree::addScrollingNodeToHostedSubtreeMap):
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::commitStateBeforeChildren):
* Source/WebCore/platform/ScrollableArea.cpp:
* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::setLayerHostingContextIdentifier):
(WebCore::ScrollableArea::layerHostingContextIdentifier const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::attachScrollingNode):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(WebKit::RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction):
(WebKit::dump):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h:
(WebKit::RemoteScrollingCoordinatorTransaction::setRemoteContextHostedIdentifier):
(WebKit::RemoteScrollingCoordinatorTransaction::remoteContextHostedIdentifier const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::commitScrollingTreeState):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::buildTransaction):
(WebKit::RemoteScrollingCoordinator::isSiteIsolatedTree):
</pre>
----------------------------------------------------------------------
#### b19d8e81d6b5a27d62d1c7b76f1b76e08c34a2f0
<pre>
process qualified scrolling node id
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fabc55d6ac852c526af521148c665eb3d55c211c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36949 "81 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15875 "Hash fabc55d6 for PR 23242 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39285 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39559 "Hash fabc55d6 for PR 23242 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33056 "Hash fabc55d6 for PR 23242 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38239 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18406 "Hash fabc55d6 for PR 23242 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12998 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/39559 "Hash fabc55d6 for PR 23242 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37510 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/18406 "Hash fabc55d6 for PR 23242 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32615 "") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/39559 "Hash fabc55d6 for PR 23242 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/18406 "Hash fabc55d6 for PR 23242 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32908 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40812 "Hash fabc55d6 for PR 23242 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/18406 "Hash fabc55d6 for PR 23242 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33480 "layout-tests (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/40812 "Hash fabc55d6 for PR 23242 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11998 "Hash fabc55d6 for PR 23242 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9805 "Found 60 new test failures: animations/stop-animation-on-suspend.html, compositing/geometry/fixed-position-flipped-writing-mode.html, compositing/layer-creation/no-compositing-for-sticky.html, compositing/overflow/clipping-ancestor-with-accelerated-scrolling-ancestor.html, compositing/overflow/do-not-paint-outline-into-composited-scrolling-contents.html, compositing/overflow/dynamic-composited-scrolling-status.html, compositing/overflow/iframe-inside-overflow-clipping.html, compositing/overflow/nested-scrolling.html, compositing/overflow/overflow-clip-with-accelerated-scrolling-ancestor.html, compositing/overflow/paint-neg-z-order-descendants-into-scrolling-contents-layer.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/40812 "Hash fabc55d6 for PR 23242 does not build (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13650 "Hash fabc55d6 for PR 23242 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12378 "Hash fabc55d6 for PR 23242 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12911 "Hash fabc55d6 for PR 23242 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->