### PR TITLE
[@starting-style] Add CSSOM

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/idlharness-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/idlharness-2-expected.txt
@@ -1,6 +1,14 @@
 
 PASS idl_test setup
 PASS idl_test validation
+PASS CSSStartingStyleRule interface: existence and properties of interface object
+PASS CSSStartingStyleRule interface object length
+PASS CSSStartingStyleRule interface object name
+PASS CSSStartingStyleRule interface: existence and properties of interface prototype object
+PASS CSSStartingStyleRule interface: existence and properties of interface prototype object's "constructor" property
+PASS CSSStartingStyleRule interface: existence and properties of interface prototype object's @@unscopables property
+PASS CSSStartingStyleRule must be primary interface of sheet.cssRules[0]
+PASS Stringification of sheet.cssRules[0]
 PASS CSSTransition interface: existence and properties of interface object
 PASS CSSTransition interface object length
 PASS CSSTransition interface object name

--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/css-transitions-2.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/css-transitions-2.idl
@@ -4,6 +4,10 @@
 // Source: CSS Transitions Level 2 (https://drafts.csswg.org/css-transitions-2/)
 
 [Exposed=Window]
+interface CSSStartingStyleRule : CSSGroupingRule {
+};
+
+[Exposed=Window]
 interface CSSTransition : Animation {
   readonly attribute CSSOMString transitionProperty;
 };

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -930,6 +930,7 @@ set(WebCore_NON_SVG_IDL_FILES
     css/CSSRule.idl
     css/CSSRuleList.idl
     css/CSSScopeRule.idl
+    css/CSSStartingStyleRule.idl
     css/CSSStyleDeclaration.idl
     css/CSSStyleRule.idl
     css/CSSStyleSheet.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1217,6 +1217,7 @@ $(PROJECT_DIR)/css/CSSPseudoSelectors.json
 $(PROJECT_DIR)/css/CSSRule.idl
 $(PROJECT_DIR)/css/CSSRuleList.idl
 $(PROJECT_DIR)/css/CSSScopeRule.idl
+$(PROJECT_DIR)/css/CSSStartingStyleRule.idl
 $(PROJECT_DIR)/css/CSSStyleDeclaration.idl
 $(PROJECT_DIR)/css/CSSStyleRule.idl
 $(PROJECT_DIR)/css/CSSStyleSheet.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -473,6 +473,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSSkewX.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSSkewX.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSSkewY.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSSkewY.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSStartingStyleRule.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSStartingStyleRule.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSStyleDeclaration+PropertyNames.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSStyleDeclaration+PropertyNames.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCSSStyleDeclaration.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -941,6 +941,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/css/CSSRule.idl \
     $(WebCore)/css/CSSRuleList.idl \
     $(WebCore)/css/CSSScopeRule.idl \
+    $(WebCore)/css/CSSStartingStyleRule.idl \
     $(WebCore)/css/CSSStyleDeclaration.idl \
     $(WebCore)/css/CSSStyleRule.idl \
     $(WebCore)/css/CSSStyleSheet.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -886,6 +886,7 @@ css/CSSSegmentedFontFace.cpp
 css/CSSSelector.cpp
 css/CSSSelectorList.cpp
 css/CSSShadowValue.cpp
+css/CSSStartingStyleRule.cpp
 css/CSSStyleDeclaration.cpp
 css/CSSStyleRule.cpp
 css/CSSStyleSheet.cpp
@@ -3288,6 +3289,7 @@ JSCSSRule.cpp
 JSCSSRuleList.cpp
 JSCSSStyleDeclaration.cpp
 JSCSSScopeRule.cpp
+JSCSSStartingStyleRule.cpp
 JSCSSStyleRule.cpp
 JSCSSStyleSheet.cpp
 JSCSSSupportsRule.cpp

--- a/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
@@ -41,6 +41,7 @@
 #include "CSSPageRule.h"
 #include "CSSPropertyRule.h"
 #include "CSSScopeRule.h"
+#include "CSSStartingStyleRule.h"
 #include "CSSStyleRule.h"
 #include "CSSSupportsRule.h"
 #include "JSCSSContainerRule.h"
@@ -58,6 +59,7 @@
 #include "JSCSSPageRule.h"
 #include "JSCSSPropertyRule.h"
 #include "JSCSSScopeRule.h"
+#include "JSCSSStartingStyleRule.h"
 #include "JSCSSStyleRule.h"
 #include "JSCSSSupportsRule.h"
 #include "JSNode.h"
@@ -116,8 +118,7 @@ JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<C
     case StyleRuleType::Scope:
         return createWrapper<CSSScopeRule>(globalObject, WTFMove(rule));
     case StyleRuleType::StartingStyle:
-        // FIXME: Implement.
-        return createWrapper<CSSRule>(globalObject, WTFMove(rule));
+        return createWrapper<CSSStartingStyleRule>(globalObject, WTFMove(rule));
     case StyleRuleType::Unknown:
     case StyleRuleType::Charset:
     case StyleRuleType::Margin:

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -156,6 +156,7 @@ namespace WebCore {
     macro(CSSSkew) \
     macro(CSSSkewX) \
     macro(CSSSkewY) \
+    macro(CSSStartingStyleRule) \
     macro(CSSStyleValue) \
     macro(CSSTransformComponent) \
     macro(CSSTransformValue) \

--- a/Source/WebCore/css/CSSStartingStyleRule.cpp
+++ b/Source/WebCore/css/CSSStartingStyleRule.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CSSStartingStyleRule.h"
+
+#include "StyleRule.h"
+
+namespace WebCore {
+
+CSSStartingStyleRule::CSSStartingStyleRule(StyleRuleStartingStyle& rule, CSSStyleSheet* parent)
+    : CSSGroupingRule(rule, parent)
+{
+}
+
+String CSSStartingStyleRule::cssText() const
+{
+    StringBuilder builder;
+    builder.append("@starting-style ");
+    appendCSSTextForItems(builder);
+    return builder.toString();
+}
+
+}

--- a/Source/WebCore/css/CSSStartingStyleRule.h
+++ b/Source/WebCore/css/CSSStartingStyleRule.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSGroupingRule.h"
+
+namespace WebCore {
+
+class StyleRuleStartingStyle;
+
+class CSSStartingStyleRule final : public CSSGroupingRule {
+public:
+    static Ref<CSSStartingStyleRule> create(StyleRuleStartingStyle& rule, CSSStyleSheet* parent)
+    {
+        return adoptRef(*new CSSStartingStyleRule(rule, parent));
+    }
+
+    String cssText() const final;
+
+private:
+    CSSStartingStyleRule(StyleRuleStartingStyle&, CSSStyleSheet*);
+
+    StyleRuleType styleRuleType() const final { return StyleRuleType::StartingStyle; }
+};
+
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_CSS_RULE(CSSStartingStyleRule, StyleRuleType::StartingStyle)
+

--- a/Source/WebCore/css/CSSStartingStyleRule.idl
+++ b/Source/WebCore/css/CSSStartingStyleRule.idl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    EnabledBySetting=CSSStartingStyleAtRuleEnabled,
+    Exposed=Window
+] interface CSSStartingStyleRule : CSSGroupingRule {
+};

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -38,6 +38,7 @@
 #include "CSSPageRule.h"
 #include "CSSPropertyRule.h"
 #include "CSSScopeRule.h"
+#include "CSSStartingStyleRule.h"
 #include "CSSStyleRule.h"
 #include "CSSSupportsRule.h"
 #include "MediaList.h"
@@ -213,9 +214,8 @@ Ref<CSSRule> StyleRuleBase::createCSSOMWrapper(CSSStyleSheet* parentSheet, CSSRu
         [&](StyleRuleScope& rule) -> Ref<CSSRule> {
             return CSSScopeRule::create(rule, parentSheet);
         },
-        [&](StyleRuleStartingStyle&) -> Ref<CSSRule> {
-            // FIXME: Implement.
-            RELEASE_ASSERT_NOT_REACHED();
+        [&](StyleRuleStartingStyle& rule) -> Ref<CSSRule> {
+            return CSSStartingStyleRule::create(rule, parentSheet);
         },
         [](StyleRuleCharset&) -> Ref<CSSRule> {
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/StyleRuleImport.cpp
+++ b/Source/WebCore/css/StyleRuleImport.cpp
@@ -28,6 +28,7 @@
 #include "CachedResourceRequest.h"
 #include "CachedResourceRequestInitiatorTypes.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "MediaList.h"
 #include "MediaQueryParserContext.h"
 #include "Page.h"

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -91,6 +91,7 @@ static RuleFlatteningStrategy flatteningStrategyForStyleRuleType(StyleRuleType s
     case StyleRuleType::Supports:
     case StyleRuleType::LayerBlock:
     case StyleRuleType::Container:
+    case StyleRuleType::StartingStyle:
         // These rules MUST be handled by the static `isValidRuleHeaderText`, `protocolGroupingTypeForStyleRuleType`,
         // and `asCSSRuleList` in order to provide functionality in Web Inspector. Additionally, they MUST have a CSSOM
         // representation created in `StyleRuleBase::createCSSOMWrapper`, otherwise we will end up with a mismatched
@@ -100,7 +101,6 @@ static RuleFlatteningStrategy flatteningStrategyForStyleRuleType(StyleRuleType s
     // FIXME: implement support for this and move this case up.
     // https://bugs.webkit.org/show_bug.cgi?id=264496
     case StyleRuleType::Scope:
-    case StyleRuleType::StartingStyle:
 
     case StyleRuleType::Unknown:
     case StyleRuleType::Charset:


### PR DESCRIPTION
#### aa0c3c8b01ffbb220b15dfb7c4ce2434acc7372a
<pre>
[@starting-style] Add CSSOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=268306">https://bugs.webkit.org/show_bug.cgi?id=268306</a>
<a href="https://rdar.apple.com/problem/121862449">rdar://problem/121862449</a>

Reviewed by Tim Nguyen.

Add CSSStartingStyleRule interface.

<a href="https://drafts.csswg.org/css-transitions-2/#the-cssstartingstylerule-interface">https://drafts.csswg.org/css-transitions-2/#the-cssstartingstylerule-interface</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/idlharness-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/interfaces/css-transitions-2.idl:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSCSSRuleCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/css/CSSStartingStyleRule.cpp: Added.
(WebCore::CSSStartingStyleRule::CSSStartingStyleRule):
(WebCore::CSSStartingStyleRule::cssText const):
* Source/WebCore/css/CSSStartingStyleRule.h: Added.
* Source/WebCore/css/CSSStartingStyleRule.idl: Added.
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleBase::createCSSOMWrapper const):
* Source/WebCore/css/StyleRuleImport.cpp:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::flatteningStrategyForStyleRuleType):

Canonical link: <a href="https://commits.webkit.org/273690@main">https://commits.webkit.org/273690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/016241424d82089a29907a711a082f8c36009a2a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39050 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12310 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12904 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11312 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40294 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/30603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37272 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/36141 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11546 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9425 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35377 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13260 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/42876 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8242 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8875 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->