### PR TITLE
Re-enable and refresh Overlay Regions

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -103,6 +103,7 @@ fast/dom/Range/mac [ Skip ]
 remote-layer-tree [ Skip ]
 inspector/page/setScreenSizeOverride.html [ Skip ]
 interaction-region [ Skip ]
+overlay-region [ Skip ]
 ipc/restrictedendpoints/mac [ Skip ]
 
 # Requires async overflow scrolling

--- a/LayoutTests/overlay-region/fixed-node-updates-expected.txt
+++ b/LayoutTests/overlay-region/fixed-node-updates-expected.txt
@@ -1,0 +1,104 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 2)
+      (overlay region [x: 0 y: 0 width: 800 height: 110])
+      (overlay region [x: 0 y: 550 width: 800 height: 50])
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 110])
+                                          (layer position [x: 400 y: 400]))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                      (layer position [x: 6 y: 6]))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48]))))))))))))

--- a/LayoutTests/overlay-region/fixed-node-updates.html
+++ b/LayoutTests/overlay-region/fixed-node-updates.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        .fixed {
+            position: fixed;
+            left: 0;
+            right: 0;
+            height: 50px;
+            background: #F67280;
+            z-index: 100;
+        }
+
+        #header {
+            top: 0;
+        }
+        #footer {
+            top: unset;
+            bottom: 0;
+        }
+
+        .sticky {
+            position: sticky;
+            top: 50px;
+            height: 50px;
+            background: #6C5B7B;
+            z-index: 10;
+        }
+
+        .long {
+            position: relative;
+            height: 1000px;
+            background: #355C7D;
+        }
+        .long::before {
+            content: "↓";
+            color: white;
+            font-size: 20em;
+            text-align: center;
+            position: absolute;
+            top: 400px;
+            left: 0;
+            right: 0;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div id="header" class="fixed">
+        <h1>This is a fixed header</h1>
+    </div>
+    <h2 class="sticky">This is a sticky header</h2>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <h2 class="sticky">This is another sticky header</h2>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div id="footer" class="fixed">
+        <h1>This is a fixed footer</h1>
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    await UIHelper.animationFrame();
+    for (let el of document.querySelectorAll(".sticky"))
+        el.remove();
+    document.getElementById("header").style.height = "110px";
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/LayoutTests/overlay-region/full-page-dynamic-expected.txt
+++ b/LayoutTests/overlay-region/full-page-dynamic-expected.txt
@@ -1,0 +1,120 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 2)
+      (overlay region [x: 0 y: 0 width: 800 height: 50])
+      (overlay region [x: 0 y: 3050 width: 800 height: 50])
+      (overlay region [x: 0 y: 50 width: 800 height: 50])
+      (overlay region [x: 0 y: 550 width: 800 height: 50])
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                      (layer position [x: 6 y: 6]))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48]))))))))))))

--- a/LayoutTests/overlay-region/full-page-dynamic.html
+++ b/LayoutTests/overlay-region/full-page-dynamic.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        #test.overflow {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            overflow: scroll;
+        }
+        .fixed {
+            position: fixed;
+            left: 0;
+            right: 0;
+            height: 50px;
+            background: #F67280;
+            z-index: 100;
+        }
+
+        #header {
+            top: 0;
+        }
+        #footer {
+            top: unset;
+            bottom: 0;
+        }
+
+        .sticky {
+            position: sticky;
+            top: 50px;
+            height: 50px;
+            background: #6C5B7B;
+            z-index: 10;
+        }
+
+        .long {
+            position: relative;
+            height: 1000px;
+            background: #355C7D;
+        }
+        .long::before {
+            content: "↓";
+            color: white;
+            font-size: 20em;
+            text-align: center;
+            position: absolute;
+            top: 400px;
+            left: 0;
+            right: 0;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test" class="overflow">
+    <div id="header" class="fixed">
+        <h1>This is a fixed header</h1>
+    </div>
+    <h2 class="sticky">This is a sticky header</h2>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <h2 class="sticky">This is another sticky header</h2>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div id="footer" class="fixed">
+        <h1>This is a fixed footer</h1>
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    await UIHelper.animationFrame();
+    document.getElementById("test").classList.remove("overflow");
+    await UIHelper.ensureStablePresentationUpdate();
+
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/LayoutTests/overlay-region/full-page-expected.txt
+++ b/LayoutTests/overlay-region/full-page-expected.txt
@@ -1,0 +1,120 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 2)
+      (overlay region [x: 0 y: 0 width: 800 height: 50])
+      (overlay region [x: 0 y: 3050 width: 800 height: 50])
+      (overlay region [x: 0 y: 50 width: 800 height: 50])
+      (overlay region [x: 0 y: 550 width: 800 height: 50])
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                      (layer position [x: 6 y: 6]))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48]))))))))))))

--- a/LayoutTests/overlay-region/full-page-horizontal-expected.txt
+++ b/LayoutTests/overlay-region/full-page-horizontal-expected.txt
@@ -1,0 +1,100 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 1)
+      (overlay region [x: 0 y: 0 width: 50 height: 600])
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 3000 height: 600])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 3000 height: 600])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 3000 height: 600])
+                  (layer position [x: 1500 y: 1500])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 3000 height: 600])
+                      (layer position [x: 1500 y: 1500])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 3000 height: 600])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 3000 height: 600])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 50 height: 600])
+                                          (layer position [x: 25 y: 25])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 50 height: 600])
+                                              (layer anchorPoint [x: 0 y: 0]))))))))))))))))))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 28 height: 6])
+                      (layer position [x: 17 y: 17]))))))))))))

--- a/LayoutTests/overlay-region/full-page-horizontal.html
+++ b/LayoutTests/overlay-region/full-page-horizontal.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        html, body { margin: 0; padding: 0; font-family: -apple-system; }
+
+        #test {
+            width: 3000px;
+            height: 100vh;
+        }
+
+        .fixed {
+            position: fixed;
+            top: 0;
+            height: 100vh;
+            width: 50px;
+            background: #F67280;
+            z-index: 100;
+        }
+
+        #header {
+            left: 0;
+        }
+
+        .large {
+            float: left;
+            position: relative;
+            height: 100vh;
+            width: 1000px;
+            background: #355C7D;
+        }
+        .large::before {
+            content: "→";
+            color: white;
+            font-size: 20em;
+            text-align: center;
+            position: absolute;
+            left: 400px;
+            top: 0;
+            bottom: 0;
+        }
+
+        #results {
+            position: absolute;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div id="header" class="fixed">
+    </div>
+    <div class="large">
+    </div>
+    <div class="large">
+    </div>
+    <div class="large">
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/LayoutTests/overlay-region/full-page-overflow-expected.txt
+++ b/LayoutTests/overlay-region/full-page-overflow-expected.txt
@@ -1,0 +1,189 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 0)
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKCompositingView]
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                      (layer position [x: 400 y: 400])
+                                      (subviews
+                                        (view [class: <class not in allowed list of classes>]
+                                          (scrolling behavior 2)
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                          (layer position [x: 400 y: 400])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 800 height: 7100])
+                                              (layer anchorPoint [x: 0 y: 0])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+                                            (view [class: <class not in allowed list of classes>]
+                                              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                              (layer position [x: 791 y: 791])
+                                              (layer zPosition 1000)
+                                              (subviews
+                                                (view [class: UIView]
+                                                  (layer bounds [x: 0 y: 0 width: 32 height: 116])
+                                                  (layer position [x: 6 y: 6]))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                  (layer position [x: 6 y: 6])
+                                                  (subviews
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                      (layer position [x: 6 y: 6])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                                                          (layer position [x: 6 y: 6]))
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                                                          (layer position [x: 6 y: 6]))))))))
+                                            (view [class: <class not in allowed list of classes>]
+                                              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+                                              (layer position [x: 400 y: 400])
+                                              (layer zPosition 1000)
+                                              (subviews
+                                                (view [class: UIView]
+                                                  (layer bounds [x: 0 y: 0 width: 116 height: 32])
+                                                  (layer position [x: 400 y: 400]))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 800 height: 12])
+                                                  (layer position [x: 400 y: 400])
+                                                  (subviews
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                      (layer position [x: 400 y: 400])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                                                          (layer position [x: 48 y: 48]))
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                                                          (layer position [x: 48 y: 48]))))))))))))
+                                    (view [class: WKCompositingView]
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                      (layer position [x: 400 y: 400])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                          (subviews
+                                            (view [class: WKTransformView]
+                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                              (layer position [x: 0 y: 0])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                                  (layer position [x: 400 y: 400]))))))))
+                                    (view [class: WKCompositingView]
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                      (layer position [x: 400 y: 400])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                          (subviews
+                                            (view [class: WKTransformView]
+                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                              (layer position [x: 0 y: 0])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                                  (layer position [x: 400 y: 400]))))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48]))))))))))))

--- a/LayoutTests/overlay-region/full-page-overflow-scrolling-expected.txt
+++ b/LayoutTests/overlay-region/full-page-overflow-scrolling-expected.txt
@@ -1,0 +1,189 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 0)
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKCompositingView]
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                      (layer position [x: 400 y: 400])
+                                      (subviews
+                                        (view [class: <class not in allowed list of classes>]
+                                          (scrolling behavior 2)
+                                          (layer bounds [x: 0 y: 4100 width: 800 height: 600])
+                                          (layer position [x: 400 y: 400])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 800 height: 7100])
+                                              (layer anchorPoint [x: 0 y: 0])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+                                            (view [class: <class not in allowed list of classes>]
+                                              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                              (layer position [x: 791 y: 791])
+                                              (layer zPosition 1000)
+                                              (subviews
+                                                (view [class: UIView]
+                                                  (layer bounds [x: 0 y: 0 width: 32 height: 116])
+                                                  (layer position [x: 6 y: 6]))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                  (layer position [x: 6 y: 6])
+                                                  (subviews
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                      (layer position [x: 6 y: 6])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                                                          (layer position [x: 6 y: 6]))
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                                                          (layer position [x: 6 y: 6]))))))))
+                                            (view [class: <class not in allowed list of classes>]
+                                              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+                                              (layer position [x: 400 y: 400])
+                                              (layer zPosition 1000)
+                                              (subviews
+                                                (view [class: UIView]
+                                                  (layer bounds [x: 0 y: 0 width: 116 height: 32])
+                                                  (layer position [x: 400 y: 400]))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 800 height: 12])
+                                                  (layer position [x: 400 y: 400])
+                                                  (subviews
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                      (layer position [x: 400 y: 400])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                                                          (layer position [x: 48 y: 48]))
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                                                          (layer position [x: 48 y: 48]))))))))))))
+                                    (view [class: WKCompositingView]
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                      (layer position [x: 400 y: 400])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 4100 width: 0 height: 0])
+                                          (subviews
+                                            (view [class: WKTransformView]
+                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                              (layer position [x: 0 y: 0])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                                  (layer position [x: 400 y: 400]))))))))
+                                    (view [class: WKCompositingView]
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                      (layer position [x: 400 y: 400])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 4100 width: 0 height: 0])
+                                          (subviews
+                                            (view [class: WKTransformView]
+                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                              (layer position [x: 0 y: 0])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                                  (layer position [x: 400 y: 400]))))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48]))))))))))))

--- a/LayoutTests/overlay-region/full-page-overflow-scrolling.html
+++ b/LayoutTests/overlay-region/full-page-overflow-scrolling.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        #test {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            overflow: scroll;
+        }
+        .fixed {
+            position: fixed;
+            left: 0;
+            right: 0;
+            height: 50px;
+            background: #F67280;
+            z-index: 100;
+        }
+
+        #header {
+            top: 0;
+        }
+        #footer {
+            top: unset;
+            bottom: 0;
+        }
+
+        .sticky {
+            position: sticky;
+            top: 50px;
+            height: 50px;
+            background: #6C5B7B;
+            z-index: 10;
+        }
+
+        .long {
+            position: relative;
+            height: 1000px;
+            background: #355C7D;
+        }
+        .long::before {
+            content: "↓";
+            color: white;
+            font-size: 20em;
+            text-align: center;
+            position: absolute;
+            top: 400px;
+            left: 0;
+            right: 0;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div id="header" class="fixed">
+        <h1>This is a fixed header</h1>
+    </div>
+    <h2 class="sticky">This is a sticky header</h2>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <h2 class="sticky">This is another sticky header</h2>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div id="footer" class="fixed">
+        <h1>This is a fixed footer</h1>
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    await UIHelper.animationFrame();
+    document.querySelectorAll(".long")[4].scrollIntoView()
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/LayoutTests/overlay-region/full-page-overflow.html
+++ b/LayoutTests/overlay-region/full-page-overflow.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        #test {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            overflow: scroll;
+        }
+        .fixed {
+            position: fixed;
+            left: 0;
+            right: 0;
+            height: 50px;
+            background: #F67280;
+            z-index: 100;
+        }
+
+        #header {
+            top: 0;
+        }
+        #footer {
+            top: unset;
+            bottom: 0;
+        }
+
+        .sticky {
+            position: sticky;
+            top: 50px;
+            height: 50px;
+            background: #6C5B7B;
+            z-index: 10;
+        }
+
+        .long {
+            position: relative;
+            height: 1000px;
+            background: #355C7D;
+        }
+        .long::before {
+            content: "↓";
+            color: white;
+            font-size: 20em;
+            text-align: center;
+            position: absolute;
+            top: 400px;
+            left: 0;
+            right: 0;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div id="header" class="fixed">
+        <h1>This is a fixed header</h1>
+    </div>
+    <h2 class="sticky">This is a sticky header</h2>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <h2 class="sticky">This is another sticky header</h2>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div id="footer" class="fixed">
+        <h1>This is a fixed footer</h1>
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/LayoutTests/overlay-region/full-page-scrolling-expected.txt
+++ b/LayoutTests/overlay-region/full-page-scrolling-expected.txt
@@ -1,0 +1,121 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 2)
+      (overlay region [x: 0 y: 0 width: 800 height: 50])
+      (overlay region [x: 0 y: 1050 width: 800 height: 50])
+      (overlay region [x: 0 y: 50 width: 800 height: 50])
+      (overlay region [x: 0 y: 550 width: 800 height: 50])
+      (layer bounds [x: 0 y: 2000 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                      (layer position [x: 6 y: 6]))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48]))))))))))))

--- a/LayoutTests/overlay-region/full-page-scrolling.html
+++ b/LayoutTests/overlay-region/full-page-scrolling.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        .fixed {
+            position: fixed;
+            left: 0;
+            right: 0;
+            height: 50px;
+            background: #F67280;
+            z-index: 100;
+        }
+
+        #header {
+            top: 0;
+        }
+        #footer {
+            top: unset;
+            bottom: 0;
+        }
+
+        .sticky {
+            position: sticky;
+            top: 50px;
+            height: 50px;
+            background: #6C5B7B;
+            z-index: 10;
+        }
+
+        .long {
+            position: relative;
+            height: 1000px;
+            background: #355C7D;
+        }
+        .long::before {
+            content: "↓";
+            color: white;
+            font-size: 20em;
+            text-align: center;
+            position: absolute;
+            top: 400px;
+            left: 0;
+            right: 0;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div id="header" class="fixed">
+        <h1>This is a fixed header</h1>
+    </div>
+    <h2 class="sticky">This is a sticky header</h2>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <h2 class="sticky">This is another sticky header</h2>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div id="footer" class="fixed">
+        <h1>This is a fixed footer</h1>
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    await UIHelper.animationFrame();
+    window.scrollTo(0, 2000);
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/LayoutTests/overlay-region/full-page.html
+++ b/LayoutTests/overlay-region/full-page.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        .fixed {
+            position: fixed;
+            left: 0;
+            right: 0;
+            height: 50px;
+            background: #F67280;
+            z-index: 100;
+        }
+
+        #header {
+            top: 0;
+        }
+        #footer {
+            top: unset;
+            bottom: 0;
+        }
+
+        .sticky {
+            position: sticky;
+            top: 50px;
+            height: 50px;
+            background: #6C5B7B;
+            z-index: 10;
+        }
+
+        .long {
+            position: relative;
+            height: 1000px;
+            background: #355C7D;
+        }
+        .long::before {
+            content: "↓";
+            color: white;
+            font-size: 20em;
+            text-align: center;
+            position: absolute;
+            top: 400px;
+            left: 0;
+            right: 0;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div id="header" class="fixed">
+        <h1>This is a fixed header</h1>
+    </div>
+    <h2 class="sticky">This is a sticky header</h2>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <h2 class="sticky">This is another sticky header</h2>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div id="footer" class="fixed">
+        <h1>This is a fixed footer</h1>
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/LayoutTests/overlay-region/many-candidates-expected.txt
+++ b/LayoutTests/overlay-region/many-candidates-expected.txt
@@ -1,0 +1,321 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 0)
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 644 height: 604])
+                                          (layer position [x: 322 y: 322])
+                                          (subviews
+                                            (view [class: <class not in allowed list of classes>]
+                                              (scrolling behavior 0)
+                                              (layer bounds [x: 0 y: 0 width: 640 height: 600])
+                                              (layer position [x: 322 y: 322])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 640 height: 7100])
+                                                  (layer anchorPoint [x: 0 y: 0])
+                                                  (subviews
+                                                    (view [class: WKCompositingView]
+                                                      (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                                    (view [class: WKTransformView]
+                                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                                      (subviews
+                                                        (view [class: WKCompositingView]
+                                                          (layer bounds [x: 0 y: 0 width: 640 height: 50])
+                                                          (layer position [x: 320 y: 320]))))
+                                                    (view [class: WKTransformView]
+                                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                                      (layer position [x: 0 y: 0])
+                                                      (subviews
+                                                        (view [class: WKCompositingView]
+                                                          (layer bounds [x: 0 y: 0 width: 640 height: 50])
+                                                          (layer position [x: 320 y: 320]))))))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                  (layer position [x: 631 y: 631])
+                                                  (layer zPosition 1000)
+                                                  (subviews
+                                                    (view [class: UIView]
+                                                      (layer bounds [x: 0 y: 0 width: 32 height: 116])
+                                                      (layer position [x: 6 y: 6]))
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                      (layer position [x: 6 y: 6])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                          (layer position [x: 6 y: 6])
+                                                          (subviews
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                                                              (layer position [x: 6 y: 6]))
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                                                              (layer position [x: 6 y: 6]))))))))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 640 height: 12])
+                                                  (layer position [x: 320 y: 320])
+                                                  (layer zPosition 1000)
+                                                  (subviews
+                                                    (view [class: UIView]
+                                                      (layer bounds [x: 0 y: 0 width: 116 height: 32])
+                                                      (layer position [x: 320 y: 320]))
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 640 height: 12])
+                                                      (layer position [x: 320 y: 320])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                          (layer position [x: 320 y: 320])
+                                                          (subviews
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                                                              (layer position [x: 48 y: 48]))
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                                                              (layer position [x: 48 y: 48]))))))))))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 192 y: 192])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 644 height: 604])
+                                          (layer position [x: 322 y: 322])
+                                          (subviews
+                                            (view [class: <class not in allowed list of classes>]
+                                              (scrolling behavior 0)
+                                              (layer bounds [x: 0 y: 0 width: 640 height: 600])
+                                              (layer position [x: 322 y: 322])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 640 height: 7100])
+                                                  (layer anchorPoint [x: 0 y: 0])
+                                                  (subviews
+                                                    (view [class: WKCompositingView]
+                                                      (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                                    (view [class: WKTransformView]
+                                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                                      (subviews
+                                                        (view [class: WKCompositingView]
+                                                          (layer bounds [x: 0 y: 0 width: 640 height: 50])
+                                                          (layer position [x: 320 y: 320]))))
+                                                    (view [class: WKTransformView]
+                                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                                      (layer position [x: 0 y: 0])
+                                                      (subviews
+                                                        (view [class: WKCompositingView]
+                                                          (layer bounds [x: 0 y: 0 width: 640 height: 50])
+                                                          (layer position [x: 320 y: 320]))))))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                  (layer position [x: 631 y: 631])
+                                                  (layer zPosition 1000)
+                                                  (subviews
+                                                    (view [class: UIView]
+                                                      (layer bounds [x: 0 y: 0 width: 32 height: 116])
+                                                      (layer position [x: 6 y: 6]))
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                      (layer position [x: 6 y: 6])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                          (layer position [x: 6 y: 6])
+                                                          (subviews
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                                                              (layer position [x: 6 y: 6]))
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                                                              (layer position [x: 6 y: 6]))))))))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 640 height: 12])
+                                                  (layer position [x: 320 y: 320])
+                                                  (layer zPosition 1000)
+                                                  (subviews
+                                                    (view [class: UIView]
+                                                      (layer bounds [x: 0 y: 0 width: 116 height: 32])
+                                                      (layer position [x: 320 y: 320]))
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 640 height: 12])
+                                                      (layer position [x: 320 y: 320])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                          (layer position [x: 320 y: 320])
+                                                          (subviews
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                                                              (layer position [x: 48 y: 48]))
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                                                              (layer position [x: 48 y: 48]))))))))))))))
+                                    (view [class: WKCompositingView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0]))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 80 y: 80])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 660 height: 604])
+                                          (layer position [x: 330 y: 330])
+                                          (subviews
+                                            (view [class: <class not in allowed list of classes>]
+                                              (scrolling behavior 2)
+                                              (overlay region [x: 2 y: 2 width: 656 height: 50])
+                                              (overlay region [x: 2 y: 3052 width: 656 height: 50])
+                                              (layer bounds [x: 0 y: 0 width: 656 height: 600])
+                                              (layer position [x: 330 y: 330])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 656 height: 7100])
+                                                  (layer anchorPoint [x: 0 y: 0])
+                                                  (subviews
+                                                    (view [class: WKCompositingView]
+                                                      (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                                    (view [class: WKTransformView]
+                                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                                      (subviews
+                                                        (view [class: WKCompositingView]
+                                                          (layer bounds [x: 0 y: 0 width: 656 height: 50])
+                                                          (layer position [x: 328 y: 328]))))
+                                                    (view [class: WKTransformView]
+                                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                                      (layer position [x: 0 y: 0])
+                                                      (subviews
+                                                        (view [class: WKCompositingView]
+                                                          (layer bounds [x: 0 y: 0 width: 656 height: 50])
+                                                          (layer position [x: 328 y: 328]))))))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                  (layer position [x: 647 y: 647])
+                                                  (layer zPosition 1000)
+                                                  (subviews
+                                                    (view [class: UIView]
+                                                      (layer bounds [x: 0 y: 0 width: 32 height: 116])
+                                                      (layer position [x: 6 y: 6]))
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                      (layer position [x: 6 y: 6])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                          (layer position [x: 6 y: 6])
+                                                          (subviews
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                                                              (layer position [x: 6 y: 6]))
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                                                              (layer position [x: 6 y: 6]))))))))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 656 height: 12])
+                                                  (layer position [x: 328 y: 328])
+                                                  (layer zPosition 1000)
+                                                  (subviews
+                                                    (view [class: UIView]
+                                                      (layer bounds [x: 0 y: 0 width: 116 height: 32])
+                                                      (layer position [x: 328 y: 328]))
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 656 height: 12])
+                                                      (layer position [x: 328 y: 328])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                          (layer position [x: 328 y: 328])
+                                                          (subviews
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                                                              (layer position [x: 48 y: 48]))
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                                                              (layer position [x: 48 y: 48]))))))))))))))))))))))))))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48]))))))))))))

--- a/LayoutTests/overlay-region/many-candidates.html
+++ b/LayoutTests/overlay-region/many-candidates.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+
+        #main {
+            position: fixed;
+            width: 82%;
+            height: 100vh;
+            top: 5%;
+            left: 10%;
+            overflow: scroll;
+            z-index: 1000;
+            border: 2px green solid;
+        }
+        #other {
+            position: fixed;
+            width: 80%;
+            top: 0;
+            left: 0;
+            height: 100vh;
+            overflow: scroll;
+            border: 2px gray solid;
+        }
+        #other-after {
+            position: fixed;
+            width: 80%;
+            height: 100vh;
+            top: 15%;
+            left: 24%;
+            overflow: scroll;
+            border: 2px blue solid;
+        }
+
+        .sticky {
+            position: sticky;
+            top: 0;
+            height: 50px;
+            background: #6C5B7B;
+            z-index: 10;
+        }
+
+        .long {
+            position: relative;
+            height: 1000px;
+            background: #355C7D;
+        }
+        .long::before {
+            content: "↓";
+            color: white;
+            font-size: 20em;
+            text-align: center;
+            position: absolute;
+            top: 400px;
+            left: 0;
+            right: 0;
+        }
+
+        #results {
+            position: absolute;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div id="other">
+        <h2 class="sticky">This is a sticky header</h2>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <h2 class="sticky">This is another sticky header</h2>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+    </div>
+    <div id="main">
+        <h2 class="sticky">This is a sticky header</h2>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <h2 class="sticky">This is another sticky header</h2>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+    </div>
+    <div id="other-after">
+        <h2 class="sticky">This is a sticky header</h2>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <h2 class="sticky">This is another sticky header</h2>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/LayoutTests/overlay-region/map-expected.txt
+++ b/LayoutTests/overlay-region/map-expected.txt
@@ -1,0 +1,148 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 0)
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKCompositingView]
+                                      (layer bounds [x: 0 y: 0 width: 640 height: 480])
+                                      (layer position [x: 400 y: 400])
+                                      (subviews
+                                        (view [class: <class not in allowed list of classes>]
+                                          (scrolling behavior 3)
+                                          (layer bounds [x: 0 y: 0 width: 640 height: 480])
+                                          (layer position [x: 320 y: 320])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 4000 height: 4000])
+                                              (layer anchorPoint [x: 0 y: 0])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+                                            (view [class: <class not in allowed list of classes>]
+                                              (layer bounds [x: 0 y: 0 width: 12 height: 480])
+                                              (layer position [x: 631 y: 631])
+                                              (layer zPosition 1000)
+                                              (subviews
+                                                (view [class: UIView]
+                                                  (layer bounds [x: 0 y: 0 width: 32 height: 116])
+                                                  (layer position [x: 6 y: 6]))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 480])
+                                                  (layer position [x: 6 y: 6])
+                                                  (subviews
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                      (layer position [x: 6 y: 6])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                                                          (layer position [x: 6 y: 6]))
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                                                          (layer position [x: 6 y: 6]))))))))
+                                            (view [class: <class not in allowed list of classes>]
+                                              (layer bounds [x: 0 y: 0 width: 640 height: 12])
+                                              (layer position [x: 320 y: 320])
+                                              (layer zPosition 1000)
+                                              (subviews
+                                                (view [class: UIView]
+                                                  (layer bounds [x: 0 y: 0 width: 116 height: 32])
+                                                  (layer position [x: 320 y: 320]))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 640 height: 12])
+                                                  (layer position [x: 320 y: 320])
+                                                  (subviews
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                      (layer position [x: 320 y: 320])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                                                          (layer position [x: 48 y: 48]))
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 28 height: 6])
+                                                          (layer position [x: 17 y: 17]))))))))))))))))))))))))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48]))))))))))))

--- a/LayoutTests/overlay-region/map-small-expected.txt
+++ b/LayoutTests/overlay-region/map-small-expected.txt
@@ -1,0 +1,145 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 0)
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKCompositingView]
+                                      (layer bounds [x: 0 y: 0 width: 160 height: 120])
+                                      (layer position [x: 400 y: 400])
+                                      (subviews
+                                        (view [class: <class not in allowed list of classes>]
+                                          (scrolling behavior 0)
+                                          (layer bounds [x: 0 y: 0 width: 160 height: 120])
+                                          (layer position [x: 80 y: 80])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 1000 height: 1000])
+                                              (layer anchorPoint [x: 0 y: 0]))
+                                            (view [class: <class not in allowed list of classes>]
+                                              (layer bounds [x: 0 y: 0 width: 12 height: 120])
+                                              (layer position [x: 151 y: 151])
+                                              (layer zPosition 1000)
+                                              (subviews
+                                                (view [class: UIView]
+                                                  (layer bounds [x: 0 y: 0 width: 32 height: 116])
+                                                  (layer position [x: 6 y: 6]))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 120])
+                                                  (layer position [x: 6 y: 6])
+                                                  (subviews
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                      (layer position [x: 6 y: 6])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                                                          (layer position [x: 6 y: 6]))
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                                                          (layer position [x: 6 y: 6]))))))))
+                                            (view [class: <class not in allowed list of classes>]
+                                              (layer bounds [x: 0 y: 0 width: 160 height: 12])
+                                              (layer position [x: 80 y: 80])
+                                              (layer zPosition 1000)
+                                              (subviews
+                                                (view [class: UIView]
+                                                  (layer bounds [x: 0 y: 0 width: 116 height: 32])
+                                                  (layer position [x: 80 y: 80]))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 160 height: 12])
+                                                  (layer position [x: 80 y: 80])
+                                                  (subviews
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                      (layer position [x: 80 y: 80])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                                                          (layer position [x: 48 y: 48]))
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 28 height: 6])
+                                                          (layer position [x: 17 y: 17]))))))))))))))))))))))))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48]))))))))))))

--- a/LayoutTests/overlay-region/map-small.html
+++ b/LayoutTests/overlay-region/map-small.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        #test {
+            position: absolute;
+            top: 40%;
+            left: 40%;
+            right: 40%;
+            bottom: 40%;
+            overflow: scroll;
+        }
+
+        .big {
+            position: relative;
+            width: 1000px;
+            height: 1000px;
+            background: #355C7D;
+        }
+        .big::before {
+            content: "↘";
+            color: white;
+            font-size: 8em;
+            text-align: center;
+            position: absolute;
+            top: 0;
+            left: 0;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div class="big"></div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/LayoutTests/overlay-region/map.html
+++ b/LayoutTests/overlay-region/map.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        #test {
+            position: absolute;
+            top: 10%;
+            left: 10%;
+            right: 10%;
+            bottom: 10%;
+            overflow: scroll;
+        }
+
+        .big {
+            position: relative;
+            width: 4000px;
+            height: 4000px;
+            background: #355C7D;
+        }
+        .big::before {
+            content: "↘";
+            color: white;
+            font-size: 8em;
+            text-align: center;
+            position: absolute;
+            top: 0;
+            left: 0;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div class="big"></div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/LayoutTests/overlay-region/split-scrollers-expected.txt
+++ b/LayoutTests/overlay-region/split-scrollers-expected.txt
@@ -1,0 +1,246 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 0)
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 160 height: 600])
+                                          (layer position [x: 80 y: 80])
+                                          (subviews
+                                            (view [class: <class not in allowed list of classes>]
+                                              (scrolling behavior 0)
+                                              (layer bounds [x: 0 y: 0 width: 160 height: 600])
+                                              (layer position [x: 80 y: 80])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 160 height: 3000])
+                                                  (layer anchorPoint [x: 0 y: 0])
+                                                  (subviews
+                                                    (view [class: WKCompositingView]
+                                                      (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                                    (view [class: WKTransformView]
+                                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                                      (subviews
+                                                        (view [class: WKCompositingView]
+                                                          (layer bounds [x: 0 y: 0 width: 160 height: 100])
+                                                          (layer position [x: 80 y: 80]))))))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                  (layer position [x: 151 y: 151])
+                                                  (layer zPosition 1000)
+                                                  (subviews
+                                                    (view [class: UIView]
+                                                      (layer bounds [x: 0 y: 0 width: 32 height: 116])
+                                                      (layer position [x: 6 y: 6]))
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                      (layer position [x: 6 y: 6])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                          (layer position [x: 6 y: 6])
+                                                          (subviews
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                                                              (layer position [x: 6 y: 6]))
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                                                              (layer position [x: 6 y: 6]))))))))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 160 height: 12])
+                                                  (layer position [x: 80 y: 80])
+                                                  (layer zPosition 1000)
+                                                  (subviews
+                                                    (view [class: UIView]
+                                                      (layer bounds [x: 0 y: 0 width: 116 height: 32])
+                                                      (layer position [x: 80 y: 80]))
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 160 height: 12])
+                                                      (layer position [x: 80 y: 80])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                          (layer position [x: 80 y: 80])
+                                                          (subviews
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                                                              (layer position [x: 48 y: 48]))
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                                                              (layer position [x: 48 y: 48]))))))))))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 160 y: 160])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 640 height: 600])
+                                          (layer position [x: 320 y: 320])
+                                          (subviews
+                                            (view [class: <class not in allowed list of classes>]
+                                              (scrolling behavior 2)
+                                              (overlay region [x: 0 y: 0 width: 640 height: 50])
+                                              (overlay region [x: 0 y: 3050 width: 640 height: 50])
+                                              (overlay region [x: 0 y: 550 width: 640 height: 50])
+                                              (layer bounds [x: 0 y: 0 width: 640 height: 600])
+                                              (layer position [x: 320 y: 320])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 640 height: 7100])
+                                                  (layer anchorPoint [x: 0 y: 0])
+                                                  (subviews
+                                                    (view [class: WKCompositingView]
+                                                      (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                                    (view [class: WKTransformView]
+                                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                                      (subviews
+                                                        (view [class: WKCompositingView]
+                                                          (layer bounds [x: 0 y: 0 width: 640 height: 50])
+                                                          (layer position [x: 320 y: 320]))))
+                                                    (view [class: WKTransformView]
+                                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                                      (layer position [x: 0 y: 0])
+                                                      (subviews
+                                                        (view [class: WKCompositingView]
+                                                          (layer bounds [x: 0 y: 0 width: 640 height: 50])
+                                                          (layer position [x: 320 y: 320]))))
+                                                    (view [class: WKTransformView]
+                                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                                      (layer position [x: 0 y: 0])
+                                                      (subviews
+                                                        (view [class: WKCompositingView]
+                                                          (layer bounds [x: 0 y: 0 width: 640 height: 50])
+                                                          (layer position [x: 320 y: 320]))))))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                  (layer position [x: 631 y: 631])
+                                                  (layer zPosition 1000)
+                                                  (subviews
+                                                    (view [class: UIView]
+                                                      (layer bounds [x: 0 y: 0 width: 32 height: 116])
+                                                      (layer position [x: 6 y: 6]))
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                      (layer position [x: 6 y: 6])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                          (layer position [x: 6 y: 6])
+                                                          (subviews
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                                                              (layer position [x: 6 y: 6]))
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                                                              (layer position [x: 6 y: 6]))))))))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 640 height: 12])
+                                                  (layer position [x: 320 y: 320])
+                                                  (layer zPosition 1000)
+                                                  (subviews
+                                                    (view [class: UIView]
+                                                      (layer bounds [x: 0 y: 0 width: 116 height: 32])
+                                                      (layer position [x: 320 y: 320]))
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 640 height: 12])
+                                                      (layer position [x: 320 y: 320])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                          (layer position [x: 320 y: 320])
+                                                          (subviews
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                                                              (layer position [x: 48 y: 48]))
+                                                            (view [class: <class not in allowed list of classes>]
+                                                              (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                                                              (layer position [x: 48 y: 48]))))))))))))))
+                                    (view [class: WKCompositingView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0]))))))))))))))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48]))))))))))))

--- a/LayoutTests/overlay-region/split-scrollers.html
+++ b/LayoutTests/overlay-region/split-scrollers.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        #menu {
+            position: fixed;
+            width: 20%;
+            top: 0;
+            left: 0;
+            bottom: 0;
+            overflow: scroll;
+        }
+
+        #main {
+            position: fixed;
+            width: 80%;
+            top: 0;
+            left: 20%;
+            bottom: 0;
+            overflow: scroll;
+        }
+
+        .fixed {
+            position: fixed;
+            left: 0;
+            height: 50px;
+            background: #F67280;
+            z-index: 100;
+        }
+
+        #header {
+            top: 0;
+            width: 20%;
+        }
+        #footer {
+            top: unset;
+            left: 20%;
+            right: 0;
+            bottom: 0;
+        }
+
+        .sticky {
+            position: sticky;
+            top: 0;
+            height: 50px;
+            background: #6C5B7B;
+            z-index: 10;
+        }
+
+        .long {
+            position: relative;
+            height: 1000px;
+            background: #355C7D;
+        }
+        .long::before {
+            content: "↓";
+            color: white;
+            font-size: 20em;
+            text-align: center;
+            position: absolute;
+            top: 400px;
+            left: 0;
+            right: 0;
+        }
+
+        #menu .long::before {
+            font-size: 8em;
+        }
+
+        #results {
+            position: absolute;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div id="menu">
+        <div id="header" class="fixed">
+            <h1>This is a fixed header</h1>
+        </div>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+    </div>
+    <div id="main">
+        <h2 class="sticky">This is a sticky header</h2>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <h2 class="sticky">This is another sticky header</h2>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <div class="long">
+        </div>
+        <div id="footer" class="fixed">
+            <h1>This is a fixed footer</h1>
+        </div>
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -62,7 +62,7 @@
 namespace WebKit {
 
 struct LayerProperties;
-using LayerPropertiesMap = HashMap<WebCore::PlatformLayerIdentifier, UniqueRef<LayerProperties>>;
+typedef HashMap<WebCore::PlatformLayerIdentifier, UniqueRef<LayerProperties>> LayerPropertiesMap;
 
 struct ChangedLayers {
     HashSet<Ref<PlatformCALayerRemote>> changedLayers; // Only used in the Web process.

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -227,7 +227,7 @@ static String allowListedClassToString(UIView *view)
 static void dumpUIView(TextStream& ts, UIView *view)
 {
     auto rectToString = [] (auto rect) {
-        return makeString("[x: ", rect.origin.x, " y: ", rect.origin.x, " width: ", rect.size.width, " height: ", rect.size.height, "]");
+        return makeString("[x: ", rect.origin.x, " y: ", rect.origin.y, " width: ", rect.size.width, " height: ", rect.size.height, "]");
     };
 
     auto pointToString = [] (auto point) {
@@ -236,6 +236,21 @@ static void dumpUIView(TextStream& ts, UIView *view)
 
 
     ts << "view [class: " << allowListedClassToString(view) << "]";
+
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    if ([view isKindOfClass:[WKBaseScrollView class]]) {
+        ts.dumpProperty("scrolling behavior", makeString([(WKBaseScrollView *)view _scrollingBehavior]));
+
+        auto rects = [(WKBaseScrollView *)view overlayRegionsForTesting];
+        auto overlaysAsStrings = adoptNS([[NSMutableArray alloc] initWithCapacity:rects.size()]);
+        for (auto rect : rects)
+            [overlaysAsStrings addObject:rectToString(CGRect(rect))];
+
+        [overlaysAsStrings sortUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
+        for (NSString *overlayAsString in overlaysAsStrings.get())
+            ts.dumpProperty("overlay region", overlayAsString);
+    }
+#endif
 
     ts.dumpProperty("layer bounds", rectToString(view.layer.bounds));
     

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -69,10 +69,6 @@ public:
 
     CALayer *layerWithIDForTesting(WebCore::PlatformLayerIdentifier) const;
 
-#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    void updateOverlayRegionIDs(const HashSet<WebCore::PlatformLayerIdentifier> &overlayRegionIDs) { m_remoteLayerTreeHost->updateOverlayRegionIDs(overlayRegionIDs); }
-#endif
-
     void viewWillStartLiveResize() final;
     void viewWillEndLiveResize() final;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -88,10 +88,6 @@ public:
     bool replayDynamicContentScalingDisplayListsIntoBackingStore() const;
     bool css3DTransformInteroperabilityEnabled() const;
     bool threadedAnimationResolutionEnabled() const;
-#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    const HashSet<WebCore::PlatformLayerIdentifier>& overlayRegionIDs() const { return m_overlayRegionIDs; }
-    void updateOverlayRegionIDs(const HashSet<WebCore::PlatformLayerIdentifier> &overlayRegionNodes) { m_overlayRegionIDs = overlayRegionNodes; }
-#endif
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     Seconds acceleratedTimelineTimeOrigin() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -30,6 +30,7 @@
 #include "RemoteScrollingCoordinatorProxy.h"
 
 OBJC_CLASS UIScrollView;
+OBJC_CLASS WKBaseScrollView;
 
 namespace WebCore {
 enum class TouchAction : uint8_t;
@@ -57,8 +58,12 @@ public:
     CGPoint nearestActiveContentInsetAdjustedSnapOffset(CGFloat topInset, const CGPoint&) const;
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    void removeFixedScrollingNodeLayerIDs(const Vector<WebCore::PlatformLayerIdentifier>&);
+    void removeDestroyedLayerIDs(const Vector<WebCore::PlatformLayerIdentifier>&);
+    void updateOverlayRegionLayerIDs(const HashSet<WebCore::PlatformLayerIdentifier>& overlayRegionLayerIDs) { m_overlayRegionLayerIDs = overlayRegionLayerIDs; }
+
     const HashSet<WebCore::PlatformLayerIdentifier>& fixedScrollingNodeLayerIDs() const { return m_fixedScrollingNodeLayerIDs; }
+    const HashSet<WebCore::PlatformLayerIdentifier>& overlayRegionLayerIDs() const { return m_overlayRegionLayerIDs; }
+    Vector<WKBaseScrollView*> overlayRegionScrollViewCandidates() const;
 #endif
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
@@ -85,6 +90,8 @@ private:
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
     HashSet<WebCore::PlatformLayerIdentifier> m_fixedScrollingNodeLayerIDs;
+    HashSet<WebCore::PlatformLayerIdentifier> m_overlayRegionLayerIDs;
+    HashMap<WebCore::PlatformLayerIdentifier, WebCore::ScrollingNodeID> m_scrollingNodesByLayerID;
 #endif
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.h
@@ -30,6 +30,11 @@
 #import "WKBrowserEngineDefinitions.h"
 #import <UIKit/UIKit.h>
 
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+#import <WebCore/IntRectHash.h>
+#import <wtf/HashSet.h>
+#endif
+
 @class WKBEScrollViewScrollUpdate;
 @class WKBaseScrollView;
 
@@ -43,6 +48,15 @@
 
 @property (nonatomic, weak) id<WKBaseScrollViewDelegate> baseScrollViewDelegate;
 @property (nonatomic, readonly) UIAxis axesToPreventMomentumScrolling;
+
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+@property (nonatomic) NSUInteger _scrollingBehavior;
+@property (nonatomic, readonly, getter=overlayRegionsForTesting) HashSet<WebCore::IntRect>& overlayRegionRects;
+
+- (BOOL)_hasEnoughContentForOverlayRegions;
+- (void)_updateOverlayRegionRects:(HashSet<WebCore::IntRect>&)overlayRegions;
+- (void)_updateOverlayRegionsBehavior:(BOOL)selected;
+#endif // ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
 
 @end
 

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
@@ -35,6 +35,12 @@
 #import <wtf/SetForScope.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+#import "UIKitUtilities.h"
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <wtf/cocoa/VectorCocoa.h>
+#endif
+
 @interface UIScrollView (GestureRecognizerDelegate) <UIGestureRecognizerDelegate>
 @end
 
@@ -42,6 +48,9 @@
     RetainPtr<UIPanGestureRecognizer> _axisLockingPanGestureRecognizer;
     UIAxis _axesToPreventMomentumScrolling;
     BOOL _isBeingRemovedFromSuperview;
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+    HashSet<WebCore::IntRect> _overlayRegionRects;
+#endif
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -164,6 +173,19 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     auto delegate = self.baseScrollViewDelegate;
     return delegate ? [delegate axesToPreventScrollingForPanGestureInScrollView:self] : UIAxisNeither;
 }
+
+
+#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
+
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WKBaseScrollViewAdditions.mm>)
+#import <WebKitAdditions/WKBaseScrollViewAdditions.mm>
+#else
+- (BOOL)_hasEnoughContentForOverlayRegions { return false; }
+- (void)_updateOverlayRegionRects:(HashSet<WebCore::IntRect>&)overlayRegions { }
+- (void)_updateOverlayRegions:(NSArray<NSData *> *)overlayRegions { }
+#endif
+
+#endif // ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
 
 #pragma mark - UIGestureRecognizerDelegate
 

--- a/Source/WebKit/UIProcess/ios/WKScrollView.h
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.h
@@ -53,10 +53,6 @@
 - (void)_resetContentInsetAdjustmentBehavior;
 #endif
 
-#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-- (bool)_updateOverlayRegions:(const Vector<CGRect> &)overlayRegions;
-#endif // ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-
 @end
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -570,52 +570,6 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
 
 #endif // HAVE(PEPPER_UI_CORE)
 
-#if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-static void addDebugOverlays(CALayer *layer, const Vector<CGRect>& overlayRegions)
-{
-    NSString *overlayDebugKey = @"WKOverlayRegionDebugFill";
-    if (![[NSUserDefaults standardUserDefaults] boolForKey:overlayDebugKey])
-        return;
-
-    Vector<CALayer *> layersToRemove;
-    for (CALayer *sublayer in layer.sublayers) {
-        if ([sublayer valueForKey:overlayDebugKey])
-            layersToRemove.append(sublayer);
-    }
-
-    for (CALayer *sublayer : layersToRemove)
-        [sublayer removeFromSuperlayer];
-
-    for (CGRect rect : overlayRegions) {
-        auto debugLayer = adoptNS([[CALayer alloc] init]);
-        [debugLayer setFrame:rect];
-        [debugLayer setBackgroundColor:WebCore::cachedCGColor({ WebCore::SRGBA<float>(1, 0, 0, .3) }).get()];
-        [debugLayer setValue:@YES forKey:overlayDebugKey];
-        [layer addSublayer:debugLayer.get()];
-    }
-}
-
-- (bool)_updateOverlayRegions:(const Vector<CGRect> &)overlayRegions
-{
-    if (_overlayRegions == overlayRegions)
-        return false;
-
-    addDebugOverlays(_internalDelegate.layer, overlayRegions);
-    [self willChangeValueForKey:@"overlayRegions"];
-    _overlayRegions = overlayRegions;
-    [self didChangeValueForKey:@"overlayRegions"];
-    return true;
-}
-
-- (NSArray<NSData *> *)overlayRegions
-{
-    return createNSArray(_overlayRegions, [] (auto& rect) {
-        return [NSData dataWithBytes:(void*)&rect length:sizeof(rect)];
-    }).autorelease();
-}
-
-#endif // ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-
 @end
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 5220b67a61e25c2737f3a6c1ba155f5cf54f231d
<pre>
Re-enable and refresh Overlay Regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=268112">https://bugs.webkit.org/show_bug.cgi?id=268112</a>
&lt;<a href="https://rdar.apple.com/119322854">rdar://119322854</a>&gt;

Reviewed by Mike Wyrzykowski.

The code for Overlay Regions is re-enabled and refreshed.
It now supports overflow scrolling and focuses on a single &quot;selected&quot;
scroll view.
A sizeable test suite is added to make future modifications easier.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
Making the LayerPropertiesMap type usable in WKWebViewIOS.
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(addOverlayEventRegions):
Updated, now only responsible to build the overlayRegionsIDs set.
(configureScrollViewWithOverlayRegionsIDs):
New function building a HashSet&lt;IntRect&gt; to pass to the
selected scroll view.
(-[WKWebView _scrollViewCanHaveOverlayRegions:]):
(-[WKWebView _selectOverlayRegionScrollView:]):
This method selects the main scroll view to use for Overlay Regions.
The top level WKScrollView takes priority, otherwise we select the
candidate covering the largest area.
(-[WKWebView _updateOverlayRegions:destroyedLayers:]):
Remove destroyed layers from the scrolling coordinator proxy tracking.
Update the overlayRegionsIDs set.
Select the overlayRegionScrollView and configure it.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::removeDestroyedLayerIDs):
(WebKit::RemoteScrollingCoordinatorProxyIOS::removeFixedScrollingNodeLayerIDs): Deleted.
Renamed. Now removes destroyed layers from all tracking properties.
(WebKit::RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers):
Now keeps track of:
- fixed and sticky nodes
- scrolling node (by PlatformLayerIdentifier so we can remove the
  destroyed layers)
(WebKit:: const):
Generates a list of scroll view candidates for Overlay Regions, based on
the scrolling node tracking.

* Source/WebKit/UIProcess/ios/WKBaseScrollView.h:
* Source/WebKit/UIProcess/ios/WKBaseScrollView.mm:
(-[WKBaseScrollView _updateOverlayRegionRects:]):
(-[WKBaseScrollView _updateOverlayRegionsBehavior:]):
New API/Addition for Overlay Regions.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
(WebKit::RemoteLayerTreeDrawingAreaProxy::updateOverlayRegionIDs): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
(WebKit::RemoteLayerTreeHost::overlayRegionIDs const): Deleted.
(WebKit::RemoteLayerTreeHost::updateOverlayRegionIDs): Deleted.
Remove dead code.

* Source/WebKit/UIProcess/ios/WKScrollView.h:
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(addDebugOverlays): Deleted.
(-[WKScrollView _updateOverlayRegions:]): Deleted.
(-[WKScrollView overlayRegions]): Deleted.
Remove dead code.

* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(dumpUIView):
Fix a typo in `rectToString`.
Add extra properties to the UIView dump for Overlay Regions.

* LayoutTests/TestExpectations:
* LayoutTests/overlay-region/fixed-node-updates-expected.txt: Added.
* LayoutTests/overlay-region/fixed-node-updates.html: Added.
* LayoutTests/overlay-region/full-page-dynamic-expected.txt: Added.
* LayoutTests/overlay-region/full-page-dynamic.html: Added.
* LayoutTests/overlay-region/full-page-expected.txt: Added.
* LayoutTests/overlay-region/full-page-horizontal-expected.txt: Added.
* LayoutTests/overlay-region/full-page-horizontal.html: Added.
* LayoutTests/overlay-region/full-page-overflow-expected.txt: Added.
* LayoutTests/overlay-region/full-page-overflow-scrolling-expected.txt: Added.
* LayoutTests/overlay-region/full-page-overflow-scrolling.html: Added.
* LayoutTests/overlay-region/full-page-overflow.html: Added.
* LayoutTests/overlay-region/full-page-scrolling-expected.txt: Added.
* LayoutTests/overlay-region/full-page-scrolling.html: Added.
* LayoutTests/overlay-region/full-page.html: Added.
* LayoutTests/overlay-region/many-candidates-expected.txt: Added.
* LayoutTests/overlay-region/many-candidates.html: Added.
* LayoutTests/overlay-region/map-expected.txt: Added.
* LayoutTests/overlay-region/map-small-expected.txt: Added.
* LayoutTests/overlay-region/map-small.html: Added.
* LayoutTests/overlay-region/map.html: Added.
* LayoutTests/overlay-region/split-scrollers-expected.txt: Added.
* LayoutTests/overlay-region/split-scrollers.html: Added.
Add a new test suite for the feature, skipping in the current runners.

Canonical link: <a href="https://commits.webkit.org/273889@main">https://commits.webkit.org/273889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f25aa6956436b01e170735c3f1d15f2197e06210

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39481 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32993 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31548 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32556 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11637 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11647 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32845 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40731 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33422 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37559 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35681 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13588 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32536 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8378 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12322 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->