### PR TITLE
REGRESSION(267658@main): `font-variant-emoji` values should not parse in `font-variant` shorthand when disabled

### DIFF
--- a/LayoutTests/fast/css/font-variant-emoji-disabled-expected.txt
+++ b/LayoutTests/fast/css/font-variant-emoji-disabled-expected.txt
@@ -1,0 +1,12 @@
+When font-variant-emoji is disabled, the following should not parse:
+
+
+PASS e.style['font-variant'] = "normal" should set the property value
+PASS e.style['font-variant'] = "text" should not set the property value
+PASS e.style['font-variant'] = "emoji" should not set the property value
+PASS e.style['font-variant'] = "unicode" should not set the property value
+PASS e.style['font-variant-emoji'] = "normal" should not set the property value
+PASS e.style['font-variant-emoji'] = "text" should not set the property value
+PASS e.style['font-variant-emoji'] = "emoji" should not set the property value
+PASS e.style['font-variant-emoji'] = "unicode" should not set the property value
+

--- a/LayoutTests/fast/css/font-variant-emoji-disabled.html
+++ b/LayoutTests/fast/css/font-variant-emoji-disabled.html
@@ -1,0 +1,25 @@
+<!-- webkit-test-runner [ CSSFontVariantEmojiEnabled=false ]-->
+<!DOCTYPE html>
+<html>
+<head>
+<title>Test font-variant parsing when font-variant-emoji is disabled</title>
+<meta charset="utf-8">
+</head>
+<body>
+<p>When font-variant-emoji is disabled, the following should not parse:</p>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/css/support/parsing-testcommon.js"></script>
+<script>
+test_valid_value("font-variant", "normal");
+test_invalid_value("font-variant", "text");
+test_invalid_value("font-variant", "emoji");
+test_invalid_value("font-variant", "unicode");
+
+test_invalid_value("font-variant-emoji", "normal");
+test_invalid_value("font-variant-emoji", "text");
+test_invalid_value("font-variant-emoji", "emoji");
+test_invalid_value("font-variant-emoji", "unicode");
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -739,7 +739,7 @@ bool CSSPropertyParser::consumeFontVariantShorthand(bool important)
         if (!eastAsianValue && (eastAsianValue = consumeFontVariantEastAsian(m_range)))
             continue;
 
-        if (!emojiValue && (emojiValue = CSSPropertyParsing::consumeFontVariantEmoji(m_range)))
+        if (m_context.propertySettings.cssFontVariantEmojiEnabled && !emojiValue && (emojiValue = CSSPropertyParsing::consumeFontVariantEmoji(m_range)))
             continue;
 
         // Saw some value that didn't match anything else.


### PR DESCRIPTION
#### 8c6d87c471e4eabfbdb9f4a77d25adb0aad3fb35
<pre>
REGRESSION(267658@main): `font-variant-emoji` values should not parse in `font-variant` shorthand when disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=268348">https://bugs.webkit.org/show_bug.cgi?id=268348</a>
<a href="https://rdar.apple.com/121890028">rdar://121890028</a>

Reviewed by Matthieu Dubet.

`font-variant: emoji` or `font-variant: unicode` should not parse when `font-variant-emoji` is disabled.

* LayoutTests/fast/css/font-variant-emoji-disabled-expected.txt: Added.
* LayoutTests/fast/css/font-variant-emoji-disabled.html: Added.
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumeFontVariantShorthand):

Canonical link: <a href="https://commits.webkit.org/273710@main">https://commits.webkit.org/273710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b8aed55592d62318d5024b927dad7790708c935

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38667 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37684 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12432 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/39139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37013 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/12984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK1-Tests-EWS "Waiting to run tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/40384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/33051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/40384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/40384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32168 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/8258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4723 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->