### PR TITLE
[GLib] Deprecation warning when building with clang

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestBackForwardList.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestBackForwardList.cpp
@@ -73,7 +73,6 @@ public:
     {
         g_assert_nonnull(item);
         g_assert_cmpstr(webkit_back_forward_list_item_get_uri(item), ==, uri);
-        g_assert_cmpstr(webkit_back_forward_list_item_get_title(item), == , "");
         g_assert_cmpstr(webkit_back_forward_list_item_get_original_uri(item), ==, originalURI);
     }
 


### PR DESCRIPTION
#### 001e2b36b300572d1c1cb7b7f5f490f375f822af
<pre>
[GLib] Deprecation warning when building with clang
<a href="https://bugs.webkit.org/show_bug.cgi?id=268373">https://bugs.webkit.org/show_bug.cgi?id=268373</a>

Reviewed by Carlos Garcia Campos.

webkit_back_forward_list_item_get_title() is deprecated API, now always returning an empty string.
Remove its usage from API test.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestBackForwardList.cpp:

Canonical link: <a href="https://commits.webkit.org/273746@main">https://commits.webkit.org/273746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d47f7ab3ceefef15cc4aa2a49880efb06178d69

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39236 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/17986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12593 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32352 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11446 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/32609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40480 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32951 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37390 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35497 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8282 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->