### PR TITLE
Add more WCLayerChange flags for individual WCLayerUpdateInfo members

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
@@ -121,20 +121,22 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
                 replicaLayer = &m_layers.get(*layerUpdate.replicaLayer)->texmapLayer;
             layer->texmapLayer.setReplicaLayer(replicaLayer);
         }
-        if (layerUpdate.changes & WCLayerChange::Geometry) {
+        if (layerUpdate.changes & WCLayerChange::Position)
             layer->texmapLayer.setPosition(layerUpdate.position);
+        if (layerUpdate.changes & WCLayerChange::AnchorPoint)
             layer->texmapLayer.setAnchorPoint(layerUpdate.anchorPoint);
+        if (layerUpdate.changes & WCLayerChange::Size)
             layer->texmapLayer.setSize(layerUpdate.size);
+        if (layerUpdate.changes & WCLayerChange::BoundsOrigin)
             layer->texmapLayer.setBoundsOrigin(layerUpdate.boundsOrigin);
-        }
         if (layerUpdate.changes & WCLayerChange::Preserves3D)
             layer->texmapLayer.setPreserves3D(layerUpdate.preserves3D);
         if (layerUpdate.changes & WCLayerChange::ContentsRect)
             layer->texmapLayer.setContentsRect(layerUpdate.contentsRect);
-        if (layerUpdate.changes & WCLayerChange::ContentsClippingRect) {
+        if (layerUpdate.changes & WCLayerChange::ContentsClippingRect)
             layer->texmapLayer.setContentsClippingRect(layerUpdate.contentsClippingRect);
+        if (layerUpdate.changes & WCLayerChange::ContentsRectClipsDescendants)
             layer->texmapLayer.setContentsRectClipsDescendants(layerUpdate.contentsRectClipsDescendants);
-        }
         if (layerUpdate.changes & WCLayerChange::ContentsVisible)
             layer->texmapLayer.setContentsVisible(layerUpdate.contentsVisible);
         if (layerUpdate.changes & WCLayerChange::BackfaceVisibility)
@@ -170,15 +172,16 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
         }
         if (layerUpdate.changes & WCLayerChange::SolidColor)
             layer->texmapLayer.setSolidColor(layerUpdate.solidColor);
-        if (layerUpdate.changes & WCLayerChange::DebugVisuals) {
+        if (layerUpdate.changes & WCLayerChange::ShowDebugBorder)
             layer->texmapLayer.setShowDebugBorder(layerUpdate.showDebugBorder);
+        if (layerUpdate.changes & WCLayerChange::DebugBorderColor)
             layer->texmapLayer.setDebugBorderColor(layerUpdate.debugBorderColor);
+        if (layerUpdate.changes & WCLayerChange::DebugBorderWidth)
             layer->texmapLayer.setDebugBorderWidth(layerUpdate.debugBorderWidth);
-        }
-        if (layerUpdate.changes & WCLayerChange::RepaintCount) {
+        if (layerUpdate.changes & WCLayerChange::ShowRepaintCounter)
             layer->texmapLayer.setShowRepaintCounter(layerUpdate.showRepaintCounter);
+        if (layerUpdate.changes & WCLayerChange::RepaintCount)
             layer->texmapLayer.setRepaintCount(layerUpdate.repaintCount);
-        }
         if (layerUpdate.changes & WCLayerChange::Opacity)
             layer->texmapLayer.setOpacity(layerUpdate.opacity);
         if (layerUpdate.changes & WCLayerChange::Transform)
@@ -187,21 +190,25 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
             layer->texmapLayer.setChildrenTransform(layerUpdate.childrenTransform);
         if (layerUpdate.changes & WCLayerChange::Filters)
             layer->texmapLayer.setFilters(layerUpdate.filters);
+        if (layerUpdate.changes & WCLayerChange::BackdropFilters || layerUpdate.changes & WCLayerChange::BackdropFiltersRect) {
+            if (!layer->backdropLayer) {
+                layer->backdropLayer = makeUnique<WebCore::TextureMapperLayer>();
+                layer->backdropLayer->setAnchorPoint({ });
+                layer->backdropLayer->setContentsVisible(true);
+                layer->backdropLayer->setMasksToBounds(true);
+            }
+        }
         if (layerUpdate.changes & WCLayerChange::BackdropFilters) {
             if (layerUpdate.backdropFilters.isEmpty())
-                layer->backdropLayer.reset();
+                layer->texmapLayer.setBackdropLayer(nullptr);
             else {
-                if (!layer->backdropLayer) {
-                    layer->backdropLayer = makeUnique<WebCore::TextureMapperLayer>();
-                    layer->backdropLayer->setAnchorPoint({ });
-                    layer->backdropLayer->setContentsVisible(true);
-                    layer->backdropLayer->setMasksToBounds(true);
-                }
                 layer->backdropLayer->setFilters(layerUpdate.backdropFilters);
-                layer->backdropLayer->setSize(layerUpdate.backdropFiltersRect.rect().size());
-                layer->backdropLayer->setPosition(layerUpdate.backdropFiltersRect.rect().location());
+                layer->texmapLayer.setBackdropLayer(layer->backdropLayer.get());
             }
-            layer->texmapLayer.setBackdropLayer(layer->backdropLayer.get());
+        }
+        if (layerUpdate.changes & WCLayerChange::BackdropFiltersRect) {
+            layer->backdropLayer->setSize(layerUpdate.backdropFiltersRect.rect().size());
+            layer->backdropLayer->setPosition(layerUpdate.backdropFiltersRect.rect().location());
             layer->texmapLayer.setBackdropFiltersRect(layerUpdate.backdropFiltersRect);
         }
         if (layerUpdate.changes & WCLayerChange::PlatformLayer) {

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h
@@ -68,9 +68,11 @@ public:
     void setReplicatedLayer(GraphicsLayer*) override;
     void setReplicatedByLayer(RefPtr<GraphicsLayer>&&) override;
     void setPosition(const WebCore::FloatPoint&) override;
+    void syncPosition(const WebCore::FloatPoint&) override;
     void setAnchorPoint(const WebCore::FloatPoint3D&) override;
     void setSize(const WebCore::FloatSize&) override;
     void setBoundsOrigin(const WebCore::FloatPoint&) override;
+    void syncBoundsOrigin(const WebCore::FloatPoint&) override;
     void setTransform(const WebCore::TransformationMatrix&) override;
     void setChildrenTransform(const WebCore::TransformationMatrix&) override;
     void setPreserves3D(bool) override;

--- a/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h
@@ -46,27 +46,35 @@ struct WCTileUpdate {
 };
 
 enum class WCLayerChange : uint32_t {
-    Children                = 1 <<  0,
-    MaskLayer               = 1 <<  1,
-    ReplicaLayer            = 1 <<  2,
-    Geometry                = 1 <<  3,
-    Preserves3D             = 1 <<  4,
-    ContentsVisible         = 1 <<  5,
-    BackfaceVisibility      = 1 <<  6,
-    MasksToBounds           = 1 <<  7,
-    SolidColor              = 1 <<  8,
-    DebugVisuals            = 1 <<  9,
-    RepaintCount            = 1 << 10,
-    ContentsRect            = 1 << 11,
-    ContentsClippingRect    = 1 << 12,
-    Opacity                 = 1 << 13,
-    Background              = 1 << 14,
-    Transform               = 1 << 15,
-    ChildrenTransform       = 1 << 16,
-    Filters                 = 1 << 17,
-    BackdropFilters         = 1 << 18,
-    PlatformLayer           = 1 << 19,
-    RemoteFrame             = 1 << 20,
+    Children                     = 1 <<  0,
+    MaskLayer                    = 1 <<  1,
+    ReplicaLayer                 = 1 <<  2,
+    Position                     = 1 <<  3,
+    AnchorPoint                  = 1 <<  4,
+    Size                         = 1 <<  5,
+    BoundsOrigin                 = 1 <<  6,
+    MasksToBounds                = 1 <<  7,
+    ContentsRectClipsDescendants = 1 <<  8,
+    ShowDebugBorder              = 1 <<  9,
+    ShowRepaintCounter           = 1 << 10,
+    ContentsVisible              = 1 << 11,
+    BackfaceVisibility           = 1 << 12,
+    Preserves3D                  = 1 << 13,
+    SolidColor                   = 1 << 14,
+    DebugBorderColor             = 1 << 15,
+    Opacity                      = 1 << 16,
+    DebugBorderWidth             = 1 << 17,
+    RepaintCount                 = 1 << 18,
+    ContentsRect                 = 1 << 19,
+    Background                   = 1 << 20,
+    Transform                    = 1 << 21,
+    ChildrenTransform            = 1 << 22,
+    Filters                      = 1 << 23,
+    BackdropFilters              = 1 << 24,
+    BackdropFiltersRect          = 1 << 25,
+    ContentsClippingRect         = 1 << 26,
+    PlatformLayer                = 1 << 27,
+    RemoteFrame                  = 1 << 28,
 };
 
 struct WCLayerUpdateInfo {
@@ -116,8 +124,14 @@ struct WCLayerUpdateInfo {
             encoder << maskLayer;
         if (changes & WCLayerChange::ReplicaLayer)
             encoder << replicaLayer;
-        if (changes & WCLayerChange::Geometry)
-            encoder << position << anchorPoint << size << boundsOrigin;
+        if (changes & WCLayerChange::Position)
+            encoder << position;
+        if (changes & WCLayerChange::AnchorPoint)
+            encoder << anchorPoint;
+        if (changes & WCLayerChange::Size)
+            encoder << size;
+        if (changes & WCLayerChange::BoundsOrigin)
+            encoder << boundsOrigin;
         if (changes & WCLayerChange::Preserves3D)
             encoder << preserves3D;
         if (changes & WCLayerChange::ContentsVisible)
@@ -128,16 +142,22 @@ struct WCLayerUpdateInfo {
             encoder << masksToBounds;
         if (changes & WCLayerChange::SolidColor)
             encoder << solidColor;
-        if (changes & WCLayerChange::DebugVisuals)
-            encoder << showDebugBorder << debugBorderColor << debugBorderWidth;
+        if (changes & WCLayerChange::ShowDebugBorder)
+            encoder << showDebugBorder;
+        if (changes & WCLayerChange::DebugBorderColor)
+            encoder << debugBorderColor;
+        if (changes & WCLayerChange::DebugBorderWidth)
+            encoder << debugBorderWidth;
+        if (changes & WCLayerChange::ShowRepaintCounter)
+            encoder << showRepaintCounter;
         if (changes & WCLayerChange::RepaintCount)
-            encoder << showRepaintCounter << repaintCount;
+            encoder << repaintCount;
         if (changes & WCLayerChange::ContentsRect)
             encoder << contentsRect;
-        if (changes & WCLayerChange::ContentsClippingRect) {
+        if (changes & WCLayerChange::ContentsClippingRect)
             encoder << contentsClippingRect;
+        if (changes & WCLayerChange::ContentsRectClipsDescendants)
             encoder << contentsRectClipsDescendants;
-        }
         if (changes & WCLayerChange::Opacity)
             encoder << opacity;
         if (changes & WCLayerChange::Background)
@@ -149,7 +169,9 @@ struct WCLayerUpdateInfo {
         if (changes & WCLayerChange::Filters)
             encoder << filters;
         if (changes & WCLayerChange::BackdropFilters)
-            encoder << backdropFilters << backdropFiltersRect;
+            encoder << backdropFilters;
+        if (changes & WCLayerChange::BackdropFiltersRect)
+            encoder << backdropFiltersRect;
         if (changes & WCLayerChange::PlatformLayer)
             encoder << hasPlatformLayer << contentBufferIdentifiers;
         if (changes & WCLayerChange::RemoteFrame)
@@ -175,13 +197,19 @@ struct WCLayerUpdateInfo {
             if (!decoder.decode(result.replicaLayer))
                 return false;
         }
-        if (result.changes & WCLayerChange::Geometry) {
+        if (result.changes & WCLayerChange::Position) {
             if (!decoder.decode(result.position))
                 return false;
+        }
+        if (result.changes & WCLayerChange::AnchorPoint) {
             if (!decoder.decode(result.anchorPoint))
                 return false;
+        }
+        if (result.changes & WCLayerChange::Size) {
             if (!decoder.decode(result.size))
                 return false;
+        }
+        if (result.changes & WCLayerChange::BoundsOrigin) {
             if (!decoder.decode(result.boundsOrigin))
                 return false;
         }
@@ -205,17 +233,23 @@ struct WCLayerUpdateInfo {
             if (!decoder.decode(result.solidColor))
                 return false;
         }
-        if (result.changes & WCLayerChange::DebugVisuals) {
+        if (result.changes & WCLayerChange::ShowDebugBorder) {
             if (!decoder.decode(result.showDebugBorder))
                 return false;
+        }
+        if (result.changes & WCLayerChange::DebugBorderColor) {
             if (!decoder.decode(result.debugBorderColor))
                 return false;
+        }
+        if (result.changes & WCLayerChange::DebugBorderWidth) {
             if (!decoder.decode(result.debugBorderWidth))
                 return false;
         }
-        if (result.changes & WCLayerChange::RepaintCount) {
+        if (result.changes & WCLayerChange::ShowRepaintCounter) {
             if (!decoder.decode(result.showRepaintCounter))
                 return false;
+        }
+        if (result.changes & WCLayerChange::RepaintCount) {
             if (!decoder.decode(result.repaintCount))
                 return false;
         }
@@ -226,6 +260,8 @@ struct WCLayerUpdateInfo {
         if (result.changes & WCLayerChange::ContentsClippingRect) {
             if (!decoder.decode(result.contentsClippingRect))
                 return false;
+        }
+        if (result.changes & WCLayerChange::ContentsRectClipsDescendants) {
             if (!decoder.decode(result.contentsRectClipsDescendants))
                 return false;
         }
@@ -256,6 +292,8 @@ struct WCLayerUpdateInfo {
         if (result.changes & WCLayerChange::BackdropFilters) {
             if (!decoder.decode(result.backdropFilters))
                 return false;
+        }
+        if (result.changes & WCLayerChange::BackdropFiltersRect) {
             if (!decoder.decode(result.backdropFiltersRect))
                 return false;
         }
@@ -286,27 +324,34 @@ struct WCUpdateInfo {
 namespace WTF {
 
 template<> struct EnumTraits<WebKit::WCLayerChange> {
-    using values = EnumValues<
-        WebKit::WCLayerChange,
+    using values = EnumValues < WebKit::WCLayerChange,
         WebKit::WCLayerChange::Children,
         WebKit::WCLayerChange::MaskLayer,
         WebKit::WCLayerChange::ReplicaLayer,
-        WebKit::WCLayerChange::Geometry,
-        WebKit::WCLayerChange::Preserves3D,
+        WebKit::WCLayerChange::Position,
+        WebKit::WCLayerChange::AnchorPoint,
+        WebKit::WCLayerChange::Size,
+        WebKit::WCLayerChange::BoundsOrigin,
+        WebKit::WCLayerChange::MasksToBounds,
+        WebKit::WCLayerChange::ContentsRectClipsDescendants,
+        WebKit::WCLayerChange::ShowDebugBorder,
+        WebKit::WCLayerChange::ShowRepaintCounter,
         WebKit::WCLayerChange::ContentsVisible,
         WebKit::WCLayerChange::BackfaceVisibility,
-        WebKit::WCLayerChange::MasksToBounds,
+        WebKit::WCLayerChange::Preserves3D,
         WebKit::WCLayerChange::SolidColor,
-        WebKit::WCLayerChange::DebugVisuals,
+        WebKit::WCLayerChange::DebugBorderColor,
+        WebKit::WCLayerChange::Opacity,
+        WebKit::WCLayerChange::DebugBorderWidth,
         WebKit::WCLayerChange::RepaintCount,
         WebKit::WCLayerChange::ContentsRect,
-        WebKit::WCLayerChange::ContentsClippingRect,
-        WebKit::WCLayerChange::Opacity,
         WebKit::WCLayerChange::Background,
         WebKit::WCLayerChange::Transform,
         WebKit::WCLayerChange::ChildrenTransform,
         WebKit::WCLayerChange::Filters,
         WebKit::WCLayerChange::BackdropFilters,
+        WebKit::WCLayerChange::BackdropFiltersRect,
+        WebKit::WCLayerChange::ContentsClippingRect,
         WebKit::WCLayerChange::PlatformLayer,
         WebKit::WCLayerChange::RemoteFrame
     >;


### PR DESCRIPTION
#### 5792a94c10c278d6dc441828444b1a585f41553d
<pre>
Add more WCLayerChange flags for individual WCLayerUpdateInfo members
<a href="https://bugs.webkit.org/show_bug.cgi?id=268119">https://bugs.webkit.org/show_bug.cgi?id=268119</a>

Reviewed by Don Olmstead.

For the new serializer generator, it should have individual change
flags for layer properties.

* Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp:
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h:
* Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h:

Canonical link: <a href="https://commits.webkit.org/273604@main">https://commits.webkit.org/273604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/822b7c638de91735ef6cbd8375c56d93d8effa4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38723 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32386 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11980 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31105 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11091 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39971 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/32712 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32483 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37055 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11273 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9185 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35139 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13015 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4664 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12111 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->