### PR TITLE
MathML does not always handle positioned objects correctly

### DIFF
--- a/LayoutTests/mathml/operator-append-fixed-container-svg-crash-expected.txt
+++ b/LayoutTests/mathml/operator-append-fixed-container-svg-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/mathml/operator-append-fixed-container-svg-crash.html
+++ b/LayoutTests/mathml/operator-append-fixed-container-svg-crash.html
@@ -1,0 +1,21 @@
+<script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+function runTest() {
+    mathElement.appendChild(svgElement);
+    result = pathElement.isPointInFill(svgElement);
+    document.write("This test passes if it does not crash.");
+}
+</script>
+<body onload=runTest()>
+  <svg id="svgElement" style="position: fixed">
+    <path id="pathElement">
+  </svg>
+  <object>
+    <math>
+      <mfrac>
+        <mo id="mathElement" style="translate: 0px">-</mo>
+      </mfrac>
+    </math>
+  </object>
+</body>

--- a/LayoutTests/mathml/token-append-fixed-container-svg-crash-expected.txt
+++ b/LayoutTests/mathml/token-append-fixed-container-svg-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/mathml/token-append-fixed-container-svg-crash.html
+++ b/LayoutTests/mathml/token-append-fixed-container-svg-crash.html
@@ -1,0 +1,21 @@
+<script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+function runTest() {
+    mathElement.appendChild(svgElement);
+    result = pathElement.isPointInFill(svgElement);
+    document.write("This test passes if it does not crash.");
+}
+</script>
+<body onload=runTest()>
+  <svg id="svgElement" style="position: fixed">
+    <path id="pathElement">
+  </svg>
+  <object>
+    <math>
+      <mfrac>
+        <mi id="mathElement" style="translate: 0px">&pi;</mi>
+      </mfrac>
+    </math>
+  </object>
+</body>

--- a/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
@@ -231,6 +231,8 @@ void RenderMathMLOperator::layoutBlock(bool relayoutChildren, LayoutUnit pageLog
             child->layoutIfNeeded();
         setLogicalWidth(leadingSpaceValue + m_mathOperator.width() + trailingSpaceValue);
         setLogicalHeight(m_mathOperator.ascent() + m_mathOperator.descent());
+
+        layoutPositionedObjects(relayoutChildren);
     } else {
         // We first do the normal layout without spacing.
         recomputeLogicalWidth();

--- a/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
@@ -594,6 +594,8 @@ void RenderMathMLToken::layoutBlock(bool relayoutChildren, LayoutUnit pageLogica
     setLogicalWidth(LayoutUnit(mathVariantGlyph.font->widthForGlyph(mathVariantGlyph.glyph)));
     setLogicalHeight(LayoutUnit(mathVariantGlyph.font->boundsForGlyph(mathVariantGlyph.glyph).height()));
 
+    layoutPositionedObjects(relayoutChildren);
+
     updateScrollInfoAfterLayout();
 
     clearNeedsLayout();


### PR DESCRIPTION
#### bfb351d566adfd5ce86790787dc63a31c70ed041
<pre>
MathML does not always handle positioned objects correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=264636">https://bugs.webkit.org/show_bug.cgi?id=264636</a>
<a href="https://rdar.apple.com/116448289">rdar://116448289</a>

Reviewed by Alan Baradlay.

For mo/mi elements positioned objects are not laid out at all so in this
case after layout the tree is still dirty. Fix this by calling layoutPositionedObjects
for tokens and operators.

* LayoutTests/mathml/operator-append-fixed-container-svg-crash-expected.txt: Added.
* LayoutTests/mathml/operator-append-fixed-container-svg-crash.html: Added.
* LayoutTests/mathml/token-append-fixed-container-svg-crash-expected.txt: Added.
* LayoutTests/mathml/token-append-fixed-container-svg-crash.html: Added.
* Source/WTF/wtf/Assertions.cpp:
* Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp:
(WebCore::RenderMathMLOperator::layoutBlock):
* Source/WebCore/rendering/mathml/RenderMathMLToken.cpp:
(WebCore::RenderMathMLToken::layoutBlock):

Originally-landed-as: 270734.4@webkit-2023.11-embargoed (f765915efb81). <a href="https://rdar.apple.com/121480773">rdar://121480773</a>
Canonical link: <a href="https://commits.webkit.org/273555@main">https://commits.webkit.org/273555@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5493b697b94a3cd0bb9fe88e65075107ef357b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38457 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32163 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30934 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10892 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10926 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39706 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32497 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36846 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8977 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34929 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31625 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8157 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11588 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11888 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->