### PR TITLE
[WGSL] Crash in attribute validation when reading size of struct member

### DIFF
--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -326,8 +326,12 @@ void AttributeValidator::visit(AST::StructureMember& member)
             auto sizeValue = constantValue->integerValue();
             if (sizeValue < 0)
                 error(attribute.span(), "@size value must be non-negative");
-            else if (sizeValue < member.type().inferredType()->size())
+            else if (m_errors.isEmpty() && sizeValue < member.type().inferredType()->size()) {
+                // We can't call Type::size() if we already have errors, as we might
+                // try to read the size of a struct, which we will not have computed
+                // if we already encountered errors
                 error(attribute.span(), "@size value must be at least the byte-size of the type of the member");
+            }
             update(attribute.span(), member.m_size, static_cast<unsigned>(sizeValue));
             continue;
         }

--- a/Source/WebGPU/WGSL/tests/invalid/attribute-validation.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/attribute-validation.wgsl
@@ -1,11 +1,11 @@
 // RUN: %not %wgslc | %check
 
 struct S {
-    // CHECK-L: @size value must be non-negative
-    @size(-1) x: i32,
-
     // CHECK-L: @size value must be at least the byte-size of the type of the member
-    @size(2) y: i32,
+    @size(2) x: i32,
+
+    // CHECK-L: @size value must be non-negative
+    @size(-1) y: i32,
 
     // CHECK-L: @align value must be non-negative
     @align(-1) z: i32,
@@ -62,3 +62,12 @@ fn f8() { }
 // CHECK-L: @workgroup_size argument must be at least 1
 @workgroup_size(-1) @compute
 fn f9() { }
+
+struct S1 {
+  @size(16) x : f32
+};
+
+struct S2 {
+  // check that we don't crash by trying to read the size of S2, which won't have been computed
+  @size(32) x: array<S1, 2>,
+};


### PR DESCRIPTION
#### 33392c4e138505df581d302bdb27c28d5ce907aa
<pre>
[WGSL] Crash in attribute validation when reading size of struct member
<a href="https://bugs.webkit.org/show_bug.cgi?id=268390">https://bugs.webkit.org/show_bug.cgi?id=268390</a>
<a href="https://rdar.apple.com/121527891">rdar://121527891</a>

Reviewed by Mike Wyrzykowski.

The AttributeValidator also computes the size of structs, since their sizes can
be affected by @size and @alignment attributes. However, we skip computing the
size if we already encountered any errors, as they might be related to either
@size or @alignment attributes which would affect the result. Because of that,
we should not call Type::size, since the type might be a struct, which would
not have had its size computed.

* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
* Source/WebGPU/WGSL/tests/invalid/attribute-validation.wgsl:

Canonical link: <a href="https://commits.webkit.org/273770@main">https://commits.webkit.org/273770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c449dce534d06b112307097888a8488a7746ecfd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36620 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39280 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32830 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12639 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13121 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32393 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11481 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/32999 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37423 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11754 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35534 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8300 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12639 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->