### PR TITLE
Move image metadata queries to a separate class named BitmapImageMetadata

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1843,6 +1843,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/CopyImageOptions.h
     platform/graphics/BifurcatedGraphicsContext.h
     platform/graphics/BitmapImage.h
+    platform/graphics/BitmapImageMetadata.h
     platform/graphics/ByteArrayPixelBuffer.h
     platform/graphics/CachedSubimage.h
     platform/graphics/Color.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2231,6 +2231,7 @@ platform/graphics/AlphaPremultiplication.cpp
 platform/graphics/AnimationFrameRate.cpp
 platform/graphics/BifurcatedGraphicsContext.cpp
 platform/graphics/BitmapImage.cpp
+platform/graphics/BitmapImageMetadata.cpp
 platform/graphics/ByteArrayPixelBuffer.cpp
 platform/graphics/CachedSubimage.cpp
 platform/graphics/CodecUtilities.cpp

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -76,7 +76,7 @@ public:
     // FloatSize due to override.
     FloatSize size(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const override { return m_source->size(orientation); }
     ImageOrientation orientation() const override { return m_source->orientation(); }
-    Color singlePixelSolidColor() const override { return m_source->singlePixelSolidColor(); }
+    std::optional<Color> singlePixelSolidColor() const override { return m_source->singlePixelSolidColor(); }
     bool frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(size_t index, const DecodingOptions& decodingOptions) const { return m_source->frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(index, decodingOptions); }
     DecodingStatus frameDecodingStatusAtIndex(size_t index) const { return m_source->frameDecodingStatusAtIndex(index); }
     bool frameIsCompleteAtIndex(size_t index) const { return frameDecodingStatusAtIndex(index) == DecodingStatus::Complete; }
@@ -104,13 +104,13 @@ public:
     bool isAsyncDecodingEnabledForTesting() const { return m_asyncDecodingEnabledForTesting; }
     void stopAsyncDecodingQueue() { m_source->stopAsyncDecodingQueue(); }
 
-    DestinationColorSpace colorSpace() final;
+    DestinationColorSpace colorSpace() final { return m_source->colorSpace(); }
 
     WEBCORE_EXPORT unsigned decodeCountForTesting() const;
 
     WEBCORE_EXPORT RefPtr<NativeImage> nativeImage(const DestinationColorSpace& = DestinationColorSpace::SRGB()) override;
     RefPtr<NativeImage> nativeImageForCurrentFrame() override;
-    RefPtr<NativeImage> preTransformedNativeImageForCurrentFrame(bool respectOrientation) override;
+    RefPtr<NativeImage> preTransformedNativeImageForCurrentFrame(ImageOrientation) override;
 
     void imageFrameAvailableAtIndex(size_t);
     void decode(Function<void()>&&);
@@ -157,7 +157,7 @@ private:
     void resetAnimation() override;
 
 #if ASSERT_ENABLED
-    bool notSolidColor() override;
+    bool notSolidColor() override { return m_source->notSolidColor(); }
 #endif
 
     void clearTimer();

--- a/Source/WebCore/platform/graphics/BitmapImageMetadata.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageMetadata.cpp
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "BitmapImageMetadata.h"
+
+#include "ImageDecoder.h"
+#include "ImageSource.h"
+
+namespace WebCore {
+
+BitmapImageMetadata::BitmapImageMetadata(ImageSource& source)
+    : m_source(source)
+{
+}
+
+template<typename MetadataType>
+MetadataType BitmapImageMetadata::imageMetadata(MetadataType& cachedValue, const MetadataType& defaultValue, CachedFlag cachedFlag, MetadataType (ImageDecoder::*functor)() const) const
+{
+    if (m_cachedFlags.contains(cachedFlag))
+        return cachedValue;
+
+    auto decoder = source().m_decoder;
+    if (!decoder || !decoder->isSizeAvailable())
+        return defaultValue;
+
+    cachedValue = (*decoder.*functor)();
+    m_cachedFlags.add(cachedFlag);
+    source().didDecodeProperties(decoder->bytesDecodedToDetermineProperties());
+    return cachedValue;
+}
+
+template<typename MetadataType>
+MetadataType BitmapImageMetadata::primaryNativeImageMetadata(MetadataType& cachedValue, const MetadataType& defaultValue, CachedFlag cachedFlag, MetadataType (NativeImage::*functor)() const) const
+{
+    if (m_cachedFlags.contains(cachedFlag))
+        return cachedValue;
+
+    auto nativeImage = const_cast<ImageSource&>(source()).frameImageAtIndexCacheIfNeeded(primaryFrameIndex());
+    if (!nativeImage)
+        return defaultValue;
+
+    cachedValue = (*nativeImage.*functor)();
+    m_cachedFlags.add(cachedFlag);
+    return cachedValue;
+}
+
+template<typename MetadataType>
+MetadataType BitmapImageMetadata::primaryImageFrameMetadata(MetadataType& cachedValue, CachedFlag cachedFlag, MetadataType (ImageFrame::*functor)() const) const
+{
+    if (m_cachedFlags.contains(cachedFlag))
+        return cachedValue;
+
+    auto& frame = const_cast<ImageSource&>(source()).frameAtIndexCacheIfNeeded(primaryFrameIndex(), ImageFrame::Caching::Metadata);
+
+    // Don't cache any unavailable frame Metadata.
+    if (!frame.hasMetadata())
+        return (frame.*functor)();
+
+    cachedValue = (frame.*functor)();
+    m_cachedFlags.add(cachedFlag);
+    return cachedValue;
+}
+
+EncodedDataStatus BitmapImageMetadata::encodedDataStatus() const
+{
+    return imageMetadata(m_encodedDataStatus, EncodedDataStatus::Unknown, CachedFlag::EncodedDataStatus, &ImageDecoder::encodedDataStatus);
+}
+
+IntSize BitmapImageMetadata::size() const
+{
+    return primaryImageFrameMetadata(m_size, CachedFlag::Size, &ImageFrame::size);
+}
+
+std::optional<IntSize> BitmapImageMetadata::densityCorrectedSize() const
+{
+    return primaryImageFrameMetadata(m_densityCorrectedSize, CachedFlag::DensityCorrectedSize, &ImageFrame::densityCorrectedSize);
+}
+
+ImageOrientation BitmapImageMetadata::orientation() const
+{
+    return primaryImageFrameMetadata(m_orientation, CachedFlag::Orientation, &ImageFrame::orientation);
+}
+
+unsigned BitmapImageMetadata::primaryFrameIndex() const
+{
+    return imageMetadata(m_primaryFrameIndex, std::size_t(0), CachedFlag::PrimaryFrameIndex, &ImageDecoder::primaryFrameIndex);
+}
+
+unsigned BitmapImageMetadata::frameCount() const
+{
+    return imageMetadata(m_frameCount, std::size_t(0), CachedFlag::FrameCount, &ImageDecoder::frameCount);
+}
+
+RepetitionCount BitmapImageMetadata::repetitionCount() const
+{
+    return imageMetadata(m_repetitionCount, static_cast<RepetitionCount>(RepetitionCountNone), CachedFlag::RepetitionCount, &ImageDecoder::repetitionCount);
+}
+
+DestinationColorSpace BitmapImageMetadata::colorSpace() const
+{
+    return primaryNativeImageMetadata(m_colorSpace, DestinationColorSpace::SRGB(), CachedFlag::ColorSpace, &NativeImage::colorSpace);
+}
+
+std::optional<Color> BitmapImageMetadata::singlePixelSolidColor() const
+{
+    return primaryNativeImageMetadata(m_singlePixelSolidColor, std::optional<Color>(), CachedFlag::SinglePixelSolidColor, &NativeImage::singlePixelSolidColor);
+}
+
+String BitmapImageMetadata::uti() const
+{
+#if USE(CG)
+    return imageMetadata(m_uti, String(), CachedFlag::UTI, &ImageDecoder::uti);
+#else
+    return String();
+#endif
+}
+
+String BitmapImageMetadata::filenameExtension() const
+{
+    return imageMetadata(m_filenameExtension, String(), CachedFlag::FilenameExtension, &ImageDecoder::filenameExtension);
+}
+
+String BitmapImageMetadata::accessibilityDescription() const
+{
+    return imageMetadata(m_accessibilityDescription, String(), CachedFlag::AccessibilityDescription, &ImageDecoder::accessibilityDescription);
+}
+
+std::optional<IntPoint> BitmapImageMetadata::hotSpot() const
+{
+    return imageMetadata(m_hotSpot, std::optional<IntPoint>(), CachedFlag::HotSpot, &ImageDecoder::hotSpot);
+}
+
+SubsamplingLevel BitmapImageMetadata::maximumSubsamplingLevel() const
+{
+    if (m_cachedFlags.contains(CachedFlag::MaximumSubsamplingLevel))
+        return m_maximumSubsamplingLevel;
+
+    auto decoder = source().m_decoder;
+    if (!decoder)
+        return SubsamplingLevel::Default;
+
+    // FIXME: this value was chosen to be appropriate for iOS since the image
+    // subsampling is only enabled by default on iOS. Choose a different value
+    // if image subsampling is enabled on other platform.
+    static constexpr int maximumImageAreaBeforeSubsampling = 5 * 1024 * 1024;
+    auto level = SubsamplingLevel::First;
+
+    for (; level < SubsamplingLevel::Last; ++level) {
+        if (source().frameSizeAtIndex(0, level).area() < maximumImageAreaBeforeSubsampling)
+            break;
+    }
+
+    m_maximumSubsamplingLevel = level;
+    m_cachedFlags.add(CachedFlag::MaximumSubsamplingLevel);
+    return m_maximumSubsamplingLevel;
+}
+
+void BitmapImageMetadata::dump(TextStream& ts) const
+{
+    ts.dumpProperty("size", size());
+    ts.dumpProperty("density-corrected-size", densityCorrectedSize());
+    ts.dumpProperty("primary-frame-index", primaryFrameIndex());
+    ts.dumpProperty("frame-count", frameCount());
+    ts.dumpProperty("repetition-count", repetitionCount());
+
+    ts.dumpProperty("uti", uti());
+    ts.dumpProperty("filename-extension", filenameExtension());
+    ts.dumpProperty("accessibility-description", accessibilityDescription());
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/BitmapImageMetadata.h
+++ b/Source/WebCore/platform/graphics/BitmapImageMetadata.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Color.h"
+#include "DestinationColorSpace.h"
+#include "ImageOrientation.h"
+#include "ImageTypes.h"
+#include "IntPoint.h"
+#include <wtf/OptionSet.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+
+namespace WebCore {
+
+class ImageSource;
+class ImageDecoder;
+class ImageFrame;
+class NativeImage;
+
+class BitmapImageMetadata {
+public:
+    BitmapImageMetadata(ImageSource&);
+
+    void clear() { m_cachedFlags = { }; }
+
+    EncodedDataStatus encodedDataStatus() const;
+    IntSize size() const;
+    std::optional<IntSize> densityCorrectedSize() const;
+    ImageOrientation orientation() const;
+    unsigned primaryFrameIndex() const;
+    unsigned frameCount() const;
+    RepetitionCount repetitionCount() const;
+    DestinationColorSpace colorSpace() const;
+    std::optional<Color> singlePixelSolidColor() const;
+
+    String uti() const;
+    String filenameExtension() const;
+    String accessibilityDescription() const;
+    std::optional<IntPoint> hotSpot() const;
+    SubsamplingLevel maximumSubsamplingLevel() const;
+
+    void dump(TextStream&) const;
+
+private:
+    enum class CachedFlag {
+        EncodedDataStatus           = 1 << 0,
+        Size                        = 1 << 1,
+        DensityCorrectedSize        = 1 << 2,
+        Orientation                 = 1 << 3,
+        PrimaryFrameIndex           = 1 << 4,
+        FrameCount                  = 1 << 5,
+        RepetitionCount             = 1 << 6,
+        ColorSpace                  = 1 << 7,
+        SinglePixelSolidColor       = 1 << 8,
+
+        UTI                         = 1 << 9,
+        FilenameExtension           = 1 << 10,
+        AccessibilityDescription    = 1 << 11,
+        HotSpot                     = 1 << 12,
+        MaximumSubsamplingLevel     = 1 << 13,
+    };
+
+    ImageSource& source() const { return *m_source.get(); }
+
+    template<typename MetadataType>
+    MetadataType imageMetadata(MetadataType& cachedValue, const MetadataType& defaultValue, CachedFlag, MetadataType (ImageDecoder::*functor)() const) const;
+
+    template<typename MetadataType>
+    MetadataType primaryNativeImageMetadata(MetadataType& cachedValue, const MetadataType& defaultValue, CachedFlag, MetadataType (NativeImage::*functor)() const) const;
+
+    template<typename MetadataType>
+    MetadataType primaryImageFrameMetadata(MetadataType& cachedValue, CachedFlag, MetadataType (ImageFrame::*functor)() const) const;
+
+    ThreadSafeWeakPtr<ImageSource> m_source;
+    mutable OptionSet<CachedFlag> m_cachedFlags;
+
+    mutable EncodedDataStatus m_encodedDataStatus { EncodedDataStatus::Unknown };
+    mutable IntSize m_size;
+    mutable std::optional<IntSize> m_densityCorrectedSize;
+    mutable ImageOrientation m_orientation;
+    mutable size_t m_primaryFrameIndex { 0 };
+    mutable size_t m_frameCount { 0 };
+    mutable RepetitionCount m_repetitionCount { RepetitionCountNone };
+    mutable DestinationColorSpace m_colorSpace { DestinationColorSpace::SRGB() };
+    mutable std::optional<Color> m_singlePixelSolidColor;
+
+    mutable String m_uti;
+    mutable String m_filenameExtension;
+    mutable String m_accessibilityDescription;
+    mutable std::optional<IntPoint> m_hotSpot;
+    mutable SubsamplingLevel m_maximumSubsamplingLevel { SubsamplingLevel::Default };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/Image.cpp
+++ b/Source/WebCore/platform/graphics/Image.cpp
@@ -170,7 +170,7 @@ void Image::fillWithSolidColor(GraphicsContext& ctxt, const FloatRect& dstRect, 
 
 void Image::drawPattern(GraphicsContext& ctxt, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, ImagePaintingOptions options)
 {
-    auto tileImage = preTransformedNativeImageForCurrentFrame(options.orientation() == ImageOrientation::Orientation::FromImage);
+    auto tileImage = preTransformedNativeImageForCurrentFrame(options.orientation());
     if (!tileImage)
         return;
 
@@ -182,9 +182,8 @@ void Image::drawPattern(GraphicsContext& ctxt, const FloatRect& destRect, const 
 
 ImageDrawResult Image::drawTiled(GraphicsContext& ctxt, const FloatRect& destRect, const FloatPoint& srcPoint, const FloatSize& scaledTileSize, const FloatSize& spacing, ImagePaintingOptions options)
 {
-    Color color = singlePixelSolidColor();
-    if (color.isValid()) {
-        fillWithSolidColor(ctxt, destRect, color, options.compositeOperator());
+    if (auto color = singlePixelSolidColor()) {
+        fillWithSolidColor(ctxt, destRect, *color, options.compositeOperator());
         return ImageDrawResult::DidDraw;
     }
 
@@ -286,9 +285,8 @@ ImageDrawResult Image::drawTiled(GraphicsContext& ctxt, const FloatRect& destRec
 // FIXME: Merge with the other drawTiled eventually, since we need a combination of both for some things.
 ImageDrawResult Image::drawTiled(GraphicsContext& ctxt, const FloatRect& dstRect, const FloatRect& srcRect, const FloatSize& tileScaleFactor, TileRule hRule, TileRule vRule, ImagePaintingOptions options)
 {    
-    Color color = singlePixelSolidColor();
-    if (color.isValid()) {
-        fillWithSolidColor(ctxt, dstRect, color, options.compositeOperator());
+    if (auto color = singlePixelSolidColor()) {
+        fillWithSolidColor(ctxt, dstRect, *color, options.compositeOperator());
         return ImageDrawResult::DidDraw;
     }
 

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -147,7 +147,7 @@ public:
 
     virtual RefPtr<NativeImage> nativeImage(const DestinationColorSpace& = DestinationColorSpace::SRGB()) { return nullptr; }
     virtual RefPtr<NativeImage> nativeImageForCurrentFrame() { return nativeImage(); }
-    virtual RefPtr<NativeImage> preTransformedNativeImageForCurrentFrame(bool = true) { return nativeImageForCurrentFrame(); }
+    virtual RefPtr<NativeImage> preTransformedNativeImageForCurrentFrame(ImageOrientation = ImageOrientation::Orientation::FromImage) { return nativeImageForCurrentFrame(); }
     virtual RefPtr<NativeImage> nativeImageAtIndex(size_t) { return nativeImage(); }
     virtual RefPtr<NativeImage> nativeImageAtIndexCacheIfNeeded(size_t index, SubsamplingLevel = SubsamplingLevel::Default, const DecodingOptions& = { }) { return nativeImageAtIndex(index); }
 
@@ -171,7 +171,7 @@ protected:
     ImageDrawResult drawTiled(GraphicsContext&, const FloatRect& dstRect, const FloatRect& srcRect, const FloatSize& tileScaleFactor, TileRule hRule, TileRule vRule, ImagePaintingOptions = { });
 
     // Supporting tiled drawing
-    virtual Color singlePixelSolidColor() const { return Color(); }
+    virtual std::optional<Color> singlePixelSolidColor() const { return std::nullopt; }
 
 private:
     RefPtr<FragmentedSharedBuffer> m_encodedImageData;

--- a/Source/WebCore/platform/graphics/ImageFrame.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrame.cpp
@@ -96,11 +96,6 @@ unsigned ImageFrame::clear()
     return frameBytes;
 }
 
-IntSize ImageFrame::size() const
-{
-    return m_size;
-}
-
 bool ImageFrame::hasNativeImage(const std::optional<SubsamplingLevel>& subsamplingLevel) const
 {
     return m_nativeImage && (!subsamplingLevel || *subsamplingLevel >= m_subsamplingLevel);
@@ -114,14 +109,6 @@ bool ImageFrame::hasFullSizeNativeImage(const std::optional<SubsamplingLevel>& s
 bool ImageFrame::hasDecodedNativeImageCompatibleWithOptions(const std::optional<SubsamplingLevel>& subsamplingLevel, const DecodingOptions& decodingOptions) const
 {
     return isComplete() && hasNativeImage(subsamplingLevel) && m_decodingOptions.isCompatibleWith(decodingOptions);
-}
-
-Color ImageFrame::singlePixelSolidColor() const
-{
-    if (!hasNativeImage() || m_size != IntSize(1, 1))
-        return Color();
-
-    return m_nativeImage->singlePixelSolidColor();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageFrame.h
+++ b/Source/WebCore/platform/graphics/ImageFrame.h
@@ -65,7 +65,8 @@ public:
     bool isPartial() const { return m_decodingStatus == DecodingStatus::Partial; }
     bool isComplete() const { return m_decodingStatus == DecodingStatus::Complete; }
 
-    IntSize size() const;
+    IntSize size() const { return m_size; }
+
     unsigned frameBytes() const { return hasNativeImage() ? (size().area() * sizeof(uint32_t)).value() : 0; }
     SubsamplingLevel subsamplingLevel() const { return m_subsamplingLevel; }
 
@@ -87,8 +88,6 @@ public:
     bool hasFullSizeNativeImage(const std::optional<SubsamplingLevel>& = { }) const;
     bool hasDecodedNativeImageCompatibleWithOptions(const std::optional<SubsamplingLevel>&, const DecodingOptions&) const;
     bool hasMetadata() const { return !size().isEmpty(); }
-
-    Color singlePixelSolidColor() const;
 
 private:
     DecodingStatus m_decodingStatus { DecodingStatus::Invalid };

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -51,7 +51,7 @@ public:
 
     WEBCORE_EXPORT IntSize size() const;
     bool hasAlpha() const;
-    Color singlePixelSolidColor() const;
+    std::optional<Color> singlePixelSolidColor() const;
     WEBCORE_EXPORT DestinationColorSpace colorSpace() const;
 
     void draw(GraphicsContext&, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions);

--- a/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
@@ -51,14 +51,14 @@ DestinationColorSpace PlatformImageNativeImageBackend::colorSpace() const
     return DestinationColorSpace::SRGB();
 }
 
-Color NativeImage::singlePixelSolidColor() const
+std::optional<Color> NativeImage::singlePixelSolidColor() const
 {
     if (size() != IntSize(1, 1))
-        return Color();
+        return std::nullopt;
 
     auto platformImage = this->platformImage().get();
     if (cairo_surface_get_type(platformImage) != CAIRO_SURFACE_TYPE_IMAGE)
-        return Color();
+        return std::nullopt;
 
     unsigned* pixel = reinterpret_cast_ptr<unsigned*>(cairo_image_surface_get_data(platformImage));
     return unpremultiplied(asSRGBA(PackedColor::ARGB { *pixel }));

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -77,16 +77,16 @@ RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& image, Rende
     return create(WTFMove(transientImage), identifier);
 }
 
-Color NativeImage::singlePixelSolidColor() const
+std::optional<Color> NativeImage::singlePixelSolidColor() const
 {
     if (size() != IntSize(1, 1))
-        return Color();
+        return std::nullopt;
 
     unsigned char pixel[4]; // RGBA
     auto bitmapContext = adoptCF(CGBitmapContextCreate(pixel, 1, 1, 8, sizeof(pixel), sRGBColorSpaceRef(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
 
     if (!bitmapContext)
-        return Color();
+        return std::nullopt;
 
     CGContextSetBlendMode(bitmapContext.get(), kCGBlendModeCopy);
     CGContextDrawImage(bitmapContext.get(), CGRectMake(0, 0, 1, 1), platformImage().get());


### PR DESCRIPTION
#### 5d5ba2e7431a66b953f72b6f253aa630d27a463f
<pre>
Move image metadata queries to a separate class named BitmapImageMetadata
<a href="https://bugs.webkit.org/show_bug.cgi?id=268127">https://bugs.webkit.org/show_bug.cgi?id=268127</a>
<a href="https://rdar.apple.com/121643757">rdar://121643757</a>

Reviewed by NOBODY (OOPS!).

ImageSource will delegate the image metadata queries to BitmapImageMetadata. The
metadata is retrieved either from the ImageDecoder for from the ImageFrame of the
primary index of the image.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::preTransformedNativeImageForCurrentFrame):
(WebCore::BitmapImage::draw):
(WebCore::BitmapImage::notSolidColor): Deleted.
(WebCore::BitmapImage::colorSpace): Deleted.
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/BitmapImageMetadata.cpp: Added.
(WebCore::BitmapImageMetadata::BitmapImageMetadata):
(WebCore::BitmapImageMetadata::imageMetadata const):
(WebCore::BitmapImageMetadata::primaryNativeImageMetadata const):
(WebCore::BitmapImageMetadata::primaryImageFrameMetadata const):
(WebCore::BitmapImageMetadata::encodedDataStatus const):
(WebCore::BitmapImageMetadata::size const):
(WebCore::BitmapImageMetadata::densityCorrectedSize const):
(WebCore::BitmapImageMetadata::orientation const):
(WebCore::BitmapImageMetadata::primaryFrameIndex const):
(WebCore::BitmapImageMetadata::frameCount const):
(WebCore::BitmapImageMetadata::repetitionCount const):
(WebCore::BitmapImageMetadata::colorSpace const):
(WebCore::BitmapImageMetadata::singlePixelSolidColor const):
(WebCore::BitmapImageMetadata::uti const):
(WebCore::BitmapImageMetadata::filenameExtension const):
(WebCore::BitmapImageMetadata::accessibilityDescription const):
(WebCore::BitmapImageMetadata::hotSpot const):
(WebCore::BitmapImageMetadata::maximumSubsamplingLevel const):
(WebCore::BitmapImageMetadata::dump const):
* Source/WebCore/platform/graphics/BitmapImageMetadata.h: Added.
(WebCore::BitmapImageMetadata::clear):
(WebCore::BitmapImageMetadata::source const):
* Source/WebCore/platform/graphics/Image.cpp:
(WebCore::Image::drawPattern):
(WebCore::Image::drawTiled):
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::preTransformedNativeImageForCurrentFrame):
(WebCore::Image::singlePixelSolidColor const):
* Source/WebCore/platform/graphics/ImageFrame.cpp:
(WebCore::ImageFrame::size const): Deleted.
(WebCore::ImageFrame::singlePixelSolidColor const): Deleted.
* Source/WebCore/platform/graphics/ImageFrame.h:
(WebCore::ImageFrame::size const):
* Source/WebCore/platform/graphics/ImageSource.cpp:
(WebCore::ImageSource::ImageSource):
(WebCore::ImageSource::dataChanged):
(WebCore::ImageSource::encodedDataStatusChanged):
(WebCore::ImageSource::encodedDataStatus const):
(WebCore::ImageSource::size const):
(WebCore::ImageSource::sourceSize const):
(WebCore::ImageSource::frameCount const):
(WebCore::ImageSource::notSolidColor const):
(WebCore::ImageSource::singlePixelSolidColor const):
(WebCore::ImageSource::clearMetadata): Deleted.
(WebCore::ImageSource::metadataCacheIfNeeded): Deleted.
(WebCore::ImageSource::firstFrameMetadataCacheIfNeeded): Deleted.
(WebCore::ImageSource::encodedDataStatus): Deleted.
(WebCore::ImageSource::frameCount): Deleted.
(WebCore::ImageSource::primaryFrameIndex): Deleted.
(WebCore::ImageSource::repetitionCount): Deleted.
(WebCore::ImageSource::uti): Deleted.
(WebCore::ImageSource::filenameExtension): Deleted.
(WebCore::ImageSource::accessibilityDescription): Deleted.
(WebCore::ImageSource::hotSpot): Deleted.
(WebCore::ImageSource::orientation): Deleted.
(WebCore::ImageSource::densityCorrectedSize): Deleted.
(WebCore::ImageSource::size): Deleted.
(WebCore::ImageSource::sourceSize): Deleted.
(WebCore::ImageSource::singlePixelSolidColor): Deleted.
(WebCore::ImageSource::maximumSubsamplingLevel): Deleted.
* Source/WebCore/platform/graphics/ImageSource.h:
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp:
(WebCore::NativeImage::singlePixelSolidColor const):
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
(WebCore::NativeImage::singlePixelSolidColor const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d5ba2e7431a66b953f72b6f253aa630d27a463f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15846 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39537 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33039 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31577 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11673 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32884 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40789 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33468 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33229 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37595 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11978 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35716 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13633 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12362 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12889 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->