### PR TITLE
[MultiRep HEIC] Ensure <attachment> creation upon insertion

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1138,6 +1138,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     history/CachedPage.h
     history/HistoryItem.h
 
+    html/AttachmentAssociatedElement.h
     html/Autocapitalize.h
     html/AutocapitalizeTypes.h
     html/Autofill.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1308,6 +1308,7 @@ history/BackForwardController.cpp
 history/CachedFrame.cpp
 history/CachedPage.cpp
 history/HistoryItem.cpp
+html/AttachmentAssociatedElement.cpp
 html/Autocapitalize.cpp
 html/Autofill.cpp
 html/BaseButtonInputType.cpp

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9708,9 +9708,9 @@ void Document::handlePopoverLightDismiss(const PointerEvent& event, Node& target
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 
-void Document::registerAttachmentIdentifier(const String& identifier, const HTMLImageElement& image)
+void Document::registerAttachmentIdentifier(const String& identifier, const AttachmentAssociatedElement& element)
 {
-    editor().registerAttachmentIdentifier(identifier, image);
+    editor().registerAttachmentIdentifier(identifier, element);
 }
 
 void Document::didInsertAttachmentElement(HTMLAttachmentElement& attachment)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -249,6 +249,10 @@ class XPathExpression;
 class XPathNSResolver;
 class XPathResult;
 
+#if ENABLE(ATTACHMENT_ELEMENT)
+class AttachmentAssociatedElement;
+#endif
+
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
 class ContentChangeObserver;
 class DOMTimerHoldingTank;
@@ -1758,7 +1762,7 @@ public:
     void handlePopoverLightDismiss(const PointerEvent&, Node&);
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    void registerAttachmentIdentifier(const String&, const HTMLImageElement&);
+    void registerAttachmentIdentifier(const String&, const AttachmentAssociatedElement&);
     void didInsertAttachmentElement(HTMLAttachmentElement&);
     void didRemoveAttachmentElement(HTMLAttachmentElement&);
     WEBCORE_EXPORT RefPtr<HTMLAttachmentElement> attachmentForIdentifier(const String&) const;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -840,6 +840,13 @@ ValidatedFormListedElement* Element::asValidatedFormListedElement()
     return nullptr;
 }
 
+#if ENABLE(ATTACHMENT_ELEMENT)
+AttachmentAssociatedElement* Element::asAttachmentAssociatedElement()
+{
+    return nullptr;
+}
+#endif
+
 bool Element::isUserActionElementHasFocusWithin() const
 {
     ASSERT(isUserActionElement());

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -85,6 +85,10 @@ class UniqueElementData;
 class ValidatedFormListedElement;
 class WebAnimation;
 
+#if ENABLE(ATTACHMENT_ELEMENT)
+class AttachmentAssociatedElement;
+#endif
+
 enum class AnimationImpact : uint8_t;
 enum class EventHandling : uint8_t;
 enum class EventProcessing : uint8_t;
@@ -323,6 +327,10 @@ public:
     virtual FormListedElement* asFormListedElement();
     virtual ValidatedFormListedElement* asValidatedFormListedElement();
     virtual bool attributeContainsJavaScriptURL(const Attribute&) const;
+
+#if ENABLE(ATTACHMENT_ELEMENT)
+    virtual AttachmentAssociatedElement* asAttachmentAssociatedElement();
+#endif
 
     // Remove attributes that might introduce scripting from the vector leaving the element unchanged.
     void stripScriptingAttributes(Vector<Attribute>&) const;

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -109,6 +109,7 @@ enum class MailBlockquoteHandling : bool {
 };
 
 #if ENABLE(ATTACHMENT_ELEMENT)
+class AttachmentAssociatedElement;
 class HTMLAttachmentElement;
 #endif
 
@@ -589,7 +590,7 @@ public:
     void registerAttachmentIdentifier(const String&, const String& contentType, const String& preferredFileName, Ref<FragmentedSharedBuffer>&& fileData);
     void registerAttachments(Vector<SerializedAttachmentData>&&);
     void registerAttachmentIdentifier(const String&, const String& contentType, const String& filePath);
-    void registerAttachmentIdentifier(const String&, const HTMLImageElement&);
+    void registerAttachmentIdentifier(const String&, const AttachmentAssociatedElement&);
     void cloneAttachmentData(const String& fromIdentifier, const String& toIdentifier);
     void didInsertAttachmentElement(HTMLAttachmentElement&);
     void didRemoveAttachmentElement(HTMLAttachmentElement&);

--- a/Source/WebCore/html/AttachmentAssociatedElement.cpp
+++ b/Source/WebCore/html/AttachmentAssociatedElement.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AttachmentAssociatedElement.h"
+
+#if ENABLE(ATTACHMENT_ELEMENT)
+
+#include "CSSPropertyNames.h"
+#include "CSSValueKeywords.h"
+#include "ElementChildIteratorInlines.h"
+#include "HTMLAttachmentElement.h"
+#include "ShadowRoot.h"
+
+namespace WebCore {
+
+void AttachmentAssociatedElement::setAttachmentElement(Ref<HTMLAttachmentElement>&& attachment)
+{
+    if (auto existingAttachment = attachmentElement())
+        existingAttachment->remove();
+
+    attachment->setInlineStyleProperty(CSSPropertyDisplay, CSSValueNone, true);
+    asHTMLElement().ensureUserAgentShadowRoot().appendChild(WTFMove(attachment));
+}
+
+RefPtr<HTMLAttachmentElement> AttachmentAssociatedElement::attachmentElement() const
+{
+    if (auto shadowRoot = asHTMLElement().userAgentShadowRoot())
+        return childrenOfType<HTMLAttachmentElement>(*shadowRoot).first();
+
+    return nullptr;
+}
+
+const String& AttachmentAssociatedElement::attachmentIdentifier() const
+{
+    if (!m_pendingClonedAttachmentID.isEmpty())
+        return m_pendingClonedAttachmentID;
+
+    if (auto attachment = attachmentElement())
+        return attachment->uniqueIdentifier();
+
+    return nullAtom();
+}
+
+void AttachmentAssociatedElement::didUpdateAttachmentIdentifier()
+{
+    m_pendingClonedAttachmentID = { };
+}
+
+void AttachmentAssociatedElement::copyAttachmentAssociatedPropertiesFromElement(const AttachmentAssociatedElement& source)
+{
+    m_pendingClonedAttachmentID = !source.m_pendingClonedAttachmentID.isEmpty() ? source.m_pendingClonedAttachmentID : source.attachmentIdentifier();
+}
+
+void AttachmentAssociatedElement::cloneAttachmentAssociatedElementWithoutAttributesAndChildren(AttachmentAssociatedElement& clone, Document& targetDocument)
+{
+    if (auto attachment = attachmentElement()) {
+        auto attachmentClone = attachment->cloneElementWithoutChildren(targetDocument);
+        clone.setAttachmentElement(checkedDowncast<HTMLAttachmentElement>(attachmentClone.get()));
+    }
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/html/AttachmentAssociatedElement.h
+++ b/Source/WebCore/html/AttachmentAssociatedElement.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(ATTACHMENT_ELEMENT)
+
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+class Document;
+class Element;
+class HTMLAttachmentElement;
+class HTMLElement;
+
+enum class AttachmentAssociatedElementType : uint8_t {
+    None,
+    Image,
+    Source,
+};
+
+class AttachmentAssociatedElement {
+public:
+    void ref() const { refAttachmentAssociatedElement(); }
+    void deref() const { derefAttachmentAssociatedElement(); }
+
+    virtual ~AttachmentAssociatedElement() = default;
+
+    virtual HTMLElement& asHTMLElement() = 0;
+    virtual const HTMLElement& asHTMLElement() const = 0;
+
+    virtual AttachmentAssociatedElementType attachmentAssociatedElementType() const = 0;
+
+    virtual void setAttachmentElement(Ref<HTMLAttachmentElement>&&);
+
+    RefPtr<HTMLAttachmentElement> attachmentElement() const;
+    const String& attachmentIdentifier() const;
+    void didUpdateAttachmentIdentifier();
+
+protected:
+    void copyAttachmentAssociatedPropertiesFromElement(const AttachmentAssociatedElement&);
+    void cloneAttachmentAssociatedElementWithoutAttributesAndChildren(AttachmentAssociatedElement&, Document&);
+
+private:
+    virtual void refAttachmentAssociatedElement() const = 0;
+    virtual void derefAttachmentAssociatedElement() const = 0;
+
+    virtual Ref<Element> cloneElementWithoutAttributesAndChildren(Document&) = 0;
+    virtual void copyNonAttributePropertiesFromElement(const Element&) = 0;
+
+    virtual AttachmentAssociatedElement* asAttachmentAssociatedElement() = 0;
+
+    String m_pendingClonedAttachmentID;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -32,6 +32,9 @@
 
 namespace WebCore {
 
+enum class AttachmentAssociatedElementType : uint8_t;
+
+class AttachmentAssociatedElement;
 class DOMRectReadOnly;
 class File;
 class HTMLImageElement;
@@ -43,7 +46,7 @@ class HTMLAttachmentElement final : public HTMLElement {
     WTF_MAKE_ISO_ALLOCATED(HTMLAttachmentElement);
 public:
     static Ref<HTMLAttachmentElement> create(const QualifiedName&, Document&);
-    WEBCORE_EXPORT static const String& getAttachmentIdentifier(HTMLImageElement&);
+    WEBCORE_EXPORT static String getAttachmentIdentifier(HTMLElement&);
     static URL archiveResourceURL(const String&);
 
     WEBCORE_EXPORT URL blobURL() const;
@@ -58,7 +61,7 @@ public:
     void copyNonAttributePropertiesFromElement(const Element&) final;
 
     WEBCORE_EXPORT void updateAttributes(std::optional<uint64_t>&& newFileSize, const AtomString& newContentType, const AtomString& newFilename);
-    WEBCORE_EXPORT void updateEnclosingImageWithData(const String& contentType, Ref<FragmentedSharedBuffer>&& data);
+    WEBCORE_EXPORT void updateAssociatedElementWithData(const String& contentType, Ref<FragmentedSharedBuffer>&& data);
     WEBCORE_EXPORT void updateThumbnailForNarrowLayout(const RefPtr<Image>& thumbnail);
     WEBCORE_EXPORT void updateThumbnailForWideLayout(Vector<uint8_t>&&);
     WEBCORE_EXPORT void updateIconForNarrowLayout(const RefPtr<Image>& icon, const WebCore::FloatSize&);
@@ -67,8 +70,9 @@ public:
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;
 
-    const String& ensureUniqueIdentifier();
-    RefPtr<HTMLImageElement> enclosingImageElement() const;
+    String ensureUniqueIdentifier();
+    AttachmentAssociatedElement* associatedElement() const;
+    AttachmentAssociatedElementType associatedElementType() const;
 
     WEBCORE_EXPORT String attachmentTitle() const;
     const AtomString& attachmentSubtitle() const;

--- a/Source/WebCore/html/HTMLAttachmentElement.idl
+++ b/Source/WebCore/html/HTMLAttachmentElement.idl
@@ -34,5 +34,5 @@
     readonly attribute DOMString uniqueIdentifier;
     readonly attribute DOMRectReadOnly? saveButtonClientRect;
 
-    static DOMString getAttachmentIdentifier(HTMLImageElement imageElement);
+    static DOMString getAttachmentIdentifier(HTMLElement associatedElement);
 };

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -869,40 +869,12 @@ void HTMLImageElement::setAllowsAnimation(std::optional<bool> allowsAnimation)
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 
-void HTMLImageElement::didUpdateAttachmentIdentifier()
-{
-    m_pendingClonedAttachmentID = { };
-}
-
 void HTMLImageElement::setAttachmentElement(Ref<HTMLAttachmentElement>&& attachment)
 {
-    if (auto existingAttachment = attachmentElement())
-        existingAttachment->remove();
-
-    attachment->setInlineStyleProperty(CSSPropertyDisplay, CSSValueNone, true);
-    ensureUserAgentShadowRoot().appendChild(WTFMove(attachment));
+    AttachmentAssociatedElement::setAttachmentElement(WTFMove(attachment));
 #if ENABLE(SERVICE_CONTROLS)
     setImageMenuEnabled(true);
 #endif
-}
-
-RefPtr<HTMLAttachmentElement> HTMLImageElement::attachmentElement() const
-{
-    if (auto shadowRoot = userAgentShadowRoot())
-        return childrenOfType<HTMLAttachmentElement>(*shadowRoot).first();
-
-    return nullptr;
-}
-
-const String& HTMLImageElement::attachmentIdentifier() const
-{
-    if (!m_pendingClonedAttachmentID.isEmpty())
-        return m_pendingClonedAttachmentID;
-
-    if (auto attachment = attachmentElement())
-        return attachment->uniqueIdentifier();
-
-    return nullAtom();
 }
 
 #endif // ENABLE(ATTACHMENT_ELEMENT)
@@ -947,11 +919,9 @@ bool HTMLImageElement::isSystemPreviewImage() const
 
 void HTMLImageElement::copyNonAttributePropertiesFromElement(const Element& source)
 {
-    auto& sourceImage = static_cast<const HTMLImageElement&>(source);
 #if ENABLE(ATTACHMENT_ELEMENT)
-    m_pendingClonedAttachmentID = !sourceImage.m_pendingClonedAttachmentID.isEmpty() ? sourceImage.m_pendingClonedAttachmentID : sourceImage.attachmentIdentifier();
-#else
-    UNUSED_PARAM(sourceImage);
+    auto& sourceImage = checkedDowncast<HTMLImageElement>(source);
+    copyAttachmentAssociatedPropertiesFromElement(sourceImage);
 #endif
     Element::copyNonAttributePropertiesFromElement(source);
 }
@@ -1057,10 +1027,7 @@ Ref<Element> HTMLImageElement::cloneElementWithoutAttributesAndChildren(Document
 {
     auto clone = create(targetDocument);
 #if ENABLE(ATTACHMENT_ELEMENT)
-    if (auto attachment = attachmentElement()) {
-        auto attachmentClone = attachment->cloneElementWithoutChildren(targetDocument);
-        clone->setAttachmentElement(checkedDowncast<HTMLAttachmentElement>(attachmentClone.get()));
-    }
+    cloneAttachmentAssociatedElementWithoutAttributesAndChildren(clone, targetDocument);
 #endif
     return clone;
 }

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "ActiveDOMObject.h"
+#include "AttachmentAssociatedElement.h"
 #include "DecodingOptions.h"
 #include "FormAssociatedElement.h"
 #include "GraphicsTypes.h"
@@ -47,7 +48,13 @@ enum class ReferrerPolicy : uint8_t;
 enum class RelevantMutation : bool;
 enum class RequestPriority : uint8_t;
 
-class HTMLImageElement : public HTMLElement, public FormAssociatedElement, public ActiveDOMObject {
+class HTMLImageElement
+    : public HTMLElement
+#if ENABLE(ATTACHMENT_ELEMENT)
+    , public AttachmentAssociatedElement
+#endif
+    , public FormAssociatedElement
+    , public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(HTMLImageElement);
 public:
     static Ref<HTMLImageElement> create(Document&);
@@ -114,10 +121,7 @@ public:
 #endif
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    void setAttachmentElement(Ref<HTMLAttachmentElement>&&);
-    RefPtr<HTMLAttachmentElement> attachmentElement() const;
-    const String& attachmentIdentifier() const;
-    void didUpdateAttachmentIdentifier();
+    void setAttachmentElement(Ref<HTMLAttachmentElement>&&) final;
 #endif
 
     WEBCORE_EXPORT size_t pendingDecodePromisesCountForTesting() const;
@@ -223,6 +227,15 @@ private:
     HTMLImageElement& asHTMLElement() final { return *this; }
     const HTMLImageElement& asHTMLElement() const final { return *this; }
 
+#if ENABLE(ATTACHMENT_ELEMENT)
+    void refAttachmentAssociatedElement() const final { HTMLElement::ref(); }
+    void derefAttachmentAssociatedElement() const final { HTMLElement::deref(); }
+
+    AttachmentAssociatedElement* asAttachmentAssociatedElement() final { return this; }
+
+    AttachmentAssociatedElementType attachmentAssociatedElementType() const final { return AttachmentAssociatedElementType::Image; };
+#endif
+
     bool isInteractiveContent() const final;
 
     void selectImageSource(RelevantMutation);
@@ -259,10 +272,6 @@ private:
     WeakPtr<HTMLSourceElement, WeakPtrImplWithEventTargetData> m_sourceElement;
 
     Vector<MQ::MediaQueryResult> m_dynamicMediaQueryResults;
-
-#if ENABLE(ATTACHMENT_ELEMENT)
-    String m_pendingClonedAttachmentID;
-#endif
 
     Image* image() const;
 

--- a/Source/WebCore/html/HTMLSourceElement.cpp
+++ b/Source/WebCore/html/HTMLSourceElement.cpp
@@ -219,4 +219,22 @@ void HTMLSourceElement::addCandidateSubresourceURLs(ListHashSet<URL>& urls) cons
     getURLsFromSrcsetAttribute(*this, attributeWithoutSynchronization(srcsetAttr), urls);
 }
 
+Ref<Element> HTMLSourceElement::cloneElementWithoutAttributesAndChildren(Document& targetDocument)
+{
+    auto clone = create(targetDocument);
+#if ENABLE(ATTACHMENT_ELEMENT)
+    cloneAttachmentAssociatedElementWithoutAttributesAndChildren(clone, targetDocument);
+#endif
+    return clone;
+}
+
+void HTMLSourceElement::copyNonAttributePropertiesFromElement(const Element& source)
+{
+#if ENABLE(ATTACHMENT_ELEMENT)
+    auto& sourceElement = checkedDowncast<HTMLSourceElement>(source);
+    copyAttachmentAssociatedPropertiesFromElement(sourceElement);
+#endif
+    Element::copyNonAttributePropertiesFromElement(source);
+}
+
 }

--- a/Source/WebCore/html/HTMLSourceElement.h
+++ b/Source/WebCore/html/HTMLSourceElement.h
@@ -26,17 +26,26 @@
 #pragma once
 
 #include "ActiveDOMObject.h"
+#include "AttachmentAssociatedElement.h"
 #include "HTMLElement.h"
 #include "MediaQuery.h"
 #include "Timer.h"
 
 namespace WebCore {
 
-class HTMLSourceElement final : public HTMLElement, public ActiveDOMObject {
+class HTMLSourceElement final
+    : public HTMLElement
+#if ENABLE(ATTACHMENT_ELEMENT)
+    , public AttachmentAssociatedElement
+#endif
+    , public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(HTMLSourceElement);
 public:
     static Ref<HTMLSourceElement> create(Document&);
     static Ref<HTMLSourceElement> create(const QualifiedName&, Document&);
+
+    using HTMLElement::ref;
+    using HTMLElement::deref;
 
     void scheduleErrorEvent();
     void cancelPendingErrorEvent();
@@ -55,6 +64,21 @@ private:
     // ActiveDOMObject.
     const char* activeDOMObjectName() const final;
     void stop() final;
+
+#if ENABLE(ATTACHMENT_ELEMENT)
+    HTMLSourceElement& asHTMLElement() final { return *this; }
+    const HTMLSourceElement& asHTMLElement() const final { return *this; }
+
+    void refAttachmentAssociatedElement() const final { HTMLElement::ref(); }
+    void derefAttachmentAssociatedElement() const final { HTMLElement::deref(); }
+
+    AttachmentAssociatedElement* asAttachmentAssociatedElement() final { return this; }
+
+    AttachmentAssociatedElementType attachmentAssociatedElementType() const final { return AttachmentAssociatedElementType::Source; }
+#endif
+
+    Ref<Element> cloneElementWithoutAttributesAndChildren(Document& targetDocument) final;
+    void copyNonAttributePropertiesFromElement(const Element&) final;
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 

--- a/Source/WebCore/page/EditorClient.h
+++ b/Source/WebCore/page/EditorClient.h
@@ -41,6 +41,10 @@ namespace WebCore {
 enum class DOMPasteAccessCategory : uint8_t;
 enum class DOMPasteAccessResponse : uint8_t;
 
+#if ENABLE(ATTACHMENT_ELEMENT)
+enum class AttachmentAssociatedElementType : uint8_t;
+#endif
+
 class SharedBuffer;
 class Document;
 class DocumentFragment;
@@ -88,7 +92,7 @@ public:
     virtual void registerAttachments(Vector<SerializedAttachmentData>&&) { }
     virtual void registerAttachmentIdentifier(const String& /* identifier */) { }
     virtual void cloneAttachmentData(const String& /* fromIdentifier */, const String& /* toIdentifier */) { }
-    virtual void didInsertAttachmentWithIdentifier(const String& /* identifier */, const String& /* source */, bool /* hasEnclosingImage */) { }
+    virtual void didInsertAttachmentWithIdentifier(const String& /* identifier */, const String& /* source */, AttachmentAssociatedElementType /* associatedElementType */) { }
     virtual void didRemoveAttachmentWithIdentifier(const String&) { }
     virtual bool supportsClientSideAttachmentData() const { return false; }
     virtual Vector<SerializedAttachmentData> serializedAttachmentDataForIdentifiers(const Vector<String>&) { return { }; }

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -765,6 +765,7 @@ def headers_for_type(type):
         'WallTime': ['<wtf/WallTime.h>'],
         'WebCore::AlternativeTextType': ['<WebCore/AlternativeTextClient.h>'],
         'WebCore::ApplyTrackingPrevention': ['<WebCore/NetworkStorageSession.h>'],
+        'WebCore::AttachmentAssociatedElementType': ['<WebCore/AttachmentAssociatedElement.h>'],
         'WebCore::AutocorrectionResponse': ['<WebCore/AlternativeTextClient.h>'],
         'WebCore::AutoplayEventFlags': ['<WebCore/AutoplayEvent.h>'],
         'WebCore::BackForwardItemIdentifier': ['<WebCore/ProcessQualified.h>', '<WebCore/BackForwardItemIdentifier.h>', '<wtf/ObjectIdentifier.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1985,6 +1985,14 @@ struct WebCore::SerializedAttachmentData {
     String mimeType;
     Ref<WebCore::SharedBuffer> data;
 };
+
+header: <WebCore/AttachmentAssociatedElement.h>
+[CustomHeader] enum class WebCore::AttachmentAssociatedElementType : uint8_t {
+    None,
+    Image,
+    Source,
+};
+
 #endif // ENABLE(ATTACHMENT_ELEMENT)
 
 header: <WebCore/FileChooser.h>

--- a/Source/WebKit/UIProcess/API/APIAttachment.cpp
+++ b/Source/WebKit/UIProcess/API/APIAttachment.cpp
@@ -100,7 +100,7 @@ std::optional<uint64_t> Attachment::fileSizeForDisplay() const
     return std::nullopt;
 }
 
-RefPtr<WebCore::FragmentedSharedBuffer> Attachment::enclosingImageData() const
+RefPtr<WebCore::FragmentedSharedBuffer> Attachment::associatedElementData() const
 {
     return nullptr;
 }

--- a/Source/WebKit/UIProcess/API/APIAttachment.h
+++ b/Source/WebKit/UIProcess/API/APIAttachment.h
@@ -29,6 +29,7 @@
 
 #include "APIObject.h"
 #include "WKBase.h"
+#include <WebCore/AttachmentAssociatedElement.h>
 #include <wtf/Function.h>
 #include <wtf/Lock.h>
 #include <wtf/RefPtr.h>
@@ -40,6 +41,8 @@ OBJC_CLASS NSFileWrapper;
 OBJC_CLASS NSString;
 
 namespace WebCore {
+enum class AttachmentAssociatedElementType : uint8_t;
+
 class SharedBuffer;
 class FragmentedSharedBuffer;
 }
@@ -83,14 +86,14 @@ public:
 
     bool isEmpty() const;
 
-    RefPtr<WebCore::FragmentedSharedBuffer> enclosingImageData() const;
+    RefPtr<WebCore::FragmentedSharedBuffer> associatedElementData() const;
 #if PLATFORM(COCOA)
-    NSData *enclosingImageNSData() const;
+    NSData *associatedElementNSData() const;
 #endif
     std::optional<uint64_t> fileSizeForDisplay() const;
 
-    void setHasEnclosingImage(bool hasEnclosingImage) { m_hasEnclosingImage = hasEnclosingImage; }
-    bool hasEnclosingImage() const { return m_hasEnclosingImage; }
+    void setAssociatedElementType(WebCore::AttachmentAssociatedElementType associatedElementType) { m_associatedElementType = associatedElementType; }
+    WebCore::AttachmentAssociatedElementType associatedElementType() const { return m_associatedElementType; }
 
     RefPtr<WebCore::SharedBuffer> createSerializedRepresentation() const;
     void updateFromSerializedRepresentation(Ref<WebCore::SharedBuffer>&&, const WTF::String& contentType);
@@ -107,7 +110,7 @@ private:
     WTF::String m_contentType;
     WeakPtr<WebKit::WebPageProxy> m_webPage;
     InsertionState m_insertionState { InsertionState::NotInserted };
-    bool m_hasEnclosingImage { false };
+    WebCore::AttachmentAssociatedElementType m_associatedElementType { WebCore::AttachmentAssociatedElementType::None };
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
@@ -138,9 +138,9 @@ std::optional<uint64_t> Attachment::fileSizeForDisplay() const
     return [m_fileWrapper regularFileContents].length;
 }
 
-RefPtr<WebCore::FragmentedSharedBuffer> Attachment::enclosingImageData() const
+RefPtr<WebCore::FragmentedSharedBuffer> Attachment::associatedElementData() const
 {
-    if (!m_hasEnclosingImage)
+    if (m_associatedElementType == WebCore::AttachmentAssociatedElementType::None)
         return nullptr;
 
     NSData *data = nil;
@@ -159,7 +159,7 @@ RefPtr<WebCore::FragmentedSharedBuffer> Attachment::enclosingImageData() const
     return WebCore::SharedBuffer::create(data);
 }
 
-NSData *Attachment::enclosingImageNSData() const
+NSData *Attachment::associatedElementNSData() const
 {
     Locker locker { m_fileWrapperLock };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.h
@@ -45,6 +45,7 @@ WK_CLASS_AVAILABLE(macos(10.14), ios(12.0))
 @property (nonatomic, readonly, nullable) NSString *filePath;
 @property (nonatomic, readonly, nullable) NSData *data;
 @property (nonatomic, readonly, nullable) NSFileWrapper *fileWrapper;
+@property (nonatomic, readonly) BOOL shouldPreserveFidelity WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @end
 
 WK_CLASS_AVAILABLE(macos(10.13.4), ios(11.3))

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm
@@ -109,6 +109,11 @@ static const NSInteger InvalidAttachmentErrorCode = 2;
     return _utiType.get();
 }
 
+- (BOOL)shouldPreserveFidelity
+{
+    return _attachment->associatedElementType() == WebCore::AttachmentAssociatedElementType::Source;
+}
+
 @end
 
 @implementation _WKAttachment

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12009,7 +12009,7 @@ void WebPageProxy::insertAttachment(Ref<API::Attachment>&& attachment, Completio
 
 void WebPageProxy::updateAttachmentAttributes(const API::Attachment& attachment, CompletionHandler<void()>&& callback)
 {
-    sendWithAsyncReply(Messages::WebPage::UpdateAttachmentAttributes(attachment.identifier(), attachment.fileSizeForDisplay(), attachment.contentType(), attachment.fileName(), IPC::SharedBufferReference(attachment.enclosingImageData())), WTFMove(callback));
+    sendWithAsyncReply(Messages::WebPage::UpdateAttachmentAttributes(attachment.identifier(), attachment.fileSizeForDisplay(), attachment.contentType(), attachment.fileName(), IPC::SharedBufferReference(attachment.associatedElementData())), WTFMove(callback));
 
 #if HAVE(QUICKLOOK_THUMBNAILING)
     requestThumbnail(attachment, attachment.identifier());
@@ -12163,17 +12163,17 @@ void WebPageProxy::platformCloneAttachment(Ref<API::Attachment>&&, Ref<API::Atta
 
 #endif
 
-void WebPageProxy::didInsertAttachmentWithIdentifier(const String& identifier, const String& source, bool hasEnclosingImage)
+void WebPageProxy::didInsertAttachmentWithIdentifier(const String& identifier, const String& source, WebCore::AttachmentAssociatedElementType associatedElementType)
 {
     MESSAGE_CHECK(m_process, m_preferences->attachmentElementEnabled());
     MESSAGE_CHECK(m_process, IdentifierToAttachmentMap::isValidKey(identifier));
 
     Ref attachment = ensureAttachment(identifier);
-    attachment->setHasEnclosingImage(hasEnclosingImage);
+    attachment->setAssociatedElementType(associatedElementType);
     attachment->setInsertionState(API::Attachment::InsertionState::Inserted);
     pageClient().didInsertAttachment(attachment, source);
 
-    if (!attachment->isEmpty() && hasEnclosingImage)
+    if (!attachment->isEmpty() && associatedElementType != WebCore::AttachmentAssociatedElementType::None)
         updateAttachmentAttributes(attachment, [] { });
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -204,6 +204,10 @@ enum class WillInternallyHandleFailure : bool;
 enum class WindowProxyProperty : uint8_t;
 enum class WritingDirection : uint8_t;
 
+#if ENABLE(ATTACHMENT_ELEMENT)
+enum class AttachmentAssociatedElementType : uint8_t;
+#endif
+
 struct AppHighlight;
 struct ApplePayAMSUIRequest;
 struct ApplicationManifest;
@@ -2819,7 +2823,7 @@ private:
     void platformRegisterAttachment(Ref<API::Attachment>&&, const String& filePath);
     void platformCloneAttachment(Ref<API::Attachment>&& fromAttachment, Ref<API::Attachment>&& toAttachment);
 
-    void didInsertAttachmentWithIdentifier(const String& identifier, const String& source, bool hasEnclosingImage);
+    void didInsertAttachmentWithIdentifier(const String& identifier, const String& source, WebCore::AttachmentAssociatedElementType);
     void didRemoveAttachmentWithIdentifier(const String& identifier);
     void didRemoveAttachment(API::Attachment&);
     Ref<API::Attachment> ensureAttachment(const String& identifier);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -508,7 +508,7 @@ messages -> WebPageProxy {
     [EnabledIf='attachmentElementEnabled()'] RegisterAttachmentIdentifier(String identifier)
     [EnabledIf='attachmentElementEnabled()'] RegisterAttachmentsFromSerializedData(Vector<WebCore::SerializedAttachmentData> data)
     [EnabledIf='attachmentElementEnabled()'] CloneAttachmentData(String fromIdentifier, String toIdentifier)
-    [EnabledIf='attachmentElementEnabled()'] DidInsertAttachmentWithIdentifier(String identifier, String source, bool hasEnclosingImage)
+    [EnabledIf='attachmentElementEnabled()'] DidInsertAttachmentWithIdentifier(String identifier, String source, enum:uint8_t WebCore::AttachmentAssociatedElementType associatedElementType)
     [EnabledIf='attachmentElementEnabled()'] DidRemoveAttachmentWithIdentifier(String identifier)
     [EnabledIf='attachmentElementEnabled()'] SerializedAttachmentDataForIdentifiers(Vector<String> identifiers) -> (Vector<WebCore::SerializedAttachmentData> seralizedData) Synchronous
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -236,7 +236,7 @@ void WebContextMenuProxyMac::setupServicesMenu()
     RetainPtr<NSItemProvider> itemProvider;
     if (hasControlledImage) {
         if (attachment)
-            itemProvider = adoptNS([[NSItemProvider alloc] initWithItem:attachment->enclosingImageNSData() typeIdentifier:attachment->utiType()]);
+            itemProvider = adoptNS([[NSItemProvider alloc] initWithItem:attachment->associatedElementNSData() typeIdentifier:attachment->utiType()]);
         else {
             RefPtr<ShareableBitmap> image = m_context.controlledImage();
             if (!image)
@@ -256,7 +256,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
         items = @[ selection.get() ];
     } else if (isPDFAttachment) {
-        itemProvider = adoptNS([[NSItemProvider alloc] initWithItem:attachment->enclosingImageNSData() typeIdentifier:attachment->utiType()]);
+        itemProvider = adoptNS([[NSItemProvider alloc] initWithItem:attachment->associatedElementNSData() typeIdentifier:attachment->utiType()]);
         items = @[ itemProvider.get() ];
     } else {
         LOG_ERROR("No service controlled item represented in the context");

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -170,9 +170,9 @@ void WebEditorClient::cloneAttachmentData(const String& fromIdentifier, const St
     m_page->send(Messages::WebPageProxy::CloneAttachmentData(fromIdentifier, toIdentifier));
 }
 
-void WebEditorClient::didInsertAttachmentWithIdentifier(const String& identifier, const String& source, bool hasEnclosingImage)
+void WebEditorClient::didInsertAttachmentWithIdentifier(const String& identifier, const String& source, WebCore::AttachmentAssociatedElementType associatedElementType)
 {
-    m_page->send(Messages::WebPageProxy::DidInsertAttachmentWithIdentifier(identifier, source, hasEnclosingImage));
+    m_page->send(Messages::WebPageProxy::DidInsertAttachmentWithIdentifier(identifier, source, associatedElementType));
 }
 
 void WebEditorClient::didRemoveAttachmentWithIdentifier(const String& identifier)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -31,6 +31,9 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
+#if ENABLE(ATTACHMENT_ELEMENT)
+enum class AttachmentAssociatedElementType : uint8_t;
+#endif
 enum class DOMPasteAccessCategory : uint8_t;
 enum class DOMPasteAccessResponse : uint8_t;
 }
@@ -73,7 +76,7 @@ private:
     void registerAttachmentIdentifier(const String&) final;
     void registerAttachments(Vector<WebCore::SerializedAttachmentData>&&) final;
     void cloneAttachmentData(const String& fromIdentifier, const String& toIdentifier) final;
-    void didInsertAttachmentWithIdentifier(const String& identifier, const String& source, bool hasEnclosingImage) final;
+    void didInsertAttachmentWithIdentifier(const String& identifier, const String& source, WebCore::AttachmentAssociatedElementType) final;
     void didRemoveAttachmentWithIdentifier(const String& identifier) final;
     bool supportsClientSideAttachmentData() const final { return true; }
     Vector<WebCore::SerializedAttachmentData> serializedAttachmentDataForIdentifiers(const Vector<String>&) final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8019,12 +8019,12 @@ void WebPage::insertAttachment(const String& identifier, std::optional<uint64_t>
     callback();
 }
 
-void WebPage::updateAttachmentAttributes(const String& identifier, std::optional<uint64_t>&& fileSize, const String& contentType, const String& fileName, const IPC::SharedBufferReference& enclosingImageData, CompletionHandler<void()>&& callback)
+void WebPage::updateAttachmentAttributes(const String& identifier, std::optional<uint64_t>&& fileSize, const String& contentType, const String& fileName, const IPC::SharedBufferReference& associatedElementData, CompletionHandler<void()>&& callback)
 {
     if (RefPtr attachment = attachmentElementWithIdentifier(identifier)) {
         attachment->document().updateLayout();
         attachment->updateAttributes(WTFMove(fileSize), AtomString { contentType }, AtomString { fileName });
-        attachment->updateEnclosingImageWithData(contentType, enclosingImageData.isNull() ? WebCore::SharedBuffer::create() : enclosingImageData.unsafeBuffer().releaseNonNull());
+        attachment->updateAssociatedElementWithData(contentType, associatedElementData.isNull() ? WebCore::SharedBuffer::create() : associatedElementData.unsafeBuffer().releaseNonNull());
     }
     callback();
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1432,7 +1432,7 @@ public:
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     void insertAttachment(const String& identifier, std::optional<uint64_t>&& fileSize, const String& fileName, const String& contentType, CompletionHandler<void()>&&);
-    void updateAttachmentAttributes(const String& identifier, std::optional<uint64_t>&& fileSize, const String& contentType, const String& fileName, const IPC::SharedBufferReference& enclosingImageData, CompletionHandler<void()>&&);
+    void updateAttachmentAttributes(const String& identifier, std::optional<uint64_t>&& fileSize, const String& contentType, const String& fileName, const IPC::SharedBufferReference& associatedElementData, CompletionHandler<void()>&&);
     void updateAttachmentThumbnail(const String& identifier, std::optional<ShareableBitmap::Handle>&& qlThumbnailHandle);
     void updateAttachmentIcon(const String& identifier, std::optional<ShareableBitmap::Handle>&& icon, const WebCore::FloatSize&);
     void requestAttachmentIcon(const String& identifier, const WebCore::FloatSize&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -629,7 +629,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     InsertAttachment(String identifier, std::optional<uint64_t> fileSize, String fileName, String contentType) -> ()
-    UpdateAttachmentAttributes(String identifier, std::optional<uint64_t> fileSize, String contentType, String fileName, IPC::SharedBufferReference enclosingImageData) -> ()
+    UpdateAttachmentAttributes(String identifier, std::optional<uint64_t> fileSize, String contentType, String fileName, IPC::SharedBufferReference associatedElementData) -> ()
     UpdateAttachmentThumbnail(String identifier, std::optional<WebKit::ShareableBitmap::Handle> qlThumbnailHandle)
     UpdateAttachmentIcon(String identifier, std::optional<WebKit::ShareableBitmap::Handle> icon, WebCore::FloatSize size)
 #endif


### PR DESCRIPTION
#### 1a21a036fbffe9356104277a52b78df35801cf1c
<pre>
[MultiRep HEIC] Ensure &lt;attachment&gt; creation upon insertion
<a href="https://bugs.webkit.org/show_bug.cgi?id=268243">https://bugs.webkit.org/show_bug.cgi?id=268243</a>
<a href="https://rdar.apple.com/121767827">rdar://121767827</a>

Reviewed by Wenson Hsieh.

Ensure that the HEIC &lt;source&gt; and PNG &lt;img&gt; are associated with &lt;attachment&gt;s
and are registered as `_WKAttachment`s in the UI process.

In order to support this functionality, refactor attachment code to support
associating &lt;source&gt; elements with an &lt;attachment&gt; element, in addition to the
existing support for &lt;img&gt; elements.

`AttachmentAssociatedElement` is introduced to share code between elements the
two elements that can be associated with &lt;attachment&gt;. Additionally rename all
methods that refer to an &quot;enclosing image&quot; to refer to an &quot;associated element&quot;.

Note that this patch does not make it so that *all* &lt;source&gt; elements are
&lt;attachment&gt; associated, only those associated with a multi-representation HEIC.
This is because, in general, not all &lt;source&gt; elements have loaded content.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::registerAttachmentIdentifier):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::asAttachmentAssociatedElement):
* Source/WebCore/dom/Element.h:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::registerAttachmentIdentifier):
(WebCore::Editor::notifyClientOfAttachmentUpdates):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::insertMultiRepresentationHEIC):

Create and register &lt;attachment&gt; elements for the inserted &lt;source&gt; and &lt;img&gt;.

* Source/WebCore/html/AttachmentAssociatedElement.cpp: Added.
(WebCore::AttachmentAssociatedElement::setAttachmentElement):
(WebCore::AttachmentAssociatedElement::attachmentElement const):
(WebCore::AttachmentAssociatedElement::attachmentIdentifier const):
(WebCore::AttachmentAssociatedElement::didUpdateAttachmentIdentifier):
(WebCore::AttachmentAssociatedElement::copyAttachmentAssociatedPropertiesFromElement):
(WebCore::AttachmentAssociatedElement::cloneAttachmentAssociatedElementWithoutAttributesAndChildren):
* Source/WebCore/html/AttachmentAssociatedElement.h: Added.

Introduce `AttachmentAssociatedElement` to share attachment-related code between
&lt;img&gt; and &lt;source&gt; elements.

(WebCore::AttachmentAssociatedElement::ref const):
(WebCore::AttachmentAssociatedElement::deref const):
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::getAttachmentIdentifier):
(WebCore::HTMLAttachmentElement::ensureUniqueIdentifier):
(WebCore::HTMLAttachmentElement::setUniqueIdentifier):
(WebCore::HTMLAttachmentElement::associatedElement const):
(WebCore::HTMLAttachmentElement::associatedElementType const):
(WebCore::HTMLAttachmentElement::updateAttributes):
(WebCore::HTMLAttachmentElement::updateAssociatedElementWithData):
(WebCore::HTMLAttachmentElement::enclosingImageElement const): Deleted.
(WebCore::HTMLAttachmentElement::updateEnclosingImageWithData): Deleted.
* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/html/HTMLAttachmentElement.idl:

Update `getAttachmentIdentifier` to take an `HTMLElement`, as both
`HTMLSourceElement` and `HTMLImageElement` can be associated with an
`HTMLAttachmentElement`.

* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::setAttachmentElement):
(WebCore::HTMLImageElement::copyNonAttributePropertiesFromElement):
(WebCore::HTMLImageElement::cloneElementWithoutAttributesAndChildren):
(WebCore::HTMLImageElement::didUpdateAttachmentIdentifier): Deleted.
(WebCore::HTMLImageElement::attachmentElement const): Deleted.
(WebCore::HTMLImageElement::attachmentIdentifier const): Deleted.
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLSourceElement.cpp:
(WebCore::HTMLSourceElement::cloneElementWithoutAttributesAndChildren):
(WebCore::HTMLSourceElement::copyNonAttributePropertiesFromElement):
* Source/WebCore/html/HTMLSourceElement.h:
* Source/WebCore/page/EditorClient.h:
(WebCore::EditorClient::didInsertAttachmentWithIdentifier):
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/APIAttachment.cpp:
(API::Attachment::associatedElementData const):
(API::Attachment::enclosingImageData const): Deleted.
* Source/WebKit/UIProcess/API/APIAttachment.h:
* Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm:
(API::Attachment::associatedElementData const):
(API::Attachment::associatedElementNSData const):
(API::Attachment::enclosingImageData const): Deleted.
(API::Attachment::enclosingImageNSData const): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.h:

Introduce a new `shouldPreserveFidelity` bit on `_WKAttachmentInfo`, to ensure
that clients do not transcode data from a &lt;source&gt; element.

* Source/WebKit/UIProcess/API/Cocoa/_WKAttachment.mm:
(-[_WKAttachmentInfo shouldPreserveFidelity]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateAttachmentAttributes):
(WebKit::WebPageProxy::didInsertAttachmentWithIdentifier):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::setupServicesMenu):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::didInsertAttachmentWithIdentifier):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updateAttachmentAttributes):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/273731@main">https://commits.webkit.org/273731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62ef275a64a17c5dc5af5b5da288dd0682aa5af6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39146 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37698 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12496 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11378 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/36594 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40391 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33057 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32872 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11633 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9496 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/35449 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4729 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12506 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->