### PR TITLE
Adopt dynamicDowncast<> in MarkupAccumulator

### DIFF
--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -114,10 +114,11 @@ static const uint8_t entityMap[maximumEscapedentityCharacter + 1] = {
 static bool elementCannotHaveEndTag(const Node& node)
 {
     using namespace ElementNames;
-    if (!is<Element>(node))
+    RefPtr element = dynamicDowncast<Element>(node);
+    if (!element)
         return false;
 
-    switch (downcast<Element>(node).elementName()) {
+    switch (element->elementName()) {
         // https://html.spec.whatwg.org/#void-elements
     case HTML::area:
     case HTML::base:
@@ -214,14 +215,14 @@ String MarkupAccumulator::serializeNodes(Node& targetNode, SerializedNodes root)
 
 bool MarkupAccumulator::appendContentsForNode(StringBuilder& result, const Node& targetNode)
 {
-    if (!targetNode.hasTagName(styleTag))
+    RefPtr styleElement = dynamicDowncast<HTMLStyleElement>(targetNode);
+    if (!styleElement)
         return false;
 
     if (m_replacementURLStrings.isEmpty() && m_replacementURLStringsForCSSStyleSheet.isEmpty())
         return false;
 
-    auto& styleElement = downcast<HTMLStyleElement>(targetNode);
-    RefPtr cssStyleSheet = styleElement.sheet();
+    RefPtr cssStyleSheet = styleElement->sheet();
     if (!cssStyleSheet)
         return false;
 
@@ -246,7 +247,7 @@ void MarkupAccumulator::serializeNodesWithNamespaces(Node& targetNode, Serialize
     RefPtr<const Node> current = &targetNode;
     do {
         bool shouldSkipNode = false;
-        if (is<Element>(current) && shouldExcludeElement(downcast<Element>(*current)))
+        if (RefPtr element = dynamicDowncast<const Element>(current); element && shouldExcludeElement(*element))
             shouldSkipNode = true;
 
         bool shouldAppendNode = !shouldSkipNode && !(current == &targetNode && root != SerializedNodes::SubtreeIncludingNode);
@@ -266,7 +267,8 @@ void MarkupAccumulator::serializeNodesWithNamespaces(Node& targetNode, Serialize
             }
 
             bool shouldSkipChidren = appendContentsForNode(m_markup, *current);
-            auto firstChild = current->hasTagName(templateTag) ? downcast<HTMLTemplateElement>(*current).content().firstChild() : current->firstChild();
+            RefPtr currentTemplate = dynamicDowncast<HTMLTemplateElement>(*current);
+            auto firstChild = currentTemplate ? currentTemplate->content().firstChild() : current->firstChild();
             if (!shouldSkipChidren && firstChild) {
                 current = firstChild;
                 namespaceStack.append(namespaceStack.last());
@@ -310,8 +312,8 @@ void MarkupAccumulator::serializeNodesWithNamespaces(Node& targetNode, Serialize
 
 String MarkupAccumulator::resolveURLIfNeeded(const Element& element, const String& urlString) const
 {
-    if (!m_replacementURLStringsForCSSStyleSheet.isEmpty() && is<HTMLLinkElement>(element)) {
-        if (RefPtr cssStyleSheet = downcast<HTMLLinkElement>(element).sheet()) {
+    if (RefPtr link = dynamicDowncast<HTMLLinkElement>(element); link && !m_replacementURLStringsForCSSStyleSheet.isEmpty()) {
+        if (RefPtr cssStyleSheet = link->sheet()) {
             auto replacementURLString = m_replacementURLStringsForCSSStyleSheet.get(cssStyleSheet);
             if (!replacementURLString.isEmpty())
                 return replacementURLString;
@@ -336,17 +338,20 @@ String MarkupAccumulator::resolveURLIfNeeded(const Element& element, const Strin
 
 RefPtr<Element> MarkupAccumulator::replacementElement(const Node& node)
 {
-    if (!m_shouldIncludeShadowDOM || !node.isShadowRoot())
+    if (!m_shouldIncludeShadowDOM)
         return nullptr;
 
-    auto& shadowRoot = downcast<ShadowRoot>(node);
-    if (shadowRoot.mode() == ShadowRootMode::UserAgent)
+    RefPtr shadowRoot = dynamicDowncast<ShadowRoot>(node);
+    if (!shadowRoot)
+        return nullptr;
+
+    if (shadowRoot->mode() == ShadowRootMode::UserAgent)
         return nullptr;
 
     auto element = HTMLTemplateElement::create(HTMLNames::templateTag, node.document());
-    if (shadowRoot.mode() == ShadowRootMode::Open)
+    if (shadowRoot->mode() == ShadowRootMode::Open)
         element->setShadowRootMode(AtomString { "open"_s });
-    else if (shadowRoot.mode() == ShadowRootMode::Closed)
+    else if (shadowRoot->mode() == ShadowRootMode::Closed)
         element->setShadowRootMode(AtomString { "closed"_s });
 
     return element;
@@ -354,8 +359,8 @@ RefPtr<Element> MarkupAccumulator::replacementElement(const Node& node)
 
 void MarkupAccumulator::startAppendingNode(const Node& node, Namespaces* namespaces)
 {
-    if (is<Element>(node))
-        appendStartTag(m_markup, downcast<Element>(node), namespaces);
+    if (RefPtr element = dynamicDowncast<Element>(node))
+        appendStartTag(m_markup, *element, namespaces);
     else if (auto element = replacementElement(node))
         appendStartTag(m_markup, *element, namespaces);
     else
@@ -631,12 +636,11 @@ LocalFrame* MarkupAccumulator::frameForAttributeReplacement(const Element& eleme
     if (inXMLFragmentSerialization() || m_replacementURLStrings.isEmpty())
         return nullptr;
 
-    auto* currentElement = const_cast<Element*>(&element);
-    if (!is<HTMLFrameElementBase>(currentElement))
+    RefPtr frameElement = dynamicDowncast<HTMLFrameElementBase>(element);
+    if (!frameElement)
         return nullptr;
 
-    auto& frameElement = downcast<HTMLFrameElementBase>(*currentElement);
-    return dynamicDowncast<LocalFrame>(frameElement.contentFrame());
+    return dynamicDowncast<LocalFrame>(frameElement->contentFrame());
 }
 
 Attribute MarkupAccumulator::replaceAttributeIfNecessary(const Element& element, const Attribute& attribute)


### PR DESCRIPTION
#### d1d58f130250d33153da12f2ae860715beaeb7dd
<pre>
Adopt dynamicDowncast&lt;&gt; in MarkupAccumulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=268220">https://bugs.webkit.org/show_bug.cgi?id=268220</a>

Reviewed by Chris Dumez.

* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::elementCannotHaveEndTag):
(WebCore::MarkupAccumulator::appendContentsForNode):
(WebCore::MarkupAccumulator::serializeNodesWithNamespaces):
(WebCore::MarkupAccumulator::resolveURLIfNeeded const):
(WebCore::MarkupAccumulator::replacementElement):
(WebCore::MarkupAccumulator::startAppendingNode):
(WebCore::MarkupAccumulator::frameForAttributeReplacement const):

Canonical link: <a href="https://commits.webkit.org/273621@main">https://commits.webkit.org/273621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/988e5e07b03b1038c130a9da8f43b907c193f44d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38841 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32472 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31168 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32044 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11154 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11176 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32220 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40087 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32790 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32584 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37115 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35200 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13095 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8208 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11849 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->