### PR TITLE
ComputeH264ReorderSizeFromSPS should use pic_width_in_mbs_minus1 and pic_height_in_map_units_minus1 to compute max_dpb_frames_from_sps

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/h264_small-size.any-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/h264_small-size.any-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Encoding and decoding H264 small size
+

--- a/LayoutTests/http/wpt/webcodecs/h264_small-size.any.html
+++ b/LayoutTests/http/wpt/webcodecs/h264_small-size.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/http/wpt/webcodecs/h264_small-size.any.js
+++ b/LayoutTests/http/wpt/webcodecs/h264_small-size.any.js
@@ -1,0 +1,44 @@
+// META: global=window,dedicatedworker
+// META: script=/webcodecs/video-encoder-utils.js
+
+promise_test(async (t) => {
+  const config = {
+    codec: 'avc1.42001E',
+    avc: {format: 'avc'},
+    width: 14,
+    height: 14,
+    bitrate: 1000000,
+    bitrateMode: "constant",
+    framerate: 30
+  };
+
+  let decoder = new VideoDecoder({
+    output(frame) {
+      frame.close();
+    },
+    error(e) {
+    }
+  });
+
+  const encoder = new VideoEncoder({
+    output(chunk, metadata) {
+      if (metadata.decoderConfig)
+        decoder.configure(metadata.decoderConfig);
+      decoder.decode(chunk);
+    },
+    error(e) {
+    }
+  });
+  encoder.configure(config);
+
+  for (let i = 0; i < 5; i++) {
+    let frame = createDottedFrame(config.width, config.height, i);
+    let keyframe = (i % 5 == 0);
+    encoder.encode(frame, { keyFrame: keyframe });
+    frame.close();
+  }
+  await encoder.flush();
+  // FIXME: We should check that flush is fine
+  await decoder.flush().then(() => { }, () => { });
+}, 'Encoding and decoding H264 small size');
+

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h264/sps_parser.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h264/sps_parser.cc
@@ -164,9 +164,17 @@ absl::optional<SpsParser::SpsState> SpsParser::ParseSpsUpToVui(
   // to signify resolutions that aren't multiples of 16.
   //
   // pic_width_in_mbs_minus1: ue(v)
+#if WEBRTC_WEBKIT_BUILD
+  sps.pic_width_in_mbs_minus1 = reader.ReadExponentialGolomb();
+  sps.width = 16 * (sps.pic_width_in_mbs_minus1 + 1);
+#else
   sps.width = 16 * (reader.ReadExponentialGolomb() + 1);
+#endif
   // pic_height_in_map_units_minus1: ue(v)
   uint32_t pic_height_in_map_units_minus1 = reader.ReadExponentialGolomb();
+#if WEBRTC_WEBKIT_BUILD
+  sps.pic_height_in_map_units_minus1 = pic_height_in_map_units_minus1;
+#endif
   // frame_mbs_only_flag: u(1)
   sps.frame_mbs_only_flag = reader.ReadBit();
   if (!sps.frame_mbs_only_flag) {

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h264/sps_parser.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h264/sps_parser.h
@@ -30,6 +30,10 @@ class SpsParser {
     SpsState(const SpsState&);
     ~SpsState();
 
+#if WEBRTC_WEBKIT_BUILD
+    uint32_t pic_width_in_mbs_minus1 = 0;
+    uint32_t pic_height_in_map_units_minus1 = 0;
+#endif
     uint32_t width = 0;
     uint32_t height = 0;
     uint32_t delta_pic_order_always_zero_flag = 0;

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/nalu_rewriter.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/nalu_rewriter.cc
@@ -678,7 +678,9 @@ static uint8_t ComputeH264ReorderSizeFromSPS(const SpsAndVuiParser::State& state
   }
 
   uint64_t max_dpb_mbs = maxDpbMbsFromLevelNumber(state.profile_idc, state.level_idc, state.constraint_set3_flag);
-  uint64_t max_dpb_frames_from_sps = max_dpb_mbs / ((state.width / 16) * (state.height / 16));
+  uint64_t pic_width_in_mbs = state.pic_width_in_mbs_minus1 + 1;
+  uint64_t frame_height_in_mbs = (2 - state.frame_mbs_only_flag) * (state.pic_height_in_map_units_minus1 + 1);
+  uint64_t max_dpb_frames_from_sps = max_dpb_mbs / (pic_width_in_mbs * frame_height_in_mbs);
   // We use a max value of 16.
   auto max_dpb_frames = static_cast<uint8_t>(std::min(max_dpb_frames_from_sps, 16ull));
 


### PR DESCRIPTION
#### a8ddee0e8c2e16cd7e5deea6fee5c46161e98301
<pre>
ComputeH264ReorderSizeFromSPS should use pic_width_in_mbs_minus1 and pic_height_in_map_units_minus1 to compute max_dpb_frames_from_sps
<a href="https://bugs.webkit.org/show_bug.cgi?id=268440">https://bugs.webkit.org/show_bug.cgi?id=268440</a>
<a href="https://rdar.apple.com/121957799">rdar://121957799</a>

Reviewed by Jean-Yves Avenard.

Using state.width and state.height for max_dpb_frames_from_sps computation can lead to divide by zero issues since either one can be below 16.
We instead use pic_width_in_mbs_minus1 and pic_height_in_map_units_minus1 to ensure we do not divide by zero.

* LayoutTests/http/wpt/webcodecs/h264_small-size.any-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/h264_small-size.any.html: Added.
* LayoutTests/http/wpt/webcodecs/h264_small-size.any.js: Added.
(promise_test.async t):
* Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h264/sps_parser.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h264/sps_parser.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/nalu_rewriter.cc:

Canonical link: <a href="https://commits.webkit.org/273823@main">https://commits.webkit.org/273823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7e8c1106292b4560cc2923449033e1052327efb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39429 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32951 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/18250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12838 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31516 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32513 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11593 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11602 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40678 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33365 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37521 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35640 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13542 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32480 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8336 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12277 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12782 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->