### PR TITLE
[WebXR] Add state checking to WebXR IPC calls

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -402,6 +402,13 @@ void WebXRSystem::resolveFeaturePermissions(XRSessionMode mode, const XRSessionI
         return;
     }
 
+    // Skip platform code for asking for user's permission as we're using simulated ones.
+    if (UNLIKELY(m_testingDevices)) {
+        device->setEnabledFeatures(mode, resolvedFeatures->granted);
+        completionHandler(resolvedFeatures->granted);
+        return;
+    }
+
     // 7. Let (consentRequired, consentOptional, granted) be the fields of result.
     // 8. The user agent MAY at this point ask the user's permission for the calling algorithm to use any of the features
     //    in consentRequired and consentOptional. The results of these prompts should be included when determining if there

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -74,7 +74,7 @@ void XRDeviceProxy::initializeTrackingAndRendering(const WebCore::SecurityOrigin
     if (!m_xrSystem)
         return;
 
-    m_xrSystem->initializeTrackingAndRendering(securityOriginData, sessionMode, requestedFeatures);
+    m_xrSystem->initializeTrackingAndRendering();
 
     // This is called from the constructor of WebXRSession. Since sessionDidInitializeInputSources()
     // ends up calling queueTaskKeepingObjectAlive() which refs the WebXRSession object, we

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -70,7 +70,7 @@ private:
     // Message handlers
     void enumerateImmersiveXRDevices(CompletionHandler<void(Vector<XRDeviceInfo>&&)>&&);
     void requestPermissionOnSessionFeatures(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, const PlatformXR::Device::FeatureList&, CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&&);
-    void initializeTrackingAndRendering(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&);
+    void initializeTrackingAndRendering();
     void shutDownTrackingAndRendering();
     void requestFrame(CompletionHandler<void(PlatformXR::FrameData&&)>&&);
     void submitFrame();
@@ -78,6 +78,19 @@ private:
     // PlatformXRCoordinator::SessionEventClient
     void sessionDidEnd(XRDeviceIdentifier) final;
     void sessionDidUpdateVisibilityState(XRDeviceIdentifier, PlatformXR::VisibilityState) final;
+
+    std::optional<PlatformXR::SessionMode> m_immersiveSessionMode;
+    std::optional<WebCore::SecurityOriginData> m_immersiveSessionSecurityOriginData;
+    std::optional<PlatformXR::Device::FeatureList> m_immersiveSessionGrantedFeatures;
+    enum class ImmersiveSessionState : uint8_t {
+        Idle,
+        RequestingPermissions,
+        PermissionsGranted,
+        SessionRunning
+    };
+    ImmersiveSessionState m_immersiveSessionState { ImmersiveSessionState::Idle };
+    void setImmersiveSessionState(ImmersiveSessionState);
+    void invalidateImmersiveSessionState();
 
     WebPageProxy& m_page;
     std::unique_ptr<ProcessThrottler::ForegroundActivity> m_immersiveSessionActivity;

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
@@ -28,7 +28,7 @@
 messages -> PlatformXRSystem NotRefCounted {
     [EnabledIf='webXREnabled()'] EnumerateImmersiveXRDevices() -> (Vector<WebKit::XRDeviceInfo> devicesInfos)
     [EnabledIf='webXREnabled()'] RequestPermissionOnSessionFeatures(WebCore::SecurityOriginData origin, PlatformXR::SessionMode mode, Vector<PlatformXR::SessionFeature> granted, Vector<PlatformXR::SessionFeature> consentRequired, Vector<PlatformXR::SessionFeature> consentOptional, Vector<PlatformXR::SessionFeature> requiredFeaturesRequested, Vector<PlatformXR::SessionFeature> optionalFeaturesRequested) -> (std::optional<Vector<PlatformXR::SessionFeature>> userGranted)
-    [EnabledIf='webXREnabled()'] InitializeTrackingAndRendering(WebCore::SecurityOriginData origin, PlatformXR::SessionMode mode, Vector<PlatformXR::SessionFeature> requestedFeatures)
+    [EnabledIf='webXREnabled()'] InitializeTrackingAndRendering()
     [EnabledIf='webXREnabled()'] ShutDownTrackingAndRendering()
     [EnabledIf='webXREnabled()'] RequestFrame() -> (struct PlatformXR::FrameData frameData)
     [EnabledIf='webXREnabled()'] SubmitFrame()

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
@@ -76,9 +76,9 @@ void PlatformXRSystemProxy::requestPermissionOnSessionFeatures(const WebCore::Se
     m_page.sendWithAsyncReply(Messages::PlatformXRSystem::RequestPermissionOnSessionFeatures(securityOriginData, mode, granted, consentRequired, consentOptional, requiredFeaturesRequested, optionalFeaturesRequested), WTFMove(completionHandler));
 }
 
-void PlatformXRSystemProxy::initializeTrackingAndRendering(const WebCore::SecurityOriginData& securityOriginData, PlatformXR::SessionMode mode, const PlatformXR::Device::FeatureList& requestedFeatures)
+void PlatformXRSystemProxy::initializeTrackingAndRendering()
 {
-    m_page.send(Messages::PlatformXRSystem::InitializeTrackingAndRendering(securityOriginData, mode, requestedFeatures));
+    m_page.send(Messages::PlatformXRSystem::InitializeTrackingAndRendering());
 }
 
 void PlatformXRSystemProxy::shutDownTrackingAndRendering()

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
@@ -47,7 +47,7 @@ public:
 
     void enumerateImmersiveXRDevices(CompletionHandler<void(const PlatformXR::Instance::DeviceList&)>&&);
     void requestPermissionOnSessionFeatures(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList& /* granted */, const PlatformXR::Device::FeatureList& /* consentRequired */, const PlatformXR::Device::FeatureList& /* consentOptional */, const PlatformXR::Device::FeatureList& /* requiredFeaturesRequested */, const PlatformXR::Device::FeatureList& /* optionalFeaturesRequested */,  CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&&);
-    void initializeTrackingAndRendering(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&);
+    void initializeTrackingAndRendering();
     void shutDownTrackingAndRendering();
     void requestFrame(PlatformXR::Device::RequestFrameCallback&&);
     std::optional<PlatformXR::LayerHandle> createLayerProjection(uint32_t, uint32_t, bool);


### PR DESCRIPTION
#### bd55010ecc7f05c22f0b94a503dd1350b18c8396
<pre>
[WebXR] Add state checking to WebXR IPC calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=268404">https://bugs.webkit.org/show_bug.cgi?id=268404</a>
<a href="https://rdar.apple.com/121553978">rdar://121553978</a>

Reviewed by Dan Glastonbury.

Track internal state in PlatformXRSystem and check that we are
in the expected state when the IPC call is made.

Remove unnecessary parameters in PlatformXRSystem::initializeTrackingAndRendering()
as that information can be cached in this class and there&apos;s no
need to pass that info over again.

* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
(WebCore::WebXRSystem::resolveFeaturePermissions const):
We should not call into platform code for requesting permissions
for simulated test devices.
* Source/WebKit/Shared/XR/XRDeviceProxy.cpp:
(WebKit::XRDeviceProxy::initializeTrackingAndRendering):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::invalidate):
(WebKit::PlatformXRSystem::ensureImmersiveSessionActivity):
(WebKit::checkFeaturesConsent):
Helper function to check whether all the features in the first
argument are included in the second list of granted features.
(WebKit::PlatformXRSystem::requestPermissionOnSessionFeatures):
For immersive modes, check that we are in the idle state before
requesting permissions via the PlatformXRCoordinator.
When we get the granted permissions back, check whether all the
required features have been granted permission. Update the
immersive session state accordingly based on whether the
session can start.
(WebKit::PlatformXRSystem::initializeTrackingAndRendering):
Remove the parameters and use the cached immersive session
mode and granted features instead.
(WebKit::PlatformXRSystem::shutDownTrackingAndRendering):
(WebKit::PlatformXRSystem::requestFrame):
(WebKit::PlatformXRSystem::submitFrame):
(WebKit::PlatformXRSystem::sessionDidEnd):
(WebKit::PlatformXRSystem::setImmersiveSessionState):
(WebKit::PlatformXRSystem::invalidateImmersiveSessionState):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in:
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp:
(WebKit::PlatformXRSystemProxy::initializeTrackingAndRendering):
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h:

Canonical link: <a href="https://commits.webkit.org/273875@main">https://commits.webkit.org/273875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f43336ec1bf841a14380deeaa5e41ca5604b8692

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39586 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13029 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37544 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/13419 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/11700 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/32924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40837 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33522 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/33273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12016 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/35744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8371 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/12929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->