### PR TITLE
Drop unused IPC coders for SHA1::Digest

### DIFF
--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -800,26 +800,6 @@ template<> struct ArgumentCoder<StringView> {
     static void encode(Encoder&, StringView);
 };
 
-template<> struct ArgumentCoder<SHA1::Digest> {
-    static void encode(Encoder& encoder, const SHA1::Digest& digest)
-    {
-        encoder.encodeSpan(std::span(digest.data(), digest.size()));
-    }
-
-    static std::optional<SHA1::Digest> decode(Decoder& decoder)
-    {
-        constexpr size_t size = std::tuple_size_v<SHA1::Digest>;
-        auto data = decoder.template decodeSpan<uint8_t>(size);
-        if (!data.data())
-            return std::nullopt;
-
-        SHA1::Digest digest;
-        static_assert(sizeof(typename decltype(data)::element_type) == 1);
-        memcpy(digest.data(), data.data(), data.size_bytes());
-        return digest;
-    }
-};
-
 template<> struct ArgumentCoder<std::monostate> {
     template<typename Encoder>
     static void encode(Encoder&, const std::monostate&) { }


### PR DESCRIPTION
#### bda7cfde5d3b164fbbdacd74cdf287e5a60647e2
<pre>
Drop unused IPC coders for SHA1::Digest
<a href="https://bugs.webkit.org/show_bug.cgi?id=268307">https://bugs.webkit.org/show_bug.cgi?id=268307</a>

Reviewed by Alex Christensen.

* Source/WebKit/Platform/IPC/ArgumentCoders.h:
(IPC::ArgumentCoder&lt;SHA1::Digest&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;SHA1::Digest&gt;::decode): Deleted.

Canonical link: <a href="https://commits.webkit.org/273686@main">https://commits.webkit.org/273686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c8cacc04ff9f716c4f8a7bcd1e96674f230b390

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39036 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32646 "Failed to checkout and rebase branch from PR 23432") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12293 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31306 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12893 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11302 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11331 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40279 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32958 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32783 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37260 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11534 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35369 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8239 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/11994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12386 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->