### PR TITLE
Followup to 273582@main — remove an unnecessary WebKitAdditions import

### DIFF
--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig
@@ -42,6 +42,17 @@ WK_AUTHKIT_LDFLAGS_IOS_SINCE_13 = -framework AuthKit;
 WK_AUTHKIT_LDFLAGS_macosx = $(WK_AUTHKIT_LDFLAGS$(WK_MACOS_1015));
 WK_AUTHKIT_LDFLAGS_MACOS_SINCE_1015 = -framework AuthKit;
 
+WK_BROWSERENGINEKIT_LDFLAGS =
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=iphone*] = -framework BrowserEngineKit
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=iphone*17.0*] =
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=iphone*17.1*] =
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=iphone*17.2*] =
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=iphone*17.3*] =
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=iphone*18.0*] =
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=appletv*] =
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=watch*] =
+WK_BROWSERENGINEKIT_LDFLAGS[sdk=xr*] =
+
 WK_REVEAL_LDFLAGS = $(WK_REVEAL_LDFLAGS_$(WK_PLATFORM_NAME));
 WK_REVEAL_LDFLAGS_macosx = $(WK_REVEAL_LDFLAGS$(WK_MACOS_1015));
 WK_REVEAL_LDFLAGS_MACOS_SINCE_1015 = -framework Reveal;
@@ -105,7 +116,7 @@ WK_IMAGEIO_LDFLAGS_MACOS_SINCE_1300 = -framework ImageIO;
 
 OTHER_CPLUSPLUSFLAGS = $(inherited) -isystem $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders;
 
-OTHER_LDFLAGS = $(inherited) -lgtest -force_load $(BUILT_PRODUCTS_DIR)/libTestWebKitAPI.a -framework JavaScriptCore -framework WebCore -framework WebKit -lWebCoreTestSupport -framework Metal -framework IOSurface $(WK_APPSERVERSUPPORT_LDFLAGS) $(WK_AUTHKIT_LDFLAGS) -framework Network -framework UniformTypeIdentifiers -framework CoreFoundation -framework CoreServices $(WK_HID_LDFLAGS) $(WK_IMAGEIO_LDFLAGS) $(WK_OPENGL_LDFLAGS) $(WK_PDFKIT_LDFLAGS) $(WK_SYSTEM_LDFLAGS) $(WK_UIKITMACHELPER_LDFLAGS) $(WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS) $(WK_VISIONKITCORE_LDFLAGS) $(WK_WEBCORE_LDFLAGS) $(WK_REVEAL_LDFLAGS) $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH));
+OTHER_LDFLAGS = $(inherited) -lgtest -force_load $(BUILT_PRODUCTS_DIR)/libTestWebKitAPI.a -framework JavaScriptCore -framework WebCore -framework WebKit -lWebCoreTestSupport -framework Metal -framework IOSurface $(WK_APPSERVERSUPPORT_LDFLAGS) $(WK_AUTHKIT_LDFLAGS) -framework Network -framework UniformTypeIdentifiers -framework CoreFoundation -framework CoreServices $(WK_BROWSERENGINEKIT_LDFLAGS) $(WK_HID_LDFLAGS) $(WK_IMAGEIO_LDFLAGS) $(WK_OPENGL_LDFLAGS) $(WK_PDFKIT_LDFLAGS) $(WK_SYSTEM_LDFLAGS) $(WK_UIKITMACHELPER_LDFLAGS) $(WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS) $(WK_VISIONKITCORE_LDFLAGS) $(WK_WEBCORE_LDFLAGS) $(WK_REVEAL_LDFLAGS) $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH));
 OTHER_LDFLAGS_PLATFORM_ = -framework Cocoa -framework Carbon;
 
 // FIXME: This should not be built on iOS. Instead we should create and use a TestWebKitAPI application.

--- a/Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm
@@ -34,10 +34,6 @@
 #import <WebCore/WebEvent.h>
 #import <WebKit/WKWebViewPrivate.h>
 
-#if USE(APPLE_INTERNAL_SDK)
-#import <WebKitAdditions/WKScrollViewTestsAdditions.mm>
-#endif
-
 constexpr CGFloat blackColorComponents[4] = { 0, 0, 0, 1 };
 constexpr CGFloat whiteColorComponents[4] = { 1, 1, 1, 1 };
 


### PR DESCRIPTION
#### 03567a5c3308e5cba514cce67f1a1e7bfaf085c4
<pre>
Followup to 273582@main — remove an unnecessary WebKitAdditions import
<a href="https://bugs.webkit.org/show_bug.cgi?id=268043">https://bugs.webkit.org/show_bug.cgi?id=268043</a>
<a href="https://rdar.apple.com/121560918">rdar://121560918</a>

Reviewed by Aditya Keerthi.

Remove this WebKitAdditions file (which previously hid an `asm()` declaration to link against
BrowserEngineKit), and instead have TestWebKitAPI link against the framework when needed.

* Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig:
* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:

Canonical link: <a href="https://commits.webkit.org/273609@main">https://commits.webkit.org/273609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a02edade7313351d34edafa1091bdc386cc7edb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38698 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32361 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31095 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11074 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39946 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32685 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37036 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11256 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35130 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13001 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8199 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11766 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12088 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->