### PR TITLE
The ProcessAssertion object should hold a AssertionCapability object

### DIFF
--- a/Source/WebKit/Platform/cocoa/AssertionCapability.h
+++ b/Source/WebKit/Platform/cocoa/AssertionCapability.h
@@ -51,6 +51,7 @@ private:
     String m_name;
     BlockPtr<void()> m_willInvalidateBlock;
     BlockPtr<void()> m_didInvalidateBlock;
+    RetainPtr<_SECapability> m_capability;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/cocoa/AssertionCapability.mm
+++ b/Source/WebKit/Platform/cocoa/AssertionCapability.mm
@@ -39,17 +39,17 @@ AssertionCapability::AssertionCapability(String environmentIdentifier, String do
     , m_willInvalidateBlock { makeBlockPtr(WTFMove(willInvalidateFunction)) }
     , m_didInvalidateBlock { makeBlockPtr(WTFMove(didInvalidateFunction)) }
 {
+#if USE(EXTENSIONKIT)
+    if ([get_SECapabilityClass() respondsToSelector:@selector(assertionWithDomain:name:environmentIdentifier:willInvalidate:didInvalidate:)])
+        m_capability = [get_SECapabilityClass() assertionWithDomain:m_domain name:m_name environmentIdentifier:m_environmentIdentifier willInvalidate:m_willInvalidateBlock.get() didInvalidate:m_didInvalidateBlock.get()];
+    if ([get_SECapabilityClass() respondsToSelector:@selector(assertionWithDomain:name:environmentIdentifier:)])
+        m_capability = [get_SECapabilityClass() assertionWithDomain:m_domain name:m_name environmentIdentifier:m_environmentIdentifier];
+#endif
 }
 
 RetainPtr<_SECapability> AssertionCapability::platformCapability() const
 {
-#if USE(EXTENSIONKIT)
-    if ([get_SECapabilityClass() respondsToSelector:@selector(assertionWithDomain:name:environmentIdentifier:willInvalidate:didInvalidate:)])
-        return [get_SECapabilityClass() assertionWithDomain:m_domain name:m_name environmentIdentifier:environmentIdentifier() willInvalidate:m_willInvalidateBlock.get() didInvalidate:m_didInvalidateBlock.get()];
-    if ([get_SECapabilityClass() respondsToSelector:@selector(assertionWithDomain:name:environmentIdentifier:)])
-        return [get_SECapabilityClass() assertionWithDomain:m_domain name:m_name environmentIdentifier:environmentIdentifier()];
-#endif
-    return nil;
+    return m_capability;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -391,10 +391,9 @@ ProcessAssertion::ProcessAssertion(AuxiliaryProcessProxy& process, const String&
                     strongThis->processAssertionWillBeInvalidated();
             });
         };
-        AssertionCapability capability { process.environmentIdentifier(), runningBoardDomain, runningBoardAssertionName, WTFMove(willInvalidateBlock), WTFMove(didInvalidateBlock) };
-        m_capability = capability.platformCapability();
+        m_capability = AssertionCapability { process.environmentIdentifier(), runningBoardDomain, runningBoardAssertionName, WTFMove(willInvalidateBlock), WTFMove(didInvalidateBlock) };
         m_process = process.extensionProcess();
-        if (m_capability)
+        if (m_capability && m_capability->platformCapability())
             return;
         RELEASE_LOG(ProcessSuspension, "%p - ProcessAssertion() Failed to create capability %s", this, runningBoardAssertionName.characters());
     }
@@ -466,9 +465,9 @@ void ProcessAssertion::acquireSync()
 {
     RELEASE_LOG(ProcessSuspension, "%p - ProcessAssertion::acquireSync Trying to take RBS assertion '%{public}s' for process with PID=%d", this, m_reason.utf8().data(), m_pid);
 #if USE(EXTENSIONKIT)
-    if (m_process) {
+    if (m_process && m_capability) {
         NSError *error = nil;
-        m_grant = [m_process grantCapability:m_capability.get() error:&error];
+        m_grant = [m_process grantCapability:m_capability->platformCapability().get() error:&error];
         if (m_grant) {
             RELEASE_LOG(ProcessSuspension, "%p - ProcessAssertion() Successfully granted capability", this);
             return;

--- a/Source/WebKit/UIProcess/ProcessAssertion.h
+++ b/Source/WebKit/UIProcess/ProcessAssertion.h
@@ -35,6 +35,10 @@
 #include <unistd.h>
 #endif
 
+#if USE(EXTENSIONKIT)
+#include "AssertionCapability.h"
+#endif
+
 #if USE(RUNNINGBOARD)
 #include <wtf/RetainPtr.h>
 
@@ -43,7 +47,6 @@ OBJC_CLASS WKRBSAssertionDelegate;
 #endif // USE(RUNNINGBOARD)
 
 #if USE(EXTENSIONKIT)
-OBJC_CLASS _SECapability;
 OBJC_CLASS _SEExtensionProcess;
 OBJC_PROTOCOL(_SEGrant);
 #endif
@@ -113,7 +116,7 @@ private:
     Function<void()> m_prepareForInvalidationHandler;
     Function<void()> m_invalidationHandler;
 #if USE(EXTENSIONKIT)
-    RetainPtr<_SECapability> m_capability;
+    std::optional<AssertionCapability> m_capability;
     RetainPtr<_SEGrant> m_grant;
     RetainPtr<_SEExtensionProcess> m_process;
 #endif


### PR DESCRIPTION
#### c0ce523ac7bf189cb5b130204736ac936c4c9312
<pre>
The ProcessAssertion object should hold a AssertionCapability object
<a href="https://bugs.webkit.org/show_bug.cgi?id=268343">https://bugs.webkit.org/show_bug.cgi?id=268343</a>
<a href="https://rdar.apple.com/121614924">rdar://121614924</a>

Reviewed by Chris Dumez.

The ProcessAssertion object should hold a AssertionCapability object, and not a platform _SECapability object.
Otherwise, the invalidation blocks will be deleted in the ProcessAssertion constructor, since we only created
a temporary object there.

* Source/WebKit/Platform/cocoa/AssertionCapability.h:
* Source/WebKit/Platform/cocoa/AssertionCapability.mm:
(WebKit::AssertionCapability::platformCapability const):
* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(WebKit::ProcessAssertion::ProcessAssertion):
(WebKit::ProcessAssertion::acquireSync):
* Source/WebKit/UIProcess/ProcessAssertion.h:

Canonical link: <a href="https://commits.webkit.org/273769@main">https://commits.webkit.org/273769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46c4894fdf1b2613ecbf7e1466e9b0d9ef733e26

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39178 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32755 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31385 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11406 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11429 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40424 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33089 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32900 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37352 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11660 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35456 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13356 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8301 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12097 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->