### PR TITLE
[Site Isolation] Fix more cases where we unnecessarily skip code on out-of-process frames

### DIFF
--- a/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp
+++ b/Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp
@@ -128,11 +128,11 @@ ExceptionOr<void> ApplePayAMSUIPaymentHandler::convertData(Document& document, J
     return { };
 }
 
-ExceptionOr<void> ApplePayAMSUIPaymentHandler::show(Document& document)
+ExceptionOr<void> ApplePayAMSUIPaymentHandler::show(Document&)
 {
     ASSERT(m_applePayAMSUIRequest);
 
-    if (!page().startApplePayAMSUISession(document.topDocument().url(), *this, *m_applePayAMSUIRequest))
+    if (!page().startApplePayAMSUISession(page().mainFrameURL(), *this, *m_applePayAMSUIRequest))
         return Exception { ExceptionCode::AbortError };
 
     return { };

--- a/Source/WebCore/Modules/applepay/ApplePaySetup.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePaySetup.cpp
@@ -95,7 +95,7 @@ void ApplePaySetup::begin(Document& document, Vector<RefPtr<ApplePaySetupFeature
         return;
     }
 
-    auto page = document.page();
+    RefPtr page = document.page();
     if (!page) {
         promise.reject(Exception { ExceptionCode::InvalidStateError });
         return;
@@ -109,7 +109,7 @@ void ApplePaySetup::begin(Document& document, Vector<RefPtr<ApplePaySetupFeature
     m_beginPromise = WTFMove(promise);
     m_pendingActivity = makePendingActivity(*this);
 
-    page->paymentCoordinator().beginApplePaySetup(m_configuration, document.topDocument().url(), WTFMove(features), [this](bool result) {
+    page->paymentCoordinator().beginApplePaySetup(m_configuration, page->mainFrameURL(), WTFMove(features), [this](bool result) {
         if (m_beginPromise)
             std::exchange(m_beginPromise, std::nullopt)->resolve(result);
     });

--- a/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
+++ b/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
@@ -99,10 +99,14 @@ bool PaymentCoordinator::beginPaymentSession(Document& document, PaymentSession&
 {
     ASSERT(!m_activeSession);
 
+    RefPtr page = document.page();
+    if (!page)
+        return false;
+
     auto linkIconURLs = LinkIconCollector { document }.iconsOfTypes({ LinkIconType::TouchIcon, LinkIconType::TouchPrecomposedIcon }).map([](auto& icon) {
         return icon.url;
     });
-    auto showPaymentUI = m_client->showPaymentUI(document.topDocument().url(), WTFMove(linkIconURLs), paymentRequest);
+    auto showPaymentUI = m_client->showPaymentUI(page->mainFrameURL(), WTFMove(linkIconURLs), paymentRequest);
     PAYMENT_COORDINATOR_RELEASE_LOG("beginPaymentSession() -> %d", showPaymentUI);
     if (!showPaymentUI)
         return false;

--- a/Source/WebCore/dom/DocumentStorageAccess.cpp
+++ b/Source/WebCore/dom/DocumentStorageAccess.cpp
@@ -266,11 +266,12 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
 {
     Ref document = m_document.get();
     RELEASE_ASSERT(document->frame() && document->frame()->page());
+    RefPtr page = document->frame()->page();
 
-    auto topFrameDomain = RegistrableDomain(document->topDocument().url());
+    auto topFrameDomain = RegistrableDomain(page->mainFrameURL());
 
     RefPtr frame = document->frame();
-    frame->protectedPage()->chrome().client().requestStorageAccess(WTFMove(requestingDomain), WTFMove(topFrameDomain), *frame, m_storageAccessScope, [this, weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (RequestStorageAccessResult result) mutable {
+    page->chrome().client().requestStorageAccess(WTFMove(requestingDomain), WTFMove(topFrameDomain), *frame, m_storageAccessScope, [this, weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)] (RequestStorageAccessResult result) mutable {
         if (!weakThis)
             return;
 

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1072,18 +1072,14 @@ static bool isElementLargeRelativeToMainFrame(const HTMLMediaElement& element)
     if (!documentFrame)
         return false;
 
-    auto* localFrame = dynamicDowncast<LocalFrame>(documentFrame->mainFrame());
-    if (!localFrame)
+    RefPtr mainFrameView = documentFrame->mainFrame().virtualView();
+    if (!mainFrameView)
         return false;
 
-    if (!localFrame->view())
-        return false;
+    auto maxVisibleClientWidth = std::min(renderer->clientWidth().toInt(), mainFrameView->visibleWidth());
+    auto maxVisibleClientHeight = std::min(renderer->clientHeight().toInt(), mainFrameView->visibleHeight());
 
-    auto& mainFrameView = *localFrame->view();
-    auto maxVisibleClientWidth = std::min(renderer->clientWidth().toInt(), mainFrameView.visibleWidth());
-    auto maxVisibleClientHeight = std::min(renderer->clientHeight().toInt(), mainFrameView.visibleHeight());
-
-    return maxVisibleClientWidth * maxVisibleClientHeight > minimumPercentageOfMainFrameAreaForMainContent * mainFrameView.visibleWidth() * mainFrameView.visibleHeight();
+    return maxVisibleClientWidth * maxVisibleClientHeight > minimumPercentageOfMainFrameAreaForMainContent * mainFrameView->visibleWidth() * mainFrameView->visibleHeight();
 }
 
 static bool isElementLargeEnoughForMainContent(const HTMLMediaElement& element, MediaSessionMainContentPurpose purpose)

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3998,13 +3998,11 @@ bool FrameLoader::shouldInterruptLoadForXFrameOptions(const String& content, con
     switch (disposition) {
     case XFrameOptionsDisposition::SameOrigin: {
         Ref origin = SecurityOrigin::create(url);
-        if (topFrame && !origin->isSameSchemeHostPort(topFrame->document()->securityOrigin()))
+        if (!topFrame || !origin->isSameSchemeHostPort(topFrame->document()->securityOrigin()))
             return true;
         for (auto* frame = m_frame->tree().parent(); frame; frame = frame->tree().parent()) {
             auto* localFrame = dynamicDowncast<LocalFrame>(frame);
-            if (!localFrame)
-                continue;
-            if (!origin->isSameSchemeHostPort(localFrame->document()->securityOrigin()))
+            if (!localFrame || !origin->isSameSchemeHostPort(localFrame->document()->securityOrigin()))
                 return true;
         }
         return false;
@@ -4075,7 +4073,7 @@ RefPtr<Frame> FrameLoader::findFrameForNavigation(const AtomString& name, Docume
         return nullptr;
 
     RefPtr frame = m_frame->tree().findBySpecifiedName(name, activeDocument->frame() ? *activeDocument->protectedFrame() : protectedFrame().get());
-    if (!activeDocument->canNavigate(dynamicDowncast<LocalFrame>(frame.get())))
+    if (!activeDocument->canNavigate(frame.get()))
         return nullptr;
 
     return frame;

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -440,10 +440,10 @@ static void drawCheckbox(const String& text, GraphicsContext& context, const Fon
 
 FloatRect InteractionRegionOverlay::rectForSettingAtIndex(unsigned index) const
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
-    if (!localMainFrame)
+    RefPtr mainFrameView = m_page.mainFrame().virtualView();
+    if (!mainFrameView)
         return FloatRect();
-    auto viewSize = localMainFrame->view()->layoutSize();
+    auto viewSize = mainFrameView->layoutSize();
     static constexpr float settingsWidth = 150;
     static constexpr float rowHeight = 16;
     return {

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -445,7 +445,8 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
     if (document) {
         loadParameters.frameURL = document->url();
 #if ENABLE(CONTENT_EXTENSIONS)
-        loadParameters.mainDocumentURL = document->topDocument().url();
+        if (auto* page = document->page())
+            loadParameters.mainDocumentURL = page->mainFrameURL();
         // FIXME: Instead of passing userContentControllerIdentifier, the NetworkProcess should be able to get it using webPageId.
         if (auto* webPage = webFrame ? webFrame->page() : nullptr)
             loadParameters.userContentControllerIdentifier = webPage->userContentControllerIdentifier();
@@ -856,7 +857,8 @@ void WebLoaderStrategy::startPingLoad(LocalFrame& frame, ResourceRequest& reques
 
     loadParameters.frameURL = document->url();
 #if ENABLE(CONTENT_EXTENSIONS)
-    loadParameters.mainDocumentURL = document->topDocument().url();
+    if (auto* page = document->page())
+        loadParameters.mainDocumentURL = page->mainFrameURL();
     // FIXME: Instead of passing userContentControllerIdentifier, we should just pass webPageId to NetworkProcess.
     loadParameters.userContentControllerIdentifier = webPage->userContentControllerIdentifier();
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
@@ -147,6 +147,10 @@ void WebResourceLoadObserver::logFontLoad(const Document& document, const String
     if (isEphemeral())
         return;
 
+    RefPtr page = document.page();
+    if (!page)
+        return;
+
 #if ENABLE(WEB_API_STATISTICS)
     RegistrableDomain registrableDomain { document.url() };
     auto& statistics = ensureResourceStatisticsForRegistrableDomain(registrableDomain);
@@ -158,7 +162,7 @@ void WebResourceLoadObserver::logFontLoad(const Document& document, const String
         if (statistics.fontsSuccessfullyLoaded.add(familyName).isNewEntry)
             shouldCallNotificationCallback = true;
     }
-    RegistrableDomain mainFrameRegistrableDomain { document.topDocument().url() };
+    RegistrableDomain mainFrameRegistrableDomain { page->mainFrameURL() };
     if (statistics.topFrameRegistrableDomainsWhichAccessedWebAPIs.add(mainFrameRegistrableDomain).isNewEntry)
         shouldCallNotificationCallback = true;
     if (shouldCallNotificationCallback)
@@ -175,10 +179,14 @@ void WebResourceLoadObserver::logCanvasRead(const Document& document)
     if (isEphemeral())
         return;
 
+    RefPtr page = document.page();
+    if (!page)
+        return;
+
 #if ENABLE(WEB_API_STATISTICS)
     RegistrableDomain registrableDomain { document.url() };
     auto& statistics = ensureResourceStatisticsForRegistrableDomain(registrableDomain);
-    RegistrableDomain mainFrameRegistrableDomain { document.topDocument().url() };
+    RegistrableDomain mainFrameRegistrableDomain { page->mainFrameURL() };
     statistics.canvasActivityRecord.wasDataRead = true;
     if (statistics.topFrameRegistrableDomainsWhichAccessedWebAPIs.add(mainFrameRegistrableDomain).isNewEntry)
         scheduleNotificationIfNeeded();
@@ -192,11 +200,15 @@ void WebResourceLoadObserver::logCanvasWriteOrMeasure(const Document& document, 
     if (isEphemeral())
         return;
 
+    RefPtr page = document.page();
+    if (!page)
+        return;
+
 #if ENABLE(WEB_API_STATISTICS)
     RegistrableDomain registrableDomain { document.url() };
     auto& statistics = ensureResourceStatisticsForRegistrableDomain(registrableDomain);
     bool shouldCallNotificationCallback = false;
-    RegistrableDomain mainFrameRegistrableDomain { document.topDocument().url() };
+    RegistrableDomain mainFrameRegistrableDomain { page->mainFrameURL() };
     if (statistics.canvasActivityRecord.recordWrittenOrMeasuredText(textWritten))
         shouldCallNotificationCallback = true;
     if (statistics.topFrameRegistrableDomainsWhichAccessedWebAPIs.add(mainFrameRegistrableDomain).isNewEntry)
@@ -214,6 +226,10 @@ void WebResourceLoadObserver::logNavigatorAPIAccessed(const Document& document, 
     if (isEphemeral())
         return;
 
+    RefPtr page = document.page();
+    if (!page)
+        return;
+
 #if ENABLE(WEB_API_STATISTICS)
     RegistrableDomain registrableDomain { document.url() };
     auto& statistics = ensureResourceStatisticsForRegistrableDomain(registrableDomain);
@@ -222,7 +238,7 @@ void WebResourceLoadObserver::logNavigatorAPIAccessed(const Document& document, 
         statistics.navigatorFunctionsAccessed.add(functionName);
         shouldCallNotificationCallback = true;
     }
-    RegistrableDomain mainFrameRegistrableDomain { document.topDocument().url() };
+    RegistrableDomain mainFrameRegistrableDomain { page->mainFrameURL() };
     if (statistics.topFrameRegistrableDomainsWhichAccessedWebAPIs.add(mainFrameRegistrableDomain).isNewEntry)
         shouldCallNotificationCallback = true;
     if (shouldCallNotificationCallback)
@@ -238,6 +254,10 @@ void WebResourceLoadObserver::logScreenAPIAccessed(const Document& document, con
     if (isEphemeral())
         return;
 
+    RefPtr page = document.page();
+    if (!page)
+        return;
+
 #if ENABLE(WEB_API_STATISTICS)
     RegistrableDomain registrableDomain { document.url() };
     auto& statistics = ensureResourceStatisticsForRegistrableDomain(registrableDomain);
@@ -246,7 +266,7 @@ void WebResourceLoadObserver::logScreenAPIAccessed(const Document& document, con
         statistics.screenFunctionsAccessed.add(functionName);
         shouldCallNotificationCallback = true;
     }
-    RegistrableDomain mainFrameRegistrableDomain { document.topDocument().url() };
+    RegistrableDomain mainFrameRegistrableDomain { page->mainFrameURL() };
     if (statistics.topFrameRegistrableDomainsWhichAccessedWebAPIs.add(mainFrameRegistrableDomain).isNewEntry)
         shouldCallNotificationCallback = true;
     if (shouldCallNotificationCallback)


### PR DESCRIPTION
#### 3cb486b7095a974e275843d9477a8cf4b1c887d8
<pre>
[Site Isolation] Fix more cases where we unnecessarily skip code on out-of-process frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=268264">https://bugs.webkit.org/show_bug.cgi?id=268264</a>
<a href="https://rdar.apple.com/121820132">rdar://121820132</a>

Reviewed by Pascoe.

* Source/WebCore/Modules/applepay-ams-ui/ApplePayAMSUIPaymentHandler.cpp:
(WebCore::ApplePayAMSUIPaymentHandler::show):
* Source/WebCore/Modules/applepay/ApplePaySetup.cpp:
(WebCore::ApplePaySetup::begin):
* Source/WebCore/Modules/applepay/PaymentCoordinator.cpp:
(WebCore::PaymentCoordinator::beginPaymentSession):
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::DocumentStorageAccess::requestStorageAccessQuirk):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::isElementLargeRelativeToMainFrame):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::shouldInterruptLoadForXFrameOptions):
(WebCore::FrameLoader::findFrameForNavigation):
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::InteractionRegionOverlay::rectForSettingAtIndex const):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
(WebKit::WebLoaderStrategy::startPingLoad):
* Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp:
(WebKit::WebResourceLoadObserver::logFontLoad):
(WebKit::WebResourceLoadObserver::logCanvasRead):
(WebKit::WebResourceLoadObserver::logCanvasWriteOrMeasure):
(WebKit::WebResourceLoadObserver::logNavigatorAPIAccessed):
(WebKit::WebResourceLoadObserver::logScreenAPIAccessed):

Canonical link: <a href="https://commits.webkit.org/273688@main">https://commits.webkit.org/273688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7311175201abc9a2329dde85a2d3250a67af8e65

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38594 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12359 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/39087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36935 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/12939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32468 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/40332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/33003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/32824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/40332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/40332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4714 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12439 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->