### PR TITLE
[Buildstream SDK] Bump to GStreamer 1.22.9

### DIFF
--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -11,7 +11,7 @@ sources:
 - kind: patch
   path: patches/fdo-0004-gst-plugins-ugly-Enable-x264-encoder.patch
 - kind: patch
-  path: patches/fdo-0005-GStreamer-Bump-to-1.22.8.patch
+  path: patches/fdo-0005-GStreamer-Bump-to-1.22.9.patch
 - kind: patch
   path: patches/fdo-0006-gst-plugins-bad-Enable-soundtouch.patch
 - kind: patch

--- a/Tools/buildstream/patches/fdo-0001-gstreamer-Additional-patches.patch
+++ b/Tools/buildstream/patches/fdo-0001-gstreamer-Additional-patches.patch
@@ -3,13 +3,11 @@ From: Philippe Normand <philn@igalia.com>
 Date: Mon, 15 Jan 2024 09:27:07 +0000
 Subject: [PATCH] gstreamer: Additional patches
 
-decodebin3 patch will ship in 1.24 and vpxdec patch will ship in 1.22.9.
+decodebin3 patch will ship in 1.24.
 ---
  ...x-clean-up-of-EOS-d-parsebin-src-pad.patch | 81 +++++++++++++++++++
- ...priate-domain-and-code-for-decoding-.patch | 38 +++++++++
- 2 files changed, 119 insertions(+)
+ 1 files changed, 119 insertions(+)
  create mode 100644 patches/gstreamer/0001-decodebin3-Fix-clean-up-of-EOS-d-parsebin-src-pad.patch
- create mode 100644 patches/gstreamer/0001-vpxdec-Use-appropriate-domain-and-code-for-decoding-.patch
 
 diff --git a/patches/gstreamer/0001-decodebin3-Fix-clean-up-of-EOS-d-parsebin-src-pad.patch b/patches/gstreamer/0001-decodebin3-Fix-clean-up-of-EOS-d-parsebin-src-pad.patch
 new file mode 100644
@@ -95,50 +93,6 @@ index 0000000..8541e2a
 +     gst_element_set_state (input->identity, GST_STATE_NULL);
 +     gst_bin_remove (GST_BIN (dbin), input->identity);
 +     gst_clear_object (&input->identity);
-+-- 
-+2.43.0
-+
-diff --git a/patches/gstreamer/0001-vpxdec-Use-appropriate-domain-and-code-for-decoding-.patch b/patches/gstreamer/0001-vpxdec-Use-appropriate-domain-and-code-for-decoding-.patch
-new file mode 100644
-index 0000000..4a08e0a
---- /dev/null
-+++ b/patches/gstreamer/0001-vpxdec-Use-appropriate-domain-and-code-for-decoding-.patch
-@@ -0,0 +1,38 @@
-+From 36518d81e75712c71df0e92ed9c2d46410554f9c Mon Sep 17 00:00:00 2001
-+From: Philippe Normand <philn@igalia.com>
-+Date: Fri, 12 Jan 2024 12:51:27 +0000
-+Subject: [PATCH] vpxdec: Use appropriate domain and code for decoding errors
-+
-+STREAM domain and DECODE error is commonly used in other decoders. ENCODE is for
-+encoders.
-+
-+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/5918>
-+---
-+ subprojects/gst-plugins-good/ext/vpx/gstvpxdec.c | 4 ++--
-+ 1 file changed, 2 insertions(+), 2 deletions(-)
-+
-+diff --git a/subprojects/gst-plugins-good/ext/vpx/gstvpxdec.c b/subprojects/gst-plugins-good/ext/vpx/gstvpxdec.c
-+index d5351b839a..091207d957 100644
-+--- a/subprojects/gst-plugins-good/ext/vpx/gstvpxdec.c
-++++ b/subprojects/gst-plugins-good/ext/vpx/gstvpxdec.c
-+@@ -725,7 +725,7 @@ gst_vpx_dec_handle_frame (GstVideoDecoder * decoder, GstVideoCodecFrame * frame)
-+   if (status) {
-+     GstVideoDecoderRequestSyncPointFlags flags = 0;
-+ 
-+-    GST_VIDEO_DECODER_ERROR (decoder, 1, LIBRARY, ENCODE,
-++    GST_VIDEO_DECODER_ERROR (decoder, 1, STREAM, DECODE,
-+         ("Failed to decode frame"), ("%s", gst_vpx_error_name (status)), ret);
-+ 
-+     if (gst_video_decoder_get_needs_sync_point (decoder))
-+@@ -740,7 +740,7 @@ gst_vpx_dec_handle_frame (GstVideoDecoder * decoder, GstVideoCodecFrame * frame)
-+   if (img) {
-+     if (vpxclass->get_frame_format (dec, img, &fmt) == FALSE) {
-+       vpx_img_free (img);
-+-      GST_ELEMENT_ERROR (decoder, LIBRARY, ENCODE,
-++      GST_ELEMENT_ERROR (decoder, STREAM, DECODE,
-+           ("Failed to decode frame"), ("Unsupported color format %d",
-+               img->fmt));
-+       gst_video_codec_frame_unref (frame);
 +-- 
 +2.43.0
 +

--- a/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.9.patch
+++ b/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.9.patch
@@ -1,7 +1,7 @@
 From 627bd29a83425c1cf7a75be3e7ad2efce9605dc0 Mon Sep 17 00:00:00 2001
 From: Philippe Normand <philn@igalia.com>
 Date: Thu, 21 Dec 2023 10:42:51 +0000
-Subject: [PATCH] GStreamer: Bump to 1.22.8
+Subject: [PATCH] GStreamer: Bump to 1.22.9
 
 ---
  .../components/gstreamer-plugins-good.bst     |  1 +
@@ -33,7 +33,7 @@ index f36b91e..8fdb4f6 100644
    url: freedesktop:gstreamer/gstreamer.git
    track: 1.*[02468].*
 -  ref: 1.22.5-0-gbf6ce1d64a0697e7910826147b48f8f658366a5a
-+  ref: 1.22.8-0-g4af14db10e8355f980bbf79733af004e59d255fc
++  ref: 1.22.9-0-g3e41b8f18b7d19b0ca98a3437c2e27aa0cfe12bb
  - kind: patch_queue
    path: patches/gstreamer
 diff --git a/patches/gstreamer/graceful-error-noopenh264.patch b/patches/gstreamer/graceful-error-noopenh264.patch


### PR DESCRIPTION
#### 58de0b7f5be831d99519eb98d7bbf729c4dd4157
<pre>
[Buildstream SDK] Bump to GStreamer 1.22.9
<a href="https://bugs.webkit.org/show_bug.cgi?id=268247">https://bugs.webkit.org/show_bug.cgi?id=268247</a>

Reviewed by Adrian Perez de Castro.

* Tools/buildstream/elements/freedesktop-sdk.bst:
* Tools/buildstream/patches/fdo-0001-gstreamer-Additional-patches.patch:
* Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.9.patch: Renamed from Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.8.patch.

Canonical link: <a href="https://commits.webkit.org/273649@main">https://commits.webkit.org/273649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66ae35549830a580c6411e0c25c35b70a7b203fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38854 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32484 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31177 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11163 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40100 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37125 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9269 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35211 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13106 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11859 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4689 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12219 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->