### PR TITLE
Web Inspector: Update COMPATIBILITY (macOS X.0, iOS X.0) comments with correct versions

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
@@ -670,8 +670,8 @@ WI.CSSManager = class CSSManager extends WI.Object
         this._styleSheetFrameURLMap.clear();
         this._modifiedStyles.clear();
 
-        // COMPATIBILITY (macOS X.0, iOS X.0): the `PrefersColorScheme` override used to be cleared on main frame navigation
-        // Since support can't be tested directly, check for the `reason` parameter of `Console.messagesCleared`.
+        // COMPATIBILITY (macOS 14.0, iOS 17.0): the `PrefersColorScheme` override used to be cleared on main frame navigation
+        // Since support can't be tested directly, check for the `reason` parameter of `Console.messagesCleared` as that change shipped in the same release.
         // FIXME: Use explicit version checking once <https://webkit.org/b/148680> is fixed.
         if (!InspectorBackend.hasEvent("Console.messagesCleared", "reason")) {
             this._overriddenUserPreferences.delete(InspectorBackend.Enum.Page.UserPreferenceName.PrefersColorScheme);

--- a/Source/WebInspectorUI/UserInterface/Models/Canvas.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Canvas.js
@@ -58,7 +58,7 @@ WI.Canvas = class Canvas extends WI.Object
         this._recordingFrames = [];
         this._recordingBufferUsed = 0;
 
-        // COMPATIBILITY (macOS X.0, iOS X.0): `Canvas.canvasSizeChanged` did not exist yet.
+        // COMPATIBILITY (macOS 14.2, iOS 17.2): `Canvas.canvasSizeChanged` did not exist yet.
         if (!InspectorBackend.hasEvent("Canvas.canvasSizeChanged")) {
             console.assert(!size);
 
@@ -112,7 +112,7 @@ WI.Canvas = class Canvas extends WI.Object
             console.error("Invalid canvas context type", payload.contextType);
         }
 
-        // COMPATIBILITY (macOS X.0, iOS X.0): `width` and `height` did not exist yet.
+        // COMPATIBILITY (macOS 14.2, iOS 17.2): `width` and `height` did not exist yet.
         let size = ("width" in payload && "height" in payload) ? new WI.Size(payload.width, payload.height) : null;
 
         // COMPATIBILITY (macOS 13.0, iOS 16.0): `backtrace` was renamed to `stackTrace`.
@@ -395,7 +395,7 @@ WI.Canvas = class Canvas extends WI.Object
     {
         // Called from WI.CanvasManager.
 
-        // COMPATIBILITY (macOS X.0, iOS X.0): `width` and `height` did not exist yet.
+        // COMPATIBILITY (macOS 14.2, iOS 17.2): `width` and `height` did not exist yet.
         if (this._size?.equals(size))
             return;
 


### PR DESCRIPTION
#### f98fe54ddfaf74e0abf3618703ca676913ae1c33
<pre>
Web Inspector: Update COMPATIBILITY (macOS X.0, iOS X.0) comments with correct versions
<a href="https://bugs.webkit.org/show_bug.cgi?id=268176">https://bugs.webkit.org/show_bug.cgi?id=268176</a>
<a href="https://rdar.apple.com/121675559">rdar://121675559</a>

Reviewed by Patrick Angle.

Retroactively update backwards compatibility comments that were
missing corresponding version numbers for when they started applying.

Related to changes introduced in
- <a href="https://commits.webkit.org/267488@main">https://commits.webkit.org/267488@main</a>
- <a href="https://commits.webkit.org/264172@main">https://commits.webkit.org/264172@main</a> (relying on protocol changes in <a href="https://commits.webkit.org/261512@main">https://commits.webkit.org/261512@main</a> for the same version check)

* Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js:
(WI.CSSManager.prototype._mainResourceDidChange):
* Source/WebInspectorUI/UserInterface/Models/Canvas.js:
(WI.Canvas.fromPayload):
(WI.Canvas.prototype.sizeChanged):

Canonical link: <a href="https://commits.webkit.org/273700@main">https://commits.webkit.org/273700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d268769a528a1f298db7e68dfa297f9365cb29c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39079 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12347 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32237 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11338 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32455 "layout-tests (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40323 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/32993 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32816 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37291 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11570 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35387 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8250 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12430 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->