### PR TITLE
[UnifiedPDF] Occasional crashes under IOSurface construction in the web content process

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -79,6 +79,8 @@ public:
     RemoteLayerBackingStore(PlatformCALayerRemote*);
     virtual ~RemoteLayerBackingStore();
 
+    static std::unique_ptr<RemoteLayerBackingStore> createForLayer(PlatformCALayerRemote*);
+
     enum class Type : bool {
         IOSurface,
         Bitmap
@@ -90,6 +92,10 @@ public:
 
     virtual bool isRemoteLayerWithRemoteRenderingBackingStore() const { return false; }
     virtual bool isRemoteLayerWithInProcessRenderingBackingStore() const { return false; }
+
+    enum class ProcessModel : uint8_t { InProcess, Remote };
+    virtual ProcessModel processModel() const = 0;
+    static ProcessModel processModelForLayer(PlatformCALayerRemote*);
 
     struct Parameters {
         Type type { Type::Bitmap };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
@@ -67,8 +67,6 @@ public:
     bool backingStoreWillBeDisplayed(RemoteLayerBackingStore&);
     void backingStoreBecameUnreachable(RemoteLayerBackingStore&);
 
-    std::unique_ptr<RemoteLayerBackingStore> createRemoteLayerBackingStore(PlatformCALayerRemote*);
-
     virtual void prepareBackingStoresForDisplay(RemoteLayerTreeTransaction&);
     virtual bool paintReachableBackingStoreContents();
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -104,15 +104,6 @@ void RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay(RemoteLay
     }
 }
 
-std::unique_ptr<RemoteLayerBackingStore> RemoteLayerBackingStoreCollection::createRemoteLayerBackingStore(PlatformCALayerRemote* layer)
-{
-    // We currently only create a single type of backing store based on the global setting, but
-    // it should be fine to mix both types in the same collection.
-    if (WebProcess::singleton().shouldUseRemoteRenderingFor(WebCore::RenderingPurpose::DOM) && !layer->needsPlatformContext())
-        return makeUnique<RemoteLayerWithRemoteRenderingBackingStore>(layer);
-    return makeUnique<RemoteLayerWithInProcessRenderingBackingStore>(layer);
-}
-
 bool RemoteLayerBackingStoreCollection::paintReachableBackingStoreContents()
 {
     bool anyNonEmptyDirtyRegion = false;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h
@@ -34,6 +34,7 @@ public:
     using RemoteLayerBackingStore::RemoteLayerBackingStore;
 
     bool isRemoteLayerWithInProcessRenderingBackingStore() const final { return true; }
+    ProcessModel processModel() const final { return ProcessModel::InProcess; }
 
     void prepareToDisplay() final;
     void createContextAndPaintContents() final;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h
@@ -37,6 +37,7 @@ public:
     RemoteLayerWithRemoteRenderingBackingStore(PlatformCALayerRemote*);
 
     bool isRemoteLayerWithRemoteRenderingBackingStore() const final { return true; }
+    ProcessModel processModel() const final { return ProcessModel::Remote; }
 
     void prepareToDisplay() final;
     void clearBackingStore() final;


### PR DESCRIPTION
#### 82c681c6142f6a73ee90cf0aec5ecbe7a98bcd45
<pre>
[UnifiedPDF] Occasional crashes under IOSurface construction in the web content process
<a href="https://bugs.webkit.org/show_bug.cgi?id=268439">https://bugs.webkit.org/show_bug.cgi?id=268439</a>

Reviewed by Said Abou-Hallawa.

LayerPool will often return layers that contain existing RemoteLayerBackingStore instances.
Before reusing the RemoteLayerBackingStore, we need to make sure it&apos;s of the correct subclass
for the layer, once the layer is reconfigured.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::createForLayer):
(WebKit::RemoteLayerBackingStore::processModelForLayer):
Hoist model picking and RLBS creation into RLBS.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::createRemoteLayerBackingStore): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h:
Make it possible to query a RLBS&apos; &quot;process model&quot; (essentially which subclass it is,
this is technically duplicative with the is... methods, but handier for comparison).

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::ensureBackingStore):
Avoid reusing the incorrect RLBS subclass.

Canonical link: <a href="https://commits.webkit.org/273848@main">https://commits.webkit.org/273848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/444f9de87be3c9109a580349897dac7f222bec67

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39410 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32937 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31507 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11584 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11585 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40658 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33325 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33116 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37512 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11865 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9682 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35633 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13528 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8351 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12263 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12763 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->