### PR TITLE
[WGSL] Cannot initialize variable with void expression

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -394,6 +394,11 @@ void TypeChecker::visitVariable(AST::Variable& variable, VariableKind variableKi
         }
 
         if (!result) {
+            if (initializerType == m_types.voidType()) {
+                typeError(InferBottom::No, variable.span(), "cannot initialize variable with expression of type 'void'");
+                initializerType = m_types.bottomType();
+            }
+
             if (variable.flavor() == AST::VariableFlavor::Const)
                 result = initializerType;
             else {
@@ -1647,6 +1652,7 @@ bool TypeChecker::isBottom(const Type* type) const
 
 void TypeChecker::introduceType(const AST::Identifier& name, const Type* type)
 {
+    ASSERT(type);
     if (!introduceVariable(name, { Binding::Type, type, std::nullopt }))
         typeError(InferBottom::No, name.span(), "redeclaration of '", name, "'");
 }
@@ -1840,6 +1846,7 @@ bool TypeChecker::convertValueImpl(const SourceSpan& span, const Type* type, Con
 
 void TypeChecker::introduceValue(const AST::Identifier& name, const Type* type, std::optional<ConstantValue> value)
 {
+    ASSERT(type);
     if (shouldDumpConstantValues && value.has_value())
         dataLogLn("> Assigning value: ", name, " => ", value);
     if (!introduceVariable(name, { Binding::Value, type , value }))

--- a/Source/WebGPU/WGSL/tests/invalid/function-call.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/function-call.wgsl
@@ -22,3 +22,9 @@ fn f2() {
     // CHECK-L: funtion call has too many arguments: expected 1, found 2
     _ = f1(0, 0);
 }
+
+fn f3() { }
+fn f4() {
+    // CHECK-L: cannot initialize variable with expression of type 'void'
+    let x = f3();
+}


### PR DESCRIPTION
#### 2e7ff8a88a60f21b566ee8a7a94017be67815cfe
<pre>
[WGSL] Cannot initialize variable with void expression
<a href="https://bugs.webkit.org/show_bug.cgi?id=268384">https://bugs.webkit.org/show_bug.cgi?id=268384</a>
<a href="https://rdar.apple.com/121528555">rdar://121528555</a>

Reviewed by Mike Wyrzykowski.

Validate that the variable initializer isn&apos;t of void type. Otherwise, we will
try to materialize the void type, which will result in a nullptr Type*.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitVariable):
(WGSL::TypeChecker::introduceType):
(WGSL::TypeChecker::introduceValue):
* Source/WebGPU/WGSL/tests/invalid/function-call.wgsl:

Canonical link: <a href="https://commits.webkit.org/273765@main">https://commits.webkit.org/273765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6feea7ec9024120fc9b9ae08e2ae0979eaf3a1e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39267 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32820 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12625 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11468 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40512 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33168 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32977 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35531 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13422 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8297 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12627 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->