### PR TITLE
More dynamicDowncast<> adoption in editing and OffscreenCanvas

### DIFF
--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -837,7 +837,9 @@ VisiblePosition midpoint(const VisiblePositionRange& range)
     RefPtr rootNode = commonInclusiveAncestor(range);
     if (!rootNode)
         return { };
-    RefPtr rootContainerNode = rootNode->isContainerNode() ? downcast<ContainerNode>(WTFMove(rootNode)) : RefPtr { rootNode->parentNode() };
+    RefPtr rootContainerNode = dynamicDowncast<ContainerNode>(rootNode);
+    if (!rootContainerNode)
+        rootContainerNode = rootNode->parentNode();
     if (!rootContainerNode)
         return { };
     auto scope = makeRangeSelectingNodeContents(*rootContainerNode);

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -252,14 +252,12 @@ ExceptionOr<std::optional<OffscreenRenderingContext>> OffscreenCanvas::getContex
         if (!m_context) {
             auto scope = DECLARE_THROW_SCOPE(state.vm());
             RETURN_IF_EXCEPTION(scope, Exception { ExceptionCode::ExistingExceptionError });
-            auto* scriptExecutionContext = this->scriptExecutionContext();
-            if (scriptExecutionContext->isWorkerGlobalScope()) {
-                auto& globalScope = downcast<WorkerGlobalScope>(*scriptExecutionContext);
-                if (auto* gpu = globalScope.navigator().gpu())
+            Ref scriptExecutionContext = *this->scriptExecutionContext();
+            if (RefPtr globalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext)) {
+                if (auto* gpu = globalScope->navigator().gpu())
                     m_context = GPUCanvasContext::create(*this, *gpu);
-            } else if (scriptExecutionContext->isDocument()) {
-                auto& document = downcast<Document>(*scriptExecutionContext);
-                if (auto* domWindow = document.domWindow()) {
+            } else if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
+                if (RefPtr domWindow = document->domWindow()) {
                     if (auto* gpu = domWindow->navigator().gpu())
                         m_context = GPUCanvasContext::create(*this, *gpu);
                 }


### PR DESCRIPTION
#### 4146bc852b243a0d9e2f5daf6446cbb5ef44cf29
<pre>
More dynamicDowncast&lt;&gt; adoption in editing and OffscreenCanvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=268256">https://bugs.webkit.org/show_bug.cgi?id=268256</a>

Reviewed by Chris Dumez.

And increase RefPtr usage while there.

* Source/WebCore/editing/InsertLineBreakCommand.cpp:
(WebCore::InsertLineBreakCommand::doApply):
* Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp:
(WebCore::isPhrasingContent):
(WebCore::InsertParagraphSeparatorCommand::doApply):
* Source/WebCore/editing/VisiblePosition.cpp:
(WebCore::midpoint):
* Source/WebCore/editing/cocoa/DataDetection.mm:
(WebCore::DataDetection::isDataDetectorLink):
(WebCore::searchForLinkRemovingExistingDDLinks):
(WebCore::DataDetection::detectContentInRange):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::getContext):

Canonical link: <a href="https://commits.webkit.org/273709@main">https://commits.webkit.org/273709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e335b66f6b7df142a6a451412f53fb75f7315748

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39023 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32633 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37516 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12279 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31301 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32195 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11296 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11315 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40265 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32941 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32765 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37247 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35339 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13239 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8257 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11983 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12372 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->