### PR TITLE
VideoTrackGenerator writer should get closed when its generator track (and all its clones) are stopped

### DIFF
--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.worker-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.worker-expected.txt
@@ -2,7 +2,7 @@
 PASS Tests that VideoTrackGenerator forwards frames to sink
 PASS Tests that creating a VideoTrackGenerator works as expected
 PASS Tests that VideoFrames are destroyed on write
-FAIL Generator writer rejects on mismatched media input promise_test: Unhandled rejection with value: object "NotSupportedError: AudioData creation failed"
+PASS Generator writer rejects on mismatched media input
 PASS Generator writer rejects on non media input
 PASS A writer rejects when generator's track is stopped
 PASS A muted writer rejects when generator's track is stopped

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
@@ -55,7 +55,7 @@ private:
 
     class Source final : public RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Source, WTF::DestructionThread::MainRunLoop> {
     public:
-        static Ref<Source> create() { return adoptRef(*new Source()); }
+        static Ref<Source> create(ScriptExecutionContextIdentifier identifier) { return adoptRef(*new Source(identifier)); }
 
         void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Source, WTF::DestructionThread::MainRunLoop>::ref(); }
         void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Source, WTF::DestructionThread::MainRunLoop>::deref(); }
@@ -63,11 +63,17 @@ private:
 
         void writeVideoFrame(VideoFrame&, VideoFrameTimeMetadata);
 
+        void setWritable(WritableStream&);
+
     private:
-        Source();
+        explicit Source(ScriptExecutionContextIdentifier);
 
         const RealtimeMediaSourceCapabilities& capabilities() final { return m_capabilities; }
         const RealtimeMediaSourceSettings& settings() final { return m_settings; }
+        void endProducingData() final;
+
+        ScriptExecutionContextIdentifier m_contextIdentifier;
+        WeakPtr<WritableStream> m_writable;
 
         RealtimeMediaSourceCapabilities m_capabilities;
         RealtimeMediaSourceSettings m_settings;

--- a/Source/WebCore/Modules/streams/WritableStream.cpp
+++ b/Source/WebCore/Modules/streams/WritableStream.cpp
@@ -92,14 +92,19 @@ WritableStream::WritableStream(Ref<InternalWritableStream>&& internalWritableStr
 {
 }
 
+void WritableStream::closeIfPossible()
+{
+    m_internalWritableStream->closeIfPossible();
+}
+
 JSC::JSValue JSWritableStream::abort(JSC::JSGlobalObject& globalObject, JSC::CallFrame& callFrame)
 {
-    return wrapped().internalWritableStream().abort(globalObject, callFrame.argument(0));
+    return wrapped().internalWritableStream().abortForBindings(globalObject, callFrame.argument(0));
 }
 
 JSC::JSValue JSWritableStream::close(JSC::JSGlobalObject& globalObject, JSC::CallFrame&)
 {
-    return wrapped().internalWritableStream().close(globalObject);
+    return wrapped().internalWritableStream().closeForBindings(globalObject);
 }
 
 JSC::JSValue JSWritableStream::getWriter(JSC::JSGlobalObject& globalObject, JSC::CallFrame&)

--- a/Source/WebCore/Modules/streams/WritableStream.h
+++ b/Source/WebCore/Modules/streams/WritableStream.h
@@ -29,6 +29,7 @@
 #include "JSDOMGlobalObject.h"
 #include <JavaScriptCore/Strong.h>
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -36,7 +37,7 @@ class InternalWritableStream;
 class JSDOMGlobalObject;
 class WritableStreamSink;
 
-class WritableStream : public RefCounted<WritableStream> {
+class WritableStream : public RefCounted<WritableStream>, public CanMakeWeakPtr<WritableStream> {
 public:
     static ExceptionOr<Ref<WritableStream>> create(JSC::JSGlobalObject&, std::optional<JSC::Strong<JSC::JSObject>>&&, std::optional<JSC::Strong<JSC::JSObject>>&&);
     static ExceptionOr<Ref<WritableStream>> create(JSDOMGlobalObject&, Ref<WritableStreamSink>&&);
@@ -46,6 +47,8 @@ public:
 
     void lock();
     bool locked() const;
+
+    void closeIfPossible();
 
     InternalWritableStream& internalWritableStream();
 

--- a/Source/WebCore/Modules/streams/WritableStreamInternals.js
+++ b/Source/WebCore/Modules/streams/WritableStreamInternals.js
@@ -208,6 +208,16 @@ function writableStreamAbort(stream, reason)
     return abortPromiseCapability.promise;
 }
 
+function writableStreamCloseIfPossible(stream)
+{
+    const state = @getByIdDirectPrivate(stream, "state");
+    if (state !== "writable")
+        return;
+
+    const promise = @writableStreamClose(stream);
+    @markPromiseAsHandled(promise);
+}
+
 function writableStreamClose(stream)
 {
     const state = @getByIdDirectPrivate(stream, "state");

--- a/Source/WebCore/bindings/js/InternalWritableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStream.cpp
@@ -117,7 +117,7 @@ void InternalWritableStream::lock()
         scope.clearException();
 }
 
-JSC::JSValue InternalWritableStream::abort(JSC::JSGlobalObject& globalObject, JSC::JSValue reason)
+JSC::JSValue InternalWritableStream::abortForBindings(JSC::JSGlobalObject& globalObject, JSC::JSValue reason)
 {
     auto* clientData = static_cast<JSVMClientData*>(globalObject.vm().clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamAbortForBindingsPrivateName();
@@ -134,7 +134,7 @@ JSC::JSValue InternalWritableStream::abort(JSC::JSGlobalObject& globalObject, JS
     return result.returnValue();
 }
 
-JSC::JSValue InternalWritableStream::close(JSC::JSGlobalObject& globalObject)
+JSC::JSValue InternalWritableStream::closeForBindings(JSC::JSGlobalObject& globalObject)
 {
     auto* clientData = static_cast<JSVMClientData*>(globalObject.vm().clientData);
     auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamCloseForBindingsPrivateName();
@@ -148,6 +148,26 @@ JSC::JSValue InternalWritableStream::close(JSC::JSGlobalObject& globalObject)
         return { };
 
     return result.returnValue();
+}
+
+void InternalWritableStream::closeIfPossible()
+{
+    auto* globalObject = this->globalObject();
+    if (!globalObject)
+        return;
+
+    auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
+
+    auto* clientData = static_cast<JSVMClientData*>(globalObject->vm().clientData);
+    auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamCloseIfPossiblePrivateName();
+
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(guardedObject());
+    ASSERT(!arguments.hasOverflowed());
+
+    invokeWritableStreamFunction(*globalObject, privateName, arguments);
+    if (UNLIKELY(scope.exception()))
+        scope.clearException();
 }
 
 JSC::JSValue InternalWritableStream::getWriter(JSC::JSGlobalObject& globalObject)

--- a/Source/WebCore/bindings/js/InternalWritableStream.h
+++ b/Source/WebCore/bindings/js/InternalWritableStream.h
@@ -39,9 +39,11 @@ public:
 
     bool locked() const;
     void lock();
-    JSC::JSValue abort(JSC::JSGlobalObject&, JSC::JSValue);
-    JSC::JSValue close(JSC::JSGlobalObject&);
+    JSC::JSValue abortForBindings(JSC::JSGlobalObject&, JSC::JSValue);
+    JSC::JSValue closeForBindings(JSC::JSGlobalObject&);
     JSC::JSValue getWriter(JSC::JSGlobalObject&);
+
+    void closeIfPossible();
 
 private:
     InternalWritableStream(JSDOMGlobalObject& globalObject, JSC::JSObject& jsObject)


### PR DESCRIPTION
#### 8783423626ac3523165d5d1ec2794eabafba010c
<pre>
VideoTrackGenerator writer should get closed when its generator track (and all its clones) are stopped
<a href="https://rdar.apple.com/121835553">rdar://121835553</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=268279">https://bugs.webkit.org/show_bug.cgi?id=268279</a>

Reviewed by Jean-Yves Avenard.

Implement VideoTrackGenerator::Source::endProducingData to make sure to close VideoTrackGenerator writable when the source is stopped.
Introduce WritableStream::close to implement this.
The VideoTrackGenerator::Source keeps a WeakPtr of the WritableStream to call WritableStream::close.

We introduce closeWritableStreamIfPossible built-in to only close the writable stream if it is not already closed.

Add corresponding WPT tests.
We also fix a test in VideoTrackGenerator.worker.js which is about trying to write to a video track generator non VideoFrames.
We use AudioData, which cannot be created yet in Cocoa ports, hence the failure.

* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.worker.js:
(make_audio_data):
(promise_test.async t):
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenerator.worker-expected.txt: Added.
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp:
(WebCore::VideoTrackGenerator::create):
(WebCore::VideoTrackGenerator::Source::Source):
(WebCore::m_contextIdentifier):
(WebCore::VideoTrackGenerator::Source::endProducingData):
(WebCore::VideoTrackGenerator::Source::setWritable):
(WebCore::VideoTrackGenerator::Source::writeVideoFrame):
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.h:
* Source/WebCore/Modules/streams/WritableStream.cpp:
(WebCore::WritableStream::closeIfPossible):
(WebCore::JSWritableStream::abort):
(WebCore::JSWritableStream::close):
* Source/WebCore/Modules/streams/WritableStream.h:
* Source/WebCore/Modules/streams/WritableStreamInternals.js:
(writableStreamCloseIfPossible):
* Source/WebCore/bindings/js/InternalWritableStream.cpp:
(WebCore::InternalWritableStream::abortForBindings):
(WebCore::InternalWritableStream::closeForBindings):
(WebCore::InternalWritableStream::closeIfPossible):
(WebCore::InternalWritableStream::abort): Deleted.
(WebCore::InternalWritableStream::close): Deleted.
* Source/WebCore/bindings/js/InternalWritableStream.h:

Canonical link: <a href="https://commits.webkit.org/273778@main">https://commits.webkit.org/273778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb729939f6178be2928b53fce514a3bf7c4d70b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39238 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32798 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31412 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13079 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11448 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11466 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40482 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37393 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11715 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9558 "Found 1 new test failure: inspector/canvas/requestShaderSource-webgl.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35500 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13399 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8308 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12139 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12600 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->