### PR TITLE
Deduplicate logic from queuePopoverToggleEventTask & queueDetailsToggleEventTask

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1290,6 +1290,7 @@ dom/PendingScript.cpp
 dom/PointerEvent.cpp
 dom/PointerEventTypeNames.cpp
 dom/PopStateEvent.cpp
+dom/PopoverData.cpp
 dom/Position.cpp
 dom/PositionIterator.cpp
 dom/ProcessingInstruction.cpp
@@ -1332,6 +1333,7 @@ dom/TextEncoderStreamEncoder.cpp
 dom/TextEvent.cpp
 dom/TextNodeTraversal.cpp
 dom/ToggleEvent.cpp
+dom/ToggleEventTask.cpp
 dom/Touch.cpp @no-unify
 dom/TouchEvent.cpp @no-unify
 dom/TouchList.cpp @no-unify

--- a/Source/WebCore/dom/PopoverData.cpp
+++ b/Source/WebCore/dom/PopoverData.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PopoverData.h"
+
+#include "ToggleEventTask.h"
+
+namespace WebCore {
+
+Ref<ToggleEventTask> PopoverData::ensureToggleEventTask(Element& element)
+{
+    if (!m_toggleEventTask)
+        m_toggleEventTask = ToggleEventTask::create(element);
+
+    return *m_toggleEventTask;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/PopoverData.h
+++ b/Source/WebCore/dom/PopoverData.h
@@ -28,6 +28,7 @@
 #include "Element.h"
 #include "HTMLElement.h"
 #include "HTMLFormControlElement.h"
+#include "ToggleEventTask.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -35,11 +36,6 @@ namespace WebCore {
 enum class PopoverVisibilityState : bool {
     Hidden,
     Showing,
-};
-
-struct PopoverToggleEventData {
-    PopoverVisibilityState oldState;
-    PopoverVisibilityState newState;
 };
 
 class PopoverData {
@@ -56,9 +52,7 @@ public:
     Element* previouslyFocusedElement() const { return m_previouslyFocusedElement.get(); }
     void setPreviouslyFocusedElement(Element* element) { m_previouslyFocusedElement = element; }
 
-    std::optional<PopoverToggleEventData> queuedToggleEventData() const { return m_queuedToggleEventData; }
-    void setQueuedToggleEventData(PopoverToggleEventData data) { m_queuedToggleEventData = data; }
-    void clearQueuedToggleEventData() { m_queuedToggleEventData = std::nullopt; }
+    Ref<ToggleEventTask> ensureToggleEventTask(Element&);
 
     HTMLFormControlElement* invoker() const { return m_invoker.get(); }
     void setInvoker(const HTMLFormControlElement* element) { m_invoker = element; }
@@ -86,8 +80,8 @@ public:
 private:
     PopoverState m_popoverState;
     PopoverVisibilityState m_visibilityState;
-    std::optional<PopoverToggleEventData> m_queuedToggleEventData;
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_previouslyFocusedElement;
+    RefPtr<ToggleEventTask> m_toggleEventTask;
     WeakPtr<HTMLFormControlElement, WeakPtrImplWithEventTargetData> m_invoker;
     bool m_isHidingOrShowingPopover = false;
 };

--- a/Source/WebCore/dom/ToggleEventTask.cpp
+++ b/Source/WebCore/dom/ToggleEventTask.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ToggleEventTask.h"
+
+#include "EventNames.h"
+#include "ToggleEvent.h"
+
+namespace WebCore {
+
+Ref<ToggleEventTask> ToggleEventTask::create(Element& element)
+{
+    return adoptRef(*new ToggleEventTask(element));
+}
+
+void ToggleEventTask::queue(ToggleState oldState, ToggleState newState)
+{
+    if (m_data)
+        oldState = m_data->oldState;
+
+    RefPtr element = m_element.get();
+    if (!element)
+        return;
+
+    m_data = { oldState, newState };
+    element->queueTaskKeepingThisNodeAlive(TaskSource::DOMManipulation, [this, newState] {
+        if (!m_data || m_data->newState != newState)
+            return;
+
+        auto stringForState = [](ToggleState state) {
+            return state == ToggleState::Closed ? "closed"_s : "open"_s;
+        };
+
+        RefPtr element = m_element.get();
+        if (!element)
+            return;
+
+        auto data = *std::exchange(m_data, std::nullopt);
+        element->dispatchEvent(ToggleEvent::create(eventNames().toggleEvent, { EventInit { }, stringForState(data.oldState), stringForState(data.newState) }, Event::IsCancelable::No));
+    });
+}
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ToggleEventTask.h
+++ b/Source/WebCore/dom/ToggleEventTask.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Keith Cirkel <webkit@keithcirkel.co.uk>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Element.h"
+
+namespace WebCore {
+
+enum class ToggleState : bool {
+    Closed,
+    Open,
+};
+
+struct ToggleEventData {
+    ToggleState oldState;
+    ToggleState newState;
+};
+
+class ToggleEventTask final: public RefCounted<ToggleEventTask> {
+public:
+    static Ref<ToggleEventTask> create(Element&);
+
+    void queue(ToggleState oldState, ToggleState newState);
+
+private:
+    ToggleEventTask(Element& element)
+        : m_element(element) { }
+
+    WeakPtr<Element, WeakPtrImplWithEventTargetData> m_element;
+    std::optional<ToggleEventData> m_data;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/html/HTMLDetailsElement.h
+++ b/Source/WebCore/html/HTMLDetailsElement.h
@@ -26,16 +26,7 @@
 namespace WebCore {
 
 class HTMLSlotElement;
-
-enum class DetailsState : bool {
-    Open,
-    Closed,
-};
-
-struct DetailsToggleEventData {
-    DetailsState oldState;
-    DetailsState newState;
-};
+class ToggleEventTask;
 
 class HTMLDetailsElement final : public HTMLElement {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(HTMLDetailsElement);
@@ -48,11 +39,7 @@ public:
 
     bool isActiveSummary(const HTMLSummaryElement&) const;
 
-    void queueDetailsToggleEventTask(DetailsState oldState, DetailsState newState);
-
-    std::optional<DetailsToggleEventData> queuedToggleEventData() const { return m_queuedToggleEventData; }
-    void setQueuedToggleEventData(DetailsToggleEventData data) { m_queuedToggleEventData = data; }
-    void clearQueuedToggleEventData() { m_queuedToggleEventData = std::nullopt; }
+    void queueDetailsToggleEventTask(ToggleState oldState, ToggleState newState);
 
 private:
     HTMLDetailsElement(const QualifiedName&, Document&);
@@ -71,7 +58,7 @@ private:
     WeakPtr<HTMLSummaryElement, WeakPtrImplWithEventTargetData> m_defaultSummary;
     RefPtr<HTMLSlotElement> m_defaultSlot;
 
-    std::optional<DetailsToggleEventData> m_queuedToggleEventData;
+    RefPtr<ToggleEventTask> m_toggleEventTask;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -46,18 +46,20 @@ struct TextRecognitionResult;
 
 enum class EnterKeyHint : uint8_t;
 enum class PageIsEditable : bool;
+enum class PopoverVisibilityState : bool;
+enum class ToggleState : bool;
+
+#if PLATFORM(IOS_FAMILY)
+enum class SelectionRenderingBehavior : bool;
+#endif
+
 enum class FireEvents : bool { No, Yes };
 enum class FocusPreviousElement : bool { No, Yes };
-enum class PopoverVisibilityState : bool;
 enum class PopoverState : uint8_t {
     None,
     Auto,
     Manual,
 };
-
-#if PLATFORM(IOS_FAMILY)
-enum class SelectionRenderingBehavior : bool;
-#endif
 
 class HTMLElement : public StyledElement {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(HTMLElement);
@@ -146,7 +148,7 @@ public:
 
     WEBCORE_EXPORT ExceptionOr<Ref<ElementInternals>> attachInternals();
 
-    void queuePopoverToggleEventTask(PopoverVisibilityState oldState, PopoverVisibilityState newState);
+    void queuePopoverToggleEventTask(ToggleState oldState, ToggleState newState);
     ExceptionOr<void> showPopover(const HTMLFormControlElement* = nullptr);
     ExceptionOr<void> hidePopover();
     ExceptionOr<void> hidePopoverInternal(FocusPreviousElement, FireEvents);


### PR DESCRIPTION
#### 9cf5cec66cd0dfae4cf02b2bc64dde5d300422bc
<pre>
Deduplicate logic from queuePopoverToggleEventTask &amp; queueDetailsToggleEventTask
<a href="https://bugs.webkit.org/show_bug.cgi?id=268230">https://bugs.webkit.org/show_bug.cgi?id=268230</a>

Reviewed by Darin Adler.

This deduplicates the logic of the two Toggle Events by creating a
separate ToggleEventTask which houses the two ToggleEvent states.
This means that Popover &amp; Details elements only need to store a
reference to ToggleEventTask, and the `queue` function will execute
the necessary logic, and retain values from the initial queue.
This enables further use of ToggleEvents by other elements, such as
the HTMLDialogElement.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/PopoverData.cpp: Added.
(WebCore::PopoverData::ensureToggleEventTask):
* Source/WebCore/dom/PopoverData.h:
(WebCore::PopoverData::queuedToggleEventData const): Deleted.
(WebCore::PopoverData::setQueuedToggleEventData): Deleted.
(WebCore::PopoverData::clearQueuedToggleEventData): Deleted.
* Source/WebCore/dom/ToggleEventTask.cpp: Added.
(WebCore::ToggleEventTask::create):
(WebCore::ToggleEventTask::queue):
* Source/WebCore/dom/ToggleEventTask.h: Added.
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::queueDetailsToggleEventTask):
(WebCore::HTMLDetailsElement::attributeChanged):
* Source/WebCore/html/HTMLDetailsElement.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::queuePopoverToggleEventTask):
(WebCore::HTMLElement::showPopover):
(WebCore::HTMLElement::hidePopoverInternal):
* Source/WebCore/html/HTMLElement.h:

Canonical link: <a href="https://commits.webkit.org/286884@main">https://commits.webkit.org/286884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94a31d9010e05ed8f22020bd4393a4036bc90ed0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/77356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/56391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/30272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/81931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/28638 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/79473 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/65539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/4688 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/60606 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/18637 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/80423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/50585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/66400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/40904 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/47987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/23898 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/26961 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/69098 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/24236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/83345 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/4736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/3218 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/68873 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/4892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/66370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/68131 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17021 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/12126 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/10229 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/4683 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/7498 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/4702 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/8137 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/6461 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->