### PR TITLE
[Site Isolation] Begin implementing window.blur()

### DIFF
--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -86,7 +86,9 @@ void RemoteDOMWindow::focus(LocalDOMWindow&)
 
 void RemoteDOMWindow::blur()
 {
-    // FIXME: Implemented this. <rdar://116203970>
+    // FIXME(268121): Add security checks here equivalent to LocalDOMWindow::blur().
+    if (m_frame && m_frame->isMainFrame())
+        m_frame->client().unfocus();
 }
 
 unsigned RemoteDOMWindow::length() const

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -49,6 +49,7 @@ public:
     virtual void broadcastFrameRemovalToOtherProcesses() = 0;
     virtual void close() = 0;
     virtual void focus() = 0;
+    virtual void unfocus() = 0;
     virtual ~RemoteFrameClient() { }
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -114,6 +114,12 @@ void WebRemoteFrameClient::focus()
         page->send(Messages::WebPageProxy::FocusRemoteFrame(m_frame->frameID()));
 }
 
+void WebRemoteFrameClient::unfocus()
+{
+    if (auto* page = m_frame->page())
+        page->send(Messages::WebPageProxy::SetFocus(false));
+}
+
 void WebRemoteFrameClient::dispatchDecidePolicyForNavigationAction(const NavigationAction& navigationAction, const ResourceRequest& request, const ResourceResponse& redirectResponse,
     FormState* formState, const String& clientRedirectSourceForHistory, uint64_t navigationID, std::optional<HitTestResult>&& hitTestResult, bool hasOpener, SandboxFlags sandboxFlags, PolicyDecisionMode policyDecisionMode, FramePolicyFunction&& function)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -51,6 +51,7 @@ private:
     void broadcastFrameRemovalToOtherProcesses() final;
     void close() final;
     void focus() final;
+    void unfocus() final;
     void dispatchDecidePolicyForNavigationAction(const WebCore::NavigationAction&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& redirectResponse, WebCore::FormState*, const String& clientRedirectSourceForHistory, uint64_t navigationID, std::optional<WebCore::HitTestResult>&&, bool hasOpener, WebCore::SandboxFlags, WebCore::PolicyDecisionMode, WebCore::FramePolicyFunction&&) final;
 
     ScopeExit<Function<void()>> m_frameInvalidator;

--- a/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
@@ -37,6 +37,7 @@
 #endif
 @property (nonatomic, copy) void (^saveDataToFile)(WKWebView *, NSData *, NSString *, NSString *, NSURL *);
 @property (nonatomic, copy) void (^focusWebView)(WKWebView *);
+@property (nonatomic, copy) void (^unfocusWebView)(WKWebView *);
 @property (nonatomic, copy) void (^webViewDidClose)(WKWebView *);
 
 - (NSString *)waitForAlert;

--- a/Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm
@@ -87,6 +87,12 @@
     if (_focusWebView)
         _focusWebView(webView);
 }
+
+- (void)_unfocusWebView:(WKWebView *)webView
+{
+    if (_unfocusWebView)
+        _unfocusWebView(webView);
+}
 #endif // PLATFORM(MAC)
 
 - (void)webViewDidClose:(WKWebView *)webView


### PR DESCRIPTION
#### afeef8f88df4278d339cba9b2ffb444f0a349cc1
<pre>
[Site Isolation] Begin implementing window.blur()
<a href="https://bugs.webkit.org/show_bug.cgi?id=268122">https://bugs.webkit.org/show_bug.cgi?id=268122</a>
<a href="https://rdar.apple.com/121629787">rdar://121629787</a>

Reviewed by Alex Christensen.

window.blur() won&apos;t remove focus from the frame in the web process, so we just need to call
`WebPageProxy::setFocus()` and verify the delegate is called.

* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::blur):
* Source/WebCore/page/RemoteFrameClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::unfocus):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/TestUIDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm:
(-[TestUIDelegate _unfocusWebView:]):

Canonical link: <a href="https://commits.webkit.org/273549@main">https://commits.webkit.org/273549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8efc3255d38fee515bf8f979ccad7b4b2cfec5d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35791 "Failed to checkout and rebase branch from PR 23269") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14734 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38516 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37009 "Failed to checkout and rebase branch from PR 23269") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11758 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/30965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36345 "Failed to checkout and rebase branch from PR 23269") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/12437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/10937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/10928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/31986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39763 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/32502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/32308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/34971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4639 "Built successfully and passed tests") | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11943 "Failed to checkout and rebase branch from PR 23269") | | | 
<!--EWS-Status-Bubble-End-->