### PR TITLE
Remove dead code from webkitpy/port

### DIFF
--- a/Tools/Scripts/webkitpy/port/base_unittest.py
+++ b/Tools/Scripts/webkitpy/port/base_unittest.py
@@ -125,14 +125,6 @@ class PortTest(unittest.TestCase):
         # This routine is a no-op. We just test it for coverage.
         port.setup_test_run()
 
-    def test_test_dirs(self):
-        port = self.make_port()
-        port.host.filesystem.write_text_file(port.layout_tests_dir() + '/canvas/test', '')
-        port.host.filesystem.write_text_file(port.layout_tests_dir() + '/css2.1/test', '')
-        dirs = port.test_dirs()
-        self.assertIn('canvas', dirs)
-        self.assertIn('css2.1', dirs)
-
     def test_skipped_perf_tests(self):
         port = self.make_port()
 

--- a/Tools/Scripts/webkitpy/port/config_unittest.py
+++ b/Tools/Scripts/webkitpy/port/config_unittest.py
@@ -42,12 +42,6 @@ import webkitpy.port.config as config
 
 
 class ConfigTest(unittest.TestCase):
-    def setUp(self):
-        config.clear_cached_configuration()
-
-    def tearDown(self):
-        config.clear_cached_configuration()
-
     def make_config(self, output='', files=None, exit_code=0, exception=None, run_command_fn=None, stderr='', port_implementation=None):
         e = MockExecutive2(output=output, exit_code=exit_code, exception=exception, run_command_fn=run_command_fn, stderr=stderr)
         fs = MockFileSystem(files)

--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -82,9 +82,6 @@ class DarwinPort(ApplePort):
         _log.info("%s total leaks found for a total of %s." % (total_leaks, total_bytes_string))
         _log.info("%s unique leaks found." % unique_leaks)
 
-    def _path_to_webcore_library(self):
-        return self._build_path('WebCore.framework/Versions/A/WebCore')
-
     def show_results_html_file(self, results_filename):
         # We don't use self._run_script() because we don't want to wait for the script
         # to exit and we want the output to show up on stdout in case there are errors
@@ -249,17 +246,6 @@ class DarwinPort(ApplePort):
             return _path_to_test
 
         return _image_diff_in_build_path
-
-    def make_command(self):
-        return self.xcrun_find('make', '/usr/bin/make')
-
-    def xcrun_find(self, command, fallback=None):
-        fallback = fallback or command
-        try:
-            return self._executive.run_command(['xcrun', '--sdk', self.SDK, '-find', command]).rstrip()
-        except ScriptError:
-            _log.warn("xcrun failed; falling back to '%s'." % fallback)
-            return fallback
 
     @memoized
     def _plist_data_from_bundle(self, app_bundle, entry):

--- a/Tools/Scripts/webkitpy/port/factory.py
+++ b/Tools/Scripts/webkitpy/port/factory.py
@@ -91,12 +91,6 @@ def configuration_options():
     ]
 
 
-def _builder_options(builder_name):
-    configuration = "Debug" if re.search(r"[d|D](ebu|b)g", builder_name) else "Release"
-    is_webkit2 = builder_name.find("WK2") != -1
-    return optparse.Values({'builder_name': builder_name, 'configuration': configuration, 'webkit_test_runner': is_webkit2})
-
-
 class PortFactory(object):
     # Order matters.  For port classes that have a port_name with a
     # common prefix, the more specific port class should be listed

--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -67,9 +67,6 @@ class GLibPort(Port):
     def _built_executables_path(self, *path):
         return self._build_path(*(('bin',) + path))
 
-    def _built_libraries_path(self, *path):
-        return self._build_path(*(('lib',) + path))
-
     def _prepend_to_env_value(self, new_value, current_value):
         if len(current_value) > 0:
             return new_value + ":" + current_value

--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -113,19 +113,6 @@ class GtkPort(GLibPort):
     def _path_to_default_image_diff(self):
         return self._path_to_image_diff()
 
-    def _path_to_webcore_library(self):
-        gtk_library_names = [
-            "libwebkitgtk-1.0.so",
-            "libwebkitgtk-3.0.so",
-            "libwebkit2gtk-1.0.so",
-        ]
-
-        for library in gtk_library_names:
-            full_library = self._built_libraries_path(library)
-            if self._filesystem.isfile(full_library):
-                return full_library
-        return None
-
     def _search_paths(self):
         search_paths = []
 
@@ -167,10 +154,6 @@ class GtkPort(GLibPort):
 
     def check_sys_deps(self):
         return super(GtkPort, self).check_sys_deps() and self._driver_class().check_driver(self)
-
-    def test_expectations_file_position(self):
-        # GTK port baseline search path is gtk -> glib -> wk2 -> generic (as gtk-wk2 and gtk baselines are merged), so port test expectations file is at third to last position.
-        return 3
 
     def build_webkit_command(self, build_style=None):
         command = super(GtkPort, self).build_webkit_command(build_style)

--- a/Tools/Scripts/webkitpy/port/gtk_unittest.py
+++ b/Tools/Scripts/webkitpy/port/gtk_unittest.py
@@ -34,7 +34,6 @@ import unittest
 
 from webkitpy.common.system.executive_mock import MockExecutive
 from webkitpy.common.system.filesystem_mock import MockFileSystem
-from webkitpy.port.config import clear_cached_configuration
 from webkitpy.port.gtk import GtkPort
 from webkitpy.port import port_testcase
 from webkitpy.thirdparty.mock import Mock
@@ -90,7 +89,6 @@ class GtkPortTest(port_testcase.PortTestCase):
         pass
 
     def test_default_upload_configuration(self):
-        clear_cached_configuration()
         port = self.make_port()
         configuration = port.configuration_for_upload()
         self.assertEqual(configuration['architecture'], port.architecture())

--- a/Tools/Scripts/webkitpy/port/ios.py
+++ b/Tools/Scripts/webkitpy/port/ios.py
@@ -108,9 +108,6 @@ class IOSPort(DevicePort):
 
         return expectations
 
-    def test_expectations_file_position(self):
-        return 5
-
     def port_adjust_environment_for_test_driver(self, env):
         env = super(IOSPort, self).port_adjust_environment_for_test_driver(env)
         env['CA_DISABLE_GENERIC_SHADERS'] = '1'

--- a/Tools/Scripts/webkitpy/port/ios_device_unittest.py
+++ b/Tools/Scripts/webkitpy/port/ios_device_unittest.py
@@ -25,7 +25,6 @@ import time
 from webkitcorepy import Version
 
 from webkitpy.common.system.executive_mock import MockExecutive2, ScriptError
-from webkitpy.port.config import clear_cached_configuration
 from webkitpy.port.ios_device import IOSDevicePort
 from webkitpy.port import ios_testcase
 from webkitpy.port import port_testcase
@@ -181,7 +180,6 @@ class IOSDeviceTest(ios_testcase.IOSTest):
         pass
 
     def test_default_upload_configuration(self):
-        clear_cached_configuration()
         port = self.make_port()
         configuration = port.configuration_for_upload()
         self.assertEqual(configuration['architecture'], port.architecture())

--- a/Tools/Scripts/webkitpy/port/ios_simulator_unittest.py
+++ b/Tools/Scripts/webkitpy/port/ios_simulator_unittest.py
@@ -25,7 +25,6 @@ from webkitcorepy import Version
 from webkitpy.port.ios_simulator import IOSSimulatorPort
 from webkitpy.port import ios_testcase
 from webkitpy.port import port_testcase
-from webkitpy.port.config import clear_cached_configuration
 from webkitpy.tool.mocktool import MockOptions
 from webkitpy.common.system.executive_mock import MockExecutive2, ScriptError
 from webkitpy.xcode.device_type import DeviceType
@@ -81,20 +80,6 @@ class IOSSimulatorTest(ios_testcase.IOSTest):
     def test_sdk_name(self):
         port = self.make_port()
         self.assertEqual(port.SDK, 'iphonesimulator')
-
-    def test_xcrun(self):
-        def throwing_run_command(args):
-            print(args)
-            raise ScriptError("MOCK script error")
-
-        port = self.make_port()
-        port._executive = MockExecutive2(run_command_fn=throwing_run_command)
-        with OutputCapture() as captured:
-            port.xcrun_find('test', 'falling')
-        self.assertEqual(
-            captured.stdout.getvalue(),
-            "['xcrun', '--sdk', 'iphonesimulator', '-find', 'test']\n",
-        )
 
     def test_layout_test_searchpath_with_apple_additions(self):
         with port_testcase.bind_mock_apple_additions():
@@ -170,7 +155,6 @@ class IOSSimulatorTest(ios_testcase.IOSTest):
         self.assertEqual(port.max_child_processes(DeviceType.from_string('Apple Watch')), 0)
 
     def test_default_upload_configuration(self):
-        clear_cached_configuration()
         port = self.make_port()
         configuration = port.configuration_for_upload()
         self.assertEqual(configuration['architecture'], port.architecture())

--- a/Tools/Scripts/webkitpy/port/mac_unittest.py
+++ b/Tools/Scripts/webkitpy/port/mac_unittest.py
@@ -177,20 +177,6 @@ class MacTest(darwin_testcase.DarwinTest):
         port = self.make_port()
         self.assertEqual(port.SDK, 'macosx')
 
-    def test_xcrun(self):
-        def throwing_run_command(args):
-            print(args)
-            raise ScriptError("MOCK script error")
-
-        port = self.make_port()
-        port._executive = MockExecutive2(run_command_fn=throwing_run_command)
-        with OutputCapture() as captured:
-            port.xcrun_find('test', 'falling')
-        self.assertEqual(
-            captured.stdout.getvalue(),
-            "['xcrun', '--sdk', 'macosx', '-find', 'test']\n"
-        )
-
     def test_layout_test_searchpath_with_apple_additions(self):
         with port_testcase.bind_mock_apple_additions():
             search_path = self.make_port().default_baseline_search_path()

--- a/Tools/Scripts/webkitpy/port/port_testcase.py
+++ b/Tools/Scripts/webkitpy/port/port_testcase.py
@@ -44,7 +44,7 @@ from webkitpy.common.system.filesystem_mock import MockFileSystem
 from webkitpy.common.system.systemhost_mock import MockSystemHost
 from webkitpy.common.version_name_map import INTERNAL_TABLE
 from webkitpy.port.base import Port
-from webkitpy.port.config import apple_additions, clear_cached_configuration
+from webkitpy.port.config import apple_additions
 from webkitpy.port.driver import DriverOutput
 from webkitpy.port.image_diff import ImageDiffer, ImageDiffResult
 from webkitpy.port.server_process_mock import MockServerProcess
@@ -518,7 +518,6 @@ class PortTestCase(unittest.TestCase):
             port._filesystem.write_text_file(path, '')
         ordered_dict = port.expectations_dict()
         self.assertEqual(port.path_to_generic_test_expectations_file(), list(ordered_dict.keys())[0])
-        self.assertEqual(port.path_to_test_expectations_file(), list(ordered_dict.keys())[port.test_expectations_file_position()])
 
         options = MockOptions(additional_expectations=['/tmp/foo', '/tmp/bar'])
         port = self.make_port(options=options)
@@ -529,20 +528,6 @@ class PortTestCase(unittest.TestCase):
         ordered_dict = port.expectations_dict()
         self.assertEqual(list(ordered_dict.keys())[-2:], options.additional_expectations)  # pylint: disable=E1101
         self.assertEqual(list(ordered_dict.values())[-2:], ['foo', 'bar'])
-
-    def test_path_to_test_expectations_file(self):
-        port = TestWebKitPort()
-        port._options = MockOptions(webkit_test_runner=False)
-        self.assertEqual(port.path_to_test_expectations_file(), '/mock-checkout/LayoutTests/platform/testwebkitport/TestExpectations')
-
-        port = TestWebKitPort()
-        port._options = MockOptions(webkit_test_runner=True)
-        self.assertEqual(port.path_to_test_expectations_file(), '/mock-checkout/LayoutTests/platform/testwebkitport/TestExpectations')
-
-        port = TestWebKitPort()
-        port.host.filesystem.files['/mock-checkout/LayoutTests/platform/testwebkitport/TestExpectations'] = 'some content'
-        port._options = MockOptions(webkit_test_runner=False)
-        self.assertEqual(port.path_to_test_expectations_file(), '/mock-checkout/LayoutTests/platform/testwebkitport/TestExpectations')
 
     def test_skipped_layout_tests(self):
         self.assertEqual(TestWebKitPort().skipped_layout_tests(), set(['media']))
@@ -731,7 +716,6 @@ MOCK output of child process
         self.assertEqual(port.max_child_processes(), float('inf'))
 
     def test_default_upload_configuration(self):
-        clear_cached_configuration()
         port = self.make_port()
         configuration = port.configuration_for_upload()
         self.assertEqual(configuration['architecture'], port.architecture())
@@ -741,17 +725,14 @@ MOCK output of child process
         self.assertEqual(configuration['version_name'], port.host.platform.os_version_name())
 
     def test_debug_upload_configuration(self):
-        clear_cached_configuration()
         port = self.make_port(options=MockOptions(configuration='Debug'))
         self.assertEqual(port.configuration_for_upload()['style'], 'debug')
 
     def test_asan_upload_configuration(self):
-        clear_cached_configuration()
         port = self.make_port()
         port.host.filesystem.write_text_file('/mock-build/ASan', 'YES')
         self.assertEqual(port.configuration_for_upload()['style'], 'asan')
 
     def test_guard_malloc_configuration(self):
-        clear_cached_configuration()
         port = self.make_port(options=MockOptions(guard_malloc=True))
         self.assertEqual(port.configuration_for_upload()['style'], 'guard-malloc')

--- a/Tools/Scripts/webkitpy/port/server_process.py
+++ b/Tools/Scripts/webkitpy/port/server_process.py
@@ -440,12 +440,3 @@ class ServerProcess(object):
         self._target_host.executive.kill_process(self._proc.pid)
         if self._proc.poll() is None:
             self._proc.wait()
-
-    def replace_outputs(self, stdout, stderr):
-        assert self._proc
-        if stdout:
-            self._proc.stdout.close()
-            self._proc.stdout = stdout
-        if stderr:
-            self._proc.stderr.close()
-            self._proc.stderr = stderr

--- a/Tools/Scripts/webkitpy/port/watch.py
+++ b/Tools/Scripts/webkitpy/port/watch.py
@@ -55,9 +55,6 @@ class WatchPort(DevicePort):
             return None
         return VersionNameMap.map(self.host.platform).to_name(self._os_version, platform=WatchPort.port_name)
 
-    def test_expectations_file_position(self):
-        return 4
-
     def default_baseline_search_path(self, **kwargs):
         versions_to_fallback = []
         if self.device_version() == self.CURRENT_VERSION:

--- a/Tools/Scripts/webkitpy/port/watch_simulator_unittest.py
+++ b/Tools/Scripts/webkitpy/port/watch_simulator_unittest.py
@@ -23,7 +23,6 @@
 from webkitcorepy import Version
 
 from webkitpy.common.system.executive_mock import MockExecutive2, ScriptError
-from webkitpy.port.config import clear_cached_configuration
 from webkitpy.port.watch_simulator import WatchSimulatorPort
 from webkitpy.port import watch_testcase
 from webkitpy.tool.mocktool import MockOptions
@@ -69,23 +68,11 @@ class WatchSimulatorTest(watch_testcase.WatchTest):
         port = self.make_port()
         self.assertEqual(port.SDK, 'watchsimulator')
 
-    def test_xcrun(self):
-        def throwing_run_command(args):
-            print(args)
-            raise ScriptError("MOCK script error")
-
-        port = self.make_port(options=MockOptions(architecture='i386'))
-        port._executive = MockExecutive2(run_command_fn=throwing_run_command)
-        with OutputCapture() as captured:
-            port.xcrun_find('test', 'falling')
-        self.assertEqual(captured.stdout.getvalue(), "['xcrun', '--sdk', 'watchsimulator', '-find', 'test']\n")
-
     def test_max_child_processes(self):
         port = self.make_port()
         self.assertEqual(port.max_child_processes(DeviceType.from_string('iPhone')), 0)
 
     def test_default_upload_configuration(self):
-        clear_cached_configuration()
         port = self.make_port()
         configuration = port.configuration_for_upload()
         self.assertEqual(configuration['architecture'], port.architecture())

--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -99,10 +99,6 @@ class WPEPort(GLibPort):
     def _port_specific_expectations_files(self, **kwargs):
         return list(map(lambda x: self._filesystem.join(self._webkit_baseline_path(x), 'TestExpectations'), reversed(self._search_paths())))
 
-    def test_expectations_file_position(self):
-        # WPE port baseline search path is wpe -> glib -> wk2 -> generic, so port test expectations file is at third to last position.
-        return 3
-
     def configuration_for_upload(self, host=None):
         configuration = super(WPEPort, self).configuration_for_upload(host=host)
         configuration['platform'] = 'WPE'

--- a/Tools/Scripts/webkitpy/port/wpe_unittest.py
+++ b/Tools/Scripts/webkitpy/port/wpe_unittest.py
@@ -33,7 +33,6 @@ import unittest
 
 from webkitpy.common.system.executive_mock import MockExecutive
 from webkitpy.common.system.filesystem_mock import MockFileSystem
-from webkitpy.port.config import clear_cached_configuration
 from webkitpy.port.wpe import WPEPort
 from webkitpy.port import port_testcase
 from webkitpy.thirdparty.mock import Mock, patch
@@ -76,7 +75,6 @@ class WPEPortTest(port_testcase.PortTestCase):
         pass
 
     def test_default_upload_configuration(self):
-        clear_cached_configuration()
         port = self.make_port()
         configuration = port.configuration_for_upload()
         self.assertEqual(configuration['architecture'], port.architecture())


### PR DESCRIPTION
#### 868bb52684d2fbe0411ee9c6a00d44884db11c3b
<pre>
Remove dead code from webkitpy/port
<a href="https://bugs.webkit.org/show_bug.cgi?id=268164">https://bugs.webkit.org/show_bug.cgi?id=268164</a>

Reviewed by Jonathan Bedard.

Largely from vulture.

* Tools/Scripts/webkitpy/port/base.py:
(Port.architecture):
(Port.driver_name):
(Port.reference_files):
(Port._natural_sort_key):
(Port.path_to_generic_test_expectations_file):
(Port.abspath_for_test):
(Port.perf_results_directory):
(Port.clean_up_test_run):
(Port.configuration_specifier_macros):
(Port._path_to_user_cache_directory):
(Port.logging_detectors_to_strip_text_start):
(Port.set_architecture): Deleted.
(Port.expected_baselines_by_extension): Deleted.
(Port.baseline_extensions): Deleted.
(Port.potential_test_names_from_expected_file): Deleted.
(Port.test_dirs): Deleted.
(Port.path_to_test_expectations_file): Deleted.
(Port.jsc_results_directory): Deleted.
(Port.bindings_results_directory): Deleted.
(Port.python_unittest_results_directory): Deleted.
(Port._value_or_default_from_environ): Deleted.
(Port.all_baseline_variants): Deleted.
(Port._path_to_webcore_library): Deleted.
(Port.test_expectations_file_position): Deleted.
* Tools/Scripts/webkitpy/port/base_unittest.py:
(PortTest.test_setup_test_run):
(PortTest.test_test_dirs): Deleted.
* Tools/Scripts/webkitpy/port/config.py:
(Config):
(Config._determine_configuration):
(clear_cached_configuration): Deleted.
* Tools/Scripts/webkitpy/port/config_unittest.py:
(ConfigTest):
(ConfigTest.setUp): Deleted.
(ConfigTest.tearDown): Deleted.
* Tools/Scripts/webkitpy/port/darwin.py:
(DarwinPort.print_leaks_summary):
(DarwinPort._path_to_image_diff):
(DarwinPort._path_to_webcore_library): Deleted.
(DarwinPort.make_command): Deleted.
(DarwinPort.xcrun_find): Deleted.
* Tools/Scripts/webkitpy/port/factory.py:
(configuration_options):
(_builder_options): Deleted.
* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort._built_executables_path):
(GLibPort._built_libraries_path): Deleted.
* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort._path_to_default_image_diff):
(GtkPort.check_sys_deps):
(GtkPort._path_to_webcore_library): Deleted.
(GtkPort.test_expectations_file_position): Deleted.
* Tools/Scripts/webkitpy/port/gtk_unittest.py:
(GtkPortTest.test_default_upload_configuration):
* Tools/Scripts/webkitpy/port/ios.py:
(IOSPort.default_baseline_search_path):
(IOSPort.test_expectations_file_position): Deleted.
* Tools/Scripts/webkitpy/port/ios_device_unittest.py:
* Tools/Scripts/webkitpy/port/ios_simulator_unittest.py:
(IOSSimulatorTest.test_sdk_name):
(IOSSimulatorTest.test_default_upload_configuration):
(IOSSimulatorTest.test_xcrun): Deleted.
(IOSSimulatorTest.test_xcrun.throwing_run_command): Deleted.
* Tools/Scripts/webkitpy/port/mac_unittest.py:
(MacTest.test_sdk_name):
(MacTest.test_xcrun): Deleted.
(MacTest.test_xcrun.throwing_run_command): Deleted.
* Tools/Scripts/webkitpy/port/port_testcase.py:
(PortTestCase.test_expectations_ordering):
(PortTestCase.test_path_to_test_expectations_file): Deleted.
* Tools/Scripts/webkitpy/port/server_process.py:
(ServerProcess._kill):
(ServerProcess.replace_outputs): Deleted.
* Tools/Scripts/webkitpy/port/watch.py:
(WatchPort.version_name):
(WatchPort.test_expectations_file_position): Deleted.
* Tools/Scripts/webkitpy/port/watch_simulator_unittest.py:
(WatchSimulatorTest.test_sdk_name):
(WatchSimulatorTest.test_default_upload_configuration):
(WatchSimulatorTest.test_xcrun): Deleted.
(WatchSimulatorTest.test_xcrun.throwing_run_command): Deleted.
* Tools/Scripts/webkitpy/port/wpe.py:
(WPEPort._port_specific_expectations_files):
(WPEPort.test_expectations_file_position): Deleted.
* Tools/Scripts/webkitpy/port/wpe_unittest.py:
(WPEPortTest.test_default_upload_configuration):

Canonical link: <a href="https://commits.webkit.org/273681@main">https://commits.webkit.org/273681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04bebc80d54262b05682f76107e99e5ffb5c1715

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38571 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32251 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31002 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32144 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10982 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/36043 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39820 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32597 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32708 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36934 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35023 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12912 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11671 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4709 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/11993 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->