### PR TITLE
[GStreamer][WebRTC] Use audiornnoise for voice activity detection

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
@@ -85,13 +85,11 @@ GstElement* GStreamerAudioCapturer::createConverter()
     gst_element_link(audioconvert, audioresample);
 
 #if USE(GSTREAMER_WEBRTC)
-    if (auto* webrtcdsp = makeGStreamerElement("webrtcdsp", nullptr)) {
-        g_object_set(webrtcdsp, "echo-cancel", FALSE, "voice-detection", TRUE, nullptr);
-
-        auto* audioconvert2 = makeGStreamerElement("audioconvert", nullptr);
-        auto* audioresample2 = makeGStreamerElement("audioresample", nullptr);
-        gst_bin_add_many(GST_BIN_CAST(bin), audioconvert2, audioresample2, webrtcdsp, nullptr);
-        gst_element_link_many(audioconvert2, audioresample2, webrtcdsp, audioconvert, nullptr);
+    if (auto audioFilter = makeGStreamerElement("audiornnoise", nullptr)) {
+        auto audioconvert2 = makeGStreamerElement("audioconvert", nullptr);
+        auto audioresample2 = makeGStreamerElement("audioresample", nullptr);
+        gst_bin_add_many(GST_BIN_CAST(bin), audioconvert2, audioresample2, audioFilter, nullptr);
+        gst_element_link_many(audioconvert2, audioresample2, audioFilter, audioconvert, nullptr);
     }
 #endif
 


### PR DESCRIPTION
#### beac34395522e84bedcfb66040620d549a43ebce
<pre>
[GStreamer][WebRTC] Use audiornnoise for voice activity detection
<a href="https://bugs.webkit.org/show_bug.cgi?id=268246">https://bugs.webkit.org/show_bug.cgi?id=268246</a>

Reviewed by Xabier Rodriguez-Calvar.

Future versions of the webrtcdsp element will not support VAD anymore, so we now do this with the
audiornnoise element.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp:
(WebCore::GStreamerAudioCapturer::createConverter):

Canonical link: <a href="https://commits.webkit.org/273745@main">https://commits.webkit.org/273745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c69926e12cd625d287ed7e8b27b820d5d51156ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38852 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32482 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31174 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11160 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32229 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40098 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32798 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32597 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37121 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9267 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35206 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13104 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8280 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11857 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12217 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->