### PR TITLE
[threaded-animation-resolution] Schedule animation updates from RemoteScrollingCoordinatorProxy on the main thread

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h
@@ -42,6 +42,8 @@ public:
     void applyEffectsFromScrollingThread(MonotonicTime now) const;
 #endif
 
+    void applyEffectsFromMainThread(PlatformLayer*, MonotonicTime now) const;
+
     void clear(PlatformLayer*);
 
 private:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm
@@ -54,6 +54,10 @@ void RemoteAcceleratedEffectStack::applyEffectsFromScrollingThread(MonotonicTime
 }
 #endif
 
+void RemoteAcceleratedEffectStack::applyEffectsFromMainThread(PlatformLayer*, MonotonicTime) const
+{
+}
+
 void RemoteAcceleratedEffectStack::clear(PlatformLayer*)
 {
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -49,6 +49,7 @@ public:
     virtual ~RemoteLayerTreeDrawingAreaProxy();
 
     virtual bool isRemoteLayerTreeDrawingAreaProxyMac() const { return false; }
+    virtual bool isRemoteLayerTreeDrawingAreaProxyIOS() const { return false; }
 
     const RemoteLayerTreeHost& remoteLayerTreeHost() const { return *m_remoteLayerTreeHost; }
     std::unique_ptr<RemoteLayerTreeHost> detachRemoteLayerTreeHost();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -268,7 +268,9 @@ void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::Acce
     m_effectStack->setEffects(WTFMove(clonedEffects));
     m_effectStack->setBaseValues(WTFMove(clonedBaseValues));
 
-#if PLATFORM(MAC)
+#if PLATFORM(IOS_FAMILY)
+    m_effectStack->applyEffectsFromMainThread(layer(), host.animationCurrentTime());
+#else
     m_effectStack->initEffectsFromMainThread(layer(), host.animationCurrentTime());
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
@@ -38,6 +38,11 @@ public:
     RemoteLayerTreeDrawingAreaProxyIOS(WebPageProxy&, WebProcessProxy&);
     virtual ~RemoteLayerTreeDrawingAreaProxyIOS();
 
+    bool isRemoteLayerTreeDrawingAreaProxyIOS() const final { return true; }
+
+    void scheduleDisplayRefreshCallbacksForAnimation();
+    void pauseDisplayRefreshCallbacksForAnimation();
+
 private:
     WebCore::DelegatedScrollingMode delegatedScrollingMode() const override;
 
@@ -47,11 +52,16 @@ private:
     void scheduleDisplayRefreshCallbacks() override;
     void pauseDisplayRefreshCallbacks() override;
 
+    void didRefreshDisplay() override;
+
     std::optional<WebCore::FramesPerSecond> displayNominalFramesPerSecond() override;
 
     WKDisplayLinkHandler *displayLinkHandler();
 
     RetainPtr<WKDisplayLinkHandler> m_displayLinkHandler;
+
+    bool m_needsDisplayRefreshCallbacksForDrawing { false };
+    bool m_needsDisplayRefreshCallbacksForAnimation { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -38,11 +38,13 @@ enum class TouchAction : uint8_t;
 
 namespace WebKit {
 
+class RemoteLayerTreeDrawingAreaProxyIOS;
 class RemoteLayerTreeNode;
 
 class RemoteScrollingCoordinatorProxyIOS final : public RemoteScrollingCoordinatorProxy {
 public:
     explicit RemoteScrollingCoordinatorProxyIOS(WebPageProxy&);
+    ~RemoteScrollingCoordinatorProxyIOS() = default;
 
     UIScrollView *scrollViewForScrollingNodeID(WebCore::ScrollingNodeID) const;
 
@@ -67,11 +69,15 @@ public:
 #endif
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    void animationsWereAddedToNode(RemoteLayerTreeNode&) override;
+    void animationsWereAddedToNode(RemoteLayerTreeNode&) override WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&) override;
+    void updateAnimations();
 #endif
 
+    void displayDidRefresh(WebCore::PlatformDisplayID) override;
+
 private:
+    RemoteLayerTreeDrawingAreaProxyIOS& drawingAreaIOS() const;
     bool propagatesMainFrameScrolls() const override { return false; }
 
     void scrollingTreeNodeWillStartPanGesture(WebCore::ScrollingNodeID) override;


### PR DESCRIPTION
#### e89a58c3716a2cee16351e230a760ed8e8e0358e
<pre>
[threaded-animation-resolution] Schedule animation updates from RemoteScrollingCoordinatorProxy on the main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=268282">https://bugs.webkit.org/show_bug.cgi?id=268282</a>
<a href="https://rdar.apple.com/121839192">rdar://121839192</a>

Reviewed by Simon Fraser.

In 273391@main we added support for scheduling animation resolution for macOS via RemoteLayerTreeEventDispatcher.
On iOS, where we don&apos;t use a scrolling thread, we schedule animations through RemoteScrollingCoordinatorProxy
using a dedicated CADisplayLink in a new WKAnimationDisplayLinkHandler. When that display link fires, we resolve
animations on the main thread by calling the new RemoteAcceleratedEffectStack::applyEffectsFromMainThread().

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm:
(WebKit::RemoteAcceleratedEffectStack::applyEffectsFromMainThread const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(-[WKAnimationDisplayLinkHandler initWithCoordinator:]):
(-[WKAnimationDisplayLinkHandler dealloc]):
(-[WKAnimationDisplayLinkHandler displayLinkFired:]):
(-[WKAnimationDisplayLinkHandler invalidate]):
(-[WKAnimationDisplayLinkHandler schedule]):
(-[WKAnimationDisplayLinkHandler pause]):
(WebKit::RemoteScrollingCoordinatorProxyIOS::~RemoteScrollingCoordinatorProxyIOS):
(WebKit::RemoteScrollingCoordinatorProxyIOS::animationsWereAddedToNode):
(WebKit::RemoteScrollingCoordinatorProxyIOS::animationsWereRemovedFromNode):
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateAnimations):

Canonical link: <a href="https://commits.webkit.org/274065@main">https://commits.webkit.org/274065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff0655cf53f77619eed17028dc5a9d817b6a1686

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40269 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33569 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31930 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38296 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13990 "Found 1 new test failure: media/video-ended-does-not-hold-sleep-assertion.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33028 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12224 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12159 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41528 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34133 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34150 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38045 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12749 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10296 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36217 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14163 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13134 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4898 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->