### PR TITLE
Sync and update 'which' across KeyboardEvent, MouseEvent and UIEvent interfaces as per web specification

### DIFF
--- a/Source/WebCore/dom/KeyboardEvent.cpp
+++ b/Source/WebCore/dom/KeyboardEvent.cpp
@@ -3,6 +3,7 @@
  * Copyright (C) 2001 Tobias Anton (anton@stud.fbi.fh-darmstadt.de)
  * Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
  * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2017 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -232,13 +233,13 @@ bool KeyboardEvent::isKeyboardEvent() const
     return true;
 }
 
-int KeyboardEvent::which() const
+unsigned KeyboardEvent::which() const
 {
     // Netscape's "which" returns a virtual key code for keydown and keyup, and a character code for keypress.
     // That's exactly what IE's "keyCode" returns. So they are the same for keyboard events.
     if (m_which)
         return m_which.value();
-    return keyCode();
+    return static_cast<unsigned>(keyCode());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/KeyboardEvent.h
+++ b/Source/WebCore/dom/KeyboardEvent.h
@@ -3,6 +3,7 @@
  * Copyright (C) 2001 Tobias Anton (anton@stud.fbi.fh-darmstadt.de)
  * Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
  * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2017 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -83,7 +84,7 @@ public:
 
     EventInterface eventInterface() const final;
     bool isKeyboardEvent() const final;
-    int which() const final;
+    unsigned which() const final;
 
     bool isComposing() const { return m_isComposing; }
 

--- a/Source/WebCore/dom/KeyboardEvent.idl
+++ b/Source/WebCore/dom/KeyboardEvent.idl
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2006-2024 Apple Inc.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
+ * Copyright (C) 2017 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -48,7 +49,6 @@
     readonly attribute [AtomString] DOMString keyIdentifier;
     readonly attribute unsigned long charCode;
     readonly attribute unsigned long keyCode;
-    readonly attribute unsigned long which;
 
     // FIXME: this does not match the version in the DOM spec.
     undefined initKeyboardEvent([AtomString] DOMString type, optional boolean canBubble = false, optional boolean cancelable = false,

--- a/Source/WebCore/dom/MouseEvent.cpp
+++ b/Source/WebCore/dom/MouseEvent.cpp
@@ -2,7 +2,8 @@
  * Copyright (C) 2001 Peter Kelly (pmk@post.com)
  * Copyright (C) 2001 Tobias Anton (anton@stud.fbi.fh-darmstadt.de)
  * Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
- * Copyright (C) 2003-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2017 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -194,14 +195,14 @@ MouseButton MouseEvent::button() const
     return isKnownButton ? static_cast<MouseButton>(m_button) : MouseButton::Other;
 }
 
-int MouseEvent::which() const
+unsigned MouseEvent::which() const
 {
     // For the DOM, the return values for left, middle and right mouse buttons are 0, 1, 2, respectively.
     // For the Netscape "which" property, the return values for left, middle and right mouse buttons are 1, 2, 3, respectively.
     // So we must add 1.
     if (!m_buttonDown)
         return 0;
-    return m_button + 1;
+    return static_cast<unsigned>(m_button + 1);
 }
 
 RefPtr<Node> MouseEvent::toElement() const

--- a/Source/WebCore/dom/MouseEvent.h
+++ b/Source/WebCore/dom/MouseEvent.h
@@ -2,7 +2,8 @@
  * Copyright (C) 2001 Peter Kelly (pmk@post.com)
  * Copyright (C) 2001 Tobias Anton (anton@stud.fbi.fh-darmstadt.de)
  * Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
- * Copyright (C) 2003-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2017 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -89,7 +90,7 @@ public:
 
     static bool canTriggerActivationBehavior(const Event&);
 
-    int which() const final;
+    unsigned which() const final;
 
 protected:
     MouseEvent(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, RefPtr<WindowProxy>&&, int detail,

--- a/Source/WebCore/dom/UIEvent.cpp
+++ b/Source/WebCore/dom/UIEvent.cpp
@@ -2,7 +2,8 @@
  * Copyright (C) 2001 Peter Kelly (pmk@post.com)
  * Copyright (C) 2001 Tobias Anton (anton@stud.fbi.fh-darmstadt.de)
  * Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
- * Copyright (C) 2003, 2005, 2006, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2017 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -99,7 +100,7 @@ int UIEvent::pageY() const
     return 0;
 }
 
-int UIEvent::which() const
+unsigned UIEvent::which() const
 {
     return 0;
 }

--- a/Source/WebCore/dom/UIEvent.h
+++ b/Source/WebCore/dom/UIEvent.h
@@ -2,7 +2,8 @@
  * Copyright (C) 2001 Peter Kelly (pmk@post.com)
  * Copyright (C) 2001 Tobias Anton (anton@stud.fbi.fh-darmstadt.de)
  * Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
- * Copyright (C) 2003, 2004, 2005, 2006, 2008, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2017 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -62,7 +63,7 @@ public:
     virtual int pageX() const;
     virtual int pageY() const;
 
-    virtual int which() const;
+    virtual unsigned which() const;
 
 protected:
     UIEvent();

--- a/Source/WebCore/dom/UIEvent.idl
+++ b/Source/WebCore/dom/UIEvent.idl
@@ -17,22 +17,21 @@
  * Boston, MA 02110-1301, USA.
  */
 
+// https://w3c.github.io/uievents/#idl-uievent
+
 [
     Exposed=Window
 ] interface UIEvent : Event {
-    constructor([AtomString] DOMString type, optional UIEventInit eventInitDict);
-
-    readonly attribute WindowProxy view;
+    constructor([AtomString] DOMString type, optional UIEventInit eventInitDict = {});
+    readonly attribute WindowProxy? view;
     readonly attribute long detail;
     
+    // https://w3c.github.io/uievents/#idl-interface-UIEvent-initializers
     undefined initUIEvent([AtomString] DOMString type, optional boolean canBubble = false, optional boolean cancelable = false, optional WindowProxy? view = null, optional long detail = 0);
 
     readonly attribute long layerX;
     readonly attribute long layerY;
     readonly attribute long pageX;
     readonly attribute long pageY;
-
-    // FIXME: This should be on KeyboardEvent only as per the specification but Firefox and Chrome
-    // still have this attribute on UIEvent as of December 2016.
-    readonly attribute long which;
+    readonly attribute unsigned long which;
 };


### PR DESCRIPTION
#### df7782c2b48baf7b7f2c5c23912ea4754232fc11
<pre>
Sync and update &apos;which&apos; across KeyboardEvent, MouseEvent and UIEvent interfaces as per web specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=253366">https://bugs.webkit.org/show_bug.cgi?id=253366</a>
<a href="https://rdar.apple.com/problem/106580687">rdar://problem/106580687</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Gecko / Firefox, Blink / Chromium and Web Specifications [1], [2] and [3].

[1] <a href="https://w3c.github.io/uievents/#idl-uievent">https://w3c.github.io/uievents/#idl-uievent</a>
[2] <a href="https://w3c.github.io/uievents/#idl-keyboardevent">https://w3c.github.io/uievents/#idl-keyboardevent</a>
[3] <a href="https://w3c.github.io/uievents/#idl-mouseevent">https://w3c.github.io/uievents/#idl-mouseevent</a>

This patch modifies &apos;which&apos; to be &apos;unsigned&apos; as per web-specification and also remove it from &apos;KeyboardEvent&apos;.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/cf13270c47f29b21ce7a8c937f598989cd66c840">https://chromium.googlesource.com/chromium/src.git/+/cf13270c47f29b21ce7a8c937f598989cd66c840</a>

* Source/WebCore/dom/KeyboardEvent.cpp:
(KeyboardEvent::which):
* Source/WebCore/dom/KeyboardEvent.h:
* Source/WebCore/dom/KeyboardEvent.idl:
* Source/WebCore/dom/MouseEvent.cpp:
(MouseEvent::which):
* Source/WebCore/dom/MouseEvent.h:
* Source/WebCore/dom/UIEvent.cpp:
(UIEvent::which):
* Source/WebCore/dom/UIEvent.h:
* Source/WebCore/dom/UIEvent.idl: Remove FIXME and align with web-spec

Canonical link: <a href="https://commits.webkit.org/273701@main">https://commits.webkit.org/273701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49be593dfa74b6ee0538b97960138e10fd211645

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38727 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32390 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37230 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31108 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31972 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11094 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11103 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39975 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32716 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32487 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37058 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35142 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13019 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8247 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11782 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12115 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->