### PR TITLE
Web process does not need to track cookie accept policy

### DIFF
--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -278,7 +278,6 @@ private:
 #elif USE(SOUP)
     static void cookiesDidChange(NetworkStorageSession*);
 
-    HTTPCookieAcceptPolicy m_cookieAcceptPolicy;
     GRefPtr<SoupCookieJar> m_cookieStorage;
     Function<void ()> m_cookieObserverHandler;
 #elif USE(CURL)

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
@@ -157,10 +157,7 @@ void WebCookieManager::stopObservingCookieChanges(PAL::SessionID sessionID)
 
 void WebCookieManager::setHTTPCookieAcceptPolicy(PAL::SessionID sessionID, HTTPCookieAcceptPolicy policy, CompletionHandler<void()>&& completionHandler)
 {
-    platformSetHTTPCookieAcceptPolicy(sessionID, policy, [policy, process = protectedProcess(), completionHandler = WTFMove(completionHandler)] () mutable {
-        process->cookieAcceptPolicyChanged(policy);
-        completionHandler();
-    });
+    platformSetHTTPCookieAcceptPolicy(sessionID, policy, WTFMove(completionHandler));
 }
 
 void WebCookieManager::getHTTPCookieAcceptPolicy(PAL::SessionID sessionID, CompletionHandler<void(HTTPCookieAcceptPolicy)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -620,11 +620,6 @@ void NetworkConnectionToWebProcess::setOnLineState(bool isOnLine)
     m_connection->send(Messages::NetworkProcessConnection::SetOnLineState(isOnLine), 0);
 }
 
-void NetworkConnectionToWebProcess::cookieAcceptPolicyChanged(HTTPCookieAcceptPolicy newPolicy)
-{
-    m_connection->send(Messages::NetworkProcessConnection::CookieAcceptPolicyChanged(newPolicy), 0);
-}
-
 void NetworkConnectionToWebProcess::removeLoadIdentifier(WebCore::ResourceLoaderIdentifier identifier)
 {
     RELEASE_ASSERT(identifier);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -210,8 +210,6 @@ public:
 
     NetworkSchemeRegistry& schemeRegistry() { return m_schemeRegistry.get(); }
 
-    void cookieAcceptPolicyChanged(WebCore::HTTPCookieAcceptPolicy);
-
     void broadcastConsoleMessage(JSC::MessageSource, JSC::MessageLevel, const String& message);
     RefPtr<NetworkResourceLoader> takeNetworkResourceLoader(WebCore::ResourceLoaderIdentifier);
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -366,8 +366,6 @@ public:
 
     static Seconds randomClosedPortDelay();
 
-    void cookieAcceptPolicyChanged(WebCore::HTTPCookieAcceptPolicy);
-
 #if ENABLE(APP_BOUND_DOMAINS)
     void hasAppBoundSession(PAL::SessionID, CompletionHandler<void(bool)>&&) const;
     void clearAppBoundSession(PAL::SessionID, CompletionHandler<void()>&&);
@@ -460,7 +458,7 @@ private:
     // Message Handlers
     bool didReceiveSyncNetworkProcessMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
     void initializeNetworkProcess(NetworkProcessCreationParameters&&, CompletionHandler<void()>&&);
-    void createNetworkConnectionToWebProcess(WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&,  CompletionHandler<void(std::optional<IPC::Connection::Handle>&&, WebCore::HTTPCookieAcceptPolicy)>&&);
+    void createNetworkConnectionToWebProcess(WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&,  CompletionHandler<void(std::optional<IPC::Connection::Handle>&&)>&&);
 
     void fetchWebsiteData(PAL::SessionID, OptionSet<WebsiteDataType>, OptionSet<WebsiteDataFetchOption>, CompletionHandler<void(WebsiteData&&)>&&);
     void deleteWebsiteData(PAL::SessionID, OptionSet<WebsiteDataType>, WallTime modifiedSince, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -23,7 +23,7 @@
 messages -> NetworkProcess LegacyReceiver {
     InitializeNetworkProcess(struct WebKit::NetworkProcessCreationParameters processCreationParameters) -> ()
 
-    CreateNetworkConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID, struct WebKit::NetworkProcessConnectionParameters parameters) -> (std::optional<IPC::Connection::Handle> connectionHandle, enum:uint8_t WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy) AllowedWhenWaitingForSyncReply
+    CreateNetworkConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID, struct WebKit::NetworkProcessConnectionParameters parameters) -> (std::optional<IPC::Connection::Handle> connectionHandle) AllowedWhenWaitingForSyncReply
 
     AddAllowedFirstPartyForCookies(WebCore::ProcessIdentifier processIdentifier, WebCore::RegistrableDomain firstPartyForCookies, enum:bool WebKit::LoadedWebArchive loadedWebArchive) -> ()
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -303,7 +303,7 @@ void NetworkProcessProxy::getNetworkProcessConnection(WebProcessProxy& webProces
 #if ENABLE(IPC_TESTING_API)
     parameters.ignoreInvalidMessageForTesting = webProcessProxy.ignoreInvalidMessageForTesting();
 #endif
-    sendWithAsyncReply(Messages::NetworkProcess::CreateNetworkConnectionToWebProcess { webProcessProxy.coreProcessIdentifier(), webProcessProxy.sessionID(), parameters }, [this, weakThis = WeakPtr { *this }, reply = WTFMove(reply)](auto&& identifier, auto cookieAcceptPolicy) mutable {
+    sendWithAsyncReply(Messages::NetworkProcess::CreateNetworkConnectionToWebProcess { webProcessProxy.coreProcessIdentifier(), webProcessProxy.sessionID(), parameters }, [this, weakThis = WeakPtr { *this }, reply = WTFMove(reply)](auto&& identifier) mutable {
         if (!weakThis) {
             RELEASE_LOG_ERROR(Process, "NetworkProcessProxy::getNetworkProcessConnection: NetworkProcessProxy deallocated during connection establishment");
             return reply({ });
@@ -316,11 +316,11 @@ void NetworkProcessProxy::getNetworkProcessConnection(WebProcessProxy& webProces
         }
 
 #if USE(UNIX_DOMAIN_SOCKETS) || OS(WINDOWS)
-        reply(NetworkProcessConnectionInfo { WTFMove(*identifier), cookieAcceptPolicy });
+        reply(NetworkProcessConnectionInfo { WTFMove(*identifier) });
         UNUSED_VARIABLE(this);
 #elif OS(DARWIN)
         MESSAGE_CHECK(*identifier);
-        reply(NetworkProcessConnectionInfo { WTFMove(*identifier) , cookieAcceptPolicy, connection()->getAuditToken() });
+        reply(NetworkProcessConnectionInfo { WTFMove(*identifier), connection()->getAuditToken() });
 #else
         notImplemented();
 #endif

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -80,9 +80,8 @@
 namespace WebKit {
 using namespace WebCore;
 
-NetworkProcessConnection::NetworkProcessConnection(IPC::Connection::Identifier connectionIdentifier, HTTPCookieAcceptPolicy cookieAcceptPolicy)
+NetworkProcessConnection::NetworkProcessConnection(IPC::Connection::Identifier connectionIdentifier)
     : m_connection(IPC::Connection::createClientConnection(connectionIdentifier))
-    , m_cookieAcceptPolicy(cookieAcceptPolicy)
 {
     m_connection->open(*this);
 
@@ -243,20 +242,6 @@ void NetworkProcessConnection::didFinishPreconnection(WebCore::ResourceLoaderIde
 void NetworkProcessConnection::setOnLineState(bool isOnLine)
 {
     WebProcess::singleton().webLoaderStrategy().setOnLineState(isOnLine);
-}
-
-bool NetworkProcessConnection::cookiesEnabled() const
-{
-    return m_cookieAcceptPolicy != HTTPCookieAcceptPolicy::Never;
-}
-
-void NetworkProcessConnection::cookieAcceptPolicyChanged(HTTPCookieAcceptPolicy newPolicy)
-{
-    if (m_cookieAcceptPolicy == newPolicy)
-        return;
-
-    m_cookieAcceptPolicy = newPolicy;
-    WebProcess::singleton().cookieJar().clearCache();
 }
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
@@ -45,7 +45,6 @@ struct Cookie;
 struct MessagePortIdentifier;
 struct MessageWithMessagePorts;
 class SecurityOriginData;
-enum class HTTPCookieAcceptPolicy : uint8_t;
 }
 
 namespace WebKit {
@@ -59,9 +58,9 @@ enum class WebsiteDataType : uint32_t;
 
 class NetworkProcessConnection : public RefCounted<NetworkProcessConnection>, IPC::Connection::Client {
 public:
-    static Ref<NetworkProcessConnection> create(IPC::Connection::Identifier&& connectionIdentifier, WebCore::HTTPCookieAcceptPolicy httpCookieAcceptPolicy)
+    static Ref<NetworkProcessConnection> create(IPC::Connection::Identifier&& connectionIdentifier)
     {
-        return adoptRef(*new NetworkProcessConnection(connectionIdentifier, httpCookieAcceptPolicy));
+        return adoptRef(*new NetworkProcessConnection(connectionIdentifier));
     }
     ~NetworkProcessConnection();
     
@@ -83,7 +82,6 @@ public:
     std::optional<audit_token_t> networkProcessAuditToken() const { return m_networkProcessAuditToken; }
 #endif
 
-    WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy() const { return m_cookieAcceptPolicy; }
     bool cookiesEnabled() const;
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
@@ -96,7 +94,7 @@ public:
     void addAllowedFirstPartyForCookies(WebCore::RegistrableDomain&&);
 
 private:
-    NetworkProcessConnection(IPC::Connection::Identifier, WebCore::HTTPCookieAcceptPolicy);
+    NetworkProcessConnection(IPC::Connection::Identifier);
 
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
@@ -107,7 +105,6 @@ private:
     void didFinishPingLoad(WebCore::ResourceLoaderIdentifier pingLoadIdentifier, WebCore::ResourceError&&, WebCore::ResourceResponse&&);
     void didFinishPreconnection(WebCore::ResourceLoaderIdentifier preconnectionIdentifier, WebCore::ResourceError&&);
     void setOnLineState(bool isOnLine);
-    void cookieAcceptPolicyChanged(WebCore::HTTPCookieAcceptPolicy);
 
     void messagesAvailableForPort(const WebCore::MessagePortIdentifier&);
 
@@ -131,7 +128,6 @@ private:
 
     RefPtr<WebSWClientConnection> m_swConnection;
     RefPtr<WebSharedWorkerObjectConnection> m_sharedWorkerConnection;
-    WebCore::HTTPCookieAcceptPolicy m_cookieAcceptPolicy;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.messages.in
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.messages.in
@@ -29,7 +29,6 @@ messages -> NetworkProcessConnection LegacyReceiver {
     DidFinishPingLoad(WebCore::ResourceLoaderIdentifier pingLoadIdentifier, WebCore::ResourceError error, WebCore::ResourceResponse response)
     DidFinishPreconnection(WebCore::ResourceLoaderIdentifier preconnectionIdentifier, WebCore::ResourceError error)
     SetOnLineState(bool isOnLine);
-    CookieAcceptPolicyChanged(enum:uint8_t WebCore::HTTPCookieAcceptPolicy policy);
     UpdateCachedCookiesEnabled();
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.h
@@ -36,7 +36,6 @@ namespace WebKit {
 
 struct NetworkProcessConnectionInfo {
     IPC::Connection::Handle connection;
-    WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy;
 #if HAVE(AUDIT_TOKEN)
     std::optional<CoreIPCAuditToken> auditToken;
 #endif

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.serialization.in
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.serialization.in
@@ -22,7 +22,6 @@
 
 [RValue] struct WebKit::NetworkProcessConnectionInfo {
     IPC::Connection::Handle connection;
-    WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy;
 #if HAVE(AUDIT_TOKEN)
     std::optional<WebKit::CoreIPCAuditToken> auditToken;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm
@@ -28,6 +28,7 @@
 
 #import "NetworkProcessConnection.h"
 #import "WebProcess.h"
+#import <WebCore/HTTPCookieAcceptPolicy.h>
 #import <WebCore/NetworkStorageSession.h>
 
 namespace WebKit {
@@ -38,8 +39,8 @@ NetworkStorageSession& WebCookieCache::inMemoryStorageSession()
 {
     if (!m_inMemoryStorageSession) {
         String sessionName = makeString("WebKitInProcessStorage-", getCurrentProcessID());
-        auto cookieAcceptPolicy = WebProcess::singleton().ensureNetworkProcessConnection().cookieAcceptPolicy();
-        auto storageSession = WebCore::createPrivateStorageSession(sessionName.createCFString().get(), cookieAcceptPolicy);
+        // WebCookieJar performs cookies blocking check, so accept policy can be AlwaysAccept in the cache.
+        auto storageSession = WebCore::createPrivateStorageSession(sessionName.createCFString().get(), HTTPCookieAcceptPolicy::AlwaysAccept);
         auto cookieStorage = adoptCF(_CFURLStorageSessionCopyCookieStorage(kCFAllocatorDefault, storageSession.get()));
         m_inMemoryStorageSession = makeUnique<NetworkStorageSession>(WebProcess::singleton().sessionID(), WTFMove(storageSession), WTFMove(cookieStorage), NetworkStorageSession::IsInMemoryCookieStore::Yes);
     }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1200,7 +1200,7 @@ NetworkProcessConnection& WebProcess::ensureNetworkProcessConnection()
     if (!m_networkProcessConnection) {
         auto connectionInfo = getNetworkProcessConnection(Ref { *parentProcessConnection() });
 
-        m_networkProcessConnection = NetworkProcessConnection::create(IPC::Connection::Identifier { WTFMove(connectionInfo.connection) }, connectionInfo.cookieAcceptPolicy);
+        m_networkProcessConnection = NetworkProcessConnection::create(IPC::Connection::Identifier { WTFMove(connectionInfo.connection) });
 #if HAVE(AUDIT_TOKEN)
         m_networkProcessConnection->setNetworkProcessAuditToken(connectionInfo.auditToken ? std::optional(connectionInfo.auditToken->auditToken()) : std::nullopt);
 #endif


### PR DESCRIPTION
#### f7e3731265ee9de2e4b18273759b2d96ddc38c0f
<pre>
Web process does not need to track cookie accept policy
<a href="https://bugs.webkit.org/show_bug.cgi?id=268326">https://bugs.webkit.org/show_bug.cgi?id=268326</a>
<a href="https://rdar.apple.com/121879052">rdar://121879052</a>

Reviewed by NOBODY (OOPS!).

Web process used to keep track of cookie accept policy to decide the result of navigator.cookiesEnabled. After
273522@main, web process starts to get the value from network process, so it is unnecessary to cache the cookie accept
policy value in web process. This will help reduce IPC messages between network process and web process.

* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp:
(WebKit::WebCookieManager::setHTTPCookieAcceptPolicy):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::cookieAcceptPolicyChanged): Deleted.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::createNetworkConnectionToWebProcess):
(WebKit::NetworkProcess::cookieAcceptPolicyChanged): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::getNetworkProcessConnection):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::NetworkProcessConnection):
(WebKit::NetworkProcessConnection::cookiesEnabled const): Deleted.
(WebKit::NetworkProcessConnection::cookieAcceptPolicyChanged): Deleted.
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.h:
(WebKit::NetworkProcessConnection::create):
(WebKit::NetworkProcessConnection::cookieAcceptPolicy const): Deleted.
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.messages.in:
* Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.h:
* Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.serialization.in:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm:
(WebKit::WebCookieCache::inMemoryStorageSession): The NetworkStorageSession in WebCookieCache used cached cookie accept
policy value, but it does not need to. It could just use the AlwaysAccept policy because the cookies set in the cache
already pass the cookie blocking check in WebCookieJar (i.e. if a cookie should be blocked, then it won&apos;t be passed to
the cache, see WebCookieJar::setCookies), and the cache does not actually store cookies persistently (the session is
in-memory only).
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::ensureNetworkProcessConnection):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7e3731265ee9de2e4b18273759b2d96ddc38c0f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38607 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39100 "Hash f7e37312 for PR 23458 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32696 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12373 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/39100 "Hash f7e37312 for PR 23458 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12944 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32254 "Found 1 new API test failure: TestWebKitAPI.WKHTTPCookieStore.CookiePolicy (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/39100 "Hash f7e37312 for PR 23458 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11374 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32480 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40345 "Hash f7e37312 for PR 23458 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33009 "Found 1 new API test failure: TestWebKitAPI.WKHTTPCookieStore.CookiePolicy (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32835 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/40345 "Hash f7e37312 for PR 23458 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11589 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9465 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/40345 "Hash f7e37312 for PR 23458 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13299 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12041 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12452 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->