### PR TITLE
Generate CGColorSpace serialization

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -441,6 +441,7 @@ $(PROJECT_DIR)/Shared/XR/XRSystem.serialization.in
 $(PROJECT_DIR)/Shared/cf/CFTypes.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCBoolean.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCCFArray.serialization.in
+$(PROJECT_DIR)/Shared/cf/CoreIPCCGColorSpace.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCNumber.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCSecCertificate.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCSecKeychainItem.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -683,6 +683,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/cf/CFTypes.serialization.in \
 	Shared/cf/CoreIPCBoolean.serialization.in \
 	Shared/cf/CoreIPCCFArray.serialization.in \
+	Shared/cf/CoreIPCCGColorSpace.serialization.in \
 	Shared/cf/CoreIPCNumber.serialization.in \
 	Shared/cf/CoreIPCSecCertificate.serialization.in \
 	Shared/cf/CoreIPCSecKeychainItem.serialization.in \

--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.h
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.h
@@ -66,13 +66,6 @@ template<> struct ArgumentCoder<RetainPtr<CFDictionaryRef>> : CFRetainPtrArgumen
     static std::optional<RetainPtr<CFDictionaryRef>> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<CGColorSpaceRef> {
-    template<typename Encoder> static void encode(Encoder&, CGColorSpaceRef);
-};
-template<> struct ArgumentCoder<RetainPtr<CGColorSpaceRef>> : CFRetainPtrArgumentCoder<CGColorSpaceRef> {
-    static std::optional<RetainPtr<CGColorSpaceRef>> decode(Decoder&);
-};
-
 #if HAVE(SEC_ACCESS_CONTROL)
 template<> struct ArgumentCoder<SecAccessControlRef> {
     template<typename Encoder> static void encode(Encoder&, SecAccessControlRef);

--- a/Source/WebKit/Shared/cf/CFTypes.serialization.in
+++ b/Source/WebKit/Shared/cf/CFTypes.serialization.in
@@ -59,6 +59,10 @@ additional_forward_declaration: typedef struct CGColor *CGColorRef
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, FromCFMethod=WebCore::Color::createAndPreserveColorSpace, ToCFMethod=WebCore::cachedCGColor(*result)] CGColorRef wrapped by WebCore::Color {
 }
 
+additional_forward_declaration: typedef struct CF_BRIDGED_TYPE(id) CGColorSpace *CGColorSpaceRef
+[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder] CGColorSpaceRef wrapped by WebKit::CoreIPCCGColorSpace {
+}
+
 #endif
 
 #if HAVE(SEC_KEYCHAIN)

--- a/Source/WebKit/Shared/cf/CoreIPCCGColorSpace.h
+++ b/Source/WebKit/Shared/cf/CoreIPCCGColorSpace.h
@@ -1,0 +1,82 @@
+/*
+  * Copyright (C) 2024 Apple Inc. All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions
+  * are met:
+  * 1. Redistributions of source code must retain the above copyright
+  *    notice, this list of conditions and the following disclaimer.
+  * 2. Redistributions in binary form must reproduce the above copyright
+  *    notice, this list of conditions and the following disclaimer in the
+  *    documentation and/or other materials provided with the distribution.
+  *
+  * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+  * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+  * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+  * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  * THE POSSIBILITY OF SUCH DAMAGE.
+  */
+
+#pragma once
+
+#if PLATFORM(COCOA)
+
+#import <CoreGraphics/CoreGraphics.h>
+#import <WebCore/Color.h>
+#import <WebCore/ColorSpace.h>
+#import <WebCore/ColorSpaceCG.h>
+#import <wtf/RetainPtr.h>
+
+using CGColorSpaceSerialization = std::variant<WebCore::ColorSpace, RetainPtr<CFStringRef>, RetainPtr<CFTypeRef>>;
+
+namespace WebKit {
+class CoreIPCCGColorSpace {
+public:
+    CoreIPCCGColorSpace(CGColorSpaceRef cgColorSpace)
+    {
+        if (auto colorSpace = WebCore::colorSpaceForCGColorSpace(cgColorSpace))
+            m_cgColorSpace = *colorSpace;
+        else if (RetainPtr<CFStringRef> name = CGColorSpaceGetName(cgColorSpace))
+            m_cgColorSpace = WTFMove(name);
+        else if (auto propertyList = adoptCF(CGColorSpaceCopyPropertyList(cgColorSpace)))
+            m_cgColorSpace = WTFMove(propertyList);
+        else
+            // FIXME: This should be removed once we can prove only non-null cgColorSpaces.
+            m_cgColorSpace = WebCore::ColorSpace::SRGB;
+    }
+
+    CoreIPCCGColorSpace(CGColorSpaceSerialization data)
+        : m_cgColorSpace(data)
+    {
+    }
+
+    RetainPtr<CGColorSpaceRef> toCF() const
+    {
+        auto colorSpace = WTF::switchOn(m_cgColorSpace,
+            [](WebCore::ColorSpace colorSpace) -> RetainPtr<CGColorSpaceRef> {
+                return RetainPtr { cachedNullableCGColorSpace(colorSpace) };
+            },
+            [](RetainPtr<CFStringRef> name) -> RetainPtr<CGColorSpaceRef> {
+                return adoptCF(CGColorSpaceCreateWithName(name.get()));
+            },
+            [](RetainPtr<CFTypeRef> propertyList) -> RetainPtr<CGColorSpaceRef> {
+                return adoptCF(CGColorSpaceCreateWithPropertyList(propertyList.get()));
+            }
+        );
+        if (UNLIKELY(!colorSpace))
+            return nullptr;
+        return colorSpace;
+    }
+
+    CGColorSpaceSerialization m_cgColorSpace;
+};
+
+}
+
+#endif

--- a/Source/WebKit/Shared/cf/CoreIPCCGColorSpace.serialization.in
+++ b/Source/WebKit/Shared/cf/CoreIPCCGColorSpace.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(COCOA)
+
+webkit_platform_headers: "CoreIPCCGColorSpace.h"
+
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCCGColorSpace {
+    CGColorSpaceSerialization m_cgColorSpace;
+}
+
+#endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5635,6 +5635,8 @@
 		52F4B46727E1197700FFD129 /* VirtualAuthenticatorUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VirtualAuthenticatorUtils.h; sourceTree = "<group>"; };
 		52F4B46827E1197700FFD129 /* VirtualAuthenticatorUtils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VirtualAuthenticatorUtils.mm; sourceTree = "<group>"; };
 		52F4B46B27E125A800FFD129 /* VirtualCredential.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VirtualCredential.h; sourceTree = "<group>"; };
+		52FB15422B646156000933CC /* CoreIPCCGColorSpace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCCGColorSpace.h; sourceTree = "<group>"; };
+		52FB15432B64680B000933CC /* CoreIPCCGColorSpace.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCCGColorSpace.serialization.in; sourceTree = "<group>"; };
 		5315876B2076B713004BF9F3 /* NetworkActivityTrackerCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkActivityTrackerCocoa.mm; sourceTree = "<group>"; };
 		5321594F1DBAE6D70054AA3C /* NetworkDataTaskCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkDataTaskCocoa.h; sourceTree = "<group>"; };
 		532159501DBAE6D70054AA3C /* NetworkSessionCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkSessionCocoa.h; sourceTree = "<group>"; };
@@ -9025,6 +9027,8 @@
 				5C57868D2B6EF92F005D51D5 /* CoreIPCCFArray.h */,
 				5C57868F2B6EF92F005D51D5 /* CoreIPCCFArray.mm */,
 				5C57868E2B6EF92F005D51D5 /* CoreIPCCFArray.serialization.in */,
+				52FB15422B646156000933CC /* CoreIPCCGColorSpace.h */,
+				52FB15432B64680B000933CC /* CoreIPCCGColorSpace.serialization.in */,
 				F4EFF36B2AF0267200479AB8 /* CoreIPCNumber.h */,
 				F4EFF36A2AF0267200479AB8 /* CoreIPCNumber.serialization.in */,
 				561A54512B61E49E00073A72 /* CoreIPCSecCertificate.h */,

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -678,6 +678,11 @@ TEST(IPCSerialization, Basic)
     auto cgColor = adoptCF(CGColorCreate(sRGBColorSpace.get(), testComponents));
     runTestCF({ cgColor.get() });
 
+    // CGColorSpace
+    runTestCF({ sRGBColorSpace.get() });
+    auto grayColorSpace = adoptCF(CGColorSpaceCreateDeviceGray());
+    runTestCF({ grayColorSpace.get() });
+
     auto runNumberTest = [&](NSNumber *number) {
         ObjCHolderForTesting::ValueType numberVariant;
         numberVariant.emplace<RetainPtr<NSNumber>>(number);


### PR DESCRIPTION
#### de7f3c388e2a3233288ed91076b2ffc2404fb19c
<pre>
Generate CGColorSpace serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=268318">https://bugs.webkit.org/show_bug.cgi?id=268318</a>
<a href="https://rdar.apple.com/121873837">rdar://121873837</a>

Reviewed by Brady Eidson.

Start using generated serialization for CGColorSpace instead of hand-rolled serializers.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/cf/ArgumentCodersCF.cpp:
(IPC::ArgumentCoder&lt;CGColorSpaceRef&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RetainPtr&lt;CGColorSpaceRef&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/cf/ArgumentCodersCF.h:
* Source/WebKit/Shared/cf/CFTypes.serialization.in:
* Source/WebKit/Shared/cf/CoreIPCCGColorSpace.h: Added.
(WebKit::CoreIPCCGColorSpace::CoreIPCCGColorSpace):
(WebKit::CoreIPCCGColorSpace::toCF const):
* Source/WebKit/Shared/cf/CoreIPCCGColorSpace.serialization.in: Copied from Source/WebKit/Shared/cf/CFTypes.serialization.in.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/274188@main">https://commits.webkit.org/274188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c87be6edf31fa7ac447214285803488088e33080

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40702 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33947 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40407 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32229 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14415 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12557 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41980 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34652 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38386 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13115 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10783 "Build was cancelled. Recent messages:OS: Sonoma (14.1), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36565 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14657 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8601 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13533 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14108 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->