### PR TITLE
Remove contains check for tabs and windows.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -446,12 +446,10 @@ bool WebExtensionAction::hasUnreadBadgeText() const
     if (m_hasUnreadBadgeText)
         return m_hasUnreadBadgeText.value();
 
-    if (m_tab)
-        return extensionContext()->getAction(m_tab->window().get())->hasUnreadBadgeText();
+    if (RefPtr fallback = fallbackAction())
+        return fallback->hasUnreadBadgeText();
 
-    if (m_window)
-        return extensionContext()->defaultAction().hasUnreadBadgeText();
-
+    // Default
     return false;
 }
 
@@ -460,14 +458,10 @@ void WebExtensionAction::setHasUnreadBadgeText(bool hasUnreadBadgeText)
     m_hasUnreadBadgeText = !badgeText().isEmpty() ? std::optional(hasUnreadBadgeText) : std::nullopt;
 
     // Only propagate the change if we're setting it to false.
-    if (hasUnreadBadgeText)
-        return;
+    if (RefPtr fallback = fallbackAction(); fallback && !hasUnreadBadgeText)
+        fallback->setHasUnreadBadgeText(false);
 
-    if (m_tab)
-        extensionContext()->getAction(m_tab->window().get())->setHasUnreadBadgeText(false);
-
-    if (m_window)
-        extensionContext()->defaultAction().setHasUnreadBadgeText(false);
+    propertiesDidChange();
 }
 
 void WebExtensionAction::incrementBlockedResourceCount(ssize_t amount)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1674,7 +1674,7 @@ void WebExtensionContext::didCloseTab(const WebExtensionTab& tab, WindowIsClosin
     if (!isLoaded() || !tab.extensionHasAccess())
         return;
 
-    auto window = tab.window(WebExtensionTab::SkipContainsCheck::Yes);
+    auto window = tab.window();
     auto windowIdentifier = window ? window->identifier() : WebExtensionWindowConstants::NoneIdentifier;
 
     fireTabsRemovedEventIfNeeded(tab.identifier(), windowIdentifier, windowIsClosing);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -257,7 +257,7 @@ bool WebExtensionTab::extensionHasPermission() const
     return extensionContext()->hasPermission(url(), const_cast<WebExtensionTab*>(this));
 }
 
-RefPtr<WebExtensionWindow> WebExtensionTab::window(SkipContainsCheck skipCheck) const
+RefPtr<WebExtensionWindow> WebExtensionTab::window() const
 {
     if (!isValid() || !m_respondsToWindow)
         return nullptr;
@@ -268,12 +268,7 @@ RefPtr<WebExtensionWindow> WebExtensionTab::window(SkipContainsCheck skipCheck) 
 
     THROW_UNLESS([window conformsToProtocol:@protocol(_WKWebExtensionWindow)], @"Object returned by windowForWebExtensionContext: does not conform to the _WKWebExtensionWindow protocol");
 
-    auto result = m_extensionContext->getOrCreateWindow(window);
-
-    if (skipCheck == SkipContainsCheck::No)
-        THROW_UNLESS(result->tabs().contains(*this), @"Window returned by windowForWebExtensionContext: does not contain the tab");
-
-    return result;
+    return m_extensionContext->getOrCreateWindow(window);
 }
 
 size_t WebExtensionTab::index() const
@@ -285,10 +280,7 @@ size_t WebExtensionTab::index() const
     if (!window)
         return notFound;
 
-    auto result = window->tabs().find(*this);
-    THROW_UNLESS(result != notFound, @"Window returned by windowForWebExtensionContext: does not contain the tab");
-
-    return result;
+    return window->tabs().find(*this);
 }
 
 RefPtr<WebExtensionTab> WebExtensionTab::parentTab() const
@@ -444,7 +436,7 @@ bool WebExtensionTab::isPrivate() const
     if (!isValid())
         return false;
 
-    auto window = this->window(SkipContainsCheck::Yes);
+    auto window = this->window();
     if (!window)
         return false;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -96,7 +96,6 @@ public:
     using ImageFormat = WebExtensionTabImageFormat;
 
     enum class AssumeWindowMatches : bool { No, Yes };
-    enum class SkipContainsCheck : bool { No, Yes };
     enum class MainWebViewOnly : bool { No, Yes };
 
     using Error = std::optional<String>;
@@ -125,7 +124,7 @@ public:
     void addChangedProperties(OptionSet<ChangedProperties> properties) { m_changedProperties.add(properties); }
     void clearChangedProperties() { m_changedProperties = { }; }
 
-    RefPtr<WebExtensionWindow> window(SkipContainsCheck = SkipContainsCheck::No) const;
+    RefPtr<WebExtensionWindow> window() const;
     size_t index() const;
 
     RefPtr<WebExtensionTab> parentTab() const;


### PR DESCRIPTION
#### 26040f2c9126e8b0e6591aa69177c58d2f8c8ed3
<pre>
Remove contains check for tabs and windows.
<a href="https://webkit.org/b/268342">https://webkit.org/b/268342</a>
<a href="https://rdar.apple.com/problem/121887064">rdar://problem/121887064</a>

Reviewed by Brian Weinstein.

The &quot;Window returned by windowForWebExtensionContext: does not contain the tab&quot; exception is hard
to avoid when the tabs is being created, and not in a window yet. This exception is causing more
issues than is solves currently, so we should just remove it for now.

All existing code paths that use window() or index() properly check for nullptr or notFound.

Also adopt the fallbackAction() helper in a couple places I missed.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::hasUnreadBadgeText const): Use fallbackAction().
(WebKit::WebExtensionAction::setHasUnreadBadgeText): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::didCloseTab): Stop using SkipContainsCheck::Yes.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::window const): Removed SkipContainsCheck param.
(WebKit::WebExtensionTab::index const): Remove contains check.
(WebKit::WebExtensionTab::isPrivate const): Stop using SkipContainsCheck::Yes.
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:

Canonical link: <a href="https://commits.webkit.org/273703@main">https://commits.webkit.org/273703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0ed245f2d393f5953660ab2d22867aeebd02014

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38648 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12411 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/39128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/36992 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/12980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/40373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/33047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/32859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/40373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/40373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4720 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->