### PR TITLE
[UnifiedPDF] Can't zoom out below scale 1

### DIFF
--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -714,6 +714,8 @@ void ViewGestureController::endMagnificationGesture()
     if (m_activeGestureType != ViewGestureType::Magnification)
         return;
 
+    auto minMagnification = m_webPageProxy.minPageZoomFactor();
+    auto maxMagnification = m_webPageProxy.maxPageZoomFactor();
     double newMagnification = clampTo<double>(m_magnification, minMagnification, maxMagnification);
 
     if (m_frameHandlesMagnificationGesture)

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -88,6 +88,8 @@ typedef struct {
     bool isEnd;
 } PlatformGtkScrollData;
 typedef PlatformGtkScrollData* PlatformScrollEvent;
+#else
+typedef void* PlatformScrollEvent;
 #endif
 
 namespace WebKit {
@@ -101,6 +103,10 @@ class ViewGestureController : public IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(ViewGestureController);
 public:
+
+    static constexpr double defaultMinMagnification { 1 };
+    static constexpr double defaultMaxMagnification { 3 };
+
     ViewGestureController(WebPageProxy&);
     ~ViewGestureController();
     void platformTeardown();
@@ -293,7 +299,7 @@ private:
     bool shouldUseSnapshotForSize(ViewSnapshot&, WebCore::FloatSize swipeLayerSize, float topContentInset);
 
 #if PLATFORM(MAC)
-    static double resistanceForDelta(double deltaScale, double currentScale);
+    static double resistanceForDelta(double deltaScale, double currentScale, double minMagnification, double maxMagnification);
 
     CALayer* determineSnapshotLayerParent() const;
     CALayer* determineLayerAdjacentToSnapshotForParent(SwipeDirection, CALayer* snapshotLayerParent) const;
@@ -485,11 +491,6 @@ private:
 
     SnapshotRemovalTracker m_snapshotRemovalTracker;
     WTF::Function<void()> m_loadCallback;
-
-#if !PLATFORM(IOS_FAMILY)
-    static constexpr double minMagnification { 1 };
-    static constexpr double maxMagnification { 3 };
-#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1222,9 +1222,14 @@ public:
     bool supportsTextZoom() const;
     double textZoomFactor() const { return m_textZoomFactor; }
     void setTextZoomFactor(double);
+
     double pageZoomFactor() const;
     void setPageZoomFactor(double);
+
     void setPageAndTextZoomFactors(double pageZoomFactor, double textZoomFactor);
+
+    double minPageZoomFactor() const;
+    double maxPageZoomFactor() const;
 
     void scalePage(double scale, const WebCore::IntPoint& origin);
     void scalePageInViewCoordinates(double scale, const WebCore::IntPoint& centerInViewCoordinates);
@@ -2408,7 +2413,7 @@ private:
     void didFirstVisuallyNonEmptyLayoutForFrame(WebCore::FrameIdentifier, const UserData&);
     void didDisplayInsecureContentForFrame(WebCore::FrameIdentifier, const UserData&);
     void didRunInsecureContentForFrame(WebCore::FrameIdentifier, const UserData&);
-    void mainFramePluginHandlesPageScaleGestureDidChange(bool);
+    void mainFramePluginHandlesPageScaleGestureDidChange(bool, double minScale, double maxScale);
     void didStartProgress();
     void didChangeProgress(double);
     void didFinishProgress();
@@ -3122,8 +3127,14 @@ private:
     double m_textZoomFactor { 1 };
     double m_pageZoomFactor { 1 };
     double m_pageScaleFactor { 1 };
+
     double m_pluginZoomFactor { 1 };
+
+    double m_pluginMinZoomFactor { 1 };
+    double m_pluginMaxZoomFactor { 1 };
+
     double m_pluginScaleFactor { 1 };
+
     double m_viewScaleFactor { 1 };
     float m_intrinsicDeviceScaleFactor { 1 };
     std::optional<float> m_customDeviceScaleFactor;

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -142,7 +142,7 @@ messages -> WebPageProxy {
 
     UpdateRemoteFrameSize(WebCore::FrameIdentifier frameID, WebCore::IntSize size)
 
-    MainFramePluginHandlesPageScaleGestureDidChange(bool mainFramePluginHandlesPageScaleGesture)
+    MainFramePluginHandlesPageScaleGestureDidChange(bool mainFramePluginHandlesPageScaleGesture, double minScale, double maxScale)
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
     # Resource load messages

--- a/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ViewGestureControllerGtk.cpp
@@ -681,6 +681,9 @@ void ViewGestureController::setMagnification(double scale, FloatPoint origin)
 
     willBeginGesture(ViewGestureType::Magnification);
 
+    auto minMagnification = m_webPageProxy.minPageZoomFactor();
+    auto maxMagnification = m_webPageProxy.maxPageZoomFactor();
+
     double absoluteScale = scale * m_initialMagnification;
     m_magnification = clampTo<double>(absoluteScale, minMagnification, maxMagnification);
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -110,6 +110,9 @@ public:
     virtual CGFloat scaleFactor() const = 0;
     virtual CGSize contentSizeRespectingZoom() const = 0;
 
+    virtual CGFloat minScaleFactor() const { return 0.25; }
+    virtual CGFloat maxScaleFactor() const { return 5; }
+
     bool isLocked() const;
 
     RetainPtr<PDFDocument> pdfDocumentForPrinting() const { return m_pdfDocument; }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -146,6 +146,8 @@ void PDFDocumentLayout::layoutSingleColumn(float availableWidth, float maxRowWid
 
         auto pageBounds = m_pageGeometry[i].normalizedBounds;
 
+        ALWAYS_LOG_WITH_STREAM(stream << "PDFDocumentLayout::layoutSingleColumn - page " << i << " bounds " << pageBounds);
+
         auto pageLeft = std::max<float>(std::floor((maxRowWidth - pageBounds.width()) / 2), 0);
         pageBounds.setLocation({ pageLeft, currentYOffset });
 
@@ -159,6 +161,8 @@ void PDFDocumentLayout::layoutSingleColumn(float availableWidth, float maxRowWid
 
     m_scale = std::max<float>(availableWidth / maxRowWidth, minScale);
     m_documentBounds = FloatRect { 0, 0, maxRowWidth, currentYOffset };
+
+    ALWAYS_LOG_WITH_STREAM(stream << "PDFDocumentLayout::layoutSingleColumn - document bounds " << m_documentBounds << " scale " << m_scale);
 }
 
 void PDFDocumentLayout::layoutTwoUpColumn(float availableWidth, float maxRowWidth)

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -406,7 +406,7 @@ void PluginView::initializePlugin()
         if (auto* frameView = frame->view())
             frameView->setNeedsLayoutAfterViewConfigurationChange();
         if (frame->isMainFrame() && m_plugin->isFullFramePlugin())
-            WebFrame::fromCoreFrame(*frame)->page()->send(Messages::WebPageProxy::MainFramePluginHandlesPageScaleGestureDidChange(true));
+            WebFrame::fromCoreFrame(*frame)->page()->send(Messages::WebPageProxy::MainFramePluginHandlesPageScaleGestureDidChange(true, m_plugin->minScaleFactor(), m_plugin->maxScaleFactor()));
     }
 }
 


### PR DESCRIPTION
#### 2fc8377fb2908ec7003d3e8591aa5a418bfdcf54
<pre>
[UnifiedPDF] Can&apos;t zoom out below scale 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=268310">https://bugs.webkit.org/show_bug.cgi?id=268310</a>
<a href="https://rdar.apple.com/121866624">rdar://121866624</a>

Reviewed by Tim Horton.

For the PDF plugin, we need to allow minimum zoom scales of less than 1. Add support
for this by allowing the plugin to vend min and max scales, keeping track of them
in WebPageProxy. ViewGestureController reads them from there.

We compute the min and max elastic zoom scales relative to the min and max,
using multipliers that gives the same results as the old hard-coded values.

The PDF min and max scale values match those in PDFKit.

* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::endMagnificationGesture):
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::minPageZoomFactor const):
(WebKit::WebPageProxy::maxPageZoomFactor const):
(WebKit::WebPageProxy::mainFramePluginHandlesPageScaleGestureDidChange):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::resistanceForDelta):
(WebKit::ViewGestureController::handleMagnificationGestureEvent):
(WebKit::ViewGestureController::didCollectGeometryForSmartMagnificationGesture):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::minScaleFactor const):
(WebKit::PDFPluginBase::maxScaleFactor const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::layoutSingleColumn):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::initializePlugin):

Canonical link: <a href="https://commits.webkit.org/273725@main">https://commits.webkit.org/273725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0de6a64b4179a1c95fbfbd67697caf7fadffc952

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39080 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32678 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31332 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12930 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32238 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11333 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11360 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40324 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32995 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37292 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9450 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35388 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13281 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8263 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12023 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->