### PR TITLE
[WebGPU] RemoteBuffer::destroy should always call unmap first

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
@@ -82,7 +82,8 @@ void RemoteBuffer::unmap(Vector<uint8_t>&& data)
     if (m_isMapped && m_mappedRange && m_mappedRange->byteLength >= data.size() && m_mapModeFlags.contains(WebCore::WebGPU::MapMode::Write))
         memcpy(m_mappedRange->source, data.data(), data.size());
 
-    m_backing->unmap();
+    if (m_isMapped)
+        m_backing->unmap();
     m_isMapped = false;
     m_mappedRange = std::nullopt;
     m_mapModeFlags = { };
@@ -90,6 +91,7 @@ void RemoteBuffer::unmap(Vector<uint8_t>&& data)
 
 void RemoteBuffer::destroy()
 {
+    unmap(Vector<uint8_t>());
     m_backing->destroy();
 }
 


### PR DESCRIPTION
#### c392218715bcb96ac8b290707801a64ef5368408
<pre>
[WebGPU] RemoteBuffer::destroy should always call unmap first
<a href="https://bugs.webkit.org/show_bug.cgi?id=268386">https://bugs.webkit.org/show_bug.cgi?id=268386</a>
&lt;radar://107265905&gt;

Reviewed by Dan Glastonbury.

A compromised web process can directly call destroy and
destroy should always call unmap first, so we can&apos;t rely
on the web content process to call unmap.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp:
(WebKit::RemoteBuffer::unmap):
(WebKit::RemoteBuffer::destroy):

Canonical link: <a href="https://commits.webkit.org/273871@main">https://commits.webkit.org/273871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b1a29f3b9a6d8a42989a7defc05fba40d95ee25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39269 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32822 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31432 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32381 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11476 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11530 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40514 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33222 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32982 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37419 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35527 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13424 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8369 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12163 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12629 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->