### PR TITLE
Use PseudoElementIdentifier in ComputedStyleExtractor and CSSComputedStyleDeclaration

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2449,6 +2449,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     storage/StorageType.h
     storage/StorageUtilities.h
 
+    style/PseudoElementIdentifier.h
     style/ScopedName.h
     style/StyleAppearance.h
     style/StyleChange.h

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -658,7 +658,8 @@ auto KeyframeEffect::getKeyframes() -> Vector<ComputedKeyframe>
     auto* lastStyleChangeEventStyle = targetStyleable()->lastStyleChangeEventStyle();
     auto& elementStyle = lastStyleChangeEventStyle ? *lastStyleChangeEventStyle : currentStyle();
 
-    ComputedStyleExtractor computedStyleExtractor { target, false, m_pseudoId };
+    auto pseudoElementIdentifier = m_pseudoId == PseudoId::None ? std::nullopt : std::optional(Style::PseudoElementIdentifier { m_pseudoId });
+    ComputedStyleExtractor computedStyleExtractor { target, false, pseudoElementIdentifier };
 
     BlendingKeyframes computedBlendingKeyframes(m_blendingKeyframes.animationName());
     computedBlendingKeyframes.copyKeyframes(m_blendingKeyframes);

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -47,28 +47,39 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSSComputedStyleDeclaration);
 
-CSSComputedStyleDeclaration::CSSComputedStyleDeclaration(Element& element, bool allowVisitedStyle)
+CSSComputedStyleDeclaration::CSSComputedStyleDeclaration(Element& element, AllowVisited allowVisited)
     : m_element(element)
-    , m_allowVisitedStyle(allowVisitedStyle)
+    , m_allowVisitedStyle(allowVisited == AllowVisited::Yes)
 {
 }
 
-CSSComputedStyleDeclaration::CSSComputedStyleDeclaration(Element& element, std::optional<PseudoId> pseudoId)
+CSSComputedStyleDeclaration::CSSComputedStyleDeclaration(Element& element, IsEmpty isEmpty)
     : m_element(element)
-    , m_pseudoElementSpecifier(pseudoId)
+    , m_isEmpty(isEmpty == IsEmpty::Yes)
+{
+}
+
+CSSComputedStyleDeclaration::CSSComputedStyleDeclaration(Element& element, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+    : m_element(element)
+    , m_pseudoElementIdentifier(pseudoElementIdentifier)
 {
 }
 
 CSSComputedStyleDeclaration::~CSSComputedStyleDeclaration() = default;
 
-Ref<CSSComputedStyleDeclaration> CSSComputedStyleDeclaration::create(Element& element, bool allowVisitedStyle)
+Ref<CSSComputedStyleDeclaration> CSSComputedStyleDeclaration::create(Element& element, AllowVisited allowVisited)
 {
-    return adoptRef(*new CSSComputedStyleDeclaration(element, allowVisitedStyle));
+    return adoptRef(*new CSSComputedStyleDeclaration(element, allowVisited));
 }
 
-Ref<CSSComputedStyleDeclaration> CSSComputedStyleDeclaration::create(Element& element, std::optional<PseudoId> pseudoId)
+Ref<CSSComputedStyleDeclaration> CSSComputedStyleDeclaration::create(Element& element, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
-    return adoptRef(*new CSSComputedStyleDeclaration(element, pseudoId));
+    return adoptRef(*new CSSComputedStyleDeclaration(element, pseudoElementIdentifier));
+}
+
+Ref<CSSComputedStyleDeclaration> CSSComputedStyleDeclaration::createEmpty(Element& element)
+{
+    return adoptRef(*new CSSComputedStyleDeclaration(element, IsEmpty::Yes));
 }
 
 String CSSComputedStyleDeclaration::cssText() const
@@ -90,16 +101,16 @@ ExceptionOr<void> CSSComputedStyleDeclaration::setCssText(const String&)
 // https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle#Notes
 RefPtr<CSSValue> CSSComputedStyleDeclaration::getPropertyCSSValue(CSSPropertyID propertyID, ComputedStyleExtractor::UpdateLayout updateLayout) const
 {
-    if (!isExposed(propertyID, settings()) || !m_pseudoElementSpecifier)
+    if (!isExposed(propertyID, settings()) || m_isEmpty)
         return nullptr;
-    return ComputedStyleExtractor(m_element.ptr(), m_allowVisitedStyle, *m_pseudoElementSpecifier).propertyValue(propertyID, updateLayout);
+    return ComputedStyleExtractor(m_element.ptr(), m_allowVisitedStyle, m_pseudoElementIdentifier).propertyValue(propertyID, updateLayout);
 }
 
 Ref<MutableStyleProperties> CSSComputedStyleDeclaration::copyProperties() const
 {
-    if (!m_pseudoElementSpecifier)
+    if (m_isEmpty)
         return MutableStyleProperties::create();
-    return ComputedStyleExtractor(m_element.ptr(), m_allowVisitedStyle, *m_pseudoElementSpecifier).copyProperties();
+    return ComputedStyleExtractor(m_element.ptr(), m_allowVisitedStyle, m_pseudoElementIdentifier).copyProperties();
 }
 
 const Settings* CSSComputedStyleDeclaration::settings() const
@@ -114,7 +125,7 @@ const FixedVector<CSSPropertyID>& CSSComputedStyleDeclaration::exposedComputedCS
 
 String CSSComputedStyleDeclaration::getPropertyValue(CSSPropertyID propertyID) const
 {
-    if (!m_pseudoElementSpecifier)
+    if (m_isEmpty)
         return emptyString(); // FIXME: Should this be null instead, as it is in StyleProperties::getPropertyValue?
 
     auto canUseShorthandSerializerForPropertyValue = [&]() {
@@ -129,7 +140,7 @@ String CSSComputedStyleDeclaration::getPropertyValue(CSSPropertyID propertyID) c
         }
     };
     if (isShorthand(propertyID) && canUseShorthandSerializerForPropertyValue())
-        return serializeShorthandValue({ m_element.ptr(), m_allowVisitedStyle, *m_pseudoElementSpecifier }, propertyID);
+        return serializeShorthandValue({ m_element.ptr(), m_allowVisitedStyle, m_pseudoElementIdentifier }, propertyID);
 
     auto value = getPropertyCSSValue(propertyID);
     if (!value)
@@ -139,12 +150,12 @@ String CSSComputedStyleDeclaration::getPropertyValue(CSSPropertyID propertyID) c
 
 unsigned CSSComputedStyleDeclaration::length() const
 {
-    if (!m_pseudoElementSpecifier)
+    if (m_isEmpty)
         return 0;
 
     ComputedStyleExtractor::updateStyleIfNeededForProperty(m_element.get(), CSSPropertyCustom);
 
-    auto* style = m_element->computedStyle(*m_pseudoElementSpecifier);
+    auto* style = m_element->computedStyle(m_pseudoElementIdentifier);
     if (!style)
         return 0;
 
@@ -153,7 +164,7 @@ unsigned CSSComputedStyleDeclaration::length() const
 
 String CSSComputedStyleDeclaration::item(unsigned i) const
 {
-    if (!m_pseudoElementSpecifier)
+    if (m_isEmpty)
         return String();
 
     if (i >= length())
@@ -162,7 +173,7 @@ String CSSComputedStyleDeclaration::item(unsigned i) const
     if (i < exposedComputedCSSPropertyIDs().size())
         return nameString(exposedComputedCSSPropertyIDs().at(i));
 
-    auto* style = m_element->computedStyle(*m_pseudoElementSpecifier);
+    auto* style = m_element->computedStyle(m_pseudoElementIdentifier);
     if (!style)
         return String();
 
@@ -191,11 +202,11 @@ CSSRule* CSSComputedStyleDeclaration::cssRules() const
 
 RefPtr<DeprecatedCSSOMValue> CSSComputedStyleDeclaration::getPropertyCSSValue(const String& propertyName)
 {
-    if (!m_pseudoElementSpecifier)
+    if (m_isEmpty)
         return nullptr;
 
     if (isCustomPropertyName(propertyName)) {
-        auto value = ComputedStyleExtractor(m_element.ptr(), m_allowVisitedStyle, *m_pseudoElementSpecifier).customPropertyValue(AtomString { propertyName });
+        auto value = ComputedStyleExtractor(m_element.ptr(), m_allowVisitedStyle, m_pseudoElementIdentifier).customPropertyValue(AtomString { propertyName });
         if (!value)
             return nullptr;
         return value->createDeprecatedCSSOMWrapper(*this);
@@ -212,11 +223,11 @@ RefPtr<DeprecatedCSSOMValue> CSSComputedStyleDeclaration::getPropertyCSSValue(co
 
 String CSSComputedStyleDeclaration::getPropertyValue(const String &propertyName)
 {
-    if (!m_pseudoElementSpecifier)
+    if (m_isEmpty)
         return String();
 
     if (isCustomPropertyName(propertyName))
-        return ComputedStyleExtractor(m_element.ptr(), m_allowVisitedStyle, *m_pseudoElementSpecifier).customPropertyText(AtomString { propertyName });
+        return ComputedStyleExtractor(m_element.ptr(), m_allowVisitedStyle, m_pseudoElementIdentifier).customPropertyText(AtomString { propertyName });
 
     CSSPropertyID propertyID = cssPropertyID(propertyName);
     if (!propertyID)

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.h
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.h
@@ -22,6 +22,7 @@
 
 #include "CSSStyleDeclaration.h"
 #include "ComputedStyleExtractor.h"
+#include "PseudoElementIdentifier.h"
 #include "RenderStyleConstants.h"
 #include <wtf/FixedVector.h>
 #include <wtf/IsoMalloc.h>
@@ -36,8 +37,11 @@ class MutableStyleProperties;
 class CSSComputedStyleDeclaration final : public CSSStyleDeclaration, public RefCounted<CSSComputedStyleDeclaration> {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(CSSComputedStyleDeclaration, WEBCORE_EXPORT);
 public:
-    WEBCORE_EXPORT static Ref<CSSComputedStyleDeclaration> create(Element&, bool allowVisitedStyle);
-    static Ref<CSSComputedStyleDeclaration> create(Element&, std::optional<PseudoId>);
+    enum class AllowVisited : bool { No, Yes };
+    WEBCORE_EXPORT static Ref<CSSComputedStyleDeclaration> create(Element&, AllowVisited);
+    static Ref<CSSComputedStyleDeclaration> create(Element&, const std::optional<Style::PseudoElementIdentifier>&);
+    static Ref<CSSComputedStyleDeclaration> createEmpty(Element&);
+
     WEBCORE_EXPORT virtual ~CSSComputedStyleDeclaration();
 
     void ref() final { RefCounted::ref(); }
@@ -46,8 +50,10 @@ public:
     String getPropertyValue(CSSPropertyID) const;
 
 private:
-    CSSComputedStyleDeclaration(Element&, bool allowVisitedStyle);
-    CSSComputedStyleDeclaration(Element&, std::optional<PseudoId>);
+    enum class IsEmpty : bool { No, Yes };
+    CSSComputedStyleDeclaration(Element&, AllowVisited);
+    CSSComputedStyleDeclaration(Element&, IsEmpty);
+    CSSComputedStyleDeclaration(Element&, const std::optional<Style::PseudoElementIdentifier>&);
 
     // CSSOM functions. Don't make these public.
     CSSRule* parentRule() const final;
@@ -73,7 +79,8 @@ private:
     const FixedVector<CSSPropertyID>& exposedComputedCSSPropertyIDs() const;
 
     mutable Ref<Element> m_element;
-    std::optional<PseudoId> m_pseudoElementSpecifier { PseudoId::None };
+    std::optional<Style::PseudoElementIdentifier> m_pseudoElementIdentifier { std::nullopt };
+    bool m_isEmpty { false };
     bool m_allowVisitedStyle { false };
 };
 

--- a/Source/WebCore/css/ComputedStyleExtractor.h
+++ b/Source/WebCore/css/ComputedStyleExtractor.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "PseudoElementIdentifier.h"
 #include <span>
 #include <wtf/RefPtr.h>
 
@@ -56,9 +57,9 @@ class ComputedStyleExtractor {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ComputedStyleExtractor);
 public:
     ComputedStyleExtractor(Node*, bool allowVisitedStyle = false);
-    ComputedStyleExtractor(Node*, bool allowVisitedStyle, PseudoId);
+    ComputedStyleExtractor(Node*, bool allowVisitedStyle, const std::optional<Style::PseudoElementIdentifier>&);
     ComputedStyleExtractor(Element*, bool allowVisitedStyle = false);
-    ComputedStyleExtractor(Element*, bool allowVisitedStyle, PseudoId);
+    ComputedStyleExtractor(Element*, bool allowVisitedStyle, const std::optional<Style::PseudoElementIdentifier>&);
 
     enum class UpdateLayout : bool { No, Yes };
     enum class PropertyValueType : bool { Resolved, Computed };
@@ -105,7 +106,7 @@ private:
     RefPtr<CSSValue> whiteSpaceShorthandValue(const RenderStyle&) const;
 
     RefPtr<Element> m_element;
-    PseudoId m_pseudoElementSpecifier;
+    std::optional<Style::PseudoElementIdentifier> m_pseudoElementIdentifier;
     bool m_allowVisitedStyle;
 };
 

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -82,9 +82,10 @@ public:
         { }
 
         const SelectorChecker::Mode resolvingMode;
+        // FIXME: Switch to PseudoElementIdentifier.
         PseudoId pseudoId { PseudoId::None };
-        std::optional<StyleScrollbarState> scrollbarState;
         AtomString pseudoElementNameArgument;
+        std::optional<StyleScrollbarState> scrollbarState;
         const ContainerNode* scope { nullptr };
         const Element* hasScope { nullptr };
         bool matchesAllHasScopes { false };

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2743,11 +2743,11 @@ auto Document::updateLayout(OptionSet<LayoutOptions> layoutOptions, const Elemen
     return result;
 }
 
-std::unique_ptr<RenderStyle> Document::styleForElementIgnoringPendingStylesheets(Element& element, const RenderStyle* parentStyle, PseudoId pseudoElementSpecifier)
+std::unique_ptr<RenderStyle> Document::styleForElementIgnoringPendingStylesheets(Element& element, const RenderStyle* parentStyle, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     ASSERT(&element.document() == this);
-    ASSERT(!element.isPseudoElement() || pseudoElementSpecifier == PseudoId::None);
-    ASSERT(pseudoElementSpecifier == PseudoId::None || parentStyle);
+    ASSERT(!element.isPseudoElement() || !pseudoElementIdentifier);
+    ASSERT(!pseudoElementIdentifier || parentStyle);
     ASSERT(Style::postResolutionCallbacksAreSuspended());
 
     std::optional<RenderStyle> updatedDocumentStyle;
@@ -2759,8 +2759,8 @@ std::unique_ptr<RenderStyle> Document::styleForElementIgnoringPendingStylesheets
     SetForScope change(m_ignorePendingStylesheets, true);
     auto& resolver = element.styleResolver();
 
-    if (pseudoElementSpecifier != PseudoId::None) {
-        auto style = resolver.styleForPseudoElement(element, { pseudoElementSpecifier }, { parentStyle });
+    if (pseudoElementIdentifier) {
+        auto style = resolver.styleForPseudoElement(element, { *pseudoElementIdentifier }, { parentStyle });
         if (!style)
             return nullptr;
         return WTFMove(style->style);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -38,6 +38,7 @@
 #include "OrientationNotifier.h"
 #include "PageIdentifier.h"
 #include "PlaybackTargetClientContextIdentifier.h"
+#include "PseudoElementIdentifier.h"
 #include "RegistrableDomain.h"
 #include "RenderPtr.h"
 #include "ReportingClient.h"
@@ -730,7 +731,7 @@ public:
     // so calling this may cause a flash of unstyled content (FOUC).
         WEBCORE_EXPORT UpdateLayoutResult updateLayoutIgnorePendingStylesheets(OptionSet<LayoutOptions> = { }, const Element* = nullptr);
 
-    std::unique_ptr<RenderStyle> styleForElementIgnoringPendingStylesheets(Element&, const RenderStyle* parentStyle, PseudoId = PseudoId::None);
+    std::unique_ptr<RenderStyle> styleForElementIgnoringPendingStylesheets(Element&, const RenderStyle* parentStyle, const std::optional<Style::PseudoElementIdentifier>& = std::nullopt);
 
     // Returns true if page box (margin boxes and page borders) is visible.
     WEBCORE_EXPORT bool isPageBoxVisible(int pageIndex);

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -124,6 +124,7 @@ enum class ContentRelevancy : uint8_t {
 namespace Style {
 class Resolver;
 enum class Change : uint8_t;
+struct PseudoElementIdentifier;
 struct ResolutionContext;
 struct ResolvedStyle;
 }
@@ -419,7 +420,8 @@ public:
     WEBCORE_EXPORT ExceptionOr<void> insertAdjacentHTML(const String& where, const String& html);
     WEBCORE_EXPORT ExceptionOr<void> insertAdjacentText(const String& where, String&& text);
 
-    const RenderStyle* computedStyle(PseudoId = PseudoId::None) override;
+    using Node::computedStyle;
+    const RenderStyle* computedStyle(const std::optional<Style::PseudoElementIdentifier>&) override;
     const RenderStyle* computedStyleForEditability();
 
     bool needsStyleInvalidation() const;
@@ -868,7 +870,7 @@ private:
 
     enum class ResolveComputedStyleMode : uint8_t { Normal, RenderedOnly, Editability };
     const RenderStyle* resolveComputedStyle(ResolveComputedStyleMode = ResolveComputedStyleMode::Normal);
-    const RenderStyle& resolvePseudoElementStyle(PseudoId);
+    const RenderStyle& resolvePseudoElementStyle(const Style::PseudoElementIdentifier&);
 
     unsigned rareDataChildIndex() const;
 

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1232,10 +1232,15 @@ Node* Node::pseudoAwareLastChild() const
     return lastChild();
 }
 
-const RenderStyle* Node::computedStyle(PseudoId pseudoElementSpecifier)
+const RenderStyle* Node::computedStyle()
+{
+    return computedStyle(std::nullopt);
+}
+
+const RenderStyle* Node::computedStyle(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     RefPtr composedParent = parentElementInComposedTree();
-    return composedParent ? composedParent->computedStyle(pseudoElementSpecifier) : nullptr;
+    return composedParent ? composedParent->computedStyle(pseudoElementIdentifier) : nullptr;
 }
 
 // FIXME: Shouldn't these functions be in the editing code?  Code that asks questions about HTML in the core DOM class

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -74,6 +74,10 @@ class ShadowRoot;
 class TouchEvent;
 class WebCoreOpaqueRoot;
 
+namespace Style {
+struct PseudoElementIdentifier;
+}
+
 }
 
 WTF_ALLOW_COMPACT_POINTERS_TO_INCOMPLETE_TYPE(WebCore::RenderObject);
@@ -450,11 +454,12 @@ public:
     // Use these two methods with caution.
     WEBCORE_EXPORT RenderBox* renderBox() const;
     RenderBoxModelObject* renderBoxModelObject() const;
-    
+
     // Wrapper for nodes that don't have a renderer, but still cache the style (like HTMLOptionElement).
     const RenderStyle* renderStyle() const;
 
-    virtual const RenderStyle* computedStyle(PseudoId pseudoElementSpecifier = PseudoId::None);
+    WEBCORE_EXPORT const RenderStyle* computedStyle();
+    virtual const RenderStyle* computedStyle(const std::optional<Style::PseudoElementIdentifier>&);
 
     enum class InsertedIntoAncestorResult {
         Done,

--- a/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp
@@ -123,7 +123,9 @@ static Ref<JSON::ArrayOf<Protocol::Animation::Keyframe>> buildObjectForKeyframes
         auto* renderer = keyframeEffect.renderer();
 
         // Synthesize CSS style declarations for each keyframe so the frontend can display them.
-        ComputedStyleExtractor computedStyleExtractor(target, false, target->pseudoId());
+
+        auto pseudoElementIdentifier = target->pseudoId() == PseudoId::None ? std::nullopt : std::optional(Style::PseudoElementIdentifier { target->pseudoId() });
+        ComputedStyleExtractor computedStyleExtractor(target, false, pseudoElementIdentifier);
 
         for (size_t i = 0; i < blendingKeyframes.size(); ++i) {
             auto& blendingKeyframe = blendingKeyframes[i];

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -546,7 +546,7 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::CSS::CSSComputedStylePropert
     if (!element->isConnected())
         return makeUnexpected("Element for given nodeId was not connected to DOM tree."_s);
 
-    auto computedStyleInfo = CSSComputedStyleDeclaration::create(*element, true);
+    auto computedStyleInfo = CSSComputedStyleDeclaration::create(*element, CSSComputedStyleDeclaration::AllowVisited::Yes);
     auto inspectorStyle = InspectorStyle::create(InspectorCSSId(), WTFMove(computedStyleInfo), nullptr);
     return inspectorStyle->buildArrayForComputedStyle();
 }

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -492,8 +492,8 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
 
     SelectorChecker::CheckingContext context(m_mode);
     context.pseudoId = m_pseudoElementRequest.pseudoId();
+    context.pseudoElementNameArgument = m_pseudoElementRequest.nameArgument();
     context.scrollbarState = m_pseudoElementRequest.scrollbarState();
-    context.pseudoElementNameArgument = m_pseudoElementRequest.pseudoElementNameArgument();
     context.styleScopeOrdinal = styleScopeOrdinal;
     context.selectorMatchingState = m_selectorMatchingState;
     context.scope = scopingRoot;

--- a/Source/WebCore/style/PseudoElementIdentifier.h
+++ b/Source/WebCore/style/PseudoElementIdentifier.h
@@ -34,7 +34,7 @@ struct PseudoElementIdentifier {
     PseudoId pseudoId;
 
     // highlight name for ::highlight or view transition name for view transition pseudo elements.
-    AtomString pseudoElementNameArgument { nullAtom() };
+    AtomString nameArgument { nullAtom() };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/PseudoElementRequest.h
+++ b/Source/WebCore/style/PseudoElementRequest.h
@@ -27,6 +27,7 @@
 
 #include "PseudoElementIdentifier.h"
 #include "RenderStyleConstants.h"
+#include "StyleScrollbarState.h"
 #include <wtf/text/AtomString.h>
 
 namespace WebCore::Style {
@@ -39,8 +40,8 @@ public:
     {
     }
 
-    PseudoElementRequest(PseudoId pseudoId, const AtomString& pseudoElementNameArgument)
-        : m_identifier({ pseudoId, pseudoElementNameArgument })
+    PseudoElementRequest(PseudoId pseudoId, const AtomString& nameArgument)
+        : m_identifier({ pseudoId, nameArgument })
     {
         ASSERT(pseudoId == PseudoId::Highlight || pseudoId == PseudoId::ViewTransitionGroup || pseudoId == PseudoId::ViewTransitionImagePair || pseudoId == PseudoId::ViewTransitionOld || pseudoId == PseudoId::ViewTransitionNew);
     }
@@ -52,7 +53,7 @@ public:
 
     const PseudoElementIdentifier& identifier() const { return m_identifier; }
     PseudoId pseudoId() const { return m_identifier.pseudoId; }
-    const AtomString& pseudoElementNameArgument() const { return m_identifier.pseudoElementNameArgument; }
+    const AtomString& nameArgument() const { return m_identifier.nameArgument; }
     const std::optional<StyleScrollbarState>& scrollbarState() const { return m_scrollbarState; }
 
 private:

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -485,8 +485,8 @@ std::optional<ResolvedStyle> Resolver::styleForPseudoElement(const Element& elem
         return { };
 
     state.style()->setPseudoElementType(pseudoElementRequest.pseudoId());
-    if (!pseudoElementRequest.pseudoElementNameArgument().isNull())
-        state.style()->setPseudoElementNameArgument(pseudoElementRequest.pseudoElementNameArgument());
+    if (!pseudoElementRequest.nameArgument().isNull())
+        state.style()->setPseudoElementNameArgument(pseudoElementRequest.nameArgument());
 
     applyMatchedProperties(state, collector.matchResult());
 

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -660,10 +660,10 @@ inline const RenderStyle* SVGElementRareData::overrideComputedStyle(Element& ele
     return m_overrideComputedStyle.get();
 }
 
-const RenderStyle* SVGElement::computedStyle(PseudoId pseudoElementSpecifier)
+const RenderStyle* SVGElement::computedStyle(const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
     if (!m_svgRareData || !m_svgRareData->useOverrideComputedStyle())
-        return Element::computedStyle(pseudoElementSpecifier);
+        return Element::computedStyle(pseudoElementIdentifier);
 
     const RenderStyle* parentStyle = nullptr;
     if (RefPtr parent = parentOrShadowHostElement()) {

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -154,8 +154,9 @@ public:
     RefPtr<SVGAttributeAnimator> createAnimator(const QualifiedName&, AnimationMode, CalcMode, bool isAccumulated, bool isAdditive);
     void animatorWillBeDeleted(const QualifiedName&);
 
-    const RenderStyle* computedStyle(PseudoId = PseudoId::None) final;
-    
+    using Node::computedStyle;
+    const RenderStyle* computedStyle(const std::optional<Style::PseudoElementIdentifier>&) final;
+
     ColorInterpolation colorInterpolation() const;
 
     // These are needed for the RenderTree, animation and DOM.

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1412,8 +1412,7 @@ void Internals::markFrontBufferVolatile(Element& element)
 
 Ref<CSSComputedStyleDeclaration> Internals::computedStyleIncludingVisitedInfo(Element& element) const
 {
-    bool allowVisitedStyle = true;
-    return CSSComputedStyleDeclaration::create(element, allowVisitedStyle);
+    return CSSComputedStyleDeclaration::create(element, CSSComputedStyleDeclaration::AllowVisited::Yes);
 }
 
 Node* Internals::ensureUserAgentShadowRoot(Element& host)


### PR DESCRIPTION
#### 741f7b16f8e63521bfd98aa8c0f81b99952b6d99
<pre>
Use PseudoElementIdentifier in ComputedStyleExtractor and CSSComputedStyleDeclaration
<a href="https://bugs.webkit.org/show_bug.cgi?id=268063">https://bugs.webkit.org/show_bug.cgi?id=268063</a>
<a href="https://rdar.apple.com/121580606">rdar://121580606</a>

Reviewed by Antti Koivisto.

In preparation of making animation code and `getComputedStyle()` work with pseudo-element name arguments (like `::highlight(name)` or `::view-transition-group(name)`).

Some of the consumers will also need refactoring to take PseudoElementIdentifier, which will be done separately.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::getKeyframes):
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::CSSComputedStyleDeclaration::CSSComputedStyleDeclaration):
(WebCore::CSSComputedStyleDeclaration::create):
(WebCore::CSSComputedStyleDeclaration::createEmpty):
(WebCore::CSSComputedStyleDeclaration::getPropertyCSSValue const):
(WebCore::CSSComputedStyleDeclaration::copyProperties const):
(WebCore::CSSComputedStyleDeclaration::getPropertyValue const):
(WebCore::CSSComputedStyleDeclaration::length const):
(WebCore::CSSComputedStyleDeclaration::item const):
(WebCore::CSSComputedStyleDeclaration::getPropertyCSSValue):
(WebCore::CSSComputedStyleDeclaration::getPropertyValue):
* Source/WebCore/css/CSSComputedStyleDeclaration.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::ComputedStyleExtractor):
(WebCore::ComputedStyleExtractor::getFontSizeCSSValuePreferringKeyword const):
(WebCore::ComputedStyleExtractor::useFixedFontDefaultSize const):
(WebCore::ComputedStyleExtractor::styledRenderer const):
(WebCore::computeRenderStyleForProperty):
(WebCore::ComputedStyleExtractor::customPropertyValue const):
(WebCore::ComputedStyleExtractor::propertyValue const):
(WebCore::ComputedStyleExtractor::propertyMatches const):
(WebCore::ComputedStyleExtractor::getLayerCount const):
* Source/WebCore/css/ComputedStyleExtractor.h:
* Source/WebCore/css/SelectorChecker.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::styleForElementIgnoringPendingStylesheets):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resolvePseudoElementStyle):
(WebCore::Element::computedStyle):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::computedStyle):
* Source/WebCore/dom/Node.h:
* Source/WebCore/inspector/agents/InspectorAnimationAgent.cpp:
(WebCore::buildObjectForKeyframes):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::getComputedStyleForNode):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::getComputedStyle const):
(WebCore::LocalDOMWindow::getMatchedCSSRules const): Deleted.
(WebCore::LocalDOMWindow::webkitConvertPointFromNodeToPage const): Deleted.
(WebCore::LocalDOMWindow::webkitConvertPointFromPageToNode const): Deleted.
(WebCore::LocalDOMWindow::devicePixelRatio const): Deleted.
(WebCore::LocalDOMWindow::scrollBy const): Deleted.
(WebCore::LocalDOMWindow::scrollTo const): Deleted.
(WebCore::LocalDOMWindow::allowedToChangeWindowGeometry const): Deleted.
(WebCore::LocalDOMWindow::moveBy const): Deleted.
(WebCore::LocalDOMWindow::moveTo const): Deleted.
(WebCore::LocalDOMWindow::resizeBy const): Deleted.
(WebCore::LocalDOMWindow::resizeTo const): Deleted.
(WebCore::LocalDOMWindow::setTimeout): Deleted.
(WebCore::LocalDOMWindow::clearTimeout): Deleted.
(WebCore::LocalDOMWindow::setInterval): Deleted.
(WebCore::LocalDOMWindow::clearInterval): Deleted.
(WebCore::LocalDOMWindow::requestAnimationFrame): Deleted.
(WebCore::LocalDOMWindow::webkitRequestAnimationFrame): Deleted.
(WebCore::LocalDOMWindow::cancelAnimationFrame): Deleted.
(WebCore::LocalDOMWindow::requestIdleCallback): Deleted.
(WebCore::LocalDOMWindow::cancelIdleCallback): Deleted.
(WebCore::LocalDOMWindow::createImageBitmap): Deleted.
(WebCore::LocalDOMWindow::isSecureContext const): Deleted.
(WebCore::LocalDOMWindow::crossOriginIsolated const): Deleted.
(WebCore::didAddStorageEventListener): Deleted.
(WebCore::LocalDOMWindow::isSameSecurityOriginAsMainFrame const): Deleted.
(WebCore::LocalDOMWindow::addEventListener): Deleted.
(WebCore::LocalDOMWindow::deviceOrientationController const): Deleted.
(WebCore::LocalDOMWindow::deviceMotionController const): Deleted.
(WebCore::LocalDOMWindow::isAllowedToUseDeviceMotionOrOrientation const): Deleted.
(WebCore::LocalDOMWindow::isAllowedToUseDeviceMotion const): Deleted.
(WebCore::LocalDOMWindow::isAllowedToUseDeviceOrientation const): Deleted.
(WebCore::LocalDOMWindow::hasPermissionToReceiveDeviceMotionOrOrientationEvents const): Deleted.
(WebCore::LocalDOMWindow::startListeningForDeviceOrientationIfNecessary): Deleted.
(WebCore::LocalDOMWindow::stopListeningForDeviceOrientationIfNecessary): Deleted.
(WebCore::LocalDOMWindow::startListeningForDeviceMotionIfNecessary): Deleted.
(WebCore::LocalDOMWindow::stopListeningForDeviceMotionIfNecessary): Deleted.
(WebCore::LocalDOMWindow::failedToRegisterDeviceMotionEventListener): Deleted.
(WebCore::LocalDOMWindow::incrementScrollEventListenersCount): Deleted.
(WebCore::LocalDOMWindow::decrementScrollEventListenersCount): Deleted.
(WebCore::LocalDOMWindow::resetAllGeolocationPermission): Deleted.
(WebCore::LocalDOMWindow::removeEventListener): Deleted.
(WebCore::LocalDOMWindow::languagesChanged): Deleted.
(WebCore::LocalDOMWindow::dispatchLoadEvent): Deleted.
(WebCore::LocalDOMWindow::dispatchEvent): Deleted.
(WebCore::LocalDOMWindow::removeAllEventListeners): Deleted.
(WebCore::LocalDOMWindow::captureEvents): Deleted.
(WebCore::LocalDOMWindow::releaseEvents): Deleted.
(WebCore::LocalDOMWindow::finishedLoading): Deleted.
(WebCore::LocalDOMWindow::setLocation): Deleted.
(WebCore::LocalDOMWindow::printErrorMessage const): Deleted.
(WebCore::LocalDOMWindow::crossDomainAccessErrorMessage): Deleted.
(WebCore::LocalDOMWindow::isInsecureScriptAccess): Deleted.
(WebCore::LocalDOMWindow::createWindow): Deleted.
(WebCore::LocalDOMWindow::open): Deleted.
(WebCore::LocalDOMWindow::showModalDialog): Deleted.
(WebCore::LocalDOMWindow::enableSuddenTermination): Deleted.
(WebCore::LocalDOMWindow::disableSuddenTermination): Deleted.
(WebCore::LocalDOMWindow::frame const): Deleted.
(WebCore::LocalDOMWindow::protectedFrame const): Deleted.
(WebCore::LocalDOMWindow::eventListenersDidChange): Deleted.
(WebCore::LocalDOMWindow::cookieStore): Deleted.
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::ruleMatches):
* Source/WebCore/style/PseudoElementIdentifier.h:
* Source/WebCore/style/PseudoElementRequest.h:
(WebCore::Style::PseudoElementRequest::PseudoElementRequest):
(WebCore::Style::PseudoElementRequest::nameArgument const):
(WebCore::Style::PseudoElementRequest::pseudoElementNameArgument const): Deleted.
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForPseudoElement):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::computedStyle):
* Source/WebCore/svg/SVGElement.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::computedStyleIncludingVisitedInfo const):

Canonical link: <a href="https://commits.webkit.org/273934@main">https://commits.webkit.org/273934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fff2c5918fc701b3e3f0b9168edfc438be7abf9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39812 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13295 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13621 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11863 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/33406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41072 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33724 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/33838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12196 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9981 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/35902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8411 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12547 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->