### PR TITLE
Harden RemoteRenderingBackendProxy on GPUP crash

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -39,6 +39,7 @@
 namespace WebKit {
 
 class RemoteRenderingBackendProxy;
+class RemoteSerializedImageBufferProxy;
 
 class RemoteImageBufferProxy : public WebCore::ImageBuffer {
     friend class RemoteSerializedImageBufferProxy;
@@ -53,7 +54,7 @@ public:
         auto info = populateBackendInfo<BackendType>(backendParameters);
         return adoptRef(new RemoteImageBufferProxy(parameters, info, remoteRenderingBackendProxy));
     }
-
+    static Ref<RemoteImageBufferProxy> create(std::unique_ptr<RemoteSerializedImageBufferProxy>, RemoteRenderingBackendProxy&);
     ~RemoteImageBufferProxy();
 
     WebCore::ImageBufferBackend* ensureBackend() const final;
@@ -103,15 +104,12 @@ private:
 };
 
 class RemoteSerializedImageBufferProxy : public WebCore::SerializedImageBuffer {
-    friend class RemoteRenderingBackendProxy;
+    friend class RemoteImageBufferProxy;
 public:
+    RemoteSerializedImageBufferProxy(WebCore::ImageBuffer::Parameters, const WebCore::ImageBufferBackend::Info&, const WebCore::RenderingResourceIdentifier&, RemoteRenderingBackendProxy&);
     ~RemoteSerializedImageBufferProxy();
 
-    static RefPtr<WebCore::ImageBuffer> sinkIntoImageBuffer(std::unique_ptr<RemoteSerializedImageBufferProxy>, RemoteRenderingBackendProxy&);
-
     WebCore::RenderingResourceIdentifier renderingResourceIdentifier() { return m_renderingResourceIdentifier; }
-
-    RemoteSerializedImageBufferProxy(WebCore::ImageBuffer::Parameters, const WebCore::ImageBufferBackend::Info&, const WebCore::RenderingResourceIdentifier&, RemoteRenderingBackendProxy&);
 
     size_t memoryCost() const final
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -271,7 +271,7 @@ void RemoteImageBufferSetProxy::willPrepareForDisplay()
     m_remoteNeedsConfigurationUpdate = false;
 }
 
-void RemoteImageBufferSetProxy::remoteBufferSetWasDestroyed()
+void RemoteImageBufferSetProxy::abandonGPUProcess()
 {
     if (m_pendingFlush) {
         m_pendingFlush->setHandles(BufferSetBackendHandle { });

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
@@ -98,7 +98,7 @@ public:
 
     void setConfiguration(WebCore::FloatSize, float, const WebCore::DestinationColorSpace&, WebCore::PixelFormat, WebCore::RenderingMode, WebCore::RenderingPurpose);
     void willPrepareForDisplay();
-    void remoteBufferSetWasDestroyed();
+    void abandonGPUProcess();
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     std::optional<WebCore::DynamicContentScalingDisplayList> dynamicContentScalingDisplayList();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -86,11 +86,10 @@ public:
 
     RemoteResourceCacheProxy& remoteResourceCacheProxy() { return m_remoteResourceCacheProxy; }
 
-    void transferImageBuffer(std::unique_ptr<RemoteSerializedImageBufferProxy>, WebCore::ImageBuffer&);
-    void moveToSerializedBuffer(WebCore::RenderingResourceIdentifier);
-    void moveToImageBuffer(WebCore::RenderingResourceIdentifier);
+    std::unique_ptr<RemoteSerializedImageBufferProxy> moveToSerializedBuffer(RemoteImageBufferProxy&);
+    Ref<RemoteImageBufferProxy> moveToImageBuffer(std::unique_ptr<RemoteSerializedImageBufferProxy>);
 
-    void createRemoteImageBuffer(WebCore::ImageBuffer&);
+    void createRemoteImageBuffer(RemoteImageBufferProxy&);
     bool isCached(const WebCore::ImageBuffer&) const;
 
     // IPC::MessageReceiver
@@ -172,7 +171,7 @@ private:
     // Connection::Client
     void didClose(IPC::Connection&) final;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) final { }
-    void disconnectGPUProcess();
+    void abandonGPUProcess();
     void ensureGPUProcessConnection();
 
     bool dispatchMessage(IPC::Connection&, IPC::Decoder&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -49,11 +49,20 @@ RemoteResourceCacheProxy::~RemoteResourceCacheProxy()
     clearRenderingResourceMap();
 }
 
-void RemoteResourceCacheProxy::clear()
+void RemoteResourceCacheProxy::connectGPUProcess()
+{
+    for (auto& weakImageBuffer : m_imageBuffers.values()) {
+        if (RefPtr imageBuffer = weakImageBuffer.get())
+            m_remoteRenderingBackendProxy.createRemoteImageBuffer(*imageBuffer);
+    }
+}
+
+void RemoteResourceCacheProxy::abandonGPUProcess()
 {
     clearImageBufferBackends();
-    m_imageBuffers.clear();
     clearRenderingResourceMap();
+    clearFontMap();
+    clearFontCustomPlatformDataMap();
 }
 
 unsigned RemoteResourceCacheProxy::imagesCount() const
@@ -75,7 +84,7 @@ RefPtr<RemoteImageBufferProxy> RemoteResourceCacheProxy::cachedImageBuffer(Rende
 }
 
 
-void RemoteResourceCacheProxy::forgetImageBuffer(RenderingResourceIdentifier identifier)
+void RemoteResourceCacheProxy::uncacheImageBuffer(RenderingResourceIdentifier identifier)
 {
     auto iterator = m_imageBuffers.find(identifier);
     RELEASE_ASSERT(iterator != m_imageBuffers.end());
@@ -328,22 +337,6 @@ void RemoteResourceCacheProxy::didPaintLayers()
     finalizeRenderingUpdateForFonts();
     prepareForNextRenderingUpdate();
     m_renderingUpdateID++;
-}
-
-void RemoteResourceCacheProxy::remoteResourceCacheWasDestroyed()
-{
-    clearImageBufferBackends();
-
-    for (auto& weakImageBuffer : m_imageBuffers.values()) {
-        auto protectedImageBuffer = weakImageBuffer.get();
-        if (!protectedImageBuffer)
-            continue;
-        m_remoteRenderingBackendProxy.createRemoteImageBuffer(*protectedImageBuffer);
-    }
-
-    clearRenderingResourceMap();
-    clearFontMap();
-    clearFontCustomPlatformDataMap();
 }
 
 void RemoteResourceCacheProxy::releaseMemory()

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -50,10 +50,12 @@ class RemoteResourceCacheProxy : public WebCore::RenderingResource::Observer {
 public:
     RemoteResourceCacheProxy(RemoteRenderingBackendProxy&);
     ~RemoteResourceCacheProxy();
+    void connectGPUProcess();
+    void abandonGPUProcess();
 
     void cacheImageBuffer(RemoteImageBufferProxy&);
     RefPtr<RemoteImageBufferProxy> cachedImageBuffer(WebCore::RenderingResourceIdentifier) const;
-    void forgetImageBuffer(WebCore::RenderingResourceIdentifier);
+    void uncacheImageBuffer(WebCore::RenderingResourceIdentifier);
 
     WebCore::NativeImage* cachedNativeImage(WebCore::RenderingResourceIdentifier) const;
 
@@ -72,8 +74,6 @@ public:
     void releaseAllImageResources();
     
     unsigned imagesCount() const;
-
-    void clear();
 
 private:
     using ImageBufferHashMap = HashMap<WebCore::RenderingResourceIdentifier, ThreadSafeWeakPtr<RemoteImageBufferProxy>>;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1009,10 +1009,12 @@ RefPtr<ImageBuffer> WebChromeClient::createImageBuffer(const FloatSize& size, Re
 
 RefPtr<ImageBuffer> WebChromeClient::sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer> imageBuffer)
 {
-    if (!is<RemoteSerializedImageBufferProxy>(imageBuffer))
-        return SerializedImageBuffer::sinkIntoImageBuffer(WTFMove(imageBuffer));
-    auto remote = std::unique_ptr<RemoteSerializedImageBufferProxy>(static_cast<RemoteSerializedImageBufferProxy*>(imageBuffer.release()));
-    return RemoteSerializedImageBufferProxy::sinkIntoImageBuffer(WTFMove(remote), protectedPage()->ensureRemoteRenderingBackendProxy());
+    if (is<RemoteSerializedImageBufferProxy>(imageBuffer)) {
+        auto remote = std::unique_ptr<RemoteSerializedImageBufferProxy>(static_cast<RemoteSerializedImageBufferProxy*>(imageBuffer.release()));
+        return protectedPage()->ensureRemoteRenderingBackendProxy().moveToImageBuffer(WTFMove(remote));
+    }
+    return SerializedImageBuffer::sinkIntoImageBuffer(WTFMove(imageBuffer));
+
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
@@ -117,13 +117,12 @@ PlatformDisplayID WebWorkerClient::displayID() const
 RefPtr<ImageBuffer> WebWorkerClient::sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer> imageBuffer)
 {
 #if ENABLE(GPU_PROCESS)
-    if (!is<RemoteSerializedImageBufferProxy>(imageBuffer))
-        return SerializedImageBuffer::sinkIntoImageBuffer(WTFMove(imageBuffer));
-    auto remote = std::unique_ptr<RemoteSerializedImageBufferProxy>(static_cast<RemoteSerializedImageBufferProxy*>(imageBuffer.release()));
-    return RemoteSerializedImageBufferProxy::sinkIntoImageBuffer(WTFMove(remote), ensureRenderingBackend());
-#else
-    return SerializedImageBuffer::sinkIntoImageBuffer(WTFMove(imageBuffer));
+    if (is<RemoteSerializedImageBufferProxy>(imageBuffer)) {
+        auto remote = std::unique_ptr<RemoteSerializedImageBufferProxy>(static_cast<RemoteSerializedImageBufferProxy*>(imageBuffer.release()));
+        return ensureRenderingBackend().moveToImageBuffer(WTFMove(remote));
+    }
 #endif
+    return SerializedImageBuffer::sinkIntoImageBuffer(WTFMove(imageBuffer));
 }
 
 RefPtr<ImageBuffer> WebWorkerClient::createImageBuffer(const FloatSize& size, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, OptionSet<ImageBufferOptions> options) const


### PR DESCRIPTION
#### f31106ce3ed1fd35780a0e44dc4127c2ee6721c7
<pre>
Harden RemoteRenderingBackendProxy on GPUP crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=268441">https://bugs.webkit.org/show_bug.cgi?id=268441</a>
<a href="https://rdar.apple.com/121996438">rdar://121996438</a>

Reviewed by NOBODY (OOPS!).

Change of behavior: avoid re-establishing GPUP connection on GPUP crash.
Instead, establish it on the next send, similar to initial connection
establishment. Avoids recursing into RemoteRenderingBackendProxy during
didClose().

Dispatch pending volatility request responses during GPUP crash. Move
the trigger to cache RemoteImageBufferProxy instances to
RemoteResourceCacheProxy from various callers to
RemoteRenderingBackendProxy. This is work towards making
RemoteRenderingBackendProxy the normal interface to all clients and the
cache an implementation detail of RemoteRenderingBackendProxy.

Send ReleaseRenderingBackend message from the
RemoteRenderingBackendProxy thread instead of main thread. This is
consistent with other engines.

* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::create):
(WebKit::RemoteImageBufferProxy::~RemoteImageBufferProxy):
(WebKit::RemoteImageBufferProxy::didCreateBackend):
(WebKit::RemoteImageBufferProxy::sinkIntoSerializedImageBuffer):
(WebKit::RemoteSerializedImageBufferProxy::RemoteSerializedImageBufferProxy):
(WebKit::RemoteSerializedImageBufferProxy::sinkIntoImageBuffer): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxy::abandonGPUProcess):
(WebKit::RemoteImageBufferSetProxy::remoteBufferSetWasDestroyed): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::~RemoteRenderingBackendProxy):
(WebKit::RemoteRenderingBackendProxy::ensureGPUProcessConnection):
(WebKit::RemoteRenderingBackendProxy::didClose):
(WebKit::RemoteRenderingBackendProxy::abandonGPUProcess):
(WebKit::RemoteRenderingBackendProxy::createRemoteImageBuffer):
(WebKit::RemoteRenderingBackendProxy::createImageBuffer):
(WebKit::RemoteRenderingBackendProxy::releaseImageBuffer):
(WebKit::RemoteRenderingBackendProxy::createRemoteImageBufferSet):
(WebKit::RemoteRenderingBackendProxy::moveToSerializedBuffer):
(WebKit::RemoteRenderingBackendProxy::moveToImageBuffer):
(WebKit::RemoteRenderingBackendProxy::disconnectGPUProcess): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::connectGPUProcess):
(WebKit::RemoteResourceCacheProxy::abandonGPUProcess):
(WebKit::RemoteResourceCacheProxy::uncacheImageBuffer):
(WebKit::RemoteResourceCacheProxy::clear): Deleted.
(WebKit::RemoteResourceCacheProxy::forgetImageBuffer): Deleted.
(WebKit::RemoteResourceCacheProxy::remoteResourceCacheWasDestroyed): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::sinkIntoImageBuffer):
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp:
(WebKit::WebWorkerClient::sinkIntoImageBuffer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f31106ce3ed1fd35780a0e44dc4127c2ee6721c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39432 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32953 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31517 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13267 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32528 "Found 1 new API test failure: TestWebKitAPI.GPUProcess.CanvasBasicCrashHandling (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11597 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11603 "Found 3 new test failures: imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-all.https.sub.html, imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imagebitmap-replication-exif-orientation.html, imported/w3c/web-platform-tests/html/canvas/offscreen/manual/filter/offscreencanvas.filter.w.html (failure)") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40681 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33366 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33138 "Found 2 new test failures: imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imagebitmap-replication-exif-orientation.html, imported/w3c/web-platform-tests/html/canvas/offscreen/manual/filter/offscreencanvas.filter.w.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37523 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11885 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9703 "Found 3 new test failures: imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer.html, imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imagebitmap-replication-exif-orientation.html, imported/w3c/web-platform-tests/html/canvas/offscreen/manual/filter/offscreencanvas.filter.w.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35648 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13545 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12279 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->