### PR TITLE
JSC fails to build using --jsc-only on Linux

### DIFF
--- a/Source/WTF/wtf/SentinelLinkedList.h
+++ b/Source/WTF/wtf/SentinelLinkedList.h
@@ -301,11 +301,15 @@ inline void SentinelLinkedList<T, RawNode>::takeFrom(SentinelLinkedList<T, RawNo
     if (other.isEmpty())
         return;
 
+// These warnings can occur if takeFrom is used on a temporary local list.
+// It's ok to ignore these warnings as the "other" list is reset to the sentinel below.
+IGNORE_GCC_WARNINGS_BEGIN("dangling-pointer")
     m_sentinel.prev()->setNext(other.m_sentinel.next());
     other.m_sentinel.next()->setPrev(m_sentinel.prev());
 
     m_sentinel.setPrev(other.m_sentinel.prev());
     m_sentinel.prev()->setNext(&m_sentinel);
+IGNORE_GCC_WARNINGS_END
 
     other.m_sentinel.setNext(&other.m_sentinel);
     other.m_sentinel.setPrev(&other.m_sentinel);


### PR DESCRIPTION
#### 54c72ceeb7d7e8ea549af9d7c89913e7ab28208e
<pre>
JSC fails to build using --jsc-only on Linux
<a href="https://bugs.webkit.org/show_bug.cgi?id=268402">https://bugs.webkit.org/show_bug.cgi?id=268402</a>

Reviewed by Yusuke Suzuki.

Fix JSC build on Linux by disabling warnings about dangling pointers in the
method below.

* Source/WTF/wtf/SentinelLinkedList.h:
(WTF::RawNode&gt;::takeFrom):

Canonical link: <a href="https://commits.webkit.org/273815@main">https://commits.webkit.org/273815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fed37d50fbdf885c8224d731d428c8631f876f5e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39305 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32849 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31453 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32409 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11505 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11513 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40551 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/30762 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37442 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/36420 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35559 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13454 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/43205 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8331 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12189 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/8931 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12664 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->