### PR TITLE
Move image decoding WorkQueue to a separate class named ImageFrameWorkQueue

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1944,6 +1944,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ImageDecoder.h
     platform/graphics/ImageDecoderIdentifier.h
     platform/graphics/ImageFrame.h
+    platform/graphics/ImageFrameWorkQueue.h
     platform/graphics/ImageObserver.h
     platform/graphics/ImageOrientation.h
     platform/graphics/ImagePaintingOptions.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2304,6 +2304,7 @@ platform/graphics/ImageBufferBackend.cpp
 platform/graphics/ImageBufferPipe.cpp
 platform/graphics/ImageDecoder.cpp
 platform/graphics/ImageFrame.cpp
+platform/graphics/ImageFrameWorkQueue.cpp
 platform/graphics/ImagePaintingOptions.cpp
 platform/graphics/ImageSource.cpp
 platform/graphics/InbandGenericCue.cpp

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -188,7 +188,7 @@ void CachedImage::removeAllClientsWaitingForAsyncDecoding()
     RefPtr bitmapImage = dynamicDowncast<BitmapImage>(image());
     if (!bitmapImage)
         return;
-    bitmapImage->stopAsyncDecodingQueue();
+    bitmapImage->stopWorkQueue();
     for (auto& client : m_clientsWaitingForAsyncDecoding)
         client.imageChanged(this);
     m_clientsWaitingForAsyncDecoding.clear();

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -77,7 +77,7 @@ public:
     FloatSize size(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const override { return m_source->size(orientation); }
     ImageOrientation orientation() const override { return m_source->orientation(); }
     Color singlePixelSolidColor() const override { return m_source->singlePixelSolidColor(); }
-    bool frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(size_t index, const DecodingOptions& decodingOptions) const { return m_source->frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(index, decodingOptions); }
+    bool frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(size_t index, SubsamplingLevel subsamplingLevel, const DecodingOptions& decodingOptions) const { return m_source->frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex(index, subsamplingLevel, decodingOptions); }
     DecodingStatus frameDecodingStatusAtIndex(size_t index) const { return m_source->frameDecodingStatusAtIndex(index); }
     bool frameIsCompleteAtIndex(size_t index) const { return frameDecodingStatusAtIndex(index) == DecodingStatus::Complete; }
     bool frameHasAlphaAtIndex(size_t index) const { return m_source->frameHasAlphaAtIndex(index); }
@@ -95,14 +95,13 @@ public:
     ImageOrientation orientationForCurrentFrame() const { return frameOrientationAtIndex(currentFrameIndex()); }
     bool canAnimate() const;
 
-    bool shouldUseAsyncDecodingForTesting() const { return m_source->frameDecodingDurationForTesting() > 0_s; }
-    void setFrameDecodingDurationForTesting(Seconds duration) { m_source->setFrameDecodingDurationForTesting(duration); }
+    void setMinimumDecodingDurationForTesting(Seconds duration) { m_source->setMinimumDecodingDurationForTesting(duration); }
     bool canUseAsyncDecodingForLargeImages() const;
     bool shouldUseAsyncDecodingForAnimatedImages() const;
     void setClearDecoderAfterAsyncFrameRequestForTesting(bool value) { m_clearDecoderAfterAsyncFrameRequestForTesting = value; }
     void setAsyncDecodingEnabledForTesting(bool enabled) { m_asyncDecodingEnabledForTesting = enabled; }
     bool isAsyncDecodingEnabledForTesting() const { return m_asyncDecodingEnabledForTesting; }
-    void stopAsyncDecodingQueue() { m_source->stopAsyncDecodingQueue(); }
+    void stopWorkQueue() { m_source->stopWorkQueue(); }
 
     DestinationColorSpace colorSpace() final;
 

--- a/Source/WebCore/platform/graphics/ImageFrameWorkQueue.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrameWorkQueue.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ImageFrameWorkQueue.h"
+
+#include "ImageDecoder.h"
+#include "ImageSource.h"
+#include "Logging.h"
+#include <wtf/SystemTracing.h>
+
+namespace WebCore {
+
+Ref<ImageFrameWorkQueue> ImageFrameWorkQueue::create(ImageSource& source)
+{
+    return adoptRef(*new ImageFrameWorkQueue(source));
+}
+
+ImageFrameWorkQueue::ImageFrameWorkQueue(ImageSource& source)
+    : m_source(source)
+{
+}
+
+ImageFrameWorkQueue::RequestQueue& ImageFrameWorkQueue::requestQueue()
+{
+    if (!m_requestQueue)
+        m_requestQueue = RequestQueue::create();
+
+    return *m_requestQueue;
+}
+
+void ImageFrameWorkQueue::start()
+{
+    if (m_workQueue)
+        return;
+
+    ASSERT(isMainThread());
+    m_workQueue = WorkQueue::create("org.webkit.ImageDecoder", WorkQueue::QOS::Default);
+
+    m_workQueue->dispatch([protectedThis = Ref { *this }, protectedWorkQueue = Ref { *m_workQueue }, protectedSource = Ref { source() }] () mutable {
+        Request request;
+        while (protectedThis->requestQueue().dequeue(request)) {
+            TraceScope tracingScope(AsyncImageDecodeStart, AsyncImageDecodeEnd);
+
+            auto decoder = protectedSource->m_decoder;
+            auto minimumDecodingDuration = protectedThis->minimumDecodingDurationForTesting();
+
+            MonotonicTime startingTime;
+            if (minimumDecodingDuration > 0_s)
+                startingTime = MonotonicTime::now();
+
+            auto platformImage = decoder->createFrameImageAtIndex(request.index, request.subsamplingLevel, request.options);
+            auto nativeImage = NativeImage::create(WTFMove(platformImage));
+
+            // Pretend as if decoding the frame took minimumDecodingDuration.
+            if (minimumDecodingDuration > 0_s) {
+                auto actualDecodingDuration = MonotonicTime::now() - startingTime;
+                if (minimumDecodingDuration > actualDecodingDuration)
+                    sleep(minimumDecodingDuration - actualDecodingDuration);
+            }
+
+            // Even if we fail to decode the frame, it is important to sync the main thread with this result.
+            callOnMainThread([protectedThis, protectedWorkQueue, protectedSource, request, nativeImage = WTFMove(nativeImage)] () mutable {
+                // The WorkQueue may have been recreated before the frame was decoded.
+                if (protectedWorkQueue.ptr() != protectedThis->m_workQueue || protectedSource.ptr() != &protectedThis->source()) {
+                    LOG(Images, "ImageFrameWorkQueue::%s - %p - url: %s. WorkQueue was recreated at index = %d.", __FUNCTION__, protectedThis.ptr(), protectedSource->sourceUTF8(), request.index);
+                    return;
+                }
+
+                // The DecodeQueue may have been cleared before the frame was decoded.
+                if (protectedThis->decodeQueue().isEmpty() || protectedThis->decodeQueue().first() != request) {
+                    LOG(Images, "ImageFrameWorkQueue::%s - %p - url: %s. DecodeQueue was cleared at index = %d.", __FUNCTION__, protectedThis.ptr(), protectedSource->sourceUTF8(), request.index);
+                    return;
+                }
+
+                protectedThis->decodeQueue().removeFirst();
+                protectedSource->cacheNativeImageAtIndexAsync(request.index, request.subsamplingLevel, request.options, WTFMove(nativeImage));
+            });
+        }
+
+        // Ensure destruction happens on creation thread.
+        callOnMainThread([protectedThis = WTFMove(protectedThis), protectedWorkQueue = WTFMove(protectedWorkQueue), protectedSource = WTFMove(protectedSource)] () mutable { });
+    });
+}
+
+void ImageFrameWorkQueue::dispatch(const Request& request)
+{
+    requestQueue().enqueue(request);
+    decodeQueue().append(request);
+
+    start();
+}
+
+void ImageFrameWorkQueue::stop()
+{
+    for (auto& request : m_decodeQueue) {
+        LOG(Images, "ImageFrameWorkQueue::%s - %p - url: %s. Decoding was cancelled for frame at index = %d.", __FUNCTION__, this, source().sourceUTF8(), request.index);
+        source().clearFrameAtIndex(request.index);
+    }
+
+    if (m_requestQueue) {
+        m_requestQueue->close();
+        m_requestQueue = nullptr;
+    }
+
+    m_decodeQueue.clear();
+    m_workQueue = nullptr;
+}
+
+bool ImageFrameWorkQueue::isPendingDecodingAtIndex(unsigned index, SubsamplingLevel subsamplingLevel, const DecodingOptions& options) const
+{
+    auto it = std::find_if(m_decodeQueue.begin(), m_decodeQueue.end(), [index, subsamplingLevel, &options](const Request& request) {
+        return request.index == index && subsamplingLevel >= request.subsamplingLevel && request.options.isCompatibleWith(options);
+    });
+    return it != m_decodeQueue.end();
+}
+
+void ImageFrameWorkQueue::dump(TextStream& ts) const
+{
+    if (isIdle())
+        return;
+
+    ts.dumpProperty("pending-for-decoding", m_decodeQueue.size());
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageFrameWorkQueue.h
+++ b/Source/WebCore/platform/graphics/ImageFrameWorkQueue.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2024 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "DecodingOptions.h"
+#include "ImageTypes.h"
+#include <wtf/SynchronizedFixedQueue.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/WorkQueue.h>
+
+namespace WebCore {
+
+class ImageSource;
+
+class ImageFrameWorkQueue : public ThreadSafeRefCounted<ImageFrameWorkQueue> {
+public:
+    struct Request {
+        unsigned index;
+        SubsamplingLevel subsamplingLevel;
+        ImageAnimatingState animatingState;
+        DecodingOptions options;
+        friend bool operator==(const Request&, const Request&) = default;
+    };
+
+    static Ref<ImageFrameWorkQueue> create(ImageSource&);
+
+    void start();
+    void dispatch(const Request&);
+    void stop();
+
+    bool isIdle() const { return m_decodeQueue.isEmpty(); }
+
+    bool isPendingDecodingAtIndex(unsigned index, SubsamplingLevel, const DecodingOptions&) const;
+
+    void setMinimumDecodingDurationForTesting(Seconds duration) { m_minimumDecodingDurationForTesting = duration; }
+
+    void dump(TextStream&) const;
+
+private:
+    ImageFrameWorkQueue(ImageSource&);
+
+    static const int BufferSize = 8;
+    using RequestQueue = SynchronizedFixedQueue<Request, BufferSize>;
+    using DecodeQueue = Deque<Request, BufferSize>;
+
+    ImageSource& source() const { return *m_source.get(); }
+    RequestQueue& requestQueue();
+    DecodeQueue& decodeQueue() { return m_decodeQueue; }
+
+    Seconds minimumDecodingDurationForTesting() const { return m_minimumDecodingDurationForTesting; }
+
+    ThreadSafeWeakPtr<ImageSource> m_source;
+
+    RefPtr<RequestQueue> m_requestQueue;
+    DecodeQueue m_decodeQueue;
+    RefPtr<WorkQueue> m_workQueue;
+
+    Seconds m_minimumDecodingDurationForTesting;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1099,7 +1099,7 @@ float Internals::imageFrameDurationAtIndex(HTMLImageElement& element, unsigned i
 void Internals::setImageFrameDecodingDuration(HTMLImageElement& element, float duration)
 {
     if (auto* bitmapImage = bitmapImageFromImageElement(element))
-        bitmapImage->setFrameDecodingDurationForTesting(Seconds { duration });
+        bitmapImage->setMinimumDecodingDurationForTesting(Seconds { duration });
 }
 
 void Internals::resetImageAnimation(HTMLImageElement& element)


### PR DESCRIPTION
#### d20aed3dd9607daca48d48dc49614f6c6a383d11
<pre>
Move image decoding WorkQueue to a separate class named ImageFrameWorkQueue
<a href="https://bugs.webkit.org/show_bug.cgi?id=268184">https://bugs.webkit.org/show_bug.cgi?id=268184</a>
<a href="https://rdar.apple.com/121677190">rdar://121677190</a>

Reviewed by NOBODY (OOPS!).

ImageSource will ask ImageFrameWorkQueue to decode the image frames. Once the
image frame is decoded, ImageSource will be notifed to cache the decoded frame
and tell the observer to repaint its renderer.

Alos ImageFrameWorkQueue will answer whether a frame is being decoded or not.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::removeAllClientsWaitingForAsyncDecoding):
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::~BitmapImage):
(WebCore::BitmapImage::destroyDecodedData):
(WebCore::BitmapImage::draw):
(WebCore::BitmapImage::canDestroyDecodedData):
(WebCore::BitmapImage::internalStartAnimation):
(WebCore::BitmapImage::advanceAnimation):
(WebCore::BitmapImage::internalAdvanceAnimation):
(WebCore::BitmapImage::stopAnimation):
(WebCore::BitmapImage::decode):
(WebCore::BitmapImage::imageFrameAvailableAtIndex):
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/ImageFrameWorkQueue.cpp: Added.
(WebCore::ImageFrameWorkQueue::create):
(WebCore::ImageFrameWorkQueue::ImageFrameWorkQueue):
(WebCore::ImageFrameWorkQueue::requestQueue):
(WebCore::ImageFrameWorkQueue::start):
(WebCore::ImageFrameWorkQueue::dispatch):
(WebCore::ImageFrameWorkQueue::stop):
(WebCore::ImageFrameWorkQueue::isPendingDecodingAtIndex const):
(WebCore::ImageFrameWorkQueue::dump const):
* Source/WebCore/platform/graphics/ImageFrameWorkQueue.h: Added.
(WebCore::ImageFrameWorkQueue::isIdle const):
(WebCore::ImageFrameWorkQueue::setMinimumDecodingDurationForTesting):
(WebCore::ImageFrameWorkQueue::decodeQueue):
(WebCore::ImageFrameWorkQueue::minimumDecodingDurationForTesting const):
* Source/WebCore/platform/graphics/ImageSource.cpp:
(WebCore::ImageSource::~ImageSource):
(WebCore::ImageSource::ensureDecoderAvailable):
(WebCore::ImageSource::cacheNativeImageAtIndex):
(WebCore::ImageSource::cacheNativeImageAtIndexAsync):
(WebCore::ImageSource::clearFrameAtIndex):
(WebCore::ImageSource::workQueue):
(WebCore::ImageSource::requestFrameAsyncDecodingAtIndex):
(WebCore::ImageSource::stopWorkQueue):
(WebCore::ImageSource::setMinimumDecodingDurationForTesting):
(WebCore::ImageSource::frameAtIndexCacheIfNeeded):
(WebCore::ImageSource::sourceUTF8 const):
(WebCore::ImageSource::frameIsBeingDecodedAndIsCompatibleWithOptionsAtIndex):
(WebCore::ImageSource::cachePlatformImageAtIndex): Deleted.
(WebCore::ImageSource::cachePlatformImageAtIndexAsync): Deleted.
(WebCore::ImageSource::decodingQueue): Deleted.
(WebCore::ImageSource::frameRequestQueue): Deleted.
(WebCore::ImageSource::startAsyncDecodingQueue): Deleted.
(WebCore::ImageSource::isAsyncDecodingQueueIdle const): Deleted.
(WebCore::ImageSource::stopAsyncDecodingQueue): Deleted.
* Source/WebCore/platform/graphics/ImageSource.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setImageFrameDecodingDuration):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d20aed3dd9607daca48d48dc49614f6c6a383d11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38068 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40615 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33859 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32148 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33342 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12507 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12436 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34055 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41891 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34559 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38318 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10706 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36510 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14591 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13455 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14041 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->