### PR TITLE
[Wasm-GC] Add test for bug 254414

### DIFF
--- a/JSTests/wasm/gc/bug254414.js
+++ b/JSTests/wasm/gc/bug254414.js
@@ -1,0 +1,53 @@
+//@ skip if !$isSIMDPlatform
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+// (module
+//   (type $0 (sub (func (param i32 i32 i32) (result i32))))
+//   (type $1 (func (param (ref null $0))))
+//   (type $2 (func (param i64 v128 v128 v128)))
+//   (type $3 (func))
+//   (memory $0 16 32)
+//   (table $0 1 3 funcref)
+//   (elem $0 (i32.const 0) $0)
+//   (tag $tag$0 (param (ref null $0)))
+//   (tag $tag$1 (param i64 v128 v128 v128))
+//   (tag $tag$2)
+//   (export "main" (func $0))
+//   (func $0 (type $0) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+//    (try $label$3 (result i32)
+//     (do
+//      (drop
+//       (i32.const 0)
+//      )
+//      (drop
+//       (f64.const 0)
+//      )
+//      (i32.store offset=20746
+//       (i32.const 0)
+//       (i32.const 0)
+//      )
+//      (throw $tag$2)
+//     )
+//     (catch $tag$0
+//      (drop
+//       (pop (ref null $0))
+//      )
+//      (i32.const 0)
+//     )
+//     (catch_all
+//      (i32.const 0)
+//     )
+//    )
+//   )
+//  )
+const m = new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x9d\x80\x80\x80\x00\x05\x50\x00\x5f\x00\x50\x00\x60\x03\x7f\x7f\x7f\x01\x7f\x60\x01\x63\x01\x00\x60\x04\x7e\x7b\x7b\x7b\x00\x60\x00\x00\x03\x82\x80\x80\x80\x00\x01\x01\x04\x85\x80\x80\x80\x00\x01\x70\x01\x01\x03\x05\x84\x80\x80\x80\x00\x01\x01\x10\x20\x0d\x87\x80\x80\x80\x00\x03\x00\x02\x00\x03\x00\x04\x07\x88\x80\x80\x80\x00\x01\x04\x6d\x61\x69\x6e\x00\x00\x09\x8b\x80\x80\x80\x00\x01\x06\x00\x41\x00\x0b\x70\x01\xd2\x00\x0b\x0a\xb0\x80\x80\x80\x00\x01\x2e\x00\x06\x7f\x41\x00\x44\x00\x00\x00\x00\x00\x00\x00\x00\x41\x00\x41\x00\x36\x02\x8a\xa2\x01\x08\x02\x9b\xaa\x45\xfe\x2c\x02\xb2\xe4\x94\x88\x05\x07\x00\x1a\x41\x00\x19\x41\x00\x0b\x0b"));
+m.exports.main();


### PR DESCRIPTION
#### a7470b0dc92e4f6290a4dcc2c212098b31a5653e
<pre>
[Wasm-GC] Add test for bug 254414
<a href="https://bugs.webkit.org/show_bug.cgi?id=254414">https://bugs.webkit.org/show_bug.cgi?id=254414</a>

Reviewed by Yusuke Suzuki.

Add test for already fixed bug.

* JSTests/wasm/gc/bug254414.js: Added.
(module):

Canonical link: <a href="https://commits.webkit.org/273945@main">https://commits.webkit.org/273945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/001b865c11105ecd4994e2345cd38d63a09aa08a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39101 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32697 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12375 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31345 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11346 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11377 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40346 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/30928 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33016 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37305 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/36207 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35420 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13300 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/42954 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8421 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12042 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8902 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12454 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->