### PR TITLE
TextureMapperLayer: Split up multi-value setters setDebugVisuals and setRepaintCounter

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp
@@ -515,11 +515,16 @@ void GraphicsLayerTextureMapper::commitLayerChanges()
     if (m_changeMask & BackingStoreChange)
         m_layer.setBackingStore(m_backingStore.get());
 
-    if (m_changeMask & DebugVisualsChange)
-        m_layer.setDebugVisuals(isShowingDebugBorder(), debugBorderColor(), debugBorderWidth());
+    if (m_changeMask & DebugVisualsChange) {
+        m_layer.setShowDebugBorder(isShowingDebugBorder());
+        m_layer.setDebugBorderColor(debugBorderColor());
+        m_layer.setDebugBorderWidth(debugBorderWidth());
+    }
 
-    if (m_changeMask & RepaintCountChange)
-        m_layer.setRepaintCounter(isShowingRepaintCounter(), repaintCount());
+    if (m_changeMask & RepaintCountChange) {
+        m_layer.setShowRepaintCounter(isShowingRepaintCounter());
+        m_layer.setRepaintCount(repaintCount());
+    }
 
     if (m_changeMask & ContentChange)
         m_layer.setContentsLayer(platformLayer());

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp
@@ -986,19 +986,6 @@ void TextureMapperLayer::setFilters(const FilterOperations& filters)
     m_state.filters = filters;
 }
 
-void TextureMapperLayer::setDebugVisuals(bool showDebugBorders, const Color& debugBorderColor, float debugBorderWidth)
-{
-    m_state.showDebugBorders = showDebugBorders;
-    m_state.debugBorderColor = debugBorderColor;
-    m_state.debugBorderWidth = debugBorderWidth;
-}
-
-void TextureMapperLayer::setRepaintCounter(bool showRepaintCounter, int repaintCount)
-{
-    m_state.showRepaintCounter = showRepaintCounter;
-    m_state.repaintCount = repaintCount;
-}
-
 void TextureMapperLayer::setContentsLayer(TextureMapperPlatformLayer* platformLayer)
 {
     m_contentsLayer = platformLayer;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -87,8 +87,13 @@ public:
         return !m_currentFilters.isEmpty();
     }
 
-    void setDebugVisuals(bool showDebugBorders, const Color& debugBorderColor, float debugBorderWidth);
-    void setRepaintCounter(bool showRepaintCounter, int repaintCount);
+    void setShowDebugBorder(bool showDebugBorder) { m_state.showDebugBorders = showDebugBorder; }
+    void setDebugBorderColor(Color debugBorderColor) { m_state.debugBorderColor = debugBorderColor; }
+    void setDebugBorderWidth(float debugBorderWidth) { m_state.debugBorderWidth = debugBorderWidth; }
+
+    void setShowRepaintCounter(bool showRepaintCounter) { m_state.showRepaintCounter = showRepaintCounter; }
+    void setRepaintCount(int repaintCount) { m_state.repaintCount = repaintCount; }
+
     void setContentsLayer(TextureMapperPlatformLayer*);
     void setAnimations(const Nicosia::Animations&);
     void setBackingStore(TextureMapperBackingStore*);

--- a/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
@@ -170,10 +170,15 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
         }
         if (layerUpdate.changes & WCLayerChange::SolidColor)
             layer->texmapLayer.setSolidColor(layerUpdate.solidColor);
-        if (layerUpdate.changes & WCLayerChange::DebugVisuals)
-            layer->texmapLayer.setDebugVisuals(layerUpdate.showDebugBorder, layerUpdate.debugBorderColor, layerUpdate.debugBorderWidth);
-        if (layerUpdate.changes & WCLayerChange::RepaintCount)
-            layer->texmapLayer.setRepaintCounter(layerUpdate.showRepaintCounter, layerUpdate.repaintCount);
+        if (layerUpdate.changes & WCLayerChange::DebugVisuals) {
+            layer->texmapLayer.setShowDebugBorder(layerUpdate.showDebugBorder);
+            layer->texmapLayer.setDebugBorderColor(layerUpdate.debugBorderColor);
+            layer->texmapLayer.setDebugBorderWidth(layerUpdate.debugBorderWidth);
+        }
+        if (layerUpdate.changes & WCLayerChange::RepaintCount) {
+            layer->texmapLayer.setShowRepaintCounter(layerUpdate.showRepaintCounter);
+            layer->texmapLayer.setRepaintCount(layerUpdate.repaintCount);
+        }
         if (layerUpdate.changes & WCLayerChange::Opacity)
             layer->texmapLayer.setOpacity(layerUpdate.opacity);
         if (layerUpdate.changes & WCLayerChange::Transform)

--- a/Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
+++ b/Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
@@ -322,11 +322,16 @@ void CoordinatedGraphicsScene::updateSceneState()
                             layer.setPreserves3D(layerState.flags.preserves3D);
                         }
 
-                        if (layerState.delta.repaintCounterChanged)
-                            layer.setRepaintCounter(layerState.repaintCounter.visible, layerState.repaintCounter.count);
+                        if (layerState.delta.repaintCounterChanged) {
+                            layer.setShowRepaintCounter(layerState.repaintCounter.visible);
+                            layer.setRepaintCount(layerState.repaintCounter.count);
+                        }
 
-                        if (layerState.delta.debugBorderChanged)
-                            layer.setDebugVisuals(layerState.debugBorder.visible, layerState.debugBorder.color, layerState.debugBorder.width);
+                        if (layerState.delta.debugBorderChanged) {
+                            layer.setShowDebugBorder(layerState.debugBorder.visible);
+                            layer.setDebugBorderColor(layerState.debugBorder.color);
+                            layer.setDebugBorderWidth(layerState.debugBorder.width);
+                        }
 
                         if (layerState.backingStore) {
                             layersByBacking.backingStore.append(


### PR DESCRIPTION
#### f6132113afc8dec16095629753f713cabfd988e9
<pre>
TextureMapperLayer: Split up multi-value setters setDebugVisuals and setRepaintCounter
<a href="https://bugs.webkit.org/show_bug.cgi?id=268133">https://bugs.webkit.org/show_bug.cgi?id=268133</a>

Reviewed by Carlos Garcia Campos.

setDebugVisuals and setRepaintCounter were setters set multiple member
variables. GraphicsLayerWC wants to set these properties individually
in GPU process to reduce a IPC message size. (bug#268119)

* Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
* Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp:
* Source/WebKit/Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp:

Canonical link: <a href="https://commits.webkit.org/273581@main">https://commits.webkit.org/273581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5d5a605b217013ec28c953a16b6b8000f2a58ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35770 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38497 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32191 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30953 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10917 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10912 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39744 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32482 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36871 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11109 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9000 "Found 1 new test failure: http/tests/inspector/dom/didFireEvent.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34957 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12847 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8176 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11614 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11923 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->