### PR TITLE
Add support for SVGAElement's text attribute

### DIFF
--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -239,4 +239,14 @@ DOMTokenList& SVGAElement::relList()
     return *m_relList;
 }
 
+String SVGAElement::text()
+{
+    return textContent();
+}
+
+void SVGAElement::setText(String&& text)
+{
+    setTextContent(WTFMove(text));
+}
+
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGAElement.h
+++ b/Source/WebCore/svg/SVGAElement.h
@@ -42,6 +42,9 @@ public:
 
     DOMTokenList& relList();
 
+    WEBCORE_EXPORT String text();
+    void setText(String&&);
+
 private:
     SVGAElement(const QualifiedName&, Document&);
 

--- a/Source/WebCore/svg/SVGAElement.idl
+++ b/Source/WebCore/svg/SVGAElement.idl
@@ -30,6 +30,7 @@
 
     [Reflect] attribute DOMString rel;
     [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
+    [CEReactions=Needed] attribute DOMString text;
 };
 
 SVGAElement includes SVGURIReference;

--- a/Source/WebCore/svg/svgattrs.in
+++ b/Source/WebCore/svg/svgattrs.in
@@ -197,6 +197,7 @@ tableValues
 target
 targetX
 targetY
+text
 text-anchor
 text-decoration
 text-rendering


### PR DESCRIPTION
#### a1601811362b4188db6a4de134773182471ebf6c
<pre>
Add support for SVGAElement&apos;s text attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=268251">https://bugs.webkit.org/show_bug.cgi?id=268251</a>

Reviewed by NOBODY (OOPS!).

Add `text` attribute support for `svg:a` similar to HTMLAnchorElement.

In SVGElement.cpp:
Add String SVGAElement::text() and return textContent()
Add void SVGAElement::setText(String&amp;&amp; text) and setTextContent(WTFMove(text))

In SVGAElement.h:
Add WEBCORE_EXPORT String text();
Add void setText(String&amp;&amp;);

In SVGAElement.idl:
Add [CEReactions=Needed] attribute DOMString text;

In svgattrs.in:
Add text

Patch aligns WebKit with Gecko / Firefox and Web-Specification [1]:
[1] <a href="https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement">https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement</a>

Amend changes:

Combined changes:
* Source/WebCore/svg/SVGAElement.cpp:
(WebCore::SVGAElement::text):
(WebCore::SVGAElement::setText):
* Source/WebCore/svg/SVGAElement.h:
* Source/WebCore/svg/SVGAElement.idl:
* Source/WebCore/svg/svgattrs.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1601811362b4188db6a4de134773182471ebf6c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39266 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37839 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12624 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13101 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11469 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/32633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40511 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33165 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/32979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/35522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12626 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->