### PR TITLE
beginParsingChildren and finishParsingChildren should only exist on Element

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3152,14 +3152,8 @@ void Element::removeAllEventListeners()
         shadowRoot->removeAllEventListeners();
 }
 
-void Element::beginParsingChildren()
-{
-    clearIsParsingChildrenFinished();
-}
-
 void Element::finishParsingChildren()
 {
-    ContainerNode::finishParsingChildren();
     setIsParsingChildrenFinished();
 
     Style::ChildChangeInvalidation::invalidateAfterFinishedParsingChildren(*this);

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -505,8 +505,9 @@ public:
     virtual void didStopBeingFullscreenElement() { }
 
     bool isFinishedParsingChildren() const { return isParsingChildrenFinished(); }
-    void finishParsingChildren() override;
-    void beginParsingChildren() final;
+    // Overriding these functions to make parsing a special case should be avoided if possible.
+    void beginParsingChildren() { clearIsParsingChildrenFinished(); }
+    virtual void finishParsingChildren();
 
     PseudoElement& ensurePseudoElement(PseudoId);
     WEBCORE_EXPORT PseudoElement* beforePseudoElement() const;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -329,15 +329,6 @@ public:
     WEBCORE_EXPORT bool isRootEditableElement() const;
     WEBCORE_EXPORT Element* rootEditableElement() const;
 
-    // Called by the parser when this element's close tag is reached,
-    // signaling that all child tags have been parsed and added.
-    // This is needed for <applet> and <object> elements, which can't lay themselves out
-    // until they know all of their nested <param>s. [Radar 3603191, 4040848].
-    // Also used for script elements and some SVG elements for similar purposes,
-    // but making parsing a special case in this respect should be avoided if possible.
-    virtual void finishParsingChildren() { }
-    virtual void beginParsingChildren() { }
-
     // For <link> and <style> elements.
     virtual bool sheetLoaded() { return true; }
     virtual void notifyLoadedSheetAndAllCriticalSubresources(bool /* error loading subresource */) { }

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -288,10 +288,4 @@ void ProcessingInstruction::removedFromAncestor(RemovalType removalType, Contain
     styleScope->didChangeActiveStyleSheetCandidates();
 }
 
-void ProcessingInstruction::finishParsingChildren()
-{
-    m_createdByParser = false;
-    CharacterData::finishParsingChildren();
-}
-
 } // namespace

--- a/Source/WebCore/dom/ProcessingInstruction.h
+++ b/Source/WebCore/dom/ProcessingInstruction.h
@@ -45,8 +45,6 @@ public:
 
     void setCreatedByParser(bool createdByParser) { m_createdByParser = createdByParser; }
 
-    void finishParsingChildren() override;
-
     const String& localHref() const { return m_localHref; }
     StyleSheet* sheet() const { return m_sheet.get(); }
     RefPtr<StyleSheet> protectedSheet() const;

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -148,10 +148,13 @@ static inline void executeInsertTask(HTMLConstructionSiteTask& task)
 
     insert(task);
 
-    task.child->beginParsingChildren();
+    RefPtr element = dynamicDowncast<Element>(task.child);
+    if (!element)
+        return;
 
+    element->beginParsingChildren();
     if (task.selfClosing)
-        task.child->finishParsingChildren();
+        element->finishParsingChildren();
 }
 
 static inline void executeReparentTask(HTMLConstructionSiteTask& task)

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -868,9 +868,9 @@ private:
         parseAttributes(element);
         if (parsingFailed())
             return element;
+        parent.parserAppendChild(element);
         element->beginParsingChildren();
         element->finishParsingChildren();
-        parent.parserAppendChild(element);
         return WTFMove(element);
     }
 };

--- a/Source/WebCore/html/parser/HTMLElementStack.cpp
+++ b/Source/WebCore/html/parser/HTMLElementStack.cpp
@@ -186,7 +186,8 @@ void HTMLElementStack::popAll()
     m_bodyElement = nullptr;
     m_stackDepth = 0;
     while (m_top) {
-        topNode().finishParsingChildren();
+        if (RefPtr element = dynamicDowncast<Element>(topNode()))
+            element->finishParsingChildren();
         m_top = m_top->releaseNext();
     }
 }


### PR DESCRIPTION
#### 74df988dc5b55d9cfb4795e9b641df9fc032c343
<pre>
beginParsingChildren and finishParsingChildren should only exist on Element
<a href="https://bugs.webkit.org/show_bug.cgi?id=268213">https://bugs.webkit.org/show_bug.cgi?id=268213</a>

Reviewed by Anne van Kesteren and Darin Adler.

Only Element and ProcessingInstruction ever override finishParsingChildren.
ProcessingInstruction::finishParsingChildren is only there to unset m_createdByParser
flag but this function is only ever called by XMLDocumentParser::processingInstruction,
which can call ProcessingInstruction::setCreatedByParser instead. Furthermore, only
Element ever implemented beginParsingChildren.

This PR therefore moves beginParsingChildren and finishParsingChildren from Node
to Element and removes ProcessingInstruction::finishParsingChildren.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::finishParsingChildren):
(WebCore::Element::beginParsingChildren): Deleted.
* Source/WebCore/dom/Element.h:
(WebCore::Element::beginParsingChildren): Moved from cpp file.
* Source/WebCore/dom/Node.h:
(WebCore::Node::finishParsingChildren): Deleted.
(WebCore::Node::beginParsingChildren): Deleted.
* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::finishParsingChildren): Deleted.
* Source/WebCore/dom/ProcessingInstruction.h:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::executeInsertTask):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::parseVoidElement):
* Source/WebCore/html/parser/HTMLElementStack.cpp:
(WebCore::HTMLElementStack::popAll):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::endElementNs):
(WebCore::XMLDocumentParser::processingInstruction):

Canonical link: <a href="https://commits.webkit.org/273673@main">https://commits.webkit.org/273673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4990c0802164940cd3efd82f0f43d41386edce3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/35998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38716 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32379 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11973 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31099 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36552 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11084 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39964 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32719 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37049 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9179 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35133 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13009 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11773 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4701 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12104 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->