### PR TITLE
Convert IPC::Signal to the new IPC serialization format

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -378,6 +378,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     NetworkProcess/storage/FileSystemStorageError.serialization.in
 
     Platform/IPC/FormDataReference.serialization.in
+    Platform/IPC/IPCEvent.serialization.in
     Platform/IPC/IPCSemaphore.serialization.in
     Platform/IPC/ObjectIdentifierReference.serialization.in
     Platform/IPC/SharedBufferReference.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -150,6 +150,7 @@ $(PROJECT_DIR)/NetworkProcess/webrtc/NetworkRTCProvider.messages.in
 $(PROJECT_DIR)/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.in
 $(PROJECT_DIR)/NetworkProcess/webtransport/NetworkTransportSession.messages.in
 $(PROJECT_DIR)/Platform/IPC/FormDataReference.serialization.in
+$(PROJECT_DIR)/Platform/IPC/IPCEvent.serialization.in
 $(PROJECT_DIR)/Platform/IPC/IPCSemaphore.serialization.in
 $(PROJECT_DIR)/Platform/IPC/ObjectIdentifierReference.serialization.in
 $(PROJECT_DIR)/Platform/IPC/SharedBufferReference.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -508,6 +508,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.serialization.in \
 	NetworkProcess/storage/FileSystemStorageError.serialization.in \
 	Platform/IPC/FormDataReference.serialization.in \
+	Platform/IPC/IPCEvent.serialization.in \
 	Platform/IPC/IPCSemaphore.serialization.in \
 	Platform/IPC/ObjectIdentifierReference.serialization.in \
 	Platform/IPC/SharedBufferReference.serialization.in \

--- a/Source/WebKit/Platform/IPC/IPCEvent.h
+++ b/Source/WebKit/Platform/IPC/IPCEvent.h
@@ -49,30 +49,20 @@ public:
 
 #if PLATFORM(COCOA)
     void signal();
-    void encode(Encoder&) &&;
-    static std::optional<Signal> decode(Decoder&);
+
+    MachSendRight takeSendRight() { return WTFMove(m_sendRight); }
 #else
     void signal()
     {
         m_semaphore.signal();
     }
 
-    void encode(Encoder& encoder) &&
-    {
-        encoder << m_semaphore;
-    }
-
-    static std::optional<Signal> decode(Decoder& decoder)
-    {
-        std::optional<Semaphore> semaphore = decoder.decode<Semaphore>();
-        if (!semaphore)
-            return std::nullopt;
-
-        return Signal(WTFMove(*semaphore));
-    }
+    const Semaphore& semaphore() const { return m_semaphore; }
 #endif
 
 private:
+    friend struct IPC::ArgumentCoder<Signal, void>;
+
     friend std::optional<EventSignalPair> createEventSignalPair();
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/Platform/IPC/IPCEvent.serialization.in
+++ b/Source/WebKit/Platform/IPC/IPCEvent.serialization.in
@@ -1,0 +1,32 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+webkit_platform_header: "IPCEvent.h"
+
+[CustomHeader, RValue, WebKitPlatform] class IPC::Signal {
+#if PLATFORM(COCOA)
+    WTF::MachSendRight takeSendRight();
+#endif
+#if !PLATFORM(COCOA)
+    IPC::Semaphore semaphore();
+#endif
+}

--- a/Source/WebKit/Platform/IPC/darwin/IPCEventDarwin.cpp
+++ b/Source/WebKit/Platform/IPC/darwin/IPCEventDarwin.cpp
@@ -73,21 +73,6 @@ void Signal::signal()
         RELEASE_LOG_ERROR(Process, "IPC::Signal::signal Could not send mach message, error %x", ret);
 }
 
-void Signal::encode(Encoder& encoder) &&
-{
-    encoder << WTFMove(m_sendRight);
-}
-
-std::optional<Signal> Signal::decode(Decoder& decoder)
-{
-    std::optional<MachSendRight> sendRight;
-    decoder >> sendRight;
-    if (!sendRight)
-        return std::nullopt;
-
-    return Signal(WTFMove(*sendRight));
-}
-
 std::optional<EventSignalPair> createEventSignalPair()
 {
     // Create the listening port.

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5196,6 +5196,7 @@
 		46B0524522668D2400265B97 /* WebDeviceOrientationAndMotionAccessController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebDeviceOrientationAndMotionAccessController.cpp; sourceTree = "<group>"; };
 		46B2452428ECA335000A5925 /* WebScreenOrientationManagerProxyIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WebScreenOrientationManagerProxyIOS.mm; path = ios/WebScreenOrientationManagerProxyIOS.mm; sourceTree = "<group>"; };
 		46B9E2372B04228A008346A5 /* LoadParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = LoadParameters.serialization.in; sourceTree = "<group>"; };
+		46BB389C2B69764600F02BE0 /* IPCEvent.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = IPCEvent.serialization.in; sourceTree = "<group>"; };
 		46C392282316EC4D008EED9B /* WebPageProxyIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebPageProxyIdentifier.h; sourceTree = "<group>"; };
 		46C5B7CB27AADDBE000C5B47 /* RemoteWorkerLibWebRTCProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteWorkerLibWebRTCProvider.h; sourceTree = "<group>"; };
 		46C5B7CC27AADDBE000C5B47 /* RemoteWorkerFrameLoaderClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteWorkerFrameLoaderClient.cpp; sourceTree = "<group>"; };
@@ -9251,6 +9252,7 @@
 				465237FA2B055C41005B3097 /* FormDataReference.serialization.in */,
 				C0CE72AC1247E78D00BC0EC4 /* HandleMessage.h */,
 				A73E66BC2AB107BB005FC327 /* IPCEvent.h */,
+				46BB389C2B69764600F02BE0 /* IPCEvent.serialization.in */,
 				A31F60A225CC7DB800AF14F4 /* IPCSemaphore.h */,
 				46CD8C442B059FF500360248 /* IPCSemaphore.serialization.in */,
 				7B9FC5AC28A3B440007570E7 /* IPCUtilities.cpp */,

--- a/Tools/TestWebKitAPI/Tests/IPC/EventTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/EventTests.cpp
@@ -83,7 +83,6 @@ TEST_P(EventTestABBA, SerializeAndSignal)
         ASSERT_TRUE(openB());
 
         bClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
-            decoder.decode<uint64_t>();
             auto signal = decoder.decode<IPC::Signal>();
             signal->signal();
 
@@ -108,7 +107,6 @@ TEST_P(EventTestABBA, InterruptOnDestruct)
         ASSERT_TRUE(openB());
 
         bClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
-            decoder.decode<uint64_t>();
             {
                 auto signal = decoder.decode<IPC::Signal>();
             }


### PR DESCRIPTION
#### 4d873d064fe0dbd50803406b2ca406342951cf99
<pre>
Convert IPC::Signal to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=268393">https://bugs.webkit.org/show_bug.cgi?id=268393</a>

Reviewed by Matt Woodrow.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Platform/IPC/IPCEvent.h:
(IPC::Signal::takeSendRight):
(IPC::Signal::semaphore const):
(IPC::Signal::encode): Deleted.
(IPC::Signal::decode): Deleted.
* Source/WebKit/Platform/IPC/IPCEvent.serialization.in: Added.
* Source/WebKit/Platform/IPC/darwin/IPCEventDarwin.cpp:
(IPC::Signal::encode): Deleted.
(IPC::Signal::decode): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

* Tools/TestWebKitAPI/Tests/IPC/EventTests.cpp:
The test was encoding a single Signal object on sender side. However,
on recipient side, it was decoding first a uint64_t and then a Signal.
I have no idea why it was trying to decode that uint64_t given that we
don&apos;t send one. One of the tests started failing on iOS only when
decoding that uint64_t. As a result, I tried dropping the decoding of
this uint64_t in ALL the tests and they are all still passing.

Canonical link: <a href="https://commits.webkit.org/273956@main">https://commits.webkit.org/273956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0612ce0897c5872f80114d79573caeb502dee89e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39830 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13315 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31714 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32770 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11874 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11861 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41090 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33741 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33850 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37780 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12214 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35926 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/8422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12565 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4833 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->