### PR TITLE
Widget::root() should return a FrameView

### DIFF
--- a/Source/WebCore/platform/Widget.cpp
+++ b/Source/WebCore/platform/Widget.cpp
@@ -26,9 +26,9 @@
 #include "config.h"
 #include "Widget.h"
 
+#include "FrameView.h"
 #include "HostWindow.h"
 #include "IntRect.h"
-#include "LocalFrameView.h"
 #include "NotImplemented.h"
 #include <wtf/Assertions.h>
 
@@ -56,13 +56,13 @@ void Widget::setParent(ScrollView* view)
         setParentVisible(true);
 }
 
-LocalFrameView* Widget::root() const
+FrameView* Widget::root() const
 {
     const Widget* top = this;
     while (top->parent())
         top = top->parent();
-    if (is<LocalFrameView>(*top))
-        return const_cast<LocalFrameView*>(downcast<LocalFrameView>(top));
+    if (auto* frameView = dynamicDowncast<FrameView>(top))
+        return const_cast<FrameView*>(frameView);
     return nullptr;
 }
     

--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -62,8 +62,8 @@ namespace WebCore {
 class Cursor;
 class Event;
 class FontCascade;
+class FrameView;
 class GraphicsContext;
-class LocalFrameView;
 class PlatformMouseEvent;
 class RegionContext;
 class ScrollView;
@@ -138,7 +138,7 @@ public:
     WEBCORE_EXPORT void removeFromParent();
     WEBCORE_EXPORT virtual void setParent(ScrollView* view);
     WEBCORE_EXPORT ScrollView* parent() const;
-    LocalFrameView* root() const;
+    FrameView* root() const;
 
     virtual void handleEvent(Event&) { }
 


### PR DESCRIPTION
#### 5373d9e1c714660e1636c33180685961dd6a3a90
<pre>
Widget::root() should return a FrameView
<a href="https://bugs.webkit.org/show_bug.cgi?id=268428">https://bugs.webkit.org/show_bug.cgi?id=268428</a>
<a href="https://rdar.apple.com/121974586">rdar://121974586</a>

Reviewed by Alex Christensen.

Widget::root() should return the top FrameView even if it is being hosted in another process.

* Source/WebCore/platform/Widget.cpp:
(WebCore::Widget::root const):
* Source/WebCore/platform/Widget.h:

Canonical link: <a href="https://commits.webkit.org/273869@main">https://commits.webkit.org/273869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd6175892caa360a4a5226ae2fc2a952681cf492

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39371 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32915 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/37971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31485 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11545 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32728 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40619 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33264 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33079 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37481 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35601 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13506 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12241 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4789 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12730 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->