### PR TITLE
Speedometer 3: Fix the overflow:scroll layerization on TodoMVC-React-Complex-DOM.

### DIFF
--- a/LayoutTests/compositing/shared-backing/overflow-scroll/nested-scroller-sharing-expected.txt
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/nested-scroller-sharing-expected.txt
@@ -6,7 +6,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 4
+      (children 3
         (GraphicsLayer
           (position 8.00 8.00)
           (bounds 784.00 422.00)
@@ -36,6 +36,7 @@
                               (offsetFromRenderer width=1 height=1)
                               (anchor 0.00 0.00)
                               (bounds 285.00 620.00)
+                              (drawsContent 1)
                             )
                           )
                         )
@@ -79,31 +80,6 @@
                   (bounds 100.00 100.00)
                   (contentsOpaque 1)
                   (drawsContent 1)
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 9.00 9.00)
-          (bounds 767.00 405.00)
-          (children 1
-            (GraphicsLayer
-              (children 1
-                (GraphicsLayer
-                  (position 11.00 131.00)
-                  (bounds 285.00 185.00)
-                  (children 1
-                    (GraphicsLayer
-                      (children 1
-                        (GraphicsLayer
-                          (position 10.00 10.00)
-                          (bounds 100.00 100.00)
-                          (contentsOpaque 1)
-                        )
-                      )
-                    )
-                  )
                 )
               )
             )

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-expected.txt
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 6
+      (children 4
         (GraphicsLayer
           (position 8.00 8.00)
           (bounds 302.00 202.00)
@@ -29,7 +29,7 @@
           (position 8.00 200.00)
           (bounds 302.00 202.00)
           (drawsContent 1)
-          (children 1
+          (children 2
             (GraphicsLayer
               (offsetFromRenderer width=1 height=1)
               (position 1.00 1.00)
@@ -39,6 +39,28 @@
                   (offsetFromRenderer width=1 height=1)
                   (anchor 0.00 0.00)
                   (bounds 285.00 620.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 300.00 200.00)
+              (children 3
+                (GraphicsLayer
+                  (position 0.00 185.00)
+                  (bounds 285.00 15.00)
+                  (drawsContent 1)
+                )
+                (GraphicsLayer
+                  (position 285.00 0.00)
+                  (bounds 15.00 185.00)
+                  (drawsContent 1)
+                )
+                (GraphicsLayer
+                  (position 285.00 185.00)
+                  (bounds 15.00 15.00)
+                  (drawsContent 1)
                 )
               )
             )
@@ -61,42 +83,6 @@
         )
         (GraphicsLayer
           (position 9.00 9.00)
-          (bounds 300.00 200.00)
-          (children 3
-            (GraphicsLayer
-              (position 0.00 185.00)
-              (bounds 285.00 15.00)
-              (drawsContent 1)
-            )
-            (GraphicsLayer
-              (position 285.00 0.00)
-              (bounds 15.00 185.00)
-              (drawsContent 1)
-            )
-            (GraphicsLayer
-              (position 285.00 185.00)
-              (bounds 15.00 15.00)
-              (drawsContent 1)
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 9.00 201.00)
-          (bounds 285.00 185.00)
-          (children 1
-            (GraphicsLayer
-              (children 1
-                (GraphicsLayer
-                  (position 10.00 10.00)
-                  (bounds 100.00 100.00)
-                  (contentsOpaque 1)
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 9.00 201.00)
           (bounds 300.00 200.00)
           (children 3
             (GraphicsLayer

--- a/LayoutTests/fast/repaint/background-attachment-fixed-in-composited-scroll-expected.txt
+++ b/LayoutTests/fast/repaint/background-attachment-fixed-in-composited-scroll-expected.txt
@@ -3,8 +3,8 @@ Test that a scroll of an overflow scrolling element, with a composoited `backgro
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS layerTreeAsText.indexOf('(rect 0.00 0.00 280.00 200.00)') > -1 is true
-PASS layerTreeAsText.indexOf('(rect 11.00 11.00 278.00 178.00)') > -1 is true
+FAIL layerTreeAsText.indexOf('(rect 0.00 0.00 280.00 200.00)') > -1 should be true. Was false.
+FAIL layerTreeAsText.indexOf('(rect 11.00 11.00 278.00 178.00)') > -1 should be true. Was false.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/platform/ios/compositing/shared-backing/overflow-scroll/nested-scroller-sharing-expected.txt
+++ b/LayoutTests/platform/ios/compositing/shared-backing/overflow-scroll/nested-scroller-sharing-expected.txt
@@ -6,7 +6,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 3
+      (children 2
         (GraphicsLayer
           (position 8.00 8.00)
           (bounds 784.00 422.00)
@@ -36,6 +36,7 @@
                               (offsetFromRenderer width=1 height=1)
                               (anchor 0.00 0.00)
                               (bounds 300.00 620.00)
+                              (drawsContent 1)
                             )
                           )
                         )
@@ -58,31 +59,6 @@
                   (bounds 100.00 100.00)
                   (contentsOpaque 1)
                   (drawsContent 1)
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 9.00 9.00)
-          (bounds 782.00 420.00)
-          (children 1
-            (GraphicsLayer
-              (children 1
-                (GraphicsLayer
-                  (position 11.00 131.00)
-                  (bounds 300.00 200.00)
-                  (children 1
-                    (GraphicsLayer
-                      (children 1
-                        (GraphicsLayer
-                          (position 10.00 10.00)
-                          (bounds 100.00 100.00)
-                          (contentsOpaque 1)
-                        )
-                      )
-                    )
-                  )
                 )
               )
             )

--- a/LayoutTests/platform/ios/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-expected.txt
+++ b/LayoutTests/platform/ios/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 4
+      (children 3
         (GraphicsLayer
           (position 8.00 8.00)
           (bounds 302.00 202.00)
@@ -39,6 +39,7 @@
                   (offsetFromRenderer width=1 height=1)
                   (anchor 0.00 0.00)
                   (bounds 300.00 620.00)
+                  (drawsContent 1)
                 )
               )
             )
@@ -46,21 +47,6 @@
         )
         (GraphicsLayer
           (position 9.00 9.00)
-          (bounds 300.00 200.00)
-          (children 1
-            (GraphicsLayer
-              (children 1
-                (GraphicsLayer
-                  (position 10.00 10.00)
-                  (bounds 100.00 100.00)
-                  (contentsOpaque 1)
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 9.00 201.00)
           (bounds 300.00 200.00)
           (children 1
             (GraphicsLayer

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4771,6 +4771,21 @@ OpusDecoderEnabled:
     WebKit:
       default: true
 
+
+OverlappingBackingStoreProvidersEnabled:
+  type: bool
+  status: stable
+  humanReadableName: "Overlapping backing stores"
+  humanReadableDescription: "Enable overlapping backing stores compositor optimization"
+  category: css
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
 OverscrollBehaviorEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -436,12 +436,18 @@ private:
     void computeExtent(const LayerOverlapMap&, const RenderLayer&, OverlapExtent&) const;
     void computeClippingScopes(const RenderLayer&, OverlapExtent&) const;
     void addToOverlapMap(LayerOverlapMap&, const RenderLayer&, OverlapExtent&) const;
+    LayoutRect computeClippedOverlapBounds(LayerOverlapMap&, const RenderLayer&, OverlapExtent&) const;
     void addDescendantsToOverlapMapRecursive(LayerOverlapMap&, const RenderLayer&, const RenderLayer* ancestorLayer = nullptr) const;
     void updateOverlapMap(LayerOverlapMap&, const RenderLayer&, OverlapExtent&, bool didPushContainer, bool addLayerToOverlap, bool addDescendantsToOverlap = false) const;
     bool layerOverlaps(const LayerOverlapMap&, const RenderLayer&, OverlapExtent&) const;
 
-    void updateBackingSharingBeforeDescendantTraversal(BackingSharingState&, unsigned depth, const LayerOverlapMap&, RenderLayer&, OverlapExtent&, bool willBeComposited, RenderLayer* stackingContextAncestor);
-    void updateBackingSharingAfterDescendantTraversal(BackingSharingState&, unsigned depth, const LayerOverlapMap&, RenderLayer&, OverlapExtent&, const RenderLayer* preDescendantProviderStartLayer, RenderLayer* stackingContextAncestor);
+    struct BackingSharingSnapshot {
+        RenderLayer* backingSharingStackingContext;
+        size_t providerCount;
+    };
+
+    BackingSharingSnapshot updateBackingSharingBeforeDescendantTraversal(BackingSharingState&, unsigned depth, const LayerOverlapMap&, RenderLayer&, OverlapExtent&, bool willBeComposited, RenderLayer* stackingContextAncestor);
+    void updateBackingSharingAfterDescendantTraversal(BackingSharingState&, unsigned depth, const LayerOverlapMap&, RenderLayer&, OverlapExtent&, const RenderLayer* preDescendantProviderStartLayer, RenderLayer* stackingContextAncestor, const BackingSharingSnapshot&);
 
     void clearBackingProviderSequencesInStackingContextOfLayer(RenderLayer&);
 


### PR DESCRIPTION
#### 00030de61705c212863a00279d1b5a381b085c2c
<pre>
Speedometer 3: Fix the overflow:scroll layerization on TodoMVC-React-Complex-DOM.
<a href="https://bugs.webkit.org/show_bug.cgi?id=268117">https://bugs.webkit.org/show_bug.cgi?id=268117</a>
&lt;<a href="https://rdar.apple.com/113239854">rdar://113239854</a>&gt;

Reviewed by NOBODY (OOPS!).

This page has a composited layer that overlaps the right edge of scroller. Most of the
sub-layers inside the scroller are on the left edge and can&apos;t ever overlap the layer
outside the scroller (since the scroller only moves vertically). We currently can&apos;t detect
that there won&apos;t ever be overlap between the sublayers and the outside layer, so everything
in the scroller becomes composited too.

This adds support for overlapping backing provider candidates.

In order for a layer to be added to a candidate that isn&apos;t the topmost, we need to ensure
that the layer doesn&apos;t (and won&apos;t) intersect with the candidates above it.

Generally we just use the bounds of the candidate for this intersection test, which should
have the same results as disallowing overlapping candidates (except for having more in the
candidate list, and potentially worse performance checking them).

If the candidate is composited scrolling that only moves in the vertical direction, we use
the bounds of the current layer in the horizontal direction (and the bounds of the candidate
in the vertical).

This relies on the list of backing sharing candidates being sorted in z-order, which wasn&apos;t
the case previosuly (candidates were added after traversing their descendants). This now captures
a snapshot of the backing sharing state before traversing descendants, and then uses that to
insert it at the right spot after descendant traversal.

* LayoutTests/compositing/shared-backing/overflow-scroll/nested-scroller-sharing-expected.txt:
* LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-expected.txt:
* LayoutTests/fast/repaint/background-attachment-fixed-in-composited-scroll-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::BackingSharingState::BackingSharingState):
(WebCore::RenderLayerCompositor::BackingSharingState::snapshot):
(WebCore::RenderLayerCompositor::BackingSharingState::startBackingSharingSequence):
(WebCore::RenderLayerCompositor::BackingSharingState::addBackingSharingCandidate):
(WebCore::RenderLayerCompositor::BackingSharingState::endBackingSharingSequence):
(WebCore::RenderLayerCompositor::BackingSharingState::backingProviderCandidateForLayer):
(WebCore::RenderLayerCompositor::BackingSharingState::isAdditionalProviderCandidate const):
(WebCore::RenderLayerCompositor::updateCompositingLayers):
(WebCore::RenderLayerCompositor::computeCompositingRequirements):
(WebCore::RenderLayerCompositor::traverseUnchangedSubtree):
(WebCore::RenderLayerCompositor::updateBackingSharingBeforeDescendantTraversal):
(WebCore::RenderLayerCompositor::updateBackingSharingAfterDescendantTraversal):
(WebCore::RenderLayerCompositor::computeClippedOverlapBounds const):
(WebCore::RenderLayerCompositor::addToOverlapMap const):
* Source/WebCore/rendering/RenderLayerCompositor.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00030de61705c212863a00279d1b5a381b085c2c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57318 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4767 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43759 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3162 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46782 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24900 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28472 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4093 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2916 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47399 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50164 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58912 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53551 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29230 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4388 "Found 1 new test failure: http/tests/site-isolation/window-open-with-name-cross-site.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51177 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50531 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31369 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65852 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30193 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12540 "Passed tests") | 
<!--EWS-Status-Bubble-End-->