### PR TITLE
[tvOS] Hosting app crashes due to unrecognized selector exceptions during fullscreen media playback

### DIFF
--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -371,6 +371,18 @@ static bool areFramesEssentiallyEqualWithTolerance(const FloatRect& a, const Flo
     _legibleContentInsets = legibleContentInsets;
 }
 
+#if PLATFORM(APPLETV)
+- (BOOL)avkit_isVisible
+{
+    return !CGRectIsEmpty(self.bounds);
+}
+
+- (CGRect)avkit_videoRectInWindow
+{
+    return self.videoRect;
+}
+#endif
+
 @end
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -113,6 +113,8 @@ static bool ignoreWatchdogForDebugging = false;
 @property (nonatomic, assign /* weak */) RefPtr<VideoPresentationInterfaceIOS> fullscreenInterface;
 #if !PLATFORM(APPLETV)
 - (BOOL)playerViewController:(AVPlayerViewController *)playerViewController shouldExitFullScreenWithReason:(AVPlayerViewControllerExitFullScreenReason)reason;
+#else
+- (BOOL)playerViewControllerShouldDismiss:(AVPlayerViewController *)playerViewController;
 #endif
 @end
 
@@ -202,6 +204,17 @@ static VideoPresentationInterfaceIOS::ExitFullScreenReason convertToExitFullScre
     UNUSED_PARAM(playerViewController);
     if (auto fullscreenInterface = self.fullscreenInterface)
         return fullscreenInterface->shouldExitFullscreenWithReason(convertToExitFullScreenReason(reason));
+
+    return YES;
+}
+
+#else
+
+- (BOOL)playerViewControllerShouldDismiss:(AVPlayerViewController *)playerViewController
+{
+    UNUSED_PARAM(playerViewController);
+    if (auto fullscreenInterface = self.fullscreenInterface)
+        return fullscreenInterface->shouldExitFullscreenWithReason(VideoPresentationInterfaceIOS::ExitFullScreenReason::PinchGestureHandled);
 
     return YES;
 }

--- a/Source/WebCore/platform/ios/WebAVPlayerController.mm
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.mm
@@ -1163,6 +1163,12 @@ Class webAVPlayerControllerClass()
     return self;
 }
 
+- (id)copyWithZone:(NSZone *)zone
+{
+    RetainPtr displayName = adoptNS([_localizedDisplayName copyWithZone:zone]);
+    return [[WebAVMediaSelectionOption allocWithZone:zone] initWithMediaType:_mediaType displayName:displayName.get()];
+}
+
 - (NSString *)displayName
 {
     return self.localizedDisplayName;
@@ -1291,6 +1297,13 @@ Class webAVPlayerControllerClass()
     WTFLogAlways("ERROR: -[WebAVMediaSelectionOption track:] unimplemented");
     return nil;
 }
+
+#if PLATFORM(APPLETV)
+- (NSString *)avkit_mediaRemoteIdentifier
+{
+    return self.displayName;
+}
+#endif
 
 @end
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -56,6 +56,7 @@
 #import "WebPasteboardProxy.h"
 #import "WebPrivacyHelpers.h"
 #import "WebProcessMessages.h"
+#import "WebProcessPool.h"
 #import "WebProcessProxy.h"
 #import "WebScreenOrientationManagerProxy.h"
 #import "WebsiteDataStore.h"

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -27,6 +27,7 @@
 #import "WebPage.h"
 
 #import "EditorState.h"
+#import "GPUProcessConnection.h"
 #import "InsertTextOptions.h"
 #import "LoadParameters.h"
 #import "MessageSenderInlines.h"


### PR DESCRIPTION
#### 57f207cd59344046b4a4047e5e32659f52783196
<pre>
[tvOS] Hosting app crashes due to unrecognized selector exceptions during fullscreen media playback
<a href="https://bugs.webkit.org/show_bug.cgi?id=268331">https://bugs.webkit.org/show_bug.cgi?id=268331</a>
<a href="https://rdar.apple.com/121881715">rdar://121881715</a>

Reviewed by Jean-Yves Avenard.

Implemented selectors expected by AVKit on WebKit&apos;s WebAVPlayerLayer, WebAVPlayerViewControllerDelegate, and WebAVMediaSelectionOption subclasses.
While here, fixed the unified sources build by adding some imports.

* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer avkit_isVisible]):
(-[WebAVPlayerLayer avkit_videoRectInWindow]):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(-[WebAVPlayerViewControllerDelegate playerViewControllerShouldDismiss:]):
* Source/WebCore/platform/ios/WebAVPlayerController.mm:
(-[WebAVMediaSelectionOption copyWithZone:]):
(-[WebAVMediaSelectionOption avkit_mediaRemoteIdentifier]):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:

Canonical link: <a href="https://commits.webkit.org/273723@main">https://commits.webkit.org/273723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f61dd06d3a9971fb39a8e35acf34d861525ee9a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39149 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37707 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12499 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12991 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11376 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40394 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32873 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11636 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35435 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8262 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12510 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->