### PR TITLE
Remove Speedometer2 from PGO profile collection process.

### DIFF
--- a/Tools/Scripts/build-and-collect-pgo-profiles
+++ b/Tools/Scripts/build-and-collect-pgo-profiles
@@ -90,13 +90,6 @@ jsargs=(
     --count 1
 )
 
-sp2args=(
-    --plan speedometer2
-    --diagnose-directory="$BASE/speedometer2"
-    --generate-pgo-profiles
-    --count 1
-)
-
 sp3args=(
     --plan speedometer3
     --diagnose-directory="$BASE/speedometer3"
@@ -113,13 +106,11 @@ mmargs=(
 
 if [[ -n $APP ]] ; then
    jsargs+=(--browser-path "$APP")
-   sp2args+=(--browser-path "$APP")
    sp3args+=(--browser-path "$APP")
    mmargs+=(--browser-path "$APP")
    deployment_target=$(vtool -show-build "$APP"/Contents/Frameworks/JavaScriptCore.framework/Versions/A/JavaScriptCore | grep -m1 minos | tr -d -c .0-9)
 else
    jsargs+=(--build-directory $BUILD)
-   sp2args+=(--build-directory $BUILD)
    sp3args+=(--build-directory $BUILD)
    mmargs+=(--build-directory $BUILD)
    deployment_target=$(vtool -show-build "$BUILD"/JavaScriptCore.framework/Versions/A/JavaScriptCore | grep -m1 minos | tr -d -c .0-9)
@@ -134,9 +125,6 @@ SPTH='OpenSource/Tools/Scripts'
 $SPTH/run-benchmark "${jsargs[@]}"
 $SPTH/pgo-profile merge "$BASE/jetstream"
 
-$SPTH/run-benchmark "${sp2args[@]}"
-$SPTH/pgo-profile merge "$BASE/speedometer2"
-
 $SPTH/run-benchmark "${sp3args[@]}"
 $SPTH/pgo-profile merge "$BASE/speedometer3"
 
@@ -145,7 +133,7 @@ $SPTH/pgo-profile merge "$BASE/motionmark"
 
 rm *.result
 
-$SPTH/pgo-profile combine --jetstream "$BASE/jetstream" --speedometer2 "$BASE/speedometer2" --speedometer3 "$BASE/speedometer3" --motionmark "$BASE/motionmark" --output "$BASE/output"
+$SPTH/pgo-profile combine --jetstream "$BASE/jetstream" --speedometer3 "$BASE/speedometer3" --motionmark "$BASE/motionmark" --output "$BASE/output"
 
 mkdir -p "$BASE/Internal/WebKit/WebKitAdditions/Profiling/$target_triple"
 $SPTH/pgo-profile compress --input "$BASE/output" --output "$BASE/Internal/WebKit/WebKitAdditions/Profiling/$target_triple"

--- a/Tools/Scripts/pgo-profile
+++ b/Tools/Scripts/pgo-profile
@@ -7,7 +7,7 @@ import subprocess
 import os
 
 PROFILED_DYLIBS = ["JavaScriptCore", "WebCore", "WebKit"]
-BENCHMARK_GROUP_WEIGHTS = [("speedometer2", 0.4), ("speedometer3", 0.2), ("jetstream", 0.2), ("motionmark", 0.2)]
+BENCHMARK_GROUP_WEIGHTS = [("speedometer3", 0.6), ("jetstream", 0.2), ("motionmark", 0.2)]
 
 
 def pad(string, max_length):


### PR DESCRIPTION
#### 93c908e51a3df5946e401a0bf234743eb9a977ff
<pre>
Remove Speedometer2 from PGO profile collection process.
<a href="https://bugs.webkit.org/show_bug.cgi?id=268109">https://bugs.webkit.org/show_bug.cgi?id=268109</a>
<a href="https://rdar.apple.com/121326220">rdar://121326220</a>

Reviewed by Ryosuke Niwa and Yusuke Suzuki.

Stop running Speedometer2 during PGO profile collection and
move the weight from Speedometer2 to Speedometer3.

* Tools/Scripts/build-and-collect-pgo-profiles:
* Tools/Scripts/pgo-profile:

Canonical link: <a href="https://commits.webkit.org/273546@main">https://commits.webkit.org/273546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/855987a64305b932c7349006d92ad91945c1d46e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38491 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36981 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11730 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12414 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10915 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/31957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39738 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32479 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32285 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/8997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/34955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12842 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8151 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11917 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->