### PR TITLE
Fix click x removed wrong url parameters

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html
@@ -84,7 +84,7 @@ class SearchView {
                         onElementMount: element => {
                             element.onclick = () => {
                                 for (let i = 0; i < self.ref.state.children.length; ++i) {
-                                    if (child.test !== self.ref.state.children[i].test && child.suite !== self.ref.state.children[i].suite)
+                                    if (child.test !== self.ref.state.children[i].test || child.suite !== self.ref.state.children[i].suite)
                                         continue;
                                     self.ref.state.children.splice(i, 1);
                                     break;
@@ -100,7 +100,7 @@ class SearchView {
                                     // This shouldn't be possible, just keep the current params if it happens.
                                     if (i >= params.test.length)
                                         break;
-                                    if (params.suite[i] !== child.suite && params.test[i] !== child.test)
+                                    if (params.suite[i] !== child.suite || params.test[i] !== child.test)
                                         continue;
                                     params.suite.splice(i, 1);
                                     params.test.splice(i, 1);


### PR DESCRIPTION
#### 0d37807b0e51c2e821da53312d43354feae6ce1c
<pre>
Fix click x removed wrong url parameters

<a href="https://bugs.webkit.org/show_bug.cgi?id=268413">https://bugs.webkit.org/show_bug.cgi?id=268413</a>
Reviewed by Jonathan Bedard.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html:

Canonical link: <a href="https://commits.webkit.org/273877@main">https://commits.webkit.org/273877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a65f052388a4e6e8ed69c5a5388f5d9c6735b502

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39589 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13032 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13414 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11701 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/37084 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32923 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40840 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33517 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33272 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12019 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/35748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/36996 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8372 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/12932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->