### PR TITLE
[Navigation] Implement navigation.updateCurrentEntry()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6889,11 +6889,11 @@ imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-e
 
 # Navigation API is not yet fully implemented
 webkit.org/b/258384 imported/w3c/web-platform-tests/navigation-api [ Skip ]
+imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/ [ Pass ]
+imported/w3c/web-platform-tests/navigation-api/currententrychange-event/ [ Pass ]
+imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-back-forward-same-doc.html [ Skip ]
+imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-back-same-doc.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/commit-behavior/after-transition-uncancelable.html [ Pass ]
-imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank.html [ Pass ]
-imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-same-doc.html [ Pass ]
-imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-same-doc-popup.html [ Pass ]
-imported/w3c/web-platform-tests/navigation-api/currententrychange-event/not-on-load.html [ Pass ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-to-javascript.html [ Pass ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/navigatesuccess-cross-document.html [ Pass ]
 imported/w3c/web-platform-tests/navigation-api/navigate-event/replaceState-in-unload-then-remove-iframe.html [ Pass ]
@@ -6909,7 +6909,10 @@ imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transitio
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-intercept-handler-modifies.html [ Pass ]
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-on-synthetic-event.html [ Pass ]
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-without-intercept.html [ Pass ]
-imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/no-args.html [ Pass ]
+imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/same-document-away-and-back-location-api.html [ Skip ]
+imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-away-and-back.html [ Skip ]
+imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-location-api.html [ Skip ]
+imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/location-reload.html [ Skip ]
 
 # -- View Transitions -- #
 # Reftest failures:

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/anchor-click-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/anchor-click-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange fires for link click null is not an object (evaluating 'navigation.currentEntry.index')
+FAIL currententrychange fires for link click assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/constructor-expected.txt
@@ -1,6 +1,6 @@
 
 PASS can't bypass required members by omitting the dictionary entirely
 PASS from is required
-FAIL all properties are reflected back Type error
-FAIL defaults are as expected Type error
+PASS all properties are reflected back
+PASS defaults are as expected
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-back-same-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-back-same-doc-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange fires for history.back() promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'navigation.currentEntry.index')"
+FAIL currententrychange fires for history.back() assert_equals: expected 3 but got 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-pushState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-pushState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange fires for history.pushState() null is not an object (evaluating 'navigation.currentEntry.index')
+FAIL currententrychange fires for history.pushState() assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-replaceState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-replaceState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange fires for history.replaceState() null is not an object (evaluating 'navigation.currentEntry.index')
+FAIL currententrychange fires for history.replaceState() assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/location-api-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/location-api-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange fires for location API navigations null is not an object (evaluating 'navigation.currentEntry.index')
+FAIL currententrychange fires for location API navigations assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-back-forward-same-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-back-forward-same-doc-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange fires for same-document navigation.back() and navigation.forward() promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'navigation.currentEntry.index')"
+FAIL currententrychange fires for same-document navigation.back() and navigation.forward() assert_equals: expected 3 but got 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-preventDefault-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-preventDefault-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange does not fire when onnavigate preventDefault() is called promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'promise.then')"
+FAIL currententrychange does not fire when onnavigate preventDefault() is called assert_unreached: Should have rejected: undefined Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-replace-same-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-replace-same-doc-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange fires for navigation.navigate() with replace promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'navigation.currentEntry.index')"
+FAIL currententrychange fires for navigation.navigate() with replace assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-same-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-same-doc-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange fires for navigation.navigate() promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'navigation.currentEntry.index')"
+FAIL currententrychange fires for navigation.navigate() assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-updateCurrentEntry-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-updateCurrentEntry-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL currententrychange fires for navigation.updateCurrentEntry() assert_equals: expected 1 but got 0
+PASS currententrychange fires for navigation.updateCurrentEntry()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/basic-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL updateCurrentEntry() works as expected null is not an object (evaluating 'navigation.currentEntry.getState')
+PASS updateCurrentEntry() works as expected
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-away-and-back-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-away-and-back-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entry.getState() behavior after navigating away and back assert_equals: expected 1 but got 0
+FAIL entry.getState() behavior after navigating away and back assert_equals: expected 1 but got 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-location-api-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-location-api-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entry.getState() behavior after cross-document location API navigation assert_equals: expected 1 but got 0
+FAIL entry.getState() behavior after cross-document location API navigation assert_equals: expected 1 but got 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/exception-order-initial-about-blank-unserializablestate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/exception-order-initial-about-blank-unserializablestate-expected.txt
@@ -2,5 +2,5 @@
 
 FAIL updateCurrentEntry() with unserializable state on the initial about:blank must throw an "InvalidStateError", not a "DataCloneError" assert_throws_dom: function "() => {
     iframe.contentWindow.navigation.updateCurrentEntry({ state: document.body });
-  }" did not throw
+  }" threw object "DataCloneError: The object can not be cloned." that is not a DOMException InvalidStateError: property "code" is equal to 25, expected 11
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/exception-order-not-fully-active-unserializablestate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/exception-order-not-fully-active-unserializablestate-expected.txt
@@ -1,5 +1,3 @@
 
-FAIL updateCurrentEntry() with unserializable state while not fully active must throw an "InvalidStateError", not a "DataCloneError" assert_throws_dom: function "() => {
-      wNavigation.updateCurrentEntry({ state: document.body });
-    }" did not throw
+PASS updateCurrentEntry() with unserializable state while not fully active must throw an "InvalidStateError", not a "DataCloneError"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/history-pushState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/history-pushState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL entry.getState() after history.pushState() null is not an object (evaluating 'navigation.currentEntry.getState')
+FAIL entry.getState() after history.pushState() assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/history-replaceState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/history-replaceState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL entry.getState() after history.replaceState() null is not an object (evaluating 'navigation.currentEntry.getState')
+FAIL entry.getState() after history.replaceState() assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/location-reload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/location-reload-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entry.getState() after location.reload() assert_equals: expected 1 but got 0
+FAIL entry.getState() after location.reload() assert_equals: expected 1 but got 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/not-fully-active-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/not-fully-active-expected.txt
@@ -1,5 +1,3 @@
 
-FAIL updateCurrentEntry() must throw if the document is not fully active assert_throws_dom: function "() => {
-      wNavigation.updateCurrentEntry({ state: 1 });
-    }" did not throw
+PASS updateCurrentEntry() must throw if the document is not fully active
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/opaque-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/opaque-origin-expected.txt
@@ -1,6 +1,4 @@
 
 
-FAIL navigation.updateCurrentEntry() in an opaque origin iframe assert_throws_dom: function "() => {
-    navigation.updateCurrentEntry({ state: 1 });
-  }" did not throw
+PASS navigation.updateCurrentEntry() in an opaque origin iframe
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/same-document-away-and-back-location-api-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/same-document-away-and-back-location-api-expected.txt
@@ -1,10 +1,10 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: null is not an object (evaluating 'entry0.index')
+CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_equals: expected 3 but got 2
 
-Harness Error (FAIL), message = Unhandled rejection: null is not an object (evaluating 'entry0.index')
+Harness Error (FAIL), message = Unhandled rejection: assert_equals: expected 3 but got 2
 
 TIMEOUT entry.getState() behavior after navigating away using the location API, then back Test timed out
 
-Harness Error (FAIL), message = Unhandled rejection: null is not an object (evaluating 'entry0.index')
+Harness Error (FAIL), message = Unhandled rejection: assert_equals: expected 3 but got 2
 
 TIMEOUT entry.getState() behavior after navigating away using the location API, then back Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/unserializable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/unserializable-expected.txt
@@ -1,8 +1,6 @@
 
 
-FAIL updateCurrentEntry() must throw if state is unserializable (WritableStream) assert_throws_dom: function "() => {
-      iframe.contentWindow.navigation.updateCurrentEntry({ state: new WritableStream() });
-    }" did not throw
+PASS updateCurrentEntry() must throw if state is unserializable (WritableStream)
 FAIL updateCurrentEntry() must throw if state is unserializable (SharedArrayBuffer) assert_throws_dom: function "() => {
       iframe.contentWindow.navigation.updateCurrentEntry({ state: buffer });
     }" did not throw

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -109,6 +109,7 @@ void HistoryItem::reset()
     m_itemSequenceNumber = generateSequenceNumber();
 
     m_stateObject = nullptr;
+    m_navigationAPIStateObject = nullptr;
     m_documentSequenceNumber = generateSequenceNumber();
 
     m_formData = nullptr;
@@ -276,6 +277,12 @@ void HistoryItem::setStateObject(RefPtr<SerializedScriptValue>&& object)
 {
     m_stateObject = WTFMove(object);
     notifyChanged();
+}
+
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#she-navigation-api-state
+void HistoryItem::setNavigationAPIStateObject(RefPtr<SerializedScriptValue>&& object)
+{
+    m_navigationAPIStateObject = WTFMove(object);
 }
 
 void HistoryItem::addChildItem(Ref<HistoryItem>&& child)

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -131,6 +131,9 @@ public:
     WEBCORE_EXPORT void setStateObject(RefPtr<SerializedScriptValue>&&);
     SerializedScriptValue* stateObject() const { return m_stateObject.get(); }
 
+    void setNavigationAPIStateObject(RefPtr<SerializedScriptValue>&&);
+    SerializedScriptValue* navigationAPIStateObject() const { return m_navigationAPIStateObject.get(); }
+
     void setItemSequenceNumber(long long number) { m_itemSequenceNumber = number; }
     long long itemSequenceNumber() const { return m_itemSequenceNumber; }
 
@@ -255,6 +258,9 @@ private:
     // Support for HTML5 History
     RefPtr<SerializedScriptValue> m_stateObject;
     
+    // Navigation API
+    RefPtr<SerializedScriptValue> m_navigationAPIStateObject;
+
     // info used to repost form data
     RefPtr<FormData> m_formData;
     String m_formContentType;

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -82,7 +82,7 @@ public:
     bool canGoBack() const { return m_canGoBack; };
     bool canGoForward() const { return m_canGoForward; };
 
-    void initializeEntries(const Ref<HistoryItem>& currentItem, const Vector<Ref<HistoryItem>> &items);
+    void initializeEntries(const Ref<HistoryItem>& currentItem, Vector<Ref<HistoryItem>> &items);
 
     Result navigate(const String& url, NavigateOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
@@ -92,7 +92,7 @@ public:
     Result back(Options&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
     Result forward(Options&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
-    void updateCurrentEntry(UpdateCurrentEntryOptions&&);
+    ExceptionOr<void> updateCurrentEntry(JSDOMGlobalObject&, UpdateCurrentEntryOptions&&);
 
 private:
     Navigation(ScriptExecutionContext*, LocalDOMWindow&);

--- a/Source/WebCore/page/Navigation.idl
+++ b/Source/WebCore/page/Navigation.idl
@@ -5,7 +5,7 @@
 ] interface Navigation : EventTarget {
   sequence<NavigationHistoryEntry> entries();
   readonly attribute NavigationHistoryEntry? currentEntry;
-  undefined updateCurrentEntry(NavigationUpdateCurrentEntryOptions options);
+  [CallWith=CurrentGlobalObject] undefined updateCurrentEntry(NavigationUpdateCurrentEntryOptions options);
   readonly attribute NavigationTransition? transition;
 
   readonly attribute boolean canGoBack;

--- a/Source/WebCore/page/NavigationHistoryEntry.idl
+++ b/Source/WebCore/page/NavigationHistoryEntry.idl
@@ -8,7 +8,7 @@
   readonly attribute long long index;
   readonly attribute boolean sameDocument;
 
-  any getState();
+  [CallWith=CurrentGlobalObject] any getState();
 
   attribute EventHandler ondispose;
 };


### PR DESCRIPTION
#### 6207ac0f032490e8fb53a51e166684b3f2edccc0
<pre>
[Navigation] Implement navigation.updateCurrentEntry()
<a href="https://bugs.webkit.org/show_bug.cgi?id=268261">https://bugs.webkit.org/show_bug.cgi?id=268261</a>

Reviewed by Alex Christensen.

This implements `navigation.UpdateCurrentEntry()`, both the method storing state, and emitting the currententryupdated event.

<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-updatecurrententry">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-updatecurrententry</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/anchor-click-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/constructor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-back-same-doc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-pushState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/history-replaceState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/location-api-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-back-forward-same-doc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-preventDefault-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-replace-same-doc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-same-doc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-updateCurrentEntry-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-away-and-back-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-location-api-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/exception-order-initial-about-blank-unserializablestate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/exception-order-not-fully-active-unserializablestate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/history-pushState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/history-replaceState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/location-reload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/not-fully-active-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/opaque-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/same-document-away-and-back-location-api-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/unserializable-expected.txt:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::updateCurrentEntry):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/Navigation.idl:
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::getState const):
* Source/WebCore/page/NavigationHistoryEntry.h:
* Source/WebCore/page/NavigationHistoryEntry.idl:

Canonical link: <a href="https://commits.webkit.org/274321@main">https://commits.webkit.org/274321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c409fda8b4fd0d10853f44dc1b8779b6c807c2c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38607 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41141 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34270 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14883 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32462 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39180 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12834 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34450 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42417 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38678 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13431 "Build is being retried. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11114 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36872 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15040 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13891 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5047 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->