### PR TITLE
[AVFObjC] [AVPlayerLayer videoPerformanceMetrics] may deadlock

### DIFF
--- a/LayoutTests/media/media-source/media-source-video-playback-quality-expected.txt
+++ b/LayoutTests/media/media-source/media-source-video-playback-quality-expected.txt
@@ -4,6 +4,11 @@ EVENT(sourceopen)
 RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
 RUN(sourceBuffer.appendBuffer(initSegment))
 EVENT(updateend)
+RUN(quality = video.getVideoPlaybackQuality())
+EXPECTED (quality.totalVideoFrames == '0') OK
+EXPECTED (quality.corruptedVideoFrames == '0') OK
+EXPECTED (quality.droppedVideoFrames == '0') OK
+EXPECTED (quality.totalFrameDelay == '0') OK
 Test that beginning a buffer with a non-sync sample results in that sample being dropped.
 RUN(sourceBuffer.appendBuffer(samples))
 EVENT(updateend)

--- a/LayoutTests/media/media-source/media-source-video-playback-quality.html
+++ b/LayoutTests/media/media-source/media-source-video-playback-quality.html
@@ -33,6 +33,11 @@
 
     function loadSample()
     {
+        run('quality = video.getVideoPlaybackQuality()');
+        testExpected('quality.totalVideoFrames', 0);
+        testExpected('quality.corruptedVideoFrames', 0);
+        testExpected('quality.droppedVideoFrames', 0);
+        testExpected('quality.totalFrameDelay', 0);
         samples = concatenateSamples([makeASample(0, 0, 1, 1, 1, SAMPLE_FLAG.NONE)]);
         waitForEventOn(sourceBuffer, 'updateend', loadMoreSamples, false, true);
         consoleWrite('Test that beginning a buffer with a non-sync sample results in that sample being dropped.')
@@ -67,7 +72,7 @@
         run('source.endOfStream()');
         run('video.play()');
         await waitFor(video, 'ended');
-        setTimeout(videoEnded, 50); // VideoPlaybackQuality is refreshed every 0.25s, wait a bit.
+        setTimeout(videoEnded, 300); // VideoPlaybackQuality is refreshed every 0.25s, wait a bit.
     }
 
     function videoEnded()

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8047,16 +8047,16 @@ RefPtr<VideoPlaybackQuality> HTMLMediaElement::getVideoPlaybackQuality()
     RefPtr domWindow = document().domWindow();
     double timestamp = domWindow ? domWindow->nowTimestamp().milliseconds() : 0;
 
-    auto metrics = m_player ? m_player->videoPlaybackQualityMetrics() : std::nullopt;
-    if (!metrics)
-        return VideoPlaybackQuality::create(timestamp, { });
-
+    VideoPlaybackQualityMetrics currentVideoPlaybackQuality;
 #if ENABLE(MEDIA_SOURCE)
-    metrics.value().totalVideoFrames += m_droppedVideoFrames;
-    metrics.value().droppedVideoFrames += m_droppedVideoFrames;
+    currentVideoPlaybackQuality.totalVideoFrames = m_droppedVideoFrames;
+    currentVideoPlaybackQuality.droppedVideoFrames = m_droppedVideoFrames;
 #endif
 
-    return VideoPlaybackQuality::create(timestamp, metrics.value());
+    if (auto metrics = m_player ? m_player->videoPlaybackQualityMetrics() : std::nullopt)
+        currentVideoPlaybackQuality += *metrics;
+
+    return VideoPlaybackQuality::create(timestamp, currentVideoPlaybackQuality);
 }
 
 DOMWrapperWorld& HTMLMediaElement::ensureIsolatedWorld()

--- a/Source/WebCore/platform/PlatformMediaError.cpp
+++ b/Source/WebCore/platform/PlatformMediaError.cpp
@@ -42,6 +42,8 @@ String convertEnumerationToString(PlatformMediaError enumerationValue)
         MAKE_STATIC_STRING_IMPL("MemoryError"),
         MAKE_STATIC_STRING_IMPL("Cancelled"),
         MAKE_STATIC_STRING_IMPL("LogicError"),
+        MAKE_STATIC_STRING_IMPL("DecoderCreationError"),
+        MAKE_STATIC_STRING_IMPL("NotSupportedError"),
     };
     static_assert(!static_cast<size_t>(PlatformMediaError::AppendError), "PlatformMediaError::AppendError is not 0 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::ClientDisconnected) == 1, "PlatformMediaError::ClientDisconnected is not 1 as expected");
@@ -52,6 +54,8 @@ String convertEnumerationToString(PlatformMediaError enumerationValue)
     static_assert(static_cast<size_t>(PlatformMediaError::MemoryError) == 6, "PlatformMediaError::MemoryError is not 6 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::Cancelled) == 7, "PlatformMediaError::Cancelled is not 7 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::LogicError) == 8, "PlatformMediaError::LogicError is not 8 as expected");
+    static_assert(static_cast<size_t>(PlatformMediaError::DecoderCreationError) == 9, "PlatformMediaError::DecoderCreationError is not 9 as expected");
+    static_assert(static_cast<size_t>(PlatformMediaError::NotSupportedError) == 10, "PlatformMediaError::NotSupportedError is not 10 as expected");
     ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }

--- a/Source/WebCore/platform/PlatformMediaError.h
+++ b/Source/WebCore/platform/PlatformMediaError.h
@@ -41,6 +41,7 @@ enum class PlatformMediaError : uint8_t {
     Cancelled,
     LogicError,
     DecoderCreationError,
+    NotSupportedError,
 };
 
 using MediaPromise = NativePromise<void, PlatformMediaError>;
@@ -73,7 +74,9 @@ template<> struct EnumTraits<WebCore::PlatformMediaError> {
         WebCore::PlatformMediaError::ParsingError,
         WebCore::PlatformMediaError::MemoryError,
         WebCore::PlatformMediaError::Cancelled,
-        WebCore::PlatformMediaError::LogicError
+        WebCore::PlatformMediaError::LogicError,
+        WebCore::PlatformMediaError::DecoderCreationError,
+        WebCore::PlatformMediaError::NotSupportedError
     >;
 };
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -51,6 +51,7 @@
 #include "VideoFrameMetadata.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <wtf/Lock.h>
+#include <wtf/NativePromise.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/CString.h>
 #include "InbandTextTrackPrivate.h"
@@ -1709,6 +1710,14 @@ std::optional<VideoPlaybackQualityMetrics> MediaPlayer::videoPlaybackQualityMetr
         return std::nullopt;
 
     return m_private->videoPlaybackQualityMetrics();
+}
+
+Ref<MediaPlayer::VideoPlaybackQualityMetricsPromise> MediaPlayer::asyncVideoPlaybackQualityMetrics()
+{
+    if (!m_private)
+        return VideoPlaybackQualityMetricsPromise::createAndReject(PlatformMediaError::Cancelled);
+
+    return m_private->asyncVideoPlaybackQualityMetrics();
 }
 
 String MediaPlayer::sourceApplicationIdentifier() const

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -642,6 +642,8 @@ public:
     unsigned long long fileSize() const;
 
     std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics();
+    using VideoPlaybackQualityMetricsPromise = NativePromise<VideoPlaybackQualityMetrics, PlatformMediaError>;
+    Ref<VideoPlaybackQualityMetricsPromise> asyncVideoPlaybackQualityMetrics();
 
     String sourceApplicationIdentifier() const;
     Vector<String> preferredAudioCharacteristics() const;

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp
@@ -30,6 +30,7 @@
 
 #include "VideoFrame.h"
 #include "VideoFrameMetadata.h"
+#include <wtf/NativePromise.h>
 
 namespace WebCore {
 
@@ -52,6 +53,13 @@ const PlatformTimeRanges& MediaPlayerPrivateInterface::seekable() const
         return PlatformTimeRanges::emptyRanges();
     m_seekable = { minMediaTimeSeekable(), maxMediaTimeSeekable() };
     return m_seekable;
+}
+
+auto MediaPlayerPrivateInterface::asyncVideoPlaybackQualityMetrics() -> Ref<VideoPlaybackQualityMetricsPromise>
+{
+    if (auto metrics = videoPlaybackQualityMetrics())
+        return VideoPlaybackQualityMetricsPromise::createAndResolve(WTFMove(*metrics));
+    return VideoPlaybackQualityMetricsPromise::createAndReject(PlatformMediaError::NotSupportedError);
 }
 
 }

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -308,6 +308,8 @@ public:
     virtual bool ended() const { return false; }
 
     virtual std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() { return std::nullopt; }
+    using VideoPlaybackQualityMetricsPromise = MediaPlayer::VideoPlaybackQualityMetricsPromise;
+    WEBCORE_EXPORT virtual Ref<VideoPlaybackQualityMetricsPromise> asyncVideoPlaybackQualityMetrics();
 
     virtual void notifyTrackModeChanged() { }
 

--- a/Source/WebCore/platform/graphics/VideoPlaybackQualityMetrics.h
+++ b/Source/WebCore/platform/graphics/VideoPlaybackQualityMetrics.h
@@ -35,6 +35,16 @@ struct VideoPlaybackQualityMetrics {
     uint32_t corruptedVideoFrames { 0 };
     double totalFrameDelay { 0 };
     uint32_t displayCompositedVideoFrames { 0 };
+
+    VideoPlaybackQualityMetrics& operator+=(const VideoPlaybackQualityMetrics& other)
+    {
+        totalVideoFrames += other.totalVideoFrames;
+        droppedVideoFrames += other.droppedVideoFrames;
+        corruptedVideoFrames += other.corruptedVideoFrames;
+        totalFrameDelay += other.totalFrameDelay;
+        displayCompositedVideoFrames += other.displayCompositedVideoFrames;
+        return *this;
+    }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -45,7 +45,7 @@ class InbandTextTrackPrivateAVF;
 
 // Use eager initialization for the WeakPtrFactory since we construct WeakPtrs on another thread.
 class MediaPlayerPrivateAVFoundation
-    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaPlayerPrivateAVFoundation>
+    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaPlayerPrivateAVFoundation, WTF::DestructionThread::Main>
     , public MediaPlayerPrivateInterface
     , public AVFInbandTrackParent
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -330,6 +330,7 @@ private:
     void updateRotationSession();
 
     std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() final;
+    Ref<VideoPlaybackQualityMetricsPromise> asyncVideoPlaybackQualityMetrics() final;
 
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const final { return "MediaPlayerPrivateAVFoundationObjC"; }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -398,6 +398,7 @@ private:
 
     Seconds m_videoPlaybackMetricsUpdateInterval;
     MonotonicTime m_nextPlaybackQualityMetricsUpdateTime;
+    bool m_hasPlaybackMetricsUpdatePending { false };
 
     float m_videoContentScale { 1.0 };
     WebCore::LayoutRect m_playerContentBoxRect;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -549,6 +549,11 @@ void MediaPlayerPrivateRemote::updateCachedState(RemoteMediaPlayerState&& state)
         m_cachedBufferedTimeRanges = *state.bufferedRanges;
 }
 
+void MediaPlayerPrivateRemote::updatePlaybackQualityMetrics(VideoPlaybackQualityMetrics&& metrics)
+{
+    m_cachedState.videoMetrics = WTFMove(metrics);
+}
+
 bool MediaPlayerPrivateRemote::shouldIgnoreIntrinsicSize()
 {
     return m_configuration.shouldIgnoreIntrinsicSize;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -116,6 +116,7 @@ public:
     void playbackStateChanged(bool, MediaTime&&, MonotonicTime&&);
     void engineFailedToLoad(int64_t);
     void updateCachedState(RemoteMediaPlayerState&&);
+    void updatePlaybackQualityMetrics(WebCore::VideoPlaybackQualityMetrics&&);
     void characteristicChanged(RemoteMediaPlayerState&&);
     void sizeChanged(WebCore::FloatSize);
     void firstVideoFrameAvailable();

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in
@@ -36,6 +36,7 @@ messages -> MediaPlayerPrivateRemote NotRefCounted {
     PlaybackStateChanged(bool paused, MediaTime mediaTime, MonotonicTime wallTime)
     EngineFailedToLoad(int64_t platformErrorCode)
     UpdateCachedState(struct WebKit::RemoteMediaPlayerState state)
+    UpdatePlaybackQualityMetrics(struct WebCore::VideoPlaybackQualityMetrics metrics);
     CharacteristicChanged(struct WebKit::RemoteMediaPlayerState state)
     SizeChanged(WebCore::FloatSize naturalSize)
     RenderingModeChanged()


### PR DESCRIPTION
#### d7e69a605f2ae52d006f4716edccd688fc6cba17
<pre>
[AVFObjC] [AVPlayerLayer videoPerformanceMetrics] may deadlock
<a href="https://bugs.webkit.org/show_bug.cgi?id=268136">https://bugs.webkit.org/show_bug.cgi?id=268136</a>
<a href="https://rdar.apple.com/121637422">rdar://121637422</a>

Reviewed by Youenn Fablet.

A call to [AVPlayerLayer videoPerformanceMetrics] may deadlock if the AVPlayer is
also waiting in the main thread for more data to be delivered.
This commonly occurs when there are lots of videos playing at once and result in
a blocked GPU process.

Dealing with getting the networking data being delivered on the main thread will be
dealt in bug 235353.
For now, call [AVPlayerLayer videoPerformanceMetrics] on a different WorkQueue.
The RemoteMediaPlayerProxy already regularly polls the MediaPlayerPrivate for the
videoPlaybackQualityMetrics, so performing the actions asynchronously doesn&apos;t have
a measurable impact.
And it does prevent the GPU process to be deadlock.

Fly-by: While the VideoPlaybackQualityMetrics were properly calculated
and updated in the GPU process at a set interval, the values weren&apos;t
being sent to the Content Process except under some limited circumstances
(video got paused, started playing or stall). As such, retrieving the
VideoPlaybackQuality from the video element would typically always return
the same values.

* LayoutTests/media/media-source/media-source-video-playback-quality-expected.txt:
* LayoutTests/media/media-source/media-source-video-playback-quality.html:
The quality metrics are calculated every 0.25s (250ms) but we were only
waiting for 50ms.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::getVideoPlaybackQuality):
* Source/WebCore/platform/PlatformMediaError.cpp: Adding new error code.
A prior change was incomplete and failed to add the serialisation data.
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/PlatformMediaError.h:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::asyncVideoPlaybackQualityMetrics):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.cpp:
(WebCore::MediaPlayerPrivateInterface::asyncVideoPlaybackQualityMetrics):
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
* Source/WebCore/platform/graphics/VideoPlaybackQualityMetrics.h:
(WebCore::VideoPlaybackQualityMetrics::operator+=):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::asyncVideoPlaybackQualityMetrics):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::maybeUpdateCachedVideoMetrics):
(WebKit::RemoteMediaPlayerProxy::updateCachedVideoMetrics):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::updatePlaybackQualityMetrics):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.messages.in:
Add specific message for sending the VideoPlaybackQualityMetrics, as sending
the entire cached state is expensive (particularly reading the video time).

Canonical link: <a href="https://commits.webkit.org/273580@main">https://commits.webkit.org/273580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9666c1011b5f87c6910e4ef3683634058fa350e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14778 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38013 "Hash 9666c101 for PR 23286 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38559 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32238 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30993 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10972 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10970 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32032 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39808 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32558 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36924 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35014 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12900 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31695 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8175 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11660 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11982 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->