### PR TITLE
Remove `:-webkit-full-screen-controls-hidden` pseudo-class

### DIFF
--- a/LayoutTests/fullscreen/fullscreen-env-expected.txt
+++ b/LayoutTests/fullscreen/fullscreen-env-expected.txt
@@ -20,10 +20,5 @@ RUN(internals.setFullscreenAutoHideDuration(30))
 EXPECTED (window.getComputedStyle(target).transitionDuration == '30s') OK
 RUN(internals.setFullscreenAutoHideDuration(0))
 EXPECTED (window.getComputedStyle(target).transitionDuration == '0s') OK
-EVENT(webkitfullscreenchange)
-RUN(internals.setFullscreenControlsHidden(true))
-EXPECTED (document.querySelector("#target:-webkit-full-screen-controls-hidden") == '[object HTMLDivElement]') OK
-RUN(internals.setFullscreenControlsHidden(false))
-EXPECTED (document.querySelector("#target:-webkit-full-screen-controls-hidden") == 'null') OK
 END OF TEST
 

--- a/LayoutTests/fullscreen/fullscreen-env.html
+++ b/LayoutTests/fullscreen/fullscreen-env.html
@@ -26,14 +26,7 @@
             testExpected('window.getComputedStyle(target).transitionDuration', '30s');
             run('internals.setFullscreenAutoHideDuration(0)');
             testExpected('window.getComputedStyle(target).transitionDuration', '0s');
-            runWithKeyDown(() => {target.webkitRequestFullscreen() });
-            waitForEventOnce(document, 'webkitfullscreenchange', event => {
-                run('internals.setFullscreenControlsHidden(true)');
-                testExpected('document.querySelector("#target:-webkit-full-screen-controls-hidden")', target);
-                run('internals.setFullscreenControlsHidden(false)');
-                testExpected('document.querySelector("#target:-webkit-full-screen-controls-hidden")', null);
-                endTest();
-            });
+            endTest();
         });
     </script>
     <style>

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -78,11 +78,6 @@
             "conditional": "ENABLE(FULLSCREEN_API)",
             "status": "non-standard"
         },
-        "-webkit-full-screen-controls-hidden": {
-            "comment": "For compatibility.",
-            "conditional": "ENABLE(FULLSCREEN_API)",
-            "status": "non-standard"
-        },
         "active": {},
         "any-link": {
             "aliases": [

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1057,8 +1057,6 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
             return matchesFullScreenAncestorPseudoClass(element);
         case CSSSelector::PseudoClass::WebKitFullScreenDocument:
             return matchesFullScreenDocumentPseudoClass(element);
-        case CSSSelector::PseudoClass::WebKitFullScreenControlsHidden:
-            return matchesFullScreenControlsHiddenPseudoClass(element);
 #endif
 #if ENABLE(PICTURE_IN_PICTURE_API)
         case CSSSelector::PseudoClass::PictureInPicture:

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -438,14 +438,6 @@ ALWAYS_INLINE bool matchesFullScreenDocumentPseudoClass(const Element& element)
     return fullscreenManager && fullscreenManager->fullscreenElement();
 }
 
-ALWAYS_INLINE bool matchesFullScreenControlsHiddenPseudoClass(const Element& element)
-{
-    CheckedPtr fullscreenManager = element.document().fullscreenManagerIfExists();
-    if (!fullscreenManager || &element != fullscreenManager->fullscreenElement())
-        return false;
-    return fullscreenManager->areFullscreenControlsHidden();
-}
-
 #endif
 
 #if ENABLE(PICTURE_IN_PICTURE_API)

--- a/Source/WebCore/css/process-css-pseudo-selectors.py
+++ b/Source/WebCore/css/process-css-pseudo-selectors.py
@@ -57,7 +57,7 @@ KNOWN_KEY_TYPES = {
 # - an `-internal-` prefix for things only meant to be styled in the user agent stylesheet
 # - an `-apple-` prefix only exposed to certain Apple clients (there is a settings-flag requirement for using this prefix)
 WEBKIT_PREFIX_COUNTS_DO_NOT_INCREASE = {
-    'pseudo-classes': 8,
+    'pseudo-classes': 7,
     'pseudo-elements': 59,
 }
 

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -110,7 +110,6 @@ using PseudoClassesSet = HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::
     v(operationMatchesFullScreenDocumentPseudoClass) \
     v(operationMatchesFullScreenAncestorPseudoClass) \
     v(operationMatchesFullScreenAnimatingFullScreenTransitionPseudoClass) \
-    v(operationMatchesFullScreenControlsHiddenPseudoClass) \
     v(operationMatchesPictureInPicturePseudoClass) \
     v(operationMatchesFutureCuePseudoClass) \
     v(operationMatchesPastCuePseudoClass) \
@@ -260,7 +259,6 @@ static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullscreen
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullScreenDocumentPseudoClass, bool, (const Element&));
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullScreenAncestorPseudoClass, bool, (const Element&));
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullScreenAnimatingFullScreenTransitionPseudoClass, bool, (const Element&));
-static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullScreenControlsHiddenPseudoClass, bool, (const Element&));
 #endif
 #if ENABLE(PICTURE_IN_PICTURE_API)
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesPictureInPicturePseudoClass, bool, (const Element&));
@@ -918,12 +916,6 @@ JSC_DEFINE_JIT_OPERATION(operationMatchesFullScreenAnimatingFullScreenTransition
     COUNT_SELECTOR_OPERATION(operationMatchesFullScreenAnimatingFullScreenTransitionPseudoClass);
     return matchesFullScreenAnimatingFullScreenTransitionPseudoClass(element);
 }
-
-JSC_DEFINE_JIT_OPERATION(operationMatchesFullScreenControlsHiddenPseudoClass, bool, (const Element& element))
-{
-    COUNT_SELECTOR_OPERATION(operationMatchesFullScreenControlsHiddenPseudoClass);
-    return matchesFullScreenControlsHiddenPseudoClass(element);
-}
 #endif
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
@@ -1124,10 +1116,6 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
         return FunctionType::SimpleSelectorChecker;
     case CSSSelector::PseudoClass::InternalAnimatingFullScreenTransition:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenAnimatingFullScreenTransitionPseudoClass));
-        return FunctionType::SimpleSelectorChecker;
-
-    case CSSSelector::PseudoClass::WebKitFullScreenControlsHidden:
-        fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenControlsHiddenPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 #endif
 

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -743,24 +743,6 @@ void FullscreenManager::setAnimatingFullscreen(bool flag)
     m_isAnimatingFullscreen = flag;
 }
 
-bool FullscreenManager::areFullscreenControlsHidden() const
-{
-    return m_areFullscreenControlsHidden;
-}
-
-void FullscreenManager::setFullscreenControlsHidden(bool flag)
-{
-    if (m_areFullscreenControlsHidden == flag)
-        return;
-
-    INFO_LOG(LOGIDENTIFIER, flag);
-
-    std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
-    if (m_fullscreenElement)
-        emplace(styleInvalidation, *m_fullscreenElement, { { CSSSelector::PseudoClass::WebKitFullScreenControlsHidden, flag } });
-    m_areFullscreenControlsHidden = flag;
-}
-
 void FullscreenManager::clear()
 {
     m_fullscreenElement = nullptr;

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -87,9 +87,6 @@ public:
     WEBCORE_EXPORT bool isAnimatingFullscreen() const;
     WEBCORE_EXPORT void setAnimatingFullscreen(bool);
 
-    WEBCORE_EXPORT bool areFullscreenControlsHidden() const;
-    WEBCORE_EXPORT void setFullscreenControlsHidden(bool);
-
     void clear();
     void emptyEventQueue();
 
@@ -127,7 +124,6 @@ private:
 
     bool m_areKeysEnabledInFullscreen { false };
     bool m_isAnimatingFullscreen { false };
-    bool m_areFullscreenControlsHidden { false };
 
 #if !RELEASE_LOG_DISABLED
     const void* m_logIdentifier;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3799,17 +3799,6 @@ void Page::setFullscreenAutoHideDuration(Seconds duration)
     });
 }
 
-void Page::setFullscreenControlsHidden(bool hidden)
-{
-#if ENABLE(FULLSCREEN_API)
-    forEachDocument([&] (Document& document) {
-        document.fullscreenManager().setFullscreenControlsHidden(hidden);
-    });
-#else
-    UNUSED_PARAM(hidden);
-#endif
-}
-
 Document* Page::outermostFullscreenDocument() const
 {
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -560,14 +560,13 @@ public:
 
     const Seconds fullscreenAutoHideDuration() const { return m_fullscreenAutoHideDuration; }
     WEBCORE_EXPORT void setFullscreenAutoHideDuration(Seconds);
-    WEBCORE_EXPORT void setFullscreenControlsHidden(bool);
 
     Document* outermostFullscreenDocument() const;
 
     bool shouldSuppressScrollbarAnimations() const { return m_suppressScrollbarAnimations; }
     WEBCORE_EXPORT void setShouldSuppressScrollbarAnimations(bool suppressAnimations);
     void lockAllOverlayScrollbarsToHidden(bool lockOverlayScrollbars);
-    
+
     WEBCORE_EXPORT void setVerticalScrollElasticity(ScrollElasticity);
     ScrollElasticity verticalScrollElasticity() const { return static_cast<ScrollElasticity>(m_verticalScrollElasticity); }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -640,7 +640,6 @@ void Internals::resetToConsistentState(Page& page)
 
     page.setFullscreenAutoHideDuration(0_s);
     page.setFullscreenInsets({ });
-    page.setFullscreenControlsHidden(false);
 
     MediaEngineConfigurationFactory::disableMock();
 
@@ -3790,14 +3789,6 @@ void Internals::setFullscreenAutoHideDuration(double duration)
     ASSERT(page);
 
     page->setFullscreenAutoHideDuration(Seconds(duration));
-}
-
-void Internals::setFullscreenControlsHidden(bool hidden)
-{
-    Page* page = contextDocument()->frame()->page();
-    ASSERT(page);
-
-    page->setFullscreenControlsHidden(hidden);
 }
 
 #if ENABLE(VIDEO)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -609,7 +609,6 @@ public:
     };
     void setFullscreenInsets(FullscreenInsets);
     void setFullscreenAutoHideDuration(double);
-    void setFullscreenControlsHidden(bool);
 
 #if ENABLE(VIDEO)
     bool isChangingPresentationMode(HTMLVideoElement&) const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -777,7 +777,6 @@ typedef (FetchRequest or FetchResponse) FetchObject;
 
     undefined setFullscreenInsets(FullscreenInsets insets);
     undefined setFullscreenAutoHideDuration(double duration);
-    undefined setFullscreenControlsHidden(boolean hidden);
 
     [Conditional=VIDEO] boolean isChangingPresentationMode(HTMLVideoElement element);
     [Conditional=VIDEO_PRESENTATION_MODE] undefined setMockVideoPresentationModeEnabled(boolean enabled);

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -163,11 +163,6 @@ void WebFullScreenManagerProxy::setFullscreenAutoHideDuration(Seconds duration)
     m_page.send(Messages::WebFullScreenManager::SetFullscreenAutoHideDuration(duration));
 }
 
-void WebFullScreenManagerProxy::setFullscreenControlsHidden(bool hidden)
-{
-    m_page.send(Messages::WebFullScreenManager::SetFullscreenControlsHidden(hidden));
-}
-
 void WebFullScreenManagerProxy::close()
 {
     m_client.closeFullScreenManager();

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -99,7 +99,6 @@ public:
     void restoreScrollPosition();
     void setFullscreenInsets(const WebCore::FloatBoxExtent&);
     void setFullscreenAutoHideDuration(Seconds);
-    void setFullscreenControlsHidden(bool);
     void closeWithCallback(CompletionHandler<void()>&&);
     bool lockFullscreenOrientation(WebCore::ScreenOrientationType);
     void unlockFullscreenOrientation();

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -260,8 +260,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             [NSLayoutConstraint deactivateConstraints:@[_topConstraint.get()]];
         _topConstraint = [[_topGuide topAnchor] constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor];
         [_topConstraint setActive:YES];
-        if (auto* manager = self._manager)
-            manager->setFullscreenControlsHidden(false);
     }];
 }
 
@@ -287,8 +285,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [_stackView setAlpha:0];
         self.prefersStatusBarHidden = YES;
         self.prefersHomeIndicatorAutoHidden = YES;
-        if (auto* manager = self._manager)
-            manager->setFullscreenControlsHidden(true);
     } completion:^(BOOL finished) {
         if (!finished)
             return;

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -458,11 +458,6 @@ void WebFullScreenManager::setFullscreenAutoHideDuration(Seconds duration)
     m_page->corePage()->setFullscreenAutoHideDuration(duration);
 }
 
-void WebFullScreenManager::setFullscreenControlsHidden(bool hidden)
-{
-    m_page->corePage()->setFullscreenControlsHidden(hidden);
-}
-
 void WebFullScreenManager::handleEvent(WebCore::ScriptExecutionContext& context, WebCore::Event& event)
 {
 #if ENABLE(VIDEO)

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -90,7 +90,6 @@ protected:
     void requestExitFullScreen();
     void setFullscreenInsets(const WebCore::FloatBoxExtent&);
     void setFullscreenAutoHideDuration(Seconds);
-    void setFullscreenControlsHidden(bool);
 
     void didReceiveWebFullScreenManagerMessage(IPC::Connection&, IPC::Decoder&);
 

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in
@@ -33,6 +33,5 @@ messages -> WebFullScreenManager LegacyReceiver {
     RestoreScrollPosition()
     SetFullscreenInsets(WebCore::RectEdges<float> insets)
     SetFullscreenAutoHideDuration(Seconds duration)
-    SetFullscreenControlsHidden(bool hidden)
 }
 #endif


### PR DESCRIPTION
#### b706dea06d356ce202580d6bc1310c1dfa141b11
<pre>
Remove `:-webkit-full-screen-controls-hidden` pseudo-class
<a href="https://bugs.webkit.org/show_bug.cgi?id=267820">https://bugs.webkit.org/show_bug.cgi?id=267820</a>
<a href="https://rdar.apple.com/121323330">rdar://121323330</a>

Reviewed by Anne van Kesteren.

This was created but never evangelized, so it ended up never getting adoption.

* LayoutTests/fullscreen/fullscreen-env-expected.txt:
* LayoutTests/fullscreen/fullscreen-env.html:
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesFullScreenControlsHiddenPseudoClass): Deleted.
* Source/WebCore/css/process-css-pseudo-selectors.py:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::JSC_DEFINE_JIT_OPERATION):
(WebCore::SelectorCompiler::addPseudoClassType):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::areFullscreenControlsHidden const): Deleted.
(WebCore::FullscreenManager::setFullscreenControlsHidden): Deleted.
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setFullscreenControlsHidden): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
(WebCore::Internals::setFullscreenControlsHidden): Deleted.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::setFullscreenControlsHidden): Deleted.
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController showUI]):
(-[WKFullScreenViewController hideUI]):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::setFullscreenControlsHidden): Deleted.
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in:

Canonical link: <a href="https://commits.webkit.org/273619@main">https://commits.webkit.org/273619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9785aee9397c1acb250e73b4c5f37a1bf844242

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38330 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/38849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37350 "Failed to checkout and rebase branch from PR 23362") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12103 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36683 "Failed to checkout and rebase branch from PR 23362") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/12731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/11161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/32227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40095 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/32796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/32595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/35208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13102 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/31889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4671 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->