### PR TITLE
SerializedTypeInfo.cpp should include members of parent classes

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -930,7 +930,6 @@ def generate_one_impl(type, template_argument):
 
 
 def generate_impl(serialized_types, serialized_enums, headers, generating_webkit_platform_impl):
-    serialized_types = resolve_inheritance(serialized_types)
     result = []
     result.append(_license_header)
     result.append('#include "config.h"')
@@ -1104,7 +1103,13 @@ def generate_one_serialized_type_info(type):
         result.append('        } },')
         return result
 
+
     serialized_members = type.members_for_serialized_type_info()
+    parent_class = type.parent_class
+    while parent_class is not None:
+        serialized_members = parent_class.members_for_serialized_type_info() + serialized_members
+        parent_class = parent_class.parent_class
+
     optional_tuple_state = None
     for member in serialized_members:
         if member.condition is not None:
@@ -1455,7 +1460,6 @@ def generate_one_dictionary_member_validation(member):
 
 
 def generate_webkit_secure_coding_impl(serialized_types, headers):
-    serialized_types = resolve_inheritance(serialized_types)
     result = []
     result.append(_license_header)
     result.append('#include "config.h"')
@@ -1529,7 +1533,6 @@ def generate_webkit_secure_coding_impl(serialized_types, headers):
 
 
 def generate_webkit_secure_coding_header(serialized_types):
-    serialized_types = resolve_inheritance(serialized_types)
     result = []
     result.append(_license_header)
     result.append('#pragma once')
@@ -1619,6 +1622,8 @@ def main(argv):
             for declaration in new_additional_forward_declarations:
                 additional_forward_declarations_set.add(declaration)
     headers = sorted(header_set)
+
+    serialized_types = resolve_inheritance(serialized_types)
 
     with open('GeneratedSerializers.h', "w+") as output:
         output.write(generate_header(serialized_types, serialized_enums, additional_forward_declarations_set))

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -162,11 +162,23 @@ Vector<SerializedTypeInfo> allSerializedTypes()
         } },
         { "WebCore::InheritsFrom"_s, {
             {
+                "int"_s,
+                "a"_s
+            },
+            {
                 "float"_s,
                 "b"_s
             },
         } },
         { "WebCore::InheritanceGrandchild"_s, {
+            {
+                "int"_s,
+                "a"_s
+            },
+            {
+                "float"_s,
+                "b"_s
+            },
             {
                 "double"_s,
                 "c"_s


### PR DESCRIPTION
#### 124252f5d451b1a7d2837d14023e60ea59215789
<pre>
SerializedTypeInfo.cpp should include members of parent classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=268303">https://bugs.webkit.org/show_bug.cgi?id=268303</a>
<a href="https://rdar.apple.com/121860213">rdar://121860213</a>

Reviewed by Chris Dumez.

* Source/WebKit/Scripts/generate-serializers.py:
(generate_impl):
(generate_one_serialized_type_info):
(generate_one_serialized_type_info.is):
(generate_webkit_secure_coding_impl):
(generate_webkit_secure_coding_header):
(main):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):

Canonical link: <a href="https://commits.webkit.org/273679@main">https://commits.webkit.org/273679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/742a118ae4d83a5e6b0455b2af83009636ef6d80

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36295 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39027 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32637 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12284 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31297 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11292 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/36456 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11324 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40270 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37252 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35357 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13242 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4707 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->