### PR TITLE
Rewrite legacy IPC decoders of WCBackingStore and WCLayerUpdateInfo to modern

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.h
@@ -54,16 +54,17 @@ public:
     }
 
     template <class Decoder>
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, WCBackingStore& result)
+    static std::optional<WCBackingStore> decode(Decoder& decoder)
     {
-        auto handle = decoder.template decode<std::optional<ImageBufferBackendHandle>>();
-        if (UNLIKELY(!decoder.isValid()))
-            return false;
+        std::optional<std::optional<ImageBufferBackendHandle>> handle;
+        decoder >> handle;
+        if (UNLIKELY(!handle))
+            return std::nullopt;
 
+        WCBackingStore result;
         if (*handle)
             result.m_bitmap = ShareableBitmap::create(WTFMove(std::get<ShareableBitmap::Handle>(**handle)));
-
-        return true;
+        return result;
     }
 
 private:

--- a/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h
@@ -179,135 +179,242 @@ struct WCLayerUpdateInfo {
     }
 
     template <class Decoder>
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, WCLayerUpdateInfo& result)
+    static std::optional<WCLayerUpdateInfo> decode(Decoder& decoder)
     {
-        if (!decoder.decode(result.id))
-            return false;
-        if (!decoder.decode(result.changes))
-            return false;
+        WCLayerUpdateInfo result;
+
+        std::optional<WebCore::PlatformLayerIdentifier> id;
+        decoder >> id;
+        if (UNLIKELY(!id))
+            return std::nullopt;
+        result.id = WTFMove(*id);
+
+        std::optional<OptionSet<WCLayerChange>> changes;
+        decoder >> changes;
+        if (UNLIKELY(!changes))
+            return std::nullopt;
+        result.changes = WTFMove(*changes);
+
         if (result.changes & WCLayerChange::Children) {
-            if (!decoder.decode(result.children))
-                return false;
+            std::optional<Vector<WebCore::PlatformLayerIdentifier>> children;
+            decoder >> children;
+            if (UNLIKELY(!children))
+                return std::nullopt;
+            result.children = WTFMove(*children);
         }
+
         if (result.changes & WCLayerChange::MaskLayer) {
-            if (!decoder.decode(result.maskLayer))
-                return false;
+            std::optional<std::optional<WebCore::PlatformLayerIdentifier>> maskLayer;
+            decoder >> maskLayer;
+            if (UNLIKELY(!maskLayer))
+                return std::nullopt;
+            result.maskLayer = WTFMove(*maskLayer);
         }
         if (result.changes & WCLayerChange::ReplicaLayer) {
-            if (!decoder.decode(result.replicaLayer))
-                return false;
+            std::optional<std::optional<WebCore::PlatformLayerIdentifier>> replicaLayer;
+            decoder >> replicaLayer;
+            if (UNLIKELY(!replicaLayer))
+                return std::nullopt;
+            result.replicaLayer = WTFMove(*replicaLayer);
         }
         if (result.changes & WCLayerChange::Position) {
-            if (!decoder.decode(result.position))
-                return false;
+            std::optional<WebCore::FloatPoint> position;
+            decoder >> position;
+            if (UNLIKELY(!position))
+                return std::nullopt;
+            result.position = WTFMove(*position);
         }
         if (result.changes & WCLayerChange::AnchorPoint) {
-            if (!decoder.decode(result.anchorPoint))
-                return false;
+            std::optional<WebCore::FloatPoint3D> anchorPoint;
+            decoder >> anchorPoint;
+            if (UNLIKELY(!anchorPoint))
+                return std::nullopt;
+            result.anchorPoint = WTFMove(*anchorPoint);
         }
         if (result.changes & WCLayerChange::Size) {
-            if (!decoder.decode(result.size))
-                return false;
+            std::optional<WebCore::FloatSize> size;
+            decoder >> size;
+            if (UNLIKELY(!size))
+                return std::nullopt;
+            result.size = WTFMove(*size);
         }
         if (result.changes & WCLayerChange::BoundsOrigin) {
-            if (!decoder.decode(result.boundsOrigin))
-                return false;
+            std::optional<WebCore::FloatPoint> boundsOrigin;
+            decoder >> boundsOrigin;
+            if (UNLIKELY(!boundsOrigin))
+                return std::nullopt;
+            result.boundsOrigin = WTFMove(*boundsOrigin);
         }
         if (result.changes & WCLayerChange::Preserves3D) {
-            if (!decoder.decode(result.preserves3D))
-                return false;
+            std::optional<bool> preserves3D;
+            decoder >> preserves3D;
+            if (UNLIKELY(!preserves3D))
+                return std::nullopt;
+            result.preserves3D = WTFMove(*preserves3D);
         }
         if (result.changes & WCLayerChange::ContentsVisible) {
-            if (!decoder.decode(result.contentsVisible))
-                return false;
+            std::optional<bool> contentsVisible;
+            decoder >> contentsVisible;
+            if (UNLIKELY(!contentsVisible))
+                return std::nullopt;
+            result.contentsVisible = WTFMove(*contentsVisible);
         }
         if (result.changes & WCLayerChange::BackfaceVisibility) {
-            if (!decoder.decode(result.backfaceVisibility))
-                return false;
+            std::optional<bool> backfaceVisibility;
+            decoder >> backfaceVisibility;
+            if (UNLIKELY(!backfaceVisibility))
+                return std::nullopt;
+            result.backfaceVisibility = WTFMove(*backfaceVisibility);
         }
         if (result.changes & WCLayerChange::MasksToBounds) {
-            if (!decoder.decode(result.masksToBounds))
-                return false;
+            std::optional<bool> masksToBounds;
+            decoder >> masksToBounds;
+            if (UNLIKELY(!masksToBounds))
+                return std::nullopt;
+            result.masksToBounds = WTFMove(*masksToBounds);
         }
         if (result.changes & WCLayerChange::SolidColor) {
-            if (!decoder.decode(result.solidColor))
-                return false;
+            std::optional<WebCore::Color> solidColor;
+            decoder >> solidColor;
+            if (UNLIKELY(!solidColor))
+                return std::nullopt;
+            result.solidColor = WTFMove(*solidColor);
         }
         if (result.changes & WCLayerChange::ShowDebugBorder) {
-            if (!decoder.decode(result.showDebugBorder))
-                return false;
+            std::optional<bool> showDebugBorder;
+            decoder >> showDebugBorder;
+            if (UNLIKELY(!showDebugBorder))
+                return std::nullopt;
+            result.showDebugBorder = WTFMove(*showDebugBorder);
         }
         if (result.changes & WCLayerChange::DebugBorderColor) {
-            if (!decoder.decode(result.debugBorderColor))
-                return false;
+            std::optional<WebCore::Color> debugBorderColor;
+            decoder >> debugBorderColor;
+            if (UNLIKELY(!debugBorderColor))
+                return std::nullopt;
+            result.debugBorderColor = WTFMove(*debugBorderColor);
         }
         if (result.changes & WCLayerChange::DebugBorderWidth) {
-            if (!decoder.decode(result.debugBorderWidth))
-                return false;
+            std::optional<float> debugBorderWidth;
+            decoder >> debugBorderWidth;
+            if (UNLIKELY(!debugBorderWidth))
+                return std::nullopt;
+            result.debugBorderWidth = WTFMove(*debugBorderWidth);
         }
         if (result.changes & WCLayerChange::ShowRepaintCounter) {
-            if (!decoder.decode(result.showRepaintCounter))
-                return false;
+            std::optional<bool> showRepaintCounter;
+            decoder >> showRepaintCounter;
+            if (UNLIKELY(!showRepaintCounter))
+                return std::nullopt;
+            result.showRepaintCounter = WTFMove(*showRepaintCounter);
         }
         if (result.changes & WCLayerChange::RepaintCount) {
-            if (!decoder.decode(result.repaintCount))
-                return false;
+            std::optional<int> repaintCount;
+            decoder >> repaintCount;
+            if (UNLIKELY(!repaintCount))
+                return std::nullopt;
+            result.repaintCount = WTFMove(*repaintCount);
         }
         if (result.changes & WCLayerChange::ContentsRect) {
-            if (!decoder.decode(result.contentsRect))
-                return false;
+            std::optional<WebCore::FloatRect> contentsRect;
+            decoder >> contentsRect;
+            if (UNLIKELY(!contentsRect))
+                return std::nullopt;
+            result.contentsRect = WTFMove(*contentsRect);
         }
         if (result.changes & WCLayerChange::ContentsClippingRect) {
-            if (!decoder.decode(result.contentsClippingRect))
-                return false;
+            std::optional<WebCore::FloatRoundedRect> contentsClippingRect;
+            decoder >> contentsClippingRect;
+            if (UNLIKELY(!contentsClippingRect))
+                return std::nullopt;
+            result.contentsClippingRect = WTFMove(*contentsClippingRect);
         }
         if (result.changes & WCLayerChange::ContentsRectClipsDescendants) {
-            if (!decoder.decode(result.contentsRectClipsDescendants))
-                return false;
+            std::optional<bool> contentsRectClipsDescendants;
+            decoder >> contentsRectClipsDescendants;
+            if (UNLIKELY(!contentsRectClipsDescendants))
+                return std::nullopt;
+            result.contentsRectClipsDescendants = WTFMove(*contentsRectClipsDescendants);
         }
         if (result.changes & WCLayerChange::Opacity) {
-            if (!decoder.decode(result.opacity))
-                return false;
+            std::optional<float> opacity;
+            decoder >> opacity;
+            if (UNLIKELY(!opacity))
+                return std::nullopt;
+            result.opacity = WTFMove(*opacity);
         }
         if (result.changes & WCLayerChange::Background) {
-            if (!decoder.decode(result.backgroundColor))
-                return false;
-            if (!decoder.decode(result.hasBackingStore))
-                return false;
-            if (!decoder.decode(result.tileUpdate))
-                return false;
+            std::optional<WebCore::Color> backgroundColor;
+            decoder >> backgroundColor;
+            if (UNLIKELY(!backgroundColor))
+                return std::nullopt;
+            result.backgroundColor = WTFMove(*backgroundColor);
+            std::optional<bool> hasBackingStore;
+            decoder >> hasBackingStore;
+            if (UNLIKELY(!hasBackingStore))
+                return std::nullopt;
+            result.hasBackingStore = WTFMove(*hasBackingStore);
+            std::optional<Vector<WCTileUpdate>> tileUpdate;
+            decoder >> tileUpdate;
+            if (UNLIKELY(!tileUpdate))
+                return std::nullopt;
+            result.tileUpdate = WTFMove(*tileUpdate);
         }
         if (result.changes & WCLayerChange::Transform) {
-            if (!decoder.decode(result.transform))
-                return false;
+            std::optional<WebCore::TransformationMatrix> transform;
+            decoder >> transform;
+            if (UNLIKELY(!transform))
+                return std::nullopt;
+            result.transform = WTFMove(*transform);
         }
         if (result.changes & WCLayerChange::ChildrenTransform) {
-            if (!decoder.decode(result.childrenTransform))
-                return false;
+            std::optional<WebCore::TransformationMatrix> childrenTransform;
+            decoder >> childrenTransform;
+            if (UNLIKELY(!childrenTransform))
+                return std::nullopt;
+            result.childrenTransform = WTFMove(*childrenTransform);
         }
         if (result.changes & WCLayerChange::Filters) {
-            if (!decoder.decode(result.filters))
-                return false;
+            std::optional<WebCore::FilterOperations> filters;
+            decoder >> filters;
+            if (UNLIKELY(!filters))
+                return std::nullopt;
+            result.filters = WTFMove(*filters);
         }
         if (result.changes & WCLayerChange::BackdropFilters) {
-            if (!decoder.decode(result.backdropFilters))
-                return false;
+            std::optional<WebCore::FilterOperations> backdropFilters;
+            decoder >> backdropFilters;
+            if (UNLIKELY(!backdropFilters))
+                return std::nullopt;
+            result.backdropFilters = WTFMove(*backdropFilters);
         }
         if (result.changes & WCLayerChange::BackdropFiltersRect) {
-            if (!decoder.decode(result.backdropFiltersRect))
-                return false;
+            std::optional<WebCore::FloatRoundedRect> backdropFiltersRect;
+            decoder >> backdropFiltersRect;
+            if (UNLIKELY(!backdropFiltersRect))
+                return std::nullopt;
+            result.backdropFiltersRect = WTFMove(*backdropFiltersRect);
         }
         if (result.changes & WCLayerChange::PlatformLayer) {
-            if (!decoder.decode(result.hasPlatformLayer))
-                return false;
-            if (!decoder.decode(result.contentBufferIdentifiers))
-                return false;
+            std::optional<bool> hasPlatformLayer;
+            decoder >> hasPlatformLayer;
+            if (UNLIKELY(!hasPlatformLayer))
+                return std::nullopt;
+            result.hasPlatformLayer = WTFMove(*hasPlatformLayer);
+            std::optional<Vector<WCContentBufferIdentifier>> contentBufferIdentifiers;
+            decoder >> contentBufferIdentifiers;
+            if (UNLIKELY(!contentBufferIdentifiers))
+                return std::nullopt;
+            result.contentBufferIdentifiers = WTFMove(*contentBufferIdentifiers);
         }
         if (result.changes & WCLayerChange::RemoteFrame) {
-            if (!decoder.decode(result.hostIdentifier))
-                return false;
+            std::optional<Markable<WebCore::LayerHostingContextIdentifier>> hostIdentifier;
+            decoder >> hostIdentifier;
+            if (UNLIKELY(!hostIdentifier))
+                return std::nullopt;
+            result.hostIdentifier = WTFMove(*hostIdentifier);
         }
-        return true;
+        return result;
     }
 };
 


### PR DESCRIPTION
#### 02af9af911d739e2b0edad0b0531750d89ae9693
<pre>
Rewrite legacy IPC decoders of WCBackingStore and WCLayerUpdateInfo to modern
<a href="https://bugs.webkit.org/show_bug.cgi?id=268437">https://bugs.webkit.org/show_bug.cgi?id=268437</a>

Reviewed by NOBODY (OOPS!).

WCBackingStore and WCLayerUpdateInfo were still using the legacy style
of IPC decoders. Rewrote them to modern style.

No behavior changes. Bug 267600 will switch WCLayerUpdateInfo to the
serializer generator.

* Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.h:
* Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02af9af911d739e2b0edad0b0531750d89ae9693

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39415 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32941 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12824 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11579 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11591 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40664 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33338 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37509 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11869 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35631 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13532 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12267 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->