### PR TITLE
Port FilterOperations to the new IPC serialization format

### DIFF
--- a/Source/WebCore/platform/graphics/filters/FilterOperations.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.h
@@ -37,7 +37,7 @@ class FilterOperations {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     FilterOperations() = default;
-    explicit FilterOperations(Vector<RefPtr<FilterOperation>>&&);
+    WEBCORE_EXPORT explicit FilterOperations(Vector<RefPtr<FilterOperation>>&&);
 
     WEBCORE_EXPORT bool operator==(const FilterOperations&) const;
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -434,33 +434,6 @@ bool ArgumentCoder<ResourceError>::decode(Decoder& decoder, ResourceError& resou
     return true;
 }
 
-#if !USE(COORDINATED_GRAPHICS)
-void ArgumentCoder<FilterOperations>::encode(Encoder& encoder, const FilterOperations& filters)
-{
-    encoder << static_cast<uint64_t>(filters.size());
-
-    for (const auto& filter : filters.operations())
-        encoder << *filter;
-}
-
-bool ArgumentCoder<FilterOperations>::decode(Decoder& decoder, FilterOperations& filters)
-{
-    uint64_t filterCount;
-    if (!decoder.decode(filterCount))
-        return false;
-
-    for (uint64_t i = 0; i < filterCount; ++i) {
-        std::optional<Ref<FilterOperation>> filter;
-        decoder >> filter;
-        if (!filter)
-            return false;
-        filters.operations().append(WTFMove(*filter));
-    }
-
-    return true;
-}
-#endif // !USE(COORDINATED_GRAPHICS)
-
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 void ArgumentCoder<MediaPlaybackTargetContext>::encode(Encoder& encoder, const MediaPlaybackTargetContext& target)
 {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -206,13 +206,6 @@ template<> struct ArgumentCoder<WebCore::CurlProxySettings> {
 };
 #endif
 
-#if !USE(COORDINATED_GRAPHICS)
-template<> struct ArgumentCoder<WebCore::FilterOperations> {
-    static void encode(Encoder&, const WebCore::FilterOperations&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::FilterOperations&);
-};
-#endif
-
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 template<> struct ArgumentCoder<WebCore::MediaPlaybackTargetContext> {
     static void encode(Encoder&, const WebCore::MediaPlaybackTargetContext&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6666,6 +6666,12 @@ struct WebCore::KeypressCommand {
 }
 #endif
 
+#if !USE(COORDINATED_GRAPHICS)
+class WebCore::FilterOperations {
+    Vector<RefPtr<WebCore::FilterOperation>> operations();
+}
+#endif // !USE(COORDINATED_GRAPHICS)
+
 [AdditionalEncoder=StreamConnectionEncoder, RefCounted] class WebCore::Filter subclasses {
     WebCore::CSSFilter
     WebCore::SVGFilter


### PR DESCRIPTION
#### aeb36164fa90220b4e475dbd364008e05e3a0cc3
<pre>
Port FilterOperations to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=268399">https://bugs.webkit.org/show_bug.cgi?id=268399</a>

Reviewed by Brent Fulgham.

* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;FilterOperations&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;FilterOperations&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/273853@main">https://commits.webkit.org/273853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd1adfc5c8466cedbbb3f84c2eb6ae6e51566efe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39296 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32841 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31448 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13132 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11498 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11507 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32680 "Found 1 new test failure: fullscreen/element-clear-during-fullscreen-crash.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40542 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33028 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37435 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35549 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13446 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12181 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4776 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12655 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->