### PR TITLE
Corrupt tiles when scrolling and selecting text quickly.

### DIFF
--- a/LayoutTests/compositing/repaint/needs-no-display-volatile-repaint-expected.html
+++ b/LayoutTests/compositing/repaint/needs-no-display-volatile-repaint-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        div {
+            width: 100px;
+            height: 100px;
+            position: absolute;
+            background-color: green;
+        }
+        #second {
+            left: 200px;
+        }
+    </style>
+</head>
+<body>
+    <div id="first">A</div>
+    <div id="second">B</div>
+</body>
+</html>

--- a/LayoutTests/compositing/repaint/needs-no-display-volatile-repaint.html
+++ b/LayoutTests/compositing/repaint/needs-no-display-volatile-repaint.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        .layer {
+            width: 100px;
+            height: 100px;
+            position: absolute;
+            transform: translate3d(0, 0, 0);
+        }
+        #first {
+            background-color: red;
+        }
+        #second {
+            left: 200px;
+            background-color: red;
+        }
+        #repaint {
+            width: 50px;
+            height: 50px;
+            background-color: red;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.waitUntilDone();
+            if (testRunner.dontForceRepaint)
+                testRunner.dontForceRepaint();
+        }
+        async function doTest()
+        {
+            await UIHelper.renderingUpdate();
+
+            // Make the front buffer of 'first' contain green, and the back red.
+            document.getElementById('first').style.backgroundColor = "green";
+            await UIHelper.renderingUpdate();
+
+            // Make 'first' volatile and trigger a paint by mutating an unrelated layer.
+            window.internals.markFrontBufferVolatile(document.getElementById('first'));
+            document.getElementById('second').style.backgroundColor = "green";
+
+            await UIHelper.renderingUpdate();
+
+            // Do a partial repaint on 'first', such that we re-use the existing
+            // red buffer and make it all green (by copying from the old front, plus
+            // repainting the new subset).
+            document.getElementById('repaint').style.backgroundColor = "green";
+
+            await UIHelper.renderingUpdate();
+            await UIHelper.renderingUpdate();
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <div class="layer" id="first">A<div id="repaint"></div></div>
+    <div class="layer" id="second">B</div>
+</body>
+</html>


### PR DESCRIPTION
#### 77e5bb39107371558f6ee94cf74b988d3231ab41
<pre>
Corrupt tiles when scrolling and selecting text quickly.
<a href="https://bugs.webkit.org/show_bug.cgi?id=268430">https://bugs.webkit.org/show_bug.cgi?id=268430</a>
&lt;<a href="https://rdar.apple.com/121934201">rdar://121934201</a>&gt;

Reviewed by Simon Fraser.

If ensureBufferForDisplay returns SwapBuffersDisplayRequirement::NeedsNoDisplay, then we don&apos;t want
to call prepareForDisplay. The latter copies pixels from the old front buffer into the new one,
and when no display is required there wasn&apos;t a front/back swap, so no copy needed.

This caused issues because we also set &apos;m_previouslyPaintedRect` to the (empty!) dirty area,
effectively recording that the front and back buffers were identical, despite it likely
not being true. The next attempt to paint these buffers would omit a back-to-front copy,
thinking the buffers were identical, and then we&apos;d do a partial update on top of stale content.

This happens when scrolling, since scrolling tiles get pooled (and made volatile), then
recycled.

* LayoutTests/compositing/repaint/needs-no-display-volatile-repaint-expected.html: Added.
* LayoutTests/compositing/repaint/needs-no-display-volatile-repaint.html: Added.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::prepareImageBufferSetsForDisplay):
(WebKit::RemoteRenderingBackend::prepareImageBufferSetsForDisplaySync):

Canonical link: <a href="https://commits.webkit.org/273838@main">https://commits.webkit.org/273838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9c1e238787b07fdcee75674bd277b8ee87b10a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39412 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32939 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12819 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31503 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11577 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11586 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40660 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33326 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33118 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37507 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11867 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35629 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13530 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32456 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8350 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12765 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->