### PR TITLE
[LBSE] Fix use-on-clip-path-with-transformation.svg

### DIFF
--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/TestExpectations
@@ -385,7 +385,6 @@ svg/batik/text/textEffect2.svg                                                  
 svg/batik/text/textProperties.svg                                                                 [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-precision-001.svg [ ImageOnlyFailure ]
 svg/clip-path/clip-path-use-referencing-clipped-text.html                                         [ ImageOnlyFailure ]
-svg/custom/use-on-clip-path-with-transformation.svg                                               [ Failure ]
 svg/repaint/image-with-clip-path.svg                                                              [ ImageOnlyFailure ]
 
 # Masking problems

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/use-on-clip-path-with-transformation-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/use-on-clip-path-with-transformation-expected.txt
@@ -1,0 +1,18 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGRoot {svg} at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGViewportContainer at (0,0) size 800x600
+layer at (0,0) size 1x1
+  RenderSVGHiddenContainer {defs} at (0,0) size 0.20x0.20
+layer at (0,0) size 1x1
+  RenderSVGRect {rect} at (0,0) size 0.20x0.20 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=0.20] [height=0.20]
+layer at (0,0) size 1x1
+  RenderSVGResourceClipper {clipPath} at (0,0) size 0.20x0.20
+layer at (0,0) size 1x1
+  RenderSVGTransformableContainer {use} at (0,0) size 0.20x0.20
+layer at (0,0) size 1x1
+  RenderSVGRect {rect} at (0,0) size 0.20x0.20 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=0.20] [height=0.20]
+layer at (0,0) size 300x300
+  RenderSVGRect {rect} at (0,0) size 300x300 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=300.00] [height=300.00]

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -278,8 +278,10 @@ Path RenderSVGModelObject::computeClipPath(AffineTransform& transform) const
         transform.multiply(layer()->currentTransform(RenderStyle::individualTransformOperations()).toAffineTransform());
 
     if (auto* useElement = dynamicDowncast<SVGUseElement>(element())) {
-        if (auto* clipChild = useElement->rendererClipChild())
-            transform.multiply(downcast<RenderLayerModelObject>(*clipChild).checkedLayer()->currentTransform(RenderStyle::individualTransformOperations()).toAffineTransform());
+        if (auto* clipChildRenderer = useElement->rendererClipChild())
+            transform.multiply(downcast<RenderLayerModelObject>(*clipChildRenderer).checkedLayer()->currentTransform(RenderStyle::individualTransformOperations()).toAffineTransform());
+        if (auto clipChild = useElement->clipChild())
+            return pathFromGraphicsElement(*clipChild);
     }
 
     return pathFromGraphicsElement(downcast<SVGGraphicsElement>(element()));


### PR DESCRIPTION
#### 3f1e7f15120b48bfc0aa895a6783c5c1dfcf4f9a
<pre>
[LBSE] Fix use-on-clip-path-with-transformation.svg
<a href="https://bugs.webkit.org/show_bug.cgi?id=268283">https://bugs.webkit.org/show_bug.cgi?id=268283</a>

Reviewed by Nikolas Zimmermann.

pathFromGraphicsElement and the layer transform both contain the use x/y translate, so avoid
calling pathFromGraphicsElement in the use case by instead directly calling pathFromGraphicsElement
on the clip child.

* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::computeClipPath const):

Canonical link: <a href="https://commits.webkit.org/274074@main">https://commits.webkit.org/274074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be3081801cbcbf3c1fcdf85a93a1565ec3086a6f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40337 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33623 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31978 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33097 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12281 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12217 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41597 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34230 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38104 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36278 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14218 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8489 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13528 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->