### PR TITLE
Crash trying to load tabPageIdentifiers() and popupPageIdentifiers().

### DIFF
--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -94,7 +94,17 @@ void PageConfiguration::setUserContentController(RefPtr<WebUserContentController
 }
 
 #if ENABLE(WK_WEB_EXTENSIONS)
-WebExtensionController* PageConfiguration::webExtensionController()
+const WTF::URL& PageConfiguration::requiredWebExtensionBaseURL() const
+{
+    return m_data.requiredWebExtensionBaseURL;
+}
+
+void PageConfiguration::setRequiredWebExtensionBaseURL(WTF::URL&& baseURL)
+{
+    m_data.requiredWebExtensionBaseURL = WTFMove(baseURL);
+}
+
+WebExtensionController* PageConfiguration::webExtensionController() const
 {
     return m_data.webExtensionController.get();
 }
@@ -104,7 +114,7 @@ void PageConfiguration::setWebExtensionController(RefPtr<WebExtensionController>
     m_data.webExtensionController = WTFMove(webExtensionController);
 }
 
-WebExtensionController* PageConfiguration::weakWebExtensionController()
+WebExtensionController* PageConfiguration::weakWebExtensionController() const
 {
     return m_data.weakWebExtensionController.get();
 }

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -92,10 +92,13 @@ public:
     void setUserContentController(RefPtr<WebKit::WebUserContentControllerProxy>&&);
 
 #if ENABLE(WK_WEB_EXTENSIONS)
-    WebKit::WebExtensionController* webExtensionController();
+    const WTF::URL& requiredWebExtensionBaseURL() const;
+    void setRequiredWebExtensionBaseURL(WTF::URL&&);
+
+    WebKit::WebExtensionController* webExtensionController() const;
     void setWebExtensionController(RefPtr<WebKit::WebExtensionController>&&);
 
-    WebKit::WebExtensionController* weakWebExtensionController();
+    WebKit::WebExtensionController* weakWebExtensionController() const;
     void setWeakWebExtensionController(WebKit::WebExtensionController*);
 #endif
 
@@ -236,6 +239,7 @@ private:
         RefPtr<WebKit::WebProcessPool> processPool { };
         RefPtr<WebKit::WebUserContentControllerProxy> userContentController { };
 #if ENABLE(WK_WEB_EXTENSIONS)
+        WTF::URL requiredWebExtensionBaseURL { };
         RefPtr<WebKit::WebExtensionController> webExtensionController { };
         WeakPtr<WebKit::WebExtensionController> weakWebExtensionController { };
 #endif

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -111,6 +111,8 @@ public:
 #endif
 
 private:
+    WebExtensionAction* fallbackAction() const;
+
     WeakPtr<WebExtensionContext> m_extensionContext;
     RefPtr<WebExtensionTab> m_tab;
     RefPtr<WebExtensionWindow> m_window;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -79,14 +79,9 @@ WebExtensionControllerParameters WebExtensionController::parameters() const
     WebExtensionControllerParameters parameters;
 
     parameters.identifier = identifier();
-
-    Vector<WebExtensionContextParameters> contextParameters;
-    contextParameters.reserveInitialCapacity(extensionContexts().size());
-
-    for (auto& context : extensionContexts())
-        contextParameters.append(context->parameters());
-
-    parameters.contextParameters = contextParameters;
+    parameters.contextParameters = WTF::map(extensionContexts(), [](auto& context) {
+        return context->parameters();
+    });
 
     return parameters;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -151,13 +151,17 @@ TEST(WKWebExtensionAPIAction, PresentPopupForAction)
     manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
         EXPECT_TRUE(action.presentsPopup);
         EXPECT_TRUE(action.isEnabled);
-        EXPECT_NULL(action.badgeText);
+        EXPECT_NS_EQUAL(action.badgeText, @"");
 
         EXPECT_NS_EQUAL(action.label, @"Test Action");
 
         auto *smallIcon = [action iconForSize:CGSizeMake(16, 16)];
         EXPECT_NOT_NULL(smallIcon);
+#if USE(APPKIT)
         EXPECT_TRUE(CGSizeEqualToSize(smallIcon.size, CGSizeMake(16, 16)));
+#else
+        EXPECT_TRUE(CGSizeEqualToSize(smallIcon.size, CGSizeMake(32, 32)));
+#endif
 
         auto *largeIcon = [action iconForSize:CGSizeMake(32, 32)];
         EXPECT_NOT_NULL(largeIcon);
@@ -171,6 +175,8 @@ TEST(WKWebExtensionAPIAction, PresentPopupForAction)
         EXPECT_NS_EQUAL(webViewURL.path, @"/popup.html");
 
         [action closePopupWebView];
+
+        [manager done];
     };
 
     [manager loadAndRun];
@@ -178,6 +184,8 @@ TEST(WKWebExtensionAPIAction, PresentPopupForAction)
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Test Popup Action");
 
     [manager.get().context performActionForTab:manager.get().defaultTab];
+
+    [manager run];
 }
 
 TEST(WKWebExtensionAPIAction, GetCurrentTabAndWindowFromPopupPage)
@@ -210,8 +218,6 @@ TEST(WKWebExtensionAPIAction, GetCurrentTabAndWindowFromPopupPage)
     manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
         EXPECT_TRUE(action.presentsPopup);
         EXPECT_NOT_NULL(action.popupWebView);
-
-        [action closePopupWebView];
     };
 
     [manager loadAndRun];
@@ -219,6 +225,8 @@ TEST(WKWebExtensionAPIAction, GetCurrentTabAndWindowFromPopupPage)
     EXPECT_NS_EQUAL(manager.get().yieldMessage, @"Test Popup Action");
 
     [manager.get().context performActionForTab:manager.get().defaultTab];
+
+    [manager run];
 }
 
 TEST(WKWebExtensionAPIAction, SetDefaultActionProperties)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm
@@ -144,7 +144,7 @@ TEST(WKWebExtensionAPIExtension, GetBackgroundPageFromBackground)
 
         @"const backgroundPage = browser.extension.getBackgroundPage()",
 
-        @"browser.test.assertEq(backgroundPage, window, 'Should be able to get the background window from itself')",
+        @"browser.test.assertTrue(backgroundPage === window, 'Should be able to get the background window from itself')",
         @"browser.test.assertSafe(() => backgroundPage.notifyTestPass())"
     ]);
 
@@ -310,6 +310,10 @@ TEST(WKWebExtensionAPIExtension, GetViewsForTab)
 
 TEST(WKWebExtensionAPIExtension, GetViewsForMultipleTabs)
 {
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
     auto *backgroundScript = Util::constructScript(@[
         @"let tabCount = 0",
 
@@ -343,11 +347,18 @@ TEST(WKWebExtensionAPIExtension, GetViewsForMultipleTabs)
 
     auto *testHTML = @"<script type='module' src='test.js'></script>";
 
-    Util::loadAndRunExtension(extensionManifest, @{
+    auto *resources = @{
         @"background.js": backgroundScript,
         @"test.html": testHTML,
         @"test.js": testScript
-    });
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:extensionManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
+
+    [manager loadAndRun];
 }
 
 TEST(WKWebExtensionAPIExtension, GetViewsForPopup)


### PR DESCRIPTION
#### 2f4ea4c094b72386cd25be293b6b6fa2c67064b1
<pre>
Crash trying to load tabPageIdentifiers() and popupPageIdentifiers().
<a href="https://webkit.org/b/268105">https://webkit.org/b/268105</a>
<a href="https://rdar.apple.com/120867910">rdar://120867910</a>

Reviewed by Brian Weinstein.

Clean up how we track extension tab and action pages, so we don&apos;t need to loop over openTabs(),
which is not safe to do while a WKWebView is being created.

Also clean up WKWebViewConfiguration, by not storing the WebExtensionController as
data members, when they are already stored on API::PageConfiguration. Also added
requiredWebExtensionBaseURL() to API::PageConfiguration.

Also made a few more tab and window getters on WebExtensionContext be const, to allow
use inside other const functions, like parameters().

* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::requiredWebExtensionBaseURL const): Added.
(API::PageConfiguration::setRequiredWebExtensionBaseURL): Added.
(API::PageConfiguration::webExtensionController const): Made const.
(API::PageConfiguration::weakWebExtensionController const): Ditto.
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration copyWithZone:]):
(-[WKWebViewConfiguration _requiredWebExtensionBaseURL]): Use APIPageConfiguration.
(-[WKWebViewConfiguration _setRequiredWebExtensionBaseURL:]): Ditto.
(-[WKWebViewConfiguration _strongWebExtensionController]): Ditto.
(-[WKWebViewConfiguration _webExtensionController]): Ditto.
(-[WKWebViewConfiguration _setWebExtensionController:]): Ditto.
(-[WKWebViewConfiguration _weakWebExtensionController]): Ditto.
(-[WKWebViewConfiguration _setWeakWebExtensionController:]): Ditto.
(-[WKWebViewConfiguration _setShouldRelaxThirdPartyCookieBlocking:]): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::fallbackAction const): Added helper.
(WebKit::WebExtensionAction::icon): Use fallbackAction().
(WebKit::WebExtensionAction::popupPath const): Ditto.
(WebKit::WebExtensionAction::popupWebView): Use new addPopupPage() method.
(WebKit::WebExtensionAction::label const): Use fallbackAction().
(WebKit::WebExtensionAction::badgeText const): Ditto.
(WebKit::WebExtensionAction::isEnabled const): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::isURLForThisExtension const): Added isValid() to bail earlier.
(WebKit::WebExtensionContext::getOrCreateWindow const): Made const.
(WebKit::WebExtensionContext::getWindow const): Ditto.
(WebKit::WebExtensionContext::getOrCreateTab const): Ditto.
(WebKit::WebExtensionContext::getTab const): Ditto.
(WebKit::WebExtensionContext::getCurrentTab const): Ditto.
(WebKit::WebExtensionContext::focusedWindow const): Ditto.
(WebKit::WebExtensionContext::frontmostWindow const): Ditto.
(WebKit::WebExtensionContext::popupPageIdentifiers const): Use the new map to build the Vector.
(WebKit::WebExtensionContext::tabPageIdentifiers const): Use the new map to build the Vector.
(WebKit::WebExtensionContext::addExtensionTabPage): Added.
(WebKit::WebExtensionContext::relatedWebView): Simplified by using requiredWebExtensionBaseURL().
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm:
(WebKit::WebExtensionURLSchemeHandler::platformStartTask): Call addExtensionTabPage().
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::parameters const): Use WTF::map().
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIExtension.mm:
(TestWebKitAPI::TEST): Tweak test to conver another case. Correct test that was logging a JSON
error for object cycles.

Canonical link: <a href="https://commits.webkit.org/273550@main">https://commits.webkit.org/273550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/094b4dda3baf6aeb0e59d712f854857e0b93cab0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38504 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32196 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11746 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31807 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10926 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39751 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36874 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9005 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/34972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12853 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4640 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11931 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->