### PR TITLE
The DigitalCredential interface should only be enabled by setting "DigitalCredentialsEnabled"

### DIFF
--- a/Source/WebCore/Modules/credentialmanagement/DigitalCredential.idl
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalCredential.idl
@@ -26,6 +26,7 @@
 [
     Exposed=Window,
     SecureContext,
+    EnabledBySetting=DigitalCredentialsEnabled
 ] interface DigitalCredential {
     [SameObject] readonly attribute ArrayBuffer data;
 };


### PR DESCRIPTION
#### 8893019315ba5d18b837554052a363b3befa2465
<pre>
The DigitalCredential interface should only be enabled by setting &quot;DigitalCredentialsEnabled&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=268140">https://bugs.webkit.org/show_bug.cgi?id=268140</a>
<a href="https://rdar.apple.com/121639268">rdar://121639268</a>

Reviewed by Chris Dumez.

Added EnabledBySetting to the DigitalCredential interface.

* Source/WebCore/Modules/credentialmanagement/DigitalCredential.idl:

Canonical link: <a href="https://commits.webkit.org/273597@main">https://commits.webkit.org/273597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c2bcaf7603e4de89c7b34eb7cfbf9cc367103d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38512 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32204 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37005 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30962 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36341 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10932 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10925 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39759 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32500 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36878 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11122 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34967 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12861 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8190 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11627 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->