### PR TITLE
Typos in SVG code where transfrom is used instead of transform

### DIFF
--- a/Source/WebCore/svg/SVGAnimateTransformElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateTransformElement.cpp
@@ -67,7 +67,7 @@ void SVGAnimateTransformElement::attributeChanged(const QualifiedName& name, con
 
 String SVGAnimateTransformElement::animateRangeString(const String& string) const
 {
-    return SVGTransformValue::prefixForTransfromType(m_type) + string + ')';
+    return SVGTransformValue::prefixForTransformType(m_type) + string + ')';
 }
 
 }

--- a/Source/WebCore/svg/SVGTransformList.cpp
+++ b/Source/WebCore/svg/SVGTransformList.cpp
@@ -115,11 +115,11 @@ bool SVGTransformList::parse(StringParsingBuffer<UChar>& buffer)
 String SVGTransformList::valueAsString() const
 {
     StringBuilder builder;
-    for (const auto& transfrom : m_items) {
+    for (const auto& transform : m_items) {
         if (builder.length())
             builder.append(' ');
 
-        builder.append(transfrom->value().valueAsString());
+        builder.append(transform->value().valueAsString());
     }
     return builder.toString();
 }

--- a/Source/WebCore/svg/SVGTransformValue.h
+++ b/Source/WebCore/svg/SVGTransformValue.h
@@ -189,7 +189,7 @@ public:
     String valueAsString() const
     {
         StringBuilder builder;
-        builder.append(prefixForTransfromType(m_type));
+        builder.append(prefixForTransformType(m_type));
         switch (m_type) {
         case SVG_TRANSFORM_UNKNOWN:
             break;
@@ -215,7 +215,7 @@ public:
         return builder.toString();
     }
 
-    static const char* prefixForTransfromType(SVGTransformType type)
+    static const char* prefixForTransformType(SVGTransformType type)
     {
         switch (type) {
         case SVG_TRANSFORM_UNKNOWN:


### PR DESCRIPTION
#### ea8fdd5062a82505a65ddbd92544140b059f32e9
<pre>
Typos in SVG code where transfrom is used instead of transform
<a href="https://bugs.webkit.org/show_bug.cgi?id=268354">https://bugs.webkit.org/show_bug.cgi?id=268354</a>
<a href="https://rdar.apple.com/121899918">rdar://121899918</a>

Reviewed by Simon Fraser and Tim Horton.

This is a simple ifx for strings with typo where &apos;transfrom&apos; has been
used instead of &apos;transform&apos;.

* Source/WebCore/svg/SVGAnimateTransformElement.cpp:
(WebCore::SVGAnimateTransformElement::animateRangeString const):
* Source/WebCore/svg/SVGTransformList.cpp:
(WebCore::SVGTransformList::valueAsString const):
* Source/WebCore/svg/SVGTransformValue.h:
(WebCore::SVGTransformValue::valueAsString const):
(WebCore::SVGTransformValue::prefixForTransformType):
(WebCore::SVGTransformValue::prefixForTransfromType): Deleted.

Canonical link: <a href="https://commits.webkit.org/273736@main">https://commits.webkit.org/273736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b318af708c7a586ed92789e025ac1378c5618fa1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39162 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32746 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31375 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13007 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11386 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40408 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32886 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37345 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9507 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35448 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13347 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8273 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12088 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12529 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->