### PR TITLE
[GStreamer] Harness: Migration from output buffer to output sample processing

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp
@@ -256,16 +256,17 @@ GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder(const String& codec
     } else
         harnessedElement = WTFMove(element);
 
-    m_harness = GStreamerElementHarness::create(WTFMove(harnessedElement), [weakThis = WeakPtr { *this }, this](auto& stream, const GRefPtr<GstBuffer>& outputBuffer) {
+    m_harness = GStreamerElementHarness::create(WTFMove(harnessedElement), [weakThis = WeakPtr { *this }, this](auto&, const GRefPtr<GstSample>& outputSample) {
         if (!weakThis)
             return;
         if (m_isClosed)
             return;
 
-        if (GST_BUFFER_FLAG_IS_SET(outputBuffer.get(), GST_BUFFER_FLAG_DECODE_ONLY))
+        auto outputBuffer = gst_sample_get_buffer(outputSample.get());
+        if (GST_BUFFER_FLAG_IS_SET(outputBuffer, GST_BUFFER_FLAG_DECODE_ONLY))
             return;
 
-        if (!gst_buffer_n_memory(outputBuffer.get()))
+        if (!gst_buffer_n_memory(outputBuffer))
             return;
 
         static std::once_flag onceFlag;
@@ -273,13 +274,9 @@ GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder(const String& codec
             m_harness->dumpGraph("audio-decoder");
         });
 
-        GST_TRACE_OBJECT(m_harness->element(), "Got frame with PTS: %" GST_TIME_FORMAT, GST_TIME_ARGS(GST_BUFFER_PTS(outputBuffer.get())));
+        GST_TRACE_OBJECT(m_harness->element(), "Got frame with PTS: %" GST_TIME_FORMAT, GST_TIME_ARGS(GST_BUFFER_PTS(outputBuffer)));
 
-        const GstSegment* segment = nullptr;
-        if (auto segmentEvent = adoptGRef(gst_pad_get_sticky_event(stream.pad().get(), GST_EVENT_SEGMENT, 0)))
-            gst_event_parse_segment(segmentEvent.get(), &segment);
-        auto sample = adoptGRef(gst_sample_new(outputBuffer.get(), stream.outputCaps().get(), segment, nullptr));
-        auto data = PlatformRawAudioDataGStreamer::create(WTFMove(sample));
+        auto data = PlatformRawAudioDataGStreamer::create(GRefPtr(outputSample));
         m_postTaskCallback([weakThis = WeakPtr { *this }, this, data = WTFMove(data)]() mutable {
             if (!weakThis)
                 return;
@@ -330,7 +327,7 @@ void GStreamerInternalAudioDecoder::decode(std::span<const uint8_t> frameData, b
             return;
 
         if (result)
-            m_harness->processOutputBuffers();
+            m_harness->processOutputSamples();
         else
             m_outputCallback(makeUnexpected("Decode error"_s));
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
@@ -145,7 +145,7 @@ void GStreamerAudioEncoder::encode(RawFrame&& frame, EncodeCallback&& callback)
 
         String resultString;
         if (result)
-            encoder->harness()->processOutputBuffers();
+            encoder->harness()->processOutputSamples();
         else
             resultString = "Encoding failed"_s;
 
@@ -247,15 +247,16 @@ GStreamerInternalAudioEncoder::GStreamerInternalAudioEncoder(AudioEncoder::Descr
         delete static_cast<ThreadSafeWeakPtr<GStreamerInternalAudioEncoder>*>(data);
     }, static_cast<GConnectFlags>(0));
 
-    m_harness = GStreamerElementHarness::create(WTFMove(harnessedElement), [weakThis = ThreadSafeWeakPtr { *this }, this](auto& stream, const GRefPtr<GstBuffer>& outputBuffer) {
+    m_harness = GStreamerElementHarness::create(WTFMove(harnessedElement), [weakThis = ThreadSafeWeakPtr { *this }, this](auto&, const GRefPtr<GstSample>& outputSample) {
         if (!weakThis.get())
             return;
         if (m_isClosed)
             return;
 
-        const auto& caps = stream.outputCaps();
-        auto structure = gst_caps_get_structure(caps.get(), 0);
-        if (gst_structure_has_name(structure, "audio/x-opus") && gst_buffer_get_size(outputBuffer.get()) < 2) {
+        auto caps = gst_sample_get_caps(outputSample.get());
+        auto outputBuffer = gst_sample_get_buffer(outputSample.get());
+        auto structure = gst_caps_get_structure(caps, 0);
+        if (gst_structure_has_name(structure, "audio/x-opus") && gst_buffer_get_size(outputBuffer) < 2) {
             GST_INFO_OBJECT(m_encoder.get(), "DTX opus packet detected, ignoring it");
             return;
         }
@@ -265,9 +266,9 @@ GStreamerInternalAudioEncoder::GStreamerInternalAudioEncoder(AudioEncoder::Descr
             m_harness->dumpGraph("audio-encoder");
         });
 
-        bool isKeyFrame = !GST_BUFFER_FLAG_IS_SET(outputBuffer.get(), GST_BUFFER_FLAG_DELTA_UNIT);
+        bool isKeyFrame = !GST_BUFFER_FLAG_IS_SET(outputBuffer, GST_BUFFER_FLAG_DELTA_UNIT);
         GST_TRACE_OBJECT(m_harness->element(), "Notifying encoded%s frame", isKeyFrame ? " key" : "");
-        GstMappedBuffer mappedBuffer(outputBuffer.get(), GST_MAP_READ);
+        GstMappedBuffer mappedBuffer(outputBuffer, GST_MAP_READ);
         AudioEncoder::EncodedFrame encodedFrame { mappedBuffer.createVector(), isKeyFrame, m_timestamp, m_duration };
         m_postTaskCallback([protectedThis = Ref { *this }, this, encodedFrame = WTFMove(encodedFrame)]() mutable {
             if (protectedThis->m_isClosed)

--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
@@ -119,9 +119,8 @@ ImageDecoderGStreamer::ImageDecoderGStreamer(FragmentedSharedBuffer& data, const
 
         GRefPtr<GstElement> element = gst_element_factory_create(lookupResult.factory.get(), nullptr);
         configureVideoDecoderForHarnessing(element);
-        m_decoderHarness = GStreamerElementHarness::create(WTFMove(element), [this](auto& stream, const auto& outputBuffer) {
-            auto outputCaps = stream.outputCaps();
-            storeDecodedSample(adoptGRef(gst_sample_new(outputBuffer.get(), outputCaps.get(), nullptr, nullptr)));
+        m_decoderHarness = GStreamerElementHarness::create(WTFMove(element), [this](auto&, const auto& outputSample) {
+            storeDecodedSample(GRefPtr(outputSample));
         }, { });
         return m_decoderHarness;
     });

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -135,7 +135,7 @@ void GStreamerVideoEncoder::encode(RawFrame&& frame, bool shouldGenerateKeyFrame
 
         String resultString;
         if (result)
-            encoder->harness()->processOutputBuffers();
+            encoder->harness()->processOutputSamples();
         else
             resultString = "Encoding failed"_s;
 
@@ -217,7 +217,7 @@ GStreamerInternalVideoEncoder::GStreamerInternalVideoEncoder(VideoEncoder::Descr
         delete static_cast<ThreadSafeWeakPtr<GStreamerInternalVideoEncoder>*>(data);
     }, static_cast<GConnectFlags>(0));
 
-    m_harness = GStreamerElementHarness::create(WTFMove(element), [weakThis = ThreadSafeWeakPtr { *this }, this](auto&, const GRefPtr<GstBuffer>& outputBuffer) {
+    m_harness = GStreamerElementHarness::create(WTFMove(element), [weakThis = ThreadSafeWeakPtr { *this }, this](auto&, const GRefPtr<GstSample>& outputSample) {
         if (!weakThis.get())
             return;
         if (m_isClosed)
@@ -228,9 +228,10 @@ GStreamerInternalVideoEncoder::GStreamerInternalVideoEncoder(VideoEncoder::Descr
             m_harness->dumpGraph("video-encoder");
         });
 
-        bool isKeyFrame = !GST_BUFFER_FLAG_IS_SET(outputBuffer.get(), GST_BUFFER_FLAG_DELTA_UNIT);
+        auto outputBuffer = gst_sample_get_buffer(outputSample.get());
+        bool isKeyFrame = !GST_BUFFER_FLAG_IS_SET(outputBuffer, GST_BUFFER_FLAG_DELTA_UNIT);
         GST_TRACE_OBJECT(m_harness->element(), "Notifying encoded%s frame", isKeyFrame ? " key" : "");
-        GstMappedBuffer encodedImage(outputBuffer.get(), GST_MAP_READ);
+        GstMappedBuffer encodedImage(outputBuffer, GST_MAP_READ);
         VideoEncoder::EncodedFrame encodedFrame {
             Vector<uint8_t> { std::span<const uint8_t> { encodedImage.data(), encodedImage.size() } },
             isKeyFrame, m_timestamp, m_duration, { }

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
@@ -72,8 +72,8 @@ static GstStaticPadTemplate s_harnessSinkPadTemplate = GST_STATIC_PAD_TEMPLATE("
  * explicitly call the `start(caps)` method, otherwise the sample-based `pushSample()` API will
  * implicitely take care of starting the harness.
  *
- * Output buffers and events can be manually pulled on the corresponding
- * `GStreamerElementHarness::Stream` using the `pullBuffer()` and `pullEvent()` methods. The list of
+ * Output samples and events can be manually pulled on the corresponding
+ * `GStreamerElementHarness::Stream` using the `pullSample()` and `pullEvent()` methods. The list of
  * output streams can be queried with the `GStreamerElementHarness::outputStreams()` method.
  *
  * The harness can work on elements exposing either a static source pad, or one-to-many "sometimes"
@@ -86,9 +86,9 @@ static GstStaticPadTemplate s_harnessSinkPadTemplate = GST_STATIC_PAD_TEMPLATE("
  * PNG using the mermaid CLI tools or the [live editor](https://mermaid.live).
  */
 
-GStreamerElementHarness::GStreamerElementHarness(GRefPtr<GstElement>&& element, ProcessBufferCallback&& processOutputBufferCallback, std::optional<PadLinkCallback>&& padLinkCallback)
+GStreamerElementHarness::GStreamerElementHarness(GRefPtr<GstElement>&& element, ProcessSampleCallback&& processOutputSampleCallback, std::optional<PadLinkCallback>&& padLinkCallback)
     : m_element(WTFMove(element))
-    , m_processOutputBufferCallback(WTFMove(processOutputBufferCallback))
+    , m_processOutputSampleCallback(WTFMove(processOutputSampleCallback))
     , m_padLinkCallback(WTFMove(padLinkCallback))
 {
     static std::once_flag debugRegisteredFlag;
@@ -202,7 +202,7 @@ void GStreamerElementHarness::reset()
     pushEvent(adoptGRef(gst_event_new_eos()));
     gst_element_set_state(m_element.get(), GST_STATE_NULL);
 
-    processOutputBuffers();
+    processOutputSamples();
 
     m_playing.store(false);
 }
@@ -292,13 +292,13 @@ GStreamerElementHarness::Stream::Stream(GRefPtr<GstPad>&& pad, RefPtr<GStreamerE
             return downstreamHarness->pushBufferFull(adoptGRef(buffer));
         }
 
-        // Make sure the stream caps are cached by calling outputCaps() here. If we don't do this
-        // and processOutputBuffers() is called after the element received EOS, the caps might be
-        // cleared on the pad. Ideally we should keep track of output samples, not only buffers.
         const auto& caps = stream.outputCaps();
-        UNUSED_VARIABLE(caps);
+        const GstSegment* segment = nullptr;
+        if (auto segmentEvent = adoptGRef(gst_pad_get_sticky_event(stream.pad().get(), GST_EVENT_SEGMENT, 0)))
+            gst_event_parse_segment(segmentEvent.get(), &segment);
 
-        return stream.chainBuffer(buffer);
+        auto outputBuffer = adoptGRef(buffer);
+        return stream.chainSample(adoptGRef(gst_sample_new(outputBuffer.get(), caps.get(), segment, nullptr)));
     }),  this, nullptr);
     gst_pad_set_event_function_full(m_targetPad.get(), reinterpret_cast<GstPadEventFunction>(+[](GstPad* pad, GstObject*, GstEvent* event) -> gboolean {
         auto& stream = *reinterpret_cast<GStreamerElementHarness::Stream*>(pad->eventdata);
@@ -318,13 +318,13 @@ GStreamerElementHarness::Stream::~Stream()
     gst_pad_set_query_function(m_targetPad.get(), nullptr);
 }
 
-GRefPtr<GstBuffer> GStreamerElementHarness::Stream::pullBuffer()
+GRefPtr<GstSample> GStreamerElementHarness::Stream::pullSample()
 {
-    GST_LOG_OBJECT(m_pad.get(), "%zu buffers currently queued", m_bufferQueue.size());
-    Locker locker { m_bufferQueueLock };
-    if (m_bufferQueue.isEmpty())
+    GST_LOG_OBJECT(m_pad.get(), "%zu samples currently queued", m_sampleQueue.size());
+    Locker locker { m_sampleQueueLock };
+    if (m_sampleQueue.isEmpty())
         return nullptr;
-    return m_bufferQueue.takeLast();
+    return m_sampleQueue.takeLast();
 }
 
 GRefPtr<GstEvent> GStreamerElementHarness::Stream::pullEvent()
@@ -354,11 +354,10 @@ const GRefPtr<GstCaps>& GStreamerElementHarness::Stream::outputCaps()
     return m_outputCaps;
 }
 
-GstFlowReturn GStreamerElementHarness::Stream::chainBuffer(GstBuffer* outputBuffer)
+GstFlowReturn GStreamerElementHarness::Stream::chainSample(GRefPtr<GstSample>&& sample)
 {
-    Locker locker { m_bufferQueueLock };
-    auto buffer = adoptGRef(outputBuffer);
-    m_bufferQueue.prepend(WTFMove(buffer));
+    Locker locker { m_sampleQueueLock };
+    m_sampleQueue.prepend(WTFMove(sample));
     return GST_FLOW_OK;
 }
 
@@ -409,11 +408,11 @@ bool GStreamerElementHarness::srcEvent(GstEvent* event)
     return true;
 }
 
-void GStreamerElementHarness::processOutputBuffers()
+void GStreamerElementHarness::processOutputSamples()
 {
     for (auto& stream : m_outputStreams) {
-        while (auto outputBuffer = stream->pullBuffer())
-            m_processOutputBufferCallback(*stream.get(), outputBuffer);
+        while (auto outputSample = stream->pullSample())
+            m_processOutputSampleCallback(*stream.get(), outputSample);
     }
 }
 
@@ -438,7 +437,7 @@ bool GStreamerElementHarness::flushBuffers()
         return false;
     }
 
-    processOutputBuffers();
+    processOutputSamples();
 
     pushEvent(adoptGRef(gst_event_new_flush_start()));
     pushEvent(adoptGRef(gst_event_new_flush_stop(FALSE)));

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
@@ -47,7 +47,7 @@ TEST_F(GStreamerTest, harnessBasic)
     auto& stream = harness->outputStreams().first();
 
     // Harness has not started processing data yet.
-    ASSERT_NULL(stream->pullBuffer());
+    ASSERT_NULL(stream->pullSample());
     ASSERT_NULL(stream->pullEvent());
 
     // Push a sample and expect initial events and an output buffer.
@@ -78,14 +78,15 @@ TEST_F(GStreamerTest, harnessBasic)
     ASSERT_TRUE(gst_caps_is_equal(stream->outputCaps().get(), caps.get()));
 
     // The harnessed element is identity, so output buffers should be the same as input buffers.
-    auto outputBuffer = stream->pullBuffer();
-    GstMappedBuffer mappedOutputBuffer(outputBuffer.get(), GST_MAP_READ);
+    auto outputSample = stream->pullSample();
+    auto outputBuffer = gst_sample_get_buffer(outputSample.get());
+    GstMappedBuffer mappedOutputBuffer(outputBuffer, GST_MAP_READ);
     ASSERT_TRUE(mappedOutputBuffer);
     EXPECT_EQ(mappedOutputBuffer.size(), 64);
     EXPECT_EQ(memcmp(mappedInputBuffer.data(), mappedOutputBuffer.data(), 64), 0);
 
     // Harness is now empty.
-    ASSERT_NULL(stream->pullBuffer());
+    ASSERT_NULL(stream->pullSample());
     ASSERT_NULL(stream->pullEvent());
 }
 
@@ -99,7 +100,7 @@ TEST_F(GStreamerTest, harnessManualStart)
     auto& stream = harness->outputStreams().first();
 
     // Harness has not started processing data yet.
-    ASSERT_NULL(stream->pullBuffer());
+    ASSERT_NULL(stream->pullSample());
     ASSERT_NULL(stream->pullEvent());
 
     // Pushing a buffer before start is not allowed.
@@ -134,14 +135,15 @@ TEST_F(GStreamerTest, harnessManualStart)
     EXPECT_TRUE(harness->pushBuffer(GRefPtr<GstBuffer>(buffer.get())));
 
     // The harnessed element is identity, so output buffers should be the same as input buffers.
-    auto outputBuffer = stream->pullBuffer();
-    GstMappedBuffer mappedOutputBuffer(outputBuffer.get(), GST_MAP_READ);
+    auto outputSample = stream->pullSample();
+    auto outputBuffer = gst_sample_get_buffer(outputSample.get());
+    GstMappedBuffer mappedOutputBuffer(outputBuffer, GST_MAP_READ);
     ASSERT_TRUE(mappedOutputBuffer);
     EXPECT_EQ(mappedOutputBuffer.size(), 64);
     EXPECT_EQ(memcmp(mappedInputBuffer.data(), mappedOutputBuffer.data(), 64), 0);
 
     // Harness is now empty.
-    ASSERT_NULL(stream->pullBuffer());
+    ASSERT_NULL(stream->pullSample());
     ASSERT_NULL(stream->pullEvent());
 }
 
@@ -149,8 +151,9 @@ TEST_F(GStreamerTest, harnessBufferProcessing)
 {
     GRefPtr<GstElement> element = gst_element_factory_make("identity", nullptr);
     unsigned counter = 0;
-    auto harness = WebCore::GStreamerElementHarness::create(WTFMove(element), [&counter](auto&, const auto& outputBuffer) mutable {
-        GstMappedBuffer mappedOutputBuffer(outputBuffer.get(), GST_MAP_READ);
+    auto harness = WebCore::GStreamerElementHarness::create(WTFMove(element), [&counter](auto&, const auto& outputSample) mutable {
+        auto outputBuffer = gst_sample_get_buffer(outputSample.get());
+        GstMappedBuffer mappedOutputBuffer(outputBuffer, GST_MAP_READ);
         ASSERT_TRUE(mappedOutputBuffer);
         EXPECT_EQ(mappedOutputBuffer.size(), 64);
         EXPECT_EQ(mappedOutputBuffer.data()[0], counter);
@@ -162,7 +165,7 @@ TEST_F(GStreamerTest, harnessBufferProcessing)
     auto& stream = harness->outputStreams().first();
 
     // Harness has not started processing data yet.
-    ASSERT_NULL(stream->pullBuffer());
+    ASSERT_NULL(stream->pullSample());
     ASSERT_NULL(stream->pullEvent());
     ASSERT_EQ(counter, 0);
 
@@ -174,7 +177,7 @@ TEST_F(GStreamerTest, harnessBufferProcessing)
         auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
         EXPECT_TRUE(harness->pushSample(WTFMove(sample)));
     }
-    harness->processOutputBuffers();
+    harness->processOutputSamples();
     ASSERT_EQ(counter, 3);
 }
 
@@ -182,8 +185,9 @@ TEST_F(GStreamerTest, harnessFlush)
 {
     GRefPtr<GstElement> element = gst_element_factory_make("identity", nullptr);
     unsigned counter = 0;
-    auto harness = WebCore::GStreamerElementHarness::create(WTFMove(element), [&counter](auto&, const auto& outputBuffer) mutable {
-        GstMappedBuffer mappedOutputBuffer(outputBuffer.get(), GST_MAP_READ);
+    auto harness = WebCore::GStreamerElementHarness::create(WTFMove(element), [&counter](auto&, const auto& outputSample) mutable {
+        auto outputBuffer = gst_sample_get_buffer(outputSample.get());
+        GstMappedBuffer mappedOutputBuffer(outputBuffer, GST_MAP_READ);
         ASSERT_TRUE(mappedOutputBuffer);
         EXPECT_EQ(mappedOutputBuffer.size(), 64);
         EXPECT_EQ(mappedOutputBuffer.data()[0], 2);
@@ -195,7 +199,7 @@ TEST_F(GStreamerTest, harnessFlush)
     auto& stream = harness->outputStreams().first();
 
     // Harness has not started processing data yet.
-    ASSERT_NULL(stream->pullBuffer());
+    ASSERT_NULL(stream->pullSample());
     ASSERT_NULL(stream->pullEvent());
     ASSERT_EQ(counter, 0);
 
@@ -208,14 +212,16 @@ TEST_F(GStreamerTest, harnessFlush)
         auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
         EXPECT_TRUE(harness->pushSample(WTFMove(sample)));
     }
-    auto firstOutputBuffer = stream->pullBuffer();
-    GstMappedBuffer mappedFirstOutputBuffer(firstOutputBuffer.get(), GST_MAP_READ);
+    auto firstOutputSample = stream->pullSample();
+    auto firstOutputBuffer = gst_sample_get_buffer(firstOutputSample.get());
+    GstMappedBuffer mappedFirstOutputBuffer(firstOutputBuffer, GST_MAP_READ);
     ASSERT_TRUE(mappedFirstOutputBuffer);
     EXPECT_EQ(mappedFirstOutputBuffer.size(), 64);
     EXPECT_EQ(mappedFirstOutputBuffer.data()[0], 0);
 
-    auto secondOutputBuffer = stream->pullBuffer();
-    GstMappedBuffer mappedSecondOutputBuffer(secondOutputBuffer.get(), GST_MAP_READ);
+    auto secondOutputSample = stream->pullSample();
+    auto secondOutputBuffer = gst_sample_get_buffer(secondOutputSample.get());
+    GstMappedBuffer mappedSecondOutputBuffer(secondOutputBuffer, GST_MAP_READ);
     ASSERT_TRUE(mappedSecondOutputBuffer);
     EXPECT_EQ(mappedSecondOutputBuffer.size(), 64);
     EXPECT_EQ(mappedSecondOutputBuffer.data()[0], 1);
@@ -224,7 +230,7 @@ TEST_F(GStreamerTest, harnessFlush)
     ASSERT_EQ(counter, 1);
 
     // Flushed harness is empty.
-    ASSERT_NULL(stream->pullBuffer());
+    ASSERT_NULL(stream->pullSample());
     ASSERT_NULL(stream->pullEvent());
 }
 


### PR DESCRIPTION
#### 2a0d30d45a600d798a84e443ae9d0ba82556837a
<pre>
[GStreamer] Harness: Migration from output buffer to output sample processing
<a href="https://bugs.webkit.org/show_bug.cgi?id=268150">https://bugs.webkit.org/show_bug.cgi?id=268150</a>

Reviewed by Xabier Rodriguez-Calvar.

Output buffers are now stored in samples along with their caps. This makes the API more coherent.

* Source/WebCore/platform/audio/gstreamer/AudioDecoderGStreamer.cpp:
(WebCore::GStreamerInternalAudioDecoder::GStreamerInternalAudioDecoder):
(WebCore::GStreamerInternalAudioDecoder::decode):
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerAudioEncoder::encode):
(WebCore::GStreamerInternalAudioEncoder::GStreamerInternalAudioEncoder):
* Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp:
(WebCore::ImageDecoderGStreamer::ImageDecoderGStreamer):
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder):
(WebCore::GStreamerInternalVideoDecoder::decode):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerVideoEncoder::encode):
(WebCore::GStreamerInternalVideoEncoder::GStreamerInternalVideoEncoder):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::GStreamerElementHarness::GStreamerElementHarness):
(WebCore::GStreamerElementHarness::reset):
(WebCore::GStreamerElementHarness::Stream::Stream):
(WebCore::GStreamerElementHarness::Stream::pullSample):
(WebCore::GStreamerElementHarness::Stream::chainSample):
(WebCore::GStreamerElementHarness::processOutputSamples):
(WebCore::GStreamerElementHarness::flushBuffers):
(WebCore::GStreamerElementHarness::Stream::pullBuffer): Deleted.
(WebCore::GStreamerElementHarness::Stream::chainBuffer): Deleted.
(WebCore::GStreamerElementHarness::processOutputBuffers): Deleted.
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.h:
(WebCore::GStreamerElementHarness::create):
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/273741@main">https://commits.webkit.org/273741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a03dddf019b3132b367f747fa26fb728b468cd0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/37982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38554 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32234 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11798 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/30988 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31856 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10967 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/10972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39803 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32560 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36915 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35006 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12896 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8277 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11652 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->