### PR TITLE
[@starting-style] Use starting style as before-change style for animations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-starting-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-starting-style-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Style rules within @starting-style are scoped assert_equals: expected "150px" but got "200px"
+PASS Style rules within @starting-style are scoped
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Overridden @starting-style - order of appearance
-FAIL @starting-style with higher specificity assert_equals: Transition of color expected "rgb(0, 192, 0)" but got "rgb(0, 128, 0)"
+PASS @starting-style with higher specificity
 PASS Starting style does not inherit from parent starting style
-FAIL Starting style inheriting from parent's after-change style assert_equals: Transition started from parent's after-change style color expected "rgb(0, 192, 0)" but got "rgb(0, 255, 0)"
-FAIL Starting style inheriting from parent's after-change style while parent transitioning assert_equals: Parent transition started expected "rgb(0, 64, 0)" but got "rgb(0, 128, 0)"
+PASS Starting style inheriting from parent's after-change style
+FAIL Starting style inheriting from parent's after-change style while parent transitioning assert_equals: Transition started from parent's after-change style color expected "rgb(0, 192, 0)" but got "rgb(0, 160, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-rule-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-rule-basic-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Triggered transition from first style update assert_equals: Background transition from @starting-style value black to white expected "rgb(128, 128, 128)" but got "rgb(255, 255, 255)"
-FAIL Triggered transition from display:none to display:block assert_equals: Background transition from @starting-style value black to white expected "rgb(128, 128, 128)" but got "rgb(255, 255, 255)"
-FAIL Triggered transition on DOM insertion assert_equals: Background transition from @starting-style value black to white expected "rgb(128, 128, 128)" but got "rgb(255, 255, 255)"
+PASS Triggered transition from first style update
+PASS Triggered transition from display:none to display:block
+PASS Triggered transition on DOM insertion
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-rule-pseudo-elements-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-rule-pseudo-elements-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Triggered transition from first style update assert_equals: Background transition from @starting-style value black to white expected "rgb(128, 128, 128)" but got "rgb(255, 255, 255)"
-FAIL Triggered transition from display:none to display:block assert_equals: Background transition from @starting-style value black to white expected "rgb(128, 128, 128)" but got "rgb(255, 255, 255)"
-FAIL Triggered transition on DOM insertion assert_equals: Background transition from @starting-style value black to white expected "rgb(128, 128, 128)" but got "rgb(255, 255, 255)"
+PASS Triggered transition from first style update
+PASS Triggered transition from display:none to display:block
+PASS Triggered transition on DOM insertion
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-size-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-size-container-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Triggered transition from first style update based on up-to-date container query assert_equals: @starting-style based on the size query evaluation from the same frame expected "rgb(128, 255, 128)" but got "rgb(0, 255, 0)"
+PASS Triggered transition from first style update based on up-to-date container query
 

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -835,6 +835,8 @@ void ElementRuleCollector::addMatchedProperties(MatchedProperties&& matchedPrope
         // It might also be beneficial to overwrite the previous declaration (insteading of appending) if it affects the same exact properties.
         return;
     }
+    if (matchedProperties.isStartingStyle == IsStartingStyle::Yes)
+        m_result->hasStartingStyle = true;
     declarations.append(WTFMove(matchedProperties));
 }
 

--- a/Source/WebCore/style/MatchResult.h
+++ b/Source/WebCore/style/MatchResult.h
@@ -53,6 +53,7 @@ struct MatchResult {
 
     bool isForLink { false };
     bool isCacheable { true };
+    bool hasStartingStyle { false };
     Vector<MatchedProperties> userAgentDeclarations;
     Vector<MatchedProperties> userDeclarations;
     Vector<MatchedProperties> authorDeclarations;

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -218,7 +218,7 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
             if (propertyAllowlist == PropertyAllowlist::Marker && !isValidMarkerStyleProperty(propertyID))
                 return false;
 
-            if (m_includedProperties.containsAll(allProperties()))
+            if (m_includedProperties.containsAll(normalProperties()))
                 return true;
 
             // If we have applied this property for some reason already we must apply anything that overrides it.

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -47,7 +47,8 @@ public:
         AfterTransition = 1 << 4,
         StartingStyle = 1 << 5,
     };
-    static constexpr OptionSet<PropertyType> allProperties() { return { PropertyType::NonInherited,  PropertyType::Inherited }; }
+    static constexpr OptionSet<PropertyType> normalProperties() { return { PropertyType::NonInherited,  PropertyType::Inherited }; }
+    static constexpr OptionSet<PropertyType> startingStyleProperties() { return normalProperties() | PropertyType::StartingStyle; }
 
     PropertyCascade(const MatchResult&, CascadeLevel, OptionSet<PropertyType> includedProperties, const HashSet<AnimatableCSSProperty>* = nullptr);
     PropertyCascade(const PropertyCascade&, CascadeLevel, std::optional<ScopeOrdinal> rollbackScope = { }, std::optional<CascadeLayerPriority> maximumCascadeLayerPriorityForRollback = { });

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -35,7 +35,7 @@ namespace Style {
 class Builder {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, CascadeLevel, OptionSet<PropertyCascade::PropertyType> = PropertyCascade::allProperties(), const HashSet<AnimatableCSSProperty>* animatedProperties = nullptr);
+    Builder(RenderStyle&, BuilderContext&&, const MatchResult&, CascadeLevel, OptionSet<PropertyCascade::PropertyType> = PropertyCascade::normalProperties(), const HashSet<AnimatableCSSProperty>* animatedProperties = nullptr);
     ~Builder();
 
     void applyAllProperties();

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -605,7 +605,7 @@ void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResu
     auto& element = *state.element();
 
     unsigned cacheHash = MatchedDeclarationsCache::computeHash(matchResult, parentStyle.inheritedCustomProperties());
-    auto includedProperties = PropertyCascade::allProperties();
+    auto includedProperties = PropertyCascade::normalProperties();
 
     auto* cacheEntry = m_matchedDeclarationsCache.find(cacheHash, matchResult, parentStyle.inheritedCustomProperties());
 

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -75,6 +75,7 @@ private:
     std::pair<ElementUpdate, DescendantsToResolve> resolveElement(Element&, const RenderStyle* existingStyle, ResolutionType);
 
     ElementUpdate createAnimatedElementUpdate(ResolvedStyle&&, const Styleable&, Change, const ResolutionContext&);
+    std::unique_ptr<RenderStyle> resolveStartingStyle(const ResolvedStyle&, const Styleable&, const ResolutionContext&) const;
     HashSet<AnimatableCSSProperty> applyCascadeAfterAnimation(RenderStyle&, const HashSet<AnimatableCSSProperty>&, bool isTransition, const MatchResult&, const Element&, const ResolutionContext&);
 
     std::optional<ElementUpdate> resolvePseudoElement(Element&, PseudoId, const ElementUpdate&);

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -260,8 +260,10 @@ void Styleable::cancelStyleOriginatedAnimations() const
 {
     if (auto* animations = this->animations()) {
         for (auto& animation : *animations) {
-            if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation.get()))
+            if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation.get())) {
                 styleOriginatedAnimation->cancelFromStyle();
+                setLastStyleChangeEventStyle(nullptr);
+            }
         }
     }
 


### PR DESCRIPTION
#### b28edead7c0c1615e7f7f934c475245e61742fe7
<pre>
[@starting-style] Use starting style as before-change style for animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=268285">https://bugs.webkit.org/show_bug.cgi?id=268285</a>
<a href="https://rdar.apple.com/121844935">rdar://121844935</a>

Reviewed by Darin Adler and Matthieu Dubet.

Compute the starting style if needed and use it.

<a href="https://drafts.csswg.org/css-transitions-2/#at-ruledef-starting-style">https://drafts.csswg.org/css-transitions-2/#at-ruledef-starting-style</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-starting-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-cascade-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-rule-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-rule-pseudo-elements-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-size-container-expected.txt:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::addMatchedProperties):
* Source/WebCore/style/MatchResult.h:

Track if MatchResult contains any starting style rules for quick testing.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):

Try to compute a starting style if we don&apos;t have an existing before-change style.

(WebCore::Style::TreeResolver::resolveStartingStyle const):

Resolve the starting style by re-applying the matched properties with @starting-style rules enabled.

* Source/WebCore/style/StyleTreeResolver.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::cancelStyleOriginatedAnimations const):

Take care to also clear the lastStyleChangeEventStyle when canceling animations.

Canonical link: <a href="https://commits.webkit.org/273734@main">https://commits.webkit.org/273734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d840623fbba45af73c9c68734d78f751a3a77fe3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39211 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12568 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13055 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11426 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40456 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33120 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32930 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37377 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11691 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35482 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13380 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8270 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->