### PR TITLE
[WGSL] Bitcast needs to concretize abstract floats

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -1718,6 +1718,14 @@ CONSTANT_FUNCTION(Bitcast)
             return makeUnexpected(makeString("value ", String::number(*abstractInt), " cannot be represented as 'i32'"));
         return { convertValue<BitwiseCast>(resultType, *result) };
     }
+
+    if (auto* abstractFloat = std::get_if<double>(&argument)) {
+        auto result = convertFloat<float>(*abstractFloat);
+        if (!result.has_value())
+            return makeUnexpected(makeString("value ", String::number(*abstractFloat), " cannot be represented as 'f32'"));
+        return { convertValue<BitwiseCast>(resultType, *result) };
+    }
+
     return { convertValue<BitwiseCast>(resultType, argument) };
 }
 

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -1355,6 +1355,8 @@ fn testBitcast()
     let f = 0f;
     let h = 0h;
 
+    { const x =bitcast<vec2<i32>>(vec2(.659341217228384203)); }
+
     // @const @must_use fn bitcast<T>(e : T) -> T
     { const x: u32 = bitcast<u32>(5u); }
     { const x: i32 = bitcast<i32>(5i); }


### PR DESCRIPTION
#### 9a42882e26f10fead443c0bcf48d3f4e8b0e05da
<pre>
[WGSL] Bitcast needs to concretize abstract floats
<a href="https://bugs.webkit.org/show_bug.cgi?id=268380">https://bugs.webkit.org/show_bug.cgi?id=268380</a>
<a href="https://rdar.apple.com/121527210">rdar://121527210</a>

Reviewed by Mike Wyrzykowski.

Bitcast doesn&apos;t concretize its arguments by default, since there&apos;s a special case
for conversions from abstract int to u32, so we need to explicitly concretize
abstract floats.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::CONSTANT_FUNCTION):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/273764@main">https://commits.webkit.org/273764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86c3b762c96b12add554058f0478386c4e48a33f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39251 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32809 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12610 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13088 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32366 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11456 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40496 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33153 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37402 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11728 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9569 "Found 1 new test failure: http/tests/inspector/dom/didFireEvent.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35509 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13411 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8296 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12150 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12613 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->