### PR TITLE
Refactor PlaybackSessionInterfaceAVKit

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -540,6 +540,8 @@ platform/ios/PlatformEventFactoryIOS.mm @no-unify
 platform/ios/PlatformPasteboardIOS.mm
 platform/ios/PlatformScreenIOS.mm
 platform/ios/PlaybackSessionInterfaceAVKit.mm @no-unify
+platform/ios/PlaybackSessionInterfaceIOS.mm @no-unify
+platform/ios/PlaybackSessionInterfaceLMK.mm @no-unify
 platform/ios/PreviewConverterIOS.mm
 platform/ios/QuickLook.mm
 platform/ios/ScrollAnimatorIOS.mm

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,40 +26,22 @@
 
 #pragma once
 
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) && HAVE(AVKIT)
 
-#include "EventListener.h"
-#include "HTMLMediaElementEnums.h"
-#include "PlaybackSessionModel.h"
-#include "Timer.h"
-#include <functional>
-#include <objc/objc.h>
-#include <wtf/Forward.h>
-#include <wtf/Ref.h>
-#include <wtf/RefCounted.h>
-#include <wtf/RetainPtr.h>
-#include <wtf/WeakPtr.h>
-
-OBJC_CLASS WebAVPlayerController;
+#include "PlaybackSessionInterfaceIOS.h"
 
 namespace WebCore {
-class IntRect;
-class PlaybackSessionModel;
-class WebPlaybackSessionChangeObserver;
 
 class WEBCORE_EXPORT PlaybackSessionInterfaceAVKit
-    : public PlaybackSessionModelClient
-    , public RefCounted<PlaybackSessionInterfaceAVKit> {
+    : public PlaybackSessionInterfaceIOS {
 
 public:
     static Ref<PlaybackSessionInterfaceAVKit> create(PlaybackSessionModel& model)
     {
         return adoptRef(*new PlaybackSessionInterfaceAVKit(model));
     }
+    WebAVPlayerController *playerController() const override;
     virtual ~PlaybackSessionInterfaceAVKit();
-    PlaybackSessionModel* playbackSessionModel() const;
-
-    // PlaybackSessionModelClient
     void durationChanged(double) override;
     void currentTimeChanged(double currentTime, double anchorTime) override;
     void bufferedTimeChanged(double) override;
@@ -72,25 +54,18 @@ public:
     void wirelessVideoPlaybackDisabledChanged(bool) override;
     void mutedChanged(bool) override;
     void volumeChanged(double) override;
-    void modelDestroyed() override;
-
     void invalidate();
 
-    WebAVPlayerController *playerController() const { return m_playerController.get(); }
-
 #if !RELEASE_LOG_DISABLED
-    const void* logIdentifier() const;
-    const Logger* loggerPtr() const;
-    const char* logClassName() const { return "PlaybackSessionInterfaceAVKit"; };
-    WTFLogChannel& logChannel() const;
+    const char* logClassName() const override;
 #endif
 
 private:
     PlaybackSessionInterfaceAVKit(PlaybackSessionModel&);
     RetainPtr<WebAVPlayerController> m_playerController;
-    PlaybackSessionModel* m_playbackSessionModel { nullptr };
+
 };
 
-}
+} // namespace WebCore
 
-#endif // PLATFORM(COCOA)
+#endif // PLATFORM(COCOA) && HAVE(AVKIT)

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#pragma once
+
+#if PLATFORM(COCOA) && HAVE(AVKIT)
+
+#include "EventListener.h"
+#include "HTMLMediaElementEnums.h"
+#include "PlaybackSessionModel.h"
+#include "Timer.h"
+#include <functional>
+#include <objc/objc.h>
+#include <wtf/Forward.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/WeakPtr.h>
+
+OBJC_CLASS WebAVPlayerController;
+
+namespace WebCore {
+class IntRect;
+class PlaybackSessionModel;
+class WebPlaybackSessionChangeObserver;
+
+class WEBCORE_EXPORT PlaybackSessionInterfaceIOS
+    : public PlaybackSessionModelClient
+    , public RefCounted<PlaybackSessionInterfaceIOS> {
+
+public:
+    virtual ~PlaybackSessionInterfaceIOS();
+    virtual WebAVPlayerController *playerController() const = 0;
+    PlaybackSessionModel* playbackSessionModel() const;
+    void durationChanged(double) override = 0;
+    void currentTimeChanged(double currentTime, double anchorTime) override = 0;
+    void bufferedTimeChanged(double) override = 0;
+    void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double playbackRate, double defaultPlaybackRate) override = 0;
+    void seekableRangesChanged(const TimeRanges&, double lastModifiedTime, double liveUpdateInterval) override = 0;
+    void canPlayFastReverseChanged(bool) override = 0;
+    void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex) override = 0;
+    void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>& options, uint64_t selectedIndex) override = 0;
+    void externalPlaybackChanged(bool enabled, PlaybackSessionModel::ExternalPlaybackTargetType, const String& localizedDeviceName) override = 0;
+    void wirelessVideoPlaybackDisabledChanged(bool) override = 0;
+    void mutedChanged(bool) override = 0;
+    void volumeChanged(double) override = 0;
+    void modelDestroyed() override;
+
+    void invalidate();
+
+#if !RELEASE_LOG_DISABLED
+    const void* logIdentifier() const;
+    const Logger* loggerPtr() const;
+    virtual const char* logClassName() const = 0;
+    WTFLogChannel& logChannel() const;
+#endif
+
+protected:
+    PlaybackSessionInterfaceIOS(PlaybackSessionModel&);
+    PlaybackSessionModel* m_playbackSessionModel { nullptr };
+
+};
+
+}
+
+#endif // PLATFORM(COCOA) && HAVE(AVKIT)

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2014-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#import "config.h"
+#import "PlaybackSessionInterfaceIOS.h"
+
+#if PLATFORM(COCOA) && HAVE(AVKIT)
+
+#import "Logging.h"
+#import "PlaybackSessionModel.h"
+#import <AVFoundation/AVTime.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/text/CString.h>
+#import <wtf/text/WTFString.h>
+
+#import <pal/cf/CoreMediaSoftLink.h>
+#import <pal/cocoa/AVFoundationSoftLink.h>
+
+
+namespace WebCore {
+
+PlaybackSessionInterfaceIOS::PlaybackSessionInterfaceIOS(PlaybackSessionModel& model)
+    : m_playbackSessionModel(&model)
+{
+    model.addClient(*this);
+}
+
+PlaybackSessionInterfaceIOS::~PlaybackSessionInterfaceIOS()
+{
+    ASSERT(isUIThread());
+    invalidate();
+}
+
+void PlaybackSessionInterfaceIOS::invalidate()
+{
+    if (!m_playbackSessionModel)
+        return;
+
+    m_playbackSessionModel->removeClient(*this);
+    m_playbackSessionModel = nullptr;
+}
+
+PlaybackSessionModel* PlaybackSessionInterfaceIOS::playbackSessionModel() const
+{
+    return m_playbackSessionModel;
+}
+
+void PlaybackSessionInterfaceIOS::modelDestroyed()
+{
+    ASSERT(isUIThread());
+    invalidate();
+    ASSERT(!m_playbackSessionModel);
+}
+
+#if !RELEASE_LOG_DISABLED
+const void* PlaybackSessionInterfaceIOS::logIdentifier() const
+{
+    return m_playbackSessionModel ? m_playbackSessionModel->logIdentifier() : nullptr;
+}
+
+const Logger* PlaybackSessionInterfaceIOS::loggerPtr() const
+{
+    return m_playbackSessionModel ? m_playbackSessionModel->loggerPtr() : nullptr;
+}
+
+WTFLogChannel& PlaybackSessionInterfaceIOS::logChannel() const
+{
+    return LogMedia;
+}
+#endif
+
+}
+
+#endif // PLATFORM(COCOA) && HAVE(AVKIT)

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceLMK.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceLMK.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(VISION) && HAVE(AVKIT)
+
+#include "PlaybackSessionInterfaceIOS.h"
+
+namespace WebCore {
+
+class WEBCORE_EXPORT PlaybackSessionInterfaceLMK : public PlaybackSessionInterfaceIOS {
+public:
+    static Ref<PlaybackSessionInterfaceLMK> create(PlaybackSessionModel&);
+    virtual ~PlaybackSessionInterfaceLMK();
+    WebAVPlayerController *playerController() const override;
+    void durationChanged(double) override;
+    void currentTimeChanged(double, double) override;
+    void bufferedTimeChanged(double) override;
+    void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double, double) override;
+    void seekableRangesChanged(const TimeRanges&, double, double) override;
+    void canPlayFastReverseChanged(bool) override;
+    void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) override;
+    void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) override;
+    void externalPlaybackChanged(bool, PlaybackSessionModel::ExternalPlaybackTargetType, const String&) override;
+    void wirelessVideoPlaybackDisabledChanged(bool) override;
+    void mutedChanged(bool) override;
+    void volumeChanged(double) override;
+
+#if !RELEASE_LOG_DISABLED
+    const char* logClassName() const override;
+#endif
+
+private:
+    PlaybackSessionInterfaceLMK(PlaybackSessionModel&);
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(VISION) && HAVE(AVKIT)

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "PlaybackSessionInterfaceLMK.h"
+
+#if PLATFORM(VISION)
+
+#import "MediaSelectionOption.h"
+#import "TimeRanges.h"
+
+namespace WebCore {
+
+Ref<PlaybackSessionInterfaceLMK> PlaybackSessionInterfaceLMK::create(PlaybackSessionModel& model)
+{
+    return adoptRef(*new PlaybackSessionInterfaceLMK(model));
+}
+
+PlaybackSessionInterfaceLMK::PlaybackSessionInterfaceLMK(PlaybackSessionModel& model)
+    : PlaybackSessionInterfaceIOS(model)
+{
+    durationChanged(model.duration());
+    currentTimeChanged(model.currentTime(), [[NSProcessInfo processInfo] systemUptime]);
+    bufferedTimeChanged(model.bufferedTime());
+    OptionSet<PlaybackSessionModel::PlaybackState> playbackState;
+    if (model.isPlaying())
+        playbackState.add(PlaybackSessionModel::PlaybackState::Playing);
+    if (model.isStalled())
+        playbackState.add(PlaybackSessionModel::PlaybackState::Stalled);
+    rateChanged(playbackState, model.playbackRate(), model.defaultPlaybackRate());
+    seekableRangesChanged(model.seekableRanges(), model.seekableTimeRangesLastModifiedTime(), model.liveUpdateInterval());
+    canPlayFastReverseChanged(model.canPlayFastReverse());
+    audioMediaSelectionOptionsChanged(model.audioMediaSelectionOptions(), model.audioMediaSelectedIndex());
+    legibleMediaSelectionOptionsChanged(model.legibleMediaSelectionOptions(), model.legibleMediaSelectedIndex());
+    externalPlaybackChanged(model.externalPlaybackEnabled(), model.externalPlaybackTargetType(), model.externalPlaybackLocalizedDeviceName());
+    wirelessVideoPlaybackDisabledChanged(model.wirelessVideoPlaybackDisabled());
+}
+
+WebAVPlayerController *PlaybackSessionInterfaceLMK::playerController() const
+{
+    return nullptr;
+}
+
+PlaybackSessionInterfaceLMK::~PlaybackSessionInterfaceLMK()
+{
+
+}
+
+void PlaybackSessionInterfaceLMK::durationChanged(double)
+{
+
+}
+
+void PlaybackSessionInterfaceLMK::currentTimeChanged(double, double)
+{
+
+}
+
+void PlaybackSessionInterfaceLMK::bufferedTimeChanged(double)
+{
+
+}
+
+void PlaybackSessionInterfaceLMK::rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double, double)
+{
+
+}
+
+void PlaybackSessionInterfaceLMK::seekableRangesChanged(const TimeRanges&, double, double)
+{
+
+}
+
+void PlaybackSessionInterfaceLMK::canPlayFastReverseChanged(bool)
+{
+
+}
+
+void PlaybackSessionInterfaceLMK::audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t)
+{
+
+}
+
+void PlaybackSessionInterfaceLMK::legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t)
+{
+
+}
+
+void PlaybackSessionInterfaceLMK::externalPlaybackChanged(bool, PlaybackSessionModel::ExternalPlaybackTargetType, const String&)
+{
+
+}
+
+void PlaybackSessionInterfaceLMK::wirelessVideoPlaybackDisabledChanged(bool)
+{
+
+}
+
+void PlaybackSessionInterfaceLMK::mutedChanged(bool)
+{
+
+}
+
+void PlaybackSessionInterfaceLMK::volumeChanged(double)
+{
+
+}
+
+#if !RELEASE_LOG_DISABLED
+const char* PlaybackSessionInterfaceLMK::logClassName() const
+{
+    return "PlaybackSessionInterfaceLMK";
+}
+#endif
+
+} // namespace WebCore
+
+#endif // PLATFORM(VISION)

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -33,7 +33,7 @@
 #include "MediaPlayerIdentifier.h"
 #include "PlatformImage.h"
 #include "PlatformLayer.h"
-#include "PlaybackSessionInterfaceAVKit.h"
+#include "PlaybackSessionInterfaceIOS.h"
 #include "VideoFullscreenCaptions.h"
 #include "VideoPresentationModel.h"
 #include <objc/objc.h>
@@ -67,10 +67,10 @@ class VideoPresentationInterfaceIOS final
     , public VideoFullscreenCaptions
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoPresentationInterfaceIOS, WTF::DestructionThread::MainRunLoop> {
 public:
-    WEBCORE_EXPORT static Ref<VideoPresentationInterfaceIOS> create(PlaybackSessionInterfaceAVKit&);
+    WEBCORE_EXPORT static Ref<VideoPresentationInterfaceIOS> create(PlaybackSessionInterfaceIOS&);
     WEBCORE_EXPORT virtual ~VideoPresentationInterfaceIOS();
     WEBCORE_EXPORT void setVideoPresentationModel(VideoPresentationModel*);
-    PlaybackSessionInterfaceAVKit& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
+    PlaybackSessionInterfaceIOS& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
 
     // VideoPresentationModelClient
@@ -171,7 +171,7 @@ public:
 #endif
 
 private:
-    WEBCORE_EXPORT VideoPresentationInterfaceIOS(PlaybackSessionInterfaceAVKit&);
+    WEBCORE_EXPORT VideoPresentationInterfaceIOS(PlaybackSessionInterfaceIOS&);
 
     void doSetup();
     void finalizeSetup();
@@ -192,7 +192,7 @@ private:
     Mode m_currentMode;
     Mode m_targetMode;
 
-    Ref<PlaybackSessionInterfaceAVKit> m_playbackSessionInterface;
+    Ref<PlaybackSessionInterfaceIOS> m_playbackSessionInterface;
     std::optional<MediaPlayerIdentifier> m_playerIdentifier;
     RetainPtr<WebAVPlayerViewControllerDelegate> m_playerViewControllerDelegate;
     RetainPtr<WebAVPlayerViewController> m_playerViewController;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -788,14 +788,14 @@ static const NSTimeInterval startPictureInPictureTimeInterval = 5.0;
 #endif
 @end
 
-Ref<VideoPresentationInterfaceIOS> VideoPresentationInterfaceIOS::create(PlaybackSessionInterfaceAVKit& playbackSessionInterface)
+Ref<VideoPresentationInterfaceIOS> VideoPresentationInterfaceIOS::create(PlaybackSessionInterfaceIOS& playbackSessionInterface)
 {
     Ref<VideoPresentationInterfaceIOS> interface = adoptRef(*new VideoPresentationInterfaceIOS(playbackSessionInterface));
     [interface->m_playerViewControllerDelegate setFullscreenInterface:interface.ptr()];
     return interface;
 }
 
-VideoPresentationInterfaceIOS::VideoPresentationInterfaceIOS(PlaybackSessionInterfaceAVKit& playbackSessionInterface)
+VideoPresentationInterfaceIOS::VideoPresentationInterfaceIOS(PlaybackSessionInterfaceIOS& playbackSessionInterface)
     : m_playbackSessionInterface(playbackSessionInterface)
     , m_playerViewControllerDelegate(adoptNS([[WebAVPlayerViewControllerDelegate alloc] init]))
     , m_watchdogTimer(RunLoop::main(), this, &VideoPresentationInterfaceIOS::watchdogTimerFired)

--- a/Source/WebCore/platform/ios/WebAVPlayerController.h
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 namespace WebCore {
 class PlaybackSessionModel;
-class PlaybackSessionInterfaceAVKit;
+class PlaybackSessionInterfaceIOS;
 }
 
 @class AVTimeRange;
@@ -51,7 +51,7 @@ class PlaybackSessionInterfaceAVKit;
 
 @property (retain) AVPlayerController *playerControllerProxy;
 @property (assign, nullable /*weak*/) WebCore::PlaybackSessionModel* delegate;
-@property (assign, nullable /*weak*/) WebCore::PlaybackSessionInterfaceAVKit* playbackSessionInterface;
+@property (assign, nullable /*weak*/) WebCore::PlaybackSessionInterfaceIOS* playbackSessionInterface;
 
 @property (readonly) BOOL canScanForward;
 @property BOOL canScanBackward;

--- a/Source/WebCore/platform/ios/WebAVPlayerController.mm
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.mm
@@ -30,7 +30,7 @@
 #if PLATFORM(COCOA) && HAVE(AVKIT)
 
 #import "Logging.h"
-#import "PlaybackSessionInterfaceAVKit.h"
+#import "PlaybackSessionInterfaceIOS.h"
 #import "PlaybackSessionModel.h"
 #import "TimeRanges.h"
 #import <AVFoundation/AVTime.h>
@@ -195,7 +195,7 @@ Class webAVPlayerControllerClass()
 
 @implementation WebAVPlayerController {
     WeakPtr<WebCore::PlaybackSessionModel> _delegate;
-    WeakPtr<WebCore::PlaybackSessionInterfaceAVKit> _playbackSessionInterface;
+    WeakPtr<WebCore::PlaybackSessionInterfaceIOS> _playbackSessionInterface;
     double _defaultPlaybackRate;
     double _rate;
     BOOL _liveStreamEventModePossible;
@@ -330,12 +330,12 @@ Class webAVPlayerControllerClass()
     _delegate = WeakPtr { delegate };
 }
 
-- (WebCore::PlaybackSessionInterfaceAVKit*)playbackSessionInterface
+- (WebCore::PlaybackSessionInterfaceIOS*)playbackSessionInterface
 {
     return _playbackSessionInterface.get();
 }
 
-- (void)setPlaybackSessionInterface:(WebCore::PlaybackSessionInterfaceAVKit*)playbackSessionInterface
+- (void)setPlaybackSessionInterface:(WebCore::PlaybackSessionInterfaceIOS*)playbackSessionInterface
 {
     _playbackSessionInterface = WeakPtr { playbackSessionInterface };
 }

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -1007,8 +1007,7 @@ void VideoFullscreenControllerContext::setUpFullscreen(HTMLVideoElement& videoEl
     RunLoop::main().dispatch([protectedThis = Ref { *this }, this, videoElementClientRect, videoDimensions, viewRef, mode, allowsPictureInPicture] {
         ASSERT(isUIThread());
         WebThreadLock();
-
-        Ref<PlaybackSessionInterfaceAVKit> sessionInterface = PlaybackSessionInterfaceAVKit::create(*this);
+        Ref<PlaybackSessionInterfaceIOS> sessionInterface = PlaybackSessionInterfaceAVKit::create(*this);
         m_interface = VideoPresentationInterfaceIOS::create(sessionInterface.get());
         m_interface->setVideoPresentationModel(this);
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -43,6 +43,8 @@
 #import <QuartzCore/CoreAnimation.h>
 #import <WebCore/MediaPlayerEnums.h>
 #import <WebCore/NullVideoPresentationInterface.h>
+#import <WebCore/PlaybackSessionInterfaceAVKit.h>
+#import <WebCore/PlaybackSessionInterfaceMac.h>
 #import <WebCore/TimeRanges.h>
 #import <WebCore/VideoPresentationInterfaceIOS.h>
 #import <WebCore/VideoPresentationInterfaceMac.h>
@@ -547,7 +549,7 @@ VideoPresentationManagerProxy::ModelInterfaceTuple VideoPresentationManagerProxy
     Ref playbackSessionModel = m_playbackSessionManagerProxy->ensureModel(contextId);
     auto model = VideoPresentationModelContext::create(*this, playbackSessionModel, contextId);
     Ref playbackSessionInterface = m_playbackSessionManagerProxy->ensureInterface(contextId);
-    Ref<PlatformVideoPresentationInterface> interface = PlatformVideoPresentationInterface::create(playbackSessionInterface);
+    Ref<PlatformVideoPresentationInterface> interface = PlatformVideoPresentationInterface::create(playbackSessionInterface.get());
     m_playbackSessionManagerProxy->addClientForContext(contextId);
 
     interface->setVideoPresentationModel(model.ptr());

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -39,6 +39,7 @@
 #import "WebPageProxy.h"
 #import "WebPreferences.h"
 #import <WebCore/LocalizedStrings.h>
+#import <WebCore/PlaybackSessionInterfaceAVKit.h>
 #import <WebCore/VideoPresentationInterfaceIOS.h>
 #import <pal/spi/cocoa/AVKitSPI.h>
 #import <wtf/RetainPtr.h>
@@ -47,10 +48,6 @@
 #if PLATFORM(VISION)
 #import "MRUIKitSPI.h"
 #endif
-
-namespace WebCore {
-class PlaybackSessionInterfaceAVKit;
-}
 
 static const NSTimeInterval showHideAnimationDuration = 0.1;
 static const NSTimeInterval pipHideAnimationDuration = 0.2;
@@ -78,7 +75,7 @@ public:
             controller.pictureInPictureActive = active;
     }
 
-    void setInterface(WebCore::PlaybackSessionInterfaceAVKit* interface)
+    void setInterface(WebCore::PlaybackSessionInterfaceIOS* interface)
     {
         if (m_interface == interface)
             return;
@@ -92,7 +89,7 @@ public:
 
 private:
     WeakObjCPtr<WKFullScreenViewController> m_parent;
-    RefPtr<WebCore::PlaybackSessionInterfaceAVKit> m_interface;
+    RefPtr<WebCore::PlaybackSessionInterfaceIOS> m_interface;
 };
 
 #pragma mark - _WKInsetLabel

--- a/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm
@@ -128,7 +128,7 @@ static WebAVPlayerView *allocWebAVPlayerViewInstance()
 
 @interface WebVideoFullscreenController () <WebAVPlayerViewDelegate, NSWindowDelegate> {
     RefPtr<WebCore::PlaybackSessionModelMediaElement> _playbackModel;
-    RefPtr<WebCore::PlaybackSessionInterfaceAVKit> _playbackInterface;
+    RefPtr<WebCore::PlaybackSessionInterfaceIOS> _playbackInterface;
     RetainPtr<NSView> _contentOverlay;
     BOOL _isFullScreen;
 }


### PR DESCRIPTION
#### 8f3c7ed80e7d7aa61480065dec88bea27bf7c997
<pre>
Refactor PlaybackSessionInterfaceAVKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=268418">https://bugs.webkit.org/show_bug.cgi?id=268418</a>
<a href="https://rdar.apple.com/121965868">rdar://121965868</a>

Reviewed by Jer Noble.

This patch refactors PlaybackSessionInterfaceAVKit. It makes a base class, PlaybackSessionInterfaceIOS,
and two classes that are derived from it: PlaybackSessionInterfaceAVKit and PlaybackSessionInterfaceLMK.
All AVKit-specific code is in PlaybackSessionInterfaceAVKit. PlaybackSessionInterfaceLMK will be used on
the vision platform in a later patch. As for now, PlaybackSessionInterfaceAVKit is the only class that is ever
instantiated.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/PlatformPlaybackSessionInterface.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm:
(WebCore::PlaybackSessionInterfaceAVKit::PlaybackSessionInterfaceAVKit):
(WebCore::PlaybackSessionInterfaceAVKit::playerController const):
(WebCore::PlaybackSessionInterfaceAVKit::invalidate):
(WebCore::PlaybackSessionInterfaceAVKit::playbackSessionModel const): Deleted.
(WebCore::PlaybackSessionInterfaceAVKit::modelDestroyed): Deleted.
(WebCore::PlaybackSessionInterfaceAVKit::logIdentifier const): Deleted.
(WebCore::PlaybackSessionInterfaceAVKit::loggerPtr const): Deleted.
(WebCore::PlaybackSessionInterfaceAVKit::logChannel const): Deleted.
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h: Copied from Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h.
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm: Added.
(WebCore::PlaybackSessionInterfaceIOS::PlaybackSessionInterfaceIOS):
(WebCore::PlaybackSessionInterfaceIOS::playbackSessionModel const):
(WebCore::PlaybackSessionInterfaceIOS::modelDestroyed):
(WebCore::PlaybackSessionInterfaceIOS::logIdentifier const):
(WebCore::PlaybackSessionInterfaceIOS::loggerPtr const):
(WebCore::PlaybackSessionInterfaceIOS::logChannel const):
* Source/WebCore/platform/ios/PlaybackSessionInterfaceLMK.h: Copied from Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h.
* Source/WebCore/platform/ios/PlaybackSessionInterfaceLMK.mm: Added.
(WebCore::PlaybackSessionInterfaceLMK::PlaybackSessionInterfaceLMK):
(WebCore::PlaybackSessionInterfaceLMK::~PlaybackSessionInterfaceLMK):
(WebCore::PlaybackSessionInterfaceLMK::durationChanged):
(WebCore::PlaybackSessionInterfaceLMK::currentTimeChanged):
(WebCore::PlaybackSessionInterfaceLMK::bufferedTimeChanged):
(WebCore::PlaybackSessionInterfaceLMK::rateChanged):
(WebCore::PlaybackSessionInterfaceLMK::seekableRangesChanged):
(WebCore::PlaybackSessionInterfaceLMK::canPlayFastReverseChanged):
(WebCore::PlaybackSessionInterfaceLMK::audioMediaSelectionOptionsChanged):
(WebCore::PlaybackSessionInterfaceLMK::legibleMediaSelectionOptionsChanged):
(WebCore::PlaybackSessionInterfaceLMK::externalPlaybackChanged):
(WebCore::PlaybackSessionInterfaceLMK::wirelessVideoPlaybackDisabledChanged):
(WebCore::PlaybackSessionInterfaceLMK::mutedChanged):
(WebCore::PlaybackSessionInterfaceLMK::volumeChanged):
(WebCore::PlaybackSessionInterfaceLMK::invalidate):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(VideoPresentationInterfaceIOS::create):
(VideoPresentationInterfaceIOS::VideoPresentationInterfaceIOS):
* Source/WebCore/platform/ios/WebAVPlayerController.h:
* Source/WebCore/platform/ios/WebAVPlayerController.mm:
(-[WebAVPlayerController playbackSessionInterface]):
(-[WebAVPlayerController setPlaybackSessionInterface:]):
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
(VideoFullscreenControllerContext::setUpFullscreen):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::createModelAndInterface):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(WKFullScreenViewControllerPlaybackSessionModelClient::setInterface):
* Source/WebKitLegacy/mac/WebView/WebVideoFullscreenController.mm:
(-[WebVideoFullscreenController init]):

Canonical link: <a href="https://commits.webkit.org/273994@main">https://commits.webkit.org/273994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa19e9baf02fc13669d1aaa1145dd9cf0e4a3aab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39942 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18904 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13449 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31767 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37981 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32840 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11952 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11936 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41205 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33826 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33938 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37831 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35987 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13976 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8441 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12913 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13292 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->