### PR TITLE
[UnifiedPDF] Make all painting be in-process

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsLayerClient.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerClient.h
@@ -132,6 +132,8 @@ public:
 
     virtual bool layerContainsBitmapOnly(const GraphicsLayer*) const { return false; }
 
+    virtual bool layerNeedsPlatformContext(const GraphicsLayer*) const { return false; }
+
 #ifndef NDEBUG
     // RenderLayerBacking overrides this to verify that it is not
     // currently painting contents. An ASSERT fails, if it is.

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1974,6 +1974,11 @@ void GraphicsLayerCA::platformCALayerLayerDisplay(PlatformCALayer* layer)
     m_contentsDisplayDelegate->display(*layer);
 }
 
+bool GraphicsLayerCA::platformCALayerNeedsPlatformContext(const PlatformCALayer*) const
+{
+    return client().layerNeedsPlatformContext(this);
+}
+
 void GraphicsLayerCA::commitLayerChangesBeforeSublayers(CommitState& commitState, float pageScaleFactor, const FloatPoint& positionRelativeToBase, bool& layerChanged)
 {
     SetForScope committingChangesChange(m_isCommittingChanges, true);

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -241,6 +241,7 @@ private:
     WEBCORE_EXPORT bool platformCALayerUseGiantTiles() const override;
     WEBCORE_EXPORT bool platformCALayerUseCSS3DTransformInteroperability() const override;
     WEBCORE_EXPORT void platformCALayerLogFilledVisibleFreshTile(unsigned) override;
+    WEBCORE_EXPORT bool platformCALayerNeedsPlatformContext(const PlatformCALayer*) const override;
     bool platformCALayerContainsBitmapOnly(const PlatformCALayer*) const override { return client().layerContainsBitmapOnly(this); }
     bool platformCALayerShouldPaintUsingCompositeCopy() const override { return shouldPaintUsingCompositeCopy(); }
 

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -335,6 +335,8 @@ public:
     virtual void purgeFrontBufferForTesting() { }
     virtual void purgeBackBufferForTesting() { }
 
+    bool needsPlatformContext() const;
+
 protected:
     PlatformCALayer(LayerType, PlatformCALayerClient* owner);
 

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
@@ -210,6 +210,11 @@ void PlatformCALayer::setDelegatedContents(const PlatformCALayerInProcessDelegat
     setDelegatedContents({ contents.surface.createSendRight(), contents.finishedFence, std::nullopt });
 }
 
+bool PlatformCALayer::needsPlatformContext() const
+{
+    return m_owner && m_owner->platformCALayerNeedsPlatformContext(this);
+}
+
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 void PlatformCALayer::clearAcceleratedEffectsAndBaseValues()
 {

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
@@ -75,6 +75,8 @@ public:
 
     virtual bool platformCALayerShouldPaintUsingCompositeCopy() const { return false; }
 
+    virtual bool platformCALayerNeedsPlatformContext(const PlatformCALayer*) const { return false; }
+
 protected:
     virtual ~PlatformCALayerClient() = default;
 };

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -754,6 +754,13 @@ bool TileGrid::isUsingDisplayListDrawing(PlatformCALayer*) const
     return false;
 }
 
+bool TileGrid::platformCALayerNeedsPlatformContext(const PlatformCALayer* layer) const
+{
+    if (auto* layerOwner = m_controller.rootLayer().owner())
+        return layerOwner->platformCALayerNeedsPlatformContext(layer);
+    return false;
+}
+
 bool TileGrid::platformCALayerContentsOpaque() const
 {
     return m_controller.tilesAreOpaque();

--- a/Source/WebCore/platform/graphics/ca/TileGrid.h
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.h
@@ -147,6 +147,7 @@ private:
     bool platformCALayerDrawsContent() const override { return true; }
     float platformCALayerDeviceScaleFactor() const override;
     bool isUsingDisplayListDrawing(PlatformCALayer*) const override;
+    bool platformCALayerNeedsPlatformContext(const PlatformCALayer*) const override;
 
     TileController& m_controller;
 #if USE(CA)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -108,7 +108,7 @@ std::unique_ptr<RemoteLayerBackingStore> RemoteLayerBackingStoreCollection::crea
 {
     // We currently only create a single type of backing store based on the global setting, but
     // it should be fine to mix both types in the same collection.
-    if (WebProcess::singleton().shouldUseRemoteRenderingFor(WebCore::RenderingPurpose::DOM))
+    if (WebProcess::singleton().shouldUseRemoteRenderingFor(WebCore::RenderingPurpose::DOM) && !layer->needsPlatformContext())
         return makeUnique<RemoteLayerWithRemoteRenderingBackingStore>(layer);
     return makeUnique<RemoteLayerWithInProcessRenderingBackingStore>(layer);
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -170,6 +170,7 @@ private:
     void paintContents(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect&, OptionSet<WebCore::GraphicsLayerPaintBehavior>) override;
     float deviceScaleFactor() const override;
     float pageScaleFactor() const override { return scaleFactor(); }
+    bool layerNeedsPlatformContext(const WebCore::GraphicsLayer*) const override { return true; }
 
     void paintPDFContent(WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect);
     void ensureLayers();


### PR DESCRIPTION
#### ae6cb8babf6ed97c7a7a1d5535844b79989b0885
<pre>
[UnifiedPDF] Make all painting be in-process
<a href="https://bugs.webkit.org/show_bug.cgi?id=268325">https://bugs.webkit.org/show_bug.cgi?id=268325</a>
&lt;<a href="https://rdar.apple.com/problem/121385041">rdar://problem/121385041</a>&gt;

Reviewed by Simon Fraser.

UnifiedPDFPlugin currently paints PDF content into an ImageBuffer in the
Web Content process (to keep PDF out of the GPU process, for security),
and then paints that ImageBuffer into the tiles in the GPU process (to follow
the normal flow of painting).

Skip this two step process by making the layers for UnifiedPDFPlugin
have in-process software backing store and painting directly into them.

* Source/WebCore/platform/graphics/GraphicsLayerClient.h:
(WebCore::GraphicsLayerClient::layerNeedsPlatformContext const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::platformCALayerNeedsPlatformContext const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.mm:
(WebCore::PlatformCALayer::needsPlatformContext const):
* Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h:
(WebCore::PlatformCALayerClient::platformCALayerNeedsPlatformContext const):
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::platformCALayerNeedsPlatformContext const):
* Source/WebCore/platform/graphics/ca/TileGrid.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::createRemoteLayerBackingStore):
Plumb around a &quot;layer needs a platform context&quot; bit, and, if set,
force in-process rendering.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
Always say that UnifiedPDFPlugin needs in-process rendering.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::paintPDFContent):
Avoid painting into an extra bitmap here.

Canonical link: <a href="https://commits.webkit.org/273699@main">https://commits.webkit.org/273699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43f029e7e307e8bc11fd3cd0ac3391be2d53f9c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39088 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37605 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12360 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11339 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40333 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32827 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11579 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/35395 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/8252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4719 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->