### PR TITLE
Replace remaining is<Attr> usage with dynamicDowncast<Attr>

### DIFF
--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -40,6 +40,7 @@ public:
     Frame* contentFrame() const { return m_contentFrame.get(); }
     WEBCORE_EXPORT WindowProxy* contentWindow() const;
     WEBCORE_EXPORT Document* contentDocument() const;
+    RefPtr<Document> protectedContentDocument() const { return contentDocument(); }
 
     WEBCORE_EXPORT void setContentFrame(Frame&);
     void clearContentFrame();

--- a/Source/WebCore/xml/XPathNodeSet.cpp
+++ b/Source/WebCore/xml/XPathNodeSet.cpp
@@ -96,8 +96,8 @@ static void sortBlock(unsigned from, unsigned to, Vector<Vector<Node*>>& parentM
         unsigned sortedEnd = from;
         // FIXME: namespace nodes are not implemented.
         for (unsigned i = sortedEnd; i < to; ++i) {
-            Node* node = parentMatrix[i][0];
-            if (is<Attr>(*node) && downcast<Attr>(*node).ownerElement() == commonAncestor)
+            auto* node = parentMatrix[i][0];
+            if (auto* attr = dynamicDowncast<Attr>(*node); attr && attr->ownerElement() == commonAncestor)
                 parentMatrix[i].swap(parentMatrix[sortedEnd++]);
         }
         if (sortedEnd != from) {
@@ -157,10 +157,10 @@ void NodeSet::sort() const
     Vector<Vector<Node*>> parentMatrix(nodeCount);
     for (unsigned i = 0; i < nodeCount; ++i) {
         Vector<Node*>& parentsVector = parentMatrix[i];
-        Node* node = m_nodes[i].get();
+        auto* node = m_nodes[i].get();
         parentsVector.append(node);
-        if (is<Attr>(*node)) {
-            node = downcast<Attr>(*node).ownerElement();
+        if (auto* attr = dynamicDowncast<Attr>(*node)) {
+            node = attr->ownerElement();
             parentsVector.append(node);
             containsAttributeNodes = true;
         }
@@ -181,8 +181,8 @@ void NodeSet::sort() const
 
 static Node* findRootNode(Node* node)
 {
-    if (is<Attr>(*node))
-        node = downcast<Attr>(*node).ownerElement();
+    if (auto* attr = dynamicDowncast<Attr>(*node))
+        node = attr->ownerElement();
     if (node->isConnected())
         node = &node->document();
     else {
@@ -212,15 +212,15 @@ void NodeSet::traversalSort() const
         if (nodes.contains(node))
             sortedNodes.append(node);
 
-        if (!containsAttributeNodes || !is<Element>(*node))
+        if (!containsAttributeNodes)
             continue;
 
-        Element& element = downcast<Element>(*node);
-        if (!element.hasAttributes())
+        RefPtr element = dynamicDowncast<Element>(*node);
+        if (!element || !element->hasAttributes())
             continue;
 
-        for (const Attribute& attribute : element.attributesIterator()) {
-            RefPtr<Attr> attr = element.attrIfExists(attribute.name());
+        for (const Attribute& attribute : element->attributesIterator()) {
+            RefPtr attr = element->attrIfExists(attribute.name());
             if (attr && nodes.contains(attr.get()))
                 sortedNodes.append(attr);
         }


### PR DESCRIPTION
#### d2719a7661ab51053c2bdfab55cd0bbdc59cc7dd
<pre>
Replace remaining is&lt;Attr&gt; usage with dynamicDowncast&lt;Attr&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=268375">https://bugs.webkit.org/show_bug.cgi?id=268375</a>

Reviewed by Chris Dumez.

* Source/WebCore/html/HTMLFrameOwnerElement.h:
(WebCore::HTMLFrameOwnerElement::protectedContentDocument const):
* Source/WebCore/inspector/InspectorNodeFinder.cpp:
(WebCore::InspectorNodeFinder::searchUsingDOMTreeTraversal):
(WebCore::InspectorNodeFinder::searchUsingXPath):
(WebCore::InspectorNodeFinder::searchUsingCSSSelectors):
* Source/WebCore/xml/XPathNodeSet.cpp:
(WebCore::XPath::sortBlock):
(WebCore::XPath::NodeSet::sort const):
(WebCore::XPath::findRootNode):
(WebCore::XPath::NodeSet::traversalSort const):

Canonical link: <a href="https://commits.webkit.org/273834@main">https://commits.webkit.org/273834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9836f9cadb50c9520e3445c8141eb09d0a55279e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39466 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32986 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38099 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12876 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11626 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40716 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33409 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33175 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37551 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35671 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13578 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8344 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12312 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12820 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->