### PR TITLE
TestShard should be able to pickle reference_files

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py
@@ -524,7 +524,14 @@ class TestShard(object):
                 expected_image_path=mutation(test_input.test.expected_image_path),
                 expected_checksum_path=mutation(test_input.test.expected_checksum_path),
                 expected_audio_path=mutation(test_input.test.expected_audio_path),
-                reference_files=None if test_input.test.reference_files is None else [mutation(file) for file in test_input.test.reference_files],
+                reference_files=(
+                    None
+                    if test_input.test.reference_files is None
+                    else tuple(
+                        (ref_type, mutation(ref_path))
+                        for ref_type, ref_path in test_input.test.reference_files
+                    )
+                ),
                 is_http_test=test_input.test.is_http_test,
                 is_websocket_test=test_input.test.is_websocket_test,
                 is_wpt_test=test_input.test.is_wpt_test,


### PR DESCRIPTION
#### 5d4d9c7ef39a8e0c948023df3eefb440070c3999
<pre>
TestShard should be able to pickle reference_files
<a href="https://bugs.webkit.org/show_bug.cgi?id=268379">https://bugs.webkit.org/show_bug.cgi?id=268379</a>

Reviewed by Jonathan Bedard.

Previously, this got the type of reference_files wrong. This happened to
work because we never actually set it anywhere. However, on a local
branch where it is set this unsurprisingly fails.

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py:
(TestShard.pack):
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py:
(LayoutTestRunnerTests.test_interrupt_if_at_failure_limits): Drive-by, remove dead variable.
(ShardTests):
(ShardTests.test_pickle):

Canonical link: <a href="https://commits.webkit.org/273789@main">https://commits.webkit.org/273789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a02c9dd0a8ad3c3603117e0ef2ccbd165d41f2e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39255 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32811 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31419 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11475 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/36709 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11488 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40500 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37405 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35512 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13413 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12152 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4747 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->