### PR TITLE
Adopt BrowserEngineCore

### DIFF
--- a/Source/JavaScriptCore/Configurations/Base.xcconfig
+++ b/Source/JavaScriptCore/Configurations/Base.xcconfig
@@ -160,12 +160,13 @@ WK_USE_RESTRICTED_ENTITLEMENTS = $(USE_INTERNAL_SDK);
 // Shared variables used for dynamic or static linking of JavaScriptCore and jsc.
 
 // Tomorrow me will be smart enough to figure out how to do this properly.
-JSC_SEC_LD_FLAGS[sdk=iphoneos*] = -weak_framework ServiceExtensionsCore;
+JSC_SEC_LD_FLAGS[sdk=iphoneos*] = -weak_framework BrowserEngineCore;
 JSC_SEC_LD_FLAGS[sdk=iphoneos17.0*] = ;
 JSC_SEC_LD_FLAGS[sdk=iphoneos17.1*] = ;
 JSC_SEC_LD_FLAGS[sdk=iphoneos17.2*] = ;
 JSC_SEC_LD_FLAGS[sdk=iphoneos17.3*] = ;
 JSC_SEC_LD_FLAGS[sdk=iphoneos17.3*] = ;
+JSC_SEC_LD_FLAGS[sdk=iphoneos18*] = ;
 JSC_SEC_LD_FLAGS[sdk=appletv*] = ;
 JSC_SEC_LD_FLAGS[sdk=watch*] = ;
 JSC_SEC_LD_FLAGS[sdk=xr*] = ;

--- a/Source/JavaScriptCore/assembler/FastJITPermissions.h
+++ b/Source/JavaScriptCore/assembler/FastJITPermissions.h
@@ -35,7 +35,7 @@
 #include <wtf/Platform.h>
 
 #if USE(INLINE_JIT_PERMISSIONS_API)
-#include <ServiceExtensions/SEMemory_Private.h>
+#include <BrowserEngineCore/BEMemory.h>
 #elif USE(PTHREAD_JIT_PERMISSIONS_API)
 #include <pthread.h>
 #elif USE(APPLE_INTERNAL_SDK)
@@ -47,7 +47,7 @@ static ALWAYS_INLINE void threadSelfRestrictRWXToRW()
     ASSERT(g_jscConfig.useFastJITPermissions);
 
 #if USE(INLINE_JIT_PERMISSIONS_API)
-    se_memory_inline_jit_restrict_rwx_to_rw_with_witness();
+    be_memory_inline_jit_restrict_rwx_to_rw_with_witness();
 #elif USE(PTHREAD_JIT_PERMISSIONS_API)
     pthread_jit_write_protect_np(false);
 #elif USE(APPLE_INTERNAL_SDK)
@@ -64,7 +64,7 @@ static ALWAYS_INLINE void threadSelfRestrictRWXToRX()
     ASSERT(g_jscConfig.useFastJITPermissions);
 
 #if USE(INLINE_JIT_PERMISSIONS_API)
-    se_memory_inline_jit_restrict_rwx_to_rx_with_witness();
+    be_memory_inline_jit_restrict_rwx_to_rx_with_witness();
 #elif USE(PTHREAD_JIT_PERMISSIONS_API)
     pthread_jit_write_protect_np(true);
 #elif USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -86,7 +86,7 @@ extern "C" {
 
 #if USE(INLINE_JIT_PERMISSIONS_API)
 #include <wtf/darwin/WeakLinking.h>
-WTF_WEAK_LINK_FORCE_IMPORT(se_memory_inline_jit_restrict_with_witness_supported);
+WTF_WEAK_LINK_FORCE_IMPORT(be_memory_inline_jit_restrict_with_witness_supported);
 #endif
 
 namespace JSC {
@@ -420,8 +420,8 @@ static ALWAYS_INLINE JITReservation initializeJITPageReservation()
         bool fastJITPermissionsIsSupported = false;
 #if OS(DARWIN) && CPU(ARM64)
 #if USE(INLINE_JIT_PERMISSIONS_API)
-        //FIXME: Check for the existence of `se_memory_inline_jit_restrict_with_witness_supported` once the fix for rdar://119669257 is in the SDK.
-        fastJITPermissionsIsSupported = !!se_memory_inline_jit_restrict_with_witness_supported();
+        fastJITPermissionsIsSupported = (be_memory_inline_jit_restrict_with_witness_supported
+            && !!be_memory_inline_jit_restrict_with_witness_supported());
 #elif USE(PTHREAD_JIT_PERMISSIONS_API)
         fastJITPermissionsIsSupported = !!pthread_jit_write_protect_supported_np();
 #elif USE(APPLE_INTERNAL_SDK)

--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -416,7 +416,10 @@
 #define USE_CORE_TEXT_VARIATIONS_CLAMPING_WORKAROUND 1
 #endif
 
-#if PLATFORM(IOS) && !PLATFORM(IOS_FAMILY_SIMULATOR) && __has_include(<ServiceExtensionsCore/SEMemory_Private.h>)
+// FIXME: Once this is forwarded to 18+, we should remove the max check.
+#if PLATFORM(IOS) && !PLATFORM(IOS_FAMILY_SIMULATOR) \
+    && __IPHONE_OS_VERSION_MAX_ALLOWED >= 170400 \
+    && __IPHONE_OS_VERSION_MAX_ALLOWED < 180000
 #define USE_INLINE_JIT_PERMISSIONS_API 1
 #endif
 

--- a/Source/WebCore/Configurations/WebCore.xcconfig
+++ b/Source/WebCore/Configurations/WebCore.xcconfig
@@ -165,12 +165,13 @@ WK_APPLEJPEGXL_LDFLAGS = $(WK_APPLEJPEGXL_LDFLAGS_$(WK_USE_APPLEJPEGXL));
 WK_APPLEJPEGXL_LDFLAGS_YES = -weak_framework AppleJPEGXL;
 
 // Tomorrow me will be smart enough to figure out how to do this properly.
-JSC_SEC_LD_FLAGS[sdk=iphoneos*] = -weak_framework ServiceExtensionsCore;
+JSC_SEC_LD_FLAGS[sdk=iphoneos*] = -weak_framework BrowserEngineCore;
 JSC_SEC_LD_FLAGS[sdk=iphoneos17.0*] = ;
 JSC_SEC_LD_FLAGS[sdk=iphoneos17.1*] = ;
 JSC_SEC_LD_FLAGS[sdk=iphoneos17.2*] = ;
 JSC_SEC_LD_FLAGS[sdk=iphoneos17.3*] = ;
 JSC_SEC_LD_FLAGS[sdk=iphoneos17.3*] = ;
+JSC_SEC_LD_FLAGS[sdk=iphoneos18*] = ;
 JSC_SEC_LD_FLAGS[sdk=appletv*] = ;
 JSC_SEC_LD_FLAGS[sdk=watch*] = ;
 JSC_SEC_LD_FLAGS[sdk=xr*] = ;


### PR DESCRIPTION
#### 676f1380f1d50dd92f84b952b1fb8305a0a83224
<pre>
Adopt BrowserEngineCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=268175">https://bugs.webkit.org/show_bug.cgi?id=268175</a>
<a href="https://rdar.apple.com/121675394">rdar://121675394</a>

Reviewed by Wenson Hsieh and Elliott Williams.

Adopt BrowserEngineCore, and compile-time assert that it is enabled.

* Source/JavaScriptCore/Configurations/Base.xcconfig:
* Source/JavaScriptCore/assembler/FastJITPermissions.h:
(threadSelfRestrictRWXToRW):
(threadSelfRestrictRWXToRX):
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::initializeJITPageReservation):
* Source/WTF/wtf/PlatformUse.h:
* Source/WebCore/Configurations/WebCore.xcconfig:

Canonical link: <a href="https://commits.webkit.org/273590@main">https://commits.webkit.org/273590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb5ab35a603e9407f14a6d11c76840b945b408b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38614 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32292 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11861 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12547 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11015 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/32116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39864 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/30347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32616 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/32437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/36975 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/35741 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35060 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12949 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/42445 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11709 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4660 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->