### PR TITLE
Port WTF::CString to the new IPC serialization format

### DIFF
--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -64,6 +64,7 @@ public:
     WTF_EXPORT_PRIVATE CString(const char*);
     WTF_EXPORT_PRIVATE CString(const char*, size_t length);
     CString(const uint8_t* data, size_t length) : CString(reinterpret_cast<const char*>(data), length) { }
+    CString(std::span<const uint8_t> bytes) : CString(reinterpret_cast<const char*>(bytes.data()), bytes.size()) { }
     CString(CStringBuffer* buffer) : m_buffer(buffer) { }
     WTF_EXPORT_PRIVATE static CString newUninitialized(size_t length, char*& characterBuffer);
     CString(HashTableDeletedValueType) : m_buffer(HashTableDeletedValue) { }

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.cpp
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.cpp
@@ -37,45 +37,6 @@
 namespace IPC {
 
 template<typename Encoder>
-void ArgumentCoder<CString>::encode(Encoder& encoder, const CString& string)
-{
-    // Special case the null string.
-    if (string.isNull()) {
-        encoder << std::numeric_limits<size_t>::max();
-        return;
-    }
-
-    encoder << static_cast<size_t>(string.length());
-    encoder.encodeSpan(string.bytes());
-}
-template void ArgumentCoder<CString>::encode<Encoder>(Encoder&, const CString&);
-
-template<typename Decoder>
-std::optional<CString> ArgumentCoder<CString>::decode(Decoder& decoder)
-{
-    auto length = decoder.template decode<size_t>();
-    if (!length)
-        return std::nullopt;
-
-    if (*length == std::numeric_limits<size_t>::max()) {
-        // This is the null string.
-        return CString();
-    }
-
-    auto data = decoder.template decodeSpan<uint8_t>(*length);
-    if (!data.data())
-        return std::nullopt;
-
-    char* buffer;
-    CString string = CString::newUninitialized(*length, buffer);
-    static_assert(sizeof(typename decltype(data)::element_type) == 1);
-    memcpy(buffer, data.data(), data.size_bytes());
-    return string;
-}
-template
-std::optional<CString> ArgumentCoder<CString>::decode<Decoder>(Decoder&);
-
-template<typename Encoder>
 void ArgumentCoder<String>::encode(Encoder& encoder, const String& string)
 {
     // Special case the null string.

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -781,13 +781,6 @@ template<typename... Types> struct ArgumentCoder<std::variant<Types...>> {
     }
 };
 
-template<> struct ArgumentCoder<CString> {
-    template<typename Encoder>
-    static void encode(Encoder&, const CString&);
-    template<typename Decoder>
-    static std::optional<CString> decode(Decoder&);
-};
-
 template<> struct ArgumentCoder<String> {
     template<typename Encoder>
     static void encode(Encoder&, const String&);

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -26,6 +26,11 @@ webkit_platform_headers: "StreamConnectionEncoder.h"
     String string()
 }
 
+header: <wtf/text/CString.h>
+[CustomHeader] class WTF::CString {
+   std::span<const uint8_t> bytes()
+}
+
 [AdditionalEncoder=StreamConnectionEncoder] class WTF::MediaTime {
     int64_t timeValue()
     uint32_t timeScale()


### PR DESCRIPTION
#### 26d7b2b161f26334318f5ceb32d42d00a27272fa
<pre>
Port WTF::CString to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=268299">https://bugs.webkit.org/show_bug.cgi?id=268299</a>

Reviewed by Alex Christensen.

* Source/WTF/wtf/text/CString.h:
* Source/WebKit/Platform/IPC/ArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;CString&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;CString&gt;::decode): Deleted.
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/273691@main">https://commits.webkit.org/273691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69ecb98054b9f72a9601368322cb059c0b3b5bc2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36289 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39022 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32632 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12278 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31295 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32196 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11290 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11318 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32398 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40264 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/30582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32944 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37263 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/36113 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11521 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35354 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13238 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/42845 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8241 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8873 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12371 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->