### PR TITLE
WebKit::displayStorageAccessAlert leaks an NSTextView

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm
@@ -104,14 +104,14 @@ void displayStorageAccessAlert(WKWebView *webView, NSString *alertTitle, NSStrin
     [alert setMessageText:alertTitle];
     [alert setInformativeText:informativeText];
     if (accessoryTextList) {
-        NSTextView *accessory = [[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, 200, 15)];
-        auto mutableString = [[accessory textStorage] mutableString];
+        auto accessory = adoptNS([[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, 200, 15)]);
+        auto *mutableString = [[accessory textStorage] mutableString];
         [mutableString setString:[accessoryTextList componentsJoinedByString:@"\n"]];
         [[accessory textStorage] setFont:[NSFont systemFontOfSize:[NSFont systemFontSize]]];
         [[accessory textStorage] setForegroundColor:NSColor.whiteColor];
         [accessory setEditable:NO];
         [accessory setDrawsBackground:NO];
-        [alert setAccessoryView:accessory];
+        [alert setAccessoryView:accessory.get()];
         [alert layout];
     }
     [alert addButtonWithTitle:allowButtonString];


### PR DESCRIPTION
#### 2a038d86cb46e23f1c1ba420f9209e9c29ed2d3c
<pre>
WebKit::displayStorageAccessAlert leaks an NSTextView
<a href="https://bugs.webkit.org/show_bug.cgi?id=268309">https://bugs.webkit.org/show_bug.cgi?id=268309</a>
&lt;<a href="https://rdar.apple.com/121864691">rdar://121864691</a>&gt;

Reviewed by Aditya Keerthi.

* Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm:
(WebKit::displayStorageAccessAlert):
- Use adoptNS() to fix the leak.
- Change `mutableString` to `auto *` type to hint that it&apos;s a pointer.

Canonical link: <a href="https://commits.webkit.org/273678@main">https://commits.webkit.org/273678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82fe3467827186c6a5d9e4769e760937dbddc2c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39044 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12302 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11305 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40288 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32781 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37265 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11540 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35363 "Failed to checkout and rebase branch from PR 23436") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4706 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->