### PR TITLE
[GTK] WebView empty with GTK Vulkan renderer

### DIFF
--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -40,6 +40,7 @@
 #include <WebCore/PlatformDisplay.h>
 #include <epoxy/egl.h>
 #include <wtf/glib/GUniquePtr.h>
+#include <wtf/glib/WTFGType.h>
 
 #if USE(GBM)
 #include <drm_fourcc.h>
@@ -139,18 +140,19 @@ AcceleratedBackingStoreDMABuf::~AcceleratedBackingStoreDMABuf()
 
     if (m_gdkGLContext) {
         gdk_gl_context_make_current(m_gdkGLContext.get());
-        m_renderer = nullptr;
+        m_renderer.setBuffer(nullptr);
         gdk_gl_context_clear_current();
     }
 }
 
-AcceleratedBackingStoreDMABuf::Buffer::Buffer(uint64_t id, const WebCore::IntSize& size)
+AcceleratedBackingStoreDMABuf::Buffer::Buffer(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor)
     : m_id(id)
     , m_size(size)
+    , m_deviceScaleFactor(deviceScaleFactor)
 {
 }
 
-RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::BufferEGLImage::create(uint64_t id, const WebCore::IntSize& size, uint32_t format, Vector<UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier)
+RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::BufferEGLImage::create(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor, uint32_t format, Vector<UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier)
 {
     auto& display = WebCore::PlatformDisplay::sharedDisplay();
     Vector<EGLAttrib> attributes = {
@@ -195,11 +197,11 @@ RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::Buf
         return nullptr;
     }
 
-    return adoptRef(*new BufferEGLImage(id, size, WTFMove(fds), image));
+    return adoptRef(*new BufferEGLImage(id, size, deviceScaleFactor, WTFMove(fds), image));
 }
 
-AcceleratedBackingStoreDMABuf::BufferEGLImage::BufferEGLImage(uint64_t id, const WebCore::IntSize& size, Vector<UnixFileDescriptor>&& fds, EGLImage image)
-    : Buffer(id, size)
+AcceleratedBackingStoreDMABuf::BufferEGLImage::BufferEGLImage(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor, Vector<UnixFileDescriptor>&& fds, EGLImage image)
+    : Buffer(id, size, deviceScaleFactor)
     , m_fds(WTFMove(fds))
     , m_image(image)
 {
@@ -208,10 +210,63 @@ AcceleratedBackingStoreDMABuf::BufferEGLImage::BufferEGLImage(uint64_t id, const
 AcceleratedBackingStoreDMABuf::BufferEGLImage::~BufferEGLImage()
 {
     WebCore::PlatformDisplay::sharedDisplay().destroyEGLImage(m_image);
+#if !USE(GTK4)
+    if (m_textureID)
+        glDeleteTextures(1, &m_textureID);
+#endif
 }
 
+#if USE(GTK4)
+struct Texture {
+    Texture()
+        : context(gdk_gl_context_get_current())
+    {
+        glGenTextures(1, &id);
+        glBindTexture(GL_TEXTURE_2D, id);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    }
+
+    ~Texture()
+    {
+        gdk_gl_context_make_current(context.get());
+        glDeleteTextures(1, &id);
+    }
+
+    GRefPtr<GdkGLContext> context;
+    unsigned id { 0 };
+};
+WEBKIT_DEFINE_ASYNC_DATA_STRUCT(Texture)
+
+void AcceleratedBackingStoreDMABuf::BufferEGLImage::didUpdateContents()
+{
+    auto* texture = createTexture();
+    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, m_image);
+
+    m_texture = adoptGRef(gdk_gl_texture_new(texture->context.get(), texture->id, m_size.width(), m_size.height(), [](gpointer userData) {
+        destroyTexture(static_cast<Texture*>(userData));
+    }, texture));
+}
+#else
+void AcceleratedBackingStoreDMABuf::BufferEGLImage::didUpdateContents()
+{
+    if (m_textureID)
+        return;
+
+    glGenTextures(1, &m_textureID);
+    glBindTexture(GL_TEXTURE_2D, m_textureID);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, m_image);
+}
+#endif
+
 #if USE(GBM)
-RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::BufferGBM::create(uint64_t id, const WebCore::IntSize& size, uint32_t format, UnixFileDescriptor&& fd, uint32_t stride)
+RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::BufferGBM::create(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor, uint32_t format, UnixFileDescriptor&& fd, uint32_t stride)
 {
     auto* device = WebCore::PlatformDisplay::sharedDisplay().gbmDevice();
     if (!device) {
@@ -226,11 +281,11 @@ RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::Buf
         return nullptr;
     }
 
-    return adoptRef(*new BufferGBM(id, size, WTFMove(fd), buffer));
+    return adoptRef(*new BufferGBM(id, size, deviceScaleFactor, WTFMove(fd), buffer));
 }
 
-AcceleratedBackingStoreDMABuf::BufferGBM::BufferGBM(uint64_t id, const WebCore::IntSize& size, UnixFileDescriptor&& fd, struct gbm_bo* buffer)
-    : Buffer(id, size)
+AcceleratedBackingStoreDMABuf::BufferGBM::BufferGBM(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor, UnixFileDescriptor&& fd, struct gbm_bo* buffer)
+    : Buffer(id, size, deviceScaleFactor)
     , m_fd(WTFMove(fd))
     , m_buffer(buffer)
 {
@@ -241,16 +296,17 @@ AcceleratedBackingStoreDMABuf::BufferGBM::~BufferGBM()
     gbm_bo_destroy(m_buffer);
 }
 
-RefPtr<cairo_surface_t> AcceleratedBackingStoreDMABuf::BufferGBM::surface() const
+void AcceleratedBackingStoreDMABuf::BufferGBM::didUpdateContents()
 {
     uint32_t mapStride = 0;
     void* mapData = nullptr;
     void* map = gbm_bo_map(m_buffer, 0, 0, static_cast<uint32_t>(m_size.width()), static_cast<uint32_t>(m_size.height()), GBM_BO_TRANSFER_READ, &mapStride, &mapData);
     if (!map)
-        return nullptr;
+        return;
 
     auto cairoFormat = gbm_bo_get_format(m_buffer) == DRM_FORMAT_ARGB8888 ? CAIRO_FORMAT_ARGB32 : CAIRO_FORMAT_RGB24;
-    RefPtr<cairo_surface_t> surface = adoptRef(cairo_image_surface_create_for_data(static_cast<unsigned char*>(map), cairoFormat, m_size.width(), m_size.height(), mapStride));
+    m_surface = adoptRef(cairo_image_surface_create_for_data(static_cast<unsigned char*>(map), cairoFormat, m_size.width(), m_size.height(), mapStride));
+    cairo_surface_set_device_scale(m_surface.get(), m_deviceScaleFactor, m_deviceScaleFactor);
     struct BufferData {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
         RefPtr<BufferGBM> buffer;
@@ -258,162 +314,103 @@ RefPtr<cairo_surface_t> AcceleratedBackingStoreDMABuf::BufferGBM::surface() cons
     };
     auto bufferData = makeUnique<BufferData>(BufferData { const_cast<BufferGBM*>(this), mapData });
     static cairo_user_data_key_t s_surfaceDataKey;
-    cairo_surface_set_user_data(surface.get(), &s_surfaceDataKey, bufferData.release(), [](void* data) {
+    cairo_surface_set_user_data(m_surface.get(), &s_surfaceDataKey, bufferData.release(), [](void* data) {
         std::unique_ptr<BufferData> bufferData(static_cast<BufferData*>(data));
         gbm_bo_unmap(bufferData->buffer->m_buffer, bufferData->data);
     });
-    return surface;
 }
 #endif
 
-RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::BufferSHM::create(uint64_t id, RefPtr<ShareableBitmap>&& bitmap)
+RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::BufferSHM::create(uint64_t id, RefPtr<ShareableBitmap>&& bitmap, float deviceScaleFactor)
 {
     if (!bitmap)
         return nullptr;
 
-    return adoptRef(*new BufferSHM(id, WTFMove(bitmap)));
+    return adoptRef(*new BufferSHM(id, WTFMove(bitmap), deviceScaleFactor));
 }
 
-AcceleratedBackingStoreDMABuf::BufferSHM::BufferSHM(uint64_t id, RefPtr<ShareableBitmap>&& bitmap)
-    : Buffer(id, bitmap->size())
+AcceleratedBackingStoreDMABuf::BufferSHM::BufferSHM(uint64_t id, RefPtr<ShareableBitmap>&& bitmap, float deviceScaleFactor)
+    : Buffer(id, bitmap->size(), deviceScaleFactor)
     , m_bitmap(WTFMove(bitmap))
 {
 }
 
-RefPtr<cairo_surface_t> AcceleratedBackingStoreDMABuf::BufferSHM::surface() const
+void AcceleratedBackingStoreDMABuf::BufferSHM::didUpdateContents()
 {
-    return m_bitmap->createCairoSurface();
-}
-
-bool AcceleratedBackingStoreDMABuf::Renderer::setBuffer(Buffer& buffer, float deviceScaleFactor)
-{
-    m_size = buffer.size();
-    m_deviceScaleFactor = deviceScaleFactor;
-
-    // We keep a reference of the committed buffer in the renderer because it might
-    // belong to a previous surface that we want to still render to avoid flickering,
-    // but we don't want to release it.
-    if (m_buffer == &buffer)
-        return false;
-
-    m_buffer = &buffer;
-    return true;
-}
-
-AcceleratedBackingStoreDMABuf::RendererGL::RendererGL()
-{
-    glGenTextures(1, &m_textureID);
-    glBindTexture(GL_TEXTURE_2D, m_textureID);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-}
-
-AcceleratedBackingStoreDMABuf::RendererGL::~RendererGL()
-{
-#if USE(GTK4)
-    m_texture[0] = nullptr;
-    m_texture[1] = nullptr;
-#endif
-
-    if (m_textureID)
-        glDeleteTextures(1, &m_textureID);
-}
-
-bool AcceleratedBackingStoreDMABuf::RendererGL::setBuffer(Buffer& buffer, float deviceScaleFactor)
-{
-    if (!Renderer::setBuffer(buffer, deviceScaleFactor))
-        return false;
-
-    ASSERT(buffer.type() == Buffer::Type::EglImage);
-    glBindTexture(GL_TEXTURE_2D, m_textureID);
-    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, static_cast<const BufferEGLImage&>(buffer).image());
-
-#if USE(GTK4)
-    if (!m_texture[0] || gdk_texture_get_width(m_texture[0].get()) != m_size.width() || gdk_texture_get_height(m_texture[0].get()) != m_size.height()) {
-        auto* context = gdk_gl_context_get_current();
-        m_texture[0] = adoptGRef(gdk_gl_texture_new(context, m_textureID, m_size.width(), m_size.height(), nullptr, nullptr));
-        m_texture[1] = adoptGRef(gdk_gl_texture_new(context, m_textureID, m_size.width(), m_size.height(), nullptr, nullptr));
-        m_textureIndex = 0;
-    }  else
-        m_textureIndex = !m_textureIndex;
-#endif
-
-    return true;
+    m_surface = m_bitmap->createCairoSurface();
+    cairo_surface_set_device_scale(m_surface.get(), m_deviceScaleFactor, m_deviceScaleFactor);
 }
 
 #if USE(GTK4)
-void AcceleratedBackingStoreDMABuf::RendererGL::snapshot(GtkSnapshot* gtkSnapshot) const
+void AcceleratedBackingStoreDMABuf::Renderer::snapshot(GtkSnapshot* gtkSnapshot) const
 {
-    if (!m_textureID)
+    if (!m_buffer)
         return;
 
-    graphene_rect_t bounds = GRAPHENE_RECT_INIT(0, 0, static_cast<float>(m_size.width() / m_deviceScaleFactor), static_cast<float>(m_size.height() / m_deviceScaleFactor));
-    gtk_snapshot_append_texture(gtkSnapshot, m_texture[m_textureIndex].get(), &bounds);
-}
-#else
-void AcceleratedBackingStoreDMABuf::RendererGL::paint(GtkWidget* widget, cairo_t* cr, const WebCore::IntRect&) const
-{
-    if (!m_textureID)
-        return;
+    switch (m_buffer->type()) {
+    case Buffer::Type::EglImage: {
+        auto* texture = m_buffer->texture();
+        if (!texture)
+            return;
 
-    cairo_save(cr);
-    gdk_cairo_draw_from_gl(cr, gtk_widget_get_window(widget), m_textureID, GL_TEXTURE, m_deviceScaleFactor, 0, 0, m_size.width(), m_size.height());
-    cairo_restore(cr);
-}
-#endif
-
-bool AcceleratedBackingStoreDMABuf::RendererCairo::setBuffer(Buffer& buffer, float deviceScaleFactor)
-{
-    if (!Renderer::setBuffer(buffer, deviceScaleFactor))
-        return false;
-
-    switch (buffer.type()) {
+        graphene_rect_t bounds = GRAPHENE_RECT_INIT(0, 0, m_buffer->unscaledWidth(), m_buffer->unscaledHeight());
+        gtk_snapshot_append_texture(gtkSnapshot, texture, &bounds);
+        break;
+    }
 #if USE(GBM)
     case Buffer::Type::Gbm:
-        m_surface = static_cast<const BufferGBM&>(buffer).surface();
-        break;
 #endif
-    case Buffer::Type::SharedMemory:
-        m_surface = static_cast<const BufferSHM&>(buffer).surface();
+    case Buffer::Type::SharedMemory: {
+        auto* surface = m_buffer->surface();
+        if (!surface)
+            return;
+
+        graphene_rect_t bounds = GRAPHENE_RECT_INIT(0, 0, m_buffer->unscaledWidth(), m_buffer->unscaledHeight());
+        RefPtr<cairo_t> cr = adoptRef(gtk_snapshot_append_cairo(gtkSnapshot, &bounds));
+        cairo_set_source_surface(cr.get(), surface, 0, 0);
+        cairo_set_operator(cr.get(), CAIRO_OPERATOR_OVER);
+        cairo_paint(cr.get());
         break;
-    case Buffer::Type::EglImage:
-        RELEASE_ASSERT_NOT_REACHED();
     }
-    if (m_surface)
-        cairo_surface_set_device_scale(m_surface.get(), m_deviceScaleFactor, m_deviceScaleFactor);
-
-    return true;
-}
-
-#if USE(GTK4)
-void AcceleratedBackingStoreDMABuf::RendererCairo::snapshot(GtkSnapshot* gtkSnapshot) const
-{
-    if (!m_surface)
-        return;
-
-    graphene_rect_t bounds = GRAPHENE_RECT_INIT(0, 0, static_cast<float>(m_size.width()), static_cast<float>(m_size.height()));
-    RefPtr<cairo_t> cr = adoptRef(gtk_snapshot_append_cairo(gtkSnapshot, &bounds));
-    cairo_set_source_surface(cr.get(), m_surface.get(), 0, 0);
-    cairo_set_operator(cr.get(), CAIRO_OPERATOR_OVER);
-    cairo_paint(cr.get());
+    }
 }
 #else
-void AcceleratedBackingStoreDMABuf::RendererCairo::paint(GtkWidget* widget, cairo_t* cr, const WebCore::IntRect& clipRect) const
+void AcceleratedBackingStoreDMABuf::Renderer::paint(GtkWidget* widget, cairo_t* cr, const WebCore::IntRect& clipRect) const
 {
-    if (!m_surface)
+    if (!m_buffer)
         return;
 
-    cairo_save(cr);
-    cairo_matrix_t transform;
-    cairo_matrix_init(&transform, 1, 0, 0, -1, 0, cairo_image_surface_get_height(m_surface.get()) / m_deviceScaleFactor);
-    cairo_transform(cr, &transform);
-    cairo_rectangle(cr, clipRect.x(), clipRect.y(), clipRect.width(), clipRect.height());
-    cairo_set_source_surface(cr, m_surface.get(), 0, 0);
-    cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
-    cairo_fill(cr);
-    cairo_restore(cr);
+    switch (m_buffer->type()) {
+    case Buffer::Type::EglImage: {
+        auto textureID = m_buffer->textureID();
+        if (!textureID)
+            return;
+
+        cairo_save(cr);
+        gdk_cairo_draw_from_gl(cr, gtk_widget_get_window(widget), textureID, GL_TEXTURE, m_buffer->deviceScaleFactor(), 0, 0, m_buffer->size().width(), m_buffer->size().height());
+        cairo_restore(cr);
+        break;
+    }
+#if USE(GBM)
+    case Buffer::Type::Gbm:
+#endif
+    case Buffer::Type::SharedMemory: {
+        auto* surface = m_buffer->surface();
+        if (!surface)
+            return;
+
+        cairo_save(cr);
+        cairo_matrix_t transform;
+        cairo_matrix_init(&transform, 1, 0, 0, -1, 0, m_buffer->unscaledHeight());
+        cairo_transform(cr, &transform);
+        cairo_rectangle(cr, clipRect.x(), clipRect.y(), clipRect.width(), clipRect.height());
+        cairo_set_source_surface(cr, surface, 0, 0);
+        cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
+        cairo_fill(cr);
+        cairo_restore(cr);
+        break;
+    }
+    }
 }
 #endif
 
@@ -422,46 +419,25 @@ void AcceleratedBackingStoreDMABuf::didCreateBuffer(uint64_t id, const WebCore::
 #if USE(GBM)
     if (!WebCore::PlatformDisplay::sharedDisplay().gtkEGLDisplay()) {
         ASSERT(fds.size() == 1 && strides.size() == 1);
-        if (auto buffer = BufferGBM::create(id, size, format, WTFMove(fds[0]), strides[0]))
+        if (auto buffer = BufferGBM::create(id, size, m_webPage.deviceScaleFactor(), format, WTFMove(fds[0]), strides[0]))
             m_buffers.add(id, WTFMove(buffer));
         return;
     }
 #endif
 
-    if (auto buffer = BufferEGLImage::create(id, size, format, WTFMove(fds), WTFMove(offsets), WTFMove(strides), modifier))
+    if (auto buffer = BufferEGLImage::create(id, size, m_webPage.deviceScaleFactor(), format, WTFMove(fds), WTFMove(offsets), WTFMove(strides), modifier))
         m_buffers.add(id, WTFMove(buffer));
 }
 
 void AcceleratedBackingStoreDMABuf::didCreateBufferSHM(uint64_t id, ShareableBitmap::Handle&& handle)
 {
-    if (auto buffer = BufferSHM::create(id, ShareableBitmap::create(WTFMove(handle), SharedMemory::Protection::ReadOnly)))
+    if (auto buffer = BufferSHM::create(id, ShareableBitmap::create(WTFMove(handle), SharedMemory::Protection::ReadOnly), m_webPage.deviceScaleFactor()))
         m_buffers.add(id, WTFMove(buffer));
 }
 
 void AcceleratedBackingStoreDMABuf::didDestroyBuffer(uint64_t id)
 {
     m_buffers.remove(id);
-}
-
-void AcceleratedBackingStoreDMABuf::ensureRenderer()
-{
-    switch (m_committedBuffer->type()) {
-    case Buffer::Type::EglImage:
-        ensureGLContext();
-        gdk_gl_context_make_current(m_gdkGLContext.get());
-        if (!m_renderer)
-            m_renderer = makeUnique<RendererGL>();
-        ASSERT(m_renderer->type() == Renderer::Type::Gl);
-        break;
-#if USE(GBM)
-    case Buffer::Type::Gbm:
-#endif
-    case Buffer::Type::SharedMemory:
-        if (!m_renderer)
-            m_renderer = makeUnique<RendererCairo>();
-        ASSERT(m_renderer->type() == Renderer::Type::Cairo);
-        break;
-    }
 }
 
 void AcceleratedBackingStoreDMABuf::frame(uint64_t bufferID)
@@ -472,6 +448,12 @@ void AcceleratedBackingStoreDMABuf::frame(uint64_t bufferID)
         frameDone();
         return;
     }
+
+    if (buffer->type() == Buffer::Type::EglImage) {
+        ensureGLContext();
+        gdk_gl_context_make_current(m_gdkGLContext.get());
+    }
+    buffer->didUpdateContents();
 
     m_pendingBuffer = buffer;
     gtk_widget_queue_draw(m_webPage.viewWidget());
@@ -486,11 +468,11 @@ void AcceleratedBackingStoreDMABuf::unrealize()
 {
     if (m_gdkGLContext) {
         gdk_gl_context_make_current(m_gdkGLContext.get());
-        m_renderer = nullptr;
+        m_renderer.setBuffer(nullptr);
         gdk_gl_context_clear_current();
         m_gdkGLContext = nullptr;
     } else
-        m_renderer = nullptr;
+        m_renderer.setBuffer(nullptr);
 }
 
 void AcceleratedBackingStoreDMABuf::ensureGLContext()
@@ -546,12 +528,11 @@ bool AcceleratedBackingStoreDMABuf::prepareForRendering()
     }
 
     if (m_committedBuffer) {
-        ensureRenderer();
-        m_renderer->setBuffer(*m_committedBuffer, m_webPage.deviceScaleFactor());
+        m_renderer.setBuffer(m_committedBuffer.get());
         return true;
     }
 
-    return m_renderer && m_renderer->buffer();
+    return m_renderer.buffer();
 }
 
 #if USE(GTK4)
@@ -561,7 +542,7 @@ void AcceleratedBackingStoreDMABuf::snapshot(GtkSnapshot* gtkSnapshot)
     if (!prepareForRendering())
         return;
 
-    m_renderer->snapshot(gtkSnapshot);
+    m_renderer.snapshot(gtkSnapshot);
     if (framePending)
         frameDone();
 }
@@ -572,7 +553,7 @@ bool AcceleratedBackingStoreDMABuf::paint(cairo_t* cr, const WebCore::IntRect& c
     if (!prepareForRendering())
         return false;
 
-    m_renderer->paint(m_webPage.viewWidget(), cr, clipRect);
+    m_renderer.paint(m_webPage.viewWidget(), cr, clipRect);
     if (framePending)
         frameDone();
 


### PR DESCRIPTION
#### 93cc2e901af9447420859e26973feb8a73b5dd81
<pre>
[GTK] WebView empty with GTK Vulkan renderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=267578">https://bugs.webkit.org/show_bug.cgi?id=267578</a>

Reviewed by Alejandro G. Castro.

The problem is that we are creating to GdkTextures and reusing them all
the time. That works for the GL renderer, but it&apos;s not the way GTK
expects the API tyo be used. GdkTexture can be cached by GTK internally,
so it&apos;s not expected to change its contents and the associated GL
resources should be released by the destroy notify. This patch creates a
new GL texture and GdkTexture every time a buffer changes its contents.

* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::~AcceleratedBackingStoreDMABuf):
(WebKit::AcceleratedBackingStoreDMABuf::Buffer::Buffer):
(WebKit::AcceleratedBackingStoreDMABuf::BufferEGLImage::create):
(WebKit::AcceleratedBackingStoreDMABuf::BufferEGLImage::BufferEGLImage):
(WebKit::AcceleratedBackingStoreDMABuf::BufferEGLImage::~BufferEGLImage):
(WebKit::Texture::Texture):
(WebKit::Texture::~Texture):
(WebKit::AcceleratedBackingStoreDMABuf::BufferEGLImage::didUpdateContents):
(WebKit::AcceleratedBackingStoreDMABuf::BufferGBM::create):
(WebKit::AcceleratedBackingStoreDMABuf::BufferGBM::BufferGBM):
(WebKit::AcceleratedBackingStoreDMABuf::BufferGBM::didUpdateContents):
(WebKit::AcceleratedBackingStoreDMABuf::BufferSHM::create):
(WebKit::AcceleratedBackingStoreDMABuf::BufferSHM::BufferSHM):
(WebKit::AcceleratedBackingStoreDMABuf::BufferSHM::didUpdateContents):
(WebKit::AcceleratedBackingStoreDMABuf::Renderer::snapshot const):
(WebKit::AcceleratedBackingStoreDMABuf::Renderer::paint const):
(WebKit::AcceleratedBackingStoreDMABuf::didCreateBuffer):
(WebKit::AcceleratedBackingStoreDMABuf::didCreateBufferSHM):
(WebKit::AcceleratedBackingStoreDMABuf::frame):
(WebKit::AcceleratedBackingStoreDMABuf::unrealize):
(WebKit::AcceleratedBackingStoreDMABuf::prepareForRendering):
(WebKit::AcceleratedBackingStoreDMABuf::snapshot):
(WebKit::AcceleratedBackingStoreDMABuf::paint):
(WebKit::AcceleratedBackingStoreDMABuf::BufferGBM::surface const): Deleted.
(WebKit::AcceleratedBackingStoreDMABuf::BufferSHM::surface const): Deleted.
(WebKit::AcceleratedBackingStoreDMABuf::Renderer::setBuffer): Deleted.
(WebKit::AcceleratedBackingStoreDMABuf::RendererGL::RendererGL): Deleted.
(WebKit::AcceleratedBackingStoreDMABuf::RendererGL::~RendererGL): Deleted.
(WebKit::AcceleratedBackingStoreDMABuf::RendererGL::setBuffer): Deleted.
(WebKit::AcceleratedBackingStoreDMABuf::RendererGL::snapshot const): Deleted.
(WebKit::AcceleratedBackingStoreDMABuf::RendererGL::paint const): Deleted.
(WebKit::AcceleratedBackingStoreDMABuf::RendererCairo::setBuffer): Deleted.
(WebKit::AcceleratedBackingStoreDMABuf::RendererCairo::snapshot const): Deleted.
(WebKit::AcceleratedBackingStoreDMABuf::RendererCairo::paint const): Deleted.
(WebKit::AcceleratedBackingStoreDMABuf::ensureRenderer): Deleted.
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:

Canonical link: <a href="https://commits.webkit.org/273818@main">https://commits.webkit.org/273818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecba8d8c8333177578b85b3ff0d52add987efab2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39206 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32775 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12563 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31393 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11420 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11444 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40451 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33112 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37367 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11686 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35472 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13376 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12116 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4763 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->