### PR TITLE
Implement toggleevents for dialog open/close

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/toggle-events.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/toggle-events.tentative-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL dialog.show() should fire beforetoggle and toggle events. assert_true: Opening beforetoggle should fire synchronously. expected true got false
-FAIL dialog.show() should fire cancelable beforetoggle which does not open dialog if canceled assert_true: Opening beforetoggle should fire synchronously. expected true got false
-FAIL dialog.show() should coalesce asynchronous toggle events. assert_true: Toggle event should have fired after tick. expected true got false
+PASS dialog.show() should fire beforetoggle and toggle events.
+PASS dialog.show() should fire cancelable beforetoggle which does not open dialog if canceled
+PASS dialog.show() should coalesce asynchronous toggle events.
 PASS dialog.show() should not double-set open/close if beforetoggle re-opens
-FAIL dialog.show() should not open if beforetoggle removes assert_false: Dialog is not connected expected false got true
-FAIL dialog.show() should not open if beforetoggle calls showPopover assert_equals: toggle event was fired for show+showPopover expected 2 but got 0
-FAIL dialog.showModal() should fire beforetoggle and toggle events. assert_true: Opening beforetoggle should fire synchronously. expected true got false
-FAIL dialog.showModal() should fire cancelable beforetoggle which does not open dialog if canceled assert_true: Opening beforetoggle should fire synchronously. expected true got false
-FAIL dialog.showModal() should coalesce asynchronous toggle events. assert_true: Toggle event should have fired after tick. expected true got false
+PASS dialog.show() should not open if beforetoggle removes
+PASS dialog.show() should not open if beforetoggle calls showPopover
+PASS dialog.showModal() should fire beforetoggle and toggle events.
+PASS dialog.showModal() should fire cancelable beforetoggle which does not open dialog if canceled
+PASS dialog.showModal() should coalesce asynchronous toggle events.
 PASS dialog.showModal() should not double-set open/close if beforetoggle re-opens
-FAIL dialog.showModal() should not open if beforetoggle removes assert_false: Dialog is not connected expected false got true
-FAIL dialog.showModal() should not open if beforetoggle calls showPopover assert_false: Dialog did not open expected false got true
+PASS dialog.showModal() should not open if beforetoggle removes
+PASS dialog.showModal() should not open if beforetoggle calls showPopover
 

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -26,8 +26,11 @@
 #pragma once
 
 #include "HTMLElement.h"
+#include "ToggleEventTask.h"
 
 namespace WebCore {
+
+class ToggleEventTask;
 
 class HTMLDialogElement final : public HTMLElement {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(HTMLDialogElement);
@@ -54,6 +57,8 @@ public:
     bool isValidCommandType(const CommandType) final;
     bool handleCommandInternal(const HTMLFormControlElement& invoker, const CommandType&) final;
 
+    void queueDialogToggleEventTask(ToggleState oldState, ToggleState newState);
+
 private:
     HTMLDialogElement(const QualifiedName&, Document&);
 
@@ -64,6 +69,8 @@ private:
     String m_returnValue;
     bool m_isModal { false };
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_previouslyFocusedElement;
+
+    RefPtr<ToggleEventTask> m_toggleEventTask;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### bd7649ea03d308c55de707c6cf8488dc552d43f9
<pre>
Implement toggleevents for dialog open/close
<a href="https://bugs.webkit.org/show_bug.cgi?id=268160">https://bugs.webkit.org/show_bug.cgi?id=268160</a>

Reviewed by Tim Nguyen.

This adds the `beforetoggle` cancelable event to `show()`/`showModal()`
calls. If `beforetoggle` isn&apos;t cancelled, it will show the dialog and
dispatch a `toggle` event.

Likewise, the close method adds a NON cancelable `beforetoggle` and
`toggle` event.

These events can help developers when prepping a dialog to be shown or
hidden, such as doing page calculations or kicking off animations.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/toggle-events.tentative-expected.txt:
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::show):
(WebCore::HTMLDialogElement::showModal):
(WebCore::HTMLDialogElement::close):
(WebCore::HTMLDialogElement::queueDialogToggleEventTask):
* Source/WebCore/html/HTMLDialogElement.h:

Canonical link: <a href="https://commits.webkit.org/289695@main">https://commits.webkit.org/289695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c17339045bbe620108b17c29cc6210f19ea4af4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/87715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/7231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/42099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/92580 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/38461 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/89766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/7612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/15402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/67743 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/25465 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/90717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/5807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/79364 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/48092 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/5594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/33766 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/37572 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/75992 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/34648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/94466 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/14883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/10920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/76571 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/15137 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/75220 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/75806 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18640 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/20170 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/18603 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/7847 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/14899 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/20201 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/14643 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/18087 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/16425 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->