### PR TITLE
Add logging to help investigate issues where keyboard input fails to insert text on iOS 17.4

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -7170,6 +7170,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 #if USE(BROWSERENGINEKIT)
     if (self.shouldUseAsyncInteractions) {
         RetainPtr inputDelegate = _asyncInputDelegate;
+        [self _logMissingSystemInputDelegateIfNeeded:__PRETTY_FUNCTION__];
         if (!inputDelegate)
             return NO;
 
@@ -7237,6 +7238,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 #if USE(BROWSERENGINEKIT)
     if (self.shouldUseAsyncInteractions) {
         RetainPtr systemDelegate = _asyncInputDelegate;
+        [self _logMissingSystemInputDelegateIfNeeded:__PRETTY_FUNCTION__];
         if (!systemDelegate)
             return NO;
 
@@ -12605,6 +12607,19 @@ static BOOL shouldUseMachineReadableCodeMenuFromImageAnalysisResult(CocoaImageAn
 {
     ASSERT([self conformsToProtocol:@protocol(BETextInput)]);
     return static_cast<id<BETextInput>>(self);
+}
+
+- (void)_logMissingSystemInputDelegateIfNeeded:(const char*)methodName
+{
+    if (_asyncInputDelegate)
+        return;
+
+    static constexpr auto delayBetweenLogStatements = 10_s;
+    static ApproximateTime lastLoggingTimestamp;
+    if (auto timestamp = ApproximateTime::now(); timestamp - lastLoggingTimestamp > delayBetweenLogStatements) {
+        RELEASE_LOG_ERROR(TextInput, "%{public}s - system input delegate is nil", methodName);
+        lastLoggingTimestamp = timestamp;
+    }
 }
 
 - (void)shiftKeyStateChangedFromState:(BEKeyModifierFlags)oldState toState:(BEKeyModifierFlags)newState


### PR DESCRIPTION
#### 1cac16a58aac599e2465832721a1dd10a483b0e0
<pre>
Add logging to help investigate issues where keyboard input fails to insert text on iOS 17.4
<a href="https://bugs.webkit.org/show_bug.cgi?id=268392">https://bugs.webkit.org/show_bug.cgi?id=268392</a>
<a href="https://rdar.apple.com/121665022">rdar://121665022</a>

Reviewed by Aditya Keerthi.

Try to zero in on cases where typing on the software keyboard fails to insert text in `WKWebView`,
by testing one of my current hypotheses that this happens when the `_asyncInputDelegate` is `nil`
when receiving calls to `-handleKeyEntry:withCompletionHandler:` and related methods.

Note that I&apos;m throttling these log messages to a maximum of just one every 10 seconds, to avoid
spamming log messages when typing, if the device is in state.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _deferKeyEventToInputMethodEditing:]):
(-[WKContentView _interpretKeyEvent:isCharEvent:]):
(-[WKContentView _logMissingSystemInputDelegateIfNeeded:]):

Canonical link: <a href="https://commits.webkit.org/273776@main">https://commits.webkit.org/273776@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d515fcfee55f53cf9c14a4c03f8e15dc2353878

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39289 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12648 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32395 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11490 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40534 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37429 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35541 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8307 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12648 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->