### PR TITLE
Drop IPC coders from CDMInstanceSession::Message

### DIFF
--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -863,25 +863,4 @@ std::optional<Ref<ControlPart>> ArgumentCoder<ControlPart>::decode(Decoder& deco
     return std::nullopt;
 }
 
-#if ENABLE(ENCRYPTED_MEDIA)
-void ArgumentCoder<WebCore::CDMInstanceSession::Message>::encode(Encoder& encoder, const WebCore::CDMInstanceSession::Message& message)
-{
-    encoder << message.first;
-    encoder << message.second;
-}
-
-std::optional<WebCore::CDMInstanceSession::Message>  ArgumentCoder<WebCore::CDMInstanceSession::Message>::decode(Decoder& decoder)
-{
-    WebCore::CDMInstanceSession::MessageType type;
-    if (!decoder.decode(type))
-        return std::nullopt;
-
-    auto buffer = decoder.decode<Ref<SharedBuffer>>();
-    if (UNLIKELY(!buffer))
-        return std::nullopt;
-
-    return std::make_optional<WebCore::CDMInstanceSession::Message>({ type, WTFMove(*buffer) });
-}
-#endif // ENABLE(ENCRYPTED_MEDIA)
-
 } // namespace IPC

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -64,11 +64,6 @@
 #include <WebCore/MediaPlaybackTargetContext.h>
 #endif
 
-#if ENABLE(ENCRYPTED_MEDIA)
-#include <WebCore/CDMInstance.h>
-#include <WebCore/CDMInstanceSession.h>
-#endif
-
 #if PLATFORM(IOS_FAMILY)
 #include <WebCore/InspectorOverlay.h>
 #endif
@@ -252,13 +247,6 @@ template<> struct ArgumentCoder<WebCore::DataDetectorElementInfo> {
     static std::optional<WebCore::DataDetectorElementInfo> decode(Decoder&);
 };
 
-#endif
-
-#if ENABLE(ENCRYPTED_MEDIA)
-template<> struct ArgumentCoder<WebCore::CDMInstanceSession::Message> {
-    static void encode(Encoder&, const WebCore::CDMInstanceSession::Message&);
-    static std::optional<WebCore::CDMInstanceSession::Message> decode(Decoder&);
-};
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4386,6 +4386,7 @@ enum class WebCore::CDMRequirement : uint8_t {
     NotAllowed
 };
 
+header: <WebCore/CDMInstanceSession.h>
 enum class WebCore::CDMInstanceSessionLoadFailure : uint8_t {
     None,
     NoSessionData,
@@ -4394,13 +4395,13 @@ enum class WebCore::CDMInstanceSessionLoadFailure : uint8_t {
     Other,
 };
 
+header: <WebCore/CDMInstance.h>
 [Nested] enum class WebCore::CDMInstance::HDCPStatus : uint8_t {
     Unknown,
     Valid,
     OutputRestricted,
     OutputDownscaled,
 };
-
 #endif
 
 #if ENABLE(WEB_RTC)


### PR DESCRIPTION
#### e8c664ea9a9243dbf7c8a9966bb87cf616ad2a92
<pre>
Drop IPC coders from CDMInstanceSession::Message
<a href="https://bugs.webkit.org/show_bug.cgi?id=268433">https://bugs.webkit.org/show_bug.cgi?id=268433</a>

Reviewed by Alex Christensen.

Drop IPC coders from CDMInstanceSession::Message. It&apos;s just a std::pair, it builds
without it.

* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;WebCore::CDMInstanceSession::Message&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::CDMInstanceSession::Message&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/273858@main">https://commits.webkit.org/273858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a91b38837e4f77a700439ce5f69f8f9818207290

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/38974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39380 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32919 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31490 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37299 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11553 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11568 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40629 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33275 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37489 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9661 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35609 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13510 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12245 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4782 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12736 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->