### PR TITLE
DigitalCredential's response attribute was renamed to data

### DIFF
--- a/Source/WebCore/Modules/credentialmanagement/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalCredential.cpp
@@ -28,15 +28,15 @@
 
 namespace WebCore {
 
-Ref<DigitalCredential> DigitalCredential::create(Ref<ArrayBuffer>&& response)
+Ref<DigitalCredential> DigitalCredential::create(Ref<ArrayBuffer>&& data)
 {
-    return adoptRef(*new DigitalCredential(WTFMove(response)));
+    return adoptRef(*new DigitalCredential(WTFMove(data)));
 }
 
 DigitalCredential::~DigitalCredential() = default;
 
-DigitalCredential::DigitalCredential(Ref<ArrayBuffer>&& response)
-    : m_response(WTFMove(response))
+DigitalCredential::DigitalCredential(Ref<ArrayBuffer>&& data)
+    : m_data(WTFMove(data))
 {
 }
 

--- a/Source/WebCore/Modules/credentialmanagement/DigitalCredential.h
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalCredential.h
@@ -38,19 +38,19 @@ using DigitalCredentialPromise = DOMPromiseDeferred<IDLInterface<DigitalCredenti
 
 class DigitalCredential : public RefCounted<DigitalCredential> {
 public:
-    static Ref<DigitalCredential> create(Ref<ArrayBuffer>&& response);
+    static Ref<DigitalCredential> create(Ref<ArrayBuffer>&& data);
 
     virtual ~DigitalCredential();
 
-    ArrayBuffer* response() const
+    ArrayBuffer* data() const
     {
-        return m_response.get();
+        return m_data.get();
     };
 
 private:
-    DigitalCredential(Ref<ArrayBuffer>&& response);
+    DigitalCredential(Ref<ArrayBuffer>&& data);
 
-    RefPtr<ArrayBuffer> m_response;
+    RefPtr<ArrayBuffer> m_data;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/DigitalCredential.idl
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalCredential.idl
@@ -27,5 +27,5 @@
     Exposed=Window,
     SecureContext,
 ] interface DigitalCredential {
-    [SameObject] readonly attribute ArrayBuffer response;
+    [SameObject] readonly attribute ArrayBuffer data;
 };


### PR DESCRIPTION
#### d686b02f00c3bb5c8ebb9b1e71df6555e3170b38
<pre>
DigitalCredential&apos;s response attribute was renamed to data
<a href="https://bugs.webkit.org/show_bug.cgi?id=268139">https://bugs.webkit.org/show_bug.cgi?id=268139</a>
<a href="https://rdar.apple.com/121639016">rdar://121639016</a>

Reviewed by Tim Nguyen.

Renames DigitalCredential&apos;s &quot;response&quot; attribute to &quot;data&quot; to match the spec.
<a href="https://github.com/WICG/digital-credentials/pull/57">https://github.com/WICG/digital-credentials/pull/57</a>

* Source/WebCore/Modules/credentialmanagement/DigitalCredential.cpp:
(WebCore::DigitalCredential::create):
(WebCore::DigitalCredential::DigitalCredential):
* Source/WebCore/Modules/credentialmanagement/DigitalCredential.h:
(WebCore::DigitalCredential::data const):
(WebCore::DigitalCredential::response const): Deleted.
* Source/WebCore/Modules/credentialmanagement/DigitalCredential.idl:

Canonical link: <a href="https://commits.webkit.org/273595@main">https://commits.webkit.org/273595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6677bfd6722b8f189cda686470f7fa30ca16334

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38511 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32203 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30964 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31808 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10935 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39758 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32498 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32301 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36879 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34968 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12860 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8188 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11626 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->