### PR TITLE
[iOS] Swiping back in an HTML Note with the keyboard presented causes SpringBoard to crash

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5982,10 +5982,18 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 
 - (void)_didChangeWebViewEditability
 {
+    BOOL webViewIsEditable = self.webView._editable;
     if ([_formAccessoryView respondsToSelector:@selector(setNextPreviousItemsVisible:)])
-        [_formAccessoryView setNextPreviousItemsVisible:!self.webView._editable];
+        [_formAccessoryView setNextPreviousItemsVisible:!webViewIsEditable];
     
-    [_twoFingerSingleTapGestureRecognizer setEnabled:!self.webView._editable];
+    [_twoFingerSingleTapGestureRecognizer setEnabled:!webViewIsEditable];
+
+    if (webViewIsEditable) {
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            class_addProtocol(self.class, @protocol(UITextInputMultiDocument));
+        });
+    }
 }
 
 - (void)insertTextSuggestion:(id)textSuggestion


### PR DESCRIPTION
#### 3a4f8bd950259fd1e2723539bad7434ccbbdf606
<pre>
[iOS] Swiping back in an HTML Note with the keyboard presented causes SpringBoard to crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=268334">https://bugs.webkit.org/show_bug.cgi?id=268334</a>
<a href="https://rdar.apple.com/121139498">rdar://121139498</a>

Reviewed by Aditya Keerthi.

As a part of `BETextInput` adoption, we stopped relying on support from various private protocols
including `UITextInputMultiDocument`, which allows UIKit to `-_preserveFocusWithToken:destructively:`
and `-_restoreFocusWithToken:`. This was previously used to keep DOM elements focused while the web
view lost first responder status, during credential AutoFill, if the user searches for other
passwords. However, now that AutoFill UI in web views in third party apps is entirely managed by
`SafariViewService`, we no longer lose first responder anyways, so we don&apos;t need to adopt this SPI.

However, there is a corner case in Notes where, when performing a swipe navigation controller
transition while the web view is first responder and `-_editable` (in the WebKit SPI sense), we
relied on this SPI to keep the web view focused even as it temporarily loses first responder status
during the swipe transition. In iOS 17.4, we no longer preserve focus, which means that we&apos;ll end up
dispatching a blur event on the body.

This, in turn, causes Notes&apos; injected JavaScript to post a message back to the UI process telling it
to make the web view non-editable. However, while this is happening, UIKit tells the web view to
become first responder again during the swipe transition, which (after an activity state update)
causes Notes to make the web view `-_editable` once again, underneath `WKInputDelegate` methods.
This endless loop of:

(UI Process)    Web view becomes editable, dispatching a message to the web process.
(Web Process)   Body is blurred, posting a message to the UI process.
…
(UI Process)    Web view receives posted message, and makes the web view non-editable.
(Web Process)   Body is focused as a result of enabling full-page editability, starting an input
                session and sending ElementDidFocus to the UI process.

...causes the keyboard to be presented and dismissed back-to-back so frequently, that SpringBoard
itself eventually crashes due to excessive memory use.

Mitigate this by restoring pre-iOS 17.4 behavior and conforming to `UITextInputMultiDocument`, but
only for WebKit SPI clients that set the `-_editable` flag on `WKWebView`. Notably, this excludes
Safari.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _didChangeWebViewEditability]):

Canonical link: <a href="https://commits.webkit.org/273715@main">https://commits.webkit.org/273715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1955ff7eaf0fc8e56b0b987e3087900aa7b34f0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36418 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39120 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12399 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12965 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11361 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40365 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33032 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32850 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11607 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35415 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8260 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12474 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->