### PR TITLE
Implement related origins for passkeys

### DIFF
--- a/Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.h
@@ -54,6 +54,7 @@ public:
     LAContext * laContext() const { return m_laContext.get(); }
     RefPtr<ArrayBuffer> largeBlob() const { return m_largeBlob; }
     const String& accessGroup() const { return m_accessGroup; }
+    const String& relyingPartyIdentifier() const { return m_relyingPartyIdentifier; }
 
     WEBCORE_EXPORT void setAuthenticatorData(Vector<uint8_t>&&);
     void setSignature(Ref<ArrayBuffer>&& signature) { m_signature = WTFMove(signature); }
@@ -65,6 +66,7 @@ public:
     void setLAContext(LAContext *context) { m_laContext = context; }
     void setLargeBlob(Ref<ArrayBuffer>&& largeBlob) { m_largeBlob = WTFMove(largeBlob); }
     void setAccessGroup(const String& accessGroup) { m_accessGroup = accessGroup; }
+    void setRelyingPartyIdentifier(const String& relyingPartyIdentifier) { m_relyingPartyIdentifier = relyingPartyIdentifier; }
 
 private:
     AuthenticatorAssertionResponse(Ref<ArrayBuffer>&&, Ref<ArrayBuffer>&&, Ref<ArrayBuffer>&&, RefPtr<ArrayBuffer>&&, AuthenticatorAttachment);
@@ -86,6 +88,7 @@ private:
     RetainPtr<LAContext> m_laContext;
     RefPtr<ArrayBuffer> m_largeBlob;
     String m_accessGroup;
+    String m_relyingPartyIdentifier;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -131,10 +131,6 @@ void AuthenticatorCoordinator::create(const Document& document, CredentialCreati
     // Step 8.
     if (!options.rp.id)
         options.rp.id = callerOrigin.domain();
-    else if (!callerOrigin.isMatchingRegistrableDomainSuffix(*options.rp.id)) {
-        promise.reject(Exception { ExceptionCode::SecurityError, "The provided RP ID is not a registrable domain suffix of the effective domain of the document."_s });
-        return;
-    }
 
     // Step 9-11.
     // Most of the jobs are done by bindings.
@@ -221,10 +217,6 @@ void AuthenticatorCoordinator::discoverFromExternalSource(const Document& docume
     }
 
     // Step 7.
-    if (!options.rpId.isEmpty() && !callerOrigin.isMatchingRegistrableDomainSuffix(options.rpId)) {
-        promise.reject(Exception { ExceptionCode::SecurityError, "The provided RP ID is not a registrable domain suffix of the effective domain of the document."_s });
-        return;
-    }
     if (options.rpId.isEmpty())
         options.rpId = callerOrigin.domain();
 

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.h
@@ -44,6 +44,7 @@ struct PublicKeyCredentialRequestOptions {
     Vector<PublicKeyCredentialDescriptor> allowCredentials;
     UserVerificationRequirement userVerification { UserVerificationRequirement::Preferred };
     mutable std::optional<AuthenticationExtensionsClientInputs> extensions;
+    Vector<String> relatedOrigins;
     std::optional<AuthenticatorAttachment> authenticatorAttachment { }; // Not serialized over IPC.
 #endif // ENABLE(WEB_AUTHN)
 };

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
@@ -32,4 +32,5 @@
     sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
     UserVerificationRequirement userVerification = "preferred";
     AuthenticationExtensionsClientInputs extensions;
+    sequence<USVString> relatedOrigins;
 };

--- a/Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h
@@ -406,17 +406,23 @@ typedef NS_ENUM(NSInteger, ASCredentialRequestStyle) {
 extern NSErrorDomain const ASCAuthorizationErrorDomain;
 
 typedef NS_ERROR_ENUM(ASCAuthorizationErrorDomain, ASCAuthorizationError) {
-    ASCAuthorizationErrorUnknown,
-    ASCAuthorizationErrorFailed,
-    ASCAuthorizationErrorUserCanceled,
-    ASCAuthorizationErrorPINRequired,
-    ASCAuthorizationErrorMultipleNFCTagsPresent,
-    ASCAuthorizationErrorNoCredentialsFound,
-    ASCAuthorizationErrorLAError,
-    ASCAuthorizationErrorLAExcludeCredentialsMatched,
-    ASCAuthorizationErrorPINInvalid,
-    ASCAuthorizationErrorAuthenticatorTemporarilyLocked,
-    ASCAuthorizationErrorAuthenticatorPermanentlyLocked,
+    ASCAuthorizationErrorUnknown = 0,
+    ASCAuthorizationErrorFailed = 1,
+    ASCAuthorizationErrorUserCanceled = 2,
+    ASCAuthorizationErrorPINRequired = 3,
+    ASCAuthorizationErrorMultipleNFCTagsPresent = 4,
+    ASCAuthorizationErrorNoCredentialsFound = 5,
+    ASCAuthorizationErrorLAError = 6,
+    ASCAuthorizationErrorLAExcludeCredentialsMatched = 7,
+    ASCAuthorizationErrorPINInvalid = 8,
+    ASCAuthorizationErrorAuthenticatorTemporarilyLocked = 9,
+    ASCAuthorizationErrorAuthenticatorPermanentlyLocked = 10,
+    ASCAuthorizationErrorAlreadyStarted = 11,
+    ASCAuthorizationErrorInternalCancel = 12,
+    ASCAuthorizationErrorKeyStoreFull = 13,
+    ASCAuthorizationErrorInvalidResponse = 14,
+    ASCAuthorizationErrorNotSupportedInSTP = 16,
+    ASCAuthorizationErrorSecurityError = 17,
 };
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1576,6 +1576,7 @@ struct WebCore::PublicKeyCredentialRequestOptions {
     Vector<WebCore::PublicKeyCredentialDescriptor> allowCredentials;
     WebCore::UserVerificationRequirement userVerification;
     std::optional<WebCore::AuthenticationExtensionsClientInputs> extensions;
+    Vector<String> relatedOrigins;
     [NotSerialized] std::optional<WebCore::AuthenticatorAttachment> authenticatorAttachment;
 #endif // ENABLE(WEB_AUTHN)
 };

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h
@@ -46,6 +46,7 @@ public:
     const WTF::String& group() const { return m_response->group(); }
     RefPtr<Data> credentialID() const;
     const WTF::String& accessGroup() const { return m_response->accessGroup(); }
+    const WTF::String& relyingPartyIdentifier() const { return m_response->relyingPartyIdentifier(); }
 
     void setLAContext(LAContext *context) { m_response->setLAContext(context); }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialRequestOptions.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialRequestOptions.h
@@ -48,6 +48,7 @@ WK_CLASS_AVAILABLE(macos(12.0), ios(15.0))
 @property (nonatomic) _WKAuthenticatorAttachment authenticatorAttachment;
 @property (nullable, nonatomic, strong) _WKAuthenticationExtensionsClientInputs *extensions;
 @property (nullable, nonatomic, copy) NSData *extensionsCBOR;
+@property (nullable, nonatomic, copy) NSArray<NSString *> *relatedOrigins;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.h
@@ -40,6 +40,7 @@ WK_CLASS_AVAILABLE(macos(11.0), ios(14.0))
 @property (nonatomic, readonly, copy) NSString *group;
 @property (nonatomic, readonly, copy) NSData *credentialID;
 @property (nonatomic, readonly, copy) NSString *accessGroup;
+@property (nonatomic, readonly, copy) NSString *relyingPartyIdentifier;
 
 - (void)setLAContext:(LAContext *)context WK_API_AVAILABLE(macos(12.0), ios(15.0));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
@@ -78,6 +78,11 @@
     return _response->accessGroup();
 }
 
+- (NSString *)relyingPartyIdentifier
+{
+    return _response->relyingPartyIdentifier();
+}
+
 #endif // ENABLE(WEB_AUTHN)
 
 - (void)setLAContext:(LAContext *)context

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -914,6 +914,14 @@ static WebCore::MediationRequirement toWebCore(_WKWebAuthenticationMediationRequ
         return WebCore::MediationRequirement::Optional;
     }
 }
+
+static Vector<String> relatedOrigins(NSArray<NSString *> *relatedOrigins)
+{
+    return Vector<String>(relatedOrigins.count, [relatedOrigins](size_t i) {
+        NSString *relatedOrigin = relatedOrigins[i];
+        return String(relatedOrigin);
+    });
+}
 #endif
 
 #if ENABLE(WEB_AUTHN)
@@ -1027,6 +1035,10 @@ static RetainPtr<_WKAuthenticatorAttestationResponse> wkAuthenticatorAttestation
         result.extensions = WebCore::AuthenticationExtensionsClientInputs::fromCBOR(asUInt8Span(options.extensionsCBOR));
     else
         result.extensions = authenticationExtensionsClientInputs(options.extensions);
+
+    if (options.relatedOrigins)
+        result.relatedOrigins = relatedOrigins(options.relatedOrigins);
+
     result.userVerification = userVerification(options.userVerification);
     result.authenticatorAttachment = authenticatorAttachment(options.authenticatorAttachment);
 #endif

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesForwardDeclarations.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesForwardDeclarations.h
@@ -206,6 +206,15 @@ typedef NS_ENUM(NSInteger, ASPublicKeyCredentialClientDataCrossOriginValue) {
 
 @end
 
+@protocol ASAuthorizationWebBrowserPlatformPublicKeyCredentialRegistrationRequest
+@property (nonatomic, readonly, nullable) ASPublicKeyCredentialClientData *clientData;
+@property (nonatomic, nullable, copy) NSArray<ASAuthorizationPlatformPublicKeyCredentialDescriptor *> *excludedCredentials;
+@property (nonatomic) BOOL shouldShowHybridTransport;
+@end
+
+@interface ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest () <ASAuthorizationWebBrowserPlatformPublicKeyCredentialRegistrationRequest>
+@end
+
 typedef NS_ENUM(NSInteger, ASAuthorizationPublicKeyCredentialLargeBlobAssertionOperation) {
     ASAuthorizationPublicKeyCredentialLargeBlobAssertionOperationRead,
     ASAuthorizationPublicKeyCredentialLargeBlobAssertionOperationWrite,
@@ -250,6 +259,14 @@ typedef NS_ENUM(NSInteger, ASAuthorizationPublicKeyCredentialLargeBlobAssertionO
 @property (nonatomic, nullable, copy) ASAuthorizationPublicKeyCredentialLargeBlobAssertionInput *largeBlob;
 @end
 
+@protocol ASAuthorizationWebBrowserPlatformPublicKeyCredentialAssertionRequest
+@property (nonatomic, readonly, nullable) ASPublicKeyCredentialClientData *clientData;
+@property (nonatomic) BOOL shouldShowHybridTransport;
+@end
+
+@interface ASAuthorizationPlatformPublicKeyCredentialAssertionRequest () <ASAuthorizationWebBrowserPlatformPublicKeyCredentialAssertionRequest>
+@end
+
 @interface ASAuthorizationPlatformPublicKeyCredentialProvider : NSObject <ASAuthorizationProvider>
 
 - (instancetype)initWithRelyingPartyIdentifier:(NSString *)relyingPartyIdentifier NS_DESIGNATED_INITIALIZER;
@@ -267,6 +284,9 @@ typedef NS_ENUM(NSInteger, ASAuthorizationPublicKeyCredentialLargeBlobAssertionO
 
 - (ASAuthorizationPlatformPublicKeyCredentialAssertionRequest *)createCredentialAssertionRequestWithClientData:(ASPublicKeyCredentialClientData *)clientData;
 
+@end
+
+@interface ASAuthorizationPlatformPublicKeyCredentialProvider () <ASAuthorizationWebBrowserPlatformPublicKeyCredentialProvider>
 @end
 
 typedef NSString *ASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport;
@@ -326,5 +346,16 @@ typedef NSString *ASAuthorizationPublicKeyCredentialResidentKeyPreference;
 @property (nonatomic, readonly, copy) NSString *relyingPartyIdentifier;
 
 @end
+
+extern NSErrorDomain const ASAuthorizationErrorDomain;
+
+typedef NS_ERROR_ENUM(ASAuthorizationErrorDomain, ASAuthorizationError) {
+    ASAuthorizationErrorUnknown = 1000,
+    ASAuthorizationErrorCanceled = 1001,
+    ASAuthorizationErrorInvalidResponse = 1002,
+    ASAuthorizationErrorNotHandled = 1003,
+    ASAuthorizationErrorFailed = 1004,
+    ASAuthorizationErrorNotInteractive = 1005,
+};
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesSoftLink.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesSoftLink.h
@@ -43,3 +43,6 @@ SOFT_LINK_CLASS_FOR_HEADER(WebKit, ASAuthorizationPublicKeyCredentialParameters)
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, ASAuthorizationPlatformPublicKeyCredentialDescriptor);
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, ASAuthorizationSecurityKeyPublicKeyCredentialDescriptor);
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, ASAuthorizationSecurityKeyPublicKeyCredentialAssertion);
+
+SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, AuthenticationServices, ASAuthorizationErrorDomain, NSErrorDomain);
+#define ASAuthorizationErrorDomain WebKit::get_AuthenticationServices_ASAuthorizationErrorDomain()

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesSoftLink.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesSoftLink.mm
@@ -41,3 +41,5 @@ SOFT_LINK_CLASS_FOR_SOURCE(WebKit, AuthenticationServices, ASAuthorizationPlatfo
 SOFT_LINK_CLASS_FOR_SOURCE(WebKit, AuthenticationServices, ASAuthorizationSecurityKeyPublicKeyCredentialDescriptor);
 SOFT_LINK_CLASS_FOR_SOURCE(WebKit, AuthenticationServices, ASAuthorizationSecurityKeyPublicKeyCredentialAssertion);
 
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebKit, AuthenticationServices, ASAuthorizationErrorDomain, NSErrorDomain);
+

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
@@ -105,8 +105,8 @@ private:
 
 #if HAVE(WEB_AUTHN_AS_MODERN)
     RetainPtr<ASAuthorizationController> constructASController(WebAuthenticationRequestData&&);
-    RetainPtr<NSArray> requestsForRegisteration(const WebCore::PublicKeyCredentialCreationOptions&, const Vector<uint8_t>& hash);
-    RetainPtr<NSArray> requestsForAssertion(const WebCore::PublicKeyCredentialRequestOptions&, const Vector<uint8_t>& hash, std::optional<WebCore::SecurityOriginData>& parentOrigin);
+    RetainPtr<NSArray> requestsForRegisteration(const WebCore::PublicKeyCredentialCreationOptions&, const Vector<uint8_t>& hash, const String&);
+    RetainPtr<NSArray> requestsForAssertion(const WebCore::PublicKeyCredentialRequestOptions&, const Vector<uint8_t>& hash, std::optional<WebCore::SecurityOriginData>& parentOrigin, const String& origin);
 #endif
 
     void performRequest(WebAuthenticationRequestData&&, RequestCompletionHandler&&);


### PR DESCRIPTION
#### 3b6e3fb133f4dc85586cd84e22bef34f2c4c8100
<pre>
Implement related origins for passkeys
Need the bug URL (OOPS!).
<a href="https://rdar.apple.com/121477240">rdar://121477240</a>

Reviewed by NOBODY (OOPS!).

This patch implements the WebKit side of related origins for passkeys. Several
things happening here:
- WebKit now uses the browser API for passkeys instead of the native app API.
This allows it to pass information about the current origin to AuthenticationServices.
- Validating the RPID against the current origin is now done by AuthenticationServices.
- Some data structures shared between WebKit and AuthenticationServices have been
modified to add some fields needed for processing related origins.

* Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.h:
(WebCore::AuthenticatorAssertionResponse::relyingPartyIdentifier const):
(WebCore::AuthenticatorAssertionResponse::setRelyingPartyIdentifier):
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::create):
(WebCore::AuthenticatorCoordinator::discoverFromExternalSource):
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.h:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl:
* Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h:
(NS_ERROR_ENUM):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialRequestOptions.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm:
(-[_WKWebAuthenticationAssertionResponse relyingPartyIdentifier]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(relatedOrigins):
(+[_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:]):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesForwardDeclarations.h:
(NS_ERROR_ENUM):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesSoftLink.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesSoftLink.mm:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticatorInternal::getExistingCredentials):
(WebKit::LocalAuthenticator::makeCredential):
(WebKit::LocalAuthenticator::getAssertion):
(WebKit::LocalAuthenticator::continueGetAssertionAfterUserVerification):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::WebAuthenticatorCoordinatorProxy::constructASController):
(WebKit::WebAuthenticatorCoordinatorProxy::requestsForRegisteration):
(WebKit::WebAuthenticatorCoordinatorProxy::requestsForAssertion):
(WebKit::WebAuthenticatorCoordinatorProxy::performRequest):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b6e3fb133f4dc85586cd84e22bef34f2c4c8100

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39353 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/32900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18123 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/12755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/37270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/13184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/11533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/32720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40600 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/33248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/33071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/12755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/35590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/12712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->