### PR TITLE
Unthrottled IPC::Connection loses messages when connection is closed

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -354,6 +354,8 @@ public:
     void removeMessageReceiver(ReceiverName, uint64_t destinationID = 0);
 
     bool open(Client&, SerialFunctionDispatcher& = RunLoop::current());
+    // Ensures that messages sent prior to the call are not affected by invalidate() or crash done after the call returns.
+    Error flushSentMessages(Timeout);
     void invalidate();
     void markCurrentlyDispatchedMessageAsInvalid();
 
@@ -561,6 +563,7 @@ private:
     // Outgoing messages.
     Lock m_outgoingMessagesLock;
     Deque<UniqueRef<Encoder>> m_outgoingMessages WTF_GUARDED_BY_LOCK(m_outgoingMessagesLock);
+    Condition m_outgoingMessagesEmptyCondition WTF_GUARDED_BY_LOCK(m_outgoingMessagesLock);
 
     Condition m_waitForMessageCondition;
     Lock m_waitForMessageLock;

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -112,6 +112,12 @@ void StreamClientConnection::open(Connection::Client& receiver, SerialFunctionDi
     m_connection->open(*m_dedicatedConnectionClient, dispatcher);
 }
 
+Error StreamClientConnection::flushSentMessages(Timeout timeout)
+{
+    wakeUpServer(WakeUpServer::Yes);
+    return m_connection->flushSentMessages(WTFMove(timeout));
+}
+
 void StreamClientConnection::invalidate()
 {
     m_connection->invalidate();

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -72,6 +72,7 @@ public:
     void setMaxBatchSize(unsigned);
 
     void open(Connection::Client&, SerialFunctionDispatcher& = RunLoop::current());
+    Error flushSentMessages(Timeout);
     void invalidate();
 
     template<typename T, typename U, typename V> Error send(T&& message, ObjectIdentifierGeneric<U, V> destinationID, Timeout);


### PR DESCRIPTION
#### d1fb58818ff3474566c2a82032c9e7431dd8c617
<pre>
Unthrottled IPC::Connection loses messages when connection is closed
<a href="https://bugs.webkit.org/show_bug.cgi?id=268362">https://bugs.webkit.org/show_bug.cgi?id=268362</a>
<a href="https://rdar.apple.com/121910136">rdar://121910136</a>

Reviewed by Matt Woodrow.

When IPC::Connection::invalidate() would be called, some of the messages
already sent might have been lost:
1. Unsent messages due to outgoing messages buffering
2. Messages not delivered at the recipient because message delivery
   would check isValid()

Fix 1. by adding a blocking IPC::Connection::flushSentMessages()
that will wait until send list flips to zero.
The flushSentMessages() call is distinct from invalidate() to preserve
the ability to call invalidate() in non-blocking manner.

Fix 2. by not checking for isValid() but for m_client / m_syncState.

isValid() flips immediately in the IPC receive queue when OS signals
that the connection was closed.
m_client, m_syncState flips to nullptr when client signals that
they do not want to receive messages anymore, via invalidate().
By contract, IPC::Connection invalidates itself after Client::didClose(),
too.

Fixes mostly upcoming GPUP cases where one connection is closed, but
not the whole per-WP session (GPUConnectionToWebProcess). The
individual connections might carry important messages up until
the disconnection, so all must be played back before handling the
connection closing.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::flushSentMessages):
(IPC::Connection::connectionDidClose):
(IPC::Connection::sendOutgoingMessages):
(IPC::Connection::dispatchMessage):
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::flushSentMessages):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/273851@main">https://commits.webkit.org/273851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0f7d303a0e900f8fe6788b4b44934d999fd06d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39484 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32996 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38120 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12894 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37406 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/13379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11641 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32860 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40734 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33426 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33189 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37561 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35684 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13591 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8355 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->