### PR TITLE
Add support for updatable list of domains with restricted openers

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
@@ -105,7 +105,7 @@ constexpr NSInteger WPResourceTypeStorageAccessPromptQuirksData = 7;
 
 typedef void (^WPStorageAccessPromptQuirksDataCompletionHandler)(WPStorageAccessPromptQuirksData *, NSError *);
 
-@interface WPResources (Staging_119342418)
+@interface WPResources (Staging_119342418_PromptQuirks)
 - (void)requestStorageAccessPromptQuirksData:(WPResourceRequestOptions *)options completionHandler:(WPStorageAccessPromptQuirksDataCompletionHandler)completion;
 @end
 #endif
@@ -123,7 +123,7 @@ constexpr NSInteger WPResourceTypeStorageAccessUserAgentStringQuirksData = 6;
 
 typedef void (^WPStorageAccessUserAgentStringQuirksDataCompletionHandler)(WPStorageAccessUserAgentStringQuirksData *, NSError *);
 
-@interface WPStorageAccessUserAgentStringQuirk (Staging_119342418)
+@interface WPResources (Staging_119342418_UAQuirks)
 - (void)requestStorageAccessUserAgentStringQuirksData:(WPResourceRequestOptions *)options completionHandler:(WPStorageAccessUserAgentStringQuirksDataCompletionHandler)completion;
 @end
 #endif
@@ -131,6 +131,26 @@ typedef void (^WPStorageAccessUserAgentStringQuirksDataCompletionHandler)(WPStor
 #if !defined(HAS_WEB_PRIVACY_LINK_FILTERING_RULE_PATH) && HAVE(WEB_PRIVACY_FRAMEWORK)
 @interface WPLinkFilteringRule (Staging_119590894)
 @property (nonatomic, readonly) NSString *path;
+@end
+#endif
+
+#if !defined(HAS_WEB_PRIVACY_RESTRICTED_OPENER_DOMAIN_CLASS)
+constexpr NSInteger WPResourceTypeRestrictedOpenerDomains = 8;
+
+typedef NS_ENUM(NSInteger, WPRestrictedOpenerType) {
+    WPRestrictedOpenerTypeNoOpener = 1,
+    WPRestrictedOpenerTypePostMessageAndClose,
+};
+
+@interface WPRestrictedOpenerDomain : NSObject
+@property (nonatomic, readonly) NSString *domain;
+@property (nonatomic, readonly) WPRestrictedOpenerType openerType;
+@end
+
+typedef void (^WPRestrictedOpenerDomainsCompletionHandler)(NSArray<WPRestrictedOpenerDomain *> *, NSError *);
+
+@interface WPResources (Staging_118208263)
+- (void)requestRestrictedOpenerDomains:(WPResourceRequestOptions *)options completionHandler:(WPRestrictedOpenerDomainsCompletionHandler)completion;
 @end
 #endif
 

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -45,6 +45,8 @@ namespace WebKit {
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
 
+enum class RestrictedOpenerType : uint8_t;
+
 void configureForAdvancedPrivacyProtections(NSURLSession *);
 void requestLinkDecorationFilteringData(CompletionHandler<void(Vector<WebCore::LinkDecorationFilteringData>&&)>&&);
 
@@ -166,6 +168,23 @@ private:
     RetainPtr<WKWebPrivacyNotificationListener> m_notificationListener;
     HashMap<WebCore::RegistrableDomain, String> m_cachedQuirks;
     WeakHashSet<StorageAccessUserAgentStringQuirkObserver> m_observers;
+};
+
+class RestrictedOpenerDomainsController {
+public:
+    static RestrictedOpenerDomainsController& shared();
+
+    RestrictedOpenerType lookup(const WebCore::RegistrableDomain&) const;
+
+private:
+    friend class NeverDestroyed<RestrictedOpenerDomainsController, MainThreadAccessTraits>;
+    RestrictedOpenerDomainsController();
+    void scheduleNextUpdate(uint64_t);
+    void update();
+
+    RetainPtr<WKWebPrivacyNotificationListener> m_notificationListener;
+    HashMap<WebCore::RegistrableDomain, RestrictedOpenerType> m_restrictedOpenerTypes;
+    uint64_t m_nextScheduledUpdateTime { 0 };
 };
 
 void configureForAdvancedPrivacyProtections(NSURLSession *);

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -29,15 +29,18 @@
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
 
 #import "Logging.h"
+#import "RestrictedOpenerType.h"
 #import <WebCore/DNS.h>
 #import <WebCore/LinkDecorationFilteringData.h>
 #import <WebCore/OrganizationStorageAccessPromptQuirk.h>
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <pal/spi/cocoa/NetworkSPI.h>
+#import <time.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/NeverDestroyed.h>
 #import <wtf/RobinHoodHashMap.h>
 #import <wtf/RunLoop.h>
+#import <wtf/WeakRandom.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 #import <pal/cocoa/WebPrivacySoftLink.h>
@@ -98,6 +101,7 @@ static NSString *notificationUserInfoResourceTypeKey()
     BlockPtr<void()> _linkFilteringDataCallback;
     BlockPtr<void()> _storageAccessPromptQuirksDataCallback;
     BlockPtr<void()> _storageAccessUserAgentStringQuirksDataCallback;
+    BlockPtr<void()> _restrictedOpenerDomainsCallback;
 }
 
 - (instancetype)init
@@ -125,6 +129,11 @@ static NSString *notificationUserInfoResourceTypeKey()
     _storageAccessUserAgentStringQuirksDataCallback = callback;
 }
 
+- (void)listenForRestrictedOpenerDomainsChanges:(void(^)())callback
+{
+    _restrictedOpenerDomainsCallback = callback;
+}
+
 - (void)dealloc
 {
     if (WebKit::canUseWebPrivacyFramework())
@@ -147,6 +156,9 @@ static NSString *notificationUserInfoResourceTypeKey()
 
     if (_storageAccessUserAgentStringQuirksDataCallback && type.integerValue == WPResourceTypeStorageAccessUserAgentStringQuirksData)
         _storageAccessUserAgentStringQuirksDataCallback();
+
+    if (_restrictedOpenerDomainsCallback && type.integerValue == WPResourceTypeRestrictedOpenerDomains)
+        _restrictedOpenerDomainsCallback();
 }
 
 @end
@@ -412,6 +424,89 @@ void StorageAccessUserAgentStringQuirkController::updateQuirks(CompletionHandler
         for (auto& completionHandler : std::exchange(lookupCompletionHandlers.get(), { }))
             completionHandler();
     }];
+}
+
+static uint64_t approximateContinuousTimeNanoseconds()
+{
+    return clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW_APPROX);
+}
+
+RestrictedOpenerDomainsController& RestrictedOpenerDomainsController::shared()
+{
+    static MainThreadNeverDestroyed<RestrictedOpenerDomainsController> sharedInstance;
+    return sharedInstance.get();
+}
+
+RestrictedOpenerDomainsController::RestrictedOpenerDomainsController()
+{
+    scheduleNextUpdate(approximateContinuousTimeNanoseconds());
+    update();
+
+    m_notificationListener = adoptNS([WKWebPrivacyNotificationListener new]);
+    [m_notificationListener listenForRestrictedOpenerDomainsChanges:^{
+        update();
+    }];
+}
+
+static RestrictedOpenerType restrictedOpenerType(WPRestrictedOpenerType type)
+{
+    switch (type) {
+    case WPRestrictedOpenerTypeNoOpener: return RestrictedOpenerType::NoOpener;
+    case WPRestrictedOpenerTypePostMessageAndClose: return RestrictedOpenerType::PostMessageAndClose;
+    default: return RestrictedOpenerType::Unrestricted;
+    }
+}
+
+void RestrictedOpenerDomainsController::scheduleNextUpdate(uint64_t now)
+{
+    // Allow the list to be re-requested from the server sometime between [24, 26) hours from now.
+    static WeakRandom random;
+    static constexpr int64_t oneDay = 24 * 60 * 60 * NSEC_PER_SEC;
+    int64_t zeroToTwoHours = random.get() * (2 * 60 * 60 * NSEC_PER_SEC);
+
+    m_nextScheduledUpdateTime = now + oneDay + zeroToTwoHours;
+}
+
+void RestrictedOpenerDomainsController::update()
+{
+    ASSERT(RunLoop::isMain());
+    if (!WebKit::canUseWebPrivacyFramework() || ![PAL::getWPResourcesClass() instancesRespondToSelector:@selector(requestRestrictedOpenerDomains:completionHandler:)])
+        return;
+
+    auto options = adoptNS([PAL::allocWPResourceRequestOptionsInstance() init]);
+    [options setAfterUpdates:NO];
+
+    [[PAL::getWPResourcesClass() sharedInstance] requestRestrictedOpenerDomains:options.get() completionHandler:^(NSArray<WPRestrictedOpenerDomain *> *domains, NSError *error) {
+        if (error) {
+            RELEASE_LOG_ERROR(ResourceLoadStatistics, "Failed to request restricted opener domains from WebPrivacy");
+            return;
+        }
+
+        HashMap<WebCore::RegistrableDomain, RestrictedOpenerType> restrictedOpenerTypes;
+        restrictedOpenerTypes.reserveInitialCapacity(domains.count);
+
+        for (WPRestrictedOpenerDomain *domainInfo in domains) {
+            auto registrableDomain = WebCore::RegistrableDomain::fromRawString(makeString("https://", String { domainInfo.domain }));
+            if (registrableDomain.isEmpty())
+                continue;
+            restrictedOpenerTypes.add(registrableDomain, restrictedOpenerType(domainInfo.openerType));
+        }
+
+        m_restrictedOpenerTypes = WTFMove(restrictedOpenerTypes);
+    }];
+}
+
+RestrictedOpenerType RestrictedOpenerDomainsController::lookup(const WebCore::RegistrableDomain& domain) const
+{
+    auto now = approximateContinuousTimeNanoseconds();
+    if (now > m_nextScheduledUpdateTime) {
+        auto mutableThis = const_cast<RestrictedOpenerDomainsController*>(this);
+        mutableThis->scheduleNextUpdate(now);
+        mutableThis->update();
+    }
+
+    auto it = m_restrictedOpenerTypes.find(domain);
+    return it == m_restrictedOpenerTypes.end() ? RestrictedOpenerType::Unrestricted : it->value;
 }
 
 #if HAVE(SYSTEM_SUPPORT_FOR_ADVANCED_PRIVACY_PROTECTIONS)

--- a/Source/WebKit/Shared/RestrictedOpenerType.h
+++ b/Source/WebKit/Shared/RestrictedOpenerType.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebKit {
+
+enum class RestrictedOpenerType : uint8_t {
+    Unrestricted,
+    NoOpener,
+    PostMessageAndClose,
+};
+
+}

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -307,6 +307,11 @@ void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization needsGlo
         for (const auto& pool : WebProcessPool::allProcessPools())
             logProcessPoolState(pool.get());
     });
+
+    PAL::registerNotifyCallback("com.apple.WebKit.restrictedDomains"_s, ^{
+        RestrictedOpenerDomainsController::shared();
+    });
+
 }
 
 void WebProcessPool::platformResolvePathsForSandboxExtensions()

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2381,6 +2381,7 @@
 		E5CBA76827A318E100DF7858 /* UnifiedSource117.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E5CBA76227A3187900DF7858 /* UnifiedSource117.cpp */; };
 		E5DEFA6826F8F42600AB68DB /* PhotosUISPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E5DEFA6726F8F42600AB68DB /* PhotosUISPI.h */; };
 		EB0FBFA72B66C61E00269CC1 /* MarketplaceKitWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB0FBFA62B66C61E00269CC1 /* MarketplaceKitWrapper.swift */; };
+		EB355DA02B6365C1008DEAA1 /* RestrictedOpenerType.h in Headers */ = {isa = PBXBuildFile; fileRef = EB355D9F2B636559008DEAA1 /* RestrictedOpenerType.h */; };
 		EB36B16827A7B4500050E00D /* PushService.h in Headers */ = {isa = PBXBuildFile; fileRef = EB36B16627A7B4500050E00D /* PushService.h */; };
 		EB36B16927A7B4500050E00D /* PushService.mm in Sources */ = {isa = PBXBuildFile; fileRef = EB36B16727A7B4500050E00D /* PushService.mm */; };
 		EB450E0F2996C7B6009724B1 /* WKWebsiteDataStoreRefPrivateMac.h in Headers */ = {isa = PBXBuildFile; fileRef = EB450E0D2996C7A1009724B1 /* WKWebsiteDataStoreRefPrivateMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -7771,6 +7772,7 @@
 		EB0D312D275AE13300863D8F /* com.apple.webkit.webpushd.mac.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = com.apple.webkit.webpushd.mac.plist; sourceTree = "<group>"; };
 		EB0D312E275AE13300863D8F /* com.apple.webkit.webpushd.ios.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = com.apple.webkit.webpushd.ios.plist; sourceTree = "<group>"; };
 		EB0FBFA62B66C61E00269CC1 /* MarketplaceKitWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarketplaceKitWrapper.swift; sourceTree = "<group>"; };
+		EB355D9F2B636559008DEAA1 /* RestrictedOpenerType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RestrictedOpenerType.h; sourceTree = "<group>"; };
 		EB36B16627A7B4500050E00D /* PushService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PushService.h; sourceTree = "<group>"; };
 		EB36B16727A7B4500050E00D /* PushService.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PushService.mm; sourceTree = "<group>"; };
 		EB450E0D2996C7A1009724B1 /* WKWebsiteDataStoreRefPrivateMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKWebsiteDataStoreRefPrivateMac.h; path = mac/WKWebsiteDataStoreRefPrivateMac.h; sourceTree = "<group>"; };
@@ -8771,6 +8773,7 @@
 				8623B1282ACE1DE4002BA9EA /* ResourceLoadInfo.serialization.in */,
 				5C00993B2417FB7E00D53C25 /* ResourceLoadStatisticsParameters.h */,
 				516BF1D42AE5FF3F009A0204 /* ResourceLoadStatisticsParameters.serialization.in */,
+				EB355D9F2B636559008DEAA1 /* RestrictedOpenerType.h */,
 				410482CB1DDD2FB500F006D0 /* RTCNetwork.cpp */,
 				410482CC1DDD2FB500F006D0 /* RTCNetwork.h */,
 				5CDFAD9C2ACFA9480040A8D8 /* RTCNetwork.serialization.in */,
@@ -15901,6 +15904,7 @@
 				6BE969CD1E54E054008B7483 /* ResourceLoadStatisticsClassifier.h in Headers */,
 				6BE969CB1E54D4CF008B7483 /* ResourceLoadStatisticsClassifierCocoa.h in Headers */,
 				1A30066E1110F4F70031937C /* ResponsivenessTimer.h in Headers */,
+				EB355DA02B6365C1008DEAA1 /* RestrictedOpenerType.h in Headers */,
 				F499BAA32947C1A4001241D6 /* RevealFocusedElementDeferrer.h in Headers */,
 				442E7BEB27B4586900C69AC1 /* RevealItem.h in Headers */,
 				410482CE1DDD324F00F006D0 /* RTCNetwork.h in Headers */,


### PR DESCRIPTION
#### ce5ed8691c6da66b81833634d7e01d7888fbd90e
<pre>
Add support for updatable list of domains with restricted openers
<a href="https://bugs.webkit.org/show_bug.cgi?id=268185">https://bugs.webkit.org/show_bug.cgi?id=268185</a>
<a href="https://rdar.apple.com/problem/121677395">rdar://problem/121677395</a>

Reviewed by Wenson Hsieh.

This adds support for a list of domains that will receive restricted window opener access. The list
is maintained and updated through WebPrivacy.

I didn&apos;t add a method to override the list for testing purposes yet. I&apos;ll do that in a future patch
which actually uses these interfaces.

* Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(-[WKWebPrivacyNotificationListener listenForRestrictedOpenerDomainsChanges:]):
(-[WKWebPrivacyNotificationListener didUpdate:]):
(WebKit::RestrictedOpenerDomainsController::shared):
(WebKit::RestrictedOpenerDomainsController::RestrictedOpenerDomainsController):
(WebKit::restrictedOpenerType):
(WebKit::RestrictedOpenerDomainsController::populate):
(WebKit::RestrictedOpenerDomainsController::lookup const):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/273693@main">https://commits.webkit.org/273693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6062f4472eb678807783e078d9b1345e5891d371

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39069 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12335 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12921 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32229 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11324 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40313 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32986 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32806 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37285 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11562 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35381 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8243 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->