### PR TITLE
Digital Credential API: DigitalCredential should inherit from Credential interface

### DIFF
--- a/LayoutTests/http/wpt/credential-management/setDigitalCredentialsEnabled.https-expected.txt
+++ b/LayoutTests/http/wpt/credential-management/setDigitalCredentialsEnabled.https-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: Test finished
+

--- a/LayoutTests/http/wpt/credential-management/setDigitalCredentialsEnabled.https.html
+++ b/LayoutTests/http/wpt/credential-management/setDigitalCredentialsEnabled.https.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>
+            Check that Credential Management parts of the API are not exposed by
+            default
+        </title>
+    </head>
+    <script>
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+
+        if (window.navigator.credentials.requestIdentity !== undefined) {
+            console.log("FAIL: requestIdentity() must not be exposed by default.");
+        }
+
+        if (window.DigitalCredential !== undefined) {
+            console.log(
+                "FAIL: DigitalCredential interface must not be exposed by default."
+            );
+        }
+
+        window.internals.settings.setDigitalCredentialsEnabled(true);
+
+        async function checkIFrame() {
+            const iframeWin = document.querySelector("iframe").contentWindow;
+
+            if (!iframeWin.navigator.credentials.requestIdentity) {
+                console.log(
+                    "FAIL: navigator.credentials.requestIdentity() must be exposed. Was enabled by pref."
+                );
+            }
+
+            const isInstanceOfDigitalCredential =
+                iframeWin.DigitalCredential.prototype instanceof
+                iframeWin.Credential;
+            if (!isInstanceOfDigitalCredential) {
+                console.log(
+                    "FAIL: DigitalCredential's prototype interface must be an instance of Credential."
+                );
+            }
+            console.log("Test finished");
+            testRunner.notifyDone();
+        }
+    </script>
+    <body>
+        <iframe src="about:blank" onload="checkIFrame()"></iframe>
+    </body>
+</html>

--- a/Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp
@@ -46,6 +46,9 @@ BasicCredential::~BasicCredential() = default;
 String BasicCredential::type() const
 {
     switch (m_type) {
+    case Type::DigitalCredential:
+        return "digital-credential"_s;
+
     case Type::PublicKey:
         return "public-key"_s;
     }

--- a/Source/WebCore/Modules/credentialmanagement/BasicCredential.h
+++ b/Source/WebCore/Modules/credentialmanagement/BasicCredential.h
@@ -39,6 +39,7 @@ namespace WebCore {
 class BasicCredential : public RefCounted<BasicCredential> {
 public:
     enum class Type {
+        DigitalCredential,
         PublicKey,
     };
 

--- a/Source/WebCore/Modules/credentialmanagement/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalCredential.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "DigitalCredential.h"
 
+#if ENABLE(WEB_AUTHN)
+
 namespace WebCore {
 
 Ref<DigitalCredential> DigitalCredential::create(Ref<ArrayBuffer>&& data)
@@ -36,8 +38,11 @@ Ref<DigitalCredential> DigitalCredential::create(Ref<ArrayBuffer>&& data)
 DigitalCredential::~DigitalCredential() = default;
 
 DigitalCredential::DigitalCredential(Ref<ArrayBuffer>&& data)
-    : m_data(WTFMove(data))
+    : BasicCredential(base64URLEncodeToString(data->data(), data->byteLength()), Type::DigitalCredential, Discovery::CredentialStore)
+    , m_data(WTFMove(data))
 {
 }
 
 } // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/DigitalCredential.h
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalCredential.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#if ENABLE(WEB_AUTHN)
+
+#include "BasicCredential.h"
 #include "IDLTypes.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <wtf/RefCounted.h>
@@ -37,7 +40,7 @@ template<typename IDLType> class DOMPromiseDeferred;
 
 using DigitalCredentialPromise = DOMPromiseDeferred<IDLInterface<DigitalCredential>>;
 
-class DigitalCredential : public RefCounted<DigitalCredential> {
+class DigitalCredential final : public BasicCredential {
 public:
     static Ref<DigitalCredential> create(Ref<ArrayBuffer>&& data);
 
@@ -51,7 +54,13 @@ public:
 private:
     DigitalCredential(Ref<ArrayBuffer>&& data);
 
+    Type credentialType() const final { return Type::DigitalCredential; }
+
     RefPtr<ArrayBuffer> m_data;
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BASIC_CREDENTIAL(DigitalCredential, BasicCredential::Type::DigitalCredential)
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/DigitalCredential.idl
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalCredential.idl
@@ -26,7 +26,8 @@
 [
     Exposed=Window,
     SecureContext,
-    EnabledBySetting=DigitalCredentialsEnabled
-] interface DigitalCredential {
+    EnabledBySetting=DigitalCredentialsEnabled,
+    Conditional=WEB_AUTHN,
+] interface DigitalCredential : BasicCredential {
     [SameObject] readonly attribute ArrayBuffer data;
 };

--- a/Source/WebCore/bindings/js/JSBasicCredentialCustom.cpp
+++ b/Source/WebCore/bindings/js/JSBasicCredentialCustom.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(WEB_AUTHN)
 
 #include "JSDOMBinding.h"
+#include "JSDigitalCredential.h"
 #include "JSPublicKeyCredential.h"
 
 namespace WebCore {
@@ -38,6 +39,8 @@ JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, 
 {
     if (is<PublicKeyCredential>(credential))
         return createWrapper<PublicKeyCredential>(globalObject, WTFMove(credential));
+    if (is<DigitalCredential>(credential))
+        return createWrapper<DigitalCredential>(globalObject, WTFMove(credential));
     return createWrapper<BasicCredential>(globalObject, WTFMove(credential));
 }
 


### PR DESCRIPTION
#### 4882b74baf008ae9c3541cc569d907d0f553634f
<pre>
Digital Credential API: DigitalCredential should inherit from Credential interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=268145">https://bugs.webkit.org/show_bug.cgi?id=268145</a>
<a href="https://rdar.apple.com/121643028">rdar://121643028</a>

Reviewed by Chris Dumez.

Implements inheriting Credential interface for DigitalCredential.

* LayoutTests/http/wpt/credential-management/setDigitalCredentialsEnabled.https-expected.txt: Added.
* LayoutTests/http/wpt/credential-management/setDigitalCredentialsEnabled.https.html: Added.
* Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp:
(WebCore::BasicCredential::type const):
* Source/WebCore/Modules/credentialmanagement/BasicCredential.h:
* Source/WebCore/Modules/credentialmanagement/DigitalCredential.cpp:
(WebCore::DigitalCredential::DigitalCredential):
* Source/WebCore/Modules/credentialmanagement/DigitalCredential.h:
(WebCore::DigitalCredential::data const): Deleted.
* Source/WebCore/Modules/credentialmanagement/DigitalCredential.idl:
* Source/WebCore/bindings/js/JSBasicCredentialCustom.cpp:
(WebCore::toJSNewlyCreated):

Canonical link: <a href="https://commits.webkit.org/273864@main">https://commits.webkit.org/273864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48438a268f3bb04ee6af4c5b5ae6a1f3e9b559d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36761 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39403 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32932 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12809 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31510 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32489 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11571 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11580 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40651 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33308 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37503 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9676 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35623 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13523 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32447 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8364 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12258 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12756 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->