### PR TITLE
365scores.com: Quirks needed to silence the resize events when putting Safari in the background (iPadOS)

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -818,7 +818,7 @@ bool Quirks::shouldSilenceWindowResizeEvents() const
     if (!page || !page->isTakingSnapshotsForApplicationSuspension())
         return false;
 
-    return isDomain("nytimes.com"_s) || isDomain("twitter.com"_s) || isDomain("zillow.com"_s);
+    return isDomain("nytimes.com"_s) || isDomain("twitter.com"_s) || isDomain("zillow.com"_s) || isDomain("365scores.com"_s);
 #else
     return false;
 #endif


### PR DESCRIPTION
#### 803558a9d300ab88449755bef93af2f769602217
<pre>
365scores.com: Quirks needed to silence the resize events when putting Safari in the background (iPadOS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=268130">https://bugs.webkit.org/show_bug.cgi?id=268130</a>
<a href="https://rdar.apple.com/116491386">rdar://116491386</a>

Reviewed by Brent Fulgham.

When setting the 365scores.com in the background/foreground on iPad,
some resize events are being fired. These events in return modifies
the layout when it should stay the same. This patch add this domain
to the existing quirk to solve this type of issues.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldSilenceWindowResizeEvents const):

Canonical link: <a href="https://commits.webkit.org/273567@main">https://commits.webkit.org/273567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/393f382b7f09f271f8011a614fa61451bfede8c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38493 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32188 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11732 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30950 "Found 13 new test failures: imported/w3c/web-platform-tests/compat/webkit-box-rtl-flex.html, imported/w3c/web-platform-tests/css/css-break/become-unfragmented-001.html, imported/w3c/web-platform-tests/css/css-pseudo/first-line-with-inline-block.html, imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-over-left-001.xht, imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-over-right-001.xht, imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-auto-last-word-001.html, imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vertical-001.html, imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-no-join-001.html, imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-no-join-002.html, imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-no-join-003.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10914 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10911 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39740 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36865 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/8998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34950 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12844 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11612 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4644 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->