### PR TITLE
Adopt dynamicDowncast<> in DragController

### DIFF
--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -380,20 +380,23 @@ static bool isInShadowTreeOfEnabledColorInput(Node& node)
 #endif
 
 // This can return null if an empty document is loaded.
-static Element* elementUnderMouse(Document* documentUnderMouse, const IntPoint& p)
+static Element* elementUnderMouse(Document& documentUnderMouse, const IntPoint& p)
 {
-    auto* frame = documentUnderMouse->frame();
+    auto* frame = documentUnderMouse.frame();
     float zoomFactor = frame ? frame->pageZoomFactor() : 1;
     LayoutPoint point(p.x() * zoomFactor, p.y() * zoomFactor);
 
     HitTestResult result(point);
-    documentUnderMouse->hitTest(HitTestRequest(), result);
+    documentUnderMouse.hitTest(HitTestRequest(), result);
 
     auto* node = result.innerNode();
     if (!node)
         return nullptr;
+
     // FIXME: Use parentElementInComposedTree here.
-    auto* element = is<Element>(*node) ? &downcast<Element>(*node) : node->parentElement();
+    auto* element = dynamicDowncast<Element>(*node);
+    if (!element)
+        element = node->parentElement();
     auto* host = element->shadowHost();
     return host ? host : element;
 }
@@ -445,7 +448,7 @@ DragHandlingMethod DragController::tryDocumentDrag(LocalFrame& frame, const Drag
         }
 
         IntPoint point = frameView->windowToContents(dragData.clientPosition());
-        Element* element = elementUnderMouse(m_documentUnderMouse.get(), point);
+        RefPtr element = elementUnderMouse(*protectedDocumentUnderMouse(), point);
         if (!element)
             return DragHandlingMethod::None;
         
@@ -559,7 +562,7 @@ bool DragController::concludeEditDrag(const DragData& dragData)
         return false;
 
     IntPoint point = m_documentUnderMouse->view()->windowToContents(dragData.clientPosition());
-    Element* element = elementUnderMouse(m_documentUnderMouse.get(), point);
+    RefPtr element = elementUnderMouse(*protectedDocumentUnderMouse(), point);
     if (!element)
         return false;
     RefPtr innerFrame = element->document().frame();
@@ -762,10 +765,11 @@ static bool imageElementIsDraggable(const HTMLImageElement& image, const LocalFr
         return true;
 
     auto* renderer = image.renderer();
-    if (!is<RenderImage>(renderer))
+    CheckedPtr renderImage = dynamicDowncast<RenderImage>(renderer);
+    if (!renderImage)
         return false;
 
-    auto* cachedImage = downcast<RenderImage>(*renderer).cachedImage();
+    CachedResourceHandle cachedImage = renderImage->cachedImage();
     return cachedImage && !cachedImage->errorOccurred() && cachedImage->imageForRenderer(renderer);
 }
 
@@ -782,13 +786,10 @@ static bool modelElementIsDraggable(const HTMLModelElement& modelElement)
 
 static RefPtr<HTMLAttachmentElement> enclosingAttachmentElement(Element& element)
 {
-    if (is<HTMLAttachmentElement>(element))
-        return downcast<HTMLAttachmentElement>(&element);
+    if (RefPtr attachment = dynamicDowncast<HTMLAttachmentElement>(element))
+        return attachment;
 
-    if (is<HTMLAttachmentElement>(element.parentOrShadowHostElement()))
-        return downcast<HTMLAttachmentElement>(element.parentOrShadowHostElement());
-
-    return { };
+    return dynamicDowncast<HTMLAttachmentElement>(element.parentOrShadowHostElement());
 }
 
 #endif
@@ -830,9 +831,9 @@ Element* DragController::draggableElement(const LocalFrame* sourceFrame, Element
             return element;
         }
         if (dragMode == UserDrag::Auto) {
-            if ((m_dragSourceAction.contains(DragSourceAction::Image))
-                && is<HTMLImageElement>(*element)
-                && imageElementIsDraggable(downcast<HTMLImageElement>(*element), *sourceFrame)) {
+            if (RefPtr image = dynamicDowncast<HTMLImageElement>(*element); image
+                && m_dragSourceAction.contains(DragSourceAction::Image)
+                && imageElementIsDraggable(*image, *sourceFrame)) {
                 state.type.add(DragSourceAction::Image);
                 return element;
             }
@@ -841,9 +842,9 @@ Element* DragController::draggableElement(const LocalFrame* sourceFrame, Element
                 return element;
             }
 #if ENABLE(ATTACHMENT_ELEMENT)
-            if (m_dragSourceAction.contains(DragSourceAction::Attachment)
-                && is<HTMLAttachmentElement>(*element)
-                && downcast<HTMLAttachmentElement>(*element).file()) {
+            if (RefPtr attachment = dynamicDowncast<HTMLAttachmentElement>(*element); attachment
+                && m_dragSourceAction.contains(DragSourceAction::Attachment)
+                && attachment->file()) {
                 state.type.add(DragSourceAction::Attachment);
                 return element;
             }
@@ -855,7 +856,9 @@ Element* DragController::draggableElement(const LocalFrame* sourceFrame, Element
             }
 #endif
 #if ENABLE(MODEL_ELEMENT)
-            if (m_dragSourceAction.contains(DragSourceAction::Model) && is<HTMLModelElement>(*element) && modelElementIsDraggable(downcast<HTMLModelElement>(*element))) {
+            if (RefPtr model = dynamicDowncast<HTMLModelElement>(*element); model
+                && m_dragSourceAction.contains(DragSourceAction::Model)
+                && modelElementIsDraggable(*model)) {
                 state.type.add(DragSourceAction::Model);
                 return element;
             }
@@ -869,11 +872,8 @@ Element* DragController::draggableElement(const LocalFrame* sourceFrame, Element
 
 static CachedImage* getCachedImage(Element& element)
 {
-    RenderObject* renderer = element.renderer();
-    if (!is<RenderImage>(renderer))
-        return nullptr;
-    auto& image = downcast<RenderImage>(*renderer);
-    return image.cachedImage();
+    CheckedPtr renderImage = dynamicDowncast<RenderImage>(element.renderer());
+    return renderImage ? renderImage->cachedImage() : nullptr;
 }
 
 static Image* getImage(Element& element)
@@ -1218,9 +1218,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
     }
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    if (is<HTMLAttachmentElement>(element) && m_dragSourceAction.contains(DragSourceAction::Attachment)) {
-        auto& attachment = downcast<HTMLAttachmentElement>(element);
-
+    if (RefPtr attachment = dynamicDowncast<HTMLAttachmentElement>(element); attachment && m_dragSourceAction.contains(DragSourceAction::Attachment)) {
         src.editor().setIgnoreSelectionChanges(true);
         auto previousSelection = src.selection().selection();
         selectElement(element);
@@ -1228,7 +1226,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
         PromisedAttachmentInfo promisedAttachment;
         if (hasData == HasNonDefaultPasteboardData::No) {
             auto& editor = src.editor();
-            promisedAttachment = editor.promisedAttachmentInfo(attachment);
+            promisedAttachment = editor.promisedAttachmentInfo(*attachment);
 #if PLATFORM(COCOA)
             if (!promisedAttachment && editor.client()) {
                 // Otherwise, if no file URL is specified, call out to the injected bundle to populate the pasteboard with data.
@@ -1243,7 +1241,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
         
         if (!dragImage) {
             TextIndicatorData textIndicator;
-            auto* attachmentRenderer = dynamicDowncast<RenderAttachment>(attachment.renderer());
+            auto* attachmentRenderer = dynamicDowncast<RenderAttachment>(attachment->renderer());
             if (attachmentRenderer)
                 attachmentRenderer->setShouldDrawBorder(false);
             dragImage = DragImage { dissolveDragImageToFraction(createDragImageForSelection(src, textIndicator), DragImageAlpha) };
@@ -1263,13 +1261,13 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
 #endif
 
 #if ENABLE(INPUT_TYPE_COLOR)
-    bool isColorControl = is<HTMLInputElement>(state.source) && downcast<HTMLInputElement>(*state.source).isColorControl();
-    if (isColorControl && m_dragSourceAction.contains(DragSourceAction::Color)) {
-        auto& input = downcast<HTMLInputElement>(*state.source);
-        auto color = input.valueAsColor();
+    if (RefPtr input = dynamicDowncast<HTMLInputElement>(state.source); input
+        && m_dragSourceAction.contains(DragSourceAction::Color)
+        && input->isColorControl()) {
+        auto color = input->valueAsColor();
 
         Path visiblePath;
-        dragImage = DragImage { createDragImageForColor(color, input.boundsInRootViewSpace(), input.document().page()->pageScaleFactor(), visiblePath) };
+        dragImage = DragImage { createDragImageForColor(color, input->boundsInRootViewSpace(), input->document().page()->pageScaleFactor(), visiblePath) };
         dragImage.setVisiblePath(visiblePath);
         dataTransfer.pasteboard().write(color);
         dragImageOffset = IntPoint { dragImageSize(dragImage.get()) };
@@ -1282,15 +1280,13 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
 #endif
 
 #if ENABLE(MODEL_ELEMENT)
-    bool isModel = is<HTMLModelElement>(state.source);
-    if (isModel && m_dragSourceAction.contains(DragSourceAction::Model)) {
-        auto& modelElement = downcast<HTMLModelElement>(*state.source);
-        dragImage = DragImage { createDragImageForNode(src, modelElement) };
+    if (RefPtr modelElement = dynamicDowncast<HTMLModelElement>(state.source); modelElement && m_dragSourceAction.contains(DragSourceAction::Model)) {
+        dragImage = DragImage { createDragImageForNode(src, *modelElement) };
 
         PasteboardImage pasteboardImage;
-        pasteboardImage.suggestedName = modelElement.currentSrc().lastPathComponent().toString();
-        pasteboardImage.resourceMIMEType = modelElement.model()->mimeType();
-        pasteboardImage.resourceData = modelElement.model()->data();
+        pasteboardImage.suggestedName = modelElement->currentSrc().lastPathComponent().toString();
+        pasteboardImage.resourceMIMEType = modelElement->model()->mimeType();
+        pasteboardImage.resourceData = modelElement->model()->data();
         dataTransfer.pasteboard().write(pasteboardImage);
 
         dragImageOffset = IntPoint { dragImageSize(dragImage.get()) };
@@ -1527,14 +1523,14 @@ void DragController::insertDroppedImagePlaceholdersAtCaret(const Vector<IntSize>
         return;
     }
 
-    auto container = commonInclusiveAncestor<ComposedTree>(*insertedContentRange);
-    if (!is<ContainerNode>(container)) {
+    RefPtr container = dynamicDowncast<ContainerNode>(commonInclusiveAncestor<ComposedTree>(*insertedContentRange));
+    if (!container) {
         ASSERT_NOT_REACHED();
         return;
     }
 
     Vector<Ref<HTMLImageElement>> placeholders;
-    for (auto& placeholder : descendantsOfType<HTMLImageElement>(downcast<ContainerNode>(*container))) {
+    for (auto& placeholder : descendantsOfType<HTMLImageElement>(*container)) {
         if (intersects<ComposedTree>(*insertedContentRange, placeholder))
             placeholders.append(placeholder);
     }

--- a/Source/WebCore/page/DragController.h
+++ b/Source/WebCore/page/DragController.h
@@ -82,6 +82,7 @@ public:
     DragHandlingMethod dragHandlingMethod() const { return m_dragHandlingMethod; }
 
     Document* documentUnderMouse() const { return m_documentUnderMouse.get(); }
+    RefPtr<Document> protectedDocumentUnderMouse() const { return m_documentUnderMouse; }
     OptionSet<DragDestinationAction> dragDestinationActionMask() const { return m_dragDestinationActionMask; }
     OptionSet<DragSourceAction> delegateDragSourceAction(const IntPoint& rootViewPoint);
 


### PR DESCRIPTION
#### bdd2db95c62291ce96f30b3ceb798403da21a53c
<pre>
Adopt dynamicDowncast&lt;&gt; in DragController
<a href="https://bugs.webkit.org/show_bug.cgi?id=268371">https://bugs.webkit.org/show_bug.cgi?id=268371</a>

Reviewed by Chris Dumez.

Also add some RefPtr.

* Source/WebCore/page/DragController.cpp:
(WebCore::elementUnderMouse):
(WebCore::DragController::tryDocumentDrag):
(WebCore::DragController::concludeEditDrag):
(WebCore::imageElementIsDraggable):
(WebCore::enclosingAttachmentElement):
(WebCore::DragController::draggableElement const):
(WebCore::getCachedImage):
(WebCore::DragController::startDrag):
(WebCore::DragController::insertDroppedImagePlaceholdersAtCaret):
* Source/WebCore/page/DragController.h:
(WebCore::DragController::protectedDocumentUnderMouse const):

Canonical link: <a href="https://commits.webkit.org/273832@main">https://commits.webkit.org/273832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4189e0aed775254129180f10825bd929dd8994c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32969 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31526 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32529 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11610 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11629 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40698 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33390 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37537 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35657 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13561 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8345 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12295 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12802 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->