### PR TITLE
Make `:-webkit-full-page-media` an internal pseudo-class

### DIFF
--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -46,6 +46,7 @@
             "conditional": "ENABLE(FULLSCREEN_API)"
         },
         "-internal-html-document": {},
+        "-internal-media-document": {},
         "-webkit-any": {
             "argument": "required",
             "comment": "Alias of :is() with different specificity rules.",
@@ -65,10 +66,6 @@
         },
         "-webkit-drag": {
             "comment": "Currently has no standard equivalent.",
-            "status": "non-standard"
-        },
-        "-webkit-full-page-media": {
-            "comment": "For UA stylesheet use.",
             "status": "non-standard"
         },
         "-webkit-full-screen-ancestor": {

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1021,8 +1021,6 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
             break;
         case CSSSelector::PseudoClass::Enabled:
             return matchesEnabledPseudoClass(element);
-        case CSSSelector::PseudoClass::WebKitFullPageMedia:
-            return isMediaDocument(element);
         case CSSSelector::PseudoClass::Default:
             return matchesDefaultPseudoClass(element);
         case CSSSelector::PseudoClass::Disabled:
@@ -1128,6 +1126,9 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
 #endif
         case CSSSelector::PseudoClass::InternalHTMLDocument:
             return matchesHtmlDocumentPseudoClass(element);
+
+        case CSSSelector::PseudoClass::InternalMediaDocument:
+            return isMediaDocument(element);
 
         case CSSSelector::PseudoClass::PopoverOpen:
             return matchesPopoverOpenPseudoClass(element);

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -159,7 +159,7 @@ dialog::backdrop {
 
 /* media elements */
 
-body:-webkit-full-page-media {
+body:-internal-media-document {
     background-color: rgb(38, 38, 38);
 }
 

--- a/Source/WebCore/css/mediaControls.css
+++ b/Source/WebCore/css/mediaControls.css
@@ -52,13 +52,13 @@
     text-align: right;
 }
 
-video:-webkit-full-page-media {
+video:-internal-media-document {
     margin: auto;
     position: absolute;
     inset: 0;
 }
 
-video:-webkit-full-page-media::-webkit-media-controls-panel {
+video:-internal-media-document::-webkit-media-controls-panel {
     bottom: 0px;
 }
 

--- a/Source/WebCore/css/process-css-pseudo-selectors.py
+++ b/Source/WebCore/css/process-css-pseudo-selectors.py
@@ -57,7 +57,7 @@ KNOWN_KEY_TYPES = {
 # - an `-internal-` prefix for things only meant to be styled in the user agent stylesheet
 # - an `-apple-` prefix only exposed to certain Apple clients (there is a settings-flag requirement for using this prefix)
 WEBKIT_PREFIX_COUNTS_DO_NOT_INCREASE = {
-    'pseudo-classes': 9,
+    'pseudo-classes': 8,
     'pseudo-elements': 59,
 }
 

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1081,9 +1081,6 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
     case CSSSelector::PseudoClass::FocusWithin:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFocusWithinPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClass::WebKitFullPageMedia:
-        fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsMediaDocument));
-        return FunctionType::SimpleSelectorChecker;
     case CSSSelector::PseudoClass::InRange:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsInRange));
         return FunctionType::SimpleSelectorChecker;
@@ -1178,6 +1175,10 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
 
     case CSSSelector::PseudoClass::InternalHTMLDocument:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesHtmlDocumentPseudoClass));
+        return FunctionType::SimpleSelectorChecker;
+
+    case CSSSelector::PseudoClass::InternalMediaDocument:
+        fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsMediaDocument));
         return FunctionType::SimpleSelectorChecker;
 
     case CSSSelector::PseudoClass::PopoverOpen:


### PR DESCRIPTION
#### 77fb3649ec46dea08154a9f96e0d06fd5b9cb0bf
<pre>
Make `:-webkit-full-page-media` an internal pseudo-class
<a href="https://bugs.webkit.org/show_bug.cgi?id=268231">https://bugs.webkit.org/show_bug.cgi?id=268231</a>
<a href="https://rdar.apple.com/121752962">rdar://121752962</a>

Reviewed by Anne van Kesteren.

This matches for media documents only, which webpages can&apos;t style anyway, so unexpose this pseudo-class to be internal only.

* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/html.css:
(body:-internal-media-document):
(body:-webkit-full-page-media): Deleted.
* Source/WebCore/css/mediaControls.css:
(video:-internal-media-document):
(video:-internal-media-document::-webkit-media-controls-panel):
(video:-webkit-full-page-media): Deleted.
(video:-webkit-full-page-media::-webkit-media-controls-panel): Deleted.
* Source/WebCore/css/process-css-pseudo-selectors.py:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):

Canonical link: <a href="https://commits.webkit.org/273618@main">https://commits.webkit.org/273618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3258afafbf9073cffb5478222060e6f4695eb65d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38753 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32416 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31130 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/31993 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11116 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40001 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32746 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37079 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9210 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35163 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13045 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/8206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11809 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4670 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->