### PR TITLE
Remove `FullscreenManager::currentFullscreenElement()`

### DIFF
--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -419,15 +419,15 @@ ALWAYS_INLINE bool matchesFullscreenPseudoClass(const Element& element)
 ALWAYS_INLINE bool matchesFullScreenAnimatingFullScreenTransitionPseudoClass(const Element& element)
 {
     CheckedPtr fullscreenManager = element.document().fullscreenManagerIfExists();
-    if (!fullscreenManager || &element != fullscreenManager->currentFullscreenElement())
+    if (!fullscreenManager || &element != fullscreenManager->fullscreenElement())
         return false;
     return fullscreenManager->isAnimatingFullscreen();
 }
 
 ALWAYS_INLINE bool matchesFullScreenAncestorPseudoClass(const Element& element)
 {
-    auto* currentFullscreenElement = element.document().fullscreenManager().currentFullscreenElement();
-    return currentFullscreenElement && currentFullscreenElement->isDescendantOrShadowDescendantOf(element);
+    auto* fullscreenElement = element.document().fullscreenManager().fullscreenElement();
+    return fullscreenElement && fullscreenElement->isDescendantOrShadowDescendantOf(element);
 }
 
 ALWAYS_INLINE bool matchesFullScreenDocumentPseudoClass(const Element& element)

--- a/Source/WebCore/dom/DocumentFullscreen.h
+++ b/Source/WebCore/dom/DocumentFullscreen.h
@@ -47,7 +47,7 @@ public:
     WEBCORE_EXPORT static void webkitExitFullscreen(Document&);
     static bool webkitIsFullScreen(Document& document) { return document.fullscreenManager().isFullscreen(); }
     static bool webkitFullScreenKeyboardInputAllowed(Document& document) { return document.fullscreenManager().isFullscreenKeyboardInputAllowed(); }
-    static Element* webkitCurrentFullScreenElement(Document& document) { return document.ancestorElementInThisScope(document.fullscreenManager().currentFullscreenElement()); }
+    static Element* webkitCurrentFullScreenElement(Document& document) { return document.ancestorElementInThisScope(document.fullscreenManager().fullscreenElement()); }
     static void webkitCancelFullScreen(Document& document) { document.fullscreenManager().cancelFullscreen(); }
 };
 

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -778,8 +778,6 @@ void FullscreenManager::addDocumentToFullscreenChangeEventQueue(Document& docume
 {
     Node* target = document.fullscreenManager().fullscreenElement();
     if (!target)
-        target = document.fullscreenManager().currentFullscreenElement();
-    if (!target)
         target = &document;
     m_fullscreenChangeEventTargetQueue.append(GCReachableRef(*target));
 }

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -61,9 +61,8 @@ public:
     WEBCORE_EXPORT void exitFullscreen(RefPtr<DeferredPromise>&&);
 
     // Mozilla versions.
-    bool isFullscreen() const { return m_fullscreenElement.get(); }
-    bool isFullscreenKeyboardInputAllowed() const { return m_fullscreenElement.get() && m_areKeysEnabledInFullscreen; }
-    Element* currentFullscreenElement() const { return m_fullscreenElement.get(); }
+    bool isFullscreen() const { return fullscreenElement(); }
+    bool isFullscreenKeyboardInputAllowed() const { return fullscreenElement() && m_areKeysEnabledInFullscreen; }
     WEBCORE_EXPORT void cancelFullscreen();
 
     enum FullscreenCheckType {

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6478,7 +6478,7 @@ bool HTMLMediaElement::elementIsHidden() const
 {
 #if ENABLE(FULLSCREEN_API)
     auto* fullscreenManager = document().fullscreenManagerIfExists();
-    if (isVideo() && fullscreenManager && fullscreenManager->isFullscreen() && fullscreenManager->currentFullscreenElement())
+    if (isVideo() && fullscreenManager && fullscreenManager->isFullscreen() && fullscreenManager->fullscreenElement())
         return false;
 #endif
 
@@ -6773,7 +6773,7 @@ bool HTMLMediaElement::isFullscreen() const
 {
 #if ENABLE(FULLSCREEN_API)
     CheckedPtr fullscreenManager = document().fullscreenManagerIfExists();
-    if (fullscreenManager && fullscreenManager->isFullscreen() && fullscreenManager->currentFullscreenElement() == this)
+    if (fullscreenManager && fullscreenManager->isFullscreen() && fullscreenManager->fullscreenElement() == this)
         return true;
 #endif
 
@@ -6784,7 +6784,7 @@ bool HTMLMediaElement::isStandardFullscreen() const
 {
 #if ENABLE(FULLSCREEN_API)
     CheckedPtr fullscreenManager = document().fullscreenManagerIfExists();
-    if (fullscreenManager && fullscreenManager->isFullscreen() && fullscreenManager->currentFullscreenElement() == this)
+    if (fullscreenManager && fullscreenManager->isFullscreen() && fullscreenManager->fullscreenElement() == this)
         return true;
 #endif
 
@@ -6892,7 +6892,7 @@ void HTMLMediaElement::exitFullscreen()
     m_waitingToEnterFullscreen = false;
 
 #if ENABLE(FULLSCREEN_API)
-    if (document().settings().fullScreenEnabled() && document().fullscreenManager().currentFullscreenElement() == this) {
+    if (document().settings().fullScreenEnabled() && document().fullscreenManager().fullscreenElement() == this) {
         if (document().fullscreenManager().isFullscreen()) {
             m_changingVideoFullscreenMode = true;
             document().fullscreenManager().cancelFullscreen();

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -626,7 +626,7 @@ bool MediaElementSession::canShowControlsManager(PlaybackControlsPurpose purpose
 #if ENABLE(FULLSCREEN_API)
     // Elements which are not descendants of the current fullscreen element cannot be main content.
     if (CheckedPtr fullsreenManager = m_element.document().fullscreenManagerIfExists()) {
-        auto* fullscreenElement = fullsreenManager->currentFullscreenElement();
+        auto* fullscreenElement = fullsreenManager->fullscreenElement();
         if (fullscreenElement && !m_element.isDescendantOf(*fullscreenElement)) {
             INFO_LOG(LOGIDENTIFIER, "returning FALSE: outside of full screen");
             return false;
@@ -1334,7 +1334,7 @@ void MediaElementSession::updateMediaUsageIfChanged()
     bool isOutsideOfFullscreen = false;
 #if ENABLE(FULLSCREEN_API)
     if (CheckedPtr fullscreenManager = document.fullscreenManagerIfExists()) {
-        if (auto* fullscreenElement = document.fullscreenManager().currentFullscreenElement())
+        if (auto* fullscreenElement = document.fullscreenManager().fullscreenElement())
             isOutsideOfFullscreen = m_element.isDescendantOf(*fullscreenElement);
     }
 #endif

--- a/Source/WebCore/style/StyleSharingResolver.cpp
+++ b/Source/WebCore/style/StyleSharingResolver.cpp
@@ -300,7 +300,7 @@ bool SharingResolver::canShareStyleWithElement(const Context& context, const Sty
         return false;
 
 #if ENABLE(FULLSCREEN_API)
-    if (CheckedPtr fullscreenManager = m_document.fullscreenManagerIfExists(); fullscreenManager && (&candidateElement == fullscreenManager->currentFullscreenElement() || &element == fullscreenManager->currentFullscreenElement()))
+    if (CheckedPtr fullscreenManager = m_document.fullscreenManagerIfExists(); fullscreenManager && (&candidateElement == fullscreenManager->fullscreenElement() || &element == fullscreenManager->fullscreenElement()))
         return false;
 #endif
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDocumentGtk.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDocumentGtk.cpp
@@ -1850,7 +1850,7 @@ WebKitDOMElement* webkit_dom_document_get_webkit_current_fullscreen_element(WebK
     g_return_val_if_fail(WEBKIT_DOM_IS_DOCUMENT(self), 0);
 #if ENABLE(FULLSCREEN_API)
     WebCore::Document* item = WebKit::core(self);
-    RefPtr<WebCore::Element> gobjectResult = WTF::getPtr(item->fullscreenManager().currentFullscreenElement());
+    RefPtr<WebCore::Element> gobjectResult = WTF::getPtr(item->fullscreenManager().fullscreenElement());
     return WebKit::kit(gobjectResult.get());
 #else
     return NULL;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -256,7 +256,7 @@ Page* WebChromeClient::createWindow(LocalFrame& frame, const WindowFeatures& fea
 #if ENABLE(FULLSCREEN_API)
     if (RefPtr document = frame.document()) {
         if (CheckedPtr fullscreenManager = document->fullscreenManagerIfExists()) {
-            if (fullscreenManager->currentFullscreenElement())
+            if (fullscreenManager->fullscreenElement())
                 fullscreenManager->cancelFullscreen();
         }
     }

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -3302,7 +3302,7 @@ IGNORE_WARNINGS_END
 #if ENABLE(FULLSCREEN_API)
     if (RefPtr document = core([frame DOMDocument]); document) {
         if (CheckedPtr fullscreenManager = document->fullscreenManagerIfExists()) {
-            if (RefPtr element = fullscreenManager->currentFullscreenElement()) {
+            if (RefPtr element = fullscreenManager->fullscreenElement()) {
                 SEL selector = @selector(webView:closeFullScreenWithListener:);
                 if ([_private->UIDelegate respondsToSelector:selector]) {
                     auto listener = adoptNS([[WebKitFullScreenListener alloc] initWithElement:element.get()]);


### PR DESCRIPTION
#### 83bc368c4e84e98d65324644eb69cc252a5b738f
<pre>
Remove `FullscreenManager::currentFullscreenElement()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=268232">https://bugs.webkit.org/show_bug.cgi?id=268232</a>
<a href="https://rdar.apple.com/121753573">rdar://121753573</a>

Reviewed by NOBODY (OOPS!).

It&apos;s a misleading function, especially in the case of an iframe being implicitly fullscreened by it&apos;s children. `currentFullscreenElement` will not work in that case.

Keep m_fullscreenElement for now as FullscreenManager relies on it internally for its logic, but eventually this should be replaced too.

* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesFullScreenAnimatingFullScreenTransitionPseudoClass):
(WebCore::matchesFullScreenAncestorPseudoClass):
* Source/WebCore/dom/DocumentFullscreen.h:
(WebCore::DocumentFullscreen::webkitCurrentFullScreenElement):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::addDocumentToFullscreenChangeEventQueue):
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::elementIsHidden const):
(WebCore::HTMLMediaElement::isFullscreen const):
(WebCore::HTMLMediaElement::isStandardFullscreen const):
(WebCore::HTMLMediaElement::exitFullscreen):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::canShowControlsManager const):
(WebCore::MediaElementSession::updateMediaUsageIfChanged):
* Source/WebCore/style/StyleSharingResolver.cpp:
(WebCore::Style::SharingResolver::canShareStyleWithElement const):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDocumentGtk.cpp:
(webkit_dom_document_get_webkit_current_fullscreen_element):
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::createWindow):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _didStartProvisionalLoadForFrame:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83bc368c4e84e98d65324644eb69cc252a5b738f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/14998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38772 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32431 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31145 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36609 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32012 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11131 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11149 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40019 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32763 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32545 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37094 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11317 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9223 "Found 60 new test failures: compositing/no-compositing-when-full-screen-is-present.html, compositing/repaint/copy-forward-dirty-region-purged.html, compositing/repaint/copy-forward-dirty-region.html, fast/html/popover-with-fullscreen-crash.html, fullscreen/event-listener-prefixed-unprefixed-document.html, fullscreen/event-listener-prefixed-unprefixed.html, fullscreen/exit-full-screen-iframe.html, fullscreen/full-screen-fixed-pos-parent.html, fullscreen/full-screen-iframe-allowFullscreen.html, fullscreen/full-screen-iframe-allowed-prefixed.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35178 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13058 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->