### PR TITLE
Make `:-webkit-full-screen-document` an internal pseudo-class

### DIFF
--- a/LayoutTests/fullscreen/full-screen-css.html
+++ b/LayoutTests/fullscreen/full-screen-css.html
@@ -2,7 +2,7 @@
 <script src="full-screen-test.js"></script>
 <style>
     :-webkit-full-screen { background: lime; }
-    :-webkit-full-screen-document { color: blue; }
+    :root:is(:fullscreen, :has(:fullscreen)) { color: blue; }
 </style>
 <span></span>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos-expected.txt
@@ -1,8 +1,14 @@
 
 PASS ":-internal-animating-full-screen-transition" should be an invalid selector
+PASS ":-internal-fullscreen-document" should be an invalid selector
 PASS ":-internal-html-document" should be an invalid selector
+PASS ":-internal-media-document" should be an invalid selector
 PASS ":-khtml-drag" should be an invalid selector
 PASS ":-webkit-animating-full-screen-transition" should be an invalid selector
+PASS ":-webkit-full-page-media" should be an invalid selector
+PASS ":-webkit-full-screen-ancestor" should be an invalid selector
+PASS ":-webkit-full-screen-controls-hidden" should be an invalid selector
+PASS ":-webkit-full-screen-document" should be an invalid selector
 PASS "::-apple-attachment-controls-container" should be an invalid selector
 PASS "::-internal-loading-auto-fill-button" should be an invalid selector
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos.html
@@ -9,9 +9,15 @@
 <script>
 // Pseudo-classes
 test_invalid_selector(":-internal-animating-full-screen-transition");
+test_invalid_selector(":-internal-fullscreen-document");
 test_invalid_selector(":-internal-html-document");
+test_invalid_selector(":-internal-media-document");
 test_invalid_selector(":-khtml-drag");
 test_invalid_selector(":-webkit-animating-full-screen-transition");
+test_invalid_selector(":-webkit-full-page-media");
+test_invalid_selector(":-webkit-full-screen-ancestor");
+test_invalid_selector(":-webkit-full-screen-controls-hidden");
+test_invalid_selector(":-webkit-full-screen-document");
 
 // Pseudo-elements
 test_invalid_selector("::-apple-attachment-controls-container");

--- a/ManualTests/fullscreen/full-screen-flash.html
+++ b/ManualTests/fullscreen/full-screen-flash.html
@@ -1,6 +1,6 @@
 <style>
     body { background: green; color: white; }
-    document:-webkit-full-screen-document > body { background: red;  }
+    :root:has(:fullscreen) > body { background: red;  }
     span { text-decoration: underline; cursor: hand; }
     div {
         background: blue;

--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
@@ -86,7 +86,7 @@
     transform-origin: 0 0;
 }
 
-:host(:-internal-animating-full-screen-transition) .media-controls {
+:host(:-internal-animating-fullscreen-transition) .media-controls {
     display: none;
 }
 

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -42,7 +42,10 @@
             "conditional": "ENABLE(ATTACHMENT_ELEMENT)",
             "settings-flag": "DeprecatedGlobalSettings::attachmentElementEnabled"
         },
-        "-internal-animating-full-screen-transition": {
+        "-internal-animating-fullscreen-transition": {
+            "conditional": "ENABLE(FULLSCREEN_API)"
+        },
+        "-internal-fullscreen-document": {
             "conditional": "ENABLE(FULLSCREEN_API)"
         },
         "-internal-html-document": {},
@@ -66,11 +69,6 @@
         },
         "-webkit-drag": {
             "comment": "Currently has no standard equivalent.",
-            "status": "non-standard"
-        },
-        "-webkit-full-screen-document": {
-            "comment": "For UA stylesheet use.",
-            "conditional": "ENABLE(FULLSCREEN_API)",
             "status": "non-standard"
         },
         "active": {},

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1051,10 +1051,10 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
 #if ENABLE(FULLSCREEN_API)
         case CSSSelector::PseudoClass::Fullscreen:
             return matchesFullscreenPseudoClass(element);
-        case CSSSelector::PseudoClass::InternalAnimatingFullScreenTransition:
-            return matchesFullScreenAnimatingFullScreenTransitionPseudoClass(element);
-        case CSSSelector::PseudoClass::WebKitFullScreenDocument:
-            return matchesFullScreenDocumentPseudoClass(element);
+        case CSSSelector::PseudoClass::InternalAnimatingFullscreenTransition:
+            return matchesAnimatingFullscreenTransitionPseudoClass(element);
+        case CSSSelector::PseudoClass::InternalFullscreenDocument:
+            return matchesFullscreenDocumentPseudoClass(element);
 #endif
 #if ENABLE(PICTURE_IN_PICTURE_API)
         case CSSSelector::PseudoClass::PictureInPicture:

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -416,7 +416,7 @@ ALWAYS_INLINE bool matchesFullscreenPseudoClass(const Element& element)
     return false;
 }
 
-ALWAYS_INLINE bool matchesFullScreenAnimatingFullScreenTransitionPseudoClass(const Element& element)
+ALWAYS_INLINE bool matchesAnimatingFullscreenTransitionPseudoClass(const Element& element)
 {
     CheckedPtr fullscreenManager = element.document().fullscreenManagerIfExists();
     if (!fullscreenManager || &element != fullscreenManager->currentFullscreenElement())
@@ -424,7 +424,7 @@ ALWAYS_INLINE bool matchesFullScreenAnimatingFullScreenTransitionPseudoClass(con
     return fullscreenManager->isAnimatingFullscreen();
 }
 
-ALWAYS_INLINE bool matchesFullScreenDocumentPseudoClass(const Element& element)
+ALWAYS_INLINE bool matchesFullscreenDocumentPseudoClass(const Element& element)
 {
     // While a Document is in the fullscreen state, the 'full-screen-document' pseudoclass applies
     // to all elements of that Document.

--- a/Source/WebCore/css/fullscreen.css
+++ b/Source/WebCore/css/fullscreen.css
@@ -45,7 +45,7 @@
   object-fit: contain;
 }
 
-*|*:root:-webkit-full-screen-document:not(:fullscreen) {
+*|*:root:-internal-fullscreen-document:not(:fullscreen) {
     overflow: hidden !important;
 }
 

--- a/Source/WebCore/css/process-css-pseudo-selectors.py
+++ b/Source/WebCore/css/process-css-pseudo-selectors.py
@@ -57,7 +57,7 @@ KNOWN_KEY_TYPES = {
 # - an `-internal-` prefix for things only meant to be styled in the user agent stylesheet
 # - an `-apple-` prefix only exposed to certain Apple clients (there is a settings-flag requirement for using this prefix)
 WEBKIT_PREFIX_COUNTS_DO_NOT_INCREASE = {
-    'pseudo-classes': 6,
+    'pseudo-classes': 5,
     'pseudo-elements': 59,
 }
 

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -107,8 +107,8 @@ using PseudoClassesSet = HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::
     v(operationIsValid) \
     v(operationIsWindowInactive) \
     v(operationMatchesFullscreenPseudoClass) \
-    v(operationMatchesFullScreenDocumentPseudoClass) \
-    v(operationMatchesFullScreenAnimatingFullScreenTransitionPseudoClass) \
+    v(operationMatchesFullscreenDocumentPseudoClass) \
+    v(operationMatchesAnimatingFullscreenTransitionPseudoClass) \
     v(operationMatchesPictureInPicturePseudoClass) \
     v(operationMatchesFutureCuePseudoClass) \
     v(operationMatchesPastCuePseudoClass) \
@@ -255,8 +255,8 @@ static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesDir, bool,
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesLangPseudoClass, bool, (const Element&, const FixedVector<PossiblyQuotedIdentifier>&));
 #if ENABLE(FULLSCREEN_API)
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullscreenPseudoClass, bool, (const Element&));
-static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullScreenDocumentPseudoClass, bool, (const Element&));
-static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullScreenAnimatingFullScreenTransitionPseudoClass, bool, (const Element&));
+static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullscreenDocumentPseudoClass, bool, (const Element&));
+static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesAnimatingFullscreenTransitionPseudoClass, bool, (const Element&));
 #endif
 #if ENABLE(PICTURE_IN_PICTURE_API)
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesPictureInPicturePseudoClass, bool, (const Element&));
@@ -897,16 +897,16 @@ JSC_DEFINE_JIT_OPERATION(operationMatchesFullscreenPseudoClass, bool, (const Ele
     return matchesFullscreenPseudoClass(element);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationMatchesFullScreenDocumentPseudoClass, bool, (const Element& element))
+JSC_DEFINE_JIT_OPERATION(operationMatchesFullscreenDocumentPseudoClass, bool, (const Element& element))
 {
-    COUNT_SELECTOR_OPERATION(operationMatchesFullScreenDocumentPseudoClass);
-    return matchesFullScreenDocumentPseudoClass(element);
+    COUNT_SELECTOR_OPERATION(operationMatchesFullscreenDocumentPseudoClass);
+    return matchesFullscreenDocumentPseudoClass(element);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationMatchesFullScreenAnimatingFullScreenTransitionPseudoClass, bool, (const Element& element))
+JSC_DEFINE_JIT_OPERATION(operationMatchesAnimatingFullscreenTransitionPseudoClass, bool, (const Element& element))
 {
-    COUNT_SELECTOR_OPERATION(operationMatchesFullScreenAnimatingFullScreenTransitionPseudoClass);
-    return matchesFullScreenAnimatingFullScreenTransitionPseudoClass(element);
+    COUNT_SELECTOR_OPERATION(operationMatchesAnimatingFullscreenTransitionPseudoClass);
+    return matchesAnimatingFullscreenTransitionPseudoClass(element);
 }
 #endif
 
@@ -1100,11 +1100,11 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
     case CSSSelector::PseudoClass::Fullscreen:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullscreenPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClass::WebKitFullScreenDocument:
-        fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenDocumentPseudoClass));
+    case CSSSelector::PseudoClass::InternalFullscreenDocument:
+        fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullscreenDocumentPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClass::InternalAnimatingFullScreenTransition:
-        fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenAnimatingFullScreenTransitionPseudoClass));
+    case CSSSelector::PseudoClass::InternalAnimatingFullscreenTransition:
+        fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesAnimatingFullscreenTransitionPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 #endif
 

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -739,7 +739,7 @@ void FullscreenManager::setAnimatingFullscreen(bool flag)
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (m_fullscreenElement)
-        emplace(styleInvalidation, *m_fullscreenElement, { { CSSSelector::PseudoClass::InternalAnimatingFullScreenTransition, flag } });
+        emplace(styleInvalidation, *m_fullscreenElement, { { CSSSelector::PseudoClass::InternalAnimatingFullscreenTransition, flag } });
     m_isAnimatingFullscreen = flag;
 }
 

--- a/Source/WebCore/html/shadow/imageOverlay.css
+++ b/Source/WebCore/html/shadow/imageOverlay.css
@@ -36,7 +36,7 @@ div#image-overlay {
     font-family: system-ui;
 }
 
-:host(:not(img)) div#image-overlay:-webkit-full-screen-document {
+:host(:not(img)) div#image-overlay:-internal-fullscreen-document {
     display: none;
 }
 


### PR DESCRIPTION
#### 705788983f0a6269351404a12ba9d3d603f62a42
<pre>
Make `:-webkit-full-screen-document` an internal pseudo-class
<a href="https://bugs.webkit.org/show_bug.cgi?id=268234">https://bugs.webkit.org/show_bug.cgi?id=268234</a>
<a href="https://rdar.apple.com/121816310">rdar://121816310</a>

Reviewed by Darin Adler.

The main use of this is the UA stylesheet. Websites can use `:root:is(:fullscreen, :has(:fullscreen))` to achieve the same effect.

Let&apos;s attempt to unexpose this pseudo-class.

Also change &apos;full-screen&apos; to &apos;fullscreen&apos; for consistency with spec language.

* LayoutTests/fullscreen/full-screen-css.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/invalid-pseudos.html:
* ManualTests/fullscreen/full-screen-flash.html:
* Source/WebCore/Modules/modern-media-controls/controls/media-controls.css:
(:host(:-internal-animating-fullscreen-transition) .media-controls):
(:host(:-internal-animating-full-screen-transition) .media-controls): Deleted.
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesAnimatingFullscreenTransitionPseudoClass):
(WebCore::matchesFullscreenDocumentPseudoClass):
(WebCore::matchesFullScreenAnimatingFullScreenTransitionPseudoClass): Deleted.
(WebCore::matchesFullScreenDocumentPseudoClass): Deleted.
* Source/WebCore/css/fullscreen.css:
(*|*:root:-internal-fullscreen-document:not(:fullscreen)):
(*|*:root:-webkit-full-screen-document:not(:fullscreen)): Deleted.
* Source/WebCore/css/process-css-pseudo-selectors.py:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::JSC_DEFINE_JIT_OPERATION):
(WebCore::SelectorCompiler::addPseudoClassType):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::setAnimatingFullscreen):
* Source/WebCore/html/shadow/imageOverlay.css:
(:host(:not(img)) div#image-overlay:-internal-fullscreen-document):
(:host(:not(img)) div#image-overlay:-webkit-full-screen-document): Deleted.

Canonical link: <a href="https://commits.webkit.org/273639@main">https://commits.webkit.org/273639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec18bcc97b7892ddc66347c8ec278162d049ab61

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38935 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32555 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31235 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11224 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40181 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32674 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37186 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9332 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35278 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13172 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/31955 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8216 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11919 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->