### PR TITLE
Use WTF::BitSet for isHTMLLineBreak

### DIFF
--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2325,8 +2325,8 @@ String HTMLInputElement::placeholder() const
     // According to the HTML5 specification, we need to remove CR and LF from
     // the attribute value.
     String attributeValue = attributeWithoutSynchronization(placeholderAttr);
-    return attributeValue.removeCharacters([](UChar c) {
-        return c == newlineCharacter || c == carriageReturn;
+    return attributeValue.removeCharacters([](auto character) {
+        return isHTMLLineBreak(character);
     });
 }
 

--- a/Source/WebCore/html/parser/HTMLParserIdioms.cpp
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.cpp
@@ -41,6 +41,13 @@
 
 namespace WebCore {
 
+const WTF::BitSet<256> isHTMLLineBreakBitSet = ([]() -> WTF::BitSet<256> {
+    WTF::BitSet<256> bitSet;
+    bitSet.set('\n');
+    bitSet.set('\r');
+    return bitSet;
+})();
+
 String serializeForNumberType(const Decimal& number)
 {
     if (number.isZero()) {

--- a/Source/WebCore/html/parser/HTMLParserIdioms.h
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <unicode/uchar.h>
+#include <wtf/BitSet.h>
 #include <wtf/Expected.h>
 #include <wtf/text/StringView.h>
 
@@ -33,9 +34,12 @@ namespace WebCore {
 class Decimal;
 class QualifiedName;
 
+
+extern WEBCORE_EXPORT const WTF::BitSet<256> isHTMLLineBreakBitSet;
+
 template<typename CharacterType> bool isComma(CharacterType);
 template<typename CharacterType> bool isHTMLSpaceOrComma(CharacterType);
-bool isHTMLLineBreak(UChar);
+template<typename CharacterType> bool isHTMLLineBreak(CharacterType);
 bool isHTMLSpaceButNotLineBreak(UChar);
 
 // 2147483647 is 2^31 - 1.
@@ -91,9 +95,13 @@ std::optional<HTMLDimension> parseHTMLMultiLength(StringView);
 
 // Inline implementations of some of the functions declared above.
 
-inline bool isHTMLLineBreak(UChar character)
+template<typename CharacterType>
+inline bool isHTMLLineBreak(CharacterType character)
 {
-    return character <= '\r' && (character == '\n' || character == '\r');
+    if constexpr (sizeof(CharacterType) == 1)
+        return isHTMLLineBreakBitSet.get(character);
+    else
+        return character <= 0xff && isHTMLLineBreakBitSet.get(character);
 }
 
 template<typename CharacterType> inline bool isComma(CharacterType character)


### PR DESCRIPTION
#### 33ada650f32d95b6c5e6063484d4c9f28c80b500
<pre>
Use WTF::BitSet for isHTMLLineBreak
<a href="https://bugs.webkit.org/show_bug.cgi?id=268146">https://bugs.webkit.org/show_bug.cgi?id=268146</a>
<a href="https://rdar.apple.com/121643135">rdar://121643135</a>

Reviewed by NOBODY (OOPS!).

Use pre-baked WTF::BitSet for isHTMLLineBreak.

* Source/WebCore/html/parser/HTMLParserIdioms.cpp:
(WebCore::=):
* Source/WebCore/html/parser/HTMLParserIdioms.h:
(WebCore::isHTMLLineBreak):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33ada650f32d95b6c5e6063484d4c9f28c80b500

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38528 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32217 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37021 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30972 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31825 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10952 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10935 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/31997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39776 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32514 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36891 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11134 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/34982 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12875 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11639 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11953 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->