### PR TITLE
Missing WebRTC stats in Safari

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-mandatory-getStats.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-mandatory-getStats.https-expected.txt
@@ -32,7 +32,7 @@ PASS RTCPeerConnectionStats's dataChannelsOpened
 PASS RTCPeerConnectionStats's dataChannelsClosed
 PASS RTCDataChannelStats's label
 PASS RTCDataChannelStats's protocol
-FAIL RTCDataChannelStats's dataChannelIdentifier assert_true: Is dataChannelIdentifier present expected true got false
+PASS RTCDataChannelStats's dataChannelIdentifier
 PASS RTCDataChannelStats's state
 PASS RTCDataChannelStats's messagesSent
 PASS RTCDataChannelStats's bytesSent

--- a/LayoutTests/webrtc/candidate-stats.html
+++ b/LayoutTests/webrtc/candidate-stats.html
@@ -26,7 +26,7 @@ promise_test(async (test) => {
     assert_true(!stats.address, "address is not exposed");
     assert_true(!stats.networkType, "networkType is not exposed");
 
-    assert_array_equals(Object.keys(stats), ["id","timestamp","type","candidateType","port","priority","protocol","transportId"], "local");
+    assert_array_equals(Object.keys(stats), ["id","timestamp","type","candidateType","foundation", "port","priority","protocol","transportId", "usernameFragment"], "local");
 
     stats = await getTypedStats(firstConnection, "remote-candidate");
 
@@ -34,7 +34,7 @@ promise_test(async (test) => {
     assert_true(!stats.address, "address is not exposed");
     assert_true(!stats.networkType, "networkType is not exposed");
 
-    assert_array_equals(Object.keys(stats), ["id","timestamp","type","candidateType","port","priority","protocol","transportId"], "remote");
+    assert_array_equals(Object.keys(stats), ["id","timestamp","type","candidateType","foundation", "port","priority","protocol","transportId", "usernameFragment"], "remote");
 }, "ICE candidate data channel stats");
         </script>
     </body>

--- a/LayoutTests/webrtc/datachannel/datachannel-stats.html
+++ b/LayoutTests/webrtc/datachannel/datachannel-stats.html
@@ -56,12 +56,12 @@ promise_test((test) => {
             getDataChannelStats(localConnection).then((stats) => {
                 stats.id = "id";
                 stats.timestamp = 1;
-                assert_equals(JSON.stringify(stats), '{"id":"id","timestamp":1,"type":"data-channel","bytesReceived":0,"bytesSent":15,"datachannelid":1,"label":"sendDataChannel","messagesReceived":0,"messagesSent":4,"protocol":"","state":"open"}');
+                assert_equals(JSON.stringify(stats), '{"id":"id","timestamp":1,"type":"data-channel","bytesReceived":0,"bytesSent":15,"dataChannelIdentifier":1,"label":"sendDataChannel","messagesReceived":0,"messagesSent":4,"protocol":"","state":"open"}');
                 return getDataChannelStats(remoteConnection);
             }).then((stats) => {
                 stats.id = "id";
                 stats.timestamp = 1;
-                assert_equals(JSON.stringify(stats), '{"id":"id","timestamp":1,"type":"data-channel","bytesReceived":15,"bytesSent":0,"datachannelid":1,"label":"sendDataChannel","messagesReceived":4,"messagesSent":0,"protocol":"","state":"open"}');
+                assert_equals(JSON.stringify(stats), '{"id":"id","timestamp":1,"type":"data-channel","bytesReceived":15,"bytesSent":0,"dataChannelIdentifier":1,"label":"sendDataChannel","messagesReceived":4,"messagesSent":0,"protocol":"","state":"open"}');
                  resolve();
             });
         };

--- a/LayoutTests/webrtc/video-stats-expected.txt
+++ b/LayoutTests/webrtc/video-stats-expected.txt
@@ -4,5 +4,9 @@ PASS Sender stats
 PASS Receiver stats
 PASS Transport stats
 PASS Check ssrc is not changing in inbound rtp stats
+PASS Local candidate stats
+PASS Remote candidate stats
+PASS Outbound rtp stats - rtx
+PASS Inbound rtp stats - rtx
 PASS Stats after pc close
 

--- a/LayoutTests/webrtc/video-stats.html
+++ b/LayoutTests/webrtc/video-stats.html
@@ -259,9 +259,22 @@ promise_test(async (test) => {
     assert_greater_than_equal(instats.totalSamplesReceived, 0, "totalSamplesReceived");
 }, "Receiver stats");
 
+async function getStatsIf(connection, type, match)
+{
+    let cptr = 0;
+    let stats = await getStatsOfType(connection, type);
+    while (!match(stats) && ++cptr < 100) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        stats = await getStatsOfType(connection, type);
+    }
+    if (cptr >= 100)
+        throw "unable to get matching stats";
+    return stats;
+}
+
 promise_test(async (test) => {
     const report = await secondConnection.getReceivers()[0].getStats();
-    let stats = await getStatsOfType(secondConnection, "transport");
+    let stats = await getStatsIf(secondConnection, "transport", (stats) => stats.dtlsState === "connected");
 
     assert_equals(stats.dtlsState, "connected");
     assert_true(!!stats.dtlsCipher, "dtlsCipher");
@@ -287,6 +300,30 @@ promise_test(async (test) => {
     });
     assert_equals(instats1.ssrc, instats2.ssrc);
 }, "Check ssrc is not changing in inbound rtp stats");
+
+promise_test(async (test) => {
+    let stats = await getStatsOfType(secondConnection, "local-candidate");
+
+    assert_true(!!stats.foundation, "foundation");
+}, "Local candidate stats");
+
+promise_test(async (test) => {
+    let stats = await getStatsOfType(secondConnection, "remote-candidate");
+
+    assert_true(!!stats.foundation, "foundation");
+}, "Remote candidate stats");
+
+promise_test(async (test) => {
+    const stats = await getStatsIf(secondConnection, "inbound-rtp", (stats) => stats.rtxSsrc !== undefined);
+    assert_equals(typeof stats.rtxSsrc, "number");
+    assert_not_equals(stats.rtxSsrc, 0);
+}, "Outbound rtp stats - rtx");
+
+promise_test(async (test) => {
+    const stats = await getStatsIf(secondConnection, "inbound-rtp", (stats) => stats.rtxSsrc !== undefined);
+    assert_equals(typeof stats.rtxSsrc, "number");
+    assert_not_equals(stats.rtxSsrc, 0);
+}, "Inbound rtp stats - rtx");
 
 promise_test(async (test) => {
     const pc = new RTCPeerConnection();

--- a/Source/WebCore/Modules/mediastream/RTCStatsReport.h
+++ b/Source/WebCore/Modules/mediastream/RTCStatsReport.h
@@ -212,7 +212,7 @@ public:
 
         String label;
         String protocol;
-        std::optional<int> datachannelid;
+        std::optional<int> dataChannelIdentifier;
         String state;
         std::optional<uint32_t> messagesSent;
         std::optional<uint64_t> bytesSent;

--- a/Source/WebCore/Modules/mediastream/RTCStatsReport.idl
+++ b/Source/WebCore/Modules/mediastream/RTCStatsReport.idl
@@ -253,7 +253,7 @@ dictionary RTCPeerConnectionStats : RTCStats {
 dictionary RTCDataChannelStats : RTCStats {
     DOMString label;
     DOMString protocol;
-    long datachannelid;
+    long dataChannelIdentifier;
     DOMString state;
     unsigned long messagesSent;
     unsigned long long bytesSent;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
@@ -28,6 +28,7 @@
 #if ENABLE(WEB_RTC) && USE(LIBWEBRTC)
 
 #include "JSDOMMapLike.h"
+#include "JSRTCIceTcpCandidateType.h"
 #include "JSRTCStatsReport.h"
 #include "LibWebRTCUtils.h"
 #include "Performance.h"
@@ -128,11 +129,19 @@ static inline void fillInboundRtpStreamStats(RTCStatsReport::InboundRtpStreamSta
         stats.totalFreezesDuration = *rtcStats.total_freezes_duration;
     if (rtcStats.last_packet_received_timestamp.is_defined())
         stats.lastPacketReceivedTimestamp = *rtcStats.last_packet_received_timestamp;
+
+    if (rtcStats.fec_packets_received.is_defined())
+        stats.fecPacketsReceived = *rtcStats.fec_packets_received;
+    if (rtcStats.fec_bytes_received.is_defined())
+        stats.fecBytesReceived = *rtcStats.fec_bytes_received;
+    if (rtcStats.fec_packets_discarded.is_defined())
+        stats.fecPacketsDiscarded = *rtcStats.fec_packets_discarded;
+    if (rtcStats.fec_ssrc.is_defined())
+        stats.fecSsrc = *rtcStats.fec_ssrc;
     if (rtcStats.header_bytes_received.is_defined())
         stats.headerBytesReceived = *rtcStats.header_bytes_received;
-    // Not Implemented
-    // if (rtcStats.fec_bytes_received.is_defined())
-    //     stats.fecBytesReceived = *rtcStats.fec_bytes_received;
+    if (rtcStats.rtx_ssrc.is_defined())
+        stats.rtxSsrc = *rtcStats.rtx_ssrc;
     if (rtcStats.packets_discarded.is_defined())
         stats.packetsDiscarded = *rtcStats.packets_discarded;
     if (rtcStats.fec_packets_received.is_defined())
@@ -195,12 +204,6 @@ static inline void fillInboundRtpStreamStats(RTCStatsReport::InboundRtpStreamSta
         stats.retransmittedPacketsReceived = *rtcStats.retransmitted_packets_received;
     if (rtcStats.retransmitted_bytes_received.is_defined())
         stats.retransmittedBytesReceived = *rtcStats.retransmitted_bytes_received;
-
-    // Not implemented
-    // if (rtcStats.frames_received.is_defined())
-    //     stats.rtxSsrc = *rtcStats.frames_received;
-    // if (rtcStats.frames_received.is_defined())
-    //     stats.fecSsrc = *rtcStats.frames_received;
 }
 
 static inline void fillRemoteInboundRtpStreamStats(RTCStatsReport::RemoteInboundRtpStreamStats& stats, const webrtc::RTCRemoteInboundRtpStreamStats& rtcStats)
@@ -258,9 +261,6 @@ static inline void fillOutboundRtpStreamStats(RTCStatsReport::OutboundRtpStreamS
         stats.retransmittedPacketsSent = *rtcStats.retransmitted_packets_sent;
     if (rtcStats.retransmitted_bytes_sent.is_defined())
         stats.retransmittedBytesSent = *rtcStats.retransmitted_bytes_sent;
-    // Not Implemented
-    // if (rtcStats.ssrc.is_defined())
-    //     stats.rtxSsrc = *rtcStats.ssrc;
     if (rtcStats.target_bitrate.is_defined())
         stats.targetBitrate = *rtcStats.target_bitrate;
     if (rtcStats.total_encoded_bytes_target.is_defined())
@@ -310,6 +310,8 @@ static inline void fillOutboundRtpStreamStats(RTCStatsReport::OutboundRtpStreamS
         stats.active = *rtcStats.active;
     if (rtcStats.scalability_mode.is_defined())
         stats.scalabilityMode = fromStdString(*rtcStats.scalability_mode);
+    if (rtcStats.rtx_ssrc.is_defined())
+        stats.rtxSsrc = *rtcStats.rtx_ssrc;
 }
 
 
@@ -340,7 +342,7 @@ static inline void fillRTCDataChannelStats(RTCStatsReport::DataChannelStats& sta
     if (rtcStats.protocol.is_defined())
         stats.protocol = fromStdString(*rtcStats.protocol);
     if (rtcStats.data_channel_identifier.is_defined())
-        stats.datachannelid = *rtcStats.data_channel_identifier;
+        stats.dataChannelIdentifier = *rtcStats.data_channel_identifier;
     if (rtcStats.state.is_defined())
         stats.state = fromStdString(*rtcStats.state);
     if (rtcStats.messages_sent.is_defined())
@@ -459,6 +461,14 @@ static inline void fillRTCIceCandidateStats(RTCStatsReport::IceCandidateStats& s
         stats.priority = *rtcStats.priority;
     if (rtcStats.url.is_defined())
         stats.url = fromStdString(*rtcStats.url);
+    if (rtcStats.foundation.is_defined())
+        stats.foundation = fromStdString(*rtcStats.foundation);
+    if (rtcStats.username_fragment.is_defined())
+        stats.usernameFragment = fromStdString(*rtcStats.username_fragment);
+    if (rtcStats.tcp_type.is_defined()) {
+        if (auto tcpType = parseEnumerationFromString<RTCIceTcpCandidateType>(fromStdString(*rtcStats.tcp_type)))
+            stats.tcpType = *tcpType;
+    }
 }
 
 static inline void fillRTCCertificateStats(RTCStatsReport::CertificateStats& stats, const webrtc::RTCCertificateStats& rtcStats)


### PR DESCRIPTION
#### 7b5229864801f85e858872ce7356e758ce32a244
<pre>
Missing WebRTC stats in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=267696">https://bugs.webkit.org/show_bug.cgi?id=267696</a>
<a href="https://rdar.apple.com/121594743">rdar://121594743</a>

Reviewed by Eric Carlson.

Update datachannelid to dataChannelIdentifier name, as per spec.
Expose more RTC stats by exposing libwebrtc backend gathered values.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-mandatory-getStats.https-expected.txt:
* LayoutTests/webrtc/candidate-stats.html:
* LayoutTests/webrtc/datachannel/datachannel-stats.html:
* LayoutTests/webrtc/video-stats-expected.txt:
* LayoutTests/webrtc/video-stats.html:
* Source/WebCore/Modules/mediastream/RTCStatsReport.h:
* Source/WebCore/Modules/mediastream/RTCStatsReport.idl:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp:
(WebCore::fillInboundRtpStreamStats):
(WebCore::fillOutboundRtpStreamStats):
(WebCore::fillRTCDataChannelStats):
(WebCore::fillRTCIceCandidateStats):

Canonical link: <a href="https://commits.webkit.org/273643@main">https://commits.webkit.org/273643@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f34ccd83e024ec25729dee5ad27d1ce99473bac3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32493 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31185 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32065 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11171 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11195 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40109 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32808 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37134 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35220 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31901 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8218 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11868 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12228 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->