### PR TITLE
HTML parser: execute self-closing SVG script element

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/support/svg-script-self-closing.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/support/svg-script-self-closing.js
@@ -1,0 +1,1 @@
+scriptSelfClosing = true;

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/support/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/support/w3c-import.log
@@ -18,3 +18,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/support/no-doctype-name-eof.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/support/no-doctype-name-line.html
 /LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/support/no-doctype-name-space.html
+/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/support/svg-script-self-closing.js

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/unclosed-svg-script-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/unclosed-svg-script-expected.txt
@@ -4,4 +4,5 @@ PASS SVG scripts with end tag should run
 PASS SVG scripts without end tag should not run
 PASS SVG scripts with bogus end tag inside should run
 PASS SVG scripts ended by HTML breakout should not run
+PASS SVG scripts with self-closing start tag should run
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/unclosed-svg-script.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/unclosed-svg-script.html
@@ -8,6 +8,7 @@
     var scriptWithoutEndTagRan = false;
     var scriptWithBogusEndTagInsideRan = false;
     var scriptWithBreakout = false;
+    var scriptSelfClosing = false;
 </script>
 <svg>
     <script>scriptWithEndTagRan = true;</script>
@@ -20,6 +21,9 @@
 </svg>
 <svg>
     <script>scriptWithBreakout = true;<s></script>
+</svg>
+<svg>
+    <script href="support/svg-script-self-closing.js"/>
 </svg>
 </s>
 <script>
@@ -35,4 +39,7 @@
     test(function() {
         assert_false(scriptWithBreakout);
     }, "SVG scripts ended by HTML breakout should not run");
+    test(function() {
+        assert_true(scriptSelfClosing);
+    }, "SVG scripts with self-closing start tag should run");
 </script>

--- a/Source/WebCore/html/parser/AtomHTMLToken.h
+++ b/Source/WebCore/html/parser/AtomHTMLToken.h
@@ -66,6 +66,7 @@ public:
 
     TagName tagName() const;
     bool selfClosing() const;
+    void setSelfClosingToFalse();
     const Vector<Attribute>& attributes() const;
 
     // Characters
@@ -136,6 +137,14 @@ inline bool AtomHTMLToken::selfClosing() const
 {
     ASSERT(m_type == Type::StartTag || m_type == Type::EndTag);
     return m_selfClosing;
+}
+
+inline void AtomHTMLToken::setSelfClosingToFalse()
+{
+    ASSERT(m_selfClosing);
+    ASSERT(m_type == Type::StartTag);
+    ASSERT(m_tagName == TagName::script);
+    m_selfClosing = false;
 }
 
 inline Vector<Attribute>& AtomHTMLToken::attributes()

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -3030,7 +3030,7 @@ void HTMLTreeBuilder::processTokenInForeignContent(AtomHTMLToken&& token)
         default:
             break;
         }
-        const AtomString& currentNamespace = adjustedCurrentNode.namespaceURI();
+        auto& currentNamespace = adjustedCurrentNode.namespaceURI();
         if (currentNamespace == MathMLNames::mathmlNamespaceURI)
             adjustMathMLAttributes(token);
         if (currentNamespace == SVGNames::svgNamespaceURI) {
@@ -3038,6 +3038,15 @@ void HTMLTreeBuilder::processTokenInForeignContent(AtomHTMLToken&& token)
             adjustSVGAttributes(token);
         }
         adjustForeignAttributes(token);
+
+        if (token.tagName() == TagName::script && token.selfClosing() && currentNamespace == SVGNames::svgNamespaceURI) {
+            token.setSelfClosingToFalse();
+            m_tree.insertForeignElement(WTFMove(token), currentNamespace);
+            AtomHTMLToken fakeToken(HTMLToken::Type::EndTag, TagName::script);
+            processTokenInForeignContent(WTFMove(fakeToken));
+            return;
+        }
+
         m_tree.insertForeignElement(WTFMove(token), currentNamespace);
         break;
     }


### PR DESCRIPTION
#### 5199ed9a65daf9800e381287819a5e496b8782b9
<pre>
HTML parser: execute self-closing SVG script element
<a href="https://bugs.webkit.org/show_bug.cgi?id=268168">https://bugs.webkit.org/show_bug.cgi?id=268168</a>

Reviewed by Ryosuke Niwa and Chris Dumez.

The code is largely structured like the HTML Standard, except we
currently do not fake an end tag as needed for m_scriptToProcess to be
properly assigned to.

As foreign content supports self-closing start tags we also have to
pretend the start tag is a non-self-closing one. This results in some
slight code smell, but it seems acceptable enough.

Gecko does this correctly already.

Aligns WPT with this commit:
<a href="https://github.com/web-platform-tests/wpt/commit/eef173b5b9ee626ff9e144c80f8082af2f086e4c">https://github.com/web-platform-tests/wpt/commit/eef173b5b9ee626ff9e144c80f8082af2f086e4c</a>

* LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/support/svg-script-self-closing.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/support/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/unclosed-svg-script-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/unclosed-svg-script.html:
* Source/WebCore/html/parser/AtomHTMLToken.h:
(WebCore::AtomHTMLToken::setSelfClosingToFalse):
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::processTokenInForeignContent):

Canonical link: <a href="https://commits.webkit.org/273697@main">https://commits.webkit.org/273697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9998564ede8e557cbbe8536cabbb861fa07f664b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39011 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32624 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31288 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12866 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32187 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11280 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40256 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32931 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37240 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9393 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35332 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32029 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8245 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11976 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->