### PR TITLE
[Site Isolation] `findString:` should have support for backwards traversal

### DIFF
--- a/Source/WebKit/UIProcess/FindStringCallbackAggregator.h
+++ b/Source/WebKit/UIProcess/FindStringCallbackAggregator.h
@@ -30,6 +30,7 @@
 
 namespace WebKit {
 
+class WebFrameProxy;
 class WebPageProxy;
 
 enum class FindOptions : uint16_t;
@@ -42,6 +43,9 @@ public:
 
 private:
     FindStringCallbackAggregator(WebPageProxy&, const String&, OptionSet<FindOptions>, unsigned maxMatchCount, CompletionHandler<void(bool)>&&);
+
+    RefPtr<WebFrameProxy> incrementFrame(WebFrameProxy&);
+    bool shouldTargetFrame(WebFrameProxy&, WebFrameProxy& focusedFrame, bool didWrap);
 
     WeakPtr<WebPageProxy> m_page;
     String m_string;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -1825,6 +1825,9 @@ TEST(SiteIsolation, FindStringSelection)
     } };
     for (auto& offsets : selectionOffsetsForFrames)
         findStringAndValidateResults(webView.get(), offsets);
+    findConfiguration.get().backwards = YES;
+    for (auto it = selectionOffsetsForFrames.rbegin() + 1; it != selectionOffsetsForFrames.rend(); ++it)
+        findStringAndValidateResults(webView.get(), *it);
 }
 
 TEST(SiteIsolation, FindStringSelectionWithEmptyFrames)
@@ -1874,6 +1877,9 @@ TEST(SiteIsolation, FindStringSelectionWithEmptyFrames)
     } };
     for (auto& offsets : selectionOffsetsForFrames)
         findStringAndValidateResults(webView.get(), offsets);
+    findConfiguration.get().backwards = YES;
+    for (auto it = selectionOffsetsForFrames.rbegin() + 1; it != selectionOffsetsForFrames.rend(); ++it)
+        findStringAndValidateResults(webView.get(), *it);
 }
 
 TEST(SiteIsolation, FindStringSelectionNoWrap)
@@ -1914,6 +1920,56 @@ TEST(SiteIsolation, FindStringSelectionNoWrap)
         { { { 0, 11 }, { 0, 0 } } },
         { { { 0, 0 }, { 0, 11 } } },
         { { { 0, 0 }, { 0, 0 } } }
+    } };
+    for (auto& offsets : selectionOffsetsForFrames)
+        findStringAndValidateResults(webView.get(), offsets);
+    findConfiguration.get().backwards = YES;
+    for (auto it = selectionOffsetsForFrames.rbegin() + 1; it != selectionOffsetsForFrames.rend(); ++it)
+        findStringAndValidateResults(webView.get(), *it);
+}
+
+TEST(SiteIsolation, FindStringSelectionBackwards)
+{
+    auto mainframeHTML = "<p>Hello world</p>"
+        "<iframe src='https://domain2.com/subframe'></iframe>"
+        "<iframe src='https://domain3.com/subframe'></iframe>"_s;
+    HTTPServer server({
+        { "/mainframe"_s, { mainframeHTML } },
+        { "/subframe"_s, { "<p>Hello world</p>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    auto findConfiguration = adoptNS([[WKFindConfiguration alloc] init]);
+    findConfiguration.get().backwards = YES;
+    using SelectionOffsets = std::array<std::pair<int, int>, 3>;
+    auto findStringAndValidateResults = [&findConfiguration](TestWKWebView *webView, const SelectionOffsets& offsets) {
+        __block RetainPtr<_WKFrameTreeNode> mainFrameNode;
+        __block bool done = false;
+        [webView _frames:^(_WKFrameTreeNode *mainFrame) {
+            EXPECT_EQ(2UL, mainFrame.childFrames.count);
+            mainFrameNode = mainFrame;
+            done = true;
+        }];
+        Util::run(&done);
+        done = false;
+
+        [webView findString:@"Hello world" withConfiguration:findConfiguration.get() completionHandler:^(WKFindResult *result) {
+            EXPECT_TRUE(result.matchFound);
+            done = true;
+        }];
+        Util::run(&done);
+        EXPECT_TRUE([webView selectionRangeHasStartOffset:offsets[0].first endOffset:offsets[0].second inFrame:mainFrameNode.get().info]);
+        EXPECT_TRUE([webView selectionRangeHasStartOffset:offsets[1].first endOffset:offsets[1].second inFrame:mainFrameNode.get().childFrames[0].info]);
+        EXPECT_TRUE([webView selectionRangeHasStartOffset:offsets[2].first endOffset:offsets[2].second inFrame:mainFrameNode.get().childFrames[1].info]);
+    };
+
+    std::array<SelectionOffsets, 4> selectionOffsetsForFrames = { {
+        { { { 0, 11 }, { 0, 0 }, { 0, 0 } } },
+        { { { 0, 0 }, { 0, 0 }, { 0, 11 } } },
+        { { { 0, 0 }, { 0, 11 }, { 0, 0 } } },
+        { { { 0, 11 }, { 0, 0 }, { 0, 0 } } }
     } };
     for (auto& offsets : selectionOffsetsForFrames)
         findStringAndValidateResults(webView.get(), offsets);
@@ -1963,6 +2019,9 @@ TEST(SiteIsolation, FindStringSelectionSameOriginFrames)
     } };
     for (auto& offsets : selectionOffsetsForFrames)
         findStringAndValidateResults(webView.get(), offsets);
+    findConfiguration.get().backwards = YES;
+    for (auto it = selectionOffsetsForFrames.rbegin() + 1; it != selectionOffsetsForFrames.rend(); ++it)
+        findStringAndValidateResults(webView.get(), *it);
 }
 
 TEST(SiteIsolation, FindStringSelectionNestedFrames)
@@ -2017,6 +2076,9 @@ TEST(SiteIsolation, FindStringSelectionNestedFrames)
     } };
     for (auto& offsets : selectionOffsetsForFrames)
         findStringAndValidateResults(webView.get(), offsets);
+    findConfiguration.get().backwards = YES;
+    for (auto it = selectionOffsetsForFrames.rbegin() + 1; it != selectionOffsetsForFrames.rend(); ++it)
+        findStringAndValidateResults(webView.get(), *it);
 }
 
 TEST(SiteIsolation, FindStringSelectionMultipleMatchesInMainFrame)
@@ -2062,6 +2124,9 @@ TEST(SiteIsolation, FindStringSelectionMultipleMatchesInMainFrame)
     } };
     for (auto& offsets : selectionOffsetsForFrames)
         findStringAndValidateResults(webView.get(), offsets);
+    findConfiguration.get().backwards = YES;
+    for (auto it = selectionOffsetsForFrames.rbegin() + 1; it != selectionOffsetsForFrames.rend(); ++it)
+        findStringAndValidateResults(webView.get(), *it);
 }
 
 TEST(SiteIsolation, FindStringSelectionMultipleMatchesInChildFrame)
@@ -2107,6 +2172,9 @@ TEST(SiteIsolation, FindStringSelectionMultipleMatchesInChildFrame)
     } };
     for (auto& offsets : selectionOffsetsForFrames)
         findStringAndValidateResults(webView.get(), offsets);
+    findConfiguration.get().backwards = YES;
+    for (auto it = selectionOffsetsForFrames.rbegin() + 1; it != selectionOffsetsForFrames.rend(); ++it)
+        findStringAndValidateResults(webView.get(), *it);
 }
 
 TEST(SiteIsolation, FindStringSelectionSameOriginFrameBeforeWrap)
@@ -2162,6 +2230,9 @@ TEST(SiteIsolation, FindStringSelectionSameOriginFrameBeforeWrap)
     } };
     for (auto& offsets : selectionOffsetsForFrames)
         findStringAndValidateResults(webView.get(), offsets);
+    findConfiguration.get().backwards = YES;
+    for (auto it = selectionOffsetsForFrames.rbegin() + 1; it != selectionOffsetsForFrames.rend(); ++it)
+        findStringAndValidateResults(webView.get(), *it);
 }
 
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 3b0ecebf15c658e0e5ecd1e3e217ff02d491733f
<pre>
[Site Isolation] `findString:` should have support for backwards traversal
<a href="https://bugs.webkit.org/show_bug.cgi?id=267905">https://bugs.webkit.org/show_bug.cgi?id=267905</a>
<a href="https://rdar.apple.com/121411333">rdar://121411333</a>

Reviewed by Alex Christensen.

When FindOptions::Backwards is passed to findString the frame traversal in the UI process should go
backwards when finding the frame closest to the focused frame.

* Source/WebKit/UIProcess/FindStringCallbackAggregator.cpp:
(WebKit::FindStringCallbackAggregator::incrementFrame):
(WebKit::FindStringCallbackAggregator::shouldTargetFrame):
(WebKit::FindStringCallbackAggregator::~FindStringCallbackAggregator):
(WebKit::shouldTargetFrame): Deleted.
* Source/WebKit/UIProcess/FindStringCallbackAggregator.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::traversePrevious const):
(WebKit::WebFrameProxy::deepLastChild const):
(WebKit::WebFrameProxy::traversePrevious): Deleted.
(WebKit::WebFrameProxy::deepLastChild): Deleted.
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):
Use the existing tests and expect the reverse order.

Canonical link: <a href="https://commits.webkit.org/273730@main">https://commits.webkit.org/273730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/619743ab731156277960b3b76541fb91c2cccf9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39174 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12531 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32305 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11397 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40420 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32896 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11656 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/35452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8265 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->