### PR TITLE
Cross-origin <embed> elements can request media permission, and prompts show main-frame URL

### DIFF
--- a/LayoutTests/fullscreen/full-screen-enabled-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-enabled-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin '' and allow attribute 'fullscreen 'none''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin '' and allow attribute 'fullscreen 'none''.
 This tests the fullscreenEnabled property laid out in section 4 of the W3C Full Screen API
 EXPECTED (iframe.contentDocument.webkitFullscreenEnabled == 'true') OK
 EXPECTED (iframe2.contentDocument.webkitFullscreenEnabled == 'false') OK

--- a/LayoutTests/fullscreen/full-screen-enabled-prefixed-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-enabled-prefixed-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin '' and allow attribute 'fullscreen 'none''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin '' and allow attribute 'fullscreen 'none''.
 This tests the fullscreenEnabled property laid out in section 4 of the W3C Full Screen API
 EXPECTED (iframe.contentDocument.webkitFullscreenEnabled == 'true') OK
 EXPECTED (iframe2.contentDocument.webkitFullscreenEnabled == 'false') OK

--- a/LayoutTests/fullscreen/full-screen-iframe-not-allowed-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-iframe-not-allowed-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin '' and allow attribute 'fullscreen 'none''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin '' and allow attribute 'fullscreen 'none''.
 Test for bug 56264: Handle entering full screen security restrictions
 
 To test manually, click the "Go full screen" button - the page should not enter full screen mode.

--- a/LayoutTests/fullscreen/full-screen-iframe-without-allow-attribute-allowed-from-parent-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-iframe-without-allow-attribute-allowed-from-parent-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin 'null' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin 'null' and allow attribute ''.
 Test entering full screen security restrictions. An iframe without an allow attribute is still permitted to fullscreen if the request comes from the containing document.
 
 To test manually, press any key - the page should enter full screen mode.

--- a/LayoutTests/fullscreen/full-screen-restrictions-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-restrictions-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin '' and allow attribute 'fullscreen 'none''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin '' and allow attribute 'fullscreen 'none''.
 This tests the restrictions to entering full screen mode laid out in section 4.1 of the W3C Full Screen API
 "The context object is not in a document."
 EVENT(webkitfullscreenerror)

--- a/LayoutTests/http/tests/fullscreen/fullscreen-feature-policy-expected.txt
+++ b/LayoutTests/http/tests/fullscreen/fullscreen-feature-policy-expected.txt
@@ -1,14 +1,14 @@
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin 'http://localhost:8000' and allow attribute ''.
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin 'http://localhost:8000' and allow attribute 'fullscreen 'none''.
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin 'http://127.0.0.1:8000' and allow attribute 'fullscreen 'none''.
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin 'http://localhost:8000' and allow attribute 'fullscreen 'self''.
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin 'http://127.0.0.1:8000' and allow attribute 'fullscreen http://localhost:8000'.
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin 'http://localhost:8000' and allow attribute 'fullscreen 'none''.
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin 'http://127.0.0.1:8000' and allow attribute 'fullscreen 'none''.
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin 'http://localhost:8000' and allow attribute 'fullscreen 'self''.
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin 'http://localhost:8000' and allow attribute 'fullscreen 'none''.
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin 'http://127.0.0.1:8000' and allow attribute 'fullscreen 'none''.
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin 'http://localhost:8000' and allow attribute 'fullscreen 'self''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin 'http://localhost:8000' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin 'http://localhost:8000' and allow attribute 'fullscreen 'none''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin 'http://127.0.0.1:8000' and allow attribute 'fullscreen 'none''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin 'http://localhost:8000' and allow attribute 'fullscreen 'self''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin 'http://127.0.0.1:8000' and allow attribute 'fullscreen http://localhost:8000'.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin 'http://localhost:8000' and allow attribute 'fullscreen 'none''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin 'http://127.0.0.1:8000' and allow attribute 'fullscreen 'none''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin 'http://localhost:8000' and allow attribute 'fullscreen 'self''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin 'http://localhost:8000' and allow attribute 'fullscreen 'none''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin 'http://127.0.0.1:8000' and allow attribute 'fullscreen 'none''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin 'http://localhost:8000' and allow attribute 'fullscreen 'self''.
 PASS iframe with src="http://loc..." should have document.webkitFullscreenEnabled === false.
 PASS iframe with src="../resourc..." should have document.webkitFullscreenEnabled === true.
 PASS iframe with allow="fullscreen", src="http://loc..." should have document.webkitFullscreenEnabled === true.

--- a/LayoutTests/http/tests/gamepad/gamepad-allow-attribute.https-expected.txt
+++ b/LayoutTests/http/tests/gamepad/gamepad-allow-attribute.https-expected.txt
@@ -1,7 +1,7 @@
-CONSOLE MESSAGE: Feature policy 'Gamepad' check failed for iframe with origin 'https://localhost:8443' and allow attribute 'gamepad 'none''.
-CONSOLE MESSAGE: Feature policy 'Gamepad' check failed for iframe with origin 'https://127.0.0.1:8443' and allow attribute 'gamepad 'none''.
-CONSOLE MESSAGE: Feature policy 'Gamepad' check failed for iframe with origin 'https://localhost:8443' and allow attribute 'gamepad 'self''.
-CONSOLE MESSAGE: Feature policy 'Gamepad' check failed for iframe with origin 'https://127.0.0.1:8443' and allow attribute 'gamepad https://localhost:8443'.
+CONSOLE MESSAGE: Feature policy 'Gamepad' check failed for element with origin 'https://localhost:8443' and allow attribute 'gamepad 'none''.
+CONSOLE MESSAGE: Feature policy 'Gamepad' check failed for element with origin 'https://127.0.0.1:8443' and allow attribute 'gamepad 'none''.
+CONSOLE MESSAGE: Feature policy 'Gamepad' check failed for element with origin 'https://localhost:8443' and allow attribute 'gamepad 'self''.
+CONSOLE MESSAGE: Feature policy 'Gamepad' check failed for element with origin 'https://127.0.0.1:8443' and allow attribute 'gamepad https://localhost:8443'.
 PASS iframe src: "https://localhost:8443/gamepad/resources/gamepad-postmessage.html" with allow="" is allowed to call getGamepads().
 PASS iframe src: "https://127.0.0.1:8443/gamepad/resources/gamepad-postmessage.html" with allow="" is allowed to call getGamepads().
 PASS iframe src: "https://localhost:8443/gamepad/resources/gamepad-postmessage.html" with allow="gamepad" is allowed to call getGamepads().

--- a/LayoutTests/http/tests/media/media-stream/enumerate-devices-iframe-allow-attribute-expected.txt
+++ b/LayoutTests/http/tests/media/media-stream/enumerate-devices-iframe-allow-attribute-expected.txt
@@ -1,21 +1,21 @@
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'http://localhost:8000' and allow attribute ''.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'http://localhost:8000' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'http://localhost:8000' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'http://localhost:8000' and allow attribute ''.
 CONSOLE MESSAGE: Not allowed to call enumerateDevices.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'http://localhost:8000' and allow attribute ''.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'http://localhost:8000' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'http://localhost:8000' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'http://localhost:8000' and allow attribute ''.
 CONSOLE MESSAGE: Not allowed to call enumerateDevices.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'http://localhost:8000' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'http://localhost:8000' and allow attribute ''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'http://localhost:8000' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'http://localhost:8000' and allow attribute ''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'http://localhost:8000' and allow attribute ''.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'http://localhost:8000' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'http://localhost:8000' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'http://localhost:8000' and allow attribute ''.
 CONSOLE MESSAGE: Not allowed to call enumerateDevices.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'http://localhost:8000' and allow attribute 'microphone'.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'http://localhost:8000' and allow attribute 'microphone'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'http://localhost:8000' and allow attribute 'camera'.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'http://localhost:8000' and allow attribute 'camera'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'http://localhost:8000' and allow attribute 'microphone;speaker-selection'.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'http://localhost:8000' and allow attribute 'microphone;speaker-selection'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
 
 

--- a/LayoutTests/http/tests/media/media-stream/get-user-media-in-embed-element-expected.txt
+++ b/LayoutTests/http/tests/media/media-stream/get-user-media-in-embed-element-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'http://localhost:8000' and allow attribute ''.
+CONSOLE MESSAGE: Not allowed to call getUserMedia.
+
+
+PASS Same origin embed should get access to camera
+PASS Cross origin embed should not get access to camera
+

--- a/LayoutTests/http/tests/media/media-stream/get-user-media-in-embed-element.html
+++ b/LayoutTests/http/tests/media/media-stream/get-user-media-in-embed-element.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+    <div id="testDiv"></div>
+
+    <script>
+promise_test(async t => {
+    testDiv.innerHTML = '<embed id="embedElement" src="resources/get-user-media-embed.html"></embed>';
+    const result = await new Promise(resolve => window.onmessage = e => resolve(e.data));
+    assert_equals(result, "OK");
+}, "Same origin embed should get access to camera");
+
+promise_test(async t => {
+    testDiv.innerHTML = '<embed id="embedElement" src="http://localhost:8000/media/media-stream/resources/get-user-media-embed.html"></embed>';
+    const result = await new Promise(resolve => window.onmessage = e => resolve(e.data));
+    assert_equals(result, "KO");
+}, "Cross origin embed should not get access to camera");
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/tests/media/media-stream/resources/get-user-media-embed.html
+++ b/LayoutTests/http/tests/media/media-stream/resources/get-user-media-embed.html
@@ -1,0 +1,9 @@
+<script>
+onload = () => {
+    navigator.mediaDevices.getUserMedia({ video: true }).then(() => {
+        parent.postMessage("OK", "*");
+    }, () => {
+        parent.postMessage("KO", "*");
+    });
+}
+</script>

--- a/LayoutTests/http/tests/paymentrequest/payment-allow-attribute.https-expected.txt
+++ b/LayoutTests/http/tests/paymentrequest/payment-allow-attribute.https-expected.txt
@@ -1,8 +1,8 @@
-CONSOLE MESSAGE: Feature policy 'Payment' check failed for iframe with origin 'https://localhost:8443' and allow attribute ''.
-CONSOLE MESSAGE: Feature policy 'Payment' check failed for iframe with origin 'https://localhost:8443' and allow attribute 'payment 'none''.
-CONSOLE MESSAGE: Feature policy 'Payment' check failed for iframe with origin 'https://127.0.0.1:8443' and allow attribute 'payment 'none''.
-CONSOLE MESSAGE: Feature policy 'Payment' check failed for iframe with origin 'https://localhost:8443' and allow attribute 'payment 'self''.
-CONSOLE MESSAGE: Feature policy 'Payment' check failed for iframe with origin 'https://127.0.0.1:8443' and allow attribute 'payment https://localhost:8443'.
+CONSOLE MESSAGE: Feature policy 'Payment' check failed for element with origin 'https://localhost:8443' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Payment' check failed for element with origin 'https://localhost:8443' and allow attribute 'payment 'none''.
+CONSOLE MESSAGE: Feature policy 'Payment' check failed for element with origin 'https://127.0.0.1:8443' and allow attribute 'payment 'none''.
+CONSOLE MESSAGE: Feature policy 'Payment' check failed for element with origin 'https://localhost:8443' and allow attribute 'payment 'self''.
+CONSOLE MESSAGE: Feature policy 'Payment' check failed for element with origin 'https://127.0.0.1:8443' and allow attribute 'payment https://localhost:8443'.
 PASS iframe src: "https://localhost:8443/paymentrequest/resources/payment-postmessage.html" with allow="" MUST NOT create a PaymentRequest. SecurityError Third-party iframes are not allowed to request payments unless explicitly allowed via Feature-Policy (payment)
 PASS iframe src: "https://127.0.0.1:8443/paymentrequest/resources/payment-postmessage.html" with allow="" is allowed to create a PaymentRequest.
 PASS iframe src: "https://localhost:8443/paymentrequest/resources/payment-postmessage.html" with allow="payment" is allowed to create a PaymentRequest.

--- a/LayoutTests/http/tests/security/sandboxed-iframe-geolocation-getCurrentPosition-expected.txt
+++ b/LayoutTests/http/tests/security/sandboxed-iframe-geolocation-getCurrentPosition-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for iframe with origin 'null' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'null' and allow attribute ''.
 Tests that navigator.geolocation.getCurrentPosition() returns error PERMISSION_DENIED when called from a document in a sandboxed iframe.
 
 

--- a/LayoutTests/http/tests/security/sandboxed-iframe-geolocation-watchPosition-expected.txt
+++ b/LayoutTests/http/tests/security/sandboxed-iframe-geolocation-watchPosition-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for iframe with origin 'null' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Geolocation' check failed for element with origin 'null' and allow attribute ''.
 Tests that navigator.geolocation.watchPosition() returns error PERMISSION_DENIED when called from a document in a sandboxed iframe.
 
 

--- a/LayoutTests/http/tests/ssl/media-stream/get-user-media-different-host-expected.txt
+++ b/LayoutTests/http/tests/ssl/media-stream/get-user-media-different-host-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://localhost:8443' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://localhost:8443' and allow attribute ''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
 Tests that getUserMedia fails when the top level document and iframe do not have the same domain.
 

--- a/LayoutTests/http/tests/ssl/media-stream/get-user-media-nested-expected.txt
+++ b/LayoutTests/http/tests/ssl/media-stream/get-user-media-nested-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://localhost:8443' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://localhost:8443' and allow attribute ''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
 Tests that getUserMedia fails when the top level document and iframe do not have the same domain.
 

--- a/LayoutTests/http/tests/webrtc/enumerateDevicesInFrames-expected.txt
+++ b/LayoutTests/http/tests/webrtc/enumerateDevicesInFrames-expected.txt
@@ -1,5 +1,5 @@
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'http://127.0.0.1:8000' and allow attribute 'microphone:'none'; camera:'none''.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'http://127.0.0.1:8000' and allow attribute 'microphone:'none'; camera:'none''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'http://127.0.0.1:8000' and allow attribute 'microphone:'none'; camera:'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'http://127.0.0.1:8000' and allow attribute 'microphone:'none'; camera:'none''.
 CONSOLE MESSAGE: Not allowed to call enumerateDevices.
 
 

--- a/LayoutTests/http/tests/webshare/webshare-allow-attribute-canShare.https-expected.txt
+++ b/LayoutTests/http/tests/webshare/webshare-allow-attribute-canShare.https-expected.txt
@@ -1,8 +1,8 @@
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://localhost:8443' and allow attribute ''.
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://localhost:8443' and allow attribute 'web-share 'none''.
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://127.0.0.1:8443' and allow attribute 'web-share 'none''.
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://localhost:8443' and allow attribute 'web-share 'self''.
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://127.0.0.1:8443' and allow attribute 'web-share https://localhost:8443'.
+CONSOLE MESSAGE: Feature policy 'WebShare' check failed for element with origin 'https://localhost:8443' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'WebShare' check failed for element with origin 'https://localhost:8443' and allow attribute 'web-share 'none''.
+CONSOLE MESSAGE: Feature policy 'WebShare' check failed for element with origin 'https://127.0.0.1:8443' and allow attribute 'web-share 'none''.
+CONSOLE MESSAGE: Feature policy 'WebShare' check failed for element with origin 'https://localhost:8443' and allow attribute 'web-share 'self''.
+CONSOLE MESSAGE: Feature policy 'WebShare' check failed for element with origin 'https://127.0.0.1:8443' and allow attribute 'web-share https://localhost:8443'.
 PASS iframe src: "https://localhost:8443/webshare/resources/webshare-postmessage.html" with allow="" MUST NOT be allowed to call canShare().
 PASS iframe src: "https://127.0.0.1:8443/webshare/resources/webshare-postmessage.html" with allow="" is allowed to call canShare().
 PASS iframe src: "https://localhost:8443/webshare/resources/webshare-postmessage.html" with allow="web-share" is allowed to call canShare().

--- a/LayoutTests/http/tests/webshare/webshare-allow-attribute-share.https-expected.txt
+++ b/LayoutTests/http/tests/webshare/webshare-allow-attribute-share.https-expected.txt
@@ -1,8 +1,8 @@
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://localhost:8443' and allow attribute ''.
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://localhost:8443' and allow attribute 'web-share 'none''.
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://127.0.0.1:8443' and allow attribute 'web-share 'none''.
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://localhost:8443' and allow attribute 'web-share 'self''.
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://127.0.0.1:8443' and allow attribute 'web-share https://localhost:8443'.
+CONSOLE MESSAGE: Feature policy 'WebShare' check failed for element with origin 'https://localhost:8443' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'WebShare' check failed for element with origin 'https://localhost:8443' and allow attribute 'web-share 'none''.
+CONSOLE MESSAGE: Feature policy 'WebShare' check failed for element with origin 'https://127.0.0.1:8443' and allow attribute 'web-share 'none''.
+CONSOLE MESSAGE: Feature policy 'WebShare' check failed for element with origin 'https://localhost:8443' and allow attribute 'web-share 'self''.
+CONSOLE MESSAGE: Feature policy 'WebShare' check failed for element with origin 'https://127.0.0.1:8443' and allow attribute 'web-share https://localhost:8443'.
 PASS iframe src: "https://localhost:8443/webshare/resources/webshare-postmessage.html" with allow="" MUST NOT be allowed to call share(). NotAllowedError Third-party iframes are not allowed to call share() unless explicitly allowed via Feature-Policy (web-share)
 PASS iframe src: "https://127.0.0.1:8443/webshare/resources/webshare-postmessage.html" with allow="" is allowed to call share().
 PASS iframe src: "https://localhost:8443/webshare/resources/webshare-postmessage.html" with allow="web-share" is allowed to call share().

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-allow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-allow-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin 'null' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin 'null' and allow attribute ''.
 
 FAIL iframe-cross-origin-allow assert_false: Feature should be denied when correct allow attribute is added, before reload expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-allowfullscreen-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-allowfullscreen-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for iframe with origin 'null' and allow attribute ''.
+CONSOLE MESSAGE: Feature policy 'Fullscreen' check failed for element with origin 'null' and allow attribute ''.
 
 PASS iframe-same-origin-allowfullscreen
 FAIL iframe-cross-origin-allowfullscreen assert_false: Fullscreen should be denied when allowfullscreen attribute is added, before reload expected false got true

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-feature-policy-none.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-feature-policy-none.https-expected.txt
@@ -1,58 +1,58 @@
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'camera 'none''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://localhost:9443' and allow attribute 'camera 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'camera 'none''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://localhost:9443' and allow attribute 'camera 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute 'camera 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute 'camera 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute 'camera 'none''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute 'camera 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute 'camera 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute 'camera 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'microphone 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://localhost:9443' and allow attribute 'microphone 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'microphone 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://localhost:9443' and allow attribute 'microphone 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'microphone 'none';camera 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://localhost:9443' and allow attribute 'microphone 'none';camera 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'microphone 'none';camera 'none''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://localhost:9443' and allow attribute 'microphone 'none';camera 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'microphone 'none';camera 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://localhost:9443' and allow attribute 'microphone 'none';camera 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'camera *;microphone 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://localhost:9443' and allow attribute 'camera *;microphone 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'camera *;microphone 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://localhost:9443' and allow attribute 'camera *;microphone 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute 'camera *;microphone 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute 'camera *;microphone 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute 'camera *;microphone 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute 'camera *;microphone 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'camera 'none';microphone *'.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://localhost:9443' and allow attribute 'camera 'none';microphone *'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'camera 'none';microphone *'.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://localhost:9443' and allow attribute 'camera 'none';microphone *'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'microphone *; microphone 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://localhost:9443' and allow attribute 'microphone *; microphone 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'microphone *; microphone 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://localhost:9443' and allow attribute 'microphone *; microphone 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute 'microphone *; camera 'self''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute 'microphone *; camera 'self''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute 'microphone *; camera 'self''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute 'microphone *; camera 'self''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'microphone *; camera http:/example.org self'.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://localhost:9443' and allow attribute 'microphone *; camera http:/example.org self'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'microphone *; camera http:/example.org self'.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://localhost:9443' and allow attribute 'microphone *; camera http:/example.org self'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute 'microphone *; camera http:/example.org 'self''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute 'microphone *; camera http:/example.org 'self''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute 'microphone *; camera http:/example.org 'self''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute 'microphone *; camera http:/example.org 'self''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'microphone https://127.0.0.1:9443'.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://localhost:9443' and allow attribute 'microphone https://127.0.0.1:9443'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'microphone https://127.0.0.1:9443'.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://localhost:9443' and allow attribute 'microphone https://127.0.0.1:9443'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute 'microphone https://127.0.0.1:9443'.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute 'microphone https://127.0.0.1:9443'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute 'microphone https://127.0.0.1:9443'.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute 'microphone https://127.0.0.1:9443'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
 
 PASS "camera 'none'" - same origin iframe

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'Payment' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute ';payment'.
+CONSOLE MESSAGE: Feature policy 'Payment' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ';payment'.
 
 PASS permissions policy allow="payment" allows same-origin navigation in an iframe.
 PASS permissions policy allow="payment" disallows cross-origin navigation in an iframe.

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'ScreenWakeLock' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute ';screen-wake-lock'.
+CONSOLE MESSAGE: Feature policy 'ScreenWakeLock' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute ';screen-wake-lock'.
 
 PASS Feature-Policy allow="screen-wake-lock" allows same-origin relocation
 PASS Feature-Policy allow="screen-wake-lock" disallows cross-origin relocation

--- a/LayoutTests/imported/w3c/web-platform-tests/web-share/disabled-by-permissions-policy-cross-origin.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-share/disabled-by-permissions-policy-cross-origin.https.sub-expected.txt
@@ -1,8 +1,8 @@
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute 'undefined'.
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute 'web-share=()'.
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute 'web-share=(self)'.
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute 'undefined'.
-CONSOLE MESSAGE: Feature policy 'WebShare' check failed for iframe with origin 'https://localhost:9443' and allow attribute 'web-share=(self)'.
+CONSOLE MESSAGE: Feature policy 'WebShare' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute 'undefined'.
+CONSOLE MESSAGE: Feature policy 'WebShare' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute 'web-share=()'.
+CONSOLE MESSAGE: Feature policy 'WebShare' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute 'web-share=(self)'.
+CONSOLE MESSAGE: Feature policy 'WebShare' check failed for element with origin 'https://127.0.0.1:9443' and allow attribute 'undefined'.
+CONSOLE MESSAGE: Feature policy 'WebShare' check failed for element with origin 'https://localhost:9443' and allow attribute 'web-share=(self)'.
 
 PASS share() is disabled by default 'self' by permissions policy for cross-origin iframes
 PASS share() is disabled explicitly by permissions policy for cross-origin iframe

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-feature-policy-none.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-feature-policy-none.https-expected.txt
@@ -1,58 +1,58 @@
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'camera 'none''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'camera 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'camera 'none''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'camera 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://www1.web-platform.test:9443' and allow attribute 'camera 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://www1.web-platform.test:9443' and allow attribute 'camera 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://www1.web-platform.test:9443' and allow attribute 'camera 'none''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://www1.web-platform.test:9443' and allow attribute 'camera 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://www1.web-platform.test:9443' and allow attribute 'camera 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://www1.web-platform.test:9443' and allow attribute 'camera 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'microphone 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'microphone 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'microphone 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'microphone 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'microphone 'none';camera 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'microphone 'none';camera 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'microphone 'none';camera 'none''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'microphone 'none';camera 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'microphone 'none';camera 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'microphone 'none';camera 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'camera *;microphone 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'camera *;microphone 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'camera *;microphone 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'camera *;microphone 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://www1.web-platform.test:9443' and allow attribute 'camera *;microphone 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://www1.web-platform.test:9443' and allow attribute 'camera *;microphone 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://www1.web-platform.test:9443' and allow attribute 'camera *;microphone 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://www1.web-platform.test:9443' and allow attribute 'camera *;microphone 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'camera 'none';microphone *'.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'camera 'none';microphone *'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'camera 'none';microphone *'.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'camera 'none';microphone *'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'microphone *; microphone 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'microphone *; microphone 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'microphone *; microphone 'none''.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'microphone *; microphone 'none''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://www1.web-platform.test:9443' and allow attribute 'microphone *; camera 'self''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://www1.web-platform.test:9443' and allow attribute 'microphone *; camera 'self''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://www1.web-platform.test:9443' and allow attribute 'microphone *; camera 'self''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://www1.web-platform.test:9443' and allow attribute 'microphone *; camera 'self''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'microphone *; camera http:/example.org self'.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'microphone *; camera http:/example.org self'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'microphone *; camera http:/example.org self'.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'microphone *; camera http:/example.org self'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://www1.web-platform.test:9443' and allow attribute 'microphone *; camera http:/example.org 'self''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://www1.web-platform.test:9443' and allow attribute 'microphone *; camera http:/example.org 'self''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://www1.web-platform.test:9443' and allow attribute 'microphone *; camera http:/example.org 'self''.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://www1.web-platform.test:9443' and allow attribute 'microphone *; camera http:/example.org 'self''.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'microphone https://www1.web-platform.test:9443'.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'microphone https://www1.web-platform.test:9443'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Microphone' check failed for iframe with origin 'https://web-platform.test:9443' and allow attribute 'microphone https://www1.web-platform.test:9443'.
+CONSOLE MESSAGE: Feature policy 'Microphone' check failed for element with origin 'https://web-platform.test:9443' and allow attribute 'microphone https://www1.web-platform.test:9443'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://www1.web-platform.test:9443' and allow attribute 'microphone https://www1.web-platform.test:9443'.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://www1.web-platform.test:9443' and allow attribute 'microphone https://www1.web-platform.test:9443'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
-CONSOLE MESSAGE: Feature policy 'Camera' check failed for iframe with origin 'https://www1.web-platform.test:9443' and allow attribute 'microphone https://www1.web-platform.test:9443'.
+CONSOLE MESSAGE: Feature policy 'Camera' check failed for element with origin 'https://www1.web-platform.test:9443' and allow attribute 'microphone https://www1.web-platform.test:9443'.
 CONSOLE MESSAGE: Not allowed to call getUserMedia.
 
 PASS "camera 'none'" - same origin iframe

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Feature policy 'ScreenWakeLock' check failed for iframe with origin 'https://www1.web-platform.test:9443' and allow attribute ';screen-wake-lock'.
+CONSOLE MESSAGE: Feature policy 'ScreenWakeLock' check failed for element with origin 'https://www1.web-platform.test:9443' and allow attribute ';screen-wake-lock'.
 
 PASS Feature-Policy allow="screen-wake-lock" allows same-origin relocation
 PASS Feature-Policy allow="screen-wake-lock" disallows cross-origin relocation

--- a/Source/WebCore/html/FeaturePolicy.h
+++ b/Source/WebCore/html/FeaturePolicy.h
@@ -36,7 +36,8 @@ class HTMLIFrameElement;
 
 class FeaturePolicy {
 public:
-    static FeaturePolicy parse(Document&, const HTMLIFrameElement&, StringView);
+    static FeaturePolicy defaultPolicy(Document& document) { return parse(document, nullptr, { }); }
+    static FeaturePolicy parse(Document& document, const HTMLIFrameElement& frame, StringView allow) { return parse(document, &frame, allow); }
 
     enum class Type {
         Camera,
@@ -72,6 +73,8 @@ public:
     };
 
 private:
+    static FeaturePolicy parse(Document&, const HTMLIFrameElement*, StringView);
+
     AllowRule m_cameraRule;
     AllowRule m_microphoneRule;
     AllowRule m_speakerSelectionRule;


### PR DESCRIPTION
#### 863558a77cbf5d2cf19869c6fb9884b6928dbbdf
<pre>
Cross-origin &lt;embed&gt; elements can request media permission, and prompts show main-frame URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=265812">https://bugs.webkit.org/show_bug.cgi?id=265812</a>
<a href="https://rdar.apple.com/119149318">rdar://119149318</a>

Reviewed by Chris Dumez.

We should apply feature policy for all elements, including embed and frame elements.
Since there are no allow attributes, we should use the default feature policy rules for those elements.
Update isFeaturePolicyAllowedByDocumentAndAllOwners accordingly.

Rebase tests according updated console log message.

* LayoutTests/fullscreen/full-screen-enabled-expected.txt:
* LayoutTests/fullscreen/full-screen-enabled-prefixed-expected.txt:
* LayoutTests/fullscreen/full-screen-iframe-not-allowed-expected.txt:
* LayoutTests/fullscreen/full-screen-iframe-without-allow-attribute-allowed-from-parent-expected.txt:
* LayoutTests/fullscreen/full-screen-restrictions-expected.txt:
* LayoutTests/http/tests/fullscreen/fullscreen-feature-policy-expected.txt:
* LayoutTests/http/tests/media/media-stream/enumerate-devices-iframe-allow-attribute-expected.txt:
* LayoutTests/http/tests/media/media-stream/get-user-media-in-embed-element-expected.txt: Added.
* LayoutTests/http/tests/media/media-stream/get-user-media-in-embed-element.html: Added.
* LayoutTests/http/tests/media/media-stream/resources/get-user-media-embed.html: Added.
* LayoutTests/http/tests/paymentrequest/payment-allow-attribute.https-expected.txt:
* LayoutTests/http/tests/security/sandboxed-iframe-geolocation-getCurrentPosition-expected.txt:
* LayoutTests/http/tests/security/sandboxed-iframe-geolocation-watchPosition-expected.txt:
* LayoutTests/http/tests/ssl/media-stream/get-user-media-different-host-expected.txt:
* LayoutTests/http/tests/ssl/media-stream/get-user-media-nested-expected.txt:
* LayoutTests/http/tests/webrtc/enumerateDevicesInFrames-expected.txt:
* LayoutTests/http/tests/webshare/webshare-allow-attribute-canShare.https-expected.txt:
* LayoutTests/http/tests/webshare/webshare-allow-attribute-share.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-allow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-allowfullscreen-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStream-feature-policy-none.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-share/disabled-by-permissions-policy-cross-origin.https.sub-expected.txt:
* Source/WebCore/html/FeaturePolicy.cpp:
(WebCore::isFeaturePolicyAllowedByDocumentAndAllOwners):
(WebCore::FeaturePolicy::parse):
* Source/WebCore/html/FeaturePolicy.h:
(WebCore::FeaturePolicy::defaultPolicy):
(WebCore::FeaturePolicy::parse):

Originally-landed-as: 267815.624@safari-7617-branch (0ad98b606305). <a href="https://rdar.apple.com/121480412">rdar://121480412</a>
Canonical link: <a href="https://commits.webkit.org/273753@main">https://commits.webkit.org/273753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8c80c597c2a6c6bac390d0135ad1c29f98fdbc3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39095 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32693 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37612 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31341 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11343 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40340 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32830 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37301 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11586 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9509 "Found 1 new test failure: http/tests/inspector/dom/didFireEvent.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35398 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32119 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8289 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12038 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12447 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->