### PR TITLE
webrtc::SctpTransportInformation::state_ is not initialized in default constructor

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/api/sctp_transport_interface.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/api/sctp_transport_interface.h
@@ -53,7 +53,7 @@ class RTC_EXPORT SctpTransportInformation {
   absl::optional<int> MaxChannels() const { return max_channels_; }
 
  private:
-  SctpTransportState state_;
+  SctpTransportState state_ { SctpTransportState::kNew }; // WEBRTC_WEBKIT_BUILD
   rtc::scoped_refptr<DtlsTransportInterface> dtls_transport_;
   absl::optional<double> max_message_size_;
   absl::optional<int> max_channels_;


### PR DESCRIPTION
#### 5201724511e7ecd69e46e6138a98e00b09b6f3a8
<pre>
webrtc::SctpTransportInformation::state_ is not initialized in default constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=268258">https://bugs.webkit.org/show_bug.cgi?id=268258</a>
&lt;<a href="https://rdar.apple.com/121811341">rdar://121811341</a>&gt;

Reviewed by Youenn Fablet.

* Source/ThirdParty/libwebrtc/Source/webrtc/api/sctp_transport_interface.h:
(webrtc::SctpTransportInformation):
- Initialize state_ to SctpTransportState::kNew.

Canonical link: <a href="https://commits.webkit.org/273738@main">https://commits.webkit.org/273738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/800099f38d6318a04edf076c135f6584b7d5c13a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38871 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32501 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31191 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32070 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11177 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11219 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40117 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32831 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37139 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35226 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13122 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11875 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4731 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12236 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->