### PR TITLE
Fix the internal iOS build after 273506@main

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
@@ -32,6 +32,8 @@
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Threading.h>
 
+OBJC_CLASS PDFDocument;
+
 namespace WebCore {
 class NetscapePlugInStreamLoader;
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -114,10 +114,12 @@ void PDFPluginBase::teardown()
 {
     m_data = nil;
 
+#if HAVE(INCREMENTAL_PDF_APIS)
     if (m_incrementalLoader) {
         m_incrementalLoader->clear();
         m_incrementalLoader = nullptr;
     }
+#endif
 
     destroyScrollbar(ScrollbarOrientation::Horizontal);
     destroyScrollbar(ScrollbarOrientation::Vertical);
@@ -262,8 +264,10 @@ void PDFPluginBase::streamDidReceiveData(const SharedBuffer& buffer)
     pdfLog(makeString("PDFPluginBase::streamDidReceiveData() - received ", buffer.size(), " bytes, total streamed bytes ", m_streamedBytes));
 #endif
 
+#if HAVE(INCREMENTAL_PDF_APIS)
     if (m_incrementalLoader)
         m_incrementalLoader->incrementalPDFStreamDidReceiveData(buffer);
+#endif
 }
 
 void PDFPluginBase::streamDidFinishLoading()
@@ -276,11 +280,15 @@ void PDFPluginBase::streamDidFinishLoading()
     m_documentFinishedLoading = true;
 
     auto incrementalPDFStreamDidFinishLoading = [&]() {
+#if HAVE(INCREMENTAL_PDF_APIS)
         if (!m_incrementalLoader)
             return false;
 
         m_incrementalLoader->incrementalPDFStreamDidFinishLoading();
         return true;
+#else
+        return false;
+#endif
     };
 
     if (!incrementalPDFStreamDidFinishLoading()) {
@@ -294,8 +302,10 @@ void PDFPluginBase::streamDidFinishLoading()
 void PDFPluginBase::streamDidFail()
 {
     m_data = nullptr;
+#if HAVE(INCREMENTAL_PDF_APIS)
     if (m_incrementalLoader)
         m_incrementalLoader->incrementalPDFStreamDidFail();
+#endif
 }
 
 #if HAVE(INCREMENTAL_PDF_APIS)


### PR DESCRIPTION
#### 15911ba29d2c2d764c956852a9fccc68e382ccb8
<pre>
Fix the internal iOS build after 273506@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=268103">https://bugs.webkit.org/show_bug.cgi?id=268103</a>
<a href="https://rdar.apple.com/121621651">rdar://121621651</a>

Unreviewed build fix.

Fix some HAVE(INCREMENTAL_PDF_APIS) and forward declare PDFDocument.

* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::teardown):
(WebKit::PDFPluginBase::streamDidReceiveData):
(WebKit::PDFPluginBase::streamDidFinishLoading):
(WebKit::PDFPluginBase::streamDidFail):

Canonical link: <a href="https://commits.webkit.org/273534@main">https://commits.webkit.org/273534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c43b9fa2b773f729df341c1cd0a3485dc3f50e4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35693 "Failed to checkout and rebase branch from PR 23256") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37832 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/38427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11661 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/38427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/36246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/12371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/38427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/32434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/32232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/39673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/8955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4628 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/11857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->