### PR TITLE
Related origins for passkeys

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure.https-expected.txt
@@ -1,8 +1,5 @@
 
 PASS PublicKeyCredential's [[create]] with timeout
-PASS PublicKeyCredential's [[create]] with a mismatched RP ID
-PASS PublicKeyCredential's [[create]] with a empty string RP ID
-PASS PublicKeyCredential's [[create]] with a null RP ID
 PASS PublicKeyCredential's [[create]] with two consecutive requests
 PASS PublicKeyCredential's [[create]] with two consecutive requests (2)
 PASS PublicKeyCredential's [[create]] with new requests in a new page

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-create-failure.https.html
@@ -33,69 +33,6 @@
         const options = {
             publicKey: {
                 rp: {
-                    name: "example.com",
-                    id: "example.com"
-                },
-                user: {
-                    name: "John Appleseed",
-                    id: asciiToUint8Array("123456"),
-                    displayName: "John",
-                },
-                challenge: asciiToUint8Array("123456"),
-                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
-            }
-        };
-
-        return promiseRejects(t, "SecurityError",
-            navigator.credentials.create(options), "The provided RP ID is not a registrable domain suffix of the effective domain of the document.");
-    }, "PublicKeyCredential's [[create]] with a mismatched RP ID");
-
-    promise_test(function(t) {
-        const options = {
-            publicKey: {
-                rp: {
-                    name: "example.com",
-                    id: ""
-                },
-                user: {
-                    name: "John Appleseed",
-                    id: asciiToUint8Array("123456"),
-                    displayName: "John",
-                },
-                challenge: asciiToUint8Array("123456"),
-                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
-            }
-        };
-
-        return promiseRejects(t, "SecurityError",
-            navigator.credentials.create(options), "The provided RP ID is not a registrable domain suffix of the effective domain of the document.");
-    }, "PublicKeyCredential's [[create]] with a empty string RP ID");
-
-    promise_test(function(t) {
-        const options = {
-            publicKey: {
-                rp: {
-                    name: "example.com",
-                    id: null
-                },
-                user: {
-                    name: "John Appleseed",
-                    id: asciiToUint8Array("123456"),
-                    displayName: "John",
-                },
-                challenge: asciiToUint8Array("123456"),
-                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
-            }
-        };
-
-        return promiseRejects(t, "SecurityError",
-            navigator.credentials.create(options), "The provided RP ID is not a registrable domain suffix of the effective domain of the document.");
-    }, "PublicKeyCredential's [[create]] with a null RP ID");
-
-    promise_test(function(t) {
-        const options = {
-            publicKey: {
-                rp: {
                     name: "example.com"
                 },
                 user: {

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure.https-expected.txt
@@ -1,6 +1,5 @@
 
 PASS PublicKeyCredential's [[get]] with timeout
-PASS PublicKeyCredential's [[get]] with a mismatched RP ID
 PASS PublicKeyCredential's [[get]] with a mismatched APP ID (invalid URLs)
 PASS PublicKeyCredential's [[get]] with a mismatched APP ID (different protocols)
 PASS PublicKeyCredential's [[get]] with a mismatched APP ID (different sites 1)

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure.https.html
@@ -23,18 +23,6 @@
     promise_test(t => {
         const options = {
             publicKey: {
-                rpId: "example.com",
-                challenge: asciiToUint8Array("123456")
-            }
-        };
-
-        return promiseRejects(t, "SecurityError",
-            navigator.credentials.get(options), "The provided RP ID is not a registrable domain suffix of the effective domain of the document.");
-    }, "PublicKeyCredential's [[get]] with a mismatched RP ID");
-
-    promise_test(t => {
-        const options = {
-            publicKey: {
                 challenge: asciiToUint8Array("123456"),
                 extensions: { appid: "abc" }
             }

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -131,10 +131,6 @@ void AuthenticatorCoordinator::create(const Document& document, CredentialCreati
     // Step 8.
     if (!options.rp.id)
         options.rp.id = callerOrigin.domain();
-    else if (!callerOrigin.isMatchingRegistrableDomainSuffix(*options.rp.id)) {
-        promise.reject(Exception { ExceptionCode::SecurityError, "The provided RP ID is not a registrable domain suffix of the effective domain of the document."_s });
-        return;
-    }
 
     // Step 9-11.
     // Most of the jobs are done by bindings.
@@ -245,10 +241,6 @@ void AuthenticatorCoordinator::discoverFromExternalSource(const Document& docume
     }
 
     // Step 7.
-    if (!options.rpId.isEmpty() && !callerOrigin.isMatchingRegistrableDomainSuffix(options.rpId)) {
-        promise.reject(Exception { ExceptionCode::SecurityError, "The provided RP ID is not a registrable domain suffix of the effective domain of the document."_s });
-        return;
-    }
     if (options.rpId.isEmpty())
         options.rpId = callerOrigin.domain();
 

--- a/Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h
@@ -406,17 +406,23 @@ typedef NS_ENUM(NSInteger, ASCredentialRequestStyle) {
 extern NSErrorDomain const ASCAuthorizationErrorDomain;
 
 typedef NS_ERROR_ENUM(ASCAuthorizationErrorDomain, ASCAuthorizationError) {
-    ASCAuthorizationErrorUnknown,
-    ASCAuthorizationErrorFailed,
-    ASCAuthorizationErrorUserCanceled,
-    ASCAuthorizationErrorPINRequired,
-    ASCAuthorizationErrorMultipleNFCTagsPresent,
-    ASCAuthorizationErrorNoCredentialsFound,
-    ASCAuthorizationErrorLAError,
-    ASCAuthorizationErrorLAExcludeCredentialsMatched,
-    ASCAuthorizationErrorPINInvalid,
-    ASCAuthorizationErrorAuthenticatorTemporarilyLocked,
-    ASCAuthorizationErrorAuthenticatorPermanentlyLocked,
+    ASCAuthorizationErrorUnknown = 0,
+    ASCAuthorizationErrorFailed = 1,
+    ASCAuthorizationErrorUserCanceled = 2,
+    ASCAuthorizationErrorPINRequired = 3,
+    ASCAuthorizationErrorMultipleNFCTagsPresent = 4,
+    ASCAuthorizationErrorNoCredentialsFound = 5,
+    ASCAuthorizationErrorLAError = 6,
+    ASCAuthorizationErrorLAExcludeCredentialsMatched = 7,
+    ASCAuthorizationErrorPINInvalid = 8,
+    ASCAuthorizationErrorAuthenticatorTemporarilyLocked = 9,
+    ASCAuthorizationErrorAuthenticatorPermanentlyLocked = 10,
+    ASCAuthorizationErrorAlreadyStarted = 11,
+    ASCAuthorizationErrorInternalCancel = 12,
+    ASCAuthorizationErrorKeyStoreFull = 13,
+    ASCAuthorizationErrorInvalidResponse = 14,
+    ASCAuthorizationErrorNotSupportedInSTP = 16,
+    ASCAuthorizationErrorSecurityError = 17,
 };
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesForwardDeclarations.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesForwardDeclarations.h
@@ -206,6 +206,15 @@ typedef NS_ENUM(NSInteger, ASPublicKeyCredentialClientDataCrossOriginValue) {
 
 @end
 
+@protocol ASAuthorizationWebBrowserPlatformPublicKeyCredentialRegistrationRequest
+@property (nonatomic, readonly, nullable) ASPublicKeyCredentialClientData *clientData;
+@property (nonatomic, nullable, copy) NSArray<ASAuthorizationPlatformPublicKeyCredentialDescriptor *> *excludedCredentials;
+@property (nonatomic) BOOL shouldShowHybridTransport;
+@end
+
+@interface ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest () <ASAuthorizationWebBrowserPlatformPublicKeyCredentialRegistrationRequest>
+@end
+
 typedef NS_ENUM(NSInteger, ASAuthorizationPublicKeyCredentialLargeBlobAssertionOperation) {
     ASAuthorizationPublicKeyCredentialLargeBlobAssertionOperationRead,
     ASAuthorizationPublicKeyCredentialLargeBlobAssertionOperationWrite,
@@ -250,6 +259,14 @@ typedef NS_ENUM(NSInteger, ASAuthorizationPublicKeyCredentialLargeBlobAssertionO
 @property (nonatomic, nullable, copy) ASAuthorizationPublicKeyCredentialLargeBlobAssertionInput *largeBlob;
 @end
 
+@protocol ASAuthorizationWebBrowserPlatformPublicKeyCredentialAssertionRequest
+@property (nonatomic, readonly, nullable) ASPublicKeyCredentialClientData *clientData;
+@property (nonatomic) BOOL shouldShowHybridTransport;
+@end
+
+@interface ASAuthorizationPlatformPublicKeyCredentialAssertionRequest () <ASAuthorizationWebBrowserPlatformPublicKeyCredentialAssertionRequest>
+@end
+
 @interface ASAuthorizationPlatformPublicKeyCredentialProvider : NSObject <ASAuthorizationProvider>
 
 - (instancetype)initWithRelyingPartyIdentifier:(NSString *)relyingPartyIdentifier NS_DESIGNATED_INITIALIZER;
@@ -272,6 +289,9 @@ typedef NS_ENUM(NSInteger, ASAuthorizationPublicKeyCredentialLargeBlobAssertionO
 
 - (ASAuthorizationPlatformPublicKeyCredentialAssertionRequest *)createCredentialAssertionRequestWithClientData:(ASPublicKeyCredentialClientData *)clientData;
 
+@end
+
+@interface ASAuthorizationPlatformPublicKeyCredentialProvider () <ASAuthorizationWebBrowserPlatformPublicKeyCredentialProvider>
 @end
 
 typedef NSString *ASAuthorizationSecurityKeyPublicKeyCredentialDescriptorTransport;
@@ -335,5 +355,16 @@ typedef NSString *ASAuthorizationPublicKeyCredentialResidentKeyPreference;
 @property (nonatomic, readonly, copy) NSString *relyingPartyIdentifier;
 
 @end
+
+extern NSErrorDomain const ASAuthorizationErrorDomain;
+
+typedef NS_ERROR_ENUM(ASAuthorizationErrorDomain, ASAuthorizationError) {
+    ASAuthorizationErrorUnknown = 1000,
+    ASAuthorizationErrorCanceled = 1001,
+    ASAuthorizationErrorInvalidResponse = 1002,
+    ASAuthorizationErrorNotHandled = 1003,
+    ASAuthorizationErrorFailed = 1004,
+    ASAuthorizationErrorNotInteractive = 1005,
+};
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesSoftLink.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesSoftLink.h
@@ -44,3 +44,6 @@ SOFT_LINK_CLASS_FOR_HEADER(WebKit, ASAuthorizationPublicKeyCredentialParameters)
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, ASAuthorizationPlatformPublicKeyCredentialDescriptor);
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, ASAuthorizationSecurityKeyPublicKeyCredentialDescriptor);
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, ASAuthorizationSecurityKeyPublicKeyCredentialAssertion);
+
+SOFT_LINK_CONSTANT_FOR_HEADER(WebKit, AuthenticationServices, ASAuthorizationErrorDomain, NSErrorDomain);
+#define ASAuthorizationErrorDomain WebKit::get_AuthenticationServices_ASAuthorizationErrorDomain()

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesSoftLink.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesSoftLink.mm
@@ -41,3 +41,5 @@ SOFT_LINK_CLASS_FOR_SOURCE(WebKit, AuthenticationServices, ASAuthorizationPlatfo
 SOFT_LINK_CLASS_FOR_SOURCE(WebKit, AuthenticationServices, ASAuthorizationSecurityKeyPublicKeyCredentialDescriptor);
 SOFT_LINK_CLASS_FOR_SOURCE(WebKit, AuthenticationServices, ASAuthorizationSecurityKeyPublicKeyCredentialAssertion);
 
+SOFT_LINK_CONSTANT_FOR_SOURCE(WebKit, AuthenticationServices, ASAuthorizationErrorDomain, NSErrorDomain);
+

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -754,7 +754,7 @@ void LocalAuthenticator::continueGetAssertionAfterUserVerification(Ref<WebCore::
     };
 
     NSDictionary *updateParams = @{
-        (id)kSecAttrLabel: requestOptions.rpId,
+        (id)kSecAttrApplicationLabel: nsCredentialId.get(),
     };
     auto status = SecItemUpdate((__bridge CFDictionaryRef)query, (__bridge CFDictionaryRef)updateParams);
     if (status)


### PR DESCRIPTION
#### ff54b35d1761a31af7ee619b0ad2b9e9bfea3e72
<pre>
Related origins for passkeys
<a href="https://bugs.webkit.org/show_bug.cgi?id=268426">https://bugs.webkit.org/show_bug.cgi?id=268426</a>
<a href="https://rdar.apple.com/121477240">rdar://121477240</a>

Reviewed by Pascoe.

This patch implements the WebKit side of related origins for passkeys.

- Validating the RPID against the current origin is now done by AuthenticationServices.

* Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.h:
(WebCore::AuthenticatorAssertionResponse::relyingPartyIdentifier const):
(WebCore::AuthenticatorAssertionResponse::setRelyingPartyIdentifier):
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::create):
(WebCore::AuthenticatorCoordinator::discoverFromExternalSource):
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.h:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl:
* Source/WebKit/Platform/spi/Cocoa/AuthenticationServicesCoreSPI.h:
(NS_ERROR_ENUM):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKPublicKeyCredentialRequestOptions.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm:
(-[_WKWebAuthenticationAssertionResponse relyingPartyIdentifier]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(relatedOrigins):
(+[_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:]):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesForwardDeclarations.h:
(NS_ERROR_ENUM):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesSoftLink.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticationServicesSoftLink.mm:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticatorInternal::getExistingCredentials):
(WebKit::LocalAuthenticator::makeCredential):
(WebKit::LocalAuthenticator::getAssertion):
(WebKit::LocalAuthenticator::continueGetAssertionAfterUserVerification):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::WebAuthenticatorCoordinatorProxy::constructASController):
(WebKit::WebAuthenticatorCoordinatorProxy::requestsForRegisteration):
(WebKit::WebAuthenticatorCoordinatorProxy::requestsForAssertion):
(WebKit::WebAuthenticatorCoordinatorProxy::performRequest):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h:

Canonical link: <a href="https://commits.webkit.org/274592@main">https://commits.webkit.org/274592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea6df9247270f6ea0600f0a8262fd4594e3bf3ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41983 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35349 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41755 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32974 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34167 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13483 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43261 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35819 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39250 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37500 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34391 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8847 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15915 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->