### PR TITLE
IPC validation for DocumentEditingContext::Range should not crash on overflow

### DIFF
--- a/Source/WebKit/Shared/DocumentEditingContext.serialization.in
+++ b/Source/WebKit/Shared/DocumentEditingContext.serialization.in
@@ -46,7 +46,7 @@
 
 [Nested] struct WebKit::DocumentEditingContext::Range {
     uint64_t location;
-    [Validator='!(Checked<uint64_t> { *location } + *length).hasOverflowed()'] uint64_t length;
+    [Validator='!(CheckedUint64 { *location } + *length).hasOverflowed()'] uint64_t length;
 }
 
 [Nested] struct WebKit::DocumentEditingContext::TextRectAndRange {


### PR DESCRIPTION
#### 6a616251c48f7ff3bed68e4281a17f06a574cd41
<pre>
IPC validation for DocumentEditingContext::Range should not crash on overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=268300">https://bugs.webkit.org/show_bug.cgi?id=268300</a>
<a href="https://rdar.apple.com/121859057">rdar://121859057</a>

Reviewed by Chris Dumez.

It&apos;s currently possible to crash the UI process by having it attempt to decode a
`DocumentEditingContext::Range` that overflows the `uint64_t` limit. This is because the validator
currently creates a `Checked&lt;uint64_t&gt;`, which (by default) uses the `CrashOnOverflow` handler. This
should use `RecordOverflow` instead, which we can get by adopting the `CheckedUint64` type alias.

* Source/WebKit/Shared/DocumentEditingContext.serialization.in:

Canonical link: <a href="https://commits.webkit.org/273671@main">https://commits.webkit.org/273671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24b9ca6b776d71398b5ee7cff9943045a32b0099

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39028 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12285 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12880 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11293 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40271 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32945 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32769 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37253 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11527 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35344 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8230 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12378 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->