### PR TITLE
[UnifiedPDF] scrolling is broken after navigating back to a PDF

### DIFF
--- a/LayoutTests/compositing/plugins/pdf/pdf-in-iframe-scrolling-tree-after-back-expected.txt
+++ b/LayoutTests/compositing/plugins/pdf/pdf-in-iframe-scrolling-tree-after-back-expected.txt
@@ -1,0 +1,78 @@
+
+Before navigation:
+
+
+(Frame scrolling node
+  (scrollable area size 800 600)
+  (contents size 800 600)
+  (scrollable area parameters
+    (horizontal scroll elasticity 2)
+    (vertical scroll elasticity 2)
+    (horizontal scrollbar mode 0)
+    (vertical scrollbar mode 0))
+  (layout viewport at (0,0) size 800x600)
+  (min layout viewport origin (0,0))
+  (max layout viewport origin (0,0))
+  (synchronous event dispatch region for event wheel
+    at (10,10) size 300x250)
+  (behavior for fixed 1)
+  (children 1
+    (Frame hosting node
+      (children 1
+        (Frame scrolling node
+          (scrollable area size 300 250)
+          (contents size 300 254)
+          (scrollable area parameters
+            (horizontal scroll elasticity 0)
+            (vertical scroll elasticity 0)
+            (horizontal scrollbar mode 1)
+            (vertical scrollbar mode 1))
+          (layout viewport at (0,0) size 300x250)
+          (min layout viewport origin (0,0))
+          (max layout viewport origin (0,4))
+          (behavior for fixed 1)
+        )
+      )
+    )
+  )
+)
+After back:
+
+
+(Frame scrolling node
+  (scrollable area size 785 600)
+  (contents size 785 891)
+  (scrollable area parameters
+    (horizontal scroll elasticity 2)
+    (vertical scroll elasticity 2)
+    (horizontal scrollbar mode 0)
+    (vertical scrollbar mode 0)
+    (allows vertical scrolling 1))
+  (layout viewport at (0,0) size 785x600)
+  (min layout viewport origin (0,0))
+  (max layout viewport origin (0,291))
+  (synchronous event dispatch region for event wheel
+    at (10,10) size 300x250)
+  (behavior for fixed 1)
+  (children 1
+    (Frame hosting node
+      (children 1
+        (Frame scrolling node
+          (scrollable area size 300 250)
+          (contents size 300 254)
+          (requested scroll position represents programmatic scroll 1)
+          (scrollable area parameters
+            (horizontal scroll elasticity 0)
+            (vertical scroll elasticity 0)
+            (horizontal scrollbar mode 1)
+            (vertical scrollbar mode 1))
+          (layout viewport at (0,0) size 300x250)
+          (min layout viewport origin (0,0))
+          (max layout viewport origin (0,4))
+          (behavior for fixed 1)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/plugins/pdf/pdf-in-iframe-scrolling-tree-after-back.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-in-iframe-scrolling-tree-after-back.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ UnifiedPDFEnabled=true ] -->
+<html>
+<head>
+    <style>
+        iframe {
+            width: 300px;
+            height: 250px;
+        }
+    </style>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        async function doOnFirstLoad()
+        {
+            await UIHelper.renderingUpdate();
+
+            let iframe = document.getElementsByTagName('iframe')[0];
+            if (window.internals)
+                document.getElementById('scrollingtree-before-navigate').innerText = internals.scrollingStateTreeAsText();
+            
+            iframe.contentWindow.location.href = 'resources/go-back.html';
+        }
+        
+        let sawFirstLoad = false;
+        function iframeLoaded(iframeLocation)
+        {
+            const path = iframeLocation.pathname;
+            const filename = path.substring(path.lastIndexOf('/') + 1)
+
+            if (filename === 'green_rectangle.pdf') {
+                if (!sawFirstLoad) {
+                    sawFirstLoad = true;
+                    doOnFirstLoad();
+                    return;
+                }
+                doAfterBack();
+            }
+        }
+
+        async function doAfterBack()
+        {
+            await UIHelper.renderingUpdate();
+
+            if (window.internals)
+                document.getElementById('scrollingtree-after-back').innerText = internals.scrollingStateTreeAsText();
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+        
+    </script>
+</head>
+<body>
+    <iframe onload="iframeLoaded(this.contentWindow.location)" src="../../../fast/images/resources/green_rectangle.pdf"></iframe>
+    <p>Before navigation:</p>
+    <pre id="scrollingtree-before-navigate"></pre>
+    <p>After back:</p>
+    <pre id="scrollingtree-after-back"></pre>
+</body>
+</html>

--- a/LayoutTests/compositing/plugins/pdf/resources/go-back.html
+++ b/LayoutTests/compositing/plugins/pdf/resources/go-back.html
@@ -1,0 +1,8 @@
+This page should go back.
+<script>
+  window.addEventListener("load", function() {
+    setTimeout(function() {
+      history.back();
+    }, 0);
+  }, false);
+</script>

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -184,7 +184,7 @@ private:
     void createScrollbarsController() override;
 
     bool usesAsyncScrolling() const final { return true; }
-    WebCore::ScrollingNodeID scrollingNodeID() const final { return m_scrollingNodeID; }
+    WebCore::ScrollingNodeID scrollingNodeID() const final;
 
     void invalidateScrollbarRect(WebCore::Scrollbar&, const WebCore::IntRect&) override;
     void invalidateScrollCornerRect(const WebCore::IntRect&) override;
@@ -199,6 +199,7 @@ private:
     void positionOverflowControlsLayers();
 
     WebCore::ScrollingCoordinator* scrollingCoordinator();
+    void createScrollingNodeIfNecessary();
 
     // ScrollableArea
     bool requestScrollToPosition(const WebCore::ScrollPosition&, const WebCore::ScrollPositionChangeOptions& = WebCore::ScrollPositionChangeOptions::createProgrammatic()) override;


### PR DESCRIPTION
#### e6168698e8a3a0a3b2df3c26747b814b55f5174f
<pre>
[UnifiedPDF] scrolling is broken after navigating back to a PDF
<a href="https://bugs.webkit.org/show_bug.cgi?id=268228">https://bugs.webkit.org/show_bug.cgi?id=268228</a>
<a href="https://rdar.apple.com/120847163">rdar://120847163</a>

Reviewed by Tim Horton.

When navigating back to a main frame PDF using the UnifiedPDF plugin, we&apos;d fail to hook up
the scrolling tree, resulting in assertions in debug builds, and scrolling failures in release.

The bug happens because when navigating back, the ordering of creating the plugin&apos;s scrolling
node, and the main frame&apos;s scrolling node is different; the plugin node gets created first,
but with no parent, so it&apos;s thrown away, and the scrolling coordinator re-creates it later
with the same ID, but without the necessary layers.

Fix by creating the plugin&apos;s scrolling node on demand, when scrollingNodeID() is called.

The new test doesn&apos;t not actually replicate the bug (we can&apos;t yet test main frame PDFs),
but seems like a good test to have that exercises history.back() in an iframe with a PDF.

* LayoutTests/compositing/plugins/pdf/pdf-in-iframe-scrolling-tree-after-back-expected.txt: Added.
* LayoutTests/compositing/plugins/pdf/pdf-in-iframe-scrolling-tree-after-back.html: Added.
* LayoutTests/compositing/plugins/pdf/resources/go-back.html: Added.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::ensureLayers):
(WebKit::UnifiedPDFPlugin::scrollingNodeID const):
(WebKit::UnifiedPDFPlugin::createScrollingNodeIfNecessary):

Canonical link: <a href="https://commits.webkit.org/273727@main">https://commits.webkit.org/273727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53f484794ec223581d76e30cf8a043b7cdab0568

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38745 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32408 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12002 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31121 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36581 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11107 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39993 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32738 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37070 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11295 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35154 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31817 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8266 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11801 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->