### PR TITLE
[WebGPU] Running api,validation,image_copy,* crashes the GPU process

### DIFF
--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2395,13 +2395,11 @@ WGPUTextureFormat Texture::aspectSpecificFormat(WGPUTextureFormat format, WGPUTe
         return format;
     case WGPUTextureAspect_StencilOnly: {
         auto result = stencilSpecificFormat(format);
-        ASSERT(result);
-        return *result;
+        return result ? *result : WGPUTextureFormat_Undefined;
     }
     case WGPUTextureAspect_DepthOnly: {
         auto result = depthSpecificFormat(format);
-        ASSERT(result);
-        return *result;
+        return result ? *result : WGPUTextureFormat_Undefined;
     }
     case WGPUTextureAspect_Force32:
         ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 0b6b7cf68c0301b8885a9bbb4aa36eba6e807e7e
<pre>
[WebGPU] Running api,validation,image_copy,* crashes the GPU process
<a href="https://bugs.webkit.org/show_bug.cgi?id=268356">https://bugs.webkit.org/show_bug.cgi?id=268356</a>
&lt;radar://121902940&gt;

Reviewed by Tadeu Zagallo.

Having api,validation,image_copy,* pass is tracked by
<a href="https://bugs.webkit.org/show_bug.cgi?id=267284">https://bugs.webkit.org/show_bug.cgi?id=267284</a>

Right now, apply a smaller set of changes such
that running the test does not crash the GPU process.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::copyBufferToTexture):
(WebGPU::CommandEncoder::copyTextureToBuffer):
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeTexture):
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::aspectSpecificFormat):

Canonical link: <a href="https://commits.webkit.org/274076@main">https://commits.webkit.org/274076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/800654ab57aeb794a29d1e5597bba95081b74844

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39662 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39924 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33334 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13432 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31760 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13724 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32836 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11939 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11928 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41187 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33817 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33922 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37825 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35979 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13968 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8491 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12905 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13284 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->