### PR TITLE
Add nt1m's <input type=checkbox switch> demo to webkit.org

### DIFF
--- a/Websites/webkit.org/demos/html-switch/demo.css
+++ b/Websites/webkit.org/demos/html-switch/demo.css
@@ -1,0 +1,46 @@
+:root {
+    color-scheme: light dark;
+    font-family: system-ui;
+}
+
+body {
+    max-width: 800px;
+    margin: auto;
+    padding: 10px 30px;
+}
+
+style, code, pre {
+    font-family: Menlo, monospace;
+    font-size-adjust: 0.5;
+}
+
+#warning {
+    background-color: rgb(255,69,58,0.2);
+    border: 1px solid rgb(255,69,58);
+    border-radius: 4px;
+    padding: 10px;
+    margin: 1em 0;
+}
+
+#warning > p:first-child {
+    margin-top: 0;
+}
+
+#warning > p:last-child {
+    margin-bottom: 0;
+}
+
+@supports selector(::thumb) {
+    #warning {
+        display: none;
+    }
+}
+
+.example details {
+    margin-top: 1em;
+}
+
+.example style {
+    display: block;
+    white-space: pre-wrap;
+}

--- a/Websites/webkit.org/demos/html-switch/index.html
+++ b/Websites/webkit.org/demos/html-switch/index.html
@@ -1,0 +1,359 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Switch control examples</title>
+    <link rel="stylesheet" href="demo.css">
+</head>
+<body>
+    <h1>Switch demos</h1>
+    <p>The markup for switches is <code>&lt;input type="checkbox" switch&gt;</code>. It comes built-in with <code>::thumb</code> and <code>::track</code> pseudo-elements. The <code>::before</code> and <code>::after</code> pseudo-elements can also be used for extra possibilities!</p>
+
+    <p>The switch control is enabled in <a href="https://developer.apple.com/safari/resources/">Safari Technology Preview</a>.</p>
+
+    <section class="example">
+        <h1>Native switch (unstyled)</h1>
+        <p>The native switch supports the <code>accent-color</code> and <code>color-scheme</code> CSS properties.</p>
+        <input type="checkbox" switch>
+    </section>
+
+    <div id="warning">
+        <p><b>Your browser does not support the <code>::thumb</code> and <code>::track</code> pseudo-elements.</b> The demos below will not render properly.</p>
+        <p>The pseudo-elements can be enabled in Safari Technology Preview behind the relevant feature flag in <em>Develop > Feature Flags</em>. See <a href="https://developer.apple.com/documentation/safari-developer-tools/develop-menu">Apple's documentation</a> on how to enable the develop menu if you don't yet have it enabled.</p>
+    </div>
+
+    <section class="example">
+        <h1>Basic styled switch</h1>
+        <input type="checkbox" switch class="basic-switch">
+        <details>
+            <summary>Show CSS</summary>
+            <style>
+.basic-switch {
+    appearance: none;
+    position: relative;
+    background-color: #98989d;
+    height: 20px;
+    width: 44px;
+    border-radius: 20px;
+}
+
+.basic-switch:checked {
+    background-color: #32d74b;
+}
+
+.basic-switch::thumb {
+    background-color: white;
+    width: 24px;
+    height: 24px;
+    margin: -2px -1px;
+    transition: all 0.3s;
+    border-radius: 100%;
+    box-shadow: 0 0 5px rgba(0,0,0,0.3)
+}
+
+.basic-switch:checked::thumb {
+    translate: 22px 0;
+}
+            </style>
+        </details>
+    </section>
+    <section class="example">
+        <h1>Basic styled switch with symbol</h1>
+        <input type="checkbox" switch class="basic-with-symbol">
+        <details>
+            <summary>Show CSS</summary>
+            <style>
+.basic-with-symbol {
+    appearance: none;
+    position: relative;
+    background-color: #98989d;
+    height: 20px;
+    width: 44px;
+    border-radius: 20px;
+}
+
+.basic-with-symbol:checked {
+    background-color: #007aff;
+}
+
+.basic-with-symbol::thumb {
+    background-color: white;
+    width: 24px;
+    height: 24px;
+    margin: -2px -1px;
+    transition: all 0.3s;
+    border-radius: 100%;
+    box-shadow: 0 0 5px rgba(0,0,0,0.3)
+}
+
+.basic-with-symbol:checked::thumb {
+    translate: 22px 0;
+}
+
+.basic-with-symbol::before {
+    content: "〇" / "";
+    font-weight: bold;
+    position: absolute;
+    font-size: 10px;
+    margin: 4px 5px;
+    top: 0;
+    left: 0;
+    color: white;
+}
+
+.basic-with-symbol:not(:checked)::before {
+    translate: 22px 0;
+}
+
+.basic-with-symbol:checked::before {
+    content: "I" / "";
+    margin-left: 10px;
+}
+            </style>
+        </details>
+    </section>
+    <section class="example">
+        <h1>Sliding track</h1>
+        <input type="checkbox" switch class="sliding-track">
+        <details>
+            <summary>Show CSS</summary>
+            <style>
+.sliding-track {
+    appearance: none;
+    color: #000;
+    overflow: hidden;
+    height: 20px;
+    width: 40px;
+    border-radius: 20px;
+    position: relative;
+}
+
+.sliding-track::before,
+.sliding-track::after,
+.sliding-track::thumb,
+.sliding-track::track {
+    transition: translate linear 0.25s;
+}
+
+.sliding-track::before,
+.sliding-track::after {
+    position: absolute;
+    top: 4px;
+    font-size: 8px;
+    margin: 1px;
+    z-index: 2;
+    text-align: center;
+    width: 20px;
+    height: 20px;
+    font-weight: 600;
+}
+
+.sliding-track::before {
+    content: "ON" / "";
+    left: -40px;
+}
+
+.sliding-track::after {
+    content: "OFF" / "";
+    right: 0;
+}
+
+.sliding-track:checked::before,
+.sliding-track:checked::after {
+    translate: 40px;
+}
+
+.sliding-track::track {
+    width: 80px;
+    background-image: linear-gradient(to right, #32d74b 50%, #ccd 50%);
+    translate: -50%;
+}
+
+.sliding-track:checked::track {
+    translate: 0;
+}
+
+.sliding-track::thumb {
+    background-color: white;
+    border-radius: 100%;
+    width: 20px;
+    height: 20px;
+    border: 1px solid #bbf;
+    box-sizing: border-box;
+    transition: translate 0.4s;
+    translate: 0;
+}
+
+.sliding-track:checked::thumb {
+    translate: 20px;
+}
+            </style>
+        </details>
+    </section>
+    <section class="example">
+        <h1>Daylight switch</h1>
+        <input type="checkbox" switch class="daylight-switch">
+        <details>
+            <summary>Show CSS</summary>
+            <style>
+.daylight-switch {
+    --star: radial-gradient(circle, transparent 0, #FFF 0, #FFF 75%, transparent 75%);
+    --star-size: 2px 2px;
+    appearance: none;
+    position: relative;
+    height: 25px;
+    width: 45px;
+    border-radius: 20px;
+    display: inline-block;
+    border: 2px solid #1C1C1C;
+    background-color: #3C4145;
+    transition: all 0.3s;
+    background-image: var(--star), var(--star), var(--star), var(--star), var(--star), var(--star), var(--star);
+    background-size: var(--star-size), var(--star-size), var(--star-size), var(--star-size), var(--star-size), var(--star-size), var(--star-size);
+    background-position: 25px 3px,
+                         35px 4px,
+                        29px 10px,
+                        32px 17px,
+                        38px 11px,
+                        26px 20px,
+                        38px 18px;
+    background-repeat: no-repeat;
+    box-sizing: content-box;
+}
+
+.daylight-switch:checked {
+    background: #9EE3FB;
+    border-color: #86C3D7;
+}
+
+.daylight-switch::thumb {
+    border-radius: 100%;
+    width: 19px;
+    height: 19px;
+    margin: 1px;
+    border: 2px solid #E3E3C7;
+    background-color: #FFFFFF;
+    transition: all 0.2s;
+}
+.daylight-switch:not(:checked)::thumb {
+    --crater: radial-gradient(circle, #FFF 0, #FFF 30%, #E3E3C7 30%, #E3E3C7 70%, transparent 70%);
+    --deep-crater: radial-gradient(circle, #FFF 0, #FFF 20%, #E3E3C7 20%, #E3E3C7 70%, transparent 70%);
+    background-image: var(--crater), var(--deep-crater), var(--crater);
+    background-size: 5px 5px, 7px 7px, 5px 5px;
+    background-position: 1px 1px, 13px 2px, 7px 14px;
+    background-repeat: no-repeat;
+}
+.daylight-switch:checked::thumb {
+    border-color: #E1C348;
+    background-color: #FFDF6D;
+    translate: 20px 0;
+}
+
+.daylight-switch::track {
+    position: absolute;
+    width: 12px;
+    height: 5px;
+    border: 2px solid #D3D3D3;
+    background: #FFF;
+    bottom: 6px;
+    left: 15px;
+    z-index: 99;
+    border-radius: 20px;
+    transition: all 0.2s;
+    transition-delay: 0.15s;
+}
+.daylight-switch::before,
+.daylight-switch::after {
+    content: "";
+    border-radius: 40px;
+    border: 2px solid #D3D3D3;
+    border-bottom: 0;
+    z-index: 100;
+    background: white;
+    position: absolute;
+    bottom: 11px;
+    transition: all 0.2s;
+    transition-delay: 0.15s;
+}
+.daylight-switch::before {
+    left: 17px;
+    translate: 0 -1px;
+    height: 3.5px;
+    width: 4.5px;
+    rotate: -20deg;
+}
+.daylight-switch::after {
+    left: 23px;
+    width: 3px;
+    height: 3px;
+    rotate: 20deg;
+}
+.daylight-switch:not(:checked)::track,
+.daylight-switch:not(:checked)::before,
+.daylight-switch:not(:checked)::after {
+    opacity: 0;
+    transform: scale(0.5);
+    transition-delay: 0s;
+}
+            </style>
+        </details>
+    </section>
+    <section class="example">
+        <h1>Toggle button</h1>
+        <input type="checkbox" switch class="toggle-button">
+        <details>
+            <summary>Show CSS</summary>
+            <style>
+.toggle-button {
+    appearance: none;
+    position: relative;
+    background-color: #ccd;
+    color: #000;
+    height: 40px;
+    width: 80px;
+    border-radius: 4px;
+    padding: 5px;
+    position: relative;
+}
+
+.toggle-button::thumb {
+    background: white;
+    height: 100%;
+    width: 50%;
+    border-radius: 2px;
+    transition: translate 0.3s;
+    z-index: 0;
+}
+
+.toggle-button:checked::thumb {
+    translate: 100%;
+}
+
+.toggle-button::before,
+.toggle-button::after {
+    position: absolute;
+    text-align: center;
+    width: 35px;
+    height: 100%;
+    line-height: 40px;
+    z-index: 2;
+}
+
+.toggle-button::before {
+    content: "OFF" / "";
+    left: 5px;
+}
+
+.toggle-button::after {
+    content: "ON" / "";
+    right: 5px;
+}
+
+.toggle-button:checked::after {
+    color: #007aff;
+}
+            </style>
+        </details>
+    </section>
+</html>


### PR DESCRIPTION
#### 1c73931b16512d904995e20c4e40db2c92bd559e
<pre>
Add nt1m&apos;s &lt;input type=checkbox switch&gt; demo to webkit.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=268286">https://bugs.webkit.org/show_bug.cgi?id=268286</a>

Reviewed by Tim Nguyen.

A copy from <a href="https://github.com/nt1m/html-switch-demos">https://github.com/nt1m/html-switch-demos</a> but with adjusted
syntax for the content properties to make them not relevant for AT as
otherwise AT end users would end up with a worse experience.

* Websites/webkit.org/demos/html-switch/demo.css: Added.
* Websites/webkit.org/demos/html-switch/index.html: Added.

Canonical link: <a href="https://commits.webkit.org/274224@main">https://commits.webkit.org/274224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ceb32c1c06a58a3dca7bb1b91d148a1788bf58c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40849 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34062 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14574 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32303 "Found 1 new test failure: media/track/media-element-enqueue-event-crash.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14550 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12666 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12647 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42127 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34855 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38487 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36684 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14783 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8623 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13638 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->