### PR TITLE
backdrop filters should be applied to the border area of the element with border-radius

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect-2-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect-2-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" href="mailto:Hironori.Fujii@sony.com">
+<style>
+.box {
+  display: inline-block;
+  box-sizing: border-box;
+  width: 100px;
+  height: 100px;
+  border-radius: 10px 20px 30px 40px;
+  border-width: 10px;
+}
+.no-bf > .box {
+  background: black;
+}
+</style>
+<div>
+  <p>Expected: Same size rounded black boxes.</p>
+</div>
+
+<div class="no-bf">
+  <div class="box"></div>
+  <div class="box"></div>
+  <div class="box"></div>
+</div>
+<div class="no-bf">
+  <div class="box"></div>
+  <div class="box"></div>
+  <div class="box"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect-2.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>backdrop-filter: Clip the filter at border box of element</title>
+<link rel="author" href="mailto:Hironori.Fujii@sony.com">
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
+<link rel="match"  href="reference/backdrop-filter-clip-rect-2-ref.html">
+<meta name="fuzzy" content="maxDifference=0-80; totalPixels=0-1000" />
+<style>
+.box {
+  display: inline-block;
+  box-sizing: border-box;
+  width: 100px;
+  height: 100px;
+  border-radius: 10px 20px 30px 40px;
+  border-width: 10px;
+}
+.no-bf > .box {
+  background: black;
+}
+.bf > .box {
+  border-color: transparent;
+  backdrop-filter: invert(1);
+}
+</style>
+<div>
+  <p>Expected: Same size rounded black boxes.</p>
+</div>
+
+<div class="no-bf">
+  <div class="box"></div>
+  <div class="box"></div>
+  <div class="box"></div>
+</div>
+<div class="bf">
+  <div class="box" style="border-style:none"></div>
+  <div class="box" style="border-style:solid"></div>
+  <div class="box" style="border-style:dotted"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect.html
@@ -4,6 +4,7 @@
 <link rel="author" href="mailto:masonf@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
 <link rel="match"  href="backdrop-filter-clip-rect-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1" />
 
 <div>
   <p>Expected: A green box, color-inverted inside the short, wide box with a<br>

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -780,7 +780,7 @@ void RenderLayerBacking::updateBackdropFiltersGeometry()
 
     FloatRoundedRect backdropFiltersRect;
     if (renderBox->style().hasBorderRadius() && !renderBox->hasClip()) {
-        auto roundedBoxRect = renderBox->roundedBorderBoxRect();
+        auto roundedBoxRect = renderBox->borderRoundedRect();
         roundedBoxRect.move(contentOffsetInCompositingLayer());
         backdropFiltersRect = roundedBoxRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor());
     } else {


### PR DESCRIPTION
#### 8411b7acd4159cb8fbe38025884e719c5531cdef
<pre>
backdrop filters should be applied to the border area of the element with border-radius
<a href="https://bugs.webkit.org/show_bug.cgi?id=268278">https://bugs.webkit.org/show_bug.cgi?id=268278</a>

Reviewed by Matt Woodrow.

Backdrop filters should be applied to the inside of border edge of the
element, not to the padding edge.

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect-2-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect-2.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect.html: Added fuzzy meta tag.
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateBackdropFiltersGeometry):
Use borderRoundedRect of renderBox instead of roundedBorderBoxRect.

Canonical link: <a href="https://commits.webkit.org/274757@main">https://commits.webkit.org/274757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/feedd05ee1f726e24b63fc9452a182b9fe2b68bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42013 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35379 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32996 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15547 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13508 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13477 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43291 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35840 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35467 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39285 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14291 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11781 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37537 "Found 1 new API test failure: /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34414 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8958 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15945 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15554 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->