### PR TITLE
Port ResourceError to the new IPC serialization format

### DIFF
--- a/Source/WebCore/platform/network/cf/ResourceError.h
+++ b/Source/WebCore/platform/network/cf/ResourceError.h
@@ -55,6 +55,15 @@ public:
     WEBCORE_EXPORT NSError *nsError() const;
     WEBCORE_EXPORT operator NSError *() const;
 
+
+    struct IPCData {
+        Type type;
+        RetainPtr<NSError> nsError;
+        bool isSanitized;
+    };
+    WEBCORE_EXPORT static ResourceError fromIPCData(std::optional<IPCData>&&);
+    WEBCORE_EXPORT std::optional<IPCData> ipcData() const;
+
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     WEBCORE_EXPORT bool blockedKnownTracker() const;
     WEBCORE_EXPORT String blockedTrackerHostName() const;

--- a/Source/WebCore/platform/network/curl/ResourceError.h
+++ b/Source/WebCore/platform/network/curl/ResourceError.h
@@ -42,6 +42,17 @@ public:
     {
     }
 
+    struct IPCData {
+        Type type;
+        String domain;
+        int errorCode;
+        URL failingURL;
+        String localizedDescription;
+        IsSanitized isSanitized;
+    };
+    WEBCORE_EXPORT static ResourceError fromIPCData(std::optional<IPCData>&&);
+    WEBCORE_EXPORT std::optional<IPCData> ipcData() const;
+
     WEBCORE_EXPORT ResourceError(int curlCode, const URL& failingURL, Type = Type::General);
 
     WEBCORE_EXPORT bool isCertificationVerificationError() const;

--- a/Source/WebCore/platform/network/curl/ResourceErrorCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceErrorCurl.cpp
@@ -43,6 +43,36 @@ ResourceError::ResourceError(int curlCode, const URL& failingURL, Type type)
 {
 }
 
+ResourceError ResourceError::fromIPCData(std::optional<IPCData>&& ipcData)
+{
+    if (!ipcData)
+        return { };
+
+    return {
+        ipcData->domain,
+        ipcData->errorCode,
+        ipcData->failingURL,
+        ipcData->localizedDescription,
+        ipcData->type,
+        ipcData->isSanitized
+    };
+}
+
+auto ResourceError::ipcData() const -> std::optional<IPCData>
+{
+    if (isNull())
+        return std::nullopt;
+
+    return IPCData {
+        type(),
+        domain(),
+        errorCode(),
+        failingURL(),
+        localizedDescription(),
+        m_isSanitized
+    };
+}
+
 bool ResourceError::isCertificationVerificationError() const
 {
     return domain() == curlErrorDomain() && errorCode() == CURLE_PEER_FAILED_VERIFICATION;

--- a/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
+++ b/Source/WebCore/platform/network/mac/ResourceErrorMac.mm
@@ -118,6 +118,30 @@ ResourceError::ResourceError(NSError *nsError)
     mapPlatformError();
 }
 
+ResourceError ResourceError::fromIPCData(std::optional<IPCData>&& ipcData)
+{
+    if (!ipcData)
+        return { };
+
+    ResourceError error(ipcData->nsError.get());
+    error.setType(ipcData->type);
+    if (ipcData->isSanitized)
+        error.setAsSanitized();
+    return error;
+}
+
+auto ResourceError::ipcData() const -> std::optional<IPCData>
+{
+    if (isNull())
+        return std::nullopt;
+
+    return IPCData {
+        type(),
+        nsError(),
+        isSanitized()
+    };
+}
+
 ResourceError::ResourceError(CFErrorRef cfError)
     : ResourceError { (__bridge NSError *)cfError }
 {

--- a/Source/WebCore/platform/network/soup/ResourceError.h
+++ b/Source/WebCore/platform/network/soup/ResourceError.h
@@ -29,6 +29,7 @@
 
 #if USE(SOUP)
 
+#include "CertificateInfo.h"
 #include <wtf/glib/GRefPtr.h>
 
 typedef struct _GTlsCertificate GTlsCertificate;
@@ -43,10 +44,19 @@ public:
     {
     }
 
-    ResourceError(const String& domain, int errorCode, const URL& failingURL, const String& localizedDescription, Type type = Type::General, IsSanitized isSanitized = IsSanitized::No)
-        : ResourceErrorBase(domain, errorCode, failingURL, localizedDescription, type, isSanitized)
-    {
-    }
+    ResourceError(const String& domain, int errorCode, const URL& failingURL, const String& localizedDescription, Type = Type::General, IsSanitized = IsSanitized::No);
+
+    struct IPCData {
+        Type type;
+        String domain;
+        int errorCode;
+        URL failingURL;
+        String localizedDescription;
+        IsSanitized isSanitized;
+        CertificateInfo certificateInfo;
+    };
+    WEBCORE_EXPORT static ResourceError fromIPCData(std::optional<IPCData>&&);
+    WEBCORE_EXPORT std::optional<IPCData> ipcData() const;
 
     static ResourceError httpError(SoupMessage*, GError*);
     static ResourceError transportError(const URL&, int statusCode, const String& reasonPhrase);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -118,7 +118,6 @@
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/Report.h>
 #include <WebCore/ReportBody.h>
-#include <WebCore/ResourceError.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/RotateTransformOperation.h>
@@ -399,40 +398,6 @@ std::optional<FontPlatformData::Attributes> ArgumentCoder<FontPlatformData::Attr
 }
 
 #endif
-
-void ArgumentCoder<ResourceError>::encode(Encoder& encoder, const ResourceError& resourceError)
-{
-    encoder << resourceError.type();
-    if (resourceError.type() == ResourceError::Type::Null)
-        return;
-    encodePlatformData(encoder, resourceError);
-    encoder << resourceError.isSanitized();
-}
-
-bool ArgumentCoder<ResourceError>::decode(Decoder& decoder, ResourceError& resourceError)
-{
-    ResourceError::Type type;
-    if (!decoder.decode(type))
-        return false;
-
-    if (type == ResourceError::Type::Null) {
-        resourceError = { };
-        return true;
-    }
-
-    if (!decodePlatformData(decoder, resourceError))
-        return false;
-
-    bool isSanitized;
-    if (!decoder.decode(isSanitized))
-        return false;
-
-    resourceError.setType(type);
-    if (isSanitized)
-        resourceError.setAsSanitized();
-
-    return true;
-}
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 void ArgumentCoder<MediaPlaybackTargetContext>::encode(Encoder& encoder, const MediaPlaybackTargetContext& target)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -112,7 +112,6 @@ class FontPlatformData;
 class FragmentedSharedBuffer;
 class PaymentInstallmentConfiguration;
 class PixelBuffer;
-class ResourceError;
 class ScriptBuffer;
 class SerializedScriptValue;
 class SharedBuffer;
@@ -168,13 +167,6 @@ template<> struct ArgumentCoder<WebCore::FontPlatformData::Attributes> {
 template<> struct ArgumentCoder<WebCore::FontCustomPlatformData> {
     static void encode(Encoder&, const WebCore::FontCustomPlatformData&);
     static std::optional<Ref<WebCore::FontCustomPlatformData>> decode(Decoder&);
-};
-
-template<> struct ArgumentCoder<WebCore::ResourceError> {
-    static void encode(Encoder&, const WebCore::ResourceError&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::ResourceError&);
-    static void encodePlatformData(Encoder&, const WebCore::ResourceError&);
-    static WARN_UNUSED_RETURN bool decodePlatformData(Decoder&, WebCore::ResourceError&);
 };
 
 #if USE(APPKIT)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1903,6 +1903,29 @@ header: <WebCore/ResourceRequest.h>
 };
 #endif
 
+[Nested] struct WebCore::ResourceError::IPCData {
+    [Validator='*type != WebCore::ResourceError::Type::Null'] WebCore::ResourceError::Type type;
+#if PLATFORM(COCOA)
+    RetainPtr<NSError> nsError;
+    bool isSanitized;
+#endif // PLATFORM(COCOA)
+#if !PLATFORM(COCOA)
+    String domain;
+    int errorCode;
+    URL failingURL;
+    String localizedDescription;
+    WebCore::ResourceError::IsSanitized isSanitized;
+#endif // !PLATFORM(COCOA)
+#if USE(SOUP)
+    WebCore::CertificateInfo certificateInfo;
+#endif // USE(SOUP)
+};
+
+header: <WebCore/ResourceError.h>
+[CreateUsing=fromIPCData] class WebCore::ResourceError {
+    std::optional<WebCore::ResourceError::IPCData> ipcData();
+};
+
 header: <WebCore/DiagnosticLoggingDomain.h>
 enum class WebCore::DiagnosticLoggingDomain : uint8_t {
     Media

--- a/Source/WebKit/Shared/curl/WebCoreArgumentCodersCurl.cpp
+++ b/Source/WebKit/Shared/curl/WebCoreArgumentCodersCurl.cpp
@@ -40,49 +40,6 @@ namespace IPC {
 
 using namespace WebCore;
 
-void ArgumentCoder<ResourceError>::encodePlatformData(Encoder& encoder, const ResourceError& resourceError)
-{
-    encoder << resourceError.type();
-    if (resourceError.isNull())
-        return;
-
-    encoder << resourceError.domain();
-    encoder << resourceError.errorCode();
-    encoder << resourceError.failingURL().string();
-    encoder << resourceError.localizedDescription();
-}
-
-bool ArgumentCoder<ResourceError>::decodePlatformData(Decoder& decoder, ResourceError& resourceError)
-{
-    ResourceErrorBase::Type errorType;
-    if (!decoder.decode(errorType))
-        return false;
-    if (errorType == ResourceErrorBase::Type::Null) {
-        resourceError = { };
-        return true;
-    }
-
-    String domain;
-    if (!decoder.decode(domain))
-        return false;
-
-    int errorCode;
-    if (!decoder.decode(errorCode))
-        return false;
-
-    String failingURL;
-    if (!decoder.decode(failingURL))
-        return false;
-
-    String localizedDescription;
-    if (!decoder.decode(localizedDescription))
-        return false;
-
-    resourceError = ResourceError(domain, errorCode, URL { failingURL }, localizedDescription, errorType);
-
-    return true;
-}
-
 void ArgumentCoder<Credential>::encodePlatformData(Encoder&, const Credential&)
 {
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm
+++ b/Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm
@@ -48,23 +48,6 @@
 
 namespace IPC {
 
-void ArgumentCoder<WebCore::ResourceError>::encodePlatformData(Encoder& encoder, const WebCore::ResourceError& resourceError)
-{
-    encoder << WebKit::CoreIPCError(resourceError.nsError());
-}
-
-
-
-bool ArgumentCoder<WebCore::ResourceError>::decodePlatformData(Decoder& decoder, WebCore::ResourceError& resourceError)
-{
-    std::optional<WebKit::CoreIPCError> error;
-    decoder >> error;
-    if (!error)
-        return false;
-    resourceError = WebCore::ResourceError(error->toID().get());
-    return true;
-}
-
 void ArgumentCoder<WebCore::Credential>::encodePlatformData(Encoder& encoder, const WebCore::Credential& credential)
 {
     NSURLCredential *nsCredential = credential.nsCredential();

--- a/Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp
+++ b/Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp
@@ -44,45 +44,6 @@
 namespace IPC {
 using namespace WebCore;
 
-void ArgumentCoder<ResourceError>::encodePlatformData(Encoder& encoder, const ResourceError& resourceError)
-{
-    encoder << resourceError.domain();
-    encoder << resourceError.errorCode();
-    encoder << resourceError.failingURL().string();
-    encoder << resourceError.localizedDescription();
-
-    encoder << CertificateInfo(resourceError);
-}
-
-bool ArgumentCoder<ResourceError>::decodePlatformData(Decoder& decoder, ResourceError& resourceError)
-{
-    String domain;
-    if (!decoder.decode(domain))
-        return false;
-
-    int errorCode;
-    if (!decoder.decode(errorCode))
-        return false;
-
-    String failingURL;
-    if (!decoder.decode(failingURL))
-        return false;
-
-    String localizedDescription;
-    if (!decoder.decode(localizedDescription))
-        return false;
-
-    resourceError = ResourceError(domain, errorCode, URL { failingURL }, localizedDescription);
-
-    CertificateInfo certificateInfo;
-    if (!decoder.decode(certificateInfo))
-        return false;
-
-    resourceError.setCertificate(certificateInfo.certificate().get());
-    resourceError.setTLSErrors(certificateInfo.tlsErrors());
-    return true;
-}
-
 void ArgumentCoder<SoupNetworkProxySettings>::encode(Encoder& encoder, const SoupNetworkProxySettings& settings)
 {
     ASSERT(!settings.isEmpty());


### PR DESCRIPTION
#### fe4132d4f3b20933f82cb4ee4675de154d9507b6
<pre>
Port ResourceError to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=268435">https://bugs.webkit.org/show_bug.cgi?id=268435</a>

Reviewed by Alex Christensen.

* Source/WebCore/platform/network/ResourceErrorBase.h:
(WebCore::ResourceErrorBase::isSanitizedEnum const):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;ResourceError&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;ResourceError&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm:
(IPC::ArgumentCoder&lt;WebCore::ResourceError&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::ResourceError&gt;::decodePlatformData): Deleted.

Canonical link: <a href="https://commits.webkit.org/273943@main">https://commits.webkit.org/273943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d137dc055d25e91081001206a2342cd862a04cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39838 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38590 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13326 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13648 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/11889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/33428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41098 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/33753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/33863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/12221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/35923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8418 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->