### PR TITLE
Remove Enumtraits<> from WebKit/Shared/Extensions/

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionStorageAccessLevel.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionStorageAccessLevel.h
@@ -38,19 +38,4 @@ enum class WebExtensionStorageAccessLevel : uint8_t {
 
 } // namespace WebKit
 
-namespace WTF {
-
-template<> struct EnumTraits<WebKit::WebExtensionStorageAccessLevel> {
-    using values = EnumValues<
-        WebKit::WebExtensionStorageAccessLevel,
-        WebKit::WebExtensionStorageAccessLevel::TrustedContexts,
-        WebKit::WebExtensionStorageAccessLevel::TrustedAndUntrustedContexts
-    >;
-};
-
-template<> struct DefaultHash<WebKit::WebExtensionStorageAccessLevel> : IntHash<WebKit::WebExtensionStorageAccessLevel> { };
-template<> struct HashTraits<WebKit::WebExtensionStorageAccessLevel> : StrongEnumHashTraits<WebKit::WebExtensionStorageAccessLevel> { };
-
-} // namespace WTF
-
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/Shared/Extensions/WebExtensionStorageType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionStorageType.h
@@ -51,20 +51,4 @@ inline String toAPIPrefixString(WebExtensionStorageType storageType)
 
 } // namespace WebKit
 
-namespace WTF {
-
-template<> struct EnumTraits<WebKit::WebExtensionStorageType> {
-    using values = EnumValues<
-        WebKit::WebExtensionStorageType,
-        WebKit::WebExtensionStorageType::Local,
-        WebKit::WebExtensionStorageType::Session,
-        WebKit::WebExtensionStorageType::Sync
-    >;
-};
-
-template<> struct DefaultHash<WebKit::WebExtensionStorageType> : IntHash<WebKit::WebExtensionStorageType> { };
-template<> struct HashTraits<WebKit::WebExtensionStorageType> : StrongEnumHashTraits<WebKit::WebExtensionStorageType> { };
-
-} // namespace WTF
-
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### 5495e9f832d3d1c122ae1868c10d107c84f481f5
<pre>
Remove Enumtraits&lt;&gt; from WebKit/Shared/Extensions/
<a href="https://bugs.webkit.org/show_bug.cgi?id=268383">https://bugs.webkit.org/show_bug.cgi?id=268383</a>

Reviewed by Timothy Hatcher.

The enums already use the new serialization format and are defined
in WebExtensionStorage.serialization.in

* Source/WebKit/Shared/Extensions/WebExtensionStorageAccessLevel.h:
* Source/WebKit/Shared/Extensions/WebExtensionStorageType.h:

Canonical link: <a href="https://commits.webkit.org/273825@main">https://commits.webkit.org/273825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cd9d9dfadb6728e3d109a2a49f163f482330d01

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39264 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32817 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12622 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31428 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32379 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11471 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11480 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40509 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33163 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37411 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35519 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13419 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8339 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12158 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12624 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->