### PR TITLE
Use consistent naming for pseudo-element name argument

### DIFF
--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1219,7 +1219,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
                 return true;
             if (checkingContext.pseudoId != PseudoId::Highlight || !selector.argumentList())
                 return false;
-            return selector.argumentList()->first() == checkingContext.nameIdentifier;
+            return selector.argumentList()->first() == checkingContext.pseudoElementNameArgument;
 
         case CSSSelector::PseudoElement::ViewTransitionGroup:
         case CSSSelector::PseudoElement::ViewTransitionImagePair:
@@ -1233,7 +1233,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
 
             // Wildcard always matches.
             auto& argument = selector.argumentList()->first();
-            return argument == starAtom() || argument == checkingContext.nameIdentifier;
+            return argument == starAtom() || argument == checkingContext.pseudoElementNameArgument;
         }
 
         default:

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -93,7 +93,7 @@ public:
         const SelectorChecker::Mode resolvingMode;
         PseudoId pseudoId { PseudoId::None };
         std::optional<StyleScrollbarState> scrollbarState;
-        AtomString nameIdentifier;
+        AtomString pseudoElementNameArgument;
         const ContainerNode* scope { nullptr };
         const Element* hasScope { nullptr };
         bool matchesAllHasScopes { false };

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -344,8 +344,8 @@ public:
 
     PseudoId pseudoElementType() const { return static_cast<PseudoId>(m_nonInheritedFlags.pseudoElementType); }
     void setPseudoElementType(PseudoId pseudoElementType) { m_nonInheritedFlags.pseudoElementType = static_cast<unsigned>(pseudoElementType); }
-    const AtomString& functionalPseudoElementArgument() const;
-    void setFunctionalPseudoElementArgument(const AtomString&);
+    const AtomString& pseudoElementNameArgument() const;
+    void setPseudoElementNameArgument(const AtomString&);
 
     RenderStyle* getCachedPseudoStyle(PseudoId) const;
     RenderStyle* addCachedPseudoStyle(std::unique_ptr<RenderStyle>);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -667,7 +667,7 @@ inline bool RenderStyle::specifiesColumns() const { return !hasAutoColumnCount()
 constexpr OptionSet<Containment> RenderStyle::strictContainment() { return { Containment::Size, Containment::Layout, Containment::Paint, Containment::Style }; }
 inline StyleColor RenderStyle::strokeColor() const { return m_rareInheritedData->strokeColor; }
 inline float RenderStyle::strokeMiterLimit() const { return m_rareInheritedData->miterLimit; }
-inline const AtomString& RenderStyle::functionalPseudoElementArgument() const { return m_nonInheritedData->rareData->functionalPseudoElementArgument; }
+inline const AtomString& RenderStyle::pseudoElementNameArgument() const { return m_nonInheritedData->rareData->pseudoElementNameArgument; }
 inline const TabSize& RenderStyle::tabSize() const { return m_rareInheritedData->tabSize; }
 inline TextAlignLast RenderStyle::textAlignLast() const { return static_cast<TextAlignLast>(m_rareInheritedData->textAlignLast); }
 inline TextBoxTrim RenderStyle::textBoxTrim() const { return static_cast<TextBoxTrim>(m_nonInheritedData->rareData->textBoxTrim); }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -465,14 +465,14 @@ inline void RenderStyle::setFlexShrink(float shrink)
     SET_DOUBLY_NESTED(m_nonInheritedData, miscData, flexibleBox, flexShrink, clampedShrink);
 }
 
-inline void RenderStyle::setFunctionalPseudoElementArgument(const AtomString& identifier)
+inline void RenderStyle::setPseudoElementNameArgument(const AtomString& identifier)
 {
     ASSERT(pseudoElementType() == PseudoId::ViewTransitionGroup
         || pseudoElementType() == PseudoId::ViewTransitionImagePair
         || pseudoElementType() == PseudoId::ViewTransitionNew
         || pseudoElementType() == PseudoId::ViewTransitionOld
         || pseudoElementType() == PseudoId::Highlight);
-    SET_NESTED(m_nonInheritedData, rareData, functionalPseudoElementArgument, identifier);
+    SET_NESTED(m_nonInheritedData, rareData, pseudoElementNameArgument, identifier);
 }
 
 inline void RenderStyle::setGridColumnList(const GridTrackList& list)

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -91,7 +91,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     // scrollbarGutter
     , scrollbarWidth(RenderStyle::initialScrollbarWidth())
     , zoom(RenderStyle::initialZoom())
-    , functionalPseudoElementArgument(nullAtom())
+    , pseudoElementNameArgument(nullAtom())
     , blockStepSize(RenderStyle::initialBlockStepSize())
     , blockStepInsert(static_cast<unsigned>(RenderStyle::initialBlockStepInsert()))
     , overscrollBehaviorX(static_cast<unsigned>(RenderStyle::initialOverscrollBehaviorX()))
@@ -180,7 +180,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , scrollbarGutter(o.scrollbarGutter)
     , scrollbarWidth(o.scrollbarWidth)
     , zoom(o.zoom)
-    , functionalPseudoElementArgument(o.functionalPseudoElementArgument)
+    , pseudoElementNameArgument(o.pseudoElementNameArgument)
     , blockStepSize(o.blockStepSize)
     , blockStepInsert(o.blockStepInsert)
     , overscrollBehaviorX(o.overscrollBehaviorX)
@@ -275,7 +275,7 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && scrollbarGutter == o.scrollbarGutter
         && scrollbarWidth == o.scrollbarWidth
         && zoom == o.zoom
-        && functionalPseudoElementArgument == o.functionalPseudoElementArgument
+        && pseudoElementNameArgument == o.pseudoElementNameArgument
         && blockStepSize == o.blockStepSize
         && blockStepInsert == o.blockStepInsert
         && overscrollBehaviorX == o.overscrollBehaviorX

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -186,7 +186,7 @@ public:
     ScrollbarWidth scrollbarWidth { ScrollbarWidth::Auto };
 
     float zoom;
-    AtomString functionalPseudoElementArgument;
+    AtomString pseudoElementNameArgument;
 
     std::optional<Length> blockStepSize;
     unsigned blockStepInsert : 1; // BlockStepInsert

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp
@@ -92,7 +92,7 @@ void RenderTreeUpdater::ViewTransition::updatePseudoElementTree(RenderElement& d
     auto* currentGroup = documentElementRenderer.view().viewTransitionRoot()->firstChild();
     for (auto& name : activeViewTransition->namedElements().keys()) {
         ASSERT(!currentGroup || currentGroup->style().pseudoElementType() == PseudoId::ViewTransitionGroup);
-        if (currentGroup && name == currentGroup->style().functionalPseudoElementArgument()) {
+        if (currentGroup && name == currentGroup->style().pseudoElementNameArgument()) {
             auto style = documentElementRenderer.getUncachedPseudoStyle({ PseudoId::ViewTransitionGroup, name }, &documentElementRenderer.style());
             if (!style || style->display() == DisplayType::None)
                 descendantsToDelete.append(currentGroup);
@@ -146,7 +146,7 @@ void RenderTreeUpdater::ViewTransition::buildPseudoElementGroup(const AtomString
 void RenderTreeUpdater::ViewTransition::updatePseudoElementGroup(const RenderStyle& groupStyle, RenderElement& group, RenderElement& documentElementRenderer)
 {
     auto& documentElementStyle = documentElementRenderer.style();
-    auto name = groupStyle.functionalPseudoElementArgument();
+    auto name = groupStyle.pseudoElementNameArgument();
 
     auto newGroupStyle = RenderStyle::clone(groupStyle);
     group.setStyle(WTFMove(newGroupStyle));

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -493,7 +493,7 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
     SelectorChecker::CheckingContext context(m_mode);
     context.pseudoId = m_pseudoElementRequest.pseudoId;
     context.scrollbarState = m_pseudoElementRequest.scrollbarState;
-    context.nameIdentifier = m_pseudoElementRequest.nameIdentifier;
+    context.pseudoElementNameArgument = m_pseudoElementRequest.pseudoElementNameArgument;
     context.styleScopeOrdinal = styleScopeOrdinal;
     context.selectorMatchingState = m_selectorMatchingState;
     context.scope = scopingRoot;

--- a/Source/WebCore/style/PseudoElementRequest.h
+++ b/Source/WebCore/style/PseudoElementRequest.h
@@ -38,9 +38,9 @@ public:
     {
     }
 
-    PseudoElementRequest(PseudoId pseudoId, const AtomString& nameIdentifier)
+    PseudoElementRequest(PseudoId pseudoId, const AtomString& pseudoElementNameArgument)
         : pseudoId(pseudoId)
-        , nameIdentifier(nameIdentifier)
+        , pseudoElementNameArgument(pseudoElementNameArgument)
     {
         ASSERT(pseudoId == PseudoId::Highlight || pseudoId == PseudoId::ViewTransitionGroup || pseudoId == PseudoId::ViewTransitionImagePair || pseudoId == PseudoId::ViewTransitionOld || pseudoId == PseudoId::ViewTransitionNew);
     }
@@ -49,7 +49,7 @@ public:
     std::optional<StyleScrollbarState> scrollbarState;
 
     // highlight name for ::highlight or view transition name for view transition pseudo elements.
-    AtomString nameIdentifier;
+    AtomString pseudoElementNameArgument;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -485,8 +485,8 @@ std::optional<ResolvedStyle> Resolver::styleForPseudoElement(const Element& elem
         return { };
 
     state.style()->setPseudoElementType(pseudoElementRequest.pseudoId);
-    if (!pseudoElementRequest.nameIdentifier.isNull())
-        state.style()->setFunctionalPseudoElementArgument(pseudoElementRequest.nameIdentifier);
+    if (!pseudoElementRequest.pseudoElementNameArgument.isNull())
+        state.style()->setPseudoElementNameArgument(pseudoElementRequest.pseudoElementNameArgument);
 
     applyMatchedProperties(state, collector.matchResult());
 


### PR DESCRIPTION
#### 415d51dc9477a1de2486c2c6d2c209ac91e2b1bb
<pre>
Use consistent naming for pseudo-element name argument
<a href="https://bugs.webkit.org/show_bug.cgi?id=268195">https://bugs.webkit.org/show_bug.cgi?id=268195</a>
<a href="https://rdar.apple.com/121690341">rdar://121690341</a>

Reviewed by Matthieu Dubet.

nameIdentifier -&gt; pseudoElementNameArgument
functionalPseudoElementArgument -&gt; pseudoElementNameArgument
setFunctionalPseudoElementArgument -&gt; setPseudoElementNameArgument

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorChecker.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::pseudoElementNameArgument const):
(WebCore::RenderStyle::functionalPseudoElementArgument const): Deleted.
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setPseudoElementNameArgument):
(WebCore::RenderStyle::setFunctionalPseudoElementArgument): Deleted.
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp:
(WebCore::RenderTreeUpdater::ViewTransition::updatePseudoElementTree):
(WebCore::RenderTreeUpdater::ViewTransition::updatePseudoElementGroup):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::ruleMatches):
* Source/WebCore/style/PseudoElementRequest.h:
(WebCore::Style::PseudoElementRequest::PseudoElementRequest):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForPseudoElement):

Canonical link: <a href="https://commits.webkit.org/273587@main">https://commits.webkit.org/273587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f899f77f8709d80c3dec711e2acbe2d7ac506675

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38628 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32307 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11876 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12554 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11025 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39877 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32622 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32412 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/36987 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11212 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9118 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35064 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8180 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->