### PR TITLE
[Wasm-GC] Add test for bug 265927

### DIFF
--- a/JSTests/wasm/gc/bug265927.js
+++ b/JSTests/wasm/gc/bug265927.js
@@ -1,0 +1,30 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+/*
+ *
+ * (module
+ *   (type $0 (sub (struct)))
+ *   (type $1 (sub (array (mut i32))))
+ *   (type $2 (sub (func (param i32 i32 i32) (result i32))))
+ *   (type $3 (func))
+ *   (table $0 1 25 funcref (ref.null func))
+ *   (table $1 0 0 (ref i31) (i32.const 0) (ref.i31))
+ *   (tag ...) ;; binary also contains a tag section, GC decoder couldn't parse it
+ *   (memory $0 16 32)
+ *   (func $0 (type 2) (i32.const 434_800_715))
+ *   (export "main" (func 0))
+ *   (elem $0 (i32.const 0) funcref (ref.func 0))
+ * )
+ *
+ */
+const m = new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x96\x80\x80\x80\x00\x04\x50\x00\x5f\x00\x50\x00\x5e\x7f\x01\x50\x00\x60\x03\x7f\x7f\x7f\x01\x7f\x60\x00\x00\x03\x82\x80\x80\x80\x00\x01\x02\x04\x96\x80\x80\x80\x00\x02\x40\x00\x70\x01\x01\x19\xd0\x70\x0b\x40\x00\x64\x6c\x01\x00\x00\x41\x00\xfb\x1c\x0b\x05\x84\x80\x80\x80\x00\x01\x01\x10\x20\x0d\x85\x80\x80\x80\x00\x02\x00\x03\x00\x03\x07\x88\x80\x80\x80\x00\x01\x04\x6d\x61\x69\x6e\x00\x00\x09\x8b\x80\x80\x80\x00\x01\x06\x00\x41\x00\x0b\x70\x01\xd2\x00\x0b\x0a\x8a\x80\x80\x80\x00\x01\x08\x00\x41\xcb\x90\xaa\xcf\x01\x0b"));
+m.exports.main();


### PR DESCRIPTION
#### 8d40b312efa87f0fd3d270ddeb11e4d14c113f28
<pre>
[Wasm-GC] Add test for bug 265927
<a href="https://bugs.webkit.org/show_bug.cgi?id=265927">https://bugs.webkit.org/show_bug.cgi?id=265927</a>

Reviewed by Justin Michaud.

Add test for already fixed bug.

* JSTests/wasm/gc/bug265927.js: Added.
(module):

Canonical link: <a href="https://commits.webkit.org/273774@main">https://commits.webkit.org/273774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b52be864f6f12d0adeef60010efdeb11c1397f66

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39084 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32682 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12356 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31344 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11335 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11365 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40329 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/30649 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37296 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/36189 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11575 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9454 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35392 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13285 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/42935 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8304 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12027 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8889 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12436 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->