### PR TITLE
Introduce & deploy insertChildrenBeforeWithoutPreInsertionValidityCheck

### DIFF
--- a/LayoutTests/fast/dom/ChildNode-before-self-expected.txt
+++ b/LayoutTests/fast/dom/ChildNode-before-self-expected.txt
@@ -1,0 +1,11 @@
+This tests ChildNode's before function allows inserting "this" object.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS testNode.before(testNode); testNode.isConnected is true
+PASS container.firstChild is testNode
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/ChildNode-before-self.html
+++ b/LayoutTests/fast/dom/ChildNode-before-self.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="container"></div>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description(`This tests ChildNode's before function allows inserting "this" object.`);
+
+const testNode = document.createElement('div');
+container.appendChild(testNode);
+shouldBeTrue('testNode.before(testNode); testNode.isConnected');
+shouldBe('container.firstChild', 'testNode');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/ParentNode-append-fragments-expected.html
+++ b/LayoutTests/fast/dom/ParentNode-append-fragments-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style>
+div {
+    display: block;
+    width: 100px;
+    height: 100px;
+    background: green;
+}
+</style>
+<p>Test passes if you see a single 100px by 100px green box below.</p>
+<div></div>
+</body>
+</html>

--- a/LayoutTests/fast/dom/ParentNode-append-fragments.html
+++ b/LayoutTests/fast/dom/ParentNode-append-fragments.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body>
+<style>
+#container > span {
+    display: block;
+    width: 100px;
+    height: 50px;
+    background: green;
+    color: green;
+}
+</style>
+<p>Test passes if you see a single 100px by 100px green box below.</p>
+<div id="container"></div>
+<script>
+
+const fragment1 = document.createDocumentFragment();
+const span1 = document.createElement('span');
+span1.textContent = 'PASS';
+fragment1.appendChild(span1);
+
+const fragment2 = document.createDocumentFragment();
+const span2 = document.createElement('span');
+span2.textContent = 'PASS';
+fragment2.appendChild(span2);
+
+container.append(fragment1, fragment2);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -32,9 +32,6 @@ class HTMLCollection;
 class RadioNodeList;
 class RenderElement;
 
-const int initialNodeVectorSize = 11; // Covers 99.5%. See webkit.org/b/80706
-typedef Vector<Ref<Node>, initialNodeVectorSize> NodeVector;
-
 class ContainerNode : public Node {
     WTF_MAKE_ISO_ALLOCATED(ContainerNode);
 public:
@@ -143,6 +140,8 @@ public:
     ExceptionOr<void> replaceChildren(FixedVector<NodeOrString>&&);
 
     ExceptionOr<void> ensurePreInsertionValidity(Node& newChild, Node* refChild);
+    ExceptionOr<void> ensurePreInsertionValidityForPhantomDocumentFragment(NodeVector& newChildren, Node* refChild = nullptr);
+    ExceptionOr<void> insertChildrenBeforeWithoutPreInsertionValidityCheck(NodeVector&&, Node* nextChild = nullptr);
 
 protected:
     explicit ContainerNode(Document&, NodeType, OptionSet<TypeFlag> = { });
@@ -165,6 +164,7 @@ private:
 
     void removeBetween(Node* previousChild, Node* nextChild, Node& oldChild);
     ExceptionOr<void> appendChildWithoutPreInsertionValidityCheck(Node&);
+
     void insertBeforeCommon(Node& nextChild, Node& oldChild);
     void appendChildCommon(Node&);
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -87,6 +87,9 @@ using MutationRecordDeliveryOptions = OptionSet<MutationObserverOptionType>;
 
 using NodeOrString = std::variant<RefPtr<Node>, String>;
 
+const int initialNodeVectorSize = 11; // Covers 99.5%. See webkit.org/b/80706
+typedef Vector<Ref<Node>, initialNodeVectorSize> NodeVector;
+
 class Node : public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(Node);
 
@@ -716,7 +719,9 @@ protected:
     void updateAncestorsForStyleRecalc();
     void markAncestorsForInvalidatedStyle();
 
+    // FIXME: Replace all uses of convertNodesOrStringsIntoNode by convertNodesOrStringsIntoNodeVector.
     ExceptionOr<RefPtr<Node>> convertNodesOrStringsIntoNode(FixedVector<NodeOrString>&&);
+    ExceptionOr<NodeVector> convertNodesOrStringsIntoNodeVector(FixedVector<NodeOrString>&&);
 
 private:
     virtual PseudoId customPseudoId() const


### PR DESCRIPTION
#### 365ed2587eaf9a02eea28caa44ca87e60882391d
<pre>
Introduce &amp; deploy insertChildrenBeforeWithoutPreInsertionValidityCheck
<a href="https://bugs.webkit.org/show_bug.cgi?id=268206">https://bugs.webkit.org/show_bug.cgi?id=268206</a>

Reviewed by Wenson Hsieh.

This PR refactors out ensurePreInsertionValidityForPhantomDocumentFragment and
insertChildrenBeforeWithoutPreInsertionValidityCheck and deploy them in ContainerNode&apos;s
append, prepend, and replaceChildren functions, and Node&apos;s before and after functions.

In addition, this PR adds two new tests for bugs that were caught incidentally by some
other tests during the development.

* LayoutTests/fast/dom/ChildNode-before-self-expected.txt: Added.
* LayoutTests/fast/dom/ChildNode-before-self.html: Added.
* LayoutTests/fast/dom/ParentNode-append-fragments-expected.html: Added.
* LayoutTests/fast/dom/ParentNode-append-fragments.html: Added.
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::ensurePreInsertionValidityForPhantomDocumentFragment):
(WebCore::ContainerNode::insertChildrenBeforeWithoutPreInsertionValidityCheck):
(WebCore::ContainerNode::append):
(WebCore::ContainerNode::prepend):
(WebCore::ContainerNode::replaceChildren):
* Source/WebCore/dom/ContainerNode.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::convertNodesOrStringsIntoNodeVector):
(WebCore::Node::before):
(WebCore::Node::after):
* Source/WebCore/dom/Node.h:

Canonical link: <a href="https://commits.webkit.org/273721@main">https://commits.webkit.org/273721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b0a3b5c9a04f487d85a163277a164efe6ed19cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39148 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37704 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12498 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12992 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11379 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40393 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33059 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32875 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11635 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/35436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32184 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4727 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12509 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->