### PR TITLE
Entitlements are not correctly applied in Simulator

### DIFF
--- a/Source/WebKit/Configurations/BaseExtension.xcconfig
+++ b/Source/WebKit/Configurations/BaseExtension.xcconfig
@@ -54,9 +54,14 @@ EXCLUDED_SOURCE_FILE_NAMES_YES[sdk=iphone*17.2*] = *;
 EXCLUDED_SOURCE_FILE_NAMES_YES[sdk=iphone*17.3*] = *;
 EXCLUDED_SOURCE_FILE_NAMES_YES[sdk=iphone*18.0*] = *;
 EXCLUDED_SOURCE_FILE_NAMES_YES[sdk=xr*] = *;
+
 CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
+
+// For simulator builds, entitlements are added to a special __entitlements section on the binary rather than the signature.
+CODE_SIGN_ENTITLEMENTS[sdk=*simulator] = Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtension.entitlements;
+
 WK_PROCESSED_XCENT_FILE=$(TEMP_FILE_DIR)/$(FULL_PRODUCT_NAME).entitlements
 WK_LIBRARY_VALIDATION_CODE_SIGN_FLAGS = --entitlements $(WK_PROCESSED_XCENT_FILE);
-WK_LIBRARY_VALIDATION_CODE_SIGN_FLAGS[sdk=*simulator] = --entitlements Shared/AuxiliaryProcessExtensions/AuxiliaryProcessExtension.entitlements;
 
 OTHER_CODE_SIGN_FLAGS = $(WK_LIBRARY_VALIDATION_CODE_SIGN_FLAGS);
+OTHER_CODE_SIGN_FLAGS[sdk=*simulator] = ;

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -495,9 +495,7 @@ plistbuddy Clear dict
 # Simulator entitlements should be added to Resources/ios/XPCService-ios-simulator.entitlements
 if [[ "${WK_PLATFORM_NAME}" =~ .*simulator ]]
 then
-    if [[ -e "${CODE_SIGN_ENTITLEMENTS}" && "${PRODUCT_NAME}" != adattributiond && "${PRODUCT_NAME}" != webpushd ]]; then
-        cp "${CODE_SIGN_ENTITLEMENTS}" "${WK_PROCESSED_XCENT_FILE}"
-    fi
+    exit 0
 elif [[ "${WK_PLATFORM_NAME}" == macosx ]]
 then
     [[ "${RC_XBS}" != YES ]] && plistbuddy Add :com.apple.security.get-task-allow bool YES


### PR DESCRIPTION
#### d94c1b592f6e84dce7a38cfd69818aa49bcb9cc3
<pre>
Entitlements are not correctly applied in Simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=268162">https://bugs.webkit.org/show_bug.cgi?id=268162</a>
<a href="https://rdar.apple.com/121541359">rdar://121541359</a>

Reviewed by Brent Fulgham and Elliott Williams.

Entitlements are not correctly applied in Simulator for WebKit extensions. This patch is
addressing this by setting CODE_SIGN_ENTITLEMENTS for Simulator, and returning early from
process-entitlements.sh, since running the script is not needed in the Simulator.

* Source/WebKit/Configurations/BaseExtension.xcconfig:
* Source/WebKit/Scripts/process-entitlements.sh:

Canonical link: <a href="https://commits.webkit.org/273606@main">https://commits.webkit.org/273606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27a5a75052ce59ee9d6b85abbc3be97b0a45a23c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38648 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32322 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31070 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31912 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11041 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/36112 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11055 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39898 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32646 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37009 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11227 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9139 "Found 1 new test failure: http/tests/inspector/dom/didFireEvent.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35092 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12974 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11739 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4665 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->