### PR TITLE
[WPE] Build fails on Ubuntu because of missing Cog dependencies

### DIFF
--- a/Tools/wpe/dependencies/apt
+++ b/Tools/wpe/dependencies/apt
@@ -40,4 +40,9 @@ PACKAGES+=(
     libxkbcommon-dev
     libxrandr-dev
     luajit
+
+    # These are dependencies necessary for building Cog.
+    libportal-dev
+    libportal-gtk4-dev
+    libxcb-cursor-dev
 )

--- a/Tools/wpe/dependencies/dnf
+++ b/Tools/wpe/dependencies/dnf
@@ -19,4 +19,9 @@ PACKAGES+=(
     libXrandr-devel
     luajit
     luajit-devel
+
+    # These are dependencies necessary for building Cog.
+    libportal-devel
+    libportal-gtk4-devel
+    xcb-util-cursor-devel
 )

--- a/Tools/wpe/dependencies/pacman
+++ b/Tools/wpe/dependencies/pacman
@@ -35,4 +35,9 @@ PACKAGES+=(
     v4l-utils
     wayland
     xorg-xrandr
+
+    # These are dependencies necessary for building Cog.
+    libportal
+    libportal-gtk4
+    xcb-util-cursor
 )


### PR DESCRIPTION
#### fa2c367bb671ef080a5f898e119892dc004addc0
<pre>
[WPE] Build fails on Ubuntu because of missing Cog dependencies
<a href="https://bugs.webkit.org/show_bug.cgi?id=268287">https://bugs.webkit.org/show_bug.cgi?id=268287</a>

Reviewed by Adrian Perez de Castro.

There are three new dependencies required by Cog:
- portal
- portal-gtk4
- xcb-cursor

* Tools/wpe/dependencies/apt:
* Tools/wpe/dependencies/dnf:
* Tools/wpe/dependencies/pacman:

Canonical link: <a href="https://commits.webkit.org/273651@main">https://commits.webkit.org/273651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e6a6c729b93be469cfa1c674c84bda5b4b6ee74

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/38978 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32596 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12232 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31267 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12841 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32161 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11256 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/32358 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40224 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32905 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32727 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37218 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11490 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9372 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35311 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13210 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11955 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4690 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12333 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->