### PR TITLE
Add constants for HTTP status codes

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2237,6 +2237,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/network/HTTPHeaderNames.in
     platform/network/HTTPHeaderValues.h
     platform/network/HTTPParsers.h
+    platform/network/HTTPStatusCodes.h
     platform/network/NetworkLoadInformation.h
     platform/network/NetworkLoadMetrics.h
     platform/network/NetworkStateNotifier.h

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
@@ -33,6 +33,7 @@
 #include "Document.h"
 #include "FetchLoader.h"
 #include "HTTPParsers.h"
+#include "HTTPStatusCodes.h"
 #include "JSBlob.h"
 #include "JSDOMFormData.h"
 #include "JSDOMPromiseDeferred.h"
@@ -308,7 +309,7 @@ FetchBodyOwner::BlobLoader::BlobLoader(FetchBodyOwner& owner)
 
 void FetchBodyOwner::BlobLoader::didReceiveResponse(const ResourceResponse& response)
 {
-    if (response.httpStatusCode() != 200)
+    if (response.httpStatusCode() != httpStatus200OK)
         didFail({ });
 }
 

--- a/Source/WebCore/Modules/fetch/FetchResponse.h
+++ b/Source/WebCore/Modules/fetch/FetchResponse.h
@@ -30,6 +30,7 @@
 
 #include "FetchBodyOwner.h"
 #include "FetchHeaders.h"
+#include "HTTPStatusCodes.h"
 #include "ReadableStreamSink.h"
 #include "ResourceResponse.h"
 #include <JavaScriptCore/TypedArrays.h>
@@ -53,7 +54,7 @@ public:
     using Type = ResourceResponse::Type;
 
     struct Init {
-        unsigned short status { 200 };
+        unsigned short status { httpStatus200OK };
         AtomString statusText;
         std::optional<FetchHeaders::Init> headers;
     };

--- a/Source/WebCore/fileapi/FileReaderLoader.cpp
+++ b/Source/WebCore/fileapi/FileReaderLoader.cpp
@@ -37,6 +37,7 @@
 #include "ExceptionCode.h"
 #include "FileReaderLoaderClient.h"
 #include "HTTPHeaderNames.h"
+#include "HTTPStatusCodes.h"
 #include "ResourceError.h"
 #include "ResourceRequest.h"
 #include "ResourceResponse.h"
@@ -136,7 +137,7 @@ void FileReaderLoader::cleanup()
 
 void FileReaderLoader::didReceiveResponse(ResourceLoaderIdentifier, const ResourceResponse& response)
 {
-    if (response.httpStatusCode() != 200) {
+    if (response.httpStatusCode() != httpStatus200OK) {
         failed(httpStatusCodeToErrorCode(response.httpStatusCode()));
         return;
     }
@@ -269,7 +270,7 @@ ExceptionCode FileReaderLoader::toErrorCode(BlobResourceHandle::Error error)
 ExceptionCode FileReaderLoader::httpStatusCodeToErrorCode(int httpStatusCode)
 {
     switch (httpStatusCode) {
-    case 403:
+    case httpStatus403Forbidden:
         return ExceptionCode::SecurityError;
     default:
         return ExceptionCode::NotReadableError;

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -37,6 +37,7 @@
 #include "ContentSecurityPolicy.h"
 #include "EventLoop.h"
 #include "EventNames.h"
+#include "HTTPStatusCodes.h"
 #include "MessageEvent.h"
 #include "ResourceError.h"
 #include "ResourceRequest.h"
@@ -174,7 +175,7 @@ bool EventSource::responseIsValid(const ResourceResponse& response) const
     // Logs to the console as a side effect.
 
     // To keep the signal-to-noise ratio low, we don't log anything if the status code is not 200.
-    if (response.httpStatusCode() != 200)
+    if (response.httpStatusCode() != httpStatus200OK)
         return false;
 
     if (!equalLettersIgnoringASCIICase(response.mimeType(), "text/event-stream"_s)) {

--- a/Source/WebCore/platform/network/HTTPStatusCodes.h
+++ b/Source/WebCore/platform/network/HTTPStatusCodes.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+// https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+
+constexpr auto httpStatus103EarlyHints = 103;
+
+constexpr auto httpStatus200OK = 200;
+constexpr auto httpStatus204NoContent = 204;
+constexpr auto httpStatus206PartialContent = 206;
+
+constexpr auto httpStatus300MultipleChoices = 300;
+constexpr auto httpStatus301MovedPermanently = 301;
+constexpr auto httpStatus302Found = 302;
+constexpr auto httpStatus303SeeOther = 303;
+constexpr auto httpStatus304NotModified = 304;
+constexpr auto httpStatus307TemporaryRedirect = 307;
+constexpr auto httpStatus308PermanentRedirect = 308;
+
+constexpr auto httpStatus400BadRequest = 400;
+constexpr auto httpStatus401Unauthorized = 401;
+constexpr auto httpStatus403Forbidden = 403;
+constexpr auto httpStatus407ProxyAuthenticationRequired = 407;
+constexpr auto httpStatus416RangeNotSatisfiable = 416;
+
+} // namespace WebCore
+
+using WebCore::httpStatus103EarlyHints;
+
+using WebCore::httpStatus200OK;
+using WebCore::httpStatus204NoContent;
+using WebCore::httpStatus206PartialContent;
+
+using WebCore::httpStatus300MultipleChoices;
+using WebCore::httpStatus301MovedPermanently;
+using WebCore::httpStatus302Found;
+using WebCore::httpStatus303SeeOther;
+using WebCore::httpStatus304NotModified;
+using WebCore::httpStatus307TemporaryRedirect;
+using WebCore::httpStatus308PermanentRedirect;
+
+using WebCore::httpStatus400BadRequest;
+using WebCore::httpStatus401Unauthorized;
+using WebCore::httpStatus403Forbidden;
+using WebCore::httpStatus407ProxyAuthenticationRequired;
+using WebCore::httpStatus416RangeNotSatisfiable;

--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -27,6 +27,7 @@
 #include "ResourceRequestBase.h"
 
 #include "HTTPHeaderNames.h"
+#include "HTTPStatusCodes.h"
 #include "Logging.h"
 #include "PublicSuffix.h"
 #include "RegistrableDomain.h"
@@ -138,9 +139,9 @@ static bool shouldUseGet(const ResourceRequestBase& request, const ResourceRespo
 {
     if (equalLettersIgnoringASCIICase(request.httpMethod(), "get"_s) || equalLettersIgnoringASCIICase(request.httpMethod(), "head"_s))
         return false;
-    if (redirectResponse.httpStatusCode() == 301 || redirectResponse.httpStatusCode() == 302)
+    if (redirectResponse.httpStatusCode() == httpStatus301MovedPermanently || redirectResponse.httpStatusCode() == httpStatus302Found)
         return equalLettersIgnoringASCIICase(request.httpMethod(), "post"_s);
-    return redirectResponse.httpStatusCode() == 303;
+    return redirectResponse.httpStatusCode() == httpStatus303SeeOther;
 }
 
 // https://fetch.spec.whatwg.org/#concept-http-redirect-fetch Step 11

--- a/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
+++ b/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "RangeResponseGenerator.h"
 
+#import "HTTPStatusCodes.h"
 #import "NetworkLoadMetrics.h"
 #import "ParsedRequestRange.h"
 #import "PlatformMediaResourceLoader.h"
@@ -84,8 +85,7 @@ static ResourceResponse synthesizedResponseForRange(const ResourceResponse& orig
     ResourceResponse newResponse = originalResponse;
     newResponse.setHTTPHeaderField(HTTPHeaderName::ContentRange, newContentRange);
     newResponse.setHTTPHeaderField(HTTPHeaderName::ContentLength, newContentLength);
-    constexpr auto partialContent = 206;
-    newResponse.setHTTPStatusCode(partialContent);
+    newResponse.setHTTPStatusCode(httpStatus206PartialContent);
     
     // Values from setHTTPStatusCode and setHTTPHeaderField are not reflected in the newly generated response without this.
     newResponse.initNSURLResponse();
@@ -294,7 +294,7 @@ bool RangeResponseGenerator::willSynthesizeRangeResponses(WebCoreNSURLSessionDat
     NSURLRequest *originalRequest = task.originalRequest;
     if (!originalRequest.URL)
         return false;
-    if (response.httpStatusCode() != 200)
+    if (response.httpStatusCode() != httpStatus200OK)
         return false;
     if (!response.httpHeaderField(HTTPHeaderName::ContentRange).isEmpty())
         return false;

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -39,6 +39,7 @@
 #include <WebCore/CrossOriginAccessControl.h>
 #include <WebCore/CrossOriginEmbedderPolicy.h>
 #include <WebCore/CrossOriginPreflightResultCache.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/LegacySchemeRegistry.h>
 #include <WebCore/OriginAccessPatterns.h>
 #include <wtf/Scope.h>
@@ -234,7 +235,7 @@ ResourceError NetworkLoadChecker::validateResponse(const ResourceRequest& reques
     ASSERT(m_options.mode == FetchOptions::Mode::Cors);
 
     // If we have a 304, the cached response is in WebProcess so we let WebProcess do the CORS check on the cached response.
-    if (response.httpStatusCode() == 304)
+    if (response.httpStatusCode() == httpStatus304NotModified)
         return { };
 
     auto result = passesAccessControlCheck(response, m_storedCredentialsPolicy, *origin(), m_networkResourceLoader.get());

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -63,6 +63,7 @@
 #include <WebCore/CrossOriginEmbedderPolicy.h>
 #include <WebCore/DiagnosticLoggingKeys.h>
 #include <WebCore/HTTPParsers.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/LegacySchemeRegistry.h>
 #include <WebCore/LinkHeader.h>
 #include <WebCore/NetworkLoadMetrics.h>
@@ -829,7 +830,7 @@ static BrowsingContextGroupSwitchDecision toBrowsingContextGroupSwitchDecision(c
 
 void NetworkResourceLoader::didReceiveInformationalResponse(ResourceResponse&& response)
 {
-    if (response.httpStatusCode() != 103)
+    if (response.httpStatusCode() != httpStatus103EarlyHints)
         return;
 
     if (!m_earlyHintsResourceLoader)
@@ -889,7 +890,7 @@ void NetworkResourceLoader::didReceiveResponse(ResourceResponse&& receivedRespon
         m_bufferedDataForCache.reset();
 
     if (m_cacheEntryForValidation) {
-        bool validationSucceeded = m_response.httpStatusCode() == 304; // 304 Not Modified
+        bool validationSucceeded = m_response.httpStatusCode() == httpStatus304NotModified;
         LOADER_RELEASE_LOG("didReceiveResponse: Received revalidation response (validationSucceeded=%d, wasOriginalRequestConditional=%d)", validationSucceeded, originalRequest().isConditional());
         if (validationSucceeded) {
             m_cacheEntryForValidation = m_cache->update(originalRequest(), *m_cacheEntryForValidation, m_response, m_privateRelayed);
@@ -1056,8 +1057,7 @@ void NetworkResourceLoader::didFinishLoading(const NetworkLoadMetrics& networkLo
         m_connection->addNetworkLoadInformationMetrics(coreIdentifier(), networkLoadMetrics);
 
     if (m_cacheEntryForValidation) {
-        // 304 Not Modified
-        ASSERT(m_response.httpStatusCode() == 304);
+        ASSERT(m_response.httpStatusCode() == httpStatus304NotModified);
         LOG(NetworkCache, "(NetworkProcess) revalidated");
         didRetrieveCacheEntry(WTFMove(m_cacheEntryForValidation));
         return;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
@@ -32,6 +32,7 @@
 #include "NetworkLoad.h"
 #include "NetworkSession.h"
 #include "PrivateRelayed.h"
+#include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/NavigationPreloadState.h>
 
 namespace WebKit {
@@ -167,7 +168,7 @@ void ServiceWorkerNavigationPreloader::didReceiveResponse(ResourceResponse&& res
     if (response.isRedirection())
         response.setTainting(ResourceResponse::Tainting::Opaqueredirect);
 
-    if (response.httpStatusCode() == 304 && m_cacheEntry) {
+    if (response.httpStatusCode() == httpStatus304NotModified && m_cacheEntry) {
         auto cacheEntry = WTFMove(m_cacheEntry);
         loadWithCacheEntry(*cacheEntry);
         completionHandler(PolicyAction::Ignore);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
@@ -31,6 +31,7 @@
 #include "NetworkLoad.h"
 #include "NetworkSession.h"
 #include <WebCore/AdvancedPrivacyProtections.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/ServiceWorkerJob.h>
 #include <WebCore/TextResourceDecoder.h>
 #include <WebCore/WorkerFetchResult.h>
@@ -137,7 +138,7 @@ void ServiceWorkerSoftUpdateLoader::willSendRedirectedRequest(ResourceRequest&&,
 void ServiceWorkerSoftUpdateLoader::didReceiveResponse(ResourceResponse&& response, PrivateRelayed, ResponseCompletionHandler&& completionHandler)
 {
     m_certificateInfo = *response.certificateInfo();
-    if (response.httpStatusCode() == 304 && m_cacheEntry) {
+    if (response.httpStatusCode() == httpStatus304NotModified && m_cacheEntry) {
         loadWithCacheEntry(*m_cacheEntry);
         completionHandler(PolicyAction::Ignore);
         return;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -36,6 +36,7 @@
 #include "WebsiteDataType.h"
 #include <WebCore/CacheValidation.h>
 #include <WebCore/HTTPHeaderNames.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/LowPowerModeNotifier.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/RegistrableDomain.h>
@@ -490,7 +491,7 @@ std::unique_ptr<Entry> Cache::store(const WebCore::ResourceRequest& request, con
         LOG(NetworkCache, "(NetworkProcess) didn't store, storeDecision=%d", static_cast<int>(storeDecision));
         auto key = makeCacheKey(request);
 
-        auto isSuccessfulRevalidation = response.httpStatusCode() == 304;
+        auto isSuccessfulRevalidation = response.httpStatusCode() == httpStatus304NotModified;
         if (!isSuccessfulRevalidation) {
             // Make sure we don't keep a stale entry in the cache.
             remove(key);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
@@ -33,6 +33,7 @@
 #include "NetworkLoad.h"
 #include "NetworkProcess.h"
 #include "NetworkSession.h"
+#include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <pal/SessionID.h>
 #include <wtf/RunLoop.h>
@@ -113,7 +114,7 @@ void SpeculativeLoad::didReceiveResponse(ResourceResponse&& receivedResponse, Pr
     if (m_response.isMultipart())
         m_bufferedDataForCache.reset();
 
-    bool validationSucceeded = m_response.httpStatusCode() == 304; // 304 Not Modified
+    bool validationSucceeded = m_response.httpStatusCode() == httpStatus304NotModified;
     if (validationSucceeded && m_cacheEntry)
         m_cacheEntry = m_cache->update(m_originalRequest, *m_cacheEntry, m_response, privateRelayed);
     else

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -49,6 +49,7 @@
 #import <WebCore/Credential.h>
 #import <WebCore/FormDataStreamMac.h>
 #import <WebCore/FrameLoaderTypes.h>
+#import <WebCore/HTTPStatusCodes.h>
 #import <WebCore/NetworkStorageSession.h>
 #import <WebCore/NotImplemented.h>
 #import <WebCore/ResourceError.h>
@@ -1083,7 +1084,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         
         // Avoid MIME type sniffing if the response comes back as 304 Not Modified.
         int statusCode = [response isKindOfClass:NSHTTPURLResponse.class] ? [(NSHTTPURLResponse *)response statusCode] : 0;
-        if (statusCode != 304) {
+        if (statusCode != httpStatus304NotModified) {
             bool isMainResourceLoad = networkDataTask->firstRequest().requester() == WebCore::ResourceRequestRequester::Main;
             WebCore::adjustMIMETypeIfNecessary(response._CFURLResponse, isMainResourceLoad);
         }
@@ -1810,7 +1811,7 @@ static CompletionHandler<void(WebKit::AuthenticationChallengeDisposition disposi
         if (credential.persistence() == WebCore::CredentialPersistence::ForSession && authenticationChallenge.protectionSpace().isPasswordBased()) {
             WebCore::Credential nonPersistentCredential(credential.user(), credential.password(), WebCore::CredentialPersistence::None);
             URL urlToStore;
-            if (authenticationChallenge.failureResponse().httpStatusCode() == 401)
+            if (authenticationChallenge.failureResponse().httpStatusCode() == httpStatus401Unauthorized)
                 urlToStore = authenticationChallenge.failureResponse().url();
             if (auto storageSession = networkProcess->storageSession(sessionID))
                 storageSession->credentialStorage().set(partition, nonPersistentCredential, authenticationChallenge.protectionSpace(), urlToStore);

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
@@ -35,6 +35,7 @@
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import "WKWebViewInternal.h"
 #import "WebPageProxy.h"
+#import <WebCore/HTTPStatusCodes.h>
 #import <WebCore/ResourceResponse.h>
 #import <wtf/BlockPtr.h>
 
@@ -149,7 +150,7 @@ void PopUpSOAuthorizationSession::abortInternal()
 void PopUpSOAuthorizationSession::completeInternal(const WebCore::ResourceResponse& response, NSData *data)
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("completeInternal: httpState=%d", response.httpStatusCode());
-    if (response.httpStatusCode() != 200 || !page()) {
+    if (response.httpStatusCode() != httpStatus200OK || !page()) {
         fallBackToWebPathInternal();
         return;
     }

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -33,6 +33,7 @@
 #import "WebFrameProxy.h"
 #import "WebPageProxy.h"
 #import "WebProcessProxy.h"
+#import <WebCore/HTTPStatusCodes.h>
 #import <WebCore/ResourceResponse.h>
 #import <wtf/RunLoop.h>
 
@@ -84,7 +85,7 @@ void SubFrameSOAuthorizationSession::abortInternal()
 void SubFrameSOAuthorizationSession::completeInternal(const WebCore::ResourceResponse& response, NSData *data)
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("completeInternal: httpState=%d", response.httpStatusCode());
-    if (response.httpStatusCode() != 200) {
+    if (response.httpStatusCode() != httpStatus200OK) {
         fallBackToWebPathInternal();
         return;
     }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
@@ -31,6 +31,7 @@
 #import "ResourceLoadInfo.h"
 #import "WebExtensionAPINamespace.h"
 #import "WebExtensionAPIWebRequest.h"
+#import <WebCore/HTTPStatusCodes.h>
 #import <WebCore/ResourceResponse.h>
 
 #if ENABLE(WK_WEB_EXTENSIONS)
@@ -244,7 +245,7 @@ void WebExtensionContextProxy::resourceLoadDidReceiveChallenge(WebExtensionTabId
     NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
     // Firefox only calls onAuthRequired when the status code is 401 or 407.
     // See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onAuthRequired
-    if (httpResponse.statusCode != 401 && httpResponse.statusCode != 407)
+    if (httpResponse.statusCode != httpStatus401Unauthorized && httpResponse.statusCode != httpStatus407ProxyAuthenticationRequired)
         return;
 
     NSMutableDictionary<NSString *, id> *details = webRequestDetailsForResourceLoad(resourceLoad);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -31,6 +31,7 @@
 #import "Logging.h"
 #import "PDFKitSPI.h"
 #import "PDFPluginBase.h"
+#import <WebCore/HTTPStatusCodes.h>
 #import <WebCore/NetscapePlugInStreamLoader.h>
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <wtf/Identified.h>
@@ -191,11 +192,8 @@ void PDFPluginStreamLoaderClient::didReceiveResponse(NetscapePlugInStreamLoader*
 
     ASSERT(request->streamLoader() == streamLoader);
 
-    constexpr int StatusCodePartialContent = 206;
-    constexpr int StatusCodeRangeNotSatisfiable = 416;
-
     // Range success! We'll expect to receive the data in future didReceiveData callbacks.
-    if (response.httpStatusCode() == StatusCodePartialContent)
+    if (response.httpStatusCode() == httpStatus206PartialContent)
         return;
 
     // If the response wasn't a successful range response, we don't need this stream loader anymore.
@@ -205,7 +203,7 @@ void PDFPluginStreamLoaderClient::didReceiveResponse(NetscapePlugInStreamLoader*
 
     // The server might support range requests and explicitly told us this range was not satisfiable.
     // In this case, we can reject the ByteRangeRequest right away.
-    if (response.httpStatusCode() == StatusCodeRangeNotSatisfiable && request) {
+    if (response.httpStatusCode() == httpStatus416RangeNotSatisfiable && request) {
         request->completeWithAccumulatedData(*loader);
         loader->removeOutstandingByteRangeRequest(request->identifier());
     }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -219,6 +219,7 @@
 #include <WebCore/HTMLSelectElement.h>
 #include <WebCore/HTMLTextFormControlElement.h>
 #include <WebCore/HTTPParsers.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/HandleUserInputEventResult.h>
 #include <WebCore/Highlight.h>
 #include <WebCore/HighlightRegistry.h>
@@ -8947,10 +8948,8 @@ bool WebPage::shouldSkipDecidePolicyForResponse(const WebCore::ResourceResponse&
     if (!m_skipDecidePolicyForResponseIfPossible)
         return false;
 
-    constexpr auto noContent = 204;
-    constexpr auto smallestError = 400;
     auto statusCode = response.httpStatusCode();
-    if (statusCode == noContent || statusCode >= smallestError)
+    if (statusCode == httpStatus204NoContent || statusCode >= httpStatus400BadRequest)
         return false;
 
     if (!equalIgnoringASCIICase(response.mimeType(), "text/html"_s))

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
@@ -36,6 +36,7 @@
 #include <WebCore/Credential.h>
 #include <WebCore/CredentialStorage.h>
 #include <WebCore/DeprecatedGlobalSettings.h>
+#include <WebCore/HTTPStatusCodes.h>
 #include <WebCore/Logging.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/ProtectionSpace.h>
@@ -529,10 +530,10 @@ void SocketStreamHandleImpl::readStreamCallback(CFStreamEventType type)
 
                 CFIndex proxyResponseCode = CFHTTPMessageGetResponseStatusCode(proxyResponse.get());
                 switch (proxyResponseCode) {
-                case 200:
+                case httpStatus200OK:
                     // Successful connection.
                     break;
-                case 407:
+                case httpStatus407ProxyAuthenticationRequired:
                     addCONNECTCredentials(proxyResponse.get());
                     return;
                 default:
@@ -613,7 +614,7 @@ void SocketStreamHandleImpl::writeStreamCallback(CFStreamEventType type)
                 // Don't write anything until read stream callback has dealt with CONNECT credentials.
                 // The order of callbacks is not defined, so this can be called before readStreamCallback's kCFStreamEventHasBytesAvailable.
                 CFIndex proxyResponseCode = CFHTTPMessageGetResponseStatusCode(proxyResponse.get());
-                if (proxyResponseCode != 200)
+                if (proxyResponseCode != httpStatus200OK)
                     return;
             }
             m_connectingSubstate = Connected;


### PR DESCRIPTION
#### 7b1232f1e3b0a361fdf7d81dd185c4943fe9267d
<pre>
Add constants for HTTP status codes
<a href="https://bugs.webkit.org/show_bug.cgi?id=268224">https://bugs.webkit.org/show_bug.cgi?id=268224</a>

Reviewed by Simon Fraser and Youenn Fablet.

Implement an idea from Simon Fraser to collect status codes in a
centralized file with the aim to improve readability. As a side effect
it might make it easier to find related code.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/fetch/FetchBodyOwner.cpp:
(WebCore::FetchBodyOwner::BlobLoader::didReceiveResponse):
* Source/WebCore/Modules/fetch/FetchResponse.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/fileapi/FileReaderLoader.cpp:
(WebCore::FileReaderLoader::didReceiveResponse):
(WebCore::FileReaderLoader::httpStatusCodeToErrorCode):
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::didReceiveResponse):
(WebCore::SubresourceLoader::didReceiveBuffer):
(WebCore::SubresourceLoader::responseHasHTTPStatusCodeError const):
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::responseIsValid const):
* Source/WebCore/platform/network/HTTPStatusCodes.h: Added.
* Source/WebCore/platform/network/ResourceRequestBase.cpp:
(WebCore::shouldUseGet):
* Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm:
(WebCore::synthesizedResponseForRange):
(WebCore::RangeResponseGenerator::willSynthesizeRangeResponses):
* Source/WebCore/platform/network/mac/ResourceHandleMac.mm:
(WebCore::ResourceHandle::willSendRequest):
(WebCore::ResourceHandle::tryHandlePasswordBasedAuthentication):
(WebCore::ResourceHandle::receivedCredential):
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::validateResponse):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didReceiveInformationalResponse):
(WebKit::NetworkResourceLoader::didReceiveResponse):
(WebKit::NetworkResourceLoader::didFinishLoading):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp:
(WebKit::ServiceWorkerNavigationPreloader::didReceiveResponse):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp:
(WebKit::ServiceWorkerSoftUpdateLoader::didReceiveResponse):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::store):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp:
(WebKit::NetworkCache::SpeculativeLoad::didReceiveResponse):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::willPerformHTTPRedirection):
(WebKit::NetworkDataTaskCocoa::tryPasswordBasedAuthentication):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:dataTask:didReceiveResponse:completionHandler:]):
(WebKit::CompletionHandler&lt;void):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm:
(WebKit::PopUpSOAuthorizationSession::completeInternal):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm:
(WebKit::RedirectSOAuthorizationSession::completeInternal):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm:
(WebKit::SubFrameSOAuthorizationSession::completeInternal):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm:
(WebKit::WebExtensionContextProxy::resourceLoadDidReceiveChallenge):
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::PDFPluginStreamLoaderClient::didReceiveResponse):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::shouldSkipDecidePolicyForResponse const):
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp:
(WebCore::SocketStreamHandleImpl::readStreamCallback):
(WebCore::SocketStreamHandleImpl::writeStreamCallback):

Canonical link: <a href="https://commits.webkit.org/273747@main">https://commits.webkit.org/273747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8c0ad91b597f789cb8f53b698643e35578e1af6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39209 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32778 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12566 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31396 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11424 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11450 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40454 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33119 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37376 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35481 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13379 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8284 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->