### PR TITLE
-[_WKApplicationManifest initWithCoreShortcut:] leaks _WKApplicationManifestIcon objects

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -214,8 +214,8 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
     if (shortcut) {
         _name = adoptNS([shortcut->name copy]);
         _url = adoptNS([shortcut->url copy]);
-        _icons = createNSArray(shortcut->icons, [] (auto& icon) -> _WKApplicationManifestIcon * {
-            return [[_WKApplicationManifestIcon alloc] initWithCoreIcon:&icon];
+        _icons = createNSArray(shortcut->icons, [] (auto& icon) {
+            return adoptNS([[_WKApplicationManifestIcon alloc] initWithCoreIcon:&icon]);
         });
     }
 


### PR DESCRIPTION
#### bdf4e72cacfce658c6b7571275ed2fe490ee2ff6
<pre>
-[_WKApplicationManifest initWithCoreShortcut:] leaks _WKApplicationManifestIcon objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=268253">https://bugs.webkit.org/show_bug.cgi?id=268253</a>
&lt;<a href="https://rdar.apple.com/121808288">rdar://121808288</a>&gt;

Reviewed by Darin Adler.

* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(-[_WKApplicationManifestShortcut initWithCoreShortcut:]):
- Use adoptNS() for the lambda return value to fix the leaks.

Canonical link: <a href="https://commits.webkit.org/273625@main">https://commits.webkit.org/273625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d85ae5c4396112b3056e556d68533a31e0457909

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38859 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32489 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12113 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31181 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11167 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11191 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40105 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32804 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32608 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37129 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11387 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9273 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35215 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13111 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11864 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4672 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->