### PR TITLE
XMLTreeViewer::transformDocumentToTreeView should not call didChangeActiveStyleSheetCandidates

### DIFF
--- a/Source/WebCore/xml/XMLTreeViewer.cpp
+++ b/Source/WebCore/xml/XMLTreeViewer.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2011 Google Inc. All rights reserved.
+ * Copyright (C) 2011-2014 Google Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  * Copyright (C) 2013 Samsung Electronics. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -61,7 +62,6 @@ void XMLTreeViewer::transformDocumentToTreeView()
     String cssString = StringImpl::createWithoutCopying(XMLViewer_css, sizeof(XMLViewer_css));
     auto text = m_document.createTextNode(WTFMove(cssString));
     m_document.getElementById(String("xml-viewer-style"_s))->appendChild(text);
-    m_document.styleScope().didChangeActiveStyleSheetCandidates();
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### ba575dadde29513f46fdb6fb181030d1e5fadaf7
<pre>
XMLTreeViewer::transformDocumentToTreeView should not call didChangeActiveStyleSheetCandidates

<a href="https://bugs.webkit.org/show_bug.cgi?id=250976">https://bugs.webkit.org/show_bug.cgi?id=250976</a>
<a href="https://rdar.apple.com/problem/104797532">rdar://problem/104797532</a>

Reviewed by Ryosuke Niwa.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/7654964eebca76141b8c44ef2f369d547963f577">https://chromium.googlesource.com/chromium/blink/+/7654964eebca76141b8c44ef2f369d547963f577</a>

transformDocumentToTreeView was calling didChangeActiveStyleSheetCandidates
after updating the text inside a `style` element. This isn&apos;t necessary since we already
updated the stylesheets.

* Source/WebCore/xml/XMLTreeViewer.cpp:
(XMLTreeViewer::transformDocumentToTreeView):

Canonical link: <a href="https://commits.webkit.org/273689@main">https://commits.webkit.org/273689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df29665a83220bfe62521da7dab6da0ea5e7b1d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38735 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32398 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/11992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31114 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11100 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11113 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32161 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39983 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32728 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32499 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37064 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9195 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35148 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13027 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/8248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11790 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4715 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->