### PR TITLE
Identity credentials: IdentityRequestOptions was renamed DigitalCredentialRequestOptions

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -311,8 +311,8 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/credentialmanagement/CredentialRequestOptions.idl
     Modules/credentialmanagement/CredentialsContainer.idl
     Modules/credentialmanagement/DigitalCredential.idl
+    Modules/credentialmanagement/DigitalCredentialRequestOptions.idl
     Modules/credentialmanagement/IdentityCredentialProtocol.idl
-    Modules/credentialmanagement/IdentityRequestOptions.idl
     Modules/credentialmanagement/IdentityRequestProvider.idl
     Modules/credentialmanagement/Navigator+Credentials.idl
 

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -434,8 +434,8 @@ $(PROJECT_DIR)/Modules/credentialmanagement/CredentialMediationRequirement.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/CredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/CredentialsContainer.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/DigitalCredential.idl
+$(PROJECT_DIR)/Modules/credentialmanagement/DigitalCredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/IdentityCredentialProtocol.idl
-$(PROJECT_DIR)/Modules/credentialmanagement/IdentityRequestOptions.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/IdentityRequestProvider.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/Navigator+Credentials.idl
 $(PROJECT_DIR)/Modules/encryptedmedia/MediaKeyEncryptionScheme.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -833,6 +833,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceOrientationOrMotionPermissi
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceOrientationOrMotionPermissionState.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredential.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredential.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialRequestOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialRequestOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDistanceModelType.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDistanceModelType.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDocument+CSSOMView.cpp
@@ -1639,8 +1641,6 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIIRFilterOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIIRFilterOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityCredentialProtocol.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityCredentialProtocol.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityRequestOptions.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityRequestOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityRequestProvider.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityRequestProvider.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdleDeadline.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -308,7 +308,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/credentialmanagement/CredentialRequestOptions.idl \
     $(WebCore)/Modules/credentialmanagement/CredentialsContainer.idl \
     $(WebCore)/Modules/credentialmanagement/DigitalCredential.idl \
-    $(WebCore)/Modules/credentialmanagement/IdentityRequestOptions.idl \
+    $(WebCore)/Modules/credentialmanagement/DigitalCredentialRequestOptions.idl \
     $(WebCore)/Modules/credentialmanagement/IdentityRequestProvider.idl \
     $(WebCore)/Modules/credentialmanagement/IdentityCredentialProtocol.idl \
     $(WebCore)/Modules/credentialmanagement/Navigator+Credentials.idl \

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
@@ -33,9 +33,9 @@
 #include "CredentialCreationOptions.h"
 #include "CredentialRequestOptions.h"
 #include "DigitalCredential.h"
+#include "DigitalCredentialRequestOptions.h"
 #include "Document.h"
 #include "ExceptionOr.h"
-#include "IdentityRequestOptions.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSDigitalCredential.h"
 #include "Page.h"
@@ -144,7 +144,7 @@ void CredentialsContainer::preventSilentAccess(DOMPromiseDeferred<void>&& promis
     promise.resolve();
 }
 
-void CredentialsContainer::requestIdentity(IdentityRequestOptions&& options, DigitalCredentialPromise&& promise)
+void CredentialsContainer::requestIdentity(DigitalCredentialRequestOptions&& options, DigitalCredentialPromise&& promise)
 {
     if (options.signal && options.signal->aborted()) {
         promise.reject(Exception { ExceptionCode::AbortError, "Aborted by AbortSignal."_s });

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
@@ -44,7 +44,7 @@ class Document;
 class WeakPtrImplWithEventTargetData;
 struct CredentialCreationOptions;
 struct CredentialRequestOptions;
-struct IdentityRequestOptions;
+struct DigitalCredentialRequestOptions;
 
 class CredentialsContainer : public RefCounted<CredentialsContainer> {
 public:
@@ -58,7 +58,7 @@ public:
 
     void preventSilentAccess(DOMPromiseDeferred<void>&&) const;
 
-    void requestIdentity(IdentityRequestOptions&&, DigitalCredentialPromise&&);
+    void requestIdentity(DigitalCredentialRequestOptions&&, DigitalCredentialPromise&&);
 
 private:
     CredentialsContainer(WeakPtr<Document, WeakPtrImplWithEventTargetData>&&);

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl
@@ -34,5 +34,5 @@
     Promise<BasicCredential> store(BasicCredential credential);
     Promise<BasicCredential?> create(optional CredentialCreationOptions options);
     Promise<undefined> preventSilentAccess();
-    [EnabledBySetting=DigitalCredentialsEnabled] Promise<DigitalCredential> requestIdentity(IdentityRequestOptions options);
+    [EnabledBySetting=DigitalCredentialsEnabled] Promise<DigitalCredential> requestIdentity(DigitalCredentialRequestOptions options);
 };

--- a/Source/WebCore/Modules/credentialmanagement/DigitalCredentialRequestOptions.h
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalCredentialRequestOptions.h
@@ -23,7 +23,21 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-dictionary IdentityRequestOptions {
-    AbortSignal signal;
-    required sequence<IdentityRequestProvider> providers;
+#pragma once
+
+#include "AbortSignal.h"
+#include "IdentityRequestProvider.h"
+#include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+struct IdentityRequestProvider;
+
+struct DigitalCredentialRequestOptions {
+    RefPtr<AbortSignal> signal;
+    Vector<IdentityRequestProvider> providers;
 };
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/DigitalCredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalCredentialRequestOptions.idl
@@ -23,21 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include "AbortSignal.h"
-#include "IdentityRequestProvider.h"
-#include <wtf/RefCounted.h>
-#include <wtf/RefPtr.h>
-#include <wtf/Vector.h>
-
-namespace WebCore {
-
-struct IdentityRequestProvider;
-
-struct IdentityRequestOptions {
-    RefPtr<AbortSignal> signal;
-    Vector<IdentityRequestProvider> providers;
+dictionary DigitalCredentialRequestOptions {
+    AbortSignal signal;
+    required sequence<IdentityRequestProvider> providers;
 };
-
-} // namespace WebCore

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3443,6 +3443,7 @@ JSDeviceMotionEvent.cpp
 JSDeviceOrientationEvent.cpp
 JSDeviceOrientationOrMotionPermissionState.cpp
 JSDigitalCredential.cpp
+JSDigitalCredentialRequestOptions.cpp
 JSDistanceModelType.cpp
 JSDocument.cpp
 JSDocumentAndElementEventHandlers.cpp
@@ -3792,7 +3793,6 @@ JSIDBTransactionDurability.cpp
 JSIDBTransactionMode.cpp
 JSIDBVersionChangeEvent.cpp
 JSIdentityCredentialProtocol.cpp
-JSIdentityRequestOptions.cpp
 JSIdentityRequestProvider.cpp
 JSIdleDeadline.cpp
 JSIdleRequestCallback.cpp


### PR DESCRIPTION
#### f3067121f0b40ece169b4591d04a905460f27727
<pre>
Identity credentials: IdentityRequestOptions was renamed DigitalCredentialRequestOptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=268135">https://bugs.webkit.org/show_bug.cgi?id=268135</a>
<a href="https://rdar.apple.com/problem/121636291">rdar://problem/121636291</a>

Reviewed by Chris Dumez and Aditya Keerthi.

Renames IdentityRequestOptions to DigitalCredentialRequestOptions throughout.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
(WebCore::CredentialsContainer::requestIdentity):
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl:
* Source/WebCore/Modules/credentialmanagement/DigitalCredentialRequestOptions.h: Renamed from Source/WebCore/Modules/credentialmanagement/IdentityRequestOptions.h.
* Source/WebCore/Modules/credentialmanagement/DigitalCredentialRequestOptions.idl: Renamed from Source/WebCore/Modules/credentialmanagement/IdentityRequestOptions.idl.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/273596@main">https://commits.webkit.org/273596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dca7d855feafdf92264b290066f88dbb5e68694c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38501 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32194 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/36994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11743 "Built successfully") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30956 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31806 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10921 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10940 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39748 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32524 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32297 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36873 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11112 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9004 "Found 1 new test failure: http/tests/inspector/dom/didFireEvent.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34959 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12851 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8189 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11617 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11928 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->