### PR TITLE
Adopt dynamicDowncast<> in TextManipulationController

### DIFF
--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -78,7 +78,10 @@ public:
         if (!node)
             return false;
 
-        RefPtr startingElement = is<Element>(*node) ? downcast<Element>(node) : node->parentElement();
+        RefPtr startingElement = dynamicDowncast<Element>(*node);
+        if (!startingElement)
+            startingElement = node->parentElement();
+
         if (!startingElement)
             return false;
 
@@ -294,7 +297,10 @@ static std::optional<TextManipulationTokenInfo> tokenInfo(Node* node)
 
     TextManipulationTokenInfo result;
     result.documentURL = node->document().url();
-    if (RefPtr element = is<Element>(node) ? downcast<Element>(node) : node->parentElement()) {
+    RefPtr element = dynamicDowncast<Element>(*node);
+    if (!element)
+        element = node->parentElement();
+    if (element) {
         result.tagName = element->tagName();
         if (element->hasAttributeWithoutSynchronization(HTMLNames::roleAttr))
             result.roleAttribute = element->attributeWithoutSynchronization(HTMLNames::roleAttr);
@@ -491,27 +497,25 @@ void TextManipulationController::observeParagraphs(const Position& start, const 
             continue;
         }
 
-        if (is<Element>(*contentNode)) {
-            Ref currentElement = downcast<Element>(*contentNode);
-            if (!content.isTextContent && canPerformTextManipulationByReplacingEntireTextContent(currentElement))
-                addItem(ManipulationItemData { Position(), Position(), currentElement, nullQName(), { TextManipulationToken { m_tokenIdentifier.generate(), currentElement->textContent(), tokenInfo(currentElement.ptr()) } } });
+        if (RefPtr currentElement = dynamicDowncast<Element>(*contentNode)) {
+            if (!content.isTextContent && canPerformTextManipulationByReplacingEntireTextContent(*currentElement))
+                addItem(ManipulationItemData { Position(), Position(), *currentElement, nullQName(), { TextManipulationToken { m_tokenIdentifier.generate(), currentElement->textContent(), tokenInfo(currentElement.get()) } } });
 
             if (currentElement->hasAttributes()) {
                 for (auto& attribute : currentElement->attributesIterator()) {
                     if (isAttributeForTextManipulation(attribute.name()))
-                        addItem(ManipulationItemData { Position(), Position(), currentElement, attribute.name(), { TextManipulationToken { m_tokenIdentifier.generate(), attribute.value(), tokenInfo(currentElement.ptr()) } } });
+                        addItem(ManipulationItemData { Position(), Position(), *currentElement, attribute.name(), { TextManipulationToken { m_tokenIdentifier.generate(), attribute.value(), tokenInfo(currentElement.get()) } } });
                 }
             }
 
-            if (is<HTMLInputElement>(currentElement)) {
-                Ref input = downcast<HTMLInputElement>(currentElement);
-                if (shouldExtractValueForTextManipulation(input))
-                    addItem(ManipulationItemData { { }, { }, currentElement, HTMLNames::valueAttr, { TextManipulationToken { m_tokenIdentifier.generate(), input->value(), tokenInfo(currentElement.ptr()) } } });
+            if (RefPtr input = dynamicDowncast<HTMLInputElement>(*currentElement)) {
+                if (shouldExtractValueForTextManipulation(*input))
+                    addItem(ManipulationItemData { { }, { }, *currentElement, HTMLNames::valueAttr, { TextManipulationToken { m_tokenIdentifier.generate(), input->value(), tokenInfo(currentElement.get()) } } });
             }
 
-            if (isEnclosingItemBoundaryElement(currentElement)) {
+            if (isEnclosingItemBoundaryElement(*currentElement)) {
                 addItemIfPossible(std::exchange(unitsInCurrentParagraph, { }));
-                enclosingItemBoundaryElements.append(WTFMove(currentElement));
+                enclosingItemBoundaryElements.append(*WTFMove(currentElement));
             }
         }
 
@@ -558,8 +562,8 @@ void TextManipulationController::didAddOrCreateRendererForNode(Node& node)
 
     scheduleObservationUpdate();
 
-    if (is<PseudoElement>(node)) {
-        if (RefPtr host = downcast<PseudoElement>(node).hostElement())
+    if (auto* pseudoElement = dynamicDowncast<PseudoElement>(node)) {
+        if (RefPtr host = pseudoElement->hostElement())
             m_addedOrNewlyRenderedNodes.add(*host);
     } else
         m_addedOrNewlyRenderedNodes.add(node);
@@ -603,7 +607,7 @@ void TextManipulationController::scheduleObservationUpdate()
             if (!node->isConnected())
                 continue;
 
-            if (RefPtr host = node->shadowHost(); is<HTMLInputElement>(host) && downcast<HTMLInputElement>(*host).lastChangeWasUserEdit())
+            if (RefPtr host = dynamicDowncast<HTMLInputElement>(node->shadowHost()); host && host->lastChangeWasUserEdit())
                 continue;
 
             if (!commonAncestor)
@@ -700,10 +704,10 @@ auto TextManipulationController::completeManipulation(const Vector<WebCore::Text
             document->updateLayoutIgnorePendingStylesheets();
 
         for (auto& container : containersWithoutVisualOverflowBeforeReplacement) {
-            if (!is<StyledElement>(container))
+            RefPtr element = dynamicDowncast<StyledElement>(container);
+            if (!element)
                 continue;
 
-            Ref element = downcast<StyledElement>(container.get());
             CheckedPtr box = element->renderBox();
             if (!box || !box->hasVisualOverflow())
                 continue;
@@ -734,7 +738,9 @@ struct ReplacementData {
 Vector<Ref<Node>> TextManipulationController::getPath(Node* ancestor, Node* node)
 {
     Vector<Ref<Node>> path;
-    RefPtr containerNode = is<ContainerNode>(*node) ? downcast<ContainerNode>(node) : node->parentNode();
+    RefPtr containerNode = dynamicDowncast<ContainerNode>(*node);
+    if (!containerNode)
+        containerNode = node->parentNode();
     for (; containerNode && containerNode != ancestor; containerNode = containerNode->parentNode())
         path.append(*containerNode);
     path.reverse();
@@ -791,8 +797,8 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
         }
         if (item.attributeName == nullQName())
             element->setTextContent(newValue.toString());
-        else if (item.attributeName == HTMLNames::valueAttr && is<HTMLInputElement>(*element))
-            downcast<HTMLInputElement>(*element).setValue(newValue.toString());
+        else if (RefPtr input = dynamicDowncast<HTMLInputElement>(*element); input && item.attributeName == HTMLNames::valueAttr)
+            input->setValue(newValue.toString());
         else
             element->setAttribute(item.attributeName, newValue.toAtomString());
 
@@ -876,7 +882,6 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
     auto startTopDownPath = getPath(commonAncestor.get(), firstContentNode.get());
     while (!startTopDownPath.isEmpty()) {
         auto lastNode = startTopDownPath.last();
-        ASSERT(is<ContainerNode>(lastNode));
         if (!downcast<ContainerNode>(lastNode.get()).hasOneChild())
             break;
         nodesToRemove.add(startTopDownPath.takeLast());


### PR DESCRIPTION
#### 3d664838baa6b2008140a7c80da369540523d541
<pre>
Adopt dynamicDowncast&lt;&gt; in TextManipulationController
<a href="https://bugs.webkit.org/show_bug.cgi?id=268389">https://bugs.webkit.org/show_bug.cgi?id=268389</a>

Reviewed by Ryosuke Niwa and Chris Dumez.

* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::ExclusionRuleMatcher::isExcluded):
(WebCore::tokenInfo):
(WebCore::TextManipulationController::observeParagraphs):
(WebCore::TextManipulationController::didAddOrCreateRendererForNode):
(WebCore::TextManipulationController::scheduleObservationUpdate):
(WebCore::TextManipulationController::completeManipulation):
(WebCore::TextManipulationController::getPath):
(WebCore::TextManipulationController::replace):

Canonical link: <a href="https://commits.webkit.org/273791@main">https://commits.webkit.org/273791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7674ade1c5bb29f48e7535f9252f0338bc4416bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39278 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32828 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12636 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31434 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32392 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11480 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11494 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40522 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33179 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32998 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37421 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35532 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13432 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8314 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12169 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->