### PR TITLE
[Wasm-GC] Add test for bug 258127

### DIFF
--- a/JSTests/wasm/gc/bug258127.js
+++ b/JSTests/wasm/gc/bug258127.js
@@ -1,0 +1,37 @@
+//@ skip unless $isSIMDPlatform
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=true", "--useWebAssemblyGC=true")
+
+function module(bytes, valid = true) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+/*
+ * Output from wasm-dis, looks to have elided some code such as struct defs (and v128 use):
+ *
+ * (module
+ *  (type $0 (sub (func)))
+ *  (type $1 (func))
+ *  (type $2 (sub (func (param i32 i32 i32) (result i32))))
+ *  (memory $0 16 32)
+ *  (table $0 4 4 funcref)
+ *  (elem $0 (i32.const 0) $0 $1 $2 $3)
+ *  (tag $tag$0)
+ *  (export "main" (func $0))
+ *  (func $0 (type $2) (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+ *   (i32.const 1060103818)
+ *  )
+ *  (func $1 (type $0)
+ *  )
+ *  (func $2 (type $0)
+ *  )
+ *  (func $3 (type $0)
+ *  )
+ * )
+ */
+const m = new WebAssembly.Instance(module("\x00\x61\x73\x6d\x01\x00\x00\x00\x01\xad\x80\x80\x80\x00\x07\x50\x00\x5f\x03\x7b\x00\x7f\x00\x7f\x00\x50\x00\x5e\x7f\x01\x50\x00\x5e\x7f\x01\x50\x00\x60\x03\x7f\x7f\x7f\x01\x7f\x50\x00\x60\x00\x00\x50\x00\x60\x00\x00\x50\x00\x60\x00\x00\x03\x85\x80\x80\x80\x00\x04\x03\x04\x05\x06\x04\x85\x80\x80\x80\x00\x01\x70\x01\x04\x04\x05\x84\x80\x80\x80\x00\x01\x01\x10\x20\x0d\x83\x80\x80\x80\x00\x01\x00\x04\x07\x88\x80\x80\x80\x00\x01\x04\x6d\x61\x69\x6e\x00\x00\x09\x94\x80\x80\x80\x00\x01\x06\x00\x41\x00\x0b\x70\x04\xd2\x00\x0b\xd2\x01\x0b\xd2\x02\x0b\xd2\x03\x0b\x0a\x93\x80\x80\x80\x00\x04\x08\x00\x41\x8a\xcd\xbf\xf9\x03\x0b\x02\x00\x0b\x02\x00\x0b\x02\x00\x0b"));
+m.exports.main();


### PR DESCRIPTION
#### c90b5e7e935e8ce65c5a10d3f148c15f25abdfb6
<pre>
[Wasm-GC] Add test for bug 258127
<a href="https://bugs.webkit.org/show_bug.cgi?id=258127">https://bugs.webkit.org/show_bug.cgi?id=258127</a>

Reviewed by Yusuke Suzuki.

Adds test for already fixed bug

* JSTests/wasm/gc/bug258127.js: Added.
(module):

Canonical link: <a href="https://commits.webkit.org/273811@main">https://commits.webkit.org/273811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/168226874017a9032b426f90a1f14d314c70d864

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39147 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32733 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12497 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31367 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/12988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11375 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11408 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40392 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/30676 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33055 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32868 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37332 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/36254 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9495 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35445 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13334 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/43025 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8328 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12076 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8919 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12507 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->