### PR TITLE
[visionOS] Volume slider is flashes while adjusting volume

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css
@@ -164,12 +164,10 @@
 .media-controls.vision:not(.audio) .volume-container > .background-tint > .blur,
 .media-controls.vision:not(.audio) button > .background-tint > .blur {
     background-color: rgba(255, 255, 255, 0.15);
-    -webkit-backdrop-filter: saturate(20%) blur(50px);
 }
 
 .media-controls.vision:not(.audio) > .controls-bar > .background-tint > .blur {
     background-color: rgba(149, 149, 149, 0.25);
-    -webkit-backdrop-filter: saturate(64%) blur(50px);
 }
 
 .media-controls.vision:not(.audio) button:active > .background-tint > .tint {

--- a/Source/WebCore/Modules/modern-media-controls/controls/vision-slider.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/vision-slider.css
@@ -53,7 +53,6 @@
 .slider.vision > .appearance > .gutter > .background {
     background-color: black;
     opacity: 0.1;
-    -webkit-backdrop-filter: blur(48px);
     mix-blend-mode: plus-darker;
 }
 


### PR DESCRIPTION
#### 0d2c7f70d644a1aa14d8f60ad9aced6e4f8cd88f
<pre>
[visionOS] Volume slider is flashes while adjusting volume
<a href="https://bugs.webkit.org/show_bug.cgi?id=268203">https://bugs.webkit.org/show_bug.cgi?id=268203</a>
<a href="https://rdar.apple.com/120855936">rdar://120855936</a>

Reviewed by Richard Robinson.

There are a number of elements in the visionOS media controls with `-webkit-background-filter`.
This causes an extremely large number of compositing layers to be created (36).

Remove these background filters for now; this will affect the look-and-feel slightly, but fixes
an extreme flicker issue occurring during layout while dragging these sliders.

* Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css:
(.media-controls.vision:not(.audio) .volume-container &gt; .background-tint &gt; .blur,):
(.media-controls.vision:not(.audio) &gt; .controls-bar &gt; .background-tint &gt; .blur):
* Source/WebCore/Modules/modern-media-controls/controls/vision-slider.css:
(.slider.vision &gt; .appearance &gt; .gutter &gt; .background):

Canonical link: <a href="https://commits.webkit.org/273629@main">https://commits.webkit.org/273629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ad7bd30ba018d248cfb42b4dbafcaa49a9c328b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38659 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32328 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31077 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11047 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39908 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32662 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32434 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37015 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9147 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35095 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/12979 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8214 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11744 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->