### PR TITLE
Generate serialization for SecKeychainItemRef

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -441,6 +441,7 @@ $(PROJECT_DIR)/Shared/cf/CFTypes.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCBoolean.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCNumber.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCSecCertificate.serialization.in
+$(PROJECT_DIR)/Shared/cf/CoreIPCSecKeychainItem.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCSecTrust.serialization.in
 $(PROJECT_DIR)/Shared/ios/DynamicViewportSizeUpdate.serialization.in
 $(PROJECT_DIR)/Shared/ios/GestureTypes.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -684,6 +684,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/cf/CoreIPCBoolean.serialization.in \
 	Shared/cf/CoreIPCNumber.serialization.in \
 	Shared/cf/CoreIPCSecCertificate.serialization.in \
+	Shared/cf/CoreIPCSecKeychainItem.serialization.in \
 	Shared/cf/CoreIPCSecTrust.serialization.in \
 	Shared/mac/PDFContextMenuItem.serialization.in \
 	Shared/mac/SecItemRequestData.serialization.in \

--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.h
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.h
@@ -30,10 +30,6 @@
 #include <wtf/ArgumentCoder.h>
 #include <wtf/RetainPtr.h>
 
-#if HAVE(SEC_KEYCHAIN)
-#include <Security/SecKeychainItem.h>
-#endif
-
 typedef struct CGColorSpace* CGColorSpaceRef;
 
 namespace IPC {
@@ -83,15 +79,6 @@ template<> struct ArgumentCoder<CGColorSpaceRef> {
 template<> struct ArgumentCoder<RetainPtr<CGColorSpaceRef>> : CFRetainPtrArgumentCoder<CGColorSpaceRef> {
     static std::optional<RetainPtr<CGColorSpaceRef>> decode(Decoder&);
 };
-
-#if HAVE(SEC_KEYCHAIN)
-template<> struct ArgumentCoder<SecKeychainItemRef> {
-    template<typename Encoder> static void encode(Encoder&, SecKeychainItemRef);
-};
-template<> struct ArgumentCoder<RetainPtr<SecKeychainItemRef>> : CFRetainPtrArgumentCoder<SecKeychainItemRef> {
-    static std::optional<RetainPtr<SecKeychainItemRef>> decode(Decoder&);
-};
-#endif
 
 #if HAVE(SEC_ACCESS_CONTROL)
 template<> struct ArgumentCoder<SecAccessControlRef> {

--- a/Source/WebKit/Shared/cf/CFTypes.serialization.in
+++ b/Source/WebKit/Shared/cf/CFTypes.serialization.in
@@ -57,3 +57,11 @@ additional_forward_declaration: typedef struct CGColor *CGColorRef
 }
 
 #endif
+
+#if HAVE(SEC_KEYCHAIN)
+
+additional_forward_declaration: typedef struct __SecKeychainItem *SecKeychainItemRef
+[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createSecKeychainItem()] SecKeychainItemRef wrapped by WebKit::CoreIPCSecKeychainItem {
+}
+
+#endif

--- a/Source/WebKit/Shared/cf/CoreIPCSecKeychainItem.h
+++ b/Source/WebKit/Shared/cf/CoreIPCSecKeychainItem.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(SEC_KEYCHAIN)
+
+#import <Security/SecKeychainItem.h>
+#import <wtf/ProcessPrivilege.h>
+#import <wtf/RetainPtr.h>
+
+namespace WebKit {
+
+// For now, the only way to serialize/deserialize SecKeychainItem objects is via
+// SecKeychainItemCreatePersistentReference()/SecKeychainItemCopyFromPersistentReference(). rdar://122050787
+
+class CoreIPCSecKeychainItem {
+public:
+    CoreIPCSecKeychainItem(SecKeychainItemRef keychainItem)
+        : m_persistentRef(persistentRefForKeychainItem(keychainItem))
+    {
+    }
+
+    CoreIPCSecKeychainItem(RetainPtr<CFDataRef> data)
+        : m_persistentRef(data)
+    {
+    }
+
+    CoreIPCSecKeychainItem(const IPC::DataReference& data)
+        : m_persistentRef(data.empty() ? nullptr : adoptCF(CFDataCreate(kCFAllocatorDefault, data.data(), data.size())))
+    {
+    }
+
+    RetainPtr<SecKeychainItemRef> createSecKeychainItem() const
+    {
+        RELEASE_ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessCredentials));
+
+        if (!m_persistentRef)
+            return nullptr;
+
+        CFDataRef data = m_persistentRef.get();
+        // SecKeychainItemCopyFromPersistentReference() cannot handle 0-length CFDataRefs.
+        if (!CFDataGetLength(data))
+            return nullptr;
+
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        SecKeychainItemRef keychainItem = NULL;
+        SecKeychainItemCopyFromPersistentReference(data, &keychainItem);
+        ALLOW_DEPRECATED_DECLARATIONS_END
+        return adoptCF(keychainItem);
+    }
+
+    IPC::DataReference dataReference() const
+    {
+        if (!m_persistentRef)
+            return { };
+
+        CFDataRef data = m_persistentRef.get();
+        return { CFDataGetBytePtr(data), static_cast<size_t>(CFDataGetLength(data)) };
+    }
+
+private:
+    RetainPtr<CFDataRef> persistentRefForKeychainItem(SecKeychainItemRef keychainItem) const
+    {
+        RELEASE_ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessCredentials));
+        if (!keychainItem)
+            return nullptr;
+
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        CFDataRef data = NULL;
+        SecKeychainItemCreatePersistentReference(keychainItem, &data);
+        ALLOW_DEPRECATED_DECLARATIONS_END
+
+        return adoptCF(data);
+    }
+
+    RetainPtr<CFDataRef> m_persistentRef;
+};
+
+} // namespace WebKit
+
+#endif // HAVE(SEC_KEYCHAIN)

--- a/Source/WebKit/Shared/cf/CoreIPCSecKeychainItem.serialization.in
+++ b/Source/WebKit/Shared/cf/CoreIPCSecKeychainItem.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if HAVE(SEC_KEYCHAIN)
+
+webkit_platform_headers: "CoreIPCSecKeychainItem.h"
+
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCSecKeychainItem {
+    IPC::DataReference dataReference();
+}
+
+#endif // HAVE(SEC_KEYCHAIN)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1330,6 +1330,7 @@
 		53BA47D11DC2EF5E004DF4AD /* NetworkDataTaskBlob.h in Headers */ = {isa = PBXBuildFile; fileRef = 539EB5471DC2EE40009D48CF /* NetworkDataTaskBlob.h */; };
 		53CFBBC82224D1B500266546 /* TextCheckerCompletion.h in Headers */ = {isa = PBXBuildFile; fileRef = 53CFBBC72224D1B000266546 /* TextCheckerCompletion.h */; };
 		561A54532B61E49E00073A72 /* CoreIPCSecCertificate.h in Headers */ = {isa = PBXBuildFile; fileRef = 561A54512B61E49E00073A72 /* CoreIPCSecCertificate.h */; };
+		561A54612B6438C000073A72 /* CoreIPCSecKeychainItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 561A54602B6438C000073A72 /* CoreIPCSecKeychainItem.h */; };
 		562674F52B69B4C8008BB425 /* CoreIPCSecTrust.h in Headers */ = {isa = PBXBuildFile; fileRef = 562674F32B69B4C7008BB425 /* CoreIPCSecTrust.h */; };
 		570AB8F320AE3BD700B8BE87 /* SecKeyProxyStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 570AB8F220AE3BD700B8BE87 /* SecKeyProxyStore.h */; };
 		570DAAAE23026F5C00E8FC04 /* NfcService.h in Headers */ = {isa = PBXBuildFile; fileRef = 570DAAAC23026F5C00E8FC04 /* NfcService.h */; };
@@ -5652,6 +5653,8 @@
 		55AD09422408A02E00DE4D2F /* RemoteImageBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteImageBuffer.h; sourceTree = "<group>"; };
 		561A54512B61E49E00073A72 /* CoreIPCSecCertificate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCSecCertificate.h; sourceTree = "<group>"; };
 		561A54522B61E49E00073A72 /* CoreIPCSecCertificate.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCSecCertificate.serialization.in; sourceTree = "<group>"; };
+		561A545F2B6438BF00073A72 /* CoreIPCSecKeychainItem.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCSecKeychainItem.serialization.in; sourceTree = "<group>"; };
+		561A54602B6438C000073A72 /* CoreIPCSecKeychainItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCSecKeychainItem.h; sourceTree = "<group>"; };
 		562674F32B69B4C7008BB425 /* CoreIPCSecTrust.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCSecTrust.h; sourceTree = "<group>"; };
 		562674F42B69B4C8008BB425 /* CoreIPCSecTrust.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCSecTrust.serialization.in; sourceTree = "<group>"; };
 		570AB8F220AE3BD700B8BE87 /* SecKeyProxyStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SecKeyProxyStore.h; sourceTree = "<group>"; };
@@ -9015,6 +9018,8 @@
 				F4EFF36A2AF0267200479AB8 /* CoreIPCNumber.serialization.in */,
 				561A54512B61E49E00073A72 /* CoreIPCSecCertificate.h */,
 				561A54522B61E49E00073A72 /* CoreIPCSecCertificate.serialization.in */,
+				561A54602B6438C000073A72 /* CoreIPCSecKeychainItem.h */,
+				561A545F2B6438BF00073A72 /* CoreIPCSecKeychainItem.serialization.in */,
 				562674F32B69B4C7008BB425 /* CoreIPCSecTrust.h */,
 				562674F42B69B4C8008BB425 /* CoreIPCSecTrust.serialization.in */,
 			);
@@ -15226,6 +15231,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				561A54612B6438C000073A72 /* CoreIPCSecKeychainItem.h in Headers */,
 				562674F52B69B4C8008BB425 /* CoreIPCSecTrust.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
#### edf8486e0ced3bf3f416bd255aa8b694d7ba01c5
<pre>
Generate serialization for SecKeychainItemRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=268182">https://bugs.webkit.org/show_bug.cgi?id=268182</a>
<a href="https://rdar.apple.com/121676431">rdar://121676431</a>

Reviewed by achristensen07 (Alex Christensen).

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/cf/ArgumentCodersCF.cpp:
(IPC::ArgumentCoder&lt;SecKeychainItemRef&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RetainPtr&lt;SecKeychainItemRef&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/cf/ArgumentCodersCF.h:
* Source/WebKit/Shared/cf/CFTypes.serialization.in:
* Source/WebKit/Shared/cf/CoreIPCSecKeychainItem.h: Added.
(WebKit::CoreIPCSecKeychainItem::CoreIPCSecKeychainItem):
(WebKit::CoreIPCSecKeychainItem::createSecKeychainItem const):
(WebKit::CoreIPCSecKeychainItem::dataReference const):
(WebKit::CoreIPCSecKeychainItem::persistentRefForKeychainItem const):
* Source/WebKit/Shared/cf/CoreIPCSecKeychainItem.serialization.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(getTempKeychain):
(destroyTempKeychain):
(TEST):

Canonical link: <a href="https://commits.webkit.org/274043@main">https://commits.webkit.org/274043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bc7b6145342ab109e1ce8b1dbe24096dddd98fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40160 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33499 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31878 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38196 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13956 "Found 1 new test failure: media/video-ended-does-not-hold-sleep-assertion.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12132 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41421 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34081 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37973 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12662 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36142 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14098 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13062 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4887 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13411 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->