### PR TITLE
[WGSL] Crash when failing to type check addressSpace and similar enums

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -1904,6 +1904,9 @@ void TypeChecker::allocateTextureStorageConstructor(ASCIILiteral name, Types::Te
 std::optional<TexelFormat> TypeChecker::texelFormat(AST::Expression& expression)
 {
     auto* formatType = infer(expression);
+    if (isBottom(formatType))
+        return std::nullopt;
+
     if (!unify(formatType, m_types.texelFormatType())) {
         typeError(InferBottom::No, expression.span(), "cannot use '", *formatType, "' as texel format");
         return std::nullopt;
@@ -1920,6 +1923,9 @@ std::optional<TexelFormat> TypeChecker::texelFormat(AST::Expression& expression)
 std::optional<AccessMode> TypeChecker::accessMode(AST::Expression& expression)
 {
     auto* accessType = infer(expression);
+    if (isBottom(accessType))
+        return std::nullopt;
+
     if (!unify(accessType, m_types.accessModeType())) {
         typeError(InferBottom::No, expression.span(), "cannot use '", *accessType, "' as access mode");
         return std::nullopt;
@@ -1936,6 +1942,9 @@ std::optional<AccessMode> TypeChecker::accessMode(AST::Expression& expression)
 std::optional<AddressSpace> TypeChecker::addressSpace(AST::Expression& expression)
 {
     auto* addressSpaceType = infer(expression);
+    if (isBottom(addressSpaceType))
+        return std::nullopt;
+
     if (!unify(addressSpaceType, m_types.addressSpaceType())) {
         typeError(InferBottom::No, expression.span(), "cannot use '", *addressSpaceType, "' as address space");
         return std::nullopt;


### PR DESCRIPTION
#### 7dc1af69d5f28486dc2dd697670eb5d90f7c6214
<pre>
[WGSL] Crash when failing to type check addressSpace and similar enums
<a href="https://bugs.webkit.org/show_bug.cgi?id=268308">https://bugs.webkit.org/show_bug.cgi?id=268308</a>
<a href="https://rdar.apple.com/121527219">rdar://121527219</a>

Reviewed by Mike Wyrzykowski.

The code assumes that if we successfully unify the type of the expression with
the addressSpace enum type, then the node must be an IdentifierExpression. This
is valid most of the time, except the type is bottom, then the expression might
be anything since bottom with unifies with all types. To fix that we explicitly
check if the type is bottom.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::texelFormat):
(WGSL::TypeChecker::accessMode):
(WGSL::TypeChecker::addressSpace):

Canonical link: <a href="https://commits.webkit.org/273749@main">https://commits.webkit.org/273749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bbd47b76b87fc71517959812a76654cb5377445

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39040 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32650 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31307 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11303 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11403 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40283 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33049 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37262 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35353 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13254 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8286 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/11998 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->