### PR TITLE
Generate Serialization for

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -375,6 +375,7 @@ set(WebKit_SERIALIZATION_IN_FILES
 
     Platform/IPC/FormDataReference.serialization.in
     Platform/IPC/IPCSemaphore.serialization.in
+    Platform/IPC/ObjectIdentifierReference.serialization.in
     Platform/IPC/SharedBufferReference.serialization.in
     Platform/IPC/SharedFileHandle.serialization.in
     Platform/IPC/StreamServerConnection.serialization.in

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -413,6 +413,7 @@ set(WebKit_SERIALIZATION_IN_FILES
     Shared/LocalFrameCreationParameters.serialization.in
     Shared/MediaPlaybackState.serialization.in
     Shared/Model.serialization.in
+    Shared/MonotonicObjectIdentifier.serialization.in
     Shared/NavigationActionData.serialization.in
     Shared/NetworkProcessConnectionParameters.serialization.in
     Shared/Pasteboard.serialization.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -286,6 +286,7 @@ $(PROJECT_DIR)/Shared/LoadParameters.serialization.in
 $(PROJECT_DIR)/Shared/LocalFrameCreationParameters.serialization.in
 $(PROJECT_DIR)/Shared/MediaPlaybackState.serialization.in
 $(PROJECT_DIR)/Shared/Model.serialization.in
+$(PROJECT_DIR)/Shared/MonotonicObjectIdentifier.serialization.in
 $(PROJECT_DIR)/Shared/NavigationActionData.serialization.in
 $(PROJECT_DIR)/Shared/NetworkProcessConnectionParameters.serialization.in
 $(PROJECT_DIR)/Shared/Notifications/NotificationManagerMessageHandler.messages.in

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -148,6 +148,7 @@ $(PROJECT_DIR)/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.messages.i
 $(PROJECT_DIR)/NetworkProcess/webtransport/NetworkTransportSession.messages.in
 $(PROJECT_DIR)/Platform/IPC/FormDataReference.serialization.in
 $(PROJECT_DIR)/Platform/IPC/IPCSemaphore.serialization.in
+$(PROJECT_DIR)/Platform/IPC/ObjectIdentifierReference.serialization.in
 $(PROJECT_DIR)/Platform/IPC/SharedBufferReference.serialization.in
 $(PROJECT_DIR)/Platform/IPC/SharedFileHandle.serialization.in
 $(PROJECT_DIR)/Platform/IPC/StreamServerConnection.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -501,6 +501,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	NetworkProcess/storage/FileSystemStorageError.serialization.in \
 	Platform/IPC/FormDataReference.serialization.in \
 	Platform/IPC/IPCSemaphore.serialization.in \
+	Platform/IPC/ObjectIdentifierReference.serialization.in \
 	Platform/IPC/SharedBufferReference.serialization.in \
 	Platform/IPC/SharedFileHandle.serialization.in \
 	Platform/IPC/StreamServerConnection.serialization.in \

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -606,6 +606,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/LocalFrameCreationParameters.serialization.in \
 	Shared/MediaPlaybackState.serialization.in \
 	Shared/Model.serialization.in \
+	Shared/MonotonicObjectIdentifier.serialization.in \
 	Shared/NavigationActionData.serialization.in \
 	Shared/NetworkProcessConnectionParameters.serialization.in \
 	Shared/Pasteboard.serialization.in \

--- a/Source/WebKit/Platform/IPC/ObjectIdentifierReference.serialization.in
+++ b/Source/WebKit/Platform/IPC/ObjectIdentifierReference.serialization.in
@@ -1,0 +1,65 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+additional_forward_declaration: namespace IPC { template<typename> class ObjectIdentifierReference; }
+additional_forward_declaration: namespace IPC { template<typename> class ObjectIdentifierWriteReference; }
+additional_forward_declaration: namespace WebCore { using RenderingResourceIdentifier = AtomicObjectIdentifier<RenderingResourceIdentifierType>; }
+additional_forward_declaration: namespace WebKit { using RemoteVideoFrameIdentifier = AtomicObjectIdentifier<RemoteVideoFrameIdentifierType>; }
+additional_forward_declaration: namespace WebKit { using RemoteSerializedImageBufferIdentifier = WebCore::RenderingResourceIdentifier; }
+additional_forward_declaration: namespace TestWebKitAPI { using TestedObjectIdentifier = AtomicObjectIdentifier<TestedObjectIdentifierType>; }
+
+header: "RemoteVideoFrameIdentifier.h"
+[Alias=class IPC::ObjectIdentifierReference<RemoteVideoFrameIdentifier>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias WebKit::RemoteVideoFrameReference {
+    WebKit::RemoteVideoFrameIdentifier identifier();
+    uint64_t version();
+};
+
+header: "RemoteVideoFrameIdentifier.h"
+[Alias=class IPC::ObjectIdentifierWriteReference<RemoteVideoFrameIdentifier>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias WebKit::RemoteVideoFrameWriteReference {
+    IPC::ObjectIdentifierReference<WebKit::RemoteVideoFrameIdentifier> reference();
+    uint64_t pendingReads();
+};
+
+header: "RemoteSerializedImageBufferIdentifier.h"
+[Alias=class IPC::ObjectIdentifierReference<RemoteSerializedImageBufferIdentifier>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias WebKit::RemoteSerializedImageBufferReference {
+    WebKit::RemoteSerializedImageBufferIdentifier identifier();
+    uint64_t version();
+};
+
+header: "RemoteSerializedImageBufferIdentifier.h"
+[Alias=class IPC::ObjectIdentifierWriteReference<RemoteSerializedImageBufferIdentifier>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias WebKit::RemoteSerializedImageBufferWriteReference {
+    IPC::ObjectIdentifierReference<WebKit::RemoteSerializedImageBufferIdentifier> reference();
+    uint64_t pendingReads();
+};
+
+header: "ThreadSafeObjectHeap.h"
+[Alias=class IPC::ObjectIdentifierReference<TestedObjectIdentifier>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias TestWebKitAPI::TestedObjectReference {
+    TestWebKitAPI::TestedObjectIdentifier identifier();
+    uint64_t version();
+};
+
+header: "ThreadSafeObjectHeap.h"
+[Alias=class IPC::ObjectIdentifierWriteReference<TestedObjectIdentifier>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias TestWebKitAPI::TestedObjectWriteReference {
+    IPC::ObjectIdentifierReference<TestWebKitAPI::TestedObjectIdentifier> reference();
+    uint64_t pendingReads();
+};

--- a/Source/WebKit/Platform/IPC/ObjectIdentifierReferenceTracker.h
+++ b/Source/WebKit/Platform/IPC/ObjectIdentifierReferenceTracker.h
@@ -60,21 +60,6 @@ public:
     {
         return m_identifier.isHashTableDeletedValue();
     }
-    template<typename Encoder> void encode(Encoder& encoder) const
-    {
-        encoder << m_identifier;
-        encoder << m_version;
-    }
-    template<typename Decoder> static std::optional<ObjectIdentifierReference> decode(Decoder& decoder)
-    {
-        std::optional<T> identifier;
-        std::optional<uint64_t> version;
-        decoder >> identifier
-            >> version;
-        if (!decoder.isValid())
-            return std::nullopt;
-        return ObjectIdentifierReference { WTFMove(*identifier), *version };
-    }
 private:
     T m_identifier;
     uint64_t m_version { 0 };
@@ -124,23 +109,6 @@ public:
     uint64_t pendingReads() const { return m_pendingReads; }
     Reference reference() const { return m_reference; }
     ObjectIdentifierReference<T> retiredReference() const { return { identifier(), version() + 1 }; }
-
-    template<typename Encoder> void encode(Encoder& encoder) const
-    {
-        encoder << m_reference;
-        encoder << m_pendingReads;
-    }
-    template<typename Decoder> static std::optional<ObjectIdentifierWriteReference> decode(Decoder& decoder)
-    {
-        std::optional<Reference> reference;
-        std::optional<uint64_t> pendingReads;
-
-        decoder >> reference
-            >> pendingReads;
-        if (!decoder.isValid())
-            return std::nullopt;
-        return ObjectIdentifierWriteReference { WTFMove(*reference), *pendingReads };
-    }
 
 private:
     Reference m_reference;

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -39,6 +39,7 @@
 #include "HeaderWithoutCondition"
 #include "LayerProperties.h"
 #include "RValueWithFunctionCalls.h"
+#include "RemoteVideoFrameIdentifier.h"
 #if ENABLE(TEST_FEATURE)
 #include "SecondMemberType.h"
 #endif
@@ -1250,6 +1251,70 @@ std::optional<WebKit::RValueWithFunctionCalls> ArgumentCoder<WebKit::RValueWithF
     return {
         WebKit::RValueWithFunctionCalls {
             WTFMove(*callFunction)
+        }
+    };
+}
+
+void ArgumentCoder<WebKit::RemoteVideoFrameReference>::encode(Encoder& encoder, const WebKit::RemoteVideoFrameReference& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.identifier())>, WebKit::RemoteVideoFrameIdentifier>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.version())>, uint64_t>);
+
+    encoder << instance.identifier();
+    encoder << instance.version();
+}
+
+void ArgumentCoder<WebKit::RemoteVideoFrameReference>::encode(StreamConnectionEncoder& encoder, const WebKit::RemoteVideoFrameReference& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.identifier())>, WebKit::RemoteVideoFrameIdentifier>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.version())>, uint64_t>);
+
+    encoder << instance.identifier();
+    encoder << instance.version();
+}
+
+std::optional<WebKit::RemoteVideoFrameReference> ArgumentCoder<WebKit::RemoteVideoFrameReference>::decode(Decoder& decoder)
+{
+    auto identifier = decoder.decode<WebKit::RemoteVideoFrameIdentifier>();
+    auto version = decoder.decode<uint64_t>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return {
+        WebKit::RemoteVideoFrameReference {
+            WTFMove(*identifier),
+            WTFMove(*version)
+        }
+    };
+}
+
+void ArgumentCoder<WebKit::RemoteVideoFrameWriteReference>::encode(Encoder& encoder, const WebKit::RemoteVideoFrameWriteReference& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.reference())>, IPC::ObjectIdentifierReference<WebKit::RemoteVideoFrameIdentifier>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.pendingReads())>, uint64_t>);
+
+    encoder << instance.reference();
+    encoder << instance.pendingReads();
+}
+
+void ArgumentCoder<WebKit::RemoteVideoFrameWriteReference>::encode(StreamConnectionEncoder& encoder, const WebKit::RemoteVideoFrameWriteReference& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.reference())>, IPC::ObjectIdentifierReference<WebKit::RemoteVideoFrameIdentifier>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.pendingReads())>, uint64_t>);
+
+    encoder << instance.reference();
+    encoder << instance.pendingReads();
+}
+
+std::optional<WebKit::RemoteVideoFrameWriteReference> ArgumentCoder<WebKit::RemoteVideoFrameWriteReference>::decode(Decoder& decoder)
+{
+    auto reference = decoder.decode<IPC::ObjectIdentifierReference<WebKit::RemoteVideoFrameIdentifier>>();
+    auto pendingReads = decoder.decode<uint64_t>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return {
+        WebKit::RemoteVideoFrameWriteReference {
+            WTFMove(*reference),
+            WTFMove(*pendingReads)
         }
     };
 }

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -71,8 +71,6 @@ class CreateUsingClass;
 namespace WebCore {
 class InheritsFrom;
 class InheritanceGrandchild;
-template<typename, typename> class ScrollSnapOffsetsInfo;
-using FloatBoxExtent = ScrollSnapOffsetsInfo<float, double>;
 class TimingFunction;
 class MoveOnlyBaseClass;
 class MoveOnlyDerivedClass;
@@ -109,6 +107,19 @@ struct RequestEncodedWithBodyRValue;
 #if USE(CFBAR)
 typedef struct __CFBar * CFBarRef;
 #endif
+namespace IPC { template<typename> class ObjectIdentifierReference; };
+namespace IPC { template<typename> class ObjectIdentifierWriteReference; };
+namespace WebKit { using RemoteVideoFrameIdentifier = AtomicObjectIdentifier<RemoteVideoFrameIdentifierType>; };
+namespace WebCore {
+template<typename, typename> class ScrollSnapOffsetsInfo;
+using FloatBoxExtent = ScrollSnapOffsetsInfo<float, double>;
+}
+namespace WebKit {
+using RemoteVideoFrameReference = IPC::ObjectIdentifierReference<RemoteVideoFrameIdentifier>;
+}
+namespace WebKit {
+using RemoteVideoFrameWriteReference = IPC::ObjectIdentifierWriteReference<RemoteVideoFrameIdentifier>;
+}
 
 namespace IPC {
 
@@ -318,6 +329,18 @@ template<> struct ArgumentCoder<RetainPtr<CFBarRef>> {
 template<> struct ArgumentCoder<WebKit::RValueWithFunctionCalls> {
     static void encode(Encoder&, WebKit::RValueWithFunctionCalls&&);
     static std::optional<WebKit::RValueWithFunctionCalls> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebKit::RemoteVideoFrameReference> {
+    static void encode(Encoder&, const WebKit::RemoteVideoFrameReference&);
+    static void encode(StreamConnectionEncoder&, const WebKit::RemoteVideoFrameReference&);
+    static std::optional<WebKit::RemoteVideoFrameReference> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebKit::RemoteVideoFrameWriteReference> {
+    static void encode(Encoder&, const WebKit::RemoteVideoFrameWriteReference&);
+    static void encode(StreamConnectionEncoder&, const WebKit::RemoteVideoFrameWriteReference&);
+    static std::optional<WebKit::RemoteVideoFrameWriteReference> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -40,6 +40,7 @@
 #include "LayerProperties.h"
 #include "PlatformClass.h"
 #include "RValueWithFunctionCalls.h"
+#include "RemoteVideoFrameIdentifier.h"
 #if ENABLE(TEST_FEATURE)
 #include "SecondMemberType.h"
 #endif
@@ -438,6 +439,26 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             {
                 "SandboxExtensionHandle"_s,
                 "callFunction()"_s
+            },
+        } },
+        { "WebKit::RemoteVideoFrameReference"_s, {
+            {
+                "WebKit::RemoteVideoFrameIdentifier"_s,
+                "identifier()"_s
+            },
+            {
+                "uint64_t"_s,
+                "version()"_s
+            },
+        } },
+        { "WebKit::RemoteVideoFrameWriteReference"_s, {
+            {
+                "IPC::ObjectIdentifierReference<WebKit::RemoteVideoFrameIdentifier>"_s,
+                "reference()"_s
+            },
+            {
+                "uint64_t"_s,
+                "pendingReads()"_s
             },
         } },
         { "WebCore::SharedStringHash"_s, {

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -274,3 +274,20 @@ additional_forward_declaration: typedef struct __CFBar * CFBarRef
 [RValue] class WebKit::RValueWithFunctionCalls {
     SandboxExtensionHandle callFunction()
 }
+
+
+additional_forward_declaration: namespace IPC { template<typename> class ObjectIdentifierReference; }
+additional_forward_declaration: namespace IPC { template<typename> class ObjectIdentifierWriteReference; }
+additional_forward_declaration: namespace WebKit { using RemoteVideoFrameIdentifier = AtomicObjectIdentifier<RemoteVideoFrameIdentifierType>; }
+
+header: "RemoteVideoFrameIdentifier.h"
+[Alias=class IPC::ObjectIdentifierReference<RemoteVideoFrameIdentifier>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias WebKit::RemoteVideoFrameReference {
+    WebKit::RemoteVideoFrameIdentifier identifier();
+    uint64_t version();
+};
+
+header: "RemoteVideoFrameIdentifier.h"
+[Alias=class IPC::ObjectIdentifierWriteReference<RemoteVideoFrameIdentifier>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias WebKit::RemoteVideoFrameWriteReference {
+    IPC::ObjectIdentifierReference<WebKit::RemoteVideoFrameIdentifier> reference();
+    uint64_t pendingReads();
+};

--- a/Source/WebKit/Shared/MonotonicObjectIdentifier.h
+++ b/Source/WebKit/Shared/MonotonicObjectIdentifier.h
@@ -29,6 +29,8 @@
 #include <wtf/HashTraits.h>
 #include <wtf/text/TextStream.h>
 #include <wtf/text/WTFString.h>
+#include <wtf/ArgumentCoder.h>
+
 
 namespace WebKit {
 
@@ -44,21 +46,6 @@ public:
     { }
 
     bool isHashTableDeletedValue() const { return m_identifier == hashTableDeletedValue(); }
-
-    template<typename Encoder> void encode(Encoder& encoder) const
-    {
-        ASSERT(isValidIdentifier(m_identifier));
-        encoder << m_identifier;
-    }
-    template<typename Decoder> static std::optional<MonotonicObjectIdentifier> decode(Decoder& decoder)
-    {
-        std::optional<uint64_t> identifier;
-        decoder >> identifier;
-        if (!identifier)
-            return std::nullopt;
-        ASSERT(isValidIdentifier(*identifier));
-        return MonotonicObjectIdentifier { *identifier };
-    }
 
     friend bool operator==(MonotonicObjectIdentifier, MonotonicObjectIdentifier) = default;
 
@@ -102,6 +89,7 @@ public:
     }
 
 private:
+    friend struct IPC::ArgumentCoder<MonotonicObjectIdentifier, void>;
     template<typename U> friend MonotonicObjectIdentifier<U> makeMonotonicObjectIdentifier(uint64_t);
     friend struct HashTraits<MonotonicObjectIdentifier>;
     template<typename U> friend struct MonotonicObjectIdentifierHash;

--- a/Source/WebKit/Shared/MonotonicObjectIdentifier.serialization.in
+++ b/Source/WebKit/Shared/MonotonicObjectIdentifier.serialization.in
@@ -1,0 +1,41 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+additional_forward_declaration: namespace WebKit { struct EditorStateIdentifierType; }
+additional_forward_declaration: namespace WebKit { struct RenderingUpdateIDType; }
+additional_forward_declaration: namespace WebKit { struct TransactionIDType; }
+
+header: "MonotonicObjectIdentifier.h"
+[Alias=class MonotonicObjectIdentifier<EditorStateIdentifierType>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias WebKit::EditorStateIdentifier {
+    [Validator='WebKit::MonotonicObjectIdentifier<WebKit::EditorStateIdentifierType>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64();
+};
+
+header: "MonotonicObjectIdentifier.h"
+[Alias=class MonotonicObjectIdentifier<RenderingUpdateIDType>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias WebKit::RenderingUpdateID {
+    [Validator='WebKit::MonotonicObjectIdentifier<WebKit::RenderingUpdateIDType>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64();
+};
+
+header: "MonotonicObjectIdentifier.h"
+[Alias=class MonotonicObjectIdentifier<TransactionIDType>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias WebKit::TransactionID {
+    [Validator='WebKit::MonotonicObjectIdentifier<WebKit::TransactionIDType>::isValidIdentifier(*toUInt64)'] uint64_t toUInt64();
+};

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -191,6 +191,7 @@ template: enum class WebKit::VideoDecoderIdentifierType
 template: enum class WebKit::VideoEncoderIdentifierType
 template: enum class WebKit::WCContentBufferIdentifierType
 template: enum class WebKit::WebGPUIdentifierType
+template: enum class TestWebKitAPI::TestedObjectIdentifierType
 template: struct IPC::AsyncReplyIDType
 template: struct WebCore::WebSocketFrame
 template: struct WebKit::ConnectionAsyncReplyHandler

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4895,6 +4895,7 @@
 		3AF5B4732A244FDC004C3D4D /* RemoteGraphicsContextGLProxyMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGLProxyMessages.h; sourceTree = "<group>"; };
 		3AF5B4742A244FDD004C3D4D /* RemoteGraphicsContextGLProxyMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteGraphicsContextGLProxyMessageReceiver.cpp; sourceTree = "<group>"; };
 		3CAECB5E27465AE300AB78D0 /* UnifiedSource113.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource113.cpp; sourceTree = "<group>"; };
+		3D3C75952B6452300013828A /* ObjectIdentifierReference.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ObjectIdentifierReference.serialization.in; sourceTree = "<group>"; };
 		3F418EF51887BD97002795FD /* VideoPresentationManagerMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoPresentationManagerMessageReceiver.cpp; sourceTree = "<group>"; };
 		3F418EF61887BD97002795FD /* VideoPresentationManagerMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoPresentationManagerMessages.h; sourceTree = "<group>"; };
 		3F418EF71887BD97002795FD /* VideoPresentationManagerProxyMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoPresentationManagerProxyMessageReceiver.cpp; sourceTree = "<group>"; };
@@ -9241,6 +9242,7 @@
 				1AAB0377185A7C6A00EDF501 /* MessageSender.cpp */,
 				1AAB0378185A7C6A00EDF501 /* MessageSender.h */,
 				93A7081029BE7D2F006CAA2D /* MessageSenderInlines.h */,
+				3D3C75952B6452300013828A /* ObjectIdentifierReference.serialization.in */,
 				7B5A3DC527AE501A006C6F97 /* ObjectIdentifierReferenceTracker.h */,
 				7BE9326227F5C75A00D5FEFB /* ReceiverMatcher.h */,
 				7BAB110F25DD02B2008FC479 /* ScopedActiveMessageReceiveQueue.h */,

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4896,6 +4896,7 @@
 		3AF5B4742A244FDD004C3D4D /* RemoteGraphicsContextGLProxyMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteGraphicsContextGLProxyMessageReceiver.cpp; sourceTree = "<group>"; };
 		3CAECB5E27465AE300AB78D0 /* UnifiedSource113.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource113.cpp; sourceTree = "<group>"; };
 		3D3C75952B6452300013828A /* ObjectIdentifierReference.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ObjectIdentifierReference.serialization.in; sourceTree = "<group>"; };
+		3D3C75A22B6875120013828A /* MonotonicObjectIdentifier.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = MonotonicObjectIdentifier.serialization.in; sourceTree = "<group>"; };
 		3F418EF51887BD97002795FD /* VideoPresentationManagerMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoPresentationManagerMessageReceiver.cpp; sourceTree = "<group>"; };
 		3F418EF61887BD97002795FD /* VideoPresentationManagerMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoPresentationManagerMessages.h; sourceTree = "<group>"; };
 		3F418EF71887BD97002795FD /* VideoPresentationManagerProxyMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoPresentationManagerProxyMessageReceiver.cpp; sourceTree = "<group>"; };
@@ -8746,6 +8747,7 @@
 				869055832912C6B000B5ECD3 /* Model.serialization.in */,
 				71E9650F2745682E00ADCF43 /* ModelIdentifier.h */,
 				7203449A26A6C44C000A5F54 /* MonotonicObjectIdentifier.h */,
+				3D3C75A22B6875120013828A /* MonotonicObjectIdentifier.serialization.in */,
 				2D50366A1BCDE17900E20BB3 /* NativeWebGestureEvent.h */,
 				C02BFF1512514FD8009CCBEA /* NativeWebKeyboardEvent.h */,
 				31EA25D3134F78D6005B1452 /* NativeWebMouseEvent.h */,

--- a/Tools/TestWebKitAPI/Tests/IPC/ThreadSafeObjectHeapTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ThreadSafeObjectHeapTests.cpp
@@ -33,7 +33,7 @@ namespace TestWebKitAPI {
 
 namespace {
 
-enum TestedObjectIdentifierType { };
+enum class TestedObjectIdentifierType { };
 using TestedObjectIdentifier = AtomicObjectIdentifier<TestedObjectIdentifierType>;
 using TestedObjectReadReference = IPC::ObjectIdentifierReadReference<TestedObjectIdentifier>;
 using TestedObjectWriteReference = IPC::ObjectIdentifierWriteReference<TestedObjectIdentifier>;


### PR DESCRIPTION
#### 3d316b6d4a7171cabc30792dd561a24a9a96975a
<pre>
Generate Serialization for MonotonicObjectIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=268401">https://bugs.webkit.org/show_bug.cgi?id=268401</a>
<a href="https://rdar.apple.com/121948853">rdar://121948853</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/MonotonicObjectIdentifier.h:
(WebKit::MonotonicObjectIdentifier::encode const): Deleted.
(WebKit::MonotonicObjectIdentifier::decode): Deleted.
* Source/WebKit/Shared/MonotonicObjectIdentifier.serialization.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
</pre>