### PR TITLE
Explore the 'serialization' issue in getAttribute('transform')

### DIFF
--- a/LayoutTests/svg/dom/SVGTransformList-basics-expected.txt
+++ b/LayoutTests/svg/dom/SVGTransformList-basics-expected.txt
@@ -31,45 +31,45 @@ PASS dumpTransform(circle1.transform.baseVal.removeItem(2)) is "type=SVG_TRANSFO
 PASS circle1.transform.baseVal.numberOfItems is 2
 PASS dumpTransform(circle1.transform.baseVal.getItem(0)) is "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(1)) is "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]"
-PASS circle1.getAttribute('transform') is "translate(10 10) scale(2 2)"
+PASS circle1.getAttribute('transform') is "translate(10, 10) scale(2, 2)"
 PASS circle1.transform.baseVal.insertItemBefore(circle1.transform.baseVal.getItem(1), circle1) is circle1.transform.baseVal.getItem(0)
 PASS dumpTransform(circle1.transform.baseVal.removeItem(2)) is "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]"
 PASS circle1.transform.baseVal.numberOfItems is 2
 PASS dumpTransform(circle1.transform.baseVal.getItem(0)) is "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(1)) is "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]"
-PASS circle1.getAttribute('transform') is "scale(2 2) translate(10 10)"
+PASS circle1.getAttribute('transform') is "scale(2, 2) translate(10, 10)"
 PASS circle1.transform.baseVal.insertItemBefore(circle1.transform.baseVal.getItem(1), null) is circle1.transform.baseVal.getItem(0)
 PASS dumpTransform(circle1.transform.baseVal.removeItem(2)) is "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]"
 PASS circle1.transform.baseVal.numberOfItems is 2
 PASS dumpTransform(circle1.transform.baseVal.getItem(0)) is "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(1)) is "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]"
-PASS circle1.getAttribute('transform') is "translate(10 10) scale(2 2)"
+PASS circle1.getAttribute('transform') is "translate(10, 10) scale(2, 2)"
 PASS circle1.transform.baseVal.insertItemBefore(circle1.transform.baseVal.getItem(1), 0) is circle1.transform.baseVal.getItem(0)
 PASS dumpTransform(circle1.transform.baseVal.removeItem(2)) is "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]"
 PASS circle1.transform.baseVal.numberOfItems is 2
 PASS dumpTransform(circle1.transform.baseVal.getItem(0)) is "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(1)) is "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]"
-PASS circle1.getAttribute('transform') is "scale(2 2) translate(10 10)"
+PASS circle1.getAttribute('transform') is "scale(2, 2) translate(10, 10)"
 PASS circle1.transform.baseVal.insertItemBefore(30, 0) threw exception TypeError: Argument 1 ('newItem') to SVGTransformList.insertItemBefore must be an instance of SVGTransform.
 PASS circle1.transform.baseVal.insertItemBefore('aString', 0) threw exception TypeError: Argument 1 ('newItem') to SVGTransformList.insertItemBefore must be an instance of SVGTransform.
 PASS circle1.transform.baseVal.insertItemBefore(circle1, 0) threw exception TypeError: Argument 1 ('newItem') to SVGTransformList.insertItemBefore must be an instance of SVGTransform.
 PASS circle1.transform.baseVal.insertItemBefore(null, 0) threw exception TypeError: Argument 1 ('newItem') to SVGTransformList.insertItemBefore must be an instance of SVGTransform.
 
 Test overlapping edge cases for removeItem()
-PASS circle1.setAttribute('transform', 'scale(2 2) translate(10 10)') is undefined.
+PASS circle1.setAttribute('transform', 'scale(2, 2) translate(10, 10)') is undefined.
 PASS dumpTransform(circle1.transform.baseVal.getItem(1)) is "type=SVG_TRANSFORM_MATRIX matrix=[1.0 0.0 0.0 1.0 20.0 20.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(1)) is "type=SVG_TRANSFORM_MATRIX matrix=[1.0 0.0 0.0 1.0 20.0 20.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(1)) is "type=SVG_TRANSFORM_MATRIX matrix=[1.0 0.0 0.0 1.0 40.0 40.0]"
 PASS circle1.transform.baseVal.numberOfItems is 0
 
-Set transform='rotate(90) scale(2 2) translate(10 10) skewX(45)' for circle1
-PASS circle1.setAttribute('transform', 'rotate(90) scale(2 2) translate(10 10) skewX(45)') is undefined.
+Set transform='rotate(90) scale(2, 2) translate(10, 10) skewX(45)' for circle1
+PASS circle1.setAttribute('transform', 'rotate(90) scale(2, 2) translate(10, 10) skewX(45)') is undefined.
 PASS circle1.transform.baseVal.numberOfItems is 4
 PASS dumpTransform(circle1.transform.baseVal.getItem(0)) is "type=SVG_TRANSFORM_ROTATE matrix=[0.0 1.0 -1.0 0.0 0.0 0.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(1)) is "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(2)) is "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(3)) is "type=SVG_TRANSFORM_SKEWX matrix=[1.0 0.0 1.0 1.0 0.0 0.0]"
-PASS circle1.getAttribute('transform') is "rotate(90) scale(2 2) translate(10 10) skewX(45)"
+PASS circle1.getAttribute('transform') is "rotate(90) scale(2, 2) translate(10, 10) skewX(45)"
 
 Test uncommon arguments for replaceItem()
 PASS circle1.transform.baseVal.replaceItem(30) threw exception TypeError: Not enough arguments.
@@ -86,27 +86,27 @@ PASS dumpTransform(circle1.transform.baseVal.getItem(0)) is "type=SVG_TRANSFORM_
 PASS dumpTransform(circle1.transform.baseVal.getItem(1)) is "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(2)) is "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(3)) is "type=SVG_TRANSFORM_SKEWX matrix=[1.0 0.0 1.0 1.0 0.0 0.0]"
-PASS circle1.getAttribute('transform') is "rotate(90) scale(2 2) translate(10 10) skewX(45)"
+PASS circle1.getAttribute('transform') is "rotate(90) scale(2, 2) translate(10, 10) skewX(45)"
 PASS circle1.transform.baseVal.replaceItem(circle1.transform.baseVal.getItem(0), 'aString') is circle1.transform.baseVal.getItem(0)
 PASS circle1.transform.baseVal.numberOfItems is 4
 PASS dumpTransform(circle1.transform.baseVal.getItem(0)) is "type=SVG_TRANSFORM_ROTATE matrix=[0.0 1.0 -1.0 0.0 0.0 0.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(1)) is "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(2)) is "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(3)) is "type=SVG_TRANSFORM_SKEWX matrix=[1.0 0.0 1.0 1.0 0.0 0.0]"
-PASS circle1.getAttribute('transform') is "rotate(90) scale(2 2) translate(10 10) skewX(45)"
+PASS circle1.getAttribute('transform') is "rotate(90) scale(2, 2) translate(10, 10) skewX(45)"
 PASS circle1.transform.baseVal.replaceItem(circle1.transform.baseVal.getItem(0), circle1) is circle1.transform.baseVal.getItem(0)
 PASS circle1.transform.baseVal.numberOfItems is 4
 PASS dumpTransform(circle1.transform.baseVal.getItem(0)) is "type=SVG_TRANSFORM_ROTATE matrix=[0.0 1.0 -1.0 0.0 0.0 0.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(1)) is "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(2)) is "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(3)) is "type=SVG_TRANSFORM_SKEWX matrix=[1.0 0.0 1.0 1.0 0.0 0.0]"
-PASS circle1.getAttribute('transform') is "rotate(90) scale(2 2) translate(10 10) skewX(45)"
+PASS circle1.getAttribute('transform') is "rotate(90) scale(2, 2) translate(10, 10) skewX(45)"
 PASS circle1.transform.baseVal.replaceItem(circle1.transform.baseVal.getItem(0), null) is circle1.transform.baseVal.getItem(0)
 PASS circle1.transform.baseVal.numberOfItems is 4
-PASS circle1.getAttribute('transform') is "rotate(90) scale(2 2) translate(10 10) skewX(45)"
+PASS circle1.getAttribute('transform') is "rotate(90) scale(2, 2) translate(10, 10) skewX(45)"
 
-Set transform='rotate(90) scale(2 2) translate(10 10) skewX(45)' for circle1
-PASS circle1.setAttribute('transform', 'rotate(90) scale(2 2) translate(10 10) skewX(45)') is undefined.
+Set transform='rotate(90) scale(2, 2) translate(10, 10) skewX(45)' for circle1
+PASS circle1.setAttribute('transform', 'rotate(90) scale(2, 2) translate(10, 10) skewX(45)') is undefined.
 
 Test uncommon arguments for removeItem()
 PASS circle1.transform.baseVal.removeItem(30) threw exception IndexSizeError: The index is not in the allowed range..
@@ -115,12 +115,12 @@ PASS circle1.transform.baseVal.numberOfItems is 3
 PASS dumpTransform(circle1.transform.baseVal.getItem(0)) is "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(1)) is "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(2)) is "type=SVG_TRANSFORM_SKEWX matrix=[1.0 0.0 1.0 1.0 0.0 0.0]"
-PASS circle1.getAttribute('transform') is "scale(2 2) translate(10 10) skewX(45)"
+PASS circle1.getAttribute('transform') is "scale(2, 2) translate(10, 10) skewX(45)"
 PASS dumpTransform(circle1.transform.baseVal.removeItem('aString')) is "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]"
 PASS circle1.transform.baseVal.numberOfItems is 2
 PASS dumpTransform(circle1.transform.baseVal.getItem(0)) is "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]"
 PASS dumpTransform(circle1.transform.baseVal.getItem(1)) is "type=SVG_TRANSFORM_SKEWX matrix=[1.0 0.0 1.0 1.0 0.0 0.0]"
-PASS circle1.getAttribute('transform') is "translate(10 10) skewX(45)"
+FAIL circle1.getAttribute('transform') should be translate(10 10) skewX(45). Was translate(10, 10) skewX(45).
 PASS dumpTransform(circle1.transform.baseVal.removeItem(circle1)) is "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]"
 PASS circle1.transform.baseVal.numberOfItems is 1
 PASS dumpTransform(circle1.transform.baseVal.getItem(0)) is "type=SVG_TRANSFORM_SKEWX matrix=[1.0 0.0 1.0 1.0 0.0 0.0]"
@@ -142,7 +142,7 @@ PASS transform.setRotate(45, 50, 100) is undefined.
 PASS dumpTransform(circle1.transform.baseVal.appendItem(transform)) is "type=SVG_TRANSFORM_ROTATE matrix=[0.7 0.7 -0.7 0.7 85.4 -6.1]"
 PASS circle1.transform.baseVal.numberOfItems is 1
 PASS dumpTransform(circle1.transform.baseVal.getItem(0)) is "type=SVG_TRANSFORM_ROTATE matrix=[0.7 0.7 -0.7 0.7 85.4 -6.1]"
-PASS circle1.getAttribute('transform') is "rotate(45 50 100)"
+FAIL circle1.getAttribute('transform') should be rotate(45 50 100). Was rotate(45, 50, 100).
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/svg/dom/SVGTransformList-basics.xhtml
+++ b/LayoutTests/svg/dom/SVGTransformList-basics.xhtml
@@ -5,7 +5,7 @@
 </head>
 <body>
 <svg id="svg" xmlns="http://www.w3.org/2000/svg" width="200" height="200">
-    <circle id="circle1" cx="40" cy="40" r="40" fill="green" transform="scale(2, 2) translate(10 10)"/>
+    <circle id="circle1" cx="40" cy="40" r="40" fill="green" transform="scale(2, 2) translate(10, 10)"/>
 </svg>
 
 <p id="description"></p>
@@ -78,28 +78,28 @@
     shouldBe("circle1.transform.baseVal.numberOfItems", "2");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(0))", "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(1))", "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]");
-    shouldBeEqualToString("circle1.getAttribute('transform')", "translate(10 10) scale(2 2)");
+    shouldBeEqualToString("circle1.getAttribute('transform')", "translate(10, 10) scale(2, 2)");
 
     shouldBe("circle1.transform.baseVal.insertItemBefore(circle1.transform.baseVal.getItem(1), circle1)", "circle1.transform.baseVal.getItem(0)");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.removeItem(2))", "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]");
     shouldBe("circle1.transform.baseVal.numberOfItems", "2");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(0))", "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(1))", "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]");
-    shouldBeEqualToString("circle1.getAttribute('transform')", "scale(2 2) translate(10 10)");
+    shouldBeEqualToString("circle1.getAttribute('transform')", "scale(2, 2) translate(10, 10)");
 
     shouldBe("circle1.transform.baseVal.insertItemBefore(circle1.transform.baseVal.getItem(1), null)", "circle1.transform.baseVal.getItem(0)");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.removeItem(2))", "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]");
     shouldBe("circle1.transform.baseVal.numberOfItems", "2");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(0))", "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(1))", "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]");
-    shouldBeEqualToString("circle1.getAttribute('transform')", "translate(10 10) scale(2 2)");
+    shouldBeEqualToString("circle1.getAttribute('transform')", "translate(10, 10) scale(2, 2)");
 
     shouldBe("circle1.transform.baseVal.insertItemBefore(circle1.transform.baseVal.getItem(1), 0)", "circle1.transform.baseVal.getItem(0)");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.removeItem(2))", "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]");
     shouldBe("circle1.transform.baseVal.numberOfItems", "2");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(0))", "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(1))", "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]");
-    shouldBeEqualToString("circle1.getAttribute('transform')", "scale(2 2) translate(10 10)");
+    shouldBeEqualToString("circle1.getAttribute('transform')", "scale(2, 2) translate(10, 10)");
 
     shouldThrow("circle1.transform.baseVal.insertItemBefore(30, 0)");
     shouldThrow("circle1.transform.baseVal.insertItemBefore('aString', 0)");
@@ -108,7 +108,7 @@
 
     debug("");
     debug("Test overlapping edge cases for removeItem()");
-    shouldBeUndefined("circle1.setAttribute('transform', 'scale(2 2) translate(10 10)')");
+    shouldBeUndefined("circle1.setAttribute('transform', 'scale(2, 2) translate(10, 10)')");
     var matrix = circle1.transform.baseVal.getItem(1).matrix;
     matrix.e *= 2;
     matrix.f *= 2;
@@ -122,14 +122,14 @@
     shouldBe("circle1.transform.baseVal.numberOfItems", "0");
 
     debug("");
-    debug("Set transform='rotate(90) scale(2 2) translate(10 10) skewX(45)' for circle1");
-    shouldBeUndefined("circle1.setAttribute('transform', 'rotate(90) scale(2 2) translate(10 10) skewX(45)')");
+    debug("Set transform='rotate(90) scale(2, 2) translate(10, 10) skewX(45)' for circle1");
+    shouldBeUndefined("circle1.setAttribute('transform', 'rotate(90) scale(2, 2) translate(10, 10) skewX(45)')");
     shouldBe("circle1.transform.baseVal.numberOfItems", "4");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(0))", "type=SVG_TRANSFORM_ROTATE matrix=[0.0 1.0 -1.0 0.0 0.0 0.0]");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(1))", "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(2))", "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(3))", "type=SVG_TRANSFORM_SKEWX matrix=[1.0 0.0 1.0 1.0 0.0 0.0]");
-    shouldBeEqualToString("circle1.getAttribute('transform')", "rotate(90) scale(2 2) translate(10 10) skewX(45)");
+    shouldBeEqualToString("circle1.getAttribute('transform')", "rotate(90) scale(2, 2) translate(10, 10) skewX(45)");
 
     debug("");
     debug("Test uncommon arguments for replaceItem()");
@@ -148,7 +148,7 @@
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(1))", "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(2))", "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(3))", "type=SVG_TRANSFORM_SKEWX matrix=[1.0 0.0 1.0 1.0 0.0 0.0]");
-    shouldBeEqualToString("circle1.getAttribute('transform')", "rotate(90) scale(2 2) translate(10 10) skewX(45)");
+    shouldBeEqualToString("circle1.getAttribute('transform')", "rotate(90) scale(2, 2) translate(10, 10) skewX(45)");
 
     shouldBe("circle1.transform.baseVal.replaceItem(circle1.transform.baseVal.getItem(0), 'aString')", "circle1.transform.baseVal.getItem(0)");
     shouldBe("circle1.transform.baseVal.numberOfItems", "4");
@@ -156,7 +156,7 @@
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(1))", "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(2))", "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(3))", "type=SVG_TRANSFORM_SKEWX matrix=[1.0 0.0 1.0 1.0 0.0 0.0]");
-    shouldBeEqualToString("circle1.getAttribute('transform')", "rotate(90) scale(2 2) translate(10 10) skewX(45)");
+    shouldBeEqualToString("circle1.getAttribute('transform')", "rotate(90) scale(2, 2) translate(10, 10) skewX(45)");
 
     shouldBe("circle1.transform.baseVal.replaceItem(circle1.transform.baseVal.getItem(0), circle1)", "circle1.transform.baseVal.getItem(0)");
     shouldBe("circle1.transform.baseVal.numberOfItems", "4");
@@ -164,15 +164,15 @@
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(1))", "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(2))", "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(3))", "type=SVG_TRANSFORM_SKEWX matrix=[1.0 0.0 1.0 1.0 0.0 0.0]");
-    shouldBeEqualToString("circle1.getAttribute('transform')", "rotate(90) scale(2 2) translate(10 10) skewX(45)");
+    shouldBeEqualToString("circle1.getAttribute('transform')", "rotate(90) scale(2, 2) translate(10, 10) skewX(45)");
 
     shouldBe("circle1.transform.baseVal.replaceItem(circle1.transform.baseVal.getItem(0), null)", "circle1.transform.baseVal.getItem(0)");
     shouldBe("circle1.transform.baseVal.numberOfItems", "4");
-    shouldBeEqualToString("circle1.getAttribute('transform')", "rotate(90) scale(2 2) translate(10 10) skewX(45)");
+    shouldBeEqualToString("circle1.getAttribute('transform')", "rotate(90) scale(2, 2) translate(10, 10) skewX(45)");
 
     debug("");
-    debug("Set transform='rotate(90) scale(2 2) translate(10 10) skewX(45)' for circle1");
-    shouldBeUndefined("circle1.setAttribute('transform', 'rotate(90) scale(2 2) translate(10 10) skewX(45)')");
+    debug("Set transform='rotate(90) scale(2, 2) translate(10, 10) skewX(45)' for circle1");
+    shouldBeUndefined("circle1.setAttribute('transform', 'rotate(90) scale(2, 2) translate(10, 10) skewX(45)')");
 
     debug("");
     debug("Test uncommon arguments for removeItem()");
@@ -183,7 +183,7 @@
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(0))", "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(1))", "type=SVG_TRANSFORM_TRANSLATE matrix=[1.0 0.0 0.0 1.0 10.0 10.0]");
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.getItem(2))", "type=SVG_TRANSFORM_SKEWX matrix=[1.0 0.0 1.0 1.0 0.0 0.0]");
-    shouldBeEqualToString("circle1.getAttribute('transform')", "scale(2 2) translate(10 10) skewX(45)");
+    shouldBeEqualToString("circle1.getAttribute('transform')", "scale(2, 2) translate(10, 10) skewX(45)");
 
     shouldBeEqualToString("dumpTransform(circle1.transform.baseVal.removeItem('aString'))", "type=SVG_TRANSFORM_SCALE matrix=[2.0 0.0 0.0 2.0 0.0 0.0]");
     shouldBe("circle1.transform.baseVal.numberOfItems", "2");

--- a/LayoutTests/svg/dom/SVGViewSpec-expected.txt
+++ b/LayoutTests/svg/dom/SVGViewSpec-expected.txt
@@ -5,11 +5,11 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 Loading external SVG resources/viewspec-target.svg
-Passing SVGViewSpec: svgView(viewBox(0,0,100,50);preserveAspectRatio(xMinYMid slice);transform(translate(0 10) translate(25 25) rotate(45) translate(-25 -25) scale(0.7 0.7));viewTarget(blub);zoomAndPan(disable))
+Passing SVGViewSpec: svgView(viewBox(0,0,100,50);preserveAspectRatio(xMinYMid slice);transform(translate(0, 10) translate(25, 25) rotate(45) translate(-25, -25) scale(0.7, 0.7));viewTarget(blub);zoomAndPan(disable))
 
 
 Check transform value
-PASS currentView.transformString is "translate(0 10) translate(25 25) rotate(45) translate(-25 -25) scale(0.7 0.7)"
+PASS currentView.transformString is "translate(0, 10) translate(25, 25) rotate(45) translate(-25, -25) scale(0.7, 0.7)"
 PASS currentView.transform.numberOfItems is 5
 PASS currentView.transform.getItem(0).type is SVGTransform.SVG_TRANSFORM_TRANSLATE
 PASS currentView.transform.getItem(0).angle is 0

--- a/LayoutTests/svg/dom/SVGViewSpec-multiple-views-expected.txt
+++ b/LayoutTests/svg/dom/SVGViewSpec-multiple-views-expected.txt
@@ -67,13 +67,13 @@ PASS currentView.viewBox.baseVal.width is 30
 PASS currentView.viewBox.baseVal.height is 30
 PASS currentView.viewBoxString is "10 10 30 30"
 
-Loading external SVG resources/multiple-view-elements.svg#svgView(viewBox(0 0 10 15);transform(scale(2 2));preserveAspectRatio(xMinYMax meet))...
+Loading external SVG resources/multiple-view-elements.svg#svgView(viewBox(0 0 10 15);transform(scale(2, 2));preserveAspectRatio(xMinYMax meet))...
 
 Verify that no load was performed, but only a different view was set on the same document
 PASS iframeElement.contentDocument.documentElement is firstDocumentElement
 
 Check transform value
-PASS currentView.transformString is "scale(2 2)"
+PASS currentView.transformString is "scale(2, 2)"
 PASS currentView.transform.numberOfItems is 1
 PASS currentView.transform.getItem(0).type is SVGTransform.SVG_TRANSFORM_SCALE
 PASS currentView.transform.getItem(0).angle is 0

--- a/LayoutTests/svg/dom/SVGViewSpec-multiple-views.html
+++ b/LayoutTests/svg/dom/SVGViewSpec-multiple-views.html
@@ -110,7 +110,7 @@ function testSecondViewElement() {
     shouldBe("currentView.viewBox.baseVal.height", "30");
     shouldBeEqualToString("currentView.viewBoxString", "10 10 30 30");
 
-    nextView = "#svgView(viewBox(0 0 10 15);transform(scale(2 2));preserveAspectRatio(xMinYMax meet))";
+    nextView = "#svgView(viewBox(0 0 10 15);transform(scale(2, 2));preserveAspectRatio(xMinYMax meet))";
     debug("");
     debug("Loading external SVG " + externalSVGFileName + nextView + "...");
     debug("");
@@ -129,7 +129,7 @@ function testCustomViewSpec() {
 
     debug("");
     debug("Check transform value");
-    shouldBeEqualToString("currentView.transformString", "scale(2 2)");
+    shouldBeEqualToString("currentView.transformString", "scale(2, 2)");
     shouldBe("currentView.transform.numberOfItems", "1");
 
     shouldBe("currentView.transform.getItem(0).type", "SVGTransform.SVG_TRANSFORM_SCALE");

--- a/LayoutTests/svg/dom/SVGViewSpec.html
+++ b/LayoutTests/svg/dom/SVGViewSpec.html
@@ -50,7 +50,7 @@ function continueTesting() {
 
     debug("");
     debug("Check transform value");
-    shouldBeEqualToString("currentView.transformString", "translate(0 10) translate(25 25) rotate(45) translate(-25 -25) scale(0.7 0.7)");
+    shouldBeEqualToString("currentView.transformString", "translate(0, 10) translate(25, 25) rotate(45) translate(-25, -25) scale(0.7, 0.7)");
     shouldBe("currentView.transform.numberOfItems", "5");
 
     shouldBe("currentView.transform.getItem(0).type", "SVGTransform.SVG_TRANSFORM_TRANSLATE");
@@ -99,7 +99,7 @@ function continueTesting() {
     completeTest();
 }
 
-testFragment("svgView(viewBox(0,0,100,50);preserveAspectRatio(xMinYMid slice);transform(translate(0 10) translate(25 25) rotate(45) translate(-25 -25) scale(0.7 0.7));viewTarget(blub);zoomAndPan(disable))");
+testFragment("svgView(viewBox(0,0,100,50);preserveAspectRatio(xMinYMid slice);transform(translate(0, 10) translate(25, 25) rotate(45) translate(-25, -25) scale(0.7, 0.7));viewTarget(blub);zoomAndPan(disable))");
 successfullyParsed = true;
 </script>
 </body>

--- a/LayoutTests/svg/dom/viewspec-parser-1-expected.txt
+++ b/LayoutTests/svg/dom/viewspec-parser-1-expected.txt
@@ -43,7 +43,7 @@ Loaded: resources/viewspec-target.svg#svgView(transform(scale(2));x
 Parsed: [initial view] from: svgView(transform(scale(2));x
 
 Loaded: resources/viewspec-target.svg#svgView(transform(scale(.5)))
-Parsed: svgView(transform(scale(0.5 0.5))) from: svgView(transform(scale(.5)))
+Parsed: svgView(transform(scale(0.5, 0.5))) from: svgView(transform(scale(.5)))
 
 Loaded: resources/viewspec-target.svg#svgView(;transform(scale(.5)))
 Parsed: [initial view] from: svgView(;transform(scale(.5)))
@@ -52,7 +52,7 @@ Loaded: resources/viewspec-target.svg#svgView(;;transform(scale(.5)))
 Parsed: [initial view] from: svgView(;;transform(scale(.5)))
 
 Loaded: resources/viewspec-target.svg#svgView(transform(scale(.5));transform(scale(2));transform(scale(2)))
-Parsed: svgView(transform(scale(0.5 0.5) scale(2 2) scale(2 2))) from: svgView(transform(scale(.5));transform(scale(2));transform(scale(2)))
+Parsed: svgView(transform(scale(0.5, 0.5) scale(2, 2) scale(2, 2))) from: svgView(transform(scale(.5));transform(scale(2));transform(scale(2)))
 
 Loaded: resources/viewspec-target.svg#svgView(viewBoxx(0,%200)
 Parsed: [initial view] from: svgView(viewBoxx(0, 0)

--- a/LayoutTests/svg/transforms/negative-scale-value-expected.txt
+++ b/LayoutTests/svg/transforms/negative-scale-value-expected.txt
@@ -3,7 +3,7 @@ SVG scale transform with negative scale values should be correctly converted to 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS g.getAttribute('transform') is "scale(-2 -4)"
+PASS g.getAttribute('transform') is "scale(-2, -4)"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/svg/transforms/negative-scale-value.html
+++ b/LayoutTests/svg/transforms/negative-scale-value.html
@@ -11,5 +11,5 @@ transform.setScale(-2, -4);
 var list = g.transform.baseVal;
 list.appendItem(transform);
 
-shouldBeEqualToString("g.getAttribute('transform')", "scale(-2 -4)");
+shouldBeEqualToString("g.getAttribute('transform')", "scale(-2, -4)");
 </script>

--- a/Source/WebCore/svg/SVGTransformValue.h
+++ b/Source/WebCore/svg/SVGTransformValue.h
@@ -247,7 +247,7 @@ private:
     static void appendFixedPrecisionNumbers(StringBuilder& builder, Number number, Numbers... numbers)
     {
         if (builder.length() && builder[builder.length() - 1] != '(')
-            builder.append(' ');
+            builder.append(", ");
         // FIXME: Shortest form would be better, but fixed precision is required for now to smooth over precision errors caused by converting float to double and back since we use AffineTransform to store transforms.
         builder.append(FormattedNumber::fixedPrecision(number));
         appendFixedPrecisionNumbers(builder, numbers...);


### PR DESCRIPTION
#### 811c0028641980f4af8906e8d5843e77c7124e07
<pre>
Explore the &apos;serialization&apos; issue in getAttribute(&apos;transform&apos;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=267401">https://bugs.webkit.org/show_bug.cgi?id=267401</a>
<a href="https://rdar.apple.com/121178816">rdar://121178816</a>

Reviewed by NOBODY (OOPS!).

Fix the serialization of the SVG transform attribute.
After setting, for example,
    svg.createSVGTransform().setScale(-2, -4)
on an SVG element, a g.getAttribute(&apos;transform&apos;) would return.
    scale(-2 -4)
This patch fixes it so it would return:
    scale(-2, -4)
as specified.
This is normalizing and fixing some tests. But we should be adding WPT
tests for this too, because this fix doesn&apos;t break any WPT tests, which
means this is not tested in WPT.

* LayoutTests/svg/dom/SVGTransformList-basics-expected.txt:
* LayoutTests/svg/dom/SVGTransformList-basics.xhtml:
* LayoutTests/svg/dom/SVGViewSpec-expected.txt:
* LayoutTests/svg/dom/SVGViewSpec-multiple-views-expected.txt:
* LayoutTests/svg/dom/SVGViewSpec-multiple-views.html:
* LayoutTests/svg/dom/SVGViewSpec.html:
* LayoutTests/svg/dom/viewspec-parser-1-expected.txt:
* LayoutTests/svg/transforms/negative-scale-value-expected.txt:
* LayoutTests/svg/transforms/negative-scale-value.html:
* Source/WebCore/svg/SVGTransformValue.h:
(WebCore::SVGTransformValue::appendFixedPrecisionNumbers):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/811c0028641980f4af8906e8d5843e77c7124e07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36583 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15522 "Hash 811c0028 for PR 23492 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39244 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32803 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31416 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13085 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32362 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11453 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11470 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32619 "Found 1 new test failure: http/tests/websocket/tests/hybi/url-parsing.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40489 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33150 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32962 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37398 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35505 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32281 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12144 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12606 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->