### PR TITLE
ImageCapture: wrap references to m_logger with !RELEASE_LOG_DISABLED

### DIFF
--- a/Source/WebCore/Modules/mediastream/ImageCapture.cpp
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.cpp
@@ -54,8 +54,10 @@ ExceptionOr<Ref<ImageCapture>> ImageCapture::create(Document& document, Ref<Medi
 ImageCapture::ImageCapture(Document& document, Ref<MediaStreamTrack> track)
     : ActiveDOMObject(document)
     , m_track(track)
+#if !RELEASE_LOG_DISABLED
     , m_logger(track->logger())
     , m_logIdentifier(track->logIdentifier())
+#endif
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 }
@@ -124,10 +126,12 @@ const char* ImageCapture::activeDOMObjectName() const
     return "ImageCapture";
 }
 
+#if !RELEASE_LOG_DISABLED
 WTFLogChannel& ImageCapture::logChannel() const
 {
     return LogWebRTC;
 }
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/mediastream/ImageCapture.h
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.h
@@ -57,10 +57,12 @@ public:
 private:
     ImageCapture(Document&, Ref<MediaStreamTrack>);
 
+#if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger.get(); }
     const void* logIdentifier() const { return m_logIdentifier; }
     const char* logClassName() const { return "ImageCapture"; }
     WTFLogChannel& logChannel() const;
+#endif
 
     // ActiveDOMObject API.
     const char* activeDOMObjectName() const final;


### PR DESCRIPTION
#### 50ebd10ba3b0154c20c4263d5714e8986b1a81b8
<pre>
ImageCapture: wrap references to m_logger with !RELEASE_LOG_DISABLED
<a href="https://bugs.webkit.org/show_bug.cgi?id=268259">https://bugs.webkit.org/show_bug.cgi?id=268259</a>

Reviewed by Tim Nguyen.

m_logger is defined conditionally, but not all references use the same
condition when accessing the member.

* Source/WebCore/Modules/mediastream/ImageCapture.cpp:
(WebCore::ImageCapture::ImageCapture):
* Source/WebCore/Modules/mediastream/ImageCapture.h:

Canonical link: <a href="https://commits.webkit.org/273631@main">https://commits.webkit.org/273631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06f1d6c0d3eec98a8a707d1eb7b1c3c9be555236

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38875 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12128 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11180 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11207 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40121 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32819 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37143 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11402 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35232 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13126 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8215 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12240 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->