### PR TITLE
Coalesce ContainerNode::childrenChanged in fast parser

### DIFF
--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -69,6 +69,8 @@ public:
     // They don't send DOM mutation events or handle reparenting.
     // However, arbitrary code may be run by beforeload handlers.
     void parserAppendChild(Node&);
+    void parserAppendChildIntoIsolatedTree(Node&);
+    void parserNotifyChildrenChanged();
     void parserRemoveChild(Node&);
     void parserInsertBefore(Node& newChild, Node& refChild);
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1048,7 +1048,9 @@ void Document::setMarkupUnsafe(const String& markup, OptionSet<ParserContentPoli
     setParserContentPolicy(policy);
     if (this->contentType() == textHTMLContentTypeAtom()) {
         auto body = HTMLBodyElement::create(*this);
+        body->beginParsingChildren();
         if (LIKELY(tryFastParsingHTMLFragment(StringView { markup }.substring(markup.find(isNotASCIIWhitespace<UChar>)), *this, body, body, policy))) {
+            body->finishParsingChildren();
             auto html = HTMLHtmlElement::create(*this);
             auto head = HTMLHeadElement::create(*this);
             html->appendChild(head);

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3154,6 +3154,9 @@ void Element::removeAllEventListeners()
 
 void Element::finishParsingChildren()
 {
+    if (hasHeldBackChildrenChanged())
+        parserNotifyChildrenChanged();
+
     setIsParsingChildrenFinished();
 
     Style::ChildChangeInvalidation::invalidateAfterFinishedParsingChildren(*this);

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -347,6 +347,10 @@ public:
 
     bool isDocumentFragmentForInnerOuterHTML() const { return isDocumentFragment() && hasTypeFlag(TypeFlag::IsSpecialInternalNode); }
 
+    bool hasHeldBackChildrenChanged() const { return hasStateFlag(StateFlag::HasHeldBackChildrenChanged); }
+    void setHasHeldBackChildrenChanged() { setStateFlag(StateFlag::HasHeldBackChildrenChanged); }
+    void clearHasHeldBackChildrenChanged() { clearStateFlag(StateFlag::HasHeldBackChildrenChanged); }
+
     void setChildNeedsStyleRecalc() { setStyleFlag(NodeStyleFlag::DescendantNeedsStyleResolution); }
     void clearChildNeedsStyleRecalc();
 
@@ -606,6 +610,7 @@ protected:
         HasInvalidRenderer = 1 << 10,
         ContainsOnlyASCIIWhitespace = 1 << 11, // Only used on CharacterData.
         ContainsOnlyASCIIWhitespaceIsValid = 1 << 12, // Only used on CharacterData.
+        HasHeldBackChildrenChanged = 1 << 13,
     };
 
     enum class TabIndexState : uint8_t {

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -688,7 +688,7 @@ private:
                 return;
 
             if (!text.isNull())
-                parent.parserAppendChild(Text::create(m_document.get(), WTFMove(text)));
+                parent.parserAppendChildIntoIsolatedTree(Text::create(m_document.get(), WTFMove(text)));
 
             if (m_parsingBuffer.atEnd())
                 return;
@@ -839,7 +839,7 @@ private:
         parseAttributes(element);
         if (parsingFailed())
             return WTFMove(element);
-        parent.parserAppendChild(element);
+        parent.parserAppendChildIntoIsolatedTree(element);
         element->beginParsingChildren();
         parseChildren<Tag>(element);
         if (parsingFailed() || m_parsingBuffer.atEnd())
@@ -868,7 +868,7 @@ private:
         parseAttributes(element);
         if (parsingFailed())
             return element;
-        parent.parserAppendChild(element);
+        parent.parserAppendChildIntoIsolatedTree(element);
         element->beginParsingChildren();
         element->finishParsingChildren();
         return WTFMove(element);


### PR DESCRIPTION
#### 21d657acd1bac107e61954490567c7685c20ee57
<pre>
Coalesce ContainerNode::childrenChanged in fast parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=268324">https://bugs.webkit.org/show_bug.cgi?id=268324</a>

Reviewed by Yusuke Suzuki.

This PR adds a new member function parserAppendChildIntoIsolatedTree to ContainerNode which inserts
child nodes without calling childrenChanged on the parent, and deploys it in HTMLFastPathParser.
childrenChanged gets called later in Element::finishParsingChildren via ContainerNode&apos;s
parserNotifyChildrenChanged. Newly introduced StateFlag::HeldBackChildrenChanged keeps track of
whether we held back childrenChanged calls when inserting child nodes or not.

Delaying calls to childrenChanged this way is safe in HTMLFastPathParser because the parsed tree
isn&apos;t exposed to scripts until the parsing ends so there won&apos;t be any event listeners that run
synchronously in response to DOM mutations.

Inspired by <a href="https://github.com/chromium/chromium/commit/b366b305efb5289f3bcf3bbbe549cbad82fc0daf">https://github.com/chromium/chromium/commit/b366b305efb5289f3bcf3bbbe549cbad82fc0daf</a>

* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::executeParserNodeInsertionIntoIsolatedTreeWithoutNotifyingParent): Added.
(WebCore::ContainerNode::parserAppendChildIntoIsolatedTree): Added.
(WebCore::ContainerNode::parserNotifyChildrenChanged): Added.
* Source/WebCore/dom/ContainerNode.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setMarkupUnsafe):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::finishParsingChildren):
* Source/WebCore/dom/Node.h:
(WebCore::Node::hasHeldBackChildrenChanged const): Added.
(WebCore::Node::setHasHeldBackChildrenChanged): Added.
(WebCore::Node::clearHasHeldBackChildrenChanged): Added.
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::parseChildren): Uses parserAppendChildIntoIsolatedTree now.
(WebCore::HTMLFastPathParser::parseContainerElement): Ditto.
(WebCore::HTMLFastPathParser::parseVoidElement): Ditto.

Canonical link: <a href="https://commits.webkit.org/273720@main">https://commits.webkit.org/273720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4ac9b054ecd68b28f484a012a3161649c5af060

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39092 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32690 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12367 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11342 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40337 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/30635 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33008 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37302 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11583 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9460 "Found 1 new test failure: http/tests/inspector/dom/didFireEvent.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35399 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13293 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4726 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12444 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->