### PR TITLE
[Wasm-GC] Add test for bug 258804

### DIFF
--- a/JSTests/wasm/gc/bug258804.js
+++ b/JSTests/wasm/gc/bug258804.js
@@ -1,0 +1,42 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+import * as assert from "../assert.js";
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+/* 
+ * (module
+ *  (type $0 (sub (struct )))
+ *  (type $1 (sub $0 (struct )))
+ *  (type $2 (func (param (ref null $1))))
+ *  (type $3 (sub (func (param i32 i32 i32) (result i32))))
+ *  (memory $0 16 32)
+ *  (table $0 1 1 funcref)
+ *  (elem $0 (i32.const 0) $0)
+ *  (tag $tag$0 (param (ref null $1)))
+ *  (export "main" (func $0))
+ *  (func $0 (type $3) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ *   (throw $tag$0
+ *    (block $label$1 (result (ref null $1))
+ *     (block $label$2 (result (ref null $1))
+ *      (ref.null none)
+ *     )
+ *    )
+ *   )
+ *  )
+ * )
+ */
+const m = new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x9d\x80\x80\x80\x00\x05\x50\x00\x5f\x00\x50\x01\x00\x5f\x00\x50\x00\x5e\x7f\x01\x50\x00\x60\x03\x7f\x7f\x7f\x01\x7f\x60\x01\x63\x01\x00\x03\x82\x80\x80\x80\x00\x01\x03\x04\x85\x80\x80\x80\x00\x01\x70\x01\x01\x01\x05\x84\x80\x80\x80\x00\x01\x01\x10\x20\x0d\x83\x80\x80\x80\x00\x01\x00\x04\x07\x88\x80\x80\x80\x00\x01\x04\x6d\x61\x69\x6e\x00\x00\x09\x8b\x80\x80\x80\x00\x01\x06\x00\x41\x00\x0b\x70\x01\xd2\x00\x0b\x0a\x96\x80\x80\x80\x00\x01\x14\x00\x02\x63\x01\x02\x63\x01\xd0\x01\x0b\x0b\x08\x00\x41\x98\xde\x8d\xd2\x78\x0b"));
+
+assert.throws(
+  () => m.exports.main(),
+  WebAssembly.Exception,
+  ""
+)


### PR DESCRIPTION
#### cb06d55fdea9a7453a4c6f3b365df5e49debb5ea
<pre>
[Wasm-GC] Add test for bug 258804
<a href="https://bugs.webkit.org/show_bug.cgi?id=258804">https://bugs.webkit.org/show_bug.cgi?id=258804</a>

Reviewed by Justin Michaud.

Adds test for already fixed bug.

* JSTests/wasm/gc/bug258804.js: Added.
(module):

Canonical link: <a href="https://commits.webkit.org/273795@main">https://commits.webkit.org/273795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be4c8fcadb18d951860dfa87af7ab7a7c5859da4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39113 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32705 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12390 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31350 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11354 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11388 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40358 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/30653 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33031 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37313 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/36220 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11600 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9474 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35411 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13308 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/42970 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8317 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12050 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8913 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12467 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->