### PR TITLE
[iOS] [Safari] Contact AutoFill fails to insert text after adopting BETextInput/BETextSuggestion

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -6057,7 +6057,7 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
     id <_WKInputDelegate> inputDelegate = [_webView _inputDelegate];
     if ([inputDelegate respondsToSelector:@selector(_webView:insertTextSuggestion:inInputSession:)]) {
 #if SERVICE_EXTENSIONS_TEXT_INPUT_IS_AVAILABLE
-        RetainPtr uiTextSuggestion = [UITextSuggestion textSuggestionWithInputText:textSuggestion.inputText];
+        RetainPtr uiTextSuggestion = [textSuggestion _uikitTextSuggestion];
 #else
         RetainPtr uiTextSuggestion = textSuggestion;
 #endif

--- a/Tools/TestWebKitAPI/Tests/ios/TestInputDelegate.h
+++ b/Tools/TestWebKitAPI/Tests/ios/TestInputDelegate.h
@@ -37,6 +37,7 @@
 @property (nonatomic, copy) void (^didStartInputSessionHandler)(WKWebView *, id <_WKFormInputSession>);
 @property (nonatomic, copy) NSDictionary<id, NSString *> * (^webViewAdditionalContextForStrongPasswordAssistanceHandler)(WKWebView *);
 @property (nonatomic, copy) BOOL (^focusRequiresStrongPasswordAssistanceHandler)(WKWebView *, id <_WKFocusedElementInfo>);
+@property (nonatomic, copy) void (^insertTextSuggestionHandler)(WKWebView *, UITextSuggestion *, id<_WKFormInputSession>);
 @end
 
 #endif

--- a/Tools/TestWebKitAPI/Tests/ios/TestInputDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/TestInputDelegate.mm
@@ -31,11 +31,22 @@
 #import <wtf/BlockPtr.h>
 
 @implementation TestInputDelegate {
-    BlockPtr<_WKFocusStartsInputSessionPolicy(WKWebView *, id <_WKFocusedElementInfo>)> _focusStartsInputSessionPolicyHandler;
-    BlockPtr<void(WKWebView *, id <_WKFormInputSession>)> _willStartInputSessionHandler;
-    BlockPtr<void(WKWebView *, id <_WKFormInputSession>)> _didStartInputSessionHandler;
+    BlockPtr<_WKFocusStartsInputSessionPolicy(WKWebView *, id<_WKFocusedElementInfo>)> _focusStartsInputSessionPolicyHandler;
+    BlockPtr<void(WKWebView *, id<_WKFormInputSession>)> _willStartInputSessionHandler;
+    BlockPtr<void(WKWebView *, id<_WKFormInputSession>)> _didStartInputSessionHandler;
     BlockPtr<NSDictionary<id, NSString *> *(WKWebView *)> _webViewAdditionalContextForStrongPasswordAssistanceHandler;
-    BlockPtr<BOOL(WKWebView *, id <_WKFocusedElementInfo>)> _focusRequiresStrongPasswordAssistanceHandler;
+    BlockPtr<BOOL(WKWebView *, id<_WKFocusedElementInfo>)> _focusRequiresStrongPasswordAssistanceHandler;
+    BlockPtr<void(WKWebView *, UITextSuggestion *, id<_WKFormInputSession>)> _insertTextSuggestionHandler;
+}
+
+- (void)setInsertTextSuggestionHandler:(void (^)(WKWebView *, UITextSuggestion *, id<_WKFormInputSession>))insertTextSuggestionHandler
+{
+    _insertTextSuggestionHandler = makeBlockPtr(insertTextSuggestionHandler);
+}
+
+- (void(^)(WKWebView *, UITextSuggestion *, id<_WKFormInputSession>))insertTextSuggestionHandler
+{
+    return _insertTextSuggestionHandler.get();
 }
 
 - (void)setFocusStartsInputSessionPolicyHandler:(_WKFocusStartsInputSessionPolicy (^)(WKWebView *, id <_WKFocusedElementInfo>))handler
@@ -117,6 +128,12 @@
     if (_focusRequiresStrongPasswordAssistanceHandler)
         return _focusRequiresStrongPasswordAssistanceHandler(webView, info);
     return NO;
+}
+
+- (void)_webView:(WKWebView *)webView insertTextSuggestion:(UITextSuggestion *)suggestion inInputSession:(id<_WKFormInputSession>)inputSession
+{
+    if (_insertTextSuggestionHandler)
+        _insertTextSuggestionHandler(webView, suggestion, inputSession);
 }
 
 @end


### PR DESCRIPTION
#### 8feab814181a193b22ed4b7a8825a5e6b6b7963d
<pre>
[iOS] [Safari] Contact AutoFill fails to insert text after adopting BETextInput/BETextSuggestion
<a href="https://bugs.webkit.org/show_bug.cgi?id=268099">https://bugs.webkit.org/show_bug.cgi?id=268099</a>
<a href="https://rdar.apple.com/121604196">rdar://121604196</a>

Reviewed by Tim Horton.

When receiving a `BETextSuggestion` in `-insertTextSuggestion:`, we currently integrate with our SPI
clients by asking for the `-inputText`, creating a `UITextSuggestion` from this text, and passing it
back to the client in `-_webView:insertTextSuggestion:inInputSession:`. However, this discards any
custom classes provided by the SPI client (in this case, Safari&apos;s `SFTextSuggestion`). Safari&apos;s
logic performs a class check on the text suggestion handed back to them in the input delegate SPI,
and drops the text suggestion on the floor in the case where the suggestion isn&apos;t a subclass of
`SFTextSuggestion`.

Simply fix this by unwrapping the `BETextSuggestion` to get the backing `UITextSuggestion` to
preserve bincompat with SPI clients.

Test: WKWebViewAutoFillTests.AutoFillPreservesTextSuggestion

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView insertTextSuggestion:]):
* Tools/TestWebKitAPI/Tests/ios/TestInputDelegate.mm:
(-[TestInputDelegate _webView:insertTextSuggestion:inInputSession:]):

Add an API test and test infrastructure to exercise this fix.

* Tools/TestWebKitAPI/Tests/ios/WKWebViewAutofillTests.mm:

Canonical link: <a href="https://commits.webkit.org/273535@main">https://commits.webkit.org/273535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51f418aa755a5a2aa4ced5fca017cde4296ca318

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38424 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11656 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12368 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/10866 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39669 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32431 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32233 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36822 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34905 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12784 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4629 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->