### PR TITLE
Rewrite LayoutTestFinder, making it own finding expectations

### DIFF
--- a/Tools/Scripts/webkitpy/common/system/filesystem.py
+++ b/Tools/Scripts/webkitpy/common/system/filesystem.py
@@ -41,12 +41,17 @@ import time
 
 from webkitcorepy import string_utils
 
+if sys.version_info < (3,):
+    # Avoid having to compile scandir where it is unneeded.
+    import scandir
+
 
 class FileSystem(object):
     """FileSystem interface for webkitpy.
 
     Unless otherwise noted, all paths are allowed to be either absolute
     or relative."""
+
     def __init__(self):
         self.sep = os.sep
         self.pardir = os.pardir
@@ -100,12 +105,20 @@ class FileSystem(object):
                 with the filesystem object and the path of each dirfound.
                 The dir is included in the result if the callback returns True.
         """
+
         def filter_all(fs, dirpath):
             return True
+
         dir_filter = dir_filter or filter_all
 
         dirs = []
-        for (dirpath, dirnames, filenames) in os.walk(path):
+
+        if sys.version_info >= (3,):
+            it = os.walk(path)
+        else:
+            it = scandir.walk(path)
+
+        for dirpath, dirnames, filenames in it:
             if dir_filter(self, dirpath):
                 dirs.append(dirpath)
         return dirs
@@ -121,6 +134,7 @@ class FileSystem(object):
                 each file found. The file is included in the result if the
                 callback returns True.
         """
+
         def filter_all(fs, dirpath, basename):
             return True
 
@@ -134,7 +148,12 @@ class FileSystem(object):
         if self.basename(path) in dirs_to_skip:
             return []
 
-        for (dirpath, dirnames, filenames) in os.walk(path):
+        if sys.version_info >= (3,):
+            it = os.walk(path)
+        else:
+            it = scandir.walk(path)
+
+        for dirpath, dirnames, filenames in it:
             for d in dirs_to_skip:
                 if d in dirnames:
                     dirnames.remove(d)
@@ -162,11 +181,20 @@ class FileSystem(object):
     def isdir(self, path):
         return os.path.isdir(path)
 
+    def islink(self, path):
+        return os.path.islink(path)
+
     def join(self, *comps):
         return os.path.join(*comps)
 
     def listdir(self, path):
         return os.listdir(path)
+
+    def scandir(self, path):
+        if sys.version_info >= (3,):
+            return os.scandir(path)
+        else:
+            return scandir.scandir(path)
 
     def mkdtemp(self, **kwargs):
         """Create and return a uniquely named directory.
@@ -180,6 +208,7 @@ class FileSystem(object):
         Note that the object returned is not a string and does not support all of the string
         methods. If you need a string, coerce the object to a string and go from there.
         """
+
         class TemporaryDirectory(object):
             def __init__(self, filesystem, **kwargs):
                 self._filesystem = filesystem

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder.py
@@ -1,0 +1,619 @@
+# Copyright (C) 2021, 2022, 2023, 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import fnmatch
+import itertools
+import json
+import re
+import sys
+import urllib
+from collections import OrderedDict
+
+from webkitpy.layout_tests.controllers.test_result_writer import TestResultWriter
+from webkitpy.layout_tests.models.test import Test
+from webkitpy.w3c.common import TEMPLATED_TEST_HEADER
+
+supported_test_extensions = (
+    ".htm",
+    ".html",
+    ".mht",
+    ".php",
+    ".pl",
+    ".py",
+    ".shtml",
+    ".svg",
+    ".xht",
+    ".xhtml",
+    ".xml",
+)
+assert len(supported_test_extensions) == len(set(supported_test_extensions))
+assert list(supported_test_extensions) == sorted(supported_test_extensions)
+
+supported_reference_extensions = (
+    ".htm",
+    ".html",
+    ".svg",
+    ".xht",
+    ".xhtml",
+    ".xml",
+)
+assert len(supported_reference_extensions) == len(set(supported_reference_extensions))
+assert list(supported_reference_extensions) == sorted(supported_reference_extensions)
+assert set(supported_reference_extensions) < set(supported_test_extensions)
+
+
+skipped_directories = {
+    ".svn",
+    "_svn",
+    "resources",
+    "support",
+    "script-tests",
+    "tools",
+    "reference",
+    "reftest",
+}
+
+# Files ending in -ref/-notref aren't considered expectations, but are skipped.
+skipped_test_suffixes = tuple(
+    "".join(pair)
+    for pair in itertools.product(
+        ("-expected", "-expected-mismatch", "-ref", "-notref"),
+        supported_reference_extensions,
+    )
+)
+
+digit_re = re.compile("([0-9]+)")
+
+
+def natsort(string_to_split):
+    """Returns a sort key to provide a strict total ordering of strings."""
+    split = digit_re.split(string_to_split)
+    # We need to return a tuple so that natsort("01") != natsort("1"), so that
+    # we actually have a strict total ordering.
+    split[1::2] = [(int(i), i) for i in split[1::2]]
+    return split
+
+
+class LayoutTestFinder(object):
+    def __init__(self, fs, layout_tests_base_dir, baseline_search_paths):
+        """Find layout tests.
+
+        :param FileSystem fs: the current filesystem object
+        :param str layout_tests_base_dir: the base directory of LayoutTests
+            (see: Port.layout_tests_dir())
+        :param List[str] baseline_search_paths: the baseline search paths, from most to
+            least specific (see: Port.baseline_search_path(device_type))
+        """
+        self.fs = fs
+
+        layout_tests_base_dir = fs.normpath(fs.realpath(layout_tests_base_dir))
+        baseline_search_paths = [
+            fs.normpath(fs.realpath(bsp)) for bsp in baseline_search_paths
+        ]
+
+        self.layout_tests_base_dir = layout_tests_base_dir
+        self.baseline_search_paths = baseline_search_paths
+
+        self.w3c_support_dirs, self.w3c_support_files = self._load_w3c_resource_data()
+
+    def _load_w3c_resource_data(self):
+        w3c_path = self.fs.join(
+            self.layout_tests_base_dir,
+            "imported",
+            "w3c",
+        )
+
+        if not self.fs.exists(w3c_path):
+            return {}, {}
+
+        path = self.fs.join(
+            w3c_path,
+            "resources",
+            "resource-files.json",
+        )
+
+        with self.fs.open_binary_file_for_reading(path) as fd:
+            json_data = json.load(fd)
+
+        dirs_by_parent = {}
+        for fullname in json_data["directories"]:
+            dirname, basename = fullname.rsplit("/", 1)
+            dirs_by_parent.setdefault(
+                ("imported/w3c/" + dirname).replace("/", self.fs.sep), set()
+            ).add(basename)
+
+        files_by_parent = {}
+        for fullname in json_data["files"]:
+            dirname, basename = fullname.rsplit("/", 1)
+            files_by_parent.setdefault(
+                ("imported/w3c/" + dirname).replace("/", self.fs.sep), set()
+            ).add(basename)
+
+        return dirs_by_parent, files_by_parent
+
+    def _canonicalize_test_path(self, path):
+        base = self.layout_tests_base_dir
+        fs = self.fs
+
+        # Fast-case the common case.
+        normpath = fs.normpath(path)
+        if normpath.startswith(base + fs.sep):
+            return normpath[len(base) + 1:]
+
+        relpath = fs.relpath(path, base)
+        if relpath.startswith(".." + fs.sep):
+            realpath = fs.realpath(path)
+            if realpath != path:
+                return self._canonicalize_test_path(realpath)
+
+            return fs.abspath(path)
+        else:
+            return relpath
+
+    def get_tests(self, globs=None):
+        """Get Test objects for those with paths specified by globs.
+
+        :param Optional[List[str]] globs: a list of globs to get tests for; if falsy
+            then "*" is used instead
+        """
+        # The majority of the implementation is actually delegated; this method just
+        # does some basic handling of the globs before deciding which directories to
+        # scan.
+
+        if not globs:
+            # We can't just call _get_tests_in_directory, because to match legacy
+            # behavior we use "*" here, which results in different ordering (see below).
+            globs = ["*"]
+
+        all_split_globs = itertools.chain.from_iterable(
+            self._split_glob(glob) for glob in globs
+        )
+
+        for dirname, group in itertools.groupby(all_split_globs, key=lambda x: x[0]):
+            if dirname:
+                dirs = sorted(
+                    {
+                        self._canonicalize_test_path(p)
+                        for p in self.fs.glob(
+                            self.fs.join(self.layout_tests_base_dir, dirname)
+                        )
+                    },
+                    key=natsort,
+                )
+            else:
+                dirs = [""]
+
+            fnfilter = [(basename or "*", variant) for _, basename, variant in group]
+
+            for d in dirs:
+                # We intermix tests and directories together from the glob, rather than
+                # (as we do when recursing) giving all tests in a directory together.
+                for item in self._process_directory(
+                    d,
+                    fnfilter=fnfilter,
+                ):
+                    if isinstance(item, Test):
+                        yield item
+                    else:
+                        for test in self._get_tests_in_directory(
+                            directory=self.fs.join(d, item)
+                        ):
+                            yield test
+
+    def _split_glob(self, glob):
+        """Split a glob string into possible (dirname, basename, variant) 3-tuples.
+
+        This deals with the ambiguity inherent in passing a name like foo?bar: is this
+        mean to match fooXbar, or is it the ?bar variant of the foo test.
+        """
+        # Ignore everything after a # (this is always a variant).
+        if "#" in glob:
+            name, variant = glob.rsplit("#", 1)
+            variant = "#" + variant
+        else:
+            name, variant = glob, ""
+
+        # Split based on ?, as we need to consider this as either a glob string
+        # or a query string.
+        splits = name.split("?")
+        for i in range(1, len(splits) + 1):
+            dirname, basename = self.fs.split("?".join(splits[:i]))
+
+            if basename and len(splits) > i:
+                # If we have more splits, we have a possible variant.
+                yield (dirname, basename, "?" + "?".join(splits[i:]) + variant)
+            elif basename or not variant and len(splits) == i:
+                # If we have a basename or no variants.
+                yield (dirname, basename, variant)
+
+    def _get_tests_in_directory(self, directory):
+        """Get all tests in directory, recursively."""
+        stack = [
+            (
+                directory,
+                [
+                    self.fs.join(search_path, directory)
+                    for search_path in self.baseline_search_paths
+                ],
+            )
+        ]
+
+        while stack:
+            current_path, current_search_paths = stack.pop()
+
+            next_paths = []
+            for item in self._process_directory(
+                current_path,
+                current_search_paths=current_search_paths,
+            ):
+                if isinstance(item, Test):
+                    yield item
+                else:
+                    next_paths.append(item)
+
+            for d in reversed(next_paths):
+                next_search_paths = [
+                    self.fs.join(cur, d) if cur is not None else None
+                    for cur in current_search_paths
+                ]
+                assert len(next_search_paths) == len(self.baseline_search_paths)
+                stack.append((self.fs.join(current_path, d), next_search_paths))
+
+    def _process_directory(
+        self,
+        path,
+        fnfilter=None,
+        current_search_paths=None,
+    ):
+        """Process a directory, optionally filtering names within it.
+
+        Names in the directory are looped over once per item in fnfilter (or once, if no
+        filter is provided), so if a test name or directory is matched by multiple items
+        in fnfilter it will appear multiple times in the returned list.
+
+        :param str path: Path to the directory, relative to layout_tests_base_dir
+        :param Optional[List[Tuple[str, str]]] fnfilter: Any fnfilter to apply, along
+            with any variants for that filter.
+        :param Optional[List[Optional[str]]] current_search_paths: A list of baseline
+            search paths for path or (optionally) None if the directory doesn't exist
+        :return List[Union[Test, str]]: Found tests and directories to recurse into.
+
+        """
+        if fnfilter is None:
+            fnfilter = [("*", "")]
+
+        if current_search_paths is None:
+            current_search_paths = [
+                self.fs.join(search_path, path)
+                for search_path in self.baseline_search_paths
+            ]
+
+        assert len(current_search_paths) == len(self.baseline_search_paths)
+
+        test_files = []
+        non_test_files = OrderedDict()
+        dirs = set()
+
+        current_layout_tests_path = self.fs.join(self.layout_tests_base_dir, path)
+        non_test_files[current_layout_tests_path] = set()
+
+        it = self.fs.scandir(current_layout_tests_path)
+        try:
+            for entry in it:
+                if entry.is_dir(follow_symlinks=False):
+                    dirs.add(entry.name)
+                elif entry.is_file(follow_symlinks=False):
+                    if self.is_test_file(path, entry.name):
+                        test_files.append(entry.name)
+                    else:
+                        non_test_files[current_layout_tests_path].add(entry.name)
+        finally:
+            if sys.version_info >= (3, 6):
+                it.close()
+
+        for search_path in reversed(current_search_paths):
+            if search_path is None or not self.fs.isdir(search_path):
+                continue
+
+            non_test_files[search_path] = set()
+            it = self.fs.scandir(search_path)
+            try:
+                for entry in it:
+                    if entry.is_file(follow_symlinks=False):
+                        non_test_files[search_path].add(entry.name)
+            finally:
+                if sys.version_info >= (3, 6):
+                    it.close()
+
+        dirs -= skipped_directories
+        dirs -= self.w3c_support_dirs.get(path, set())
+
+        merged_items = sorted(test_files + [d + "/" for d in dirs], key=natsort)
+        found = []
+
+        for pattern, variant in fnfilter:
+            compiled = re.compile(fnmatch.translate(pattern))
+            for f in merged_items:
+                if f[-1] == "/":
+                    d = f[:-1]
+                    if pattern == "*" or compiled.match(d):
+                        found.append(d)
+                elif pattern == "*" or compiled.match(f):
+                    found.extend(
+                        self._tests_for_path(
+                            path,
+                            f,
+                            [variant] if variant else None,
+                            non_test_files,
+                        )
+                    )
+
+        return found
+
+    def is_test_file(self, dirname, basename):
+        if (
+            not basename.endswith(supported_test_extensions)
+            or basename.startswith(("ref-", "notref-"))
+            or basename.endswith(skipped_test_suffixes)
+            or basename.endswith("_wsh.py")
+            or basename in ("boot.xml", "root.xml")
+            or dirname.startswith(self.fs.join("imported", "w3c", ""))
+            and (
+                basename.endswith(".py")
+                or basename in self.w3c_support_files.get(dirname, set())
+            )
+        ):
+            return False
+        return True
+
+    def _tests_for_path(
+        self, dirname, basename, variants, non_test_files_by_search_path
+    ):
+        """Find tests for a given (dirname, basename)
+
+        :param str dirname: dirname of the test
+        :param str basename: basename of the test
+        :param Optional[List[str]] variants: a list of variants to create Test objects
+            for, or None in which case all known variants are run
+        :param OrderedDict[str, Set[str]] non_test_files_by_search_path: an OrderedDict,
+            whose key is dirnames, starting with the current dirname above followed by
+            baseline search paths in increasing specificity, and whose value is sets of
+            basenames that exist in that dirname
+        :return Iterable[Test]: an iterator over Test objects
+        """
+        path = self.fs.join(self.layout_tests_base_dir, dirname, basename)
+
+        if variants is None:
+            variants = self._find_variants(path)
+        else:
+            variants = [self._percent_encoded_variant(v) for v in variants]
+
+        assert len(variants) >= 1
+
+        for variant in variants:
+            trimmed_path = self._canonicalize_test_path(path)
+            if not self.fs.isabs(trimmed_path):
+                trimmed_path = trimmed_path.replace(self.fs.sep, "/")
+
+            (
+                expected_text_path,
+                expected_image_path,
+                expected_audio_path,
+                reference_files,
+            ) = self._expectations_for_test(
+                basename + variant, non_test_files_by_search_path
+            )
+
+            assert expected_text_path is None or self.fs.isabs(expected_text_path)
+            assert expected_image_path is None or self.fs.isabs(expected_image_path)
+            assert expected_audio_path is None or self.fs.isabs(expected_audio_path)
+            assert reference_files is None or all(
+                self.fs.isabs(ref_path) for (_, ref_path) in reference_files
+            )
+
+            yield Test(
+                test_path=trimmed_path + variant,
+                expected_text_path=expected_text_path,
+                expected_audio_path=expected_audio_path,
+                expected_image_path=expected_image_path,
+                reference_files=(
+                    tuple(reference_files) if reference_files is not None else None
+                ),
+                is_http_test="http/test" in trimmed_path,
+                is_websocket_test=(
+                    "websocket/" in trimmed_path
+                    or "http/test" in trimmed_path
+                    and "websocket" in trimmed_path + variant
+                ),
+                is_wpt_test=(
+                    "imported/w3c/web-platform-tests/" in trimmed_path
+                    or "http/wpt/" in trimmed_path
+                ),
+                is_wpt_crash_test=self.is_wpt_crash_test(trimmed_path),
+            )
+
+    def _find_variants(self, f):
+        """Find variants for path `f`"""
+        # This shouldn't exist, we should be reading the WPT manifest instead.
+        if "web-platform-tests" not in f:
+            return [""]
+
+        opened_file = self.fs.open_text_file_for_reading(f)
+        try:
+            first_line = opened_file.readline()
+            if not first_line:
+                return [""]
+
+            variants = []
+
+            if first_line.strip() == TEMPLATED_TEST_HEADER:
+                for line in iter(opened_file.readline, ""):
+                    results = re.match(r"<!--\s*META:\s*variant=(\S*)\s*-->", line)
+                    if not results:
+                        continue
+                    variants.append(results.group(1))
+            else:
+                for line in iter(opened_file.readline, ""):
+                    try:
+                        line = line.lstrip()
+                        if not line.startswith("<meta"):
+                            continue
+                        if not re.search(r"name=['\"]?variant['\"]?", line):
+                            continue
+                        start_index = line.find("content=")
+                        if start_index < 0:
+                            continue
+                        start_index += 8
+                        end_chars = ()
+                        if line[start_index] == '"' or line[start_index] == "'":
+                            end_chars = (line[start_index],)
+                            start_index += 1
+                        else:
+                            end_chars = (" ", ">")
+                        end_index = start_index
+                        while line[end_index] not in end_chars:
+                            end_index += 1
+                        variants.append(line[start_index:end_index])
+                    except IndexError:
+                        continue
+
+            variants = [
+                self._percent_encoded_variant(v)
+                for v in variants
+                if self._is_valid_variant(v)
+            ]
+        except UnicodeDecodeError:
+            return [""]
+
+        if not variants:
+            return [""]
+
+        return variants
+
+    def _percent_encoded_variant(self, variant):
+        m = re.search(
+            "^(?P<path>[^?#]*)(?P<variant>(?P<query>\\?[^#]*)?(?P<fragment>#.*)?)$",
+            variant,
+        )
+        path, _, query, fragment = m.groups()
+        assert m.group("path") == ""
+
+        # This is all code points not in the "query percent-encode set" [URL], minus
+        # characters urllib.parse.quote never quotes.
+        safe_query = "!$%&'()*+,/:;=?@[\\]^`{|}~"
+
+        # This is all code points not in the "fragment percent-encode set" [URL], minus
+        # characters urllib.parse.quote never quotes.
+        safe_fragment = "!#$%&'()*+,/:;=?@[\\]^{|}~"
+
+        query = "" if query is None else query
+        fragment = "" if fragment is None else fragment
+
+        if sys.version_info > (3,):
+            query = urllib.parse.quote(query, safe=safe_query, encoding="utf-8")
+            fragment = urllib.parse.quote(
+                fragment, safe=safe_fragment, encoding="utf-8"
+            )
+        else:
+            query = urllib.quote(query.encode("utf-8"), safe=safe_query).decode("ascii")
+            fragment = urllib.quote(
+                fragment.encode("utf-8"), safe=safe_fragment
+            ).decode("ascii")
+
+        return "{}{}".format(query, fragment)
+
+    def _is_valid_variant(self, variant):
+        """Check whether a given variant is valid"""
+        return variant == "" or (
+            len(variant) > 1 and variant[0] in ("?", "#") and variant != "?#"
+        )
+
+    def _expectations_for_test(self, name, non_test_files_by_search_path):
+        """Given a test basename, find expectations in non_test_files_by_search_path"""
+
+        expected_without_ext = TestResultWriter.expected_filename(
+            name, self.fs, suffix=""
+        )
+        assert expected_without_ext[-1] == "."
+        expected_without_ext = expected_without_ext[:-1]
+
+        expected_text_path = None
+        expected_webarchive_path = None
+        expected_image_path = None
+        expected_audio_path = None
+        reference_files = None
+
+        txt_name = expected_without_ext + ".txt"
+        webarchive_name = expected_without_ext + ".webarchive"
+        png_name = expected_without_ext + ".png"
+        wav_name = expected_without_ext + ".wav"
+
+        match_reference_names = {
+            expected_without_ext + ext for ext in supported_reference_extensions
+        }
+
+        mismatch_reference_names = {
+            "".join((expected_without_ext, "-mismatch", ext))
+            for ext in supported_reference_extensions
+        }
+
+        for dirname, basename_set in reversed(non_test_files_by_search_path.items()):
+            if expected_text_path is None and txt_name in basename_set:
+                expected_text_path = self.fs.join(dirname, txt_name)
+
+            if expected_webarchive_path is None and webarchive_name in basename_set:
+                expected_webarchive_path = self.fs.join(dirname, webarchive_name)
+
+            if expected_image_path is None and png_name in basename_set:
+                expected_image_path = self.fs.join(dirname, png_name)
+
+            if expected_audio_path is None and wav_name in basename_set:
+                expected_audio_path = self.fs.join(dirname, wav_name)
+
+            if reference_files is None:
+                matches = basename_set & match_reference_names
+                mismatches = basename_set & mismatch_reference_names
+                if matches or mismatches:
+                    # For historic reasons, we return matches first, and we sort them by
+                    # the filename of the match. This is significant when we currently
+                    # only run the first reference
+                    # (https://bugs.webkit.org/show_bug.cgi?id=270794).
+                    reference_files = [
+                        ("==", self.fs.join(dirname, m)) for m in sorted(matches)
+                    ] + [("!=", self.fs.join(dirname, m)) for m in sorted(mismatches)]
+
+        return (
+            expected_text_path or expected_webarchive_path,
+            expected_image_path,
+            expected_audio_path,
+            reference_files,
+        )
+
+    def is_wpt_crash_test(self, name):
+        # This shouldn't exist, we should be reading the WPT manifest instead.
+        if "imported/w3c/web-platform-tests/" not in name and "http/wpt/" not in name:
+            return False
+
+        filename, _ = self.fs.splitext(name)
+        return (
+            filename.endswith(("-crash", "-crash.tentative")) or "/crashtests/" in name
+        )

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
@@ -27,53 +27,21 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import errno
-import json
 import logging
 import re
-import sys
-import urllib
 
-from webkitpy.common import find_files
-from webkitpy.layout_tests.models.test import Test
-from webkitpy.port.base import Port
-from webkitpy.w3c.common import TEMPLATED_TEST_HEADER
-
+from .layout_test_finder import (
+    LayoutTestFinder as LayoutTestFinder_New,
+    skipped_test_suffixes,
+)
 
 _log = logging.getLogger(__name__)
 
 
-# When collecting test cases, we include any file with these extensions.
-_supported_test_extensions = set(['.html', '.shtml', '.xml', '.xhtml', '.pl', '.py', '.htm', '.php', '.svg', '.mht', '.xht'])
-
-_skipped_filename_patterns = set([
-    # Special case for WebSocket tooling.
-    r'.*_wsh.py',
-
-    # The WebKit1 bot sometimes creates these files during the course of testing.
-    # https://webkit.org/b/208477
-    r'boot\.xml',
-    r'root\.xml'
-])
-
-
-# If any changes are made here be sure to update the isUsedInReftest method in old-run-webkit-tests as well.
 def _is_reference_html_file(filesystem, dirname, filename):
-    if filename.startswith('ref-') or filename.startswith('notref-'):
-        return True
-    filename_wihout_ext, ext = filesystem.splitext(filename)
-    # FIXME: _supported_reference_extensions should be here, https://bugs.webkit.org/show_bug.cgi?id=220421
-    if ext not in Port._supported_reference_extensions:
-        return False
-    for suffix in ['-expected', '-expected-mismatch', '-ref', '-notref']:
-        if filename_wihout_ext.endswith(suffix):
-            return True
-    return False
-
-
-def _has_supported_extension(filesystem, filename):
-    """Return true if filename is one of the file extensions we want to run a test on."""
-    extension = filesystem.splitext(filename)[1]
-    return extension in _supported_test_extensions
+    return filename.startswith(("ref-", "notref-")) or filename.endswith(
+        skipped_test_suffixes
+    )
 
 
 class LayoutTestFinder(object):
@@ -91,13 +59,6 @@ class LayoutTestFinder(object):
         self._options = options
         self._filesystem = self._port.host.filesystem
         self.LAYOUT_TESTS_DIRECTORY = 'LayoutTests'
-        self._w3c_resource_files = None
-        self.http_subdir = 'http' + port.TEST_PATH_SEPARATOR + 'test'
-        self.websocket_subdir = 'websocket' + port.TEST_PATH_SEPARATOR
-        self.web_platform_test_subdir = port.web_platform_test_server_doc_root()
-        self.webkit_specific_web_platform_test_subdir = (
-            'http' + port.TEST_PATH_SEPARATOR + 'wpt' + port.TEST_PATH_SEPARATOR
-        )
 
     def find_tests(self, options, args, device_type=None, with_expectations=False):
         paths = self._strip_test_dir_prefixes(args)
@@ -108,200 +69,50 @@ class LayoutTestFinder(object):
 
     def find_tests_by_path(self, paths, device_type=None, with_expectations=False):
         """Return the list of tests found. Both generic and platform-specific tests matching paths should be returned."""
-        return [
-            Test(
-                test_file,
-                reference_files=(
-                    tuple(self._port.reference_files(test_file, device_type)) or None
-                    if with_expectations
-                    else None
-                ),
-                expected_text_path=(
-                    (
-                        self._port.expected_filename(
-                            test_file,
-                            ".txt",
-                            return_default=False,
-                            device_type=device_type,
-                        )
-                        or self._port.expected_filename(
-                            test_file,
-                            ".webarchive",
-                            return_default=False,
-                            device_type=device_type,
-                        )
-                    )
-                    if with_expectations
-                    else None
-                ),
-                expected_image_path=(
-                    self._port.expected_filename(
-                        test_file, ".png", return_default=False, device_type=device_type
-                    )
-                    if with_expectations
-                    else None
-                ),
-                expected_audio_path=(
-                    self._port.expected_filename(
-                        test_file, ".wav", return_default=False, device_type=device_type
-                    )
-                    if with_expectations
-                    else None
-                ),
-                is_http_test=self.http_subdir in test_file,
-                is_websocket_test=(
-                    self.websocket_subdir in test_file
-                    or (self.http_subdir in test_file and "websocket" in test_file)
-                ),
-                is_wpt_test=self._is_wpt_test(test_file),
-                is_wpt_crash_test=self._is_wpt_crash_test(test_file),
-            )
-            for test_file in self._real_tests(paths)
-        ]
+        finder = LayoutTestFinder_New(
+            self._port.host.filesystem,
+            self._port.layout_tests_dir(),
+            self._port.baseline_search_path(device_type),
+        )
 
-    def _is_wpt_test(self, test_file):
-        return self.web_platform_test_subdir in test_file or self.webkit_specific_web_platform_test_subdir in test_file
-
-    def _is_wpt_crash_test(self, test_file):
-        if not self._is_wpt_test(test_file):
-            return False
-        filename, _ = self._filesystem.splitext(test_file)
-        crashtests_dirname = self._port.TEST_PATH_SEPARATOR + 'crashtests' + self._port.TEST_PATH_SEPARATOR
-        return filename.endswith('-crash') or filename.endswith('-crash.tentative') or crashtests_dirname in test_file
-
-    def _expand_variants(self, files):
-        expanded = []
-        fs = self._port._filesystem
-        for f in files:
-            if "web-platform-tests" not in f:
-                expanded.append(f)
-                continue
-            m = re.search("^(?P<path>[^?#]*)(?P<variant>(?P<query>\\?[^#]*)?(?P<fragment>#.*)?)$", f)
-            f = m.group("path")
-            passed_variant = self._percent_encoded_variant(m.group("variant"))
-            opened_file = fs.open_text_file_for_reading(f)
-            try:
-                first_line = opened_file.readline()
-                if not first_line:
-                    expanded.append(f)
-                    continue
-
-                variants = []
-                if first_line.strip() == TEMPLATED_TEST_HEADER:
-                    for line in iter(opened_file.readline, ''):
-                        results = re.match(r'<!--\s*META:\s*variant=(\S*)\s*-->', line)
-                        if not results:
-                            continue
-                        variant = results.group(1)
-                        variants.append(variant)
-                else:
-                    for line in iter(opened_file.readline, ''):
-                        try:
-                            line = line.lstrip()
-                            if not line.startswith("<meta"):
-                                continue
-                            if not re.search(r"name=['\"]?variant['\"]?", line):
-                                continue
-                            start_index = line.find("content=")
-                            if start_index < 0:
-                                continue
-                            start_index += 8
-                            end_chars = ()
-                            if line[start_index] == '"' or line[start_index] == '\'':
-                                end_chars = (line[start_index],)
-                                start_index += 1
-                            else:
-                                end_chars = (' ', '>')
-                            end_index = start_index
-                            while line[end_index] not in end_chars:
-                                end_index += 1
-                            variant = line[start_index:end_index]
-                            variants.append(variant)
-                        except IndexError:
-                            continue
-
-                variants = [v for v in variants if self._is_valid_variant(v)]
-                if len(variants):
-                    for variant in variants:
-                        variant = self._percent_encoded_variant(variant)
-                        if not passed_variant or variant.startswith(passed_variant):
-                            expanded.append(f + variant)
-                else:
-                    expanded.append(f)
-            except UnicodeDecodeError:
-                expanded.append(f)
-                continue
-        return expanded
-
-    def _percent_encoded_variant(self, variant):
-        m = re.search("^(?P<path>[^?#]*)(?P<variant>(?P<query>\\?[^#]*)?(?P<fragment>#.*)?)$", variant)
-        path, _, query, fragment = m.groups()
-        assert m.group("path") == ""
-
-        # This is all code points not in the "query percent-encode set" [URL], minus
-        # characters urllib.parse.quote never quotes.
-        safe_query = "!$%&'()*+,/:;=?@[\\]^`{|}~"
-
-        # This is all code points not in the "fragment percent-encode set" [URL], minus
-        # characters urllib.parse.quote never quotes.
-        safe_fragment = "!#$%&'()*+,/:;=?@[\\]^{|}~"
-
-        query = "" if query is None else query
-        fragment = "" if fragment is None else fragment
-
-        if sys.version_info > (3,):
-            query = urllib.parse.quote(query, safe=safe_query, encoding="utf-8")
-            fragment = urllib.parse.quote(fragment, safe=safe_fragment, encoding="utf-8")
-        else:
-            query = urllib.quote(query.encode("utf-8"), safe=safe_query).decode("ascii")
-            fragment = urllib.quote(fragment.encode("utf-8"), safe=safe_fragment).decode("ascii")
-
-        return "{}{}".format(query, fragment)
-
-    def _is_valid_variant(self, variant):
-        return variant == "" or (len(variant) > 1 and variant[0] in ("?", "#")) and variant != "?#"
-
-    def _real_tests(self, paths):
-        # When collecting test cases, skip these directories
-        skipped_directories = set(['.svn', '_svn', 'resources', 'support', 'script-tests', 'tools', 'reference', 'reftest'])
-        files = find_files.find(self._port._filesystem, self._port.layout_tests_dir(), paths, skipped_directories, self._is_test_file, self._port.test_key)
-        files = self._expand_variants(files)
-        return [self._port.relative_test_filename(f) for f in files]
+        return list(finder.get_tests(paths))
 
     def _is_test_file(self, filesystem, dirname, filename):
-        if not _has_supported_extension(filesystem, filename):
-            return False
-        if _is_reference_html_file(filesystem, dirname, filename):
-            return False
-        if self._is_w3c_resource_file(filesystem, dirname, filename):
-            return False
-
-        for pattern in _skipped_filename_patterns:
-            if re.match(pattern, filename):
-                return False
-        return True
+        finder = LayoutTestFinder_New(
+            self._port.host.filesystem,
+            self._port.layout_tests_dir(),
+            self._port.baseline_search_path(),
+        )
+        return finder.is_test_file(
+            dirname, filename
+        ) and not self._is_w3c_resource_file(filesystem, dirname, filename)
 
     def _is_w3c_resource_file(self, filesystem, dirname, filename):
-        path = filesystem.join(dirname, filename)
-        w3c_path = filesystem.join(self._port.layout_tests_dir(), "imported", "w3c")
-        if w3c_path not in path:
-            return False
+        finder = LayoutTestFinder_New(
+            self._port.host.filesystem,
+            self._port.layout_tests_dir(),
+            self._port.baseline_search_path(),
+        )
 
-        if not self._w3c_resource_files:
-            filepath = filesystem.join(w3c_path, "resources", "resource-files.json")
-            json_data = filesystem.read_text_file(filepath)
-            self._w3c_resource_files = json.loads(json_data)
+        if dirname:
+            dirname = self._filesystem.relpath(dirname, self._port.layout_tests_dir())
 
-        _, extension = filesystem.splitext(filename)
-        if extension == '.py':
+        w3c_path = filesystem.join("imported", "w3c")
+        if dirname.startswith(w3c_path) and filename.endswith(".py"):
+            # For legacy compatibility handle this here.
             return True
 
-        subpath = path[len(w3c_path) + 1:].replace('\\', '/')
-        if subpath in self._w3c_resource_files["files"]:
+        if filename in finder.w3c_support_files.get(dirname, set()):
             return True
-        for dirpath in self._w3c_resource_files["directories"]:
-            if dirpath in subpath:
+
+        prev = None
+        head, tail = self._filesystem.split(dirname)
+        while head and head != prev:
+            if tail in finder.w3c_support_dirs.get(head, set()):
                 return True
+            prev = head
+            head, tail = self._filesystem.split(head)
+
         return False
 
     def _strip_test_dir_prefixes(self, paths):

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_unittest.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from pyfakefs.fake_filesystem_unittest import TestCaseMixin
+
+from webkitpy.common.host_mock import MockHost
+from webkitpy.common.system.filesystem import FileSystem
+from webkitpy.layout_tests.controllers.layout_test_finder import (
+    LayoutTestFinder,
+)
+from webkitpy.port.test import (
+    TestPort,
+    add_unit_tests_to_mock_filesystem,
+)
+
+
+class LayoutTestFinderTests(unittest.TestCase, TestCaseMixin):
+    def __init__(self, *args, **kwargs):
+        super(LayoutTestFinderTests, self).__init__(*args, **kwargs)
+        self.port = None
+        self.finder = None
+
+    def setUp(self):
+        self.setUpPyfakefs()
+        host = MockHost(create_stub_repository_files=True, filesystem=FileSystem())
+        add_unit_tests_to_mock_filesystem(host.filesystem)
+        self.port = TestPort(host)
+        self.finder = LayoutTestFinder(
+            self.port.host.filesystem,
+            self.port.layout_tests_dir(),
+            self.port.baseline_search_path(),
+        )
+
+    def tearDown(self):
+        self.port = None
+        self.finder = None
+
+    def test_split_glob(self):
+        v = list(self.finder._split_glob("a"))
+        self.assertEqual([("", "a", "")], v)
+
+        v = list(self.finder._split_glob("a/"))
+        self.assertEqual([("a", "", "")], v)
+
+        v = list(self.finder._split_glob("a/b"))
+        self.assertEqual([("a", "b", "")], v)
+
+        v = list(self.finder._split_glob("a/b/"))
+        self.assertEqual([("a/b", "", "")], v)
+
+        v = list(self.finder._split_glob("a/b/c"))
+        self.assertEqual([("a/b", "c", "")], v)
+
+        v = list(self.finder._split_glob("a/b#c"))
+        self.assertEqual([("a", "b", "#c")], v)
+
+        v = list(self.finder._split_glob("a/b?c"))
+        self.assertEqual([("a", "b", "?c"), ("a", "b?c", "")], v)
+
+        v = list(self.finder._split_glob("a/b?c?d"))
+        self.assertEqual(
+            [("a", "b", "?c?d"), ("a", "b?c", "?d"), ("a", "b?c?d", "")], v
+        )
+
+        v = list(self.finder._split_glob("a/b?c#d"))
+        self.assertEqual([("a", "b", "?c#d"), ("a", "b?c", "#d")], v)
+
+        v = list(self.finder._split_glob("a/?b"))
+        self.assertEqual([("a", "?b", "")], v)
+
+        v = list(self.finder._split_glob("a/?b?c"))
+        self.assertEqual([("a", "?b", "?c"), ("a", "?b?c", "")], v)
+
+        v = list(self.finder._split_glob("a?b"))
+        self.assertEqual([("", "a", "?b"), ("", "a?b", "")], v)
+
+        v = list(self.finder._split_glob("a??b"))
+        self.assertEqual([("", "a", "??b"), ("", "a?", "?b"), ("", "a??b", "")], v)
+
+        v = list(self.finder._split_glob("a?b?c"))
+        self.assertEqual([("", "a", "?b?c"), ("", "a?b", "?c"), ("", "a?b?c", "")], v)
+
+        v = list(self.finder._split_glob("a/#b"))
+        self.assertEqual([], v)

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -448,9 +448,9 @@ def _print_expectations(port, options, args, logging_stream):
         return exit_code
     except Exception as error:
         _log.error('Error printing expectations: {}'.format(error))
+        return -1
     finally:
         printer.cleanup()
-        return -1
 
 
 def _set_up_derived_options(port, options):

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
@@ -29,7 +29,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
-import sys
 import unittest
 
 from webkitcorepy import StringIO, OutputCapture
@@ -1050,7 +1049,9 @@ class RunTest(unittest.TestCase, StreamTestingMixin):
 
         with OutputCapture() as captured:
             logging = StringIO()
-            run_webkit_tests._print_expectations(port, run_webkit_tests.parse_args(['--print-expectations'])[0], [], logging_stream=logging)
+            exit_code = run_webkit_tests._print_expectations(port, run_webkit_tests.parse_args(['--print-expectations'])[0], [], logging_stream=logging)
+
+        self.assertEqual(0, exit_code)
 
         current_type = None
         by_type = {}
@@ -1096,7 +1097,9 @@ class RunTest(unittest.TestCase, StreamTestingMixin):
 
         with OutputCapture() as captured:
             logging = StringIO()
-            run_webkit_tests._print_expectations(port, run_webkit_tests.parse_args(['--print-expectations'])[0], [], logging_stream=logging)
+            exit_code = run_webkit_tests._print_expectations(port, run_webkit_tests.parse_args(['--print-expectations'])[0], [], logging_stream=logging)
+
+        self.assertEqual(0, exit_code)
 
         current_type = None
         by_type = {}

--- a/Tools/Scripts/webkitpy/port/test.py
+++ b/Tools/Scripts/webkitpy/port/test.py
@@ -425,7 +425,7 @@ class TestPort(Port):
         # the mock_drt Driver. We return something, but make sure it's useless.
         return 'MOCK _path_to_driver'
 
-    def baseline_search_path(self, **kwargs):
+    def baseline_search_path(self, device_type=None):
         search_paths = {
             'test-mac-snowleopard': ['test-mac-snowleopard'],
             'test-mac-leopard': ['test-mac-leopard', 'test-mac-snowleopard'],

--- a/Tools/Scripts/webkitpy/test/main.py
+++ b/Tools/Scripts/webkitpy/test/main.py
@@ -200,6 +200,7 @@ def main():
         "webkitpy.common.watchlist.watchlistrule_unittest",
         "webkitpy.featuredefines.matcher_unittest",
         "webkitpy.layout_tests.controllers.layout_test_finder_legacy_unittest",
+        "webkitpy.layout_tests.controllers.layout_test_finder_unittest",
         "webkitpy.layout_tests.controllers.layout_test_runner_unittest",
         "webkitpy.layout_tests.controllers.manager_unittest",
         "webkitpy.layout_tests.controllers.single_test_runner_unittest",

--- a/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
@@ -47,22 +47,16 @@ FAKE_FILES = {
     '/mock-checkout/LayoutTests/w3c/css-fake-1/README.txt': '',
 }
 
-FAKE_REPOSITORY = {
+FAKE_RESOURCES = {
     '/mock-checkout/LayoutTests/imported/w3c/resources/import-expectations.json': '''
 {
     "test1": "import",
     "test2": "skip"
-}'''
+}''',
+    '/mock-checkout/LayoutTests/imported/w3c/resources/resource-files.json': '{"directories": [], "files": []}',
 }
 
-
-FAKE_REPOSITORIES = {
-    '/mock-checkout/LayoutTests/imported/w3c/resources/import-expectations.json': '''
-{
-    "test1": "import",
-    "test2": "skip"
-}'''
-}
+FAKE_FILES.update(FAKE_RESOURCES)
 
 
 MINIMAL_TESTHARNESS = '''
@@ -73,14 +67,11 @@ MINIMAL_TESTHARNESS = '''
 
 
 class TestImporterTest(unittest.TestCase):
-
     def _parse_options(self, args):
         options, args = parse_args(args)
         return options
 
     def test_import_dir_with_no_tests_and_no_hg(self):
-        FAKE_FILES.update(FAKE_REPOSITORIES)
-
         host = MockHost()
         host.executive = MockExecutive2(exception=OSError())
         port = host.port_factory.get()
@@ -94,8 +85,6 @@ class TestImporterTest(unittest.TestCase):
             importer.do_import()
 
     def test_import_dir_with_no_tests(self):
-        FAKE_FILES.update(FAKE_REPOSITORIES)
-
         host = MockHost()
         host.executive = MockExecutive2(exception=ScriptError("abort: no repository found in '/Volumes/Source/src/wk/Tools/Scripts/webkitpy/w3c' (.hg not found)!"))
         port = host.port_factory.get()
@@ -112,7 +101,7 @@ class TestImporterTest(unittest.TestCase):
             '/tests/csswg/web-platform-tests/test1/__init__.py': '',
             '/tests/csswg/web-platform-tests/test2/__init__.py': 'NOTEMPTY',
         }
-        FAKE_FILES.update(FAKE_REPOSITORIES)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         host = MockHost()
         port = host.port_factory.get()
@@ -165,7 +154,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/Source/WebCore/css/CSSProperties.json': '',
             '/mock-checkout/Source/WebCore/css/CSSValueKeywords.in': '',
         }
-        FAKE_FILES.update(FAKE_REPOSITORIES)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
 
@@ -175,7 +164,9 @@ class TestImporterTest(unittest.TestCase):
         self.assertTrue('src="/resources/testharness.js"' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/css/t/test.html'))
 
     def test_skip_test_import_download(self):
-        FAKE_FILES = {
+        FAKE_FILES = {}
+        FAKE_FILES.update(FAKE_RESOURCES)
+        FAKE_FILES.update({
             '/mock-checkout/WebKitBuild/w3c-tests/streams-api/reference-implementation/web-platform-tests/test.html': MINIMAL_TESTHARNESS,
             '/mock-checkout/LayoutTests/imported/w3c/resources/import-expectations.json': '''
 {
@@ -187,7 +178,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/dir-to-skip/dir-to-import/test-to-import.html': 'to be imported',
             '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/dir-to-skip/dir-to-not-import/test-to-not-import.html': 'to be skipped',
             '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/dir-to-skip/file-to-import.html': 'to be imported',
-        }
+        })
 
         fs = self.import_downloaded_tests(['--no-fetch', '-d', 'w3c'], FAKE_FILES)
 
@@ -197,7 +188,9 @@ class TestImporterTest(unittest.TestCase):
         self.assertFalse(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/dir-to-skip/test-to-skip.html'))
 
     def test_skip_test_import_source(self):
-        FAKE_FILES = {
+        FAKE_FILES = {}
+        FAKE_FILES.update(FAKE_RESOURCES)
+        FAKE_FILES.update({
             '/home/user/wpt/streams-api/reference-implementation/web-platform-tests/test.html': MINIMAL_TESTHARNESS,
             '/mock-checkout/LayoutTests/imported/w3c/resources/import-expectations.json': '''
 {
@@ -209,7 +202,7 @@ class TestImporterTest(unittest.TestCase):
             '/home/user/wpt/web-platform-tests/dir-to-skip/dir-to-import/test-to-import.html': 'to be imported',
             '/home/user/wpt/web-platform-tests/dir-to-skip/dir-to-not-import/test-to-not-import.html': 'to be skipped',
             '/home/user/wpt/web-platform-tests/dir-to-skip/file-to-import.html': 'to be imported',
-        }
+        })
 
         fs = self.import_downloaded_tests(['-s', '/home/user/wpt', '--no-fetch', '-d', 'w3c'], FAKE_FILES)
 
@@ -224,7 +217,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/css/css-images/support/test2.html': MINIMAL_TESTHARNESS,
             '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/css/css-images/work-in-progress/test3.html': MINIMAL_TESTHARNESS,
         }
-        FAKE_FILES.update(FAKE_REPOSITORIES)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         fs = self.import_directory(['-d', '/mock-checkout/LayoutTests/w3c/web-platform-tests'], FAKE_FILES, ['web-platform-tests/css/css-images'])
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/web-platform-tests/css/css-images/tools/test1.html'))
@@ -237,7 +230,7 @@ class TestImporterTest(unittest.TestCase):
             '/home/user/wpt/web-platform-tests/css/css-images/support/test2.html': MINIMAL_TESTHARNESS,
             '/home/user/wpt/web-platform-tests/css/css-images/work-in-progress/test3.html': MINIMAL_TESTHARNESS,
         }
-        FAKE_FILES.update(FAKE_REPOSITORIES)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         fs = self.import_directory(['-s', '/home/user/wpt', '-d', '/mock-checkout/LayoutTests/w3c/web-platform-tests'], FAKE_FILES, ['web-platform-tests/css/css-images'])
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/web-platform-tests/css/css-images/tools/test1.html'))
@@ -250,7 +243,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/WebKitBuild2/w3c-tests/csswg-tests/test.html': '1',
         }
 
-        FAKE_FILES.update(FAKE_REPOSITORIES)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         os.environ['WEBKIT_OUTPUTDIR'] = '/mock-checkout/WebKitBuild2'
         try:
@@ -273,7 +266,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/WebKitBuild/w3c-tests/csswg-tests/test.html': '1',
         }
 
-        FAKE_FILES.update(FAKE_REPOSITORIES)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c', '--clean-dest-dir'], FAKE_FILES)
 
@@ -304,7 +297,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/WebKitBuild/w3c-tests/csswg-tests/test.html': '-1',
         }
 
-        FAKE_FILES.update(FAKE_REPOSITORIES)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         fs = self.import_downloaded_tests(['--no-fetch', '--import-all'], FAKE_FILES)
 
@@ -327,7 +320,9 @@ class TestImporterTest(unittest.TestCase):
             "imported/w3c/web-platform-tests/b/existing-test.html": ["slow"],
         }
 
-        FAKE_FILES = {
+        FAKE_FILES = {}
+        FAKE_FILES.update(FAKE_RESOURCES)
+        FAKE_FILES.update({
             '/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/a/old-test.html': '1',
             '/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/a/old-test-expected.txt': '2',
             '/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/a/old-support.html': '3',
@@ -340,9 +335,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/LayoutTests/tests-options.json': json.dumps(existing_tests_options),
             '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/b/existing-test.html': MINIMAL_TESTHARNESS,
             '/mock-checkout/WebKitBuild/w3c-tests/csswg-tests/test.html': '-1',
-        }
-
-        FAKE_FILES.update(FAKE_REPOSITORIES)
+        })
 
         fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--clean-dest-dir', 'web-platform-tests/b'], FAKE_FILES)
 
@@ -376,7 +369,9 @@ class TestImporterTest(unittest.TestCase):
             "imported/w3c/web-platform-tests/cssom/existing-test.html": ["slow"],
         }
 
-        FAKE_FILES = {
+        FAKE_FILES = {}
+        FAKE_FILES.update(FAKE_RESOURCES)
+        FAKE_FILES.update({
             '/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/cssom-view/old-test.html': '1',
             '/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/cssom-view/old-test-expected.txt': '2',
             '/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/cssom-view/old-support.html': '3',
@@ -389,9 +384,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/LayoutTests/tests-options.json': json.dumps(existing_tests_options),
             '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/cssom/existing-test.html': MINIMAL_TESTHARNESS,
             '/mock-checkout/WebKitBuild/w3c-tests/csswg-tests/test.html': '-1',
-        }
-
-        FAKE_FILES.update(FAKE_REPOSITORIES)
+        })
 
         fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--clean-dest-dir', 'web-platform-tests/cssom'], FAKE_FILES)
 
@@ -416,7 +409,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/.gitmodules': '[submodule "tools/resources"]\n	path = tools/resources\n	url = https://github.com/w3c/testharness.js.git\n  ignore = dirty\n',
         }
 
-        FAKE_FILES.update(FAKE_REPOSITORIES)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         host = MockHost()
         host.executive = MockExecutive2()
@@ -437,7 +430,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/LayoutTests/w3c/web-platform-tests/t/obsolete-expected.txt': 'PASS',
         }
 
-        FAKE_FILES.update(FAKE_REPOSITORIES)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         host = MockHost()
         host.executive = MockExecutive2()
@@ -455,7 +448,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/WebKitBuild/w3c-tests/csswg-tests/temp': '',
             '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/t/new-manual.html': '<!doctype html><meta name="timeout" content="long"><script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script>',
             '/mock-checkout/LayoutTests/tests-options.json': tests_options}
-        FAKE_FILES.update(FAKE_REPOSITORIES)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         host = MockHost()
         host.executive = MockExecutive2()
@@ -472,7 +465,7 @@ class TestImporterTest(unittest.TestCase):
             '/home/user/wpt/web-platform-tests/css/css-images/resources/some-file.html': '<!DOCTYPE html>',
             '/mock-checkout/LayoutTests/imported/w3c/resources/resource-files.json': '{"directories": [], "files": []}',
         }
-        FAKE_FILES.update(FAKE_REPOSITORIES)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         fs = self.import_directory(['-s', '/home/user/wpt', '-d', '/mock-checkout/LayoutTests/imported/w3c/web-platform-tests'], FAKE_FILES, ['web-platform-tests/css/css-images'])
         self.assertTrue(fs.exists('/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/web-platform-tests/css/css-images/test-crash.html'))
@@ -498,7 +491,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/Source/WebCore/css/CSSProperties.json': '',
             '/mock-checkout/Source/WebCore/css/CSSValueKeywords.in': '',
         }
-        FAKE_FILES.update(FAKE_REPOSITORIES)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
 
@@ -522,7 +515,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/css/css-images/test5.html': '<html><head><link rel=match href="     /some/directory/in/wpt-root/test5-ref.html    "></head></html>',
             '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/some/directory/in/wpt-root/test5-ref.html': '<html></html>',
         }
-        FAKE_FILES.update(FAKE_REPOSITORIES)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
         # test3
@@ -547,7 +540,7 @@ class TestImporterTest(unittest.TestCase):
             '/home/user/wpt/web-platform-tests/css/css-images/test4-ref.html': '<html></html>',
 
         }
-        FAKE_FILES.update(FAKE_REPOSITORIES)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         fs = self.import_directory(['-s', '/home/user/wpt', '-d', '/mock-checkout/LayoutTests/w3c/web-platform-tests'], FAKE_FILES, ['web-platform-tests/css/css-images'])
         # test1
@@ -571,7 +564,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/t/test4.any.js': '\n// META: global=dedicatedworker\n',
             '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/t/test5.any.js': '\n// META: global=window,worker\n',
         }
-        FAKE_FILES.update(FAKE_REPOSITORY)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
 
@@ -604,7 +597,7 @@ class TestImporterTest(unittest.TestCase):
         FAKE_FILES = {
             '/mock-checkout/WebKitBuild/w3c-tests/web-platform-tests/t/variant.any.js': '// META: variant=?1-10\n// META: variant=?11-20',
         }
-        FAKE_FILES.update(FAKE_REPOSITORY)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
 
@@ -620,7 +613,7 @@ class TestImporterTest(unittest.TestCase):
             '/mock-checkout/LayoutTests/w3c/web-platform-tests/t/variant.any_11-20-expected.txt': '2',
             '/mock-checkout/LayoutTests/w3c/web-platform-tests/t/variant.any_21-30-expected.txt': '3',
         }
-        FAKE_FILES.update(FAKE_REPOSITORY)
+        FAKE_FILES.update(FAKE_RESOURCES)
 
         fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
 


### PR DESCRIPTION
#### bee9faa82faa4c52bc1c75dbc2f98b02c9d3f3a4
<pre>
Rewrite LayoutTestFinder, making it own finding expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=220421">https://bugs.webkit.org/show_bug.cgi?id=220421</a>
<a href="https://rdar.apple.com/problem/72894403">rdar://problem/72894403</a>

Reviewed by Jonathan Bedard.

Previously we have relied on the test runner to probe for expectation
files; this can end up taking a significant amount of time, as it
requires opening the directory file for each item in the baseline search
path, looking for one file at a time. Instead, we should just open each
directory once, when we are finding tests in that directory, and store
the paths to the expected results.

This refactoring also puts us in an easier place to implement
per-directory special-cases for LayoutTestFinder: this is most obviously
useful for making http/wpt and imported/w3c/web-platform-tests more
closely match WPT semantics (and a future patch will move to primarily
relying on the WPT manifest to find tests in these directories, rather
than our existing behaviour).

* Tools/Scripts/webkitpy/common/system/filesystem.py:
(FileSystem):
(FileSystem.dirs_under):
(FileSystem.dirs_under.filter_all):
(FileSystem.files_under):
(FileSystem.islink):
(FileSystem.scandir):
(FileSystem.mkdtemp):
* Tools/Scripts/webkitpy/common/system/filesystem_mock.py:
(MockFileSystem.islink):
(MockFileSystem.scandir):
(ScanDirMock):
(ScanDirMock.__init__):
(ScanDirMock.__iter__):
(ScanDirMock.__enter__):
(ScanDirMock.__exit__):
(ScanDirMock.close):
(DirEntryMock):
(DirEntryMock.__init__):
(DirEntryMock.name):
(DirEntryMock.is_dir):
(DirEntryMock.is_file):
(DirEntryMock.is_symlink):
(DirEntryMock.stat):
(DirEntryMock.inode):
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder.py: Added.
(natsort):
(LayoutTestFinder):
(LayoutTestFinder.__init__):
(LayoutTestFinder._load_w3c_resource_data):
(LayoutTestFinder._canonicalize_test_path):
(LayoutTestFinder.get_tests):
(LayoutTestFinder._split_glob):
(LayoutTestFinder._get_tests_in_directory):
(LayoutTestFinder._process_directory):
(LayoutTestFinder.is_test_file):
(LayoutTestFinder._tests_for_path):
(LayoutTestFinder._find_variants):
(LayoutTestFinder._percent_encoded_variant):
(LayoutTestFinder._is_valid_variant):
(LayoutTestFinder._expectations_for_test):
(LayoutTestFinder.is_wpt_crash_test):
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py:
(_is_reference_html_file):
(LayoutTestFinder.__init__):
(LayoutTestFinder.find_tests_by_path):
(LayoutTestFinder._is_test_file):
(LayoutTestFinder._is_w3c_resource_file):
(_has_supported_extension): Deleted.
(LayoutTestFinder._is_wpt_test): Deleted.
(LayoutTestFinder._is_wpt_crash_test): Deleted.
(LayoutTestFinder._expand_variants): Deleted.
(LayoutTestFinder._percent_encoded_variant): Deleted.
(LayoutTestFinder._is_valid_variant): Deleted.
(LayoutTestFinder._real_tests): Deleted.
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy_unittest.py:
(LayoutTestFinderTests.tearDown):
(LayoutTestFinderTests.test_find_glob_b2):
(LayoutTestFinderTests.test_supported_test_extensions): Deleted.
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_unittest.py: Added.
(LayoutTestFinderTests):
(LayoutTestFinderTests.__init__):
(LayoutTestFinderTests.setUp):
(LayoutTestFinderTests.tearDown):
(LayoutTestFinderTests.test_split_glob):
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(_print_expectations):
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py:
(RunTest.test_device_type_specific_listing):
(RunTest.test_ipad_listing):
* Tools/Scripts/webkitpy/port/test.py:
* Tools/Scripts/webkitpy/test/main.py:
(main):
* Tools/Scripts/webkitpy/w3c/test_importer_unittest.py:
(TestImporterTest): Deleted.
(TestImporterTest._parse_options): Deleted.
(TestImporterTest.test_import_dir_with_no_tests_and_no_hg): Deleted.
(TestImporterTest.test_import_dir_with_no_tests): Deleted.
(TestImporterTest.test_import_dir_with_empty_init_py): Deleted.
(TestImporterTest.import_directory): Deleted.
(TestImporterTest.import_downloaded_tests): Deleted.
(TestImporterTest.test_harnesslinks_conversion): Deleted.
(TestImporterTest.test_skip_test_import_download): Deleted.

Canonical link: <a href="https://commits.webkit.org/276129@main">https://commits.webkit.org/276129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b61eed66c9c283e116ebd36212dc7677dd42be91

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46436 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39891 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46097 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20249 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17154 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/43660 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38797 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1847 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47993 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18820 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15403 "Found 1 new test failure: http/tests/navigation/parsed-iframe-dynamic-form-back-entry.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42962 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20223 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41652 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9745 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20419 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->