### PR TITLE
REGRESSION (273517@main): [ iOS17 mOS Debug ] TestWebKitAPI.IPCTestingAPI.CanInterceptFindString is a consistent failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -463,18 +463,33 @@ TEST(IPCTestingAPI, CanInterceptFindString)
     }];
     TestWebKitAPI::Util::run(&done);
 
-    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"messages = messages.filter((message) => message.name == IPC.messages.WebPage_FindString.name); messages.length"].UTF8String, "1");
+    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"messages = messages.filter((message) => message.name == IPC.messages.WebPage_FindString.name); messages.length"].UTF8String, "2");
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"messages[0].description"].UTF8String, "WebPage_FindString");
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"args = messages[0].arguments; args.length"].intValue, 3);
-    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"args[0].type"].UTF8String, "String");
-    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"args[0].value"].UTF8String, "hello");
-    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"args[1].type"].UTF8String, "uint16_t");
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"args[1].value"].intValue, 0x11);
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"args[1].isOptionSet"].boolValue, YES);
-    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"args[2].type"].UTF8String, "uint32_t");
-    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"args[2].value"].intValue, 1);
+    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"messages[1].description"].UTF8String, "WebPage_FindString");
+
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"firstMessageArgs = messages[0].arguments; firstMessageArgs.length"].intValue, 3);
+    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"firstMessageArgs[0].type"].UTF8String, "String");
+    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"firstMessageArgs[0].value"].UTF8String, "hello");
+    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"firstMessageArgs[1].type"].UTF8String, "uint16_t");
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"firstMessageArgs[1].value"].intValue, 0x811);
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"firstMessageArgs[1].isOptionSet"].boolValue, YES);
+    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"firstMessageArgs[2].type"].UTF8String, "uint32_t");
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"firstMessageArgs[2].value"].intValue, 1);
+
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"secondMessageArgs = messages[1].arguments; secondMessageArgs.length"].intValue, 3);
+    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"secondMessageArgs[0].type"].UTF8String, "String");
+    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"secondMessageArgs[0].value"].UTF8String, "hello");
+    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"secondMessageArgs[1].type"].UTF8String, "uint16_t");
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"secondMessageArgs[1].value"].intValue, 0x11);
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"secondMessageArgs[1].isOptionSet"].boolValue, YES);
+    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"secondMessageArgs[2].type"].UTF8String, "uint32_t");
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"secondMessageArgs[2].value"].intValue, 1);
+
     EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"typeof(messages[0].syncRequestID)"].UTF8String, "undefined");
+    EXPECT_STREQ([webView stringByEvaluatingJavaScript:@"typeof(messages[1].syncRequestID)"].UTF8String, "undefined");
     EXPECT_EQ([webView stringByEvaluatingJavaScript:@"messages[0].destinationID"].intValue,
+        [webView stringByEvaluatingJavaScript:@"IPC.webPageProxyID.toString()"].intValue);
+    EXPECT_EQ([webView stringByEvaluatingJavaScript:@"messages[1].destinationID"].intValue,
         [webView stringByEvaluatingJavaScript:@"IPC.webPageProxyID.toString()"].intValue);
 }
 


### PR DESCRIPTION
#### ea392aae9da93d263298e7ca7a0321389b69cc38
<pre>
REGRESSION (273517@main): [ iOS17 mOS Debug ] TestWebKitAPI.IPCTestingAPI.CanInterceptFindString is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=268186">https://bugs.webkit.org/show_bug.cgi?id=268186</a>
<a href="https://rdar.apple.com/121678803">rdar://121678803</a>

Reviewed by Aditya Keerthi.

273517@main changed the IPC message and made it so the UI process will now send two messages. Update the
expected values and add expectations for the second IPC message.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:

Canonical link: <a href="https://commits.webkit.org/273576@main">https://commits.webkit.org/273576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8878f4541849e0719f3e0c35f6902125e199067

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/35900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/14843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/38089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/38622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/37119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/17263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/11869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/38622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/36454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/17263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/38089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/38622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/17263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/38089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/17263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/38089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/39871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/11869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/39871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/38089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4651 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/12038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->