### PR TITLE
[GStreamer] Use m_videoSize for DMABuf dimensions if available

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3475,8 +3475,14 @@ void MediaPlayerPrivateGStreamer::pushDMABufToCompositor()
 
                 object.format = DMABufFormat::create(fourcc);
                 object.colorSpace = colorSpaceForColorimetry(&GST_VIDEO_INFO_COLORIMETRY(&videoInfo));
-                object.width = GST_VIDEO_INFO_WIDTH(&videoInfo);
-                object.height = GST_VIDEO_INFO_HEIGHT(&videoInfo);
+
+                if (m_videoSize.isEmpty()) {
+                    object.width = GST_VIDEO_INFO_WIDTH(&videoInfo);
+                    object.height = GST_VIDEO_INFO_HEIGHT(&videoInfo);
+                } else {
+                    object.width = m_videoSize.width();
+                    object.height = m_videoSize.height();
+                }
 
                 // The dmabuf object itself doesn't provide anything useful, but the decoder won't
                 // reuse the dmabuf until the relevant GstSample reference is dropped by the


### PR DESCRIPTION
#### b3d3dc5c2be0d1836ef3feba7680721399109725
<pre>
[GStreamer] Use m_videoSize for DMABuf dimensions if available
<a href="https://bugs.webkit.org/show_bug.cgi?id=268416">https://bugs.webkit.org/show_bug.cgi?id=268416</a>

Reviewed by Philippe Normand.

In case of hardware decoding of H.264 video with dimensions that are
not macroblock aligned, e.g. 1080x1920, the VideoMeta might indicate
the actual physical dimensions of the buffer containing the decoded
video data, as written by the hardware decoder, that is 1088x1920
instead of 1080x1920 . This leads to an 8px wide stripe of corrupted
pixels at the edge of the displayed video.

The valid video data are a subset of that buffer content and their
dimensions can be obtained from caps. The code already stores those
dimensions in m_videoSize, so in case m_videoSize is not empty, use
dimensions from m_videoSize instead of the buffer dimensions.

This happens on NXP i.MX8M Plus with Hantro G1 VPU .

This fix is similar to GStreamer commit:
0b648f9a2d1e (&quot;waylandsink: Crop surfaces to their display width height&quot;)

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::pushDMABufToCompositor):

Canonical link: <a href="https://commits.webkit.org/273819@main">https://commits.webkit.org/273819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/152a3b59dee3ad2856c13a4c481c7f0d9d8890f6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39343 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32895 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31471 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37258 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11526 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11545 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40590 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33055 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37466 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11816 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9640 "Found 1 new test failure: http/tests/inspector/dom/didFireEvent.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35586 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13486 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8333 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12221 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->