### PR TITLE
[visionOS] Payment sheet not showing up when a view service tries to present it on a host application owned scene

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -418,7 +418,7 @@ private:
     IPC::Connection* paymentCoordinatorConnection(const WebPaymentCoordinatorProxy&) final;
     UIViewController *paymentCoordinatorPresentingViewController(const WebPaymentCoordinatorProxy&) final;
 #if ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
-    void getWindowSceneIdentifierForPaymentPresentation(WebPageProxyIdentifier, CompletionHandler<void(const String&)>&&) final;
+    void getWindowSceneAndBundleIdentifierForPaymentPresentation(WebPageProxyIdentifier, CompletionHandler<void(const String&, const String&)>&&) final;
 #endif
     const String& paymentCoordinatorBoundInterfaceIdentifier(const WebPaymentCoordinatorProxy&) final;
     const String& paymentCoordinatorCTDataConnectionServiceType(const WebPaymentCoordinatorProxy&) final;

--- a/Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
+++ b/Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
@@ -55,9 +55,9 @@ UIViewController *NetworkConnectionToWebProcess::paymentCoordinatorPresentingVie
 }
 
 #if ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
-void NetworkConnectionToWebProcess::getWindowSceneIdentifierForPaymentPresentation(WebPageProxyIdentifier webPageProxyIdentifier, CompletionHandler<void(const String&)>&& completionHandler)
+void NetworkConnectionToWebProcess::getWindowSceneAndBundleIdentifierForPaymentPresentation(WebPageProxyIdentifier webPageProxyIdentifier, CompletionHandler<void(const String&, const String&)>&& completionHandler)
 {
-    networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::GetWindowSceneIdentifierForPaymentPresentation(webPageProxyIdentifier), WTFMove(completionHandler));
+    networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::GetWindowSceneAndBundleIdentifierForPaymentPresentation(webPageProxyIdentifier), WTFMove(completionHandler));
 }
 #endif
 

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h
@@ -87,8 +87,9 @@ public:
 #if PLATFORM(IOS_FAMILY)
     virtual void present(UIViewController *, CompletionHandler<void(bool)>&&) = 0;
 #if ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
-    virtual void presentInScene(const String&, CompletionHandler<void(bool)>&&) = 0;
+    virtual void presentInScene(const String& sceneIdentifier, const String& bundleIdentifier, CompletionHandler<void(bool)>&&) = 0;
     const String& sceneIdentifier() const { return m_sceneIdentifier; }
+    const String& bundleIdentifier() const { return m_bundleIdentifier; }
 #endif
 #endif
 
@@ -102,6 +103,7 @@ protected:
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
     String m_sceneIdentifier;
+    String m_bundleIdentifier;
 #endif
 
 private:

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.h
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.h
@@ -50,7 +50,7 @@ private:
 #if PLATFORM(IOS_FAMILY)
     void present(UIViewController *, CompletionHandler<void(bool)>&&) final;
 #if ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
-    void presentInScene(const String&, CompletionHandler<void(bool)>&&) final;
+    void presentInScene(const String& sceneIdentifier, const String& bundleIdentifier, CompletionHandler<void(bool)>&&) final;
 #endif
 #endif
 

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.mm
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.mm
@@ -156,7 +156,7 @@ void PaymentAuthorizationViewController::present(UIViewController *presentingVie
 }
 
 #if ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
-void PaymentAuthorizationViewController::presentInScene(const String&, CompletionHandler<void(bool)>&& completionHandler)
+void PaymentAuthorizationViewController::presentInScene(const String&, const String&, CompletionHandler<void(bool)>&& completionHandler)
 {
     ASSERT_NOT_REACHED();
     completionHandler(false);

--- a/Source/WebKit/Platform/ios/PaymentAuthorizationController.h
+++ b/Source/WebKit/Platform/ios/PaymentAuthorizationController.h
@@ -47,7 +47,7 @@ private:
     void dismiss() final;
     void present(UIViewController *, CompletionHandler<void(bool)>&&) final;
 #if ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
-    void presentInScene(const String&, CompletionHandler<void(bool)>&&) final;
+    void presentInScene(const String& sceneIdentifier, const String& bundleIdentifier, CompletionHandler<void(bool)>&&) final;
 #endif
 
     RetainPtr<PKPaymentAuthorizationController> m_controller;

--- a/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
+++ b/Source/WebKit/Platform/ios/PaymentAuthorizationController.mm
@@ -121,7 +121,9 @@
 
 - (NSString *)presentationSceneBundleIdentifierForPaymentAuthorizationController:(PKPaymentAuthorizationController *)controller
 {
-    return nsStringNilIfEmpty(WebCore::applicationBundleIdentifier());
+    if (!_presenter)
+        return WebCore::applicationBundleIdentifier();
+    return nsStringNilIfEmpty(_presenter->bundleIdentifier());
 }
 #endif
 
@@ -167,9 +169,10 @@ void PaymentAuthorizationController::present(UIViewController *, CompletionHandl
 }
 
 #if ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
-void PaymentAuthorizationController::presentInScene(const String& sceneIdentifier, CompletionHandler<void(bool)>&& completionHandler)
+void PaymentAuthorizationController::presentInScene(const String& sceneIdentifier, const String& bundleIdentifier, CompletionHandler<void(bool)>&& completionHandler)
 {
     m_sceneIdentifier = sceneIdentifier;
+    m_bundleIdentifier = bundleIdentifier;
     present(nil, WTFMove(completionHandler));
 }
 #endif

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
@@ -92,7 +92,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
         virtual UIViewController *paymentCoordinatorPresentingViewController(const WebPaymentCoordinatorProxy&) = 0;
 #if ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
-        virtual void getWindowSceneIdentifierForPaymentPresentation(WebPageProxyIdentifier, CompletionHandler<void(const String&)>&&) = 0;
+        virtual void getWindowSceneAndBundleIdentifierForPaymentPresentation(WebPageProxyIdentifier, CompletionHandler<void(const String&, const String&)>&&) = 0;
 #endif
         virtual const String& paymentCoordinatorCTDataConnectionServiceType(const WebPaymentCoordinatorProxy&) = 0;
         virtual std::unique_ptr<PaymentAuthorizationPresenter> paymentCoordinatorAuthorizationPresenter(WebPaymentCoordinatorProxy&, PKPaymentRequest *) = 0;

--- a/Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm
+++ b/Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm
@@ -55,7 +55,7 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
         return completionHandler(false);
 
 #if ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
-    m_client.getWindowSceneIdentifierForPaymentPresentation(webPageProxyID, [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](const String& sceneID) mutable {
+    m_client.getWindowSceneAndBundleIdentifierForPaymentPresentation(webPageProxyID, [weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](const String& sceneIdentifier, const String& bundleIdentifier) mutable {
         if (!weakThis) {
             completionHandler(false);
             return;
@@ -66,7 +66,7 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
             return;
         }
 
-        weakThis->m_authorizationPresenter->presentInScene(sceneID, WTFMove(completionHandler));
+        weakThis->m_authorizationPresenter->presentInScene(sceneIdentifier, bundleIdentifier, WTFMove(completionHandler));
     });
 #else
     UNUSED_PARAM(webPageProxyID);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -241,6 +241,7 @@ struct UIEdgeInsets;
 - (UIViewController *)_webView:(WKWebView *)webView previewViewControllerForAnimatedImageAtURL:(NSURL *)url defaultActions:(NSArray<_WKElementAction *> *)actions elementInfo:(_WKActivatedElementInfo *)elementInfo imageSize:(CGSize)imageSize WK_API_DEPRECATED_WITH_REPLACEMENT("webView:contextMenuConfigurationForElement:completionHandler:", ios(9.0, 13.0));
 - (UIViewController *)_presentingViewControllerForWebView:(WKWebView *)webView WK_API_AVAILABLE(ios(10.0));
 - (NSString *)_hostSceneIdentifierForWebView:(WKWebView *)webView WK_API_AVAILABLE(ios(WK_IOS_TBA));
+- (NSString *)_hostSceneBundleIdentifierForWebView:(WKWebView *)webView WK_API_AVAILABLE(ios(WK_IOS_TBA));
 - (void)_webView:(WKWebView *)webView getAlternateURLFromImage:(UIImage *)image completionHandler:(void (^)(NSURL *alternateURL, NSDictionary *userInfo))completionHandler WK_API_AVAILABLE(ios(11.0));
 - (NSURL *)_webView:(WKWebView *)webView alternateURLFromImage:(UIImage *)image userInfo:(NSDictionary **)userInfo WK_API_AVAILABLE(ios(11.0));
 - (UIViewController *)_webView:(WKWebView *)webView previewViewControllerForImage:(UIImage *)image alternateURL:(NSURL *)url defaultActions:(NSArray<_WKElementAction *> *)actions elementInfo:(_WKActivatedElementInfo *)elementInfo WK_API_DEPRECATED_WITH_REPLACEMENT("webView:contextMenuConfigurationForElement:completionHandler:", ios(11.0, 13.0));

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1302,18 +1302,6 @@ void NetworkProcessProxy::setManagedDomainsForResourceLoadStatistics(PAL::Sessio
 }
 #endif
 
-#if ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
-void NetworkProcessProxy::getWindowSceneIdentifierForPaymentPresentation(WebPageProxyIdentifier webPageProxyIdentifier, CompletionHandler<void(const String&)>&& completionHandler)
-{
-    auto page = WebProcessProxy::webPage(webPageProxyIdentifier);
-    if (!page) {
-        completionHandler(nullString());
-        return;
-    }
-    completionHandler(page->pageClient().sceneID());
-}
-#endif
-
 void NetworkProcessProxy::setShouldDowngradeReferrerForTesting(bool enabled, CompletionHandler<void()>&& completionHandler)
 {
     if (!canSendMessage()) {

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -281,7 +281,7 @@ public:
 #endif
 
 #if ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
-    void getWindowSceneIdentifierForPaymentPresentation(WebPageProxyIdentifier, CompletionHandler<void(const String&)>&&);
+    void getWindowSceneAndBundleIdentifierForPaymentPresentation(WebPageProxyIdentifier, CompletionHandler<void(const String&, const String&)>&&);
 #endif
     // ProcessThrottlerClient
     void sendPrepareToSuspend(IsSuspensionImminent, double remainingRunTime, CompletionHandler<void()>&&) final;

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
@@ -82,7 +82,7 @@ messages -> NetworkProcessProxy LegacyReceiver {
 #endif
 
 #if ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
-    GetWindowSceneIdentifierForPaymentPresentation(WebKit::WebPageProxyIdentifier webPageProxyIdentifier) -> (String sceneID)
+    GetWindowSceneAndBundleIdentifierForPaymentPresentation(WebKit::WebPageProxyIdentifier webPageProxyIdentifier) -> (String sceneIdentifier, String bundleIdentifier)
 #endif
 
     DataTaskReceivedChallenge(WebKit::DataTaskIdentifier identifier, WebCore::AuthenticationChallenge challenge) -> (enum:uint8_t WebKit::AuthenticationChallengeDisposition disposition, WebCore::Credential credential)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm
@@ -28,7 +28,12 @@
 
 #import "LaunchServicesDatabaseXPCConstants.h"
 #import "NetworkProcessMessages.h"
+#import "PageClient.h"
+#import "WKUIDelegatePrivate.h"
+#import "WKWebViewInternal.h"
+#import "WebPageProxy.h"
 #import "WebProcessPool.h"
+#import "WebProcessProxy.h"
 #import "XPCEndpoint.h"
 #import <wtf/EnumTraits.h>
 
@@ -121,6 +126,29 @@ void NetworkProcessProxy::setBackupExclusionPeriodForTesting(PAL::SessionID sess
     sendWithAsyncReply(Messages::NetworkProcess::SetBackupExclusionPeriodForTesting(sessionID, period), WTFMove(completionHandler));
 }
 
+#endif
+
+#if ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
+void NetworkProcessProxy::getWindowSceneAndBundleIdentifierForPaymentPresentation(WebPageProxyIdentifier webPageProxyIdentifier, CompletionHandler<void(const String&, const String&)>&& completionHandler)
+{
+    auto sceneIdentifier = nullString();
+    auto bundleIdentifier = WebCore::applicationBundleIdentifier();
+    auto page = WebProcessProxy::webPage(webPageProxyIdentifier);
+    if (!page) {
+        completionHandler(sceneIdentifier, bundleIdentifier);
+        return;
+    }
+
+    sceneIdentifier = page->pageClient().sceneID();
+    RetainPtr<WKWebView> webView = page->cocoaView();
+    id webViewUIDelegate = [webView UIDelegate];
+    if ([webViewUIDelegate respondsToSelector:@selector(_hostSceneIdentifierForWebView:)])
+        sceneIdentifier = [webViewUIDelegate _hostSceneIdentifierForWebView:webView.get()];
+    if ([webViewUIDelegate respondsToSelector:@selector(_hostSceneBundleIdentifierForWebView:)])
+        bundleIdentifier = [webViewUIDelegate _hostSceneBundleIdentifierForWebView:webView.get()];
+
+    completionHandler(sceneIdentifier, bundleIdentifier);
+}
 #endif
 
 }

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -341,7 +341,7 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
     std::unique_ptr<PaymentAuthorizationPresenter> paymentCoordinatorAuthorizationPresenter(WebPaymentCoordinatorProxy&, PKPaymentRequest *) final;
 #endif
 #if ENABLE(APPLE_PAY) && PLATFORM(IOS_FAMILY) && ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
-    void getWindowSceneIdentifierForPaymentPresentation(WebPageProxyIdentifier, CompletionHandler<void(const String&)>&&) final;
+    void getWindowSceneAndBundleIdentifierForPaymentPresentation(WebPageProxyIdentifier, CompletionHandler<void(const String&, const String&)>&&) final;
 #endif
 #if ENABLE(APPLE_PAY) && PLATFORM(MAC)
     NSWindow *paymentCoordinatorPresentingWindow(const WebPaymentCoordinatorProxy&) final;

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1320,10 +1320,10 @@ const String& WebPageProxy::Internals::paymentCoordinatorCTDataConnectionService
 
 #if ENABLE(APPLE_PAY) && ENABLE(APPLE_PAY_REMOTE_UI_USES_SCENE)
 
-void WebPageProxy::Internals::getWindowSceneIdentifierForPaymentPresentation(WebPageProxyIdentifier, CompletionHandler<void(const String&)>&& completionHandler)
+void WebPageProxy::Internals::getWindowSceneAndBundleIdentifierForPaymentPresentation(WebPageProxyIdentifier, CompletionHandler<void(const String&, const String&)>&& completionHandler)
 {
     ASSERT_NOT_REACHED();
-    completionHandler(nullString());
+    completionHandler(nullString(), nullString());
 }
 
 #endif


### PR DESCRIPTION
#### d9d8f6844b91cd29bf8f8b0182f08a53364ae0a9
<pre>
[visionOS] Payment sheet not showing up when a view service tries to present it on a host application owned scene
<a href="https://bugs.webkit.org/show_bug.cgi?id=268400">https://bugs.webkit.org/show_bug.cgi?id=268400</a>
<a href="https://rdar.apple.com/121673521">rdar://121673521</a>

Reviewed by Tim Horton.

PKPaymentAuthorizationController needs to be vended a scene ID and bundle
ID pair that correspond to each other for it to successfully present a
payment sheet on a scene. Unfortunately, when there is an embedded view
service in a host application, we:

1. Supply a bogus scene ID because view services don&apos;t have an associated
scene ID.
2. Supply the bundle identifier of the view service and not the hosting
application, which actually owns the scene to be presented in.

To address (1), we consult `-[WKUIDelegatePrivate _hostSceneBundleIdentifierForWebView:]`
when we fetch a scene identifier for payment presentation. This ensures
that we supply the _host_ scene identifier to PKPaymentAuthorizationController,
where it can actually present a payment sheet.

However, since we don&apos;t provide the bundle identifier of the host
application, we&apos;re still supplying a mismatching scene/bundle ID pair, so
the controller can&apos;t present a payment sheet successfully. This is
resolved by addressing (2), for which we introduce a new
WKUIDelegatePrivate method `_hostSceneBundleIdentifierForWebView:`. We
consult this when we fetch a bundle identifier for payment presentation,
ensuring that we supply the bundle identifier corresponding to the _host_
application that owns the scene where we would like to present a payment
sheet.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm:
(WebKit::NetworkConnectionToWebProcess::getWindowSceneAndBundleIdentifierForPaymentPresentation):
(WebKit::NetworkConnectionToWebProcess::getWindowSceneIdentifierForPaymentPresentation): Deleted.
* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h:
(WebKit::PaymentAuthorizationPresenter::bundleIdentifier const):
* Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.h:
* Source/WebKit/Platform/cocoa/PaymentAuthorizationViewController.mm:
(WebKit::PaymentAuthorizationViewController::presentInScene):
* Source/WebKit/Platform/ios/PaymentAuthorizationController.h:
* Source/WebKit/Platform/ios/PaymentAuthorizationController.mm:
(-[WKPaymentAuthorizationControllerDelegate presentationSceneBundleIdentifierForPaymentAuthorizationController:]):
(WebKit::PaymentAuthorizationController::presentInScene):
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h:
* Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm:
(WebKit::WebPaymentCoordinatorProxy::platformShowPaymentUI):
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::getWindowSceneIdentifierForPaymentPresentation): Deleted.
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in:
* Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm:
(WebKit::NetworkProcessProxy::getWindowSceneAndBundleIdentifierForPaymentPresentation):
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::Internals::getWindowSceneAndBundleIdentifierForPaymentPresentation):
(WebKit::WebPageProxy::Internals::getWindowSceneIdentifierForPaymentPresentation): Deleted.

Canonical link: <a href="https://commits.webkit.org/273801@main">https://commits.webkit.org/273801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaa2cbfb36a9607e8a400d4e043a37d4e1a9416b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39301 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32845 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31449 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11500 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11511 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40547 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33202 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37439 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35555 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13450 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8319 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12660 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->