### PR TITLE
Move WebGL extensions approved on 2024-01-25 out of draft

### DIFF
--- a/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-default-expected.txt
+++ b/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-default-expected.txt
@@ -2,22 +2,16 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 14 PASS, 0 FAIL
+TEST COMPLETE: 8 PASS, 0 FAIL
 
 
-PASS webgl:EXT_texture_mirror_clamp_to_edge: Supported
-PASS webgl:EXT_texture_mirror_clamp_to_edge: Has object.
 PASS webgl2:EXT_render_snorm: Supported
 PASS webgl2:EXT_render_snorm: Has object.
-PASS webgl2:EXT_texture_mirror_clamp_to_edge: Supported
-PASS webgl2:EXT_texture_mirror_clamp_to_edge: Has object.
 PASS webgl2:OES_sample_variables: Supported
 PASS webgl2:OES_sample_variables: Has object.
 PASS webgl2:OES_shader_multisample_interpolation: Not supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Not supported
-PASS webgl2:WEBGL_stencil_texturing: Supported
-PASS webgl2:WEBGL_stencil_texturing: Has object.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-on-expected.txt
+++ b/LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-on-expected.txt
@@ -2,22 +2,16 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 14 PASS, 0 FAIL
+TEST COMPLETE: 8 PASS, 0 FAIL
 
 
-PASS webgl:EXT_texture_mirror_clamp_to_edge: Supported
-PASS webgl:EXT_texture_mirror_clamp_to_edge: Has object.
 PASS webgl2:EXT_render_snorm: Supported
 PASS webgl2:EXT_render_snorm: Has object.
-PASS webgl2:EXT_texture_mirror_clamp_to_edge: Supported
-PASS webgl2:EXT_texture_mirror_clamp_to_edge: Has object.
 PASS webgl2:OES_sample_variables: Supported
 PASS webgl2:OES_sample_variables: Has object.
 PASS webgl2:OES_shader_multisample_interpolation: Not supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Not supported
-PASS webgl2:WEBGL_stencil_texturing: Supported
-PASS webgl2:WEBGL_stencil_texturing: Has object.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/webgl/resources/webgl-draft-extensions-flag.js
+++ b/LayoutTests/webgl/resources/webgl-draft-extensions-flag.js
@@ -4,19 +4,13 @@
 
 let currentDraftExtensions = {
     "webgl": [
-        "EXT_texture_mirror_clamp_to_edge",
     ],
     "webgl2" : [
         "EXT_render_snorm",
-        "EXT_texture_mirror_clamp_to_edge",
         "OES_sample_variables",
         "OES_shader_multisample_interpolation",
         "WEBGL_draw_instanced_base_vertex_base_instance",
         "WEBGL_multi_draw_instanced_base_vertex_base_instance",
-        // Not checked here because availability would be
-        // different for Intel and Apple silicon Macs
-        // "WEBGL_render_shared_exponent",
-        "WEBGL_stencil_texturing",
     ]
 };
 

--- a/LayoutTests/webgl/webgl-draft-extensions-flag-default-expected.txt
+++ b/LayoutTests/webgl/webgl-draft-extensions-flag-default-expected.txt
@@ -2,15 +2,11 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 17 PASS, 0 FAIL
+TEST COMPLETE: 11 PASS, 0 FAIL
 
 
-PASS webgl:EXT_texture_mirror_clamp_to_edge: Supported
-PASS webgl:EXT_texture_mirror_clamp_to_edge: Has object.
 PASS webgl2:EXT_render_snorm: Supported
 PASS webgl2:EXT_render_snorm: Has object.
-PASS webgl2:EXT_texture_mirror_clamp_to_edge: Supported
-PASS webgl2:EXT_texture_mirror_clamp_to_edge: Has object.
 PASS webgl2:OES_sample_variables: Supported
 PASS webgl2:OES_sample_variables: Has object.
 PASS webgl2:OES_shader_multisample_interpolation: Supported
@@ -19,8 +15,6 @@ PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Has object.
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Has object.
-PASS webgl2:WEBGL_stencil_texturing: Supported
-PASS webgl2:WEBGL_stencil_texturing: Has object.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/webgl/webgl-draft-extensions-flag-off-expected.txt
+++ b/LayoutTests/webgl/webgl-draft-extensions-flag-off-expected.txt
@@ -2,17 +2,14 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 9 PASS, 0 FAIL
+TEST COMPLETE: 6 PASS, 0 FAIL
 
 
-PASS webgl:EXT_texture_mirror_clamp_to_edge: Not supported
 PASS webgl2:EXT_render_snorm: Not supported
-PASS webgl2:EXT_texture_mirror_clamp_to_edge: Not supported
 PASS webgl2:OES_sample_variables: Not supported
 PASS webgl2:OES_shader_multisample_interpolation: Not supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Not supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Not supported
-PASS webgl2:WEBGL_stencil_texturing: Not supported
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/webgl/webgl-draft-extensions-flag-on-expected.txt
+++ b/LayoutTests/webgl/webgl-draft-extensions-flag-on-expected.txt
@@ -2,15 +2,11 @@ This test outputs which WebGL draft extensions are available.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 17 PASS, 0 FAIL
+TEST COMPLETE: 11 PASS, 0 FAIL
 
 
-PASS webgl:EXT_texture_mirror_clamp_to_edge: Supported
-PASS webgl:EXT_texture_mirror_clamp_to_edge: Has object.
 PASS webgl2:EXT_render_snorm: Supported
 PASS webgl2:EXT_render_snorm: Has object.
-PASS webgl2:EXT_texture_mirror_clamp_to_edge: Supported
-PASS webgl2:EXT_texture_mirror_clamp_to_edge: Has object.
 PASS webgl2:OES_sample_variables: Supported
 PASS webgl2:OES_sample_variables: Has object.
 PASS webgl2:OES_shader_multisample_interpolation: Supported
@@ -19,8 +15,6 @@ PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Supported
 PASS webgl2:WEBGL_draw_instanced_base_vertex_base_instance: Has object.
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Supported
 PASS webgl2:WEBGL_multi_draw_instanced_base_vertex_base_instance: Has object.
-PASS webgl2:WEBGL_stencil_texturing: Supported
-PASS webgl2:WEBGL_stencil_texturing: Has object.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -2606,7 +2606,7 @@ std::optional<WebGLExtensionAny> WebGL2RenderingContext::getExtension(const Stri
     ENABLE_IF_REQUESTED(EXTTextureCompressionBPTC, m_extTextureCompressionBPTC, "EXT_texture_compression_bptc"_s, EXTTextureCompressionBPTC::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTTextureCompressionRGTC, m_extTextureCompressionRGTC, "EXT_texture_compression_rgtc"_s, EXTTextureCompressionRGTC::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTTextureFilterAnisotropic, m_extTextureFilterAnisotropic, "EXT_texture_filter_anisotropic"_s, EXTTextureFilterAnisotropic::supported(*m_context));
-    ENABLE_IF_REQUESTED(EXTTextureMirrorClampToEdge, m_extTextureMirrorClampToEdge, "EXT_texture_mirror_clamp_to_edge"_s, EXTTextureMirrorClampToEdge::supported(*m_context) && enableDraftExtensions);
+    ENABLE_IF_REQUESTED(EXTTextureMirrorClampToEdge, m_extTextureMirrorClampToEdge, "EXT_texture_mirror_clamp_to_edge"_s, EXTTextureMirrorClampToEdge::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTTextureNorm16, m_extTextureNorm16, "EXT_texture_norm16"_s, EXTTextureNorm16::supported(*m_context));
     ENABLE_IF_REQUESTED(KHRParallelShaderCompile, m_khrParallelShaderCompile, "KHR_parallel_shader_compile"_s, KHRParallelShaderCompile::supported(*m_context));
     ENABLE_IF_REQUESTED(NVShaderNoperspectiveInterpolation, m_nvShaderNoperspectiveInterpolation, "NV_shader_noperspective_interpolation"_s, NVShaderNoperspectiveInterpolation::supported(*m_context));
@@ -2631,8 +2631,8 @@ std::optional<WebGLExtensionAny> WebGL2RenderingContext::getExtension(const Stri
     ENABLE_IF_REQUESTED(WebGLMultiDrawInstancedBaseVertexBaseInstance, m_webglMultiDrawInstancedBaseVertexBaseInstance, "WEBGL_multi_draw_instanced_base_vertex_base_instance"_s, WebGLMultiDrawInstancedBaseVertexBaseInstance::supported(*m_context) && enableDraftExtensions);
     ENABLE_IF_REQUESTED(WebGLPolygonMode, m_webglPolygonMode, "WEBGL_polygon_mode"_s, WebGLPolygonMode::supported(*m_context));
     ENABLE_IF_REQUESTED(WebGLProvokingVertex, m_webglProvokingVertex, "WEBGL_provoking_vertex"_s, WebGLProvokingVertex::supported(*m_context));
-    ENABLE_IF_REQUESTED(WebGLRenderSharedExponent, m_webglRenderSharedExponent, "WEBGL_render_shared_exponent"_s, WebGLRenderSharedExponent::supported(*m_context) && enableDraftExtensions);
-    ENABLE_IF_REQUESTED(WebGLStencilTexturing, m_webglStencilTexturing, "WEBGL_stencil_texturing"_s, WebGLStencilTexturing::supported(*m_context) && enableDraftExtensions);
+    ENABLE_IF_REQUESTED(WebGLRenderSharedExponent, m_webglRenderSharedExponent, "WEBGL_render_shared_exponent"_s, WebGLRenderSharedExponent::supported(*m_context));
+    ENABLE_IF_REQUESTED(WebGLStencilTexturing, m_webglStencilTexturing, "WEBGL_stencil_texturing"_s, WebGLStencilTexturing::supported(*m_context));
     return std::nullopt;
 }
 
@@ -2661,7 +2661,7 @@ std::optional<Vector<String>> WebGL2RenderingContext::getSupportedExtensions()
     APPEND_IF_SUPPORTED("EXT_texture_compression_bptc", EXTTextureCompressionBPTC::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_texture_compression_rgtc", EXTTextureCompressionRGTC::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_texture_filter_anisotropic", EXTTextureFilterAnisotropic::supported(*m_context))
-    APPEND_IF_SUPPORTED("EXT_texture_mirror_clamp_to_edge", EXTTextureMirrorClampToEdge::supported(*m_context) && enableDraftExtensions)
+    APPEND_IF_SUPPORTED("EXT_texture_mirror_clamp_to_edge", EXTTextureMirrorClampToEdge::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_texture_norm16", EXTTextureNorm16::supported(*m_context))
     APPEND_IF_SUPPORTED("KHR_parallel_shader_compile", KHRParallelShaderCompile::supported(*m_context))
     APPEND_IF_SUPPORTED("NV_shader_noperspective_interpolation", NVShaderNoperspectiveInterpolation::supported(*m_context))
@@ -2686,8 +2686,8 @@ std::optional<Vector<String>> WebGL2RenderingContext::getSupportedExtensions()
     APPEND_IF_SUPPORTED("WEBGL_multi_draw_instanced_base_vertex_base_instance", WebGLMultiDrawInstancedBaseVertexBaseInstance::supported(*m_context) && enableDraftExtensions)
     APPEND_IF_SUPPORTED("WEBGL_polygon_mode", WebGLPolygonMode::supported(*m_context))
     APPEND_IF_SUPPORTED("WEBGL_provoking_vertex", WebGLProvokingVertex::supported(*m_context))
-    APPEND_IF_SUPPORTED("WEBGL_render_shared_exponent", WebGLRenderSharedExponent::supported(*m_context) && enableDraftExtensions)
-    APPEND_IF_SUPPORTED("WEBGL_stencil_texturing", WebGLStencilTexturing::supported(*m_context) && enableDraftExtensions)
+    APPEND_IF_SUPPORTED("WEBGL_render_shared_exponent", WebGLRenderSharedExponent::supported(*m_context))
+    APPEND_IF_SUPPORTED("WEBGL_stencil_texturing", WebGLStencilTexturing::supported(*m_context))
 
     return result;
 }

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -135,7 +135,7 @@ std::optional<WebGLExtensionAny> WebGLRenderingContext::getExtension(const Strin
         return std::nullopt;
 
     // When adding extensions that use enableDraftExtensions, add them to the webgl-draft-extensions-flag.js test.
-    const bool enableDraftExtensions = scriptExecutionContext()->settingsValues().webGLDraftExtensionsEnabled;
+    [[maybe_unused]] const bool enableDraftExtensions = scriptExecutionContext()->settingsValues().webGLDraftExtensionsEnabled;
 
 #define ENABLE_IF_REQUESTED(type, variable, nameLiteral, canEnable) \
     if (equalIgnoringASCIICase(name, nameLiteral ## _s)) { \
@@ -161,7 +161,7 @@ std::optional<WebGLExtensionAny> WebGLRenderingContext::getExtension(const Strin
     ENABLE_IF_REQUESTED(EXTTextureCompressionBPTC, m_extTextureCompressionBPTC, "EXT_texture_compression_bptc", EXTTextureCompressionBPTC::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTTextureCompressionRGTC, m_extTextureCompressionRGTC, "EXT_texture_compression_rgtc", EXTTextureCompressionRGTC::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTTextureFilterAnisotropic, m_extTextureFilterAnisotropic, "EXT_texture_filter_anisotropic", EXTTextureFilterAnisotropic::supported(*m_context));
-    ENABLE_IF_REQUESTED(EXTTextureMirrorClampToEdge, m_extTextureMirrorClampToEdge, "EXT_texture_mirror_clamp_to_edge", EXTTextureMirrorClampToEdge::supported(*m_context) && enableDraftExtensions);
+    ENABLE_IF_REQUESTED(EXTTextureMirrorClampToEdge, m_extTextureMirrorClampToEdge, "EXT_texture_mirror_clamp_to_edge", EXTTextureMirrorClampToEdge::supported(*m_context));
     ENABLE_IF_REQUESTED(EXTsRGB, m_extsRGB, "EXT_sRGB", EXTsRGB::supported(*m_context));
     ENABLE_IF_REQUESTED(KHRParallelShaderCompile, m_khrParallelShaderCompile, "KHR_parallel_shader_compile", KHRParallelShaderCompile::supported(*m_context));
     ENABLE_IF_REQUESTED(OESElementIndexUint, m_oesElementIndexUint, "OES_element_index_uint", OESElementIndexUint::supported(*m_context));
@@ -198,7 +198,7 @@ std::optional<Vector<String>> WebGLRenderingContext::getSupportedExtensions()
 
     Vector<String> result;
 
-    const bool enableDraftExtensions = scriptExecutionContext()->settingsValues().webGLDraftExtensionsEnabled;
+    [[maybe_unused]] const bool enableDraftExtensions = scriptExecutionContext()->settingsValues().webGLDraftExtensionsEnabled;
 
 #define APPEND_IF_SUPPORTED(nameLiteral, condition) \
     if (condition) \
@@ -217,7 +217,7 @@ std::optional<Vector<String>> WebGLRenderingContext::getSupportedExtensions()
     APPEND_IF_SUPPORTED("EXT_texture_compression_bptc", EXTTextureCompressionBPTC::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_texture_compression_rgtc", EXTTextureCompressionRGTC::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_texture_filter_anisotropic", EXTTextureFilterAnisotropic::supported(*m_context))
-    APPEND_IF_SUPPORTED("EXT_texture_mirror_clamp_to_edge", EXTTextureMirrorClampToEdge::supported(*m_context) && enableDraftExtensions)
+    APPEND_IF_SUPPORTED("EXT_texture_mirror_clamp_to_edge", EXTTextureMirrorClampToEdge::supported(*m_context))
     APPEND_IF_SUPPORTED("EXT_sRGB", EXTsRGB::supported(*m_context))
     APPEND_IF_SUPPORTED("KHR_parallel_shader_compile", KHRParallelShaderCompile::supported(*m_context))
     APPEND_IF_SUPPORTED("OES_element_index_uint", OESElementIndexUint::supported(*m_context))


### PR DESCRIPTION
#### e65977cbea63da31c3c8c9644d8384bb27fe46d0
<pre>
Move WebGL extensions approved on 2024-01-25 out of draft
<a href="https://bugs.webkit.org/show_bug.cgi?id=268163">https://bugs.webkit.org/show_bug.cgi?id=268163</a>

Reviewed by Kimmo Kinnunen.

Enabled support for the following approved extensions:
* EXT_texture_mirror_clamp_to_edge
* WEBGL_render_shared_exponent
* WEBGL_stencil_texturing

* LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-default-expected.txt:
* LayoutTests/platform/ios-simulator/webgl/webgl-draft-extensions-flag-on-expected.txt:
* LayoutTests/webgl/resources/webgl-draft-extensions-flag.js:
* LayoutTests/webgl/webgl-draft-extensions-flag-default-expected.txt:
* LayoutTests/webgl/webgl-draft-extensions-flag-off-expected.txt:
* LayoutTests/webgl/webgl-draft-extensions-flag-on-expected.txt:
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::getExtension):
(WebCore::WebGL2RenderingContext::getSupportedExtensions):
* Source/WebCore/html/canvas/WebGLRenderingContext.cpp:
(WebCore::WebGLRenderingContext::getExtension):
(WebCore::WebGLRenderingContext::getSupportedExtensions):

Canonical link: <a href="https://commits.webkit.org/273645@main">https://commits.webkit.org/273645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8dd6db81e8e256d9e1f05f3dbcad0ecbdf19c33b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38579 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32258 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31008 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/10988 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11023 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39829 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32603 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32375 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36942 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9073 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35031 "Found 3 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events, /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12919 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8221 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11679 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12000 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->