### PR TITLE
Add some extra hardening to prevent crashes in -[WKScrollingNodeScrollViewDelegate axesToPreventScrollingForPanGestureInScrollView:]

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
@@ -117,6 +117,17 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         break;
     }
 
+    switch ([_axisLockingPanGestureRecognizer state]) {
+    case UIGestureRecognizerStateCancelled:
+    case UIGestureRecognizerStateFailed:
+        return;
+    case UIGestureRecognizerStatePossible:
+    case UIGestureRecognizerStateBegan:
+    case UIGestureRecognizerStateChanged:
+    case UIGestureRecognizerStateEnded:
+        break;
+    }
+
     auto axesToPrevent = self._axesToPreventScrollingFromDelegate;
     if (axesToPrevent == UIAxisNeither)
         return;


### PR DESCRIPTION
#### 05300cb368e3a4d9bce9c55e3030bb7570dafcc3
<pre>
Add some extra hardening to prevent crashes in -[WKScrollingNodeScrollViewDelegate axesToPreventScrollingForPanGestureInScrollView:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=268229">https://bugs.webkit.org/show_bug.cgi?id=268229</a>
<a href="https://rdar.apple.com/121329521">rdar://121329521</a>

Reviewed by Aditya Keerthi.

While re-reading some of the crash logs in <a href="https://rdar.apple.com/121329521">rdar://121329521</a>, I realized that the speculative
mitigation in 273443@main only takes care of the case where the scroll view is either directly
removed with a call to `-removeFromSuperview`, or no longer in the view hierarchy. However, it&apos;s
possible that a view above the `WKBaseScrollView` was unparented, which might cause UIKit to
internally transition the axis locking pan gesture to either `.failed` or `.cancelled` state and
invoke the action.

Add some extra hardening to be robust in this scenario as well, by bailing in the case where the
axis-locking pan gesture is either cancelled or failed.

* Source/WebKit/UIProcess/ios/WKBaseScrollView.mm:
(-[WKBaseScrollView _updatePanGestureToPreventScrolling]):

Canonical link: <a href="https://commits.webkit.org/273613@main">https://commits.webkit.org/273613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6ac4b8c0d9b7225ea97f3644a091d71b8c3d204

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38750 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32413 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31127 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11113 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11130 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/39998 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32743 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37077 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11300 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35161 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13042 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8201 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11806 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12138 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->