### PR TITLE
Update GPU Process VP9/VP8 preferences when other media preferences are updated

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1095,13 +1095,6 @@ void GPUConnectionToWebProcess::dispatchDisplayWasReconfigured()
 {
     for (auto& context : m_remoteGraphicsContextGLMap.values())
         context->displayWasReconfigured();
-}
-#endif
-
-#if ENABLE(VP9)
-void GPUConnectionToWebProcess::enableVP9Decoders(bool shouldEnableVP8Decoder, bool shouldEnableVP9Decoder, bool shouldEnableVP9SWDecoder)
-{
-    m_gpuProcess->enableVP9Decoders(shouldEnableVP8Decoder, shouldEnableVP9Decoder, shouldEnableVP9SWDecoder);
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -282,10 +282,6 @@ private:
 
     void clearNowPlayingInfo();
     void setNowPlayingInfo(WebCore::NowPlayingInfo&&);
-
-#if ENABLE(VP9)
-    void enableVP9Decoders(bool shouldEnableVP8Decoder, bool shouldEnableVP9Decoder, bool shouldEnableVP9SWDecoder);
-#endif
 
 #if ENABLE(MEDIA_SOURCE)
     void enableMockMediaSource();

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2019-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,9 +39,6 @@ messages -> GPUConnectionToWebProcess WantsDispatchMessage {
 #endif
 #if PLATFORM(IOS_FAMILY)
     EnsureMediaSessionHelper()
-#endif
-#if ENABLE(VP9)
-    EnableVP9Decoders(bool shouldEnableVP8Decoder, bool shouldEnableVP9Decoder, bool shouldEnableVP9SWDecoder)
 #endif
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     CreateVisibilityPropagationContextForPage(WebKit::WebPageProxyIdentifier pageProxyID, WebCore::PageIdentifier pageID, bool canShowWhileLocked);

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -336,6 +336,36 @@ void GPUProcess::updateGPUProcessPreferences(GPUProcessPreferences&& preferences
     if (updatePreference(m_preferences.mediaCapabilityGrantsEnabled, preferences.mediaCapabilityGrantsEnabled))
         PlatformMediaSessionManager::setMediaCapabilityGrantsEnabled(*m_preferences.mediaCapabilityGrantsEnabled);
 #endif
+
+#if ENABLE(VP9)
+    if (updatePreference(m_preferences.vp8DecoderEnabled, preferences.vp8DecoderEnabled)) {
+        PlatformMediaSessionManager::setShouldEnableVP8Decoder(*m_preferences.vp8DecoderEnabled);
+#if PLATFORM(COCOA)
+        if (!m_haveEnabledVP8Decoder && *m_preferences.vp8DecoderEnabled) {
+            m_haveEnabledVP8Decoder = true;
+            WebCore::registerWebKitVP8Decoder();
+        }
+#endif
+    }
+    if (updatePreference(m_preferences.vp9DecoderEnabled, preferences.vp9DecoderEnabled)) {
+        PlatformMediaSessionManager::setShouldEnableVP9Decoder(*m_preferences.vp9DecoderEnabled);
+#if PLATFORM(COCOA)
+        if (!m_haveEnabledVP9Decoder && *m_preferences.vp9DecoderEnabled) {
+            m_haveEnabledVP9Decoder = true;
+            WebCore::registerSupplementalVP9Decoder();
+        }
+#endif
+    }
+    if (updatePreference(m_preferences.vp9SWDecoderEnabled, preferences.vp9SWDecoderEnabled)) {
+        PlatformMediaSessionManager::setShouldEnableVP9SWDecoder(*m_preferences.vp9SWDecoderEnabled);
+#if PLATFORM(COCOA)
+        if (!m_haveEnabledVP9SWDecoder && *m_preferences.vp9SWDecoderEnabled) {
+            m_haveEnabledVP9SWDecoder = true;
+            WebCore::registerWebKitVP9Decoder();
+        }
+#endif
+    }
+#endif
 }
 
 bool GPUProcess::updatePreference(std::optional<bool>& oldPreference, std::optional<bool>& newPreference)
@@ -555,30 +585,6 @@ WorkQueue& GPUProcess::libWebRTCCodecsQueue()
     if (!m_libWebRTCCodecsQueue)
         m_libWebRTCCodecsQueue = WorkQueue::create("LibWebRTCCodecsQueue", WorkQueue::QOS::UserInitiated);
     return *m_libWebRTCCodecsQueue;
-}
-#endif
-
-#if ENABLE(VP9)
-void GPUProcess::enableVP9Decoders(bool shouldEnableVP8Decoder, bool shouldEnableVP9Decoder, bool shouldEnableVP9SWDecoder)
-{
-    if (shouldEnableVP9Decoder && !m_enableVP9Decoder) {
-        m_enableVP9Decoder = true;
-#if PLATFORM(COCOA)
-        WebCore::registerSupplementalVP9Decoder();
-#endif
-    }
-    if (shouldEnableVP8Decoder && !m_enableVP8Decoder) {
-        m_enableVP8Decoder = true;
-#if PLATFORM(COCOA)
-        WebCore::registerWebKitVP8Decoder();
-#endif
-    }
-    if (shouldEnableVP9SWDecoder && !m_enableVP9SWDecoder) {
-        m_enableVP9SWDecoder = true;
-#if PLATFORM(COCOA)
-        WebCore::registerWebKitVP9Decoder();
-#endif
-    }
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -110,10 +110,6 @@ public:
 
 #if USE(GRAPHICS_LAYER_WC)
     WCSharedSceneContextHolder& sharedSceneContext() { return m_sharedSceneContext; }
-#endif
-
-#if ENABLE(VP9)
-    void enableVP9Decoders(bool shouldEnableVP8Decoder, bool shouldEnableVP9Decoder, bool shouldEnableVP9SWDecoder);
 #endif
 
     void tryExitIfUnusedAndUnderMemoryPressure();
@@ -240,10 +236,10 @@ private:
 #if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
     mutable std::unique_ptr<RemoteAudioSessionProxyManager> m_audioSessionManager;
 #endif
-#if ENABLE(VP9)
-    bool m_enableVP8Decoder { false };
-    bool m_enableVP9Decoder { false };
-    bool m_enableVP9SWDecoder { false };
+#if ENABLE(VP9) && PLATFORM(COCOA)
+    bool m_haveEnabledVP8Decoder { false };
+    bool m_haveEnabledVP9Decoder { false };
+    bool m_haveEnabledVP9SWDecoder { false };
 #endif
 
 };

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 20220-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,10 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "WebPreferences.h"
+
+#if PLATFORM(COCOA)
+#include <WebCore/SystemBattery.h>
+#endif
 
 namespace WebKit {
 
@@ -72,6 +76,19 @@ void GPUProcessPreferences::copyEnabledWebPreferences(const WebPreferences& webP
 #if ENABLE(EXTENSION_CAPABILITIES)
     if (webPreferences.mediaCapabilityGrantsEnabled())
         mediaCapabilityGrantsEnabled = true;
+#endif
+
+#if ENABLE(VP9)
+    if (webPreferences.vp8DecoderEnabled())
+        vp8DecoderEnabled = true;
+    if (webPreferences.vp9DecoderEnabled()) {
+        vp9DecoderEnabled = true;
+#if PLATFORM(COCOA)
+        if (!WebCore::systemHasBattery() || webPreferences.vp9SWDecoderEnabledOnBattery())
+            vp9SWDecoderEnabled = true;
+#endif
+
+    }
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.h
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -70,6 +70,12 @@ struct GPUProcessPreferences {
 
 #if ENABLE(EXTENSION_CAPABILITIES)
     std::optional<bool> mediaCapabilityGrantsEnabled;
+#endif
+
+#if ENABLE(VP9)
+    std::optional<bool> vp8DecoderEnabled;
+    std::optional<bool> vp9DecoderEnabled;
+    std::optional<bool> vp9SWDecoderEnabled;
 #endif
 };
 

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in
@@ -50,6 +50,11 @@ struct WebKit::GPUProcessPreferences {
 #if ENABLE(EXTENSION_CAPABILITIES)
     std::optional<bool> mediaCapabilityGrantsEnabled;
 #endif
+#if ENABLE(VP9)
+    std::optional<bool> vp8DecoderEnabled;
+    std::optional<bool> vp9DecoderEnabled;
+    std::optional<bool> vp9SWDecoderEnabled;
+#endif
 };
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -136,9 +136,6 @@ GPUProcessConnection::GPUProcessConnection(IPC::Connection::Identifier&& connect
     m_connection->open(*this);
 
     if (WebProcess::singleton().shouldUseRemoteRenderingFor(RenderingPurpose::MediaPainting)) {
-#if ENABLE(VP9)
-        enableVP9Decoders(PlatformMediaSessionManager::shouldEnableVP8Decoder(), PlatformMediaSessionManager::shouldEnableVP9Decoder(), PlatformMediaSessionManager::shouldEnableVP9SWDecoder());
-#endif
     }
 }
 
@@ -367,19 +364,6 @@ void GPUProcessConnection::configureLoggingChannel(const String& channelName, WT
 {
     connection().send(Messages::GPUConnectionToWebProcess::ConfigureLoggingChannel(channelName, state, level), { });
 }
-
-#if ENABLE(VP9)
-void GPUProcessConnection::enableVP9Decoders(bool enableVP8Decoder, bool enableVP9Decoder, bool enableVP9SWDecoder)
-{
-    if (m_enableVP8Decoder == enableVP8Decoder && m_enableVP9Decoder == enableVP9Decoder && m_enableVP9SWDecoder == enableVP9SWDecoder)
-        return;
-
-    m_enableVP8Decoder = enableVP8Decoder;
-    m_enableVP9Decoder = enableVP9Decoder;
-    m_enableVP9SWDecoder = enableVP9SWDecoder;
-    connection().send(Messages::GPUConnectionToWebProcess::EnableVP9Decoders(enableVP8Decoder, enableVP9Decoder, enableVP9SWDecoder), { });
-}
-#endif
 
 void GPUProcessConnection::updateMediaConfiguration(bool forceUpdate)
 {

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -90,14 +90,6 @@ public:
 
     void updateMediaConfiguration(bool forceUpdate);
 
-#if ENABLE(VP9)
-    void enableVP9Decoders(bool enableVP8Decoder, bool enableVP9Decoder, bool enableVP9SWDecoder);
-
-    bool isVP8DecoderEnabled() const { return m_enableVP8Decoder; }
-    bool isVP9DecoderEnabled() const { return m_enableVP9Decoder; }
-    bool isVPSWDecoderEnabled() const { return m_enableVP9SWDecoder; }
-#endif
-
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     void createVisibilityPropagationContextForPage(WebPage&);
     void destroyVisibilityPropagationContextForPage(WebPage&);
@@ -160,11 +152,6 @@ private:
 #endif
 #if PLATFORM(COCOA) && ENABLE(WEB_AUDIO)
     RefPtr<RemoteAudioSourceProviderManager> m_audioSourceProviderManager;
-#endif
-#if ENABLE(VP9)
-    bool m_enableVP8Decoder { false };
-    bool m_enableVP9Decoder { false };
-    bool m_enableVP9SWDecoder { false };
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
@@ -129,9 +129,15 @@ static bool shouldUseLocalDecoder(std::optional<VideoCodecType> type, const Vide
     if (!type)
         return true;
 
-#if PLATFORM(MAC) && CPU(X86_64)
+#if PLATFORM(MAC)
+#if CPU(X86_64)
     if (*type == VideoCodecType::VP9 && config.decoding == VideoDecoder::HardwareAcceleration::No)
         return true;
+#else
+    // FIXME: remove this once rdar://121693406 has been fixed
+    if (*type == VideoCodecType::VP9)
+        return true;
+#endif
 #endif
 
     return false;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2012 Intel Corporation. All rights reserved.
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies)
  *
@@ -989,8 +989,6 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     PlatformMediaSessionManager::setShouldEnableVP8Decoder(parameters.shouldEnableVP8Decoder);
     PlatformMediaSessionManager::setShouldEnableVP9Decoder(parameters.shouldEnableVP9Decoder);
     PlatformMediaSessionManager::setShouldEnableVP9SWDecoder(parameters.shouldEnableVP9SWDecoder);
-    if (m_shouldPlayMediaInGPUProcess && WebProcess::singleton().existingGPUProcessConnection())
-        WebProcess::singleton().existingGPUProcessConnection()->enableVP9Decoders(parameters.shouldEnableVP8Decoder, parameters.shouldEnableVP9Decoder, parameters.shouldEnableVP9SWDecoder);
 #endif
 
     m_page->setCanUseCredentialStorage(parameters.canUseCredentialStorage);


### PR DESCRIPTION
#### 5c0212750833211421500e54474dca63c53a0c65
<pre>
Update GPU Process VP9/VP8 preferences when other media preferences are updated
<a href="https://bugs.webkit.org/show_bug.cgi?id=268104">https://bugs.webkit.org/show_bug.cgi?id=268104</a>
<a href="https://rdar.apple.com/108641943">rdar://108641943</a>

Reviewed by Jean-Yves Avenard.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::enableVP9Decoders): Deleted.
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in:

* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::updateGPUProcessPreferences): Include VP8/VP9 preferences.
(WebKit::GPUProcess::enableVP9Decoders): Deleted.
* Source/WebKit/GPUProcess/GPUProcess.h:

* Source/WebKit/GPUProcess/GPUProcessPreferences.cpp:
(WebKit::GPUProcessPreferences::copyEnabledWebPreferences): Ditto.
* Source/WebKit/GPUProcess/GPUProcessPreferences.h: Ditto.
* Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in:

* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::GPUProcessConnection):
(WebKit::GPUProcessConnection::enableVP9Decoders): Deleted.
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h:
(WebKit::GPUProcessConnection::isVP8DecoderEnabled const): Deleted.
(WebKit::GPUProcessConnection::isVP9DecoderEnabled const): Deleted.
(WebKit::GPUProcessConnection::isVPSWDecoderEnabled const): Deleted.

* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::shouldUseLocalDecoder): Disable the VP9 hardware decoder on macOS/AppleSilicon for
now to maintain the current behavior.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::WebPage):

Canonical link: <a href="https://commits.webkit.org/273656@main">https://commits.webkit.org/273656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ee16a5227edaeb92c47cdc11950364b85d14c1c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38969 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32588 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12223 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31261 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12831 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32152 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11250 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11282 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40215 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32895 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32717 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37212 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11483 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35305 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13203 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8225 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11948 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12326 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->