### PR TITLE
Implement basic infrastructure to extract (primarily text) content from webpages

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -140,6 +140,7 @@ set(WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/page"
     "${WEBCORE_DIR}/page/csp"
     "${WEBCORE_DIR}/page/scrolling"
+    "${WEBCORE_DIR}/page/text-extraction"
     "${WEBCORE_DIR}/platform"
     "${WEBCORE_DIR}/platform/animation"
     "${WEBCORE_DIR}/platform/audio"

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1628,6 +1628,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/scrolling/ScrollingTreeStickyNode.h
     page/scrolling/ThreadedScrollingTree.h
 
+    page/text-extraction/TextExtraction.h
+    page/text-extraction/TextExtractionTypes.h
+
     platform/AbortableTaskQueue.h
     platform/AudioSampleFormat.h
     platform/CaretAnimator.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2054,6 +2054,7 @@ page/scrolling/ScrollingTreeStickyNode.cpp
 page/scrolling/ThreadedScrollingCoordinator.cpp
 page/scrolling/ThreadedScrollingTree.cpp
 page/scrolling/ThreadedScrollingTreeScrollingNodeDelegate.cpp
+page/text-extraction/TextExtraction.cpp
 platform/AudioDecoder.cpp
 platform/AudioEncoder.cpp
 platform/CaretAnimator.cpp

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -158,6 +158,7 @@
 #include "StyleScope.h"
 #include "SubframeLoader.h"
 #include "SubresourceLoader.h"
+#include "TextExtraction.h"
 #include "TextIterator.h"
 #include "TextRecognitionResult.h"
 #include "TextResourceDecoder.h"

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TextExtraction.h"
+
+#include "ComposedTreeIterator.h"
+#include "HTMLBodyElement.h"
+#include "HTMLButtonElement.h"
+#include "HTMLImageElement.h"
+#include "HTMLInputElement.h"
+#include "Page.h"
+#include "RenderBox.h"
+#include "RenderLayer.h"
+#include "RenderLayerModelObject.h"
+#include "RenderLayerScrollableArea.h"
+#include "SimpleRange.h"
+#include "Text.h"
+#include "TextIterator.h"
+
+namespace WebCore {
+namespace TextExtraction {
+
+static inline HashMap<Ref<Text>, String> collectText(ContainerNode& container)
+{
+    HashMap<Ref<Text>, String> nodeToTextMap;
+    RefPtr<Text> lastTextNode;
+    StringBuilder textForLastTextNode;
+    for (TextIterator iterator { makeRangeSelectingNodeContents(container) }; !iterator.atEnd(); iterator.advance()) {
+        if (iterator.text().isEmpty())
+            continue;
+
+        RefPtr textNode = dynamicDowncast<Text>(iterator.node());
+        if (!textNode)
+            continue;
+
+        if (!lastTextNode)
+            lastTextNode = textNode;
+
+        if (lastTextNode == textNode) {
+            textForLastTextNode.append(iterator.text());
+            continue;
+        }
+
+        if (auto text = textForLastTextNode.toString().trim(isASCIIWhitespace<UChar>); !text.isEmpty())
+            nodeToTextMap.add(*lastTextNode, textForLastTextNode.toString());
+
+        textForLastTextNode.clear();
+        textForLastTextNode.append(iterator.text());
+        lastTextNode = textNode;
+    }
+
+    if (auto text = textForLastTextNode.toString().trim(isASCIIWhitespace<UChar>); lastTextNode && !text.isEmpty())
+        nodeToTextMap.add(*lastTextNode, textForLastTextNode.toString());
+
+    return nodeToTextMap;
+}
+
+static bool shouldIncludeChildren(const ItemData& data)
+{
+    return WTF::switchOn(data,
+        [&](const TextItemData&) { return false; },
+        [&](const ScrollableItemData&) { return true; },
+        [&](const EditableItemData&) { return true; },
+        [&](const ImageItemData&) { return false; },
+        [&](const InteractiveItemData&) { return true; },
+        [&](ContainerType) { return true; }
+    );
+}
+
+static inline FloatRect rootViewBounds(Node& node)
+{
+    auto view = node.document().protectedView();
+    if (UNLIKELY(!view))
+        return { };
+
+    if (!node.renderer())
+        return { };
+
+    return view->contentsToRootView(node.renderer()->absoluteBoundingBoxRect());
+}
+
+static inline std::optional<ItemData> extractItemData(Node& node, const HashMap<Ref<Text>, String>& extractedText)
+{
+    CheckedPtr renderer = node.renderer();
+    if (!renderer)
+        return std::nullopt;
+
+    if (renderer->style().visibility() == Visibility::Hidden)
+        return std::nullopt;
+
+    if (RefPtr textNode = dynamicDowncast<Text>(node)) {
+        if (auto iterator = extractedText.find(*textNode); iterator != extractedText.end())
+            return { { TextItemData { iterator->value } } };
+        return std::nullopt;
+    }
+
+    RefPtr element = dynamicDowncast<Element>(node);
+    if (!element)
+        return std::nullopt;
+
+    if (!element->isInUserAgentShadowTree() && element->isRootEditableElement())
+        return { { EditableItemData { element == element->document().activeElement() } } };
+
+    if (RefPtr image = dynamicDowncast<HTMLImageElement>(element))
+        return { { ImageItemData { image->src().lastPathComponent().toString(), image->altText() } } };
+
+    if (RefPtr button = dynamicDowncast<HTMLButtonElement>(element))
+        return { { InteractiveItemData { !button->isDisabledFormControl() } } };
+
+    if (RefPtr input = dynamicDowncast<HTMLInputElement>(element)) {
+        if (input->isTextButton())
+            return { { InteractiveItemData { !input->isDisabledFormControl() } } };
+
+        if (input->isTextField())
+            return { { EditableItemData { input == input->document().activeElement() } } };
+    }
+
+    if (CheckedPtr box = dynamicDowncast<RenderBox>(node.renderer()); box && box->canBeScrolledAndHasScrollableArea()) {
+        if (auto layer = box->checkedLayer(); layer && layer->scrollableArea())
+            return { { ScrollableItemData { layer->scrollableArea()->totalContentsSize() } } };
+    }
+
+    if (renderer->style().hasViewportConstrainedPosition())
+        return { { ContainerType::ViewportConstrained } };
+
+    return std::nullopt;
+}
+
+static inline void extractRecursive(Node& node, Item& parentItem, const HashMap<Ref<Text>, String>& extractedText)
+{
+    std::optional<Item> item;
+    if (auto itemData = extractItemData(node, extractedText))
+        item = { { WTFMove(*itemData), rootViewBounds(node), { } } };
+
+    if (!item || shouldIncludeChildren(item->data)) {
+        if (RefPtr container = dynamicDowncast<ContainerNode>(node)) {
+            for (auto& child : composedTreeChildren(*container))
+                extractRecursive(child, item ? *item : parentItem, extractedText);
+        }
+    }
+
+    if (item)
+        parentItem.children.append(WTFMove(*item));
+}
+
+Item extractItem(Page& page)
+{
+    Item root { ContainerType::Root, { }, { } };
+    RefPtr mainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
+    if (!mainFrame) {
+        // FIXME: Propagate text extraction to RemoteFrames.
+        return root;
+    }
+
+    RefPtr mainDocument = mainFrame->document();
+    if (!mainDocument)
+        return root;
+
+    RefPtr bodyElement = mainDocument->body();
+    if (!bodyElement)
+        return root;
+
+    mainDocument->updateLayoutIgnorePendingStylesheets();
+    extractRecursive(*bodyElement, root, collectText(*bodyElement));
+    return root;
+}
+
+} // namespace TextExtractor
+} // namespace WebCore

--- a/Source/WebCore/page/text-extraction/TextExtraction.h
+++ b/Source/WebCore/page/text-extraction/TextExtraction.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "TextExtractionTypes.h"
+
+namespace WebCore {
+
+class Page;
+
+namespace TextExtraction {
+
+WEBCORE_EXPORT Item extractItem(Page&);
+
+} // namespace TextExtraction
+} // namespace WebCore

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FloatRect.h"
+#include "FloatSize.h"
+#include <wtf/Forward.h>
+
+namespace WebCore {
+namespace TextExtraction {
+
+struct TextItemData {
+    String content;
+};
+
+struct ScrollableItemData {
+    FloatSize contentSize;
+};
+
+struct EditableItemData {
+    bool isFocused { false };
+};
+
+struct ImageItemData {
+    String name;
+    String altText;
+};
+
+struct InteractiveItemData {
+    bool isEnabled { false };
+};
+
+enum class ContainerType : uint8_t {
+    Root,
+    ViewportConstrained,
+};
+
+using ItemData = std::variant<ContainerType, TextItemData, ScrollableItemData, EditableItemData, ImageItemData, InteractiveItemData>;
+
+struct Item {
+    ItemData data;
+    FloatRect rectInRootView;
+    Vector<Item> children;
+};
+
+} // namespace TextExtraction
+} // namespace WebCore

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -896,6 +896,7 @@ def headers_for_type(type):
         'WebCore::TextCheckingRequestData': ['<WebCore/TextChecking.h>'],
         'WebCore::TextCheckingResult': ['<WebCore/TextCheckerClient.h>'],
         'WebCore::TextCheckingType': ['<WebCore/TextChecking.h>'],
+        'WebCore::TextExtraction::Item': ['<WebCore/TextExtractionTypes.h>'],
         'WebCore::TextIndicatorData': ['<WebCore/TextIndicator.h>'],
         'WebCore::TextManipulationTokenIdentifier': ['<WebCore/TextManipulationToken.h>'],
         'WebCore::ThirdPartyCookieBlockingMode': ['<WebCore/NetworkStorageSession.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5938,6 +5938,45 @@ header: <WebCore/RenderTreeAsText.h>
     ShowLayoutState
 };
 
+header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] struct WebCore::TextExtraction::TextItemData {
+    String content;
+};
+
+header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] struct WebCore::TextExtraction::ScrollableItemData {
+    WebCore::FloatSize contentSize;
+};
+
+header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] struct WebCore::TextExtraction::EditableItemData {
+    bool isFocused;
+};
+
+header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] struct WebCore::TextExtraction::ImageItemData {
+    String name;
+    String altText;
+};
+
+header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] struct WebCore::TextExtraction::InteractiveItemData {
+    bool isEnabled;
+};
+
+header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] enum class WebCore::TextExtraction::ContainerType : uint8_t {
+    Root,
+    ViewportConstrained
+};
+
+header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] struct WebCore::TextExtraction::Item {
+    std::variant<WebCore::TextExtraction::ContainerType, WebCore::TextExtraction::TextItemData, WebCore::TextExtraction::ScrollableItemData, WebCore::TextExtraction::EditableItemData, WebCore::TextExtraction::ImageItemData, WebCore::TextExtraction::InteractiveItemData> data;
+    WebCore::FloatRect rectInRootView;
+    Vector<WebCore::TextExtraction::Item> children;
+};
+
 header: <WebCore/WebGPUTextureFormat.h>
 enum class WebCore::WebGPU::TextureFormat : uint8_t {
     R8unorm,

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -221,6 +221,7 @@
 #include <WebCore/SleepDisabler.h>
 #include <WebCore/StoredCredentialsPolicy.h>
 #include <WebCore/TextCheckerClient.h>
+#include <WebCore/TextExtractionTypes.h>
 #include <WebCore/TextIndicator.h>
 #include <WebCore/ValidationBubble.h>
 #include <WebCore/WindowFeatures.h>
@@ -13538,6 +13539,13 @@ void WebPageProxy::renderTreeAsText(WebCore::FrameIdentifier frameID, size_t bas
 
     auto [result] = sendResult.takeReply();
     completionHandler(WTFMove(result));
+}
+
+void WebPageProxy::requestTextExtraction(CompletionHandler<void(WebCore::TextExtraction::Item&&)>&& completion)
+{
+    if (!hasRunningProcess())
+        return completion({ });
+    sendWithAsyncReply(Messages::WebPage::RequestTextExtraction(), WTFMove(completion));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -275,6 +275,10 @@ struct ViewportArguments;
 struct WheelEventHandlingResult;
 struct WindowFeatures;
 
+namespace TextExtraction {
+struct Item;
+}
+
 template<typename> class ProcessQualified;
 template<typename> class RectEdges;
 
@@ -2318,6 +2322,8 @@ public:
     const std::optional<MediaCapability>& mediaCapability() const;
     void updateMediaCapability();
 #endif
+
+    void requestTextExtraction(CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
 
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -286,6 +286,7 @@
 #include <WebCore/SubframeLoader.h>
 #include <WebCore/SubresourceLoader.h>
 #include <WebCore/SubstituteData.h>
+#include <WebCore/TextExtraction.h>
 #include <WebCore/TextIterator.h>
 #include <WebCore/TextRecognitionOptions.h>
 #include <WebCore/TranslationContextMenuInfo.h>
@@ -9078,6 +9079,11 @@ void WebPage::renderTreeAsText(WebCore::FrameIdentifier frameID, size_t baseInde
     ts.setIndent(baseIndent);
     WebCore::externalRepresentationForLocalFrame(ts, *coreLocalFrame, behavior);
     completionHandler(ts.release());
+}
+
+void WebPage::requestTextExtraction(CompletionHandler<void(TextExtraction::Item&&)>&& completion)
+{
+    completion(TextExtraction::extractItem(Ref { *corePage() }));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -302,7 +302,12 @@ class HandleUserInputEventResult;
 #if HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)
 struct TranslationContextMenuInfo;
 #endif
+
+namespace TextExtraction {
+struct Item;
 }
+
+} // namespace WebCore
 
 namespace WebKit {
 
@@ -2160,6 +2165,8 @@ private:
 
     void remotePostMessage(WebCore::FrameIdentifier source, const String& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData>&& targetOrigin, const WebCore::MessageWithMessagePorts&);
     void renderTreeAsText(WebCore::FrameIdentifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>, CompletionHandler<void(String&&)>&&);
+
+    void requestTextExtraction(CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
 
 #if HAVE(SANDBOX_STATE_FLAGS)
     static void setHasLaunchedWebContentProcess();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -749,6 +749,8 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     RemotePostMessage(WebCore::FrameIdentifier source, String sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, struct WebCore::MessageWithMessagePorts message)
     RenderTreeAsText(WebCore::FrameIdentifier frameID, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior) -> (String renderTreeDump) Synchronous
 
+    RequestTextExtraction() -> (struct WebCore::TextExtraction::Item item)
+
 #if ENABLE(EXTENSION_CAPABILITIES)
     SetMediaEnvironment(String mediaEnvironment)
 #endif


### PR DESCRIPTION
#### 569a8bd61f85e335544610a543eb86b808b09fa4
<pre>
Implement basic infrastructure to extract (primarily text) content from webpages
<a href="https://bugs.webkit.org/show_bug.cgi?id=268171">https://bugs.webkit.org/show_bug.cgi?id=268171</a>
<a href="https://rdar.apple.com/121132162">rdar://121132162</a>

Reviewed by Aditya Keerthi.

Add some infrastructure to WebKit, to extract visible text from web content for (eventual) donation
to system services. No change in behavior (yet).

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/Page.cpp:
* Source/WebCore/page/text-extraction/TextExtraction.cpp: Added.
(WebCore::TextExtraction::collectText):

Add a utility function to collect text over the entire document, and then recursively walk the DOM
to collect any other elements that are interesting for the purposes of text extraction; note that
this skips subframes for the time being, and doesn&apos;t handle `RemoteFrame`. Support will be added in
subsequent patches.

(WebCore::TextExtraction::shouldIncludeChildren):
(WebCore::TextExtraction::rootViewBounds):
(WebCore::TextExtraction::extractItemData):
(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::extractItem):
* Source/WebCore/page/text-extraction/TextExtraction.h: Added.
* Source/WebCore/page/text-extraction/TextExtractionTypes.h: Added.
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestTextExtraction):

Add an unused `WebPageProxy` method and IPC endpoint for now that will be adopted in `WebViewImpl`
and `WKContentView` in subsequent patches to vend collected items to system services.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::requestTextExtraction):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/273598@main">https://commits.webkit.org/273598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71646313e49706c9c975cfcf8872bcc3e6b062ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32346 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11936 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11065 "Passed tests") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/36141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/32130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39931 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32672 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32452 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37031 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11244 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35113 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8191 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12075 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->