### PR TITLE
[Xcode] Additions SDKs need to have platform-specific names

### DIFF
--- a/Configurations/SDKAdditions.xcconfig
+++ b/Configurations/SDKAdditions.xcconfig
@@ -41,6 +41,6 @@ WK_ADDITIONAL_SDKS_UNVERSIONED_YES_VERSIONED_YES = $(WK_UNVERSIONED_SDK_ADDITION
 // The SDK directory where private frameworks are expected to be. Set to the base SDK when building
 // internally or on macOS, and the additions SDK otherwise.
 WK_PRIVATE_SDK_DIR = $(WK_PRIVATE_SDK_DIR_$(USE_INTERNAL_SDK));
-WK_PRIVATE_SDK_DIR_ = $(SDK_DIR_WebKitSDKAdditions);
+WK_PRIVATE_SDK_DIR_ = $(SDK_DIR_WebKitSDKAdditions_$(PLATFORM_NAME));
 WK_PRIVATE_SDK_DIR_[sdk=macos*] = $(SDK_DIR);
 WK_PRIVATE_SDK_DIR_YES = $(SDK_DIR);

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -3794,14 +3794,14 @@
 			files = (
 			);
 			inputFileListPaths = (
-				"$(SDK_DIR_WebKitSDKAdditions:default=Scripts)/SymlinkedHeaders.xcfilelist",
+				"$(SDK_DIR_WebKitSDKAdditions_$(PLATFORM_NAME):default=Scripts)/SymlinkedHeaders.xcfilelist",
 			);
 			inputPaths = (
 				"$(SRCROOT)/Scripts/symlink-public-sdk-headers-for-embedded-platforms",
 			);
 			name = "Symlink public SDK headers";
 			outputFileListPaths = (
-				"$(SDK_DIR_WebKitSDKAdditions:default=Scripts)/SymlinkedHeaders-output.xcfilelist",
+				"$(SDK_DIR_WebKitSDKAdditions_$(PLATFORM_NAME):default=Scripts)/SymlinkedHeaders-output.xcfilelist",
 			);
 			outputPaths = (
 				"$(WK_DERIVED_SDK_HEADERS_DIR)",

--- a/WebKitLibraries/SDKs/appletvos16.0-additions.sdk/SDKSettings.plist
+++ b/WebKitLibraries/SDKs/appletvos16.0-additions.sdk/SDKSettings.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CanonicalName</key>
-	<string>WebKitSDKAdditions</string>
+	<string>WebKitSDKAdditions_appletvos</string>
 	<key>IsBaseSDK</key>
 	<string>NO</string>
     <key>FrameworkSearchPaths</key>

--- a/WebKitLibraries/SDKs/appletvos17.0-additions.sdk/SDKSettings.plist
+++ b/WebKitLibraries/SDKs/appletvos17.0-additions.sdk/SDKSettings.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CanonicalName</key>
-	<string>WebKitSDKAdditions</string>
+	<string>WebKitSDKAdditions_appletvos</string>
 	<key>IsBaseSDK</key>
 	<string>NO</string>
     <key>FrameworkSearchPaths</key>

--- a/WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/SDKSettings.plist
+++ b/WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/SDKSettings.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CanonicalName</key>
-	<string>WebKitSDKAdditions</string>
+	<string>WebKitSDKAdditions_appletvsimulator</string>
 	<key>IsBaseSDK</key>
 	<string>NO</string>
     <key>FrameworkSearchPaths</key>

--- a/WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/SDKSettings.plist
+++ b/WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/SDKSettings.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>CanonicalName</key>
-    <string>WebKitSDKAdditions</string>
+    <string>WebKitSDKAdditions_iphoneos</string>
     <key>IsBaseSDK</key>
     <string>NO</string>
     <key>FrameworkSearchPaths</key>

--- a/WebKitLibraries/SDKs/iphoneos17.0-additions.sdk/SDKSettings.plist
+++ b/WebKitLibraries/SDKs/iphoneos17.0-additions.sdk/SDKSettings.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CanonicalName</key>
-	<string>WebKitSDKAdditions</string>
+	<string>WebKitSDKAdditions_iphoneos</string>
 	<key>IsBaseSDK</key>
 	<string>NO</string>
     <key>HeaderSearchPaths</key>

--- a/WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/SDKSettings.plist
+++ b/WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/SDKSettings.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>CanonicalName</key>
-    <string>WebKitSDKAdditions</string>
+    <string>WebKitSDKAdditions_iphonesimulator</string>
     <key>IsBaseSDK</key>
     <string>NO</string>
     <key>FrameworkSearchPaths</key>

--- a/WebKitLibraries/SDKs/iphonesimulator17.0-additions.sdk/SDKSettings.plist
+++ b/WebKitLibraries/SDKs/iphonesimulator17.0-additions.sdk/SDKSettings.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CanonicalName</key>
-	<string>WebKitSDKAdditions</string>
+	<string>WebKitSDKAdditions_iphonesimulator</string>
 	<key>IsBaseSDK</key>
 	<string>NO</string>
     <key>HeaderSearchPaths</key>

--- a/WebKitLibraries/SDKs/macosx12.0-additions.sdk/SDKSettings.plist
+++ b/WebKitLibraries/SDKs/macosx12.0-additions.sdk/SDKSettings.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CanonicalName</key>
-	<string>WebKitSDKAdditions</string>
+	<string>WebKitSDKAdditions_macosx</string>
 	<key>IsBaseSDK</key>
 	<string>NO</string>
 	<!-- The public macOS SDK has a private frameworks directory, so we need to add a search path instead of overriding it via WK_PRIVATE_SDK_DIR. -->

--- a/WebKitLibraries/SDKs/macosx13.0-additions.sdk/SDKSettings.plist
+++ b/WebKitLibraries/SDKs/macosx13.0-additions.sdk/SDKSettings.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CanonicalName</key>
-	<string>WebKitSDKAdditions</string>
+	<string>WebKitSDKAdditions_macosx</string>
 	<key>IsBaseSDK</key>
 	<string>NO</string>
 	<!-- The public macOS SDK has a private frameworks directory, so we need to add a search path instead of overriding it via WK_PRIVATE_SDK_DIR. -->

--- a/WebKitLibraries/SDKs/macosx14.0-additions.sdk/SDKSettings.plist
+++ b/WebKitLibraries/SDKs/macosx14.0-additions.sdk/SDKSettings.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CanonicalName</key>
-	<string>WebKitSDKAdditions</string>
+	<string>WebKitSDKAdditions_macosx</string>
 	<key>HeaderSearchPaths</key>
 	<array>
 		<string>usr/local/include</string>

--- a/WebKitLibraries/SDKs/watchos10.0-additions.sdk/SDKSettings.plist
+++ b/WebKitLibraries/SDKs/watchos10.0-additions.sdk/SDKSettings.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CanonicalName</key>
-	<string>WebKitSDKAdditions</string>
+	<string>WebKitSDKAdditions_watchos</string>
 	<key>IsBaseSDK</key>
 	<string>NO</string>
     <key>FrameworkSearchPaths</key>

--- a/WebKitLibraries/SDKs/watchos9.0-additions.sdk/SDKSettings.plist
+++ b/WebKitLibraries/SDKs/watchos9.0-additions.sdk/SDKSettings.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CanonicalName</key>
-	<string>WebKitSDKAdditions</string>
+	<string>WebKitSDKAdditions_watchos</string>
 	<key>IsBaseSDK</key>
 	<string>NO</string>
     <key>FrameworkSearchPaths</key>

--- a/WebKitLibraries/SDKs/watchsimulator10.0-additions.sdk/SDKSettings.plist
+++ b/WebKitLibraries/SDKs/watchsimulator10.0-additions.sdk/SDKSettings.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CanonicalName</key>
-	<string>WebKitSDKAdditions</string>
+	<string>WebKitSDKAdditions_watchsimulator</string>
 	<key>IsBaseSDK</key>
 	<string>NO</string>
     <key>FrameworkSearchPaths</key>


### PR DESCRIPTION
#### 0b964655403e152cc5f3553db576cb0cd5bb9d7d
<pre>
[Xcode] Additions SDKs need to have platform-specific names
<a href="https://rdar.apple.com/121698895">rdar://121698895</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=268205">https://bugs.webkit.org/show_bug.cgi?id=268205</a>

Reviewed by Alexey Proskuryakov.

Instead of calling all additions SDKs &quot;WebKitSDKAdditions&quot;, include a
platform name suffix, so that the build can refer to the active
additions SDK with:

    SDK_DIR_WebKitSDKAdditions_$(PLATFORM_NAME))

This appears to fix build issues when using the Xcode IDE.

Use PLATFORM_NAME and not WK_PLATFORM_NAME so that Mac Catalyst does not
get a special platform name. This matters since the same macOS SDK
supports both variants.

* Configurations/SDKAdditions.xcconfig:
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* WebKitLibraries/SDKs/appletvos16.0-additions.sdk/SDKSettings.plist:
* WebKitLibraries/SDKs/appletvos17.0-additions.sdk/SDKSettings.plist:
* WebKitLibraries/SDKs/appletvsimulator17.0-additions.sdk/SDKSettings.plist:
* WebKitLibraries/SDKs/iphoneos16.0-additions.sdk/SDKSettings.plist:
* WebKitLibraries/SDKs/iphoneos17.0-additions.sdk/SDKSettings.plist:
* WebKitLibraries/SDKs/iphonesimulator16.0-additions.sdk/SDKSettings.plist:
* WebKitLibraries/SDKs/iphonesimulator17.0-additions.sdk/SDKSettings.plist:
* WebKitLibraries/SDKs/macosx12.0-additions.sdk/SDKSettings.plist:
* WebKitLibraries/SDKs/macosx13.0-additions.sdk/SDKSettings.plist:
* WebKitLibraries/SDKs/macosx14.0-additions.sdk/SDKSettings.plist:
* WebKitLibraries/SDKs/watchos10.0-additions.sdk/SDKSettings.plist:
* WebKitLibraries/SDKs/watchos9.0-additions.sdk/SDKSettings.plist:
* WebKitLibraries/SDKs/watchsimulator10.0-additions.sdk/SDKSettings.plist:

Canonical link: <a href="https://commits.webkit.org/273594@main">https://commits.webkit.org/273594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c361e39223a5098caf1885e111558caaae8dcbb2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38662 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32331 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11917 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36499 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/12595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/31927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11049 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/32123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39911 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/30380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32663 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/32444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/35776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/35098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/12982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/42493 "Built successfully") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/8187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4663 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/12065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->