### PR TITLE
[WGSL] Validate against array type without template arguments

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -1320,8 +1320,10 @@ void TypeChecker::visit(AST::AbstractFloatLiteral& literal)
 // Types
 void TypeChecker::visit(AST::ArrayTypeExpression& array)
 {
-    // FIXME: handle the case where there is no element type
-    ASSERT(array.maybeElementType());
+    if (!array.maybeElementType()) {
+        typeError(array.span(), "'array' requires at least 1 template argument");
+        return;
+    }
 
     auto* elementType = resolve(*array.maybeElementType());
     if (isBottom(elementType)) {

--- a/Source/WebGPU/WGSL/tests/invalid/array.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/array.wgsl
@@ -1,5 +1,8 @@
 // RUN: %not %wgslc | %check
 
+// CHECK-L: 'array' requires at least 1 template argument
+var<private> a:array;
+
 fn testArrayLengthMismatch() {
   // CHECK-L: array count must be greater than 0
   let x1 = array<i32, 0>();


### PR DESCRIPTION
#### b2f46f05872251e3abce99e1b47d1456952611c4
<pre>
[WGSL] Validate against array type without template arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=268092">https://bugs.webkit.org/show_bug.cgi?id=268092</a>
<a href="https://rdar.apple.com/117905213">rdar://117905213</a>

Reviewed by Mike Wyrzykowski.

We were failing an assertion instead of returning a type error.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/array.wgsl:

Canonical link: <a href="https://commits.webkit.org/273563@main">https://commits.webkit.org/273563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51698d06e41a65763381d95a336bdb13bc64f40b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38399 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32122 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/16992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11629 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30904 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10843 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10850 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39644 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32211 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36808 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34890 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12760 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8166 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11549 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11828 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->