### PR TITLE
[Cocoa] Introduce WKSLinearMediaPlayer

### DIFF
--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1863,6 +1863,8 @@
 		A14F9B632B686DD300AD9C56 /* WKSLinearMediaTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = A14F9B612B686DD200AD9C56 /* WKSLinearMediaTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A14F9B642B686DD300AD9C56 /* LinearMediaTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14F9B622B686DD200AD9C56 /* LinearMediaTypes.swift */; };
 		A14F9B672B686E0200AD9C56 /* WebKitSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = A14F9B662B686E0200AD9C56 /* WebKitSwift.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A14F9B762B68CA6C00AD9C56 /* WKSLinearMediaPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = A14F9B742B68CA6B00AD9C56 /* WKSLinearMediaPlayer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A14F9B772B68CA6C00AD9C56 /* LinearMediaPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14F9B752B68CA6B00AD9C56 /* LinearMediaPlayer.swift */; };
 		A15797642582B1DB00528236 /* MediaFormatReader.bundle in Copy Plug-ins */ = {isa = PBXBuildFile; fileRef = A16E66002581930800EE1749 /* MediaFormatReader.bundle */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		A15799B72584433200528236 /* MediaTrackReader.h in Headers */ = {isa = PBXBuildFile; fileRef = A15799AE2584433100528236 /* MediaTrackReader.h */; };
 		A15799BC2584433200528236 /* CoreMediaWrapped.h in Headers */ = {isa = PBXBuildFile; fileRef = A15799B32584433100528236 /* CoreMediaWrapped.h */; };
@@ -6776,6 +6778,8 @@
 		A14F9B622B686DD200AD9C56 /* LinearMediaTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinearMediaTypes.swift; sourceTree = "<group>"; };
 		A14F9B652B686E0200AD9C56 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		A14F9B662B686E0200AD9C56 /* WebKitSwift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebKitSwift.h; sourceTree = "<group>"; };
+		A14F9B742B68CA6B00AD9C56 /* WKSLinearMediaPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKSLinearMediaPlayer.h; sourceTree = "<group>"; };
+		A14F9B752B68CA6B00AD9C56 /* LinearMediaPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinearMediaPlayer.swift; sourceTree = "<group>"; };
 		A15799AE2584433100528236 /* MediaTrackReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaTrackReader.h; sourceTree = "<group>"; };
 		A15799AF2584433100528236 /* MediaSampleCursor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaSampleCursor.cpp; sourceTree = "<group>"; };
 		A15799B02584433100528236 /* MediaFormatReader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaFormatReader.cpp; sourceTree = "<group>"; };
@@ -12870,7 +12874,9 @@
 		A14F9B602B686DAE00AD9C56 /* LinearMediaKit */ = {
 			isa = PBXGroup;
 			children = (
+				A14F9B752B68CA6B00AD9C56 /* LinearMediaPlayer.swift */,
 				A14F9B622B686DD200AD9C56 /* LinearMediaTypes.swift */,
+				A14F9B742B68CA6B00AD9C56 /* WKSLinearMediaPlayer.h */,
 				A14F9B612B686DD200AD9C56 /* WKSLinearMediaTypes.h */,
 			);
 			path = LinearMediaKit;
@@ -16873,6 +16879,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A14F9B672B686E0200AD9C56 /* WebKitSwift.h in Headers */,
+				A14F9B762B68CA6C00AD9C56 /* WKSLinearMediaPlayer.h in Headers */,
 				A14F9B632B686DD300AD9C56 /* WKSLinearMediaTypes.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -18992,6 +18999,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CDF1B915266F396A0007EC10 /* GroupSession.swift in Sources */,
+				A14F9B772B68CA6C00AD9C56 /* LinearMediaPlayer.swift in Sources */,
 				A14F9B642B686DD300AD9C56 /* LinearMediaTypes.swift in Sources */,
 				EB0FBFA72B66C61E00269CC1 /* MarketplaceKitWrapper.swift in Sources */,
 			);

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
@@ -1,0 +1,537 @@
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if canImport(LinearMediaKit)
+
+import AVFoundation
+import Combine
+import LinearMediaKit
+import RealityFoundation
+import UIKit
+import WebKitSwift
+
+private class SwiftOnlyData: NSObject {
+    var renderingConfiguration: RenderingConfiguration?
+    var thumbnailMaterial: VideoMaterial?
+    var videoMaterial: VideoMaterial?
+    var peculiarEntity: PeculiarEntity?
+    var contentMetadata: ContentMetadataContainer?
+    
+    // FIXME: It should be possible to store these directly on WKSLinearMediaPlayer since they are
+    // bridged to NSDate, but a bug prevents that from compiling (rdar://121877511).
+    var startDate: Date?
+    var endDate: Date?
+}
+
+@_objcImplementation extension WKSLinearMediaPlayer {
+    weak var delegate: WKSLinearMediaPlayerDelegate?
+    var selectedPlaybackRate = 1.0
+    var presentationMode: WKSLinearMediaPresentationMode = .inline
+    var error: Error?
+    var canTogglePlayback = false
+    var requiresLinearPlayback = false
+    var interstitialRanges: [WKSLinearMediaTimeRange] = []
+    var isInterstitialActive = false
+    var duration: TimeInterval = .nan
+    var currentTime: TimeInterval = .nan
+    var remainingTime: TimeInterval = .nan
+    var playbackRate = 0.0
+    var playbackRates: [NSNumber] = [0.5, 1.0, 1.25, 1.5, 2.0]
+    var isLoading = false
+    var isTrimming = false
+    var trimView: UIView?
+    var thumbnailLayer: CALayer?
+    var captionLayer: CALayer?
+    var captionContentInsets: UIEdgeInsets = .zero
+    var showsPlaybackControls = true
+    var canSeek = false
+    var seekableTimeRanges: [WKSLinearMediaTimeRange] = []
+    var isSeeking = false
+    var canScanBackward = false
+    var canScanForward = false
+    var contentInfoViewControllers: [UIViewController] = []
+    var contextualActions: [UIAction] = []
+    var contextualActionsInfoView: UIView?
+    var contentDimensions: NSValue?
+    var contentMode: WKSLinearMediaContentMode = .default
+    var videoLayer: CALayer?
+    var anticipatedViewingMode: WKSLinearMediaViewingMode = .none
+    var contentOverlay: UIView?
+    var contentOverlayViewController: UIViewController?
+    var volume = 1.0
+    var isMuted = false
+    var sessionDisplayTitle: String?
+    var sessionThumbnail: UIImage?
+    var isSessionExtended = false
+    var hasAudioContent = true
+    var currentAudioTrack: WKSLinearMediaTrack?
+    var audioTracks: [WKSLinearMediaTrack] = []
+    var currentLegibleTrack: WKSLinearMediaTrack?
+    var legibleTracks: [WKSLinearMediaTrack] = []
+    var contentType: WKSLinearMediaContentType = .none
+    var transportBarIncludesTitleView = true
+    var artwork: Data?
+    var isPlayableOffline = false
+    var allowPip = true
+    var allowFullScreenFromInline = true
+    var isLiveStream: NSNumber?
+    var recommendedViewingRatio: NSNumber?
+    var fullscreenSceneBehaviors: WKSLinearMediaFullscreenBehaviors = []
+    var startTime: Double = .nan
+    var endTime: Double = .nan
+
+    // FIXME: These should be stored properties on WKSLinearMediaPlayer, but a bug prevents that from compiling (rdar://121877511).
+    var startDate: Date? {
+        get { swiftOnlyData.startDate }
+        set { swiftOnlyData.startDate = newValue }
+    }
+    var endDate: Date? {
+        get { swiftOnlyData.endDate }
+        set { swiftOnlyData.endDate = newValue }
+    }
+
+    @nonobjc private var swiftOnlyData: SwiftOnlyData
+
+    public override init() {
+        swiftOnlyData = .init()
+        super.init()
+    }
+}
+
+extension WKSLinearMediaPlayer: @retroactive Playable {
+    public var selectedPlaybackRatePublisher: AnyPublisher<Double, Never> {
+        publisher(for: \.selectedPlaybackRate).eraseToAnyPublisher()
+    }
+
+    public var presentationModePublisher: AnyPublisher<PresentationMode, Never> {
+        publisher(for: \.presentationMode).compactMap { $0.presentationMode }.eraseToAnyPublisher()
+    }
+
+    public func updateRenderingConfiguration(_ config: RenderingConfiguration) {
+        swiftOnlyData.renderingConfiguration = config
+    }
+
+    public var errorPublisher: AnyPublisher<Error?, Never> {
+        publisher(for: \.error).eraseToAnyPublisher()
+    }
+
+    public var canTogglePlaybackPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.canTogglePlayback).eraseToAnyPublisher()
+    }
+
+    public var requiresLinearPlaybackPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.requiresLinearPlayback).eraseToAnyPublisher()
+    }
+
+    public var interstitialRangesPublisher: AnyPublisher<[Range<TimeInterval>], Never> {
+        publisher(for: \.interstitialRanges).map { $0.map { $0.range } }.eraseToAnyPublisher()
+    }
+
+    public var isInterstitialActivePublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.isInterstitialActive).eraseToAnyPublisher()
+    }
+
+    public var durationPublisher: AnyPublisher<TimeInterval, Never> {
+        publisher(for: \.duration).eraseToAnyPublisher()
+    }
+
+    public var currentTimePublisher: AnyPublisher<TimeInterval, Never> {
+        publisher(for: \.currentTime).eraseToAnyPublisher()
+    }
+
+    public var remainingTimePublisher: AnyPublisher<TimeInterval, Never> {
+        publisher(for: \.remainingTime).eraseToAnyPublisher()
+    }
+
+    public var playbackRatePublisher: AnyPublisher<Double, Never> {
+        publisher(for: \.playbackRate).eraseToAnyPublisher()
+    }
+
+    public var playbackRatesPublisher: AnyPublisher<[Double], Never> {
+        publisher(for: \.playbackRates).map { $0.map { $0.doubleValue } }.eraseToAnyPublisher()
+    }
+
+    public var isPlayingPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.playbackRate).map { $0 != 0.0 }.eraseToAnyPublisher()
+    }
+
+    public var isLoadingPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.isLoading).eraseToAnyPublisher()
+    }
+
+    public var isTrimmingPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.isTrimming).eraseToAnyPublisher()
+    }
+
+    private static let preferredTimescale: CMTimeScale = 600
+
+    public var forwardPlaybackEndTimePublisher: AnyPublisher<CMTime?, Never> {
+        publisher(for: \.endTime)
+            .dropFirst()
+            .map { $0.isNaN ? .invalid : CMTime(seconds: $0, preferredTimescale: Self.preferredTimescale) }
+            .eraseToAnyPublisher()
+    }
+
+    public var reversePlaybackEndTimePublisher: AnyPublisher<CMTime?, Never> {
+        publisher(for: \.startTime)
+            .dropFirst()
+            .map { $0.isNaN ? .invalid : CMTime(seconds: $0, preferredTimescale: Self.preferredTimescale) }
+            .eraseToAnyPublisher()
+    }
+
+    public var trimViewPublisher: AnyPublisher<UIView?, Never> {
+        publisher(for: \.trimView).eraseToAnyPublisher()
+    }
+
+    public var thumbnailLayerPublisher: AnyPublisher<CALayer?, Never> {
+        publisher(for: \.thumbnailLayer).eraseToAnyPublisher()
+    }
+
+    public var thumbnailMaterialPublisher: AnyPublisher<VideoMaterial?, Never> {
+        publisher(for: \.swiftOnlyData.thumbnailMaterial).eraseToAnyPublisher()
+    }
+
+    public var captionLayerPublisher: AnyPublisher<CALayer?, Never> {
+        publisher(for: \.captionLayer).eraseToAnyPublisher()
+    }
+
+    public var captionContentInsetsPublisher: AnyPublisher<UIEdgeInsets, Never> {
+        publisher(for: \.captionContentInsets).eraseToAnyPublisher()
+    }
+
+    public var showsPlaybackControlsPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.showsPlaybackControls).eraseToAnyPublisher()
+    }
+
+    public var canSeekPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.canSeek).eraseToAnyPublisher()
+    }
+
+    public var seekableTimeRangesPublisher: AnyPublisher<[ClosedRange<TimeInterval>], Never> {
+        publisher(for: \.seekableTimeRanges).map { $0.map { $0.closedRange } }.eraseToAnyPublisher()
+    }
+
+    public var isSeekingPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.isSeeking).eraseToAnyPublisher()
+    }
+
+    public var canScanBackwardPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.canScanBackward).eraseToAnyPublisher()
+    }
+
+    public var canScanForwardPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.canScanForward).eraseToAnyPublisher()
+    }
+
+    public var contentInfoViewControllersPublisher: AnyPublisher<[UIViewController], Never> {
+        publisher(for: \.contentInfoViewControllers).eraseToAnyPublisher()
+    }
+
+    public var contextualActionsPublisher: AnyPublisher<[UIAction], Never> {
+        publisher(for: \.contextualActions).eraseToAnyPublisher()
+    }
+
+    public var contextualActionsInfoViewPublisher: AnyPublisher<UIView?, Never> {
+        publisher(for: \.contextualActionsInfoView).eraseToAnyPublisher()
+    }
+
+    public var contentDimensionsPublisher: AnyPublisher<CGSize, Never> {
+        publisher(for: \.contentDimensions).compactMap { $0?.cgSizeValue }.eraseToAnyPublisher()
+    }
+
+    public var contentModePublisher: AnyPublisher<ContentMode, Never> {
+        publisher(for: \.contentMode).compactMap { $0.contentMode }.eraseToAnyPublisher()
+    }
+
+    public var videoLayerPublisher: AnyPublisher<CALayer?, Never> {
+        publisher(for: \.videoLayer).eraseToAnyPublisher()
+    }
+
+    public var videoMaterialPublisher: AnyPublisher<VideoMaterial?, Never> {
+        publisher(for: \.swiftOnlyData.videoMaterial).eraseToAnyPublisher()
+    }
+
+    public var peculiarEntityPublisher: AnyPublisher<PeculiarEntity?, Never> {
+        publisher(for: \.swiftOnlyData.peculiarEntity).eraseToAnyPublisher()
+    }
+
+    public var anticipatedViewingModePublisher: AnyPublisher<ViewingMode?, Never> {
+        publisher(for: \.anticipatedViewingMode).compactMap { $0.viewingMode }.eraseToAnyPublisher()
+    }
+
+    public var contentOverlayPublisher: AnyPublisher<UIView?, Never> {
+        publisher(for: \.contentOverlay).eraseToAnyPublisher()
+    }
+
+    public var contentOverlayViewControllerPublisher: AnyPublisher<UIViewController?, Never> {
+        publisher(for: \.contentOverlayViewController).eraseToAnyPublisher()
+    }
+
+    public var volumePublisher: AnyPublisher<Double, Never> {
+        publisher(for: \.volume).eraseToAnyPublisher()
+    }
+
+    public var isMutedPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.isMuted).eraseToAnyPublisher()
+    }
+
+    public var sessionDisplayTitlePublisher: AnyPublisher<String?, Never> {
+        publisher(for: \.sessionDisplayTitle).eraseToAnyPublisher()
+    }
+
+    public var sessionThumbnailPublisher: AnyPublisher<UIImage?, Never> {
+        publisher(for: \.sessionThumbnail).eraseToAnyPublisher()
+    }
+
+    public var isSessionExtendedPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.isSessionExtended).eraseToAnyPublisher()
+    }
+
+    public var hasAudioContentPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.hasAudioContent).eraseToAnyPublisher()
+    }
+
+    public var currentAudioTrackPublisher: AnyPublisher<Track?, Never> {
+        publisher(for: \.currentAudioTrack).map { $0 }.eraseToAnyPublisher()
+    }
+
+    public var audioTracksPublisher: AnyPublisher<[Track]?, Never> {
+        publisher(for: \.audioTracks).map { $0 }.eraseToAnyPublisher()
+    }
+
+    public var currentLegibleTrackPublisher: AnyPublisher<Track?, Never> {
+        publisher(for: \.currentLegibleTrack).map { $0 }.eraseToAnyPublisher()
+    }
+
+    public var legibleTracksPublisher: AnyPublisher<[Track]?, Never> {
+        publisher(for: \.legibleTracks).map { $0 }.eraseToAnyPublisher()
+    }
+
+    public var contentTypePublisher: AnyPublisher<ContentType?, Never> {
+        publisher(for: \.contentType).map { $0.contentType }.eraseToAnyPublisher()
+    }
+
+    public var contentMetadataPublisher: AnyPublisher<ContentMetadataContainer, Never> {
+        publisher(for: \.swiftOnlyData.contentMetadata).compactMap { $0 }.eraseToAnyPublisher()
+    }
+
+    public var transportBarIncludesTitleViewPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.transportBarIncludesTitleView).eraseToAnyPublisher()
+    }
+
+    public var artworkPublisher: AnyPublisher<Data?, Never> {
+        publisher(for: \.artwork).eraseToAnyPublisher()
+    }
+
+    public var isPlayableOfflinePublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.isPlayableOffline).eraseToAnyPublisher()
+    }
+
+    public var allowPipPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.allowPip).eraseToAnyPublisher()
+    }
+
+    public var allowFullScreenFromInlinePublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.allowFullScreenFromInline).eraseToAnyPublisher()
+    }
+
+    public var isLiveStreamPublisher: AnyPublisher<Bool, Never> {
+        publisher(for: \.isLiveStream).compactMap { $0?.boolValue }.eraseToAnyPublisher()
+    }
+
+    public var startDatePublisher: AnyPublisher<Date, Never> {
+        publisher(for: \.swiftOnlyData.startDate).compactMap { $0 }.eraseToAnyPublisher()
+    }
+
+    public var endDatePublisher: AnyPublisher<Date, Never> {
+        publisher(for: \.swiftOnlyData.endDate).compactMap { $0 }.eraseToAnyPublisher()
+    }
+
+    public var recommendedViewingRatioPublisher: AnyPublisher<Double?, Never> {
+        publisher(for: \.recommendedViewingRatio).compactMap { $0?.doubleValue }.eraseToAnyPublisher()
+    }
+
+    public var fullscreenSceneBehaviorsPublisher: AnyPublisher<[FullscreenBehaviors], Never> {
+        publisher(for: \.fullscreenSceneBehaviors).compactMap { [$0.fullscreenBehaviors] }.eraseToAnyPublisher()
+    }
+
+    public func play() {
+        delegate?.linearMediaPlayerPlay?(self)
+    }
+
+    public func pause() {
+        delegate?.linearMediaPlayerPause?(self)
+    }
+
+    public func togglePlayback() {
+        delegate?.linearMediaPlayerTogglePlayback?(self)
+    }
+
+    public func setPlaybackRate(_ rate: Double) {
+        delegate?.linearMediaPlayer?(self, setPlaybackRate: rate)
+    }
+
+    public func seek(to time: TimeInterval) {
+        delegate?.linearMediaPlayer?(self, seekToTime: time)
+    }
+
+    public func seek(delta: TimeInterval) {
+        delegate?.linearMediaPlayer?(self, seekByDelta: delta)
+    }
+
+    public func seek(to destination: TimeInterval, from source: TimeInterval, metadata: SeekMetadata) -> TimeInterval {
+        delegate?.linearMediaPlayer?(self, seekToDestination: destination, fromSource: source) ?? TimeInterval.zero
+    }
+
+    public func completeTrimming(commitChanges: Bool) {
+        delegate?.linearMediaPlayer?(self, completeTrimming: commitChanges)
+    }
+
+    public func updateStartTime(_ time: TimeInterval) {
+        delegate?.linearMediaPlayer?(self, updateStartTime: time)
+    }
+
+    public func updateEndTime(_ time: TimeInterval) {
+        delegate?.linearMediaPlayer?(self, updateEndTime: time)
+    }
+
+    public func beginEditingVolume() {
+        delegate?.linearMediaPlayerBeginEditingVolume?(self)
+    }
+
+    public func endEditingVolume() {
+        delegate?.linearMediaPlayerEndEditingVolume?(self)
+    }
+
+    public func setAudioTrack(_ newTrack: Track?) {
+        delegate?.linearMediaPlayer?(self, setAudioTrack: newTrack as? WKSLinearMediaTrack)
+    }
+
+    public func setLegibleTrack(_ newTrack: Track?) {
+        delegate?.linearMediaPlayer?(self, setLegibleTrack: newTrack as? WKSLinearMediaTrack)
+    }
+
+    public func skipActiveInterstitial() {
+        delegate?.linearMediaPlayerSkipActiveInterstitial?(self)
+    }
+
+    public func setCaptionContentInsets(_ insets: UIEdgeInsets) {
+        delegate?.linearMediaPlayer?(self, setCaptionContentInsets: insets)
+    }
+
+    public func updateVideoBounds(_ bounds: CGRect) {
+        delegate?.linearMediaPlayer?(self, updateVideoBounds: bounds)
+    }
+
+    public func updateViewingMode(_ mode: ViewingMode?) {
+        delegate?.linearMediaPlayer?(self, update: .init(mode))
+    }
+
+    public func togglePip() {
+        delegate?.linearMediaPlayerTogglePip?(self)
+    }
+
+    public func toggleInlineMode() {
+        delegate?.linearMediaPlayerToggleInlineMode?(self)
+    }
+
+    public func willEnterFullscreen() {
+        delegate?.linearMediaPlayerWillEnterFullscreen?(self)
+    }
+
+    public func didCompleteEnterFullscreen(result: Result<Void, Error>) {
+        switch result {
+        case .success():
+            delegate?.linearMediaPlayer?(self, didEnterFullscreenWithError: nil)
+        case .failure(let error):
+            delegate?.linearMediaPlayer?(self, didEnterFullscreenWithError: error)
+        }
+    }
+
+    public func willExitFullscreen() {
+        delegate?.linearMediaPlayerWillExitFullscreen?(self)
+    }
+
+    public func didCompleteExitFullscreen(result: Result<Void, Error>) {
+        switch result {
+        case .success():
+            delegate?.linearMediaPlayer?(self, didExitFullscreenWithError: nil)
+        case .failure(let error):
+            delegate?.linearMediaPlayer?(self, didExitFullscreenWithError: error)
+        }
+    }
+
+    public func makeDefaultEntity() -> Entity? {
+        nil
+    }
+
+    public func setTimeResolverInterval(_ interval: TimeInterval) {
+        delegate?.linearMediaPlayer?(self, setTimeResolverInterval: interval)
+    }
+
+    public func setTimeResolverResolution(_ resolution: TimeInterval) {
+        delegate?.linearMediaPlayer?(self, setTimeResolverResolution: resolution)
+    }
+
+    public func setThumbnailSize(_ size: CGSize) {
+        delegate?.linearMediaPlayer?(self, setThumbnailSize: size)
+    }
+
+    public func seekThumbnail(to time: TimeInterval) {
+        delegate?.linearMediaPlayer?(self, seekThumbnailToTime: time)
+    }
+
+    public func beginScrubbing() {
+        delegate?.linearMediaPlayerBeginScrubbing?(self)
+    }
+
+    public func endScrubbing() {
+        delegate?.linearMediaPlayerEndScrubbing?(self)
+    }
+
+    public func beginScanningForward() {
+        delegate?.linearMediaPlayerBeginScanningForward?(self)
+    }
+
+    public func endScanningForward() {
+        delegate?.linearMediaPlayerEndScanningForward?(self)
+    }
+
+    public func beginScanningBackward() {
+        delegate?.linearMediaPlayerBeginScanningBackward?(self)
+    }
+
+    public func endScanningBackward() {
+        delegate?.linearMediaPlayerEndScanningBackward?(self)
+    }
+
+    public func setVolume(_ volume: Double) {
+        delegate?.linearMediaPlayer?(self, setVolume: volume)
+    }
+
+    public func setIsMuted(_ value: Bool) {
+        delegate?.linearMediaPlayer?(self, setMuted: value)
+    }
+}
+
+#endif // canImport(LinearMediaKit)

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift
@@ -23,7 +23,6 @@
 
 #if os(visionOS)
 
-import LinearMediaKit
 import WebKitSwift
 
 // MARK: Objective-C Implementations
@@ -45,6 +44,10 @@ import WebKitSwift
         self.localizedDisplayName = localizedDisplayName
     }
 }
+
+#if canImport(LinearMediaKit)
+
+import LinearMediaKit
 
 // MARK: LinearMediaKit Extensions
 
@@ -180,5 +183,7 @@ extension WKSLinearMediaTimeRange {
 
 extension WKSLinearMediaTrack: @retroactive Track {
 }
+
+#endif // canImport(LinearMediaKit)
 
 #endif // os(visionOS)

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+
+#if defined(TARGET_OS_VISION) && TARGET_OS_VISION
+
+#import <UIKit/UIKit.h>
+#import <WebKitSwift/WKSLinearMediaTypes.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class WKSLinearMediaPlayer;
+
+API_AVAILABLE(visionos(1.0))
+@protocol WKSLinearMediaPlayerDelegate <NSObject>
+@optional
+- (void)linearMediaPlayerPlay:(WKSLinearMediaPlayer *)player;
+- (void)linearMediaPlayerPause:(WKSLinearMediaPlayer *)player;
+- (void)linearMediaPlayerTogglePlayback:(WKSLinearMediaPlayer *)player;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setPlaybackRate:(double)playbackRate;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player seekToTime:(NSTimeInterval)time;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player seekByDelta:(NSTimeInterval)delta;
+- (NSTimeInterval)linearMediaPlayer:(WKSLinearMediaPlayer *)player seekToDestination:(NSTimeInterval)destination fromSource:(NSTimeInterval)source;
+- (void)linearMediaPlayerBeginScrubbing:(WKSLinearMediaPlayer *)player;
+- (void)linearMediaPlayerEndScrubbing:(WKSLinearMediaPlayer *)player;
+- (void)linearMediaPlayerBeginScanningForward:(WKSLinearMediaPlayer *)player;
+- (void)linearMediaPlayerEndScanningForward:(WKSLinearMediaPlayer *)player;
+- (void)linearMediaPlayerBeginScanningBackward:(WKSLinearMediaPlayer *)player;
+- (void)linearMediaPlayerEndScanningBackward:(WKSLinearMediaPlayer *)player;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setVolume:(double)volume;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setMuted:(BOOL)muted;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player completeTrimming:(BOOL)commitChanges;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player updateStartTime:(NSTimeInterval)startTime;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player updateEndTime:(NSTimeInterval)endTime;
+- (void)linearMediaPlayerBeginEditingVolume:(WKSLinearMediaPlayer *)player;
+- (void)linearMediaPlayerEndEditingVolume:(WKSLinearMediaPlayer *)player;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setAudioTrack:(WKSLinearMediaTrack * _Nullable)audioTrack;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setLegibleTrack:(WKSLinearMediaTrack * _Nullable)legibleTrack;
+- (void)linearMediaPlayerSkipActiveInterstitial:(WKSLinearMediaPlayer *)player;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setCaptionContentInsets:(UIEdgeInsets)insets;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player updateVideoBounds:(CGRect)videoBounds;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player updateViewingMode:(WKSLinearMediaViewingMode)viewingMode;
+- (void)linearMediaPlayerTogglePip:(WKSLinearMediaPlayer *)player;
+- (void)linearMediaPlayerToggleInlineMode:(WKSLinearMediaPlayer *)player;
+- (void)linearMediaPlayerWillEnterFullscreen:(WKSLinearMediaPlayer *)player;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player didEnterFullscreenWithError:(NSError * _Nullable)error;
+- (void)linearMediaPlayerWillExitFullscreen:(WKSLinearMediaPlayer *)player;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player didExitFullscreenWithError:(NSError * _Nullable)error;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setTimeResolverInterval:(NSTimeInterval)interval;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setTimeResolverResolution:(NSTimeInterval)resolution;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setThumbnailSize:(CGSize)size;
+- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player seekThumbnailToTime:(NSTimeInterval)time;
+@end
+
+API_AVAILABLE(visionos(1.0))
+@interface WKSLinearMediaPlayer : NSObject
+@property (nonatomic, weak, nullable) id <WKSLinearMediaPlayerDelegate> delegate;
+@property (nonatomic) double selectedPlaybackRate;
+@property (nonatomic) WKSLinearMediaPresentationMode presentationMode;
+@property (nonatomic, strong, nullable) NSError *error;
+@property (nonatomic) BOOL canTogglePlayback;
+@property (nonatomic) BOOL requiresLinearPlayback;
+@property (nonatomic, copy) NSArray<WKSLinearMediaTimeRange *> *interstitialRanges;
+@property (nonatomic) BOOL isInterstitialActive;
+@property (nonatomic) NSTimeInterval duration;
+@property (nonatomic) NSTimeInterval currentTime;
+@property (nonatomic) NSTimeInterval remainingTime;
+@property (nonatomic) double playbackRate;
+@property (nonatomic, copy) NSArray<NSNumber *> *playbackRates;
+@property (nonatomic) BOOL isLoading;
+@property (nonatomic) BOOL isTrimming;
+@property (nonatomic, strong, nullable) UIView *trimView;
+@property (nonatomic, strong, nullable) CALayer *thumbnailLayer;
+@property (nonatomic, strong, nullable) CALayer *captionLayer;
+@property (nonatomic) UIEdgeInsets captionContentInsets;
+@property (nonatomic) BOOL showsPlaybackControls;
+@property (nonatomic) BOOL canSeek;
+@property (nonatomic, copy) NSArray<WKSLinearMediaTimeRange *> *seekableTimeRanges;
+@property (nonatomic) BOOL isSeeking;
+@property (nonatomic) BOOL canScanBackward;
+@property (nonatomic) BOOL canScanForward;
+@property (nonatomic, copy) NSArray<UIViewController *> *contentInfoViewControllers;
+@property (nonatomic, copy) NSArray<UIAction *> *contextualActions;
+@property (nonatomic, strong, nullable) UIView *contextualActionsInfoView;
+@property (nonatomic, strong, nullable) NSValue *contentDimensions;
+@property (nonatomic) WKSLinearMediaContentMode contentMode;
+@property (nonatomic, strong, nullable) CALayer *videoLayer;
+@property (nonatomic) WKSLinearMediaViewingMode anticipatedViewingMode;
+@property (nonatomic, strong, nullable) UIView *contentOverlay;
+@property (nonatomic, strong, nullable) UIViewController *contentOverlayViewController;
+@property (nonatomic) double volume;
+@property (nonatomic) BOOL isMuted;
+@property (nonatomic, copy, nullable) NSString *sessionDisplayTitle;
+@property (nonatomic, strong, nullable) UIImage *sessionThumbnail;
+@property (nonatomic) BOOL isSessionExtended;
+@property (nonatomic) BOOL hasAudioContent;
+@property (nonatomic, strong, nullable) WKSLinearMediaTrack *currentAudioTrack;
+@property (nonatomic, copy) NSArray<WKSLinearMediaTrack *> *audioTracks;
+@property (nonatomic, strong, nullable) WKSLinearMediaTrack *currentLegibleTrack;
+@property (nonatomic, copy) NSArray<WKSLinearMediaTrack *> *legibleTracks;
+@property (nonatomic) WKSLinearMediaContentType contentType;
+@property (nonatomic) BOOL transportBarIncludesTitleView;
+@property (nonatomic, copy, nullable) NSData *artwork;
+@property (nonatomic) BOOL isPlayableOffline;
+@property (nonatomic) BOOL allowPip;
+@property (nonatomic) BOOL allowFullScreenFromInline;
+@property (nonatomic, strong, nullable) NSNumber *isLiveStream;
+@property (nonatomic, strong, nullable) NSNumber *recommendedViewingRatio;
+@property (nonatomic) WKSLinearMediaFullscreenBehaviors fullscreenSceneBehaviors;
+@property (nonatomic) double startTime;
+@property (nonatomic) double endTime;
+@property (nonatomic, strong, nullable) NSDate *startDate;
+@property (nonatomic, strong, nullable) NSDate *endDate;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* defined(TARGET_OS_VISION) && TARGET_OS_VISION */

--- a/Source/WebKit/WebKitSwift/WebKitSwift.h
+++ b/Source/WebKit/WebKitSwift/WebKitSwift.h
@@ -23,4 +23,5 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <WebKitSwift/WKSLinearMediaPlayer.h>
 #import <WebKitSwift/WKSLinearMediaTypes.h>


### PR DESCRIPTION
#### 4de0f4880b7b12b8f995bfbe480b41503219ab67
<pre>
[Cocoa] Introduce WKSLinearMediaPlayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=268361">https://bugs.webkit.org/show_bug.cgi?id=268361</a>
<a href="https://rdar.apple.com/121907476">rdar://121907476</a>

Reviewed by Jer Noble.

Declared an Objective-C interface for WKSLinearMediaPlayer and a protocol for
WKSLinearMediaPlayerDelegate. The interface is implemented in Swift, where it conforms to the
Playable protocol. The properties exposed to Objective-C are bound to Publishers via key-value
observing, and Playable functions are exposed to Objective-C via the delegate. Since
@_objcImplementation classes can only contain stored properties representable in Objective-C,
Swift-only types are stored indirectly via SwiftOnlyData.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift: Added.
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaTypes.swift: Drive-by fix to support Public SDK builds on visionOS.
* Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h: Added.
* Source/WebKit/WebKitSwift/WebKitSwift.h:

Canonical link: <a href="https://commits.webkit.org/273806@main">https://commits.webkit.org/273806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab9a948b4448af8c6bb526adac360fb7dd18ec1f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39310 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32853 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31455 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11509 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11517 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40556 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33208 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37453 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35570 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13458 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8324 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12193 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12669 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->