### PR TITLE
Implement safe alignment in flexbox.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1530,7 +1530,6 @@ webkit.org/b/136754 css3/flexbox/csswg/ttwf-reftest-flex-order.html [ ImageOnlyF
 webkit.org/b/136754 css3/flexbox/csswg/ttwf-reftest-flex-wrap-reverse.html [ ImageOnlyFailure ]
 webkit.org/b/136754 css3/flexbox/csswg/ttwf-reftest-flex-wrap.html [ ImageOnlyFailure ]
 webkit.org/b/136754 imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-row-015.html [ ImageOnlyFailure ]
-webkit.org/b/136754 imported/w3c/web-platform-tests/css/css-flexbox/flexbox-safe-overflow-position-001.html [ ImageOnlyFailure ]
 webkit.org/b/210243 imported/w3c/web-platform-tests/css/css-flexbox/percentage-size-quirks-002.html [ Failure ]
 webkit.org/b/136754 imported/w3c/web-platform-tests/css/css-flexbox/scrollbars-no-margin.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-flexbox/fieldset-baseline-alignment.html [ ImageOnlyFailure ]
@@ -4591,9 +4590,6 @@ webkit.org/b/233196 imported/w3c/web-platform-tests/css/css-flexbox/percentage-h
 webkit.org/b/233196 imported/w3c/web-platform-tests/css/css-flexbox/percentage-heights-017.html [ ImageOnlyFailure ]
 webkit.org/b/233196 imported/w3c/web-platform-tests/css/css-flexbox/percentage-heights-018.html [ ImageOnlyFailure ]
 
-# Static position alignment in Flexbox.
-webkit.org/b/221472 imported/w3c/web-platform-tests/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-safe-001.html [ ImageOnlyFailure ]
-
 # Tables as flex items.
 webkit.org/b/221473 imported/w3c/web-platform-tests/css/css-flexbox/table-as-item-min-height-1.html [ ImageOnlyFailure ]
 
@@ -4859,10 +4855,6 @@ webkit.org/b/214458 imported/w3c/web-platform-tests/css/css-multicol/multicol-fi
 webkit.org/b/214458 imported/w3c/web-platform-tests/css/css-multicol/multicol-list-item-002.html [ ImageOnlyFailure ]
 webkit.org/b/214458 imported/w3c/web-platform-tests/css/css-multicol/nested-with-too-tall-line.html [ ImageOnlyFailure ]
 
-webkit.org/b/263893 imported/w3c/web-platform-tests/css/css-overflow/overflow-alignment-flex-col-reverse-001.html [ ImageOnlyFailure ]
-webkit.org/b/263893 imported/w3c/web-platform-tests/css/css-overflow/overflow-alignment-flex-col-wrap-001.html [ ImageOnlyFailure ]
-webkit.org/b/263893 imported/w3c/web-platform-tests/css/css-overflow/overflow-alignment-flex-row-reverse-001.html [ ImageOnlyFailure ]
-webkit.org/b/263893 imported/w3c/web-platform-tests/css/css-overflow/overflow-alignment-flex-row-wrap-001.html [ ImageOnlyFailure ]
 webkit.org/b/214459 imported/w3c/web-platform-tests/css/css-overflow/text-overflow-ellipsis-editing-input.html [ ImageOnlyFailure ]
 webkit.org/b/214459 imported/w3c/web-platform-tests/css/css-overflow/text-overflow-ellipsis-vertical-001.html [ ImageOnlyFailure ]
 webkit.org/b/214459 imported/w3c/web-platform-tests/css/css-overflow/text-overflow-ellipsis-vertical-rtl-001.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-safe-overflow-position-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-safe-overflow-position-002.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#overflow-values">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert"
-  content="safe flex-start allows for overflow past the flex-end edge, which is top in the case of wrap-reverse" />
+  content="safe flex-start allows for overflow past the end edge, which is bottom/right even in the case of wrap-reverse" />
 
 <style>
   #reference-overlapped-red {
@@ -16,16 +16,16 @@
 
   .flex {
     display: flex;
-    width: 100px;
+    width: 90px;
     height: 90px;
     align-content: safe flex-start;
+    justify-content: safe flex-start;
     flex-wrap: wrap-reverse;
-    /* Make the green square cover the red square. */
-    translate: 0 10px;
   }
 
   .item {
     flex: 0 0 100px;
+    width: 100px;
     height: 100px;
     background: green;
   }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-safe-overflow-position-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-safe-overflow-position-003.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#overflow-values">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert"
-  content="safe flex-start allows for overflow past the flex-end edge, which is left in the case of row-reverse" />
+  content="safe flex-start allows for overflow past the end edge, which is bottom/right even in the case of row-reverse" />
 
 <style>
   #reference-overlapped-red {
@@ -18,14 +18,14 @@
     display: flex;
     flex-flow: row-reverse;
     width: 90px;
-    height: 100px;
+    height: 90px;
+    align-content: safe flex-start;
     justify-content: safe flex-start;
-    /* Make the green square cover the red square. */
-    translate: 10px 0;
   }
 
   .item {
     flex: 0 0 100px;
+    width: 100px;
     height: 100px;
     background: green;
   }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-safe-overflow-position-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-safe-overflow-position-004.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#overflow-values">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert"
-  content="safe flex-start allows for overflow past the flex-end edge, which is top in the case of column-reverse" />
+  content="safe flex-start allows for overflow past the end edge, which is bottom/right even in the case of column-reverse" />
 
 <style>
   #reference-overlapped-red {
@@ -17,15 +17,15 @@
   .flex {
     display: flex;
     flex-flow: column-reverse;
-    width: 100px;
+    width: 90px;
     height: 90px;
     align-content: safe flex-start;
-    /* Make the green square cover the red square. */
-    translate: 0 10px;
+    justify-content: safe flex-start;
   }
 
   .item {
     flex: 0 0 100px;
+    width: 100px;
     height: 100px;
     background: green;
   }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-safe-overflow-position-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-safe-overflow-position-005.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#overflow-values">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="assert"
-  content="safe flex-start allows for overflow past the flex-end edge, which is left in the case of wrap-reverse + vertical-lr" />
+  content="safe flex-start allows for overflow past the end edge, which is bottom/right in the case of wrap-reverse + vertical-lr" />
 
 <style>
   #reference-overlapped-red {
@@ -16,18 +16,18 @@
 
   .flex {
     display: flex;
-    inline-size: 100px;
+    flex-flow: wrap-reverse;
+    writing-mode: vertical-lr;
+    inline-size: 90px;
     block-size: 90px;
     align-content: safe flex-start;
-    flex-wrap: wrap-reverse;
-    writing-mode: vertical-lr;
-    /* Make the green square cover the red square. */
-    translate: 10px 0;
+    justify-content: safe flex-start;
   }
 
   .item {
     flex: 0 0 100px;
-    block-size: 100px;
+    width: 100px;
+    height: 100px;
     background: green;
   }
 

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -199,6 +199,7 @@ private:
     void maybeCacheChildMainIntrinsicSize(RenderBox& child, bool relayoutChildren);
     void adjustAlignmentForChild(RenderBox& child, LayoutUnit);
     ItemPosition alignmentForChild(const RenderBox& child) const;
+    inline OverflowAlignment overflowAlignmentForChild(const RenderBox& child) const;
     bool canComputePercentageFlexBasis(const RenderBox& child, const Length& flexBasis, UpdatePercentageHeightDescendants);
     bool childMainSizeIsDefinite(const RenderBox&, const Length& flexBasis);
     bool childCrossSizeIsDefinite(const RenderBox&, const Length& flexBasis);


### PR DESCRIPTION
#### 4258e7ee63a17d362a9d57f91615925b176962ca
<pre>
Implement safe alignment in flexbox.
<a href="https://bugs.webkit.org/show_bug.cgi?id=263893">https://bugs.webkit.org/show_bug.cgi?id=263893</a>
<a href="https://rdar.apple.com/118000717">rdar://118000717</a>

Reviewed by Sammy Gill.

Coverts alignment to Start when available space is negative and overflow alignment safety is on.

* LayoutTests/TestExpectations: Pass more tests!
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-safe-overflow-position-002.html: Fix (and augment) incorrect test.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-safe-overflow-position-003.html: Fix (and augment) incorrect test.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-safe-overflow-position-004.html: Fix (and augment) incorrect test.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/flexbox-safe-overflow-position-005.html: Fix (and augment) incorrect test.
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::initialJustifyContentOffset): Apply overflow safety to main-axis content alignment.
(WebCore::RenderFlexibleBox::staticCrossAxisPositionForPositionedChild): Apply overflow safety to static positioning.
(WebCore::RenderFlexibleBox::overflowAlignmentForChild const): Implement new helper method.
(WebCore::initialAlignContentOffset): Apply overflow safety to main-axis content alignment.
(WebCore::RenderFlexibleBox::alignFlexLines): Don&apos;t skip alignment calculation when safety is on, pass safety value to initialAlignContentOffset().
(WebCore::RenderFlexibleBox::alignChildren): Apply overflow safety to cross-axis item alignment.
(WebCore::RenderFlexibleBox::allowedLayoutOverflow const): Apply overflow safety to overflow bounds.
* Source/WebCore/rendering/RenderFlexibleBox.h: Add helper method overflowAlignmentForChild(), parallel to alignmentForChild().

Canonical link: <a href="https://commits.webkit.org/274304@main">https://commits.webkit.org/274304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/232226f41aee368505033eb4fbbd4b51a3c0f27d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41070 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34213 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32398 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33522 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12781 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12764 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42346 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34995 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34786 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38599 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36808 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/33681 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8668 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13843 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14449 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->