### PR TITLE
[web-animations] don't normalize progress for `visibility` and `content-visibility` while animating

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-interpolation-expected.txt
@@ -47,16 +47,16 @@ PASS Web Animations: property <content-visibility> from [hidden] to [visible] at
 PASS Web Animations: property <content-visibility> from [hidden] to [visible] at (0.9) should be [visible]
 PASS Web Animations: property <content-visibility> from [hidden] to [visible] at (1) should be [visible]
 PASS Web Animations: property <content-visibility> from [hidden] to [visible] at (1.5) should be [visible]
-FAIL CSS Transitions: property <content-visibility> from [auto] to [visible] at (-0.3) should be [visible] assert_equals: expected "visible " but got "auto "
-FAIL CSS Transitions: property <content-visibility> from [auto] to [visible] at (0) should be [visible] assert_equals: expected "visible " but got "auto "
-FAIL CSS Transitions: property <content-visibility> from [auto] to [visible] at (0.3) should be [visible] assert_equals: expected "visible " but got "auto "
+PASS CSS Transitions: property <content-visibility> from [auto] to [visible] at (-0.3) should be [visible]
+PASS CSS Transitions: property <content-visibility> from [auto] to [visible] at (0) should be [visible]
+PASS CSS Transitions: property <content-visibility> from [auto] to [visible] at (0.3) should be [visible]
 PASS CSS Transitions: property <content-visibility> from [auto] to [visible] at (0.5) should be [visible]
 PASS CSS Transitions: property <content-visibility> from [auto] to [visible] at (0.6) should be [visible]
 PASS CSS Transitions: property <content-visibility> from [auto] to [visible] at (1) should be [visible]
 PASS CSS Transitions: property <content-visibility> from [auto] to [visible] at (1.5) should be [visible]
-FAIL CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (-0.3) should be [visible] assert_equals: expected "visible " but got "auto "
-FAIL CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (0) should be [visible] assert_equals: expected "visible " but got "auto "
-FAIL CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (0.3) should be [visible] assert_equals: expected "visible " but got "auto "
+PASS CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (-0.3) should be [visible]
+PASS CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (0) should be [visible]
+PASS CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (0.3) should be [visible]
 PASS CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (0.5) should be [visible]
 PASS CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (0.6) should be [visible]
 PASS CSS Transitions with transition: all: property <content-visibility> from [auto] to [visible] at (1) should be [visible]


### PR DESCRIPTION
#### e4117be9080c9b337a0e9753bb66916a16002669
<pre>
[web-animations] don&apos;t normalize progress for `visibility` and `content-visibility` while animating
<a href="https://bugs.webkit.org/show_bug.cgi?id=268366">https://bugs.webkit.org/show_bug.cgi?id=268366</a>

Reviewed by Tim Nguyen.

For CSS properties using a &quot;discrete&quot; animation type, we normalize the animated value to be either
0 or 1 depending on which side of the 0.5 progress value we stand. However, the `visibility` and
`content-visibility` properties have a special type of discrete animation support that requires
to not perform this value normalization, as will the `display` property when we add animation
support for it (see bug 267762).

We introduce a new wrapper type `NonNormalizedDiscretePropertyWrapper` to do just that and use
it for the two properties listed above. This addresses the last remaining failure for the
`content-visibility` interpolation test.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-interpolation-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::AnimationPropertyWrapperBase::normalizesProgressForDiscreteInterpolation const):
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
(WebCore::blendStandardProperty):

Canonical link: <a href="https://commits.webkit.org/273742@main">https://commits.webkit.org/273742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6da45ccb5fe279550011d65e25ce55bc92c7e1e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39207 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32776 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37779 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12564 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13051 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11422 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40452 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33116 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32926 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37369 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9531 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35474 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13377 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12117 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4732 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12573 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->