### PR TITLE
Have ResourceResponse use String members instead of AtomString

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -110,9 +110,9 @@ ExceptionOr<Ref<FetchResponse>> FetchResponse::create(ScriptExecutionContext& co
     auto r = adoptRef(*new FetchResponse(&context, WTFMove(body), WTFMove(headers), { }));
     r->suspendIfNeeded();
 
-    AtomString mimeType { extractMIMETypeFromMediaType(contentType) };
-    r->m_internalResponse.setMimeType(mimeType.isEmpty() ? AtomString { defaultMIMEType() } : mimeType);
-    r->m_internalResponse.setTextEncodingName(extractCharsetFromMediaType(contentType).toAtomString());
+    auto mimeType = extractMIMETypeFromMediaType(contentType);
+    r->m_internalResponse.setMimeType(mimeType.isEmpty() ? String { defaultMIMEType() } : WTFMove(mimeType));
+    r->m_internalResponse.setTextEncodingName(extractCharsetFromMediaType(contentType).toString());
 
     if (auto expectedContentLength = parseContentLength(r->m_headers->fastGet(HTTPHeaderName::ContentLength)))
         r->m_internalResponse.setExpectedContentLength(*expectedContentLength);
@@ -120,7 +120,7 @@ ExceptionOr<Ref<FetchResponse>> FetchResponse::create(ScriptExecutionContext& co
     // 3. Set response’s response’s status to init["status"].
     r->m_internalResponse.setHTTPStatusCode(init.status);
     // 4. Set response’s response’s status message to init["statusText"].
-    r->m_internalResponse.setHTTPStatusText(init.statusText);
+    r->m_internalResponse.setHTTPStatusText(init.statusText.releaseString());
 
     return r;
 }

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -220,7 +220,7 @@ int WebSocketHandshake::readServerHandshake(const uint8_t* header, size_t len)
 {
     m_mode = Incomplete;
     int statusCode;
-    AtomString statusText;
+    String statusText;
     int lineLength = readStatusLine(header, len, statusCode, statusText);
     if (lineLength == -1)
         return -1;
@@ -232,7 +232,7 @@ int WebSocketHandshake::readServerHandshake(const uint8_t* header, size_t len)
 
     m_serverHandshakeResponse = ResourceResponse();
     m_serverHandshakeResponse.setHTTPStatusCode(statusCode);
-    m_serverHandshakeResponse.setHTTPStatusText(statusText);
+    m_serverHandshakeResponse.setHTTPStatusText(WTFMove(statusText));
 
     if (statusCode != 101) {
         m_mode = Failed;
@@ -356,7 +356,7 @@ static inline bool headerHasValidHTTPVersion(StringView httpStatusLine)
 // Returns the header length (including "\r\n"), or -1 if we have not received enough data yet.
 // If the line is malformed or the status code is not a 3-digit number,
 // statusCode and statusText will be set to -1 and a null string, respectively.
-int WebSocketHandshake::readStatusLine(const uint8_t* header, size_t headerLength, int& statusCode, AtomString& statusText)
+int WebSocketHandshake::readStatusLine(const uint8_t* header, size_t headerLength, int& statusCode, String& statusText)
 {
     // Arbitrary size limit to prevent the server from sending an unbounded
     // amount of data with no newlines and forcing us to buffer it all.
@@ -426,7 +426,7 @@ int WebSocketHandshake::readStatusLine(const uint8_t* header, size_t headerLengt
     }
 
     statusCode = parseInteger<int>(statusCodeString).value();
-    statusText = AtomString(space2 + 1, end - space2 - 3); // Exclude "\r\n".
+    statusText = String(space2 + 1, end - space2 - 3); // Exclude "\r\n".
     return lineLength;
 }
 

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.h
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.h
@@ -88,7 +88,7 @@ public:
 
 private:
 
-    int readStatusLine(const uint8_t* header, size_t headerLength, int& statusCode, AtomString& statusText);
+    int readStatusLine(const uint8_t* header, size_t headerLength, int& statusCode, String& statusText);
 
     // Reads all headers except for the two predefined ones.
     const uint8_t* readHTTPHeaders(const uint8_t* start, const uint8_t* end);

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -117,7 +117,7 @@ public:
         m_statusCode = response.httpStatusCode();
 
         // FIXME: This assumes text only responses. We should support non-text responses as well.
-        PAL::TextEncoding textEncoding(response.textEncodingName().string());
+        PAL::TextEncoding textEncoding(response.textEncodingName());
         bool useDetector = false;
         if (!textEncoding.isValid()) {
             textEncoding = PAL::UTF8Encoding();
@@ -1275,9 +1275,9 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptWithResponse(const
     if (status)
         overrideResponse.setHTTPStatusCode(*status);
     if (!!statusText)
-        overrideResponse.setHTTPStatusText(AtomString { statusText });
+        overrideResponse.setHTTPStatusText(String { statusText });
     if (!!mimeType)
-        overrideResponse.setMimeType(AtomString { mimeType });
+        overrideResponse.setMimeType(String { mimeType });
     if (headers) {
         HTTPHeaderMap explicitHeaders;
         for (auto& header : *headers) {
@@ -1333,7 +1333,7 @@ Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequestWithRespons
     ResourceResponse response(pendingRequest->m_loader->url(), mimeType, data->size(), String());
     response.setSource(ResourceResponse::Source::InspectorOverride);
     response.setHTTPStatusCode(status);
-    response.setHTTPStatusText(AtomString { statusText });
+    response.setHTTPStatusText(String { statusText });
     HTTPHeaderMap explicitHeaders;
     for (auto& header : headers.get()) {
         auto headerValue = header.value->asString();

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1934,9 +1934,9 @@ URL DocumentLoader::documentURL() const
 #if PLATFORM(IOS_FAMILY)
 
 // FIXME: This method seems to violate the encapsulation of this class.
-void DocumentLoader::setResponseMIMEType(const AtomString& responseMIMEType)
+void DocumentLoader::setResponseMIMEType(const String& responseMIMEType)
 {
-    m_response.setMimeType(responseMIMEType);
+    m_response.setMimeType(String { responseMIMEType });
 }
 
 #endif

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -217,7 +217,7 @@ public:
     const String& responseMIMEType() const;
 #if PLATFORM(IOS_FAMILY)
     // FIXME: This method seems to violate the encapsulation of this class.
-    WEBCORE_EXPORT void setResponseMIMEType(const AtomString&);
+    WEBCORE_EXPORT void setResponseMIMEType(const String&);
 #endif
     const String& currentContentType() const;
     void replaceRequestURLForSameDocumentNavigation(const URL&);

--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -574,7 +574,7 @@ void BlobResourceHandle::notifyResponseOnSuccess()
     response.setHTTPStatusText(m_isRangeRequest ? httpPartialContentText : httpOKText);
 
     response.setHTTPHeaderField(HTTPHeaderName::ContentType, m_blobData->contentType());
-    response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toAtomString());
+    response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toString());
     response.setHTTPHeaderField(HTTPHeaderName::ContentLength, String::number(m_totalRemainingSize));
     addPolicyContainerHeaders(response, m_blobData->policyContainer());
 

--- a/Source/WebCore/platform/network/ResourceResponseBase.h
+++ b/Source/WebCore/platform/network/ResourceResponseBase.h
@@ -88,24 +88,24 @@ public:
     WEBCORE_EXPORT const URL& url() const;
     WEBCORE_EXPORT void setURL(const URL&);
 
-    WEBCORE_EXPORT const AtomString& mimeType() const;
-    WEBCORE_EXPORT void setMimeType(const AtomString&);
+    WEBCORE_EXPORT const String& mimeType() const;
+    WEBCORE_EXPORT void setMimeType(String&&);
 
     WEBCORE_EXPORT long long expectedContentLength() const;
     WEBCORE_EXPORT void setExpectedContentLength(long long expectedContentLength);
 
-    WEBCORE_EXPORT const AtomString& textEncodingName() const;
-    WEBCORE_EXPORT void setTextEncodingName(AtomString&&);
+    WEBCORE_EXPORT const String& textEncodingName() const;
+    WEBCORE_EXPORT void setTextEncodingName(String&&);
 
     WEBCORE_EXPORT int httpStatusCode() const;
     WEBCORE_EXPORT void setHTTPStatusCode(int);
     WEBCORE_EXPORT bool isRedirection() const;
 
-    WEBCORE_EXPORT const AtomString& httpStatusText() const;
-    WEBCORE_EXPORT void setHTTPStatusText(const AtomString&);
+    WEBCORE_EXPORT const String& httpStatusText() const;
+    WEBCORE_EXPORT void setHTTPStatusText(String&&);
 
-    WEBCORE_EXPORT const AtomString& httpVersion() const;
-    WEBCORE_EXPORT void setHTTPVersion(const AtomString&);
+    WEBCORE_EXPORT const String& httpVersion() const;
+    WEBCORE_EXPORT void setHTTPVersion(String&&);
     WEBCORE_EXPORT bool isHTTP09() const;
 
     WEBCORE_EXPORT const HTTPHeaderMap& httpHeaderFields() const;
@@ -245,11 +245,11 @@ private:
 
 protected:
     URL m_url;
-    AtomString m_mimeType;
+    String m_mimeType;
     long long m_expectedContentLength { 0 };
-    AtomString m_textEncodingName;
-    AtomString m_httpStatusText;
-    AtomString m_httpVersion;
+    String m_textEncodingName;
+    String m_httpStatusText;
+    String m_httpVersion;
     HTTPHeaderMap m_httpHeaderFields;
     Box<NetworkLoadMetrics> m_networkLoadMetrics;
 

--- a/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
@@ -106,8 +106,8 @@ ResourceResponse::ResourceResponse(CurlResponse& response)
         break;
     }
 
-    setMimeType(AtomString { extractMIMETypeFromMediaType(httpHeaderField(HTTPHeaderName::ContentType)).convertToASCIILowercase() });
-    setTextEncodingName(extractCharsetFromMediaType(httpHeaderField(HTTPHeaderName::ContentType)).toAtomString());
+    setMimeType(extractMIMETypeFromMediaType(httpHeaderField(HTTPHeaderName::ContentType)).convertToASCIILowercase());
+    setTextEncodingName(extractCharsetFromMediaType(httpHeaderField(HTTPHeaderName::ContentType)).toString());
     setCertificateInfo(WTFMove(response.certificateInfo));
     setSource(ResourceResponse::Source::Network);
 }
@@ -115,7 +115,7 @@ ResourceResponse::ResourceResponse(CurlResponse& response)
 void ResourceResponse::appendHTTPHeaderField(const String& header)
 {
     if (startsWithLettersIgnoringASCIICase(header, "http/"_s)) {
-        setHTTPStatusText(extractReasonPhraseFromHTTPStatusLine(header.trim(deprecatedIsSpaceOrNewline)));
+        setHTTPStatusText(String { extractReasonPhraseFromHTTPStatusLine(header.trim(deprecatedIsSpaceOrNewline)) });
         return;
     }
 

--- a/Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp
+++ b/Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp
@@ -55,7 +55,7 @@ ResourceResponse::ResourceResponse(SoupMessage* soupMessage, const CString& snif
     }
 
     m_httpStatusCode = soup_message_get_status(soupMessage);
-    setHTTPStatusText(AtomString::fromLatin1(soup_message_get_reason_phrase(soupMessage)));
+    setHTTPStatusText(String::fromLatin1(soup_message_get_reason_phrase(soupMessage)));
 
     m_certificate = soup_message_get_tls_peer_certificate(soupMessage);
     m_tlsErrors = soup_message_get_tls_peer_certificate_errors(soupMessage);
@@ -69,10 +69,10 @@ ResourceResponse::ResourceResponse(SoupMessage* soupMessage, const CString& snif
         contentType = String::fromLatin1(sniffedContentType.data());
     else
         contentType = String::fromLatin1(officialType);
-    setMimeType(AtomString { extractMIMETypeFromMediaType(contentType) });
+    setMimeType(extractMIMETypeFromMediaType(contentType));
     if (m_mimeType.isEmpty() && m_httpStatusCode != SOUP_STATUS_NOT_MODIFIED)
-        setMimeType(AtomString { MIMETypeRegistry::mimeTypeForPath(m_url.path()) });
-    setTextEncodingName(extractCharsetFromMediaType(contentType).toAtomString());
+        setMimeType(MIMETypeRegistry::mimeTypeForPath(m_url.path()));
+    setTextEncodingName(extractCharsetFromMediaType(contentType).toString());
 
     setExpectedContentLength(soup_message_headers_get_content_length(responseHeaders));
 }

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -268,7 +268,7 @@ void NetworkDataTaskBlob::dispatchDidReceiveResponse()
     response.setHTTPStatusText(m_isRangeRequest ? httpPartialContentText : httpOKText);
 
     response.setHTTPHeaderField(HTTPHeaderName::ContentType, m_blobData->contentType());
-    response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toAtomString());
+    response.setTextEncodingName(extractCharsetFromMediaType(m_blobData->contentType()).toString());
     response.setHTTPHeaderField(HTTPHeaderName::ContentLength, String::number(m_totalRemainingSize));
     addPolicyContainerHeaders(response, m_blobData->policyContainer());
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -840,7 +840,7 @@ void NetworkResourceLoader::didReceiveInformationalResponse(ResourceResponse&& r
 
 void NetworkResourceLoader::didReceiveResponse(ResourceResponse&& receivedResponse, PrivateRelayed privateRelayed, ResponseCompletionHandler&& completionHandler)
 {
-    LOADER_RELEASE_LOG("didReceiveResponse: (httpStatusCode=%d, MIMEType=%" PUBLIC_LOG_STRING ", expectedContentLength=%" PRId64 ", hasCachedEntryForValidation=%d, hasNetworkLoadChecker=%d)", receivedResponse.httpStatusCode(), receivedResponse.mimeType().string().utf8().data(), receivedResponse.expectedContentLength(), !!m_cacheEntryForValidation, !!m_networkLoadChecker);
+    LOADER_RELEASE_LOG("didReceiveResponse: (httpStatusCode=%d, MIMEType=%" PUBLIC_LOG_STRING ", expectedContentLength=%" PRId64 ", hasCachedEntryForValidation=%d, hasNetworkLoadChecker=%d)", receivedResponse.httpStatusCode(), receivedResponse.mimeType().utf8().data(), receivedResponse.expectedContentLength(), !!m_cacheEntryForValidation, !!m_networkLoadChecker);
 
 #if ENABLE(CONTENT_FILTERING)
     if (m_contentFilter && !m_contentFilter->continueAfterResponseReceived(receivedResponse))

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -239,7 +239,7 @@ void ServiceWorkerFetchTask::processResponse(ResourceResponse&& response, bool n
         return;
 #endif
 
-    SWFETCH_RELEASE_LOG("processResponse: (httpStatusCode=%d, MIMEType=%" PUBLIC_LOG_STRING ", expectedContentLength=%" PRId64 ", needsContinueDidReceiveResponseMessage=%d, source=%u)", response.httpStatusCode(), response.mimeType().string().utf8().data(), response.expectedContentLength(), needsContinueDidReceiveResponseMessage, static_cast<unsigned>(response.source()));
+    SWFETCH_RELEASE_LOG("processResponse: (httpStatusCode=%d, MIMEType=%" PUBLIC_LOG_STRING ", expectedContentLength=%" PRId64 ", needsContinueDidReceiveResponseMessage=%d, source=%u)", response.httpStatusCode(), response.mimeType().utf8().data(), response.expectedContentLength(), needsContinueDidReceiveResponseMessage, static_cast<unsigned>(response.source()));
     m_wasHandled = true;
     if (m_timeoutTimer)
         m_timeoutTimer->stop();

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -1705,10 +1705,10 @@ void NetworkDataTaskSoup::didGetFileInfo(GFileInfo* info)
         m_response.setExpectedContentLength(-1);
     } else {
         auto contentType = String::fromLatin1(g_file_info_get_content_type(info));
-        m_response.setMimeType(AtomString { extractMIMETypeFromMediaType(contentType) });
-        m_response.setTextEncodingName(extractCharsetFromMediaType(contentType).toAtomString());
+        m_response.setMimeType(extractMIMETypeFromMediaType(contentType));
+        m_response.setTextEncodingName(extractCharsetFromMediaType(contentType).toString());
         if (m_response.mimeType().isEmpty())
-            m_response.setMimeType(AtomString { MIMETypeRegistry::mimeTypeForPath(m_response.url().path().toString()) });
+            m_response.setMimeType(MIMETypeRegistry::mimeTypeForPath(m_response.url().path().toString()));
         m_response.setExpectedContentLength(g_file_info_get_size(info));
     }
 }

--- a/Source/WebKit/Shared/API/glib/WebKitURIResponse.cpp
+++ b/Source/WebKit/Shared/API/glib/WebKitURIResponse.cpp
@@ -233,7 +233,7 @@ const gchar* webkit_uri_response_get_mime_type(WebKitURIResponse* response)
 {
     g_return_val_if_fail(WEBKIT_IS_URI_RESPONSE(response), 0);
 
-    response->priv->mimeType = response->priv->resourceResponse.mimeType().string().utf8();
+    response->priv->mimeType = response->priv->resourceResponse.mimeType().utf8();
     return response->priv->mimeType.data();
 }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp
@@ -246,17 +246,17 @@ static void webkitURISchemeRequestReadCallback(GInputStream* inputStream, GAsync
     if (!priv->bytesRead) {
         auto contentType = String::fromLatin1(webKitURISchemeResponseGetContentType(resp).data());
         ResourceResponse response(priv->task->request().url(), extractMIMETypeFromMediaType(contentType), webKitURISchemeResponseGetStreamLength(resp), emptyString());
-        response.setTextEncodingName(extractCharsetFromMediaType(contentType).toAtomString());
+        response.setTextEncodingName(extractCharsetFromMediaType(contentType).toString());
         const CString& statusMessage = webKitURISchemeResponseGetStatusMessage(resp);
         if (statusMessage.isNull()) {
             response.setHTTPStatusCode(200);
             response.setHTTPStatusText("OK"_s);
         } else {
             response.setHTTPStatusCode(webKitURISchemeResponseGetStatusCode(resp));
-            response.setHTTPStatusText(AtomString::fromLatin1(statusMessage.data()));
+            response.setHTTPStatusText(String::fromLatin1(statusMessage.data()));
         }
         if (response.mimeType().isEmpty())
-            response.setMimeType(AtomString { MIMETypeRegistry::mimeTypeForPath(response.url().path()) });
+            response.setMimeType(MIMETypeRegistry::mimeTypeForPath(response.url().path()));
         if (auto* headers = webKitURISchemeResponseGetHeaders(resp))
             response.updateFromSoupMessageHeaders(headers);
         priv->task->didReceiveResponse(response);


### PR DESCRIPTION
#### 54068d0bb01823cccf54d42a42187487e0c4b7c7
<pre>
Have ResourceResponse use String members instead of AtomString
<a href="https://bugs.webkit.org/show_bug.cgi?id=268367">https://bugs.webkit.org/show_bug.cgi?id=268367</a>
<a href="https://rdar.apple.com/121916584">rdar://121916584</a>

Reviewed by Youenn Fablet.

To be usable with WorkQueue, we can&apos;t use AtomString with ResourceResponse.
So we change the members to be String instead.

No change in observable behaviour.

* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::create):
* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::WebSocketHandshake::readServerHandshake):
(WebCore::WebSocketHandshake::readStatusLine):
* Source/WebCore/Modules/websockets/WebSocketHandshake.h:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::interceptWithResponse):
(WebCore::InspectorNetworkAgent::interceptRequestWithResponse):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::setResponseMIMEType):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::notifyResponseOnSuccess):
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::m_textEncodingName):
(WebCore::m_httpStatusText):
(WebCore::m_httpVersion):
(WebCore::ResourceResponseBase::crossThreadData const):
(WebCore::ResourceResponseBase::fromCrossThreadData):
(WebCore::ResourceResponseBase::mimeType const):
(WebCore::ResourceResponseBase::setMimeType):
(WebCore::ResourceResponseBase::textEncodingName const):
(WebCore::ResourceResponseBase::setTextEncodingName):
(WebCore::ResourceResponseBase::httpStatusText const):
(WebCore::ResourceResponseBase::setHTTPStatusText):
(WebCore::ResourceResponseBase::httpVersion const):
(WebCore::ResourceResponseBase::setHTTPVersion):
(WebCore::ResourceResponseBase::getResponseData const):
* Source/WebCore/platform/network/ResourceResponseBase.h:
* Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp:
(WebCore::ResourceResponse::ResourceResponse):
(WebCore::ResourceResponse::appendHTTPHeaderField):
* Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp:
(WebCore::ResourceResponse::ResourceResponse):
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::dispatchDidReceiveResponse):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didReceiveResponse):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::processResponse):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::didGetFileInfo):
* Source/WebKit/Shared/API/glib/WebKitURIResponse.cpp:
(webkit_uri_response_get_mime_type):
* Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp:
(webkitURISchemeRequestReadCallback):

Canonical link: <a href="https://commits.webkit.org/273784@main">https://commits.webkit.org/273784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2e2d3ee891d31aa07d0f5df3c4b4ecde4756507

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36554 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39216 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32782 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12573 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31401 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11432 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40461 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33125 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37378 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35483 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13383 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8310 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12123 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12581 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->