### PR TITLE
[LBSE] Fix clipping/masking related assertion failure in debug builds

### DIFF
--- a/Source/WebCore/rendering/svg/SVGPaintServerHandling.h
+++ b/Source/WebCore/rendering/svg/SVGPaintServerHandling.h
@@ -139,7 +139,6 @@ private:
     inline void prepareStrokeOperation(const RenderLayerModelObject& renderer, const RenderStyle& style, const Color& strokeColor) const
     {
         const auto& svgStyle = style.svgStyle();
-        ASSERT_UNUSED(renderer, !renderer.view().frameView().paintBehavior().contains(PaintBehavior::RenderingSVGClipOrMask));
         m_context.setAlpha(svgStyle.strokeOpacity());
         m_context.setStrokeColor(style.colorByApplyingColorFilter(strokeColor));
         SVGRenderSupport::applyStrokeStyleToContext(m_context, style, renderer);


### PR DESCRIPTION
#### fdde18e9a3547b68b7e5e2ea33103d0b1fc13abc
<pre>
[LBSE] Fix clipping/masking related assertion failure in debug builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=267764">https://bugs.webkit.org/show_bug.cgi?id=267764</a>

Reviewed by Rob Buis.

Both svg/clip-path/clip-path-content-syling.svg and svg/W3C-SVG-1.1/masking-intro-01-f.svg
assert in debug builds due to a spurious assertion in SVGPaintServerHandling stroking code.

Remove the assertion, the tests already work as expected.
No new tests, only fixes an assertion in existing tests.

* Source/WebCore/rendering/svg/SVGPaintServerHandling.h:
(WebCore::SVGPaintServerHandling::prepareStrokeOperation const):

Canonical link: <a href="https://commits.webkit.org/273893@main">https://commits.webkit.org/273893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6814c9c9527a49121026cde5ebc6fb1bb9613047

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39455 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32975 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31534 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11619 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11624 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40704 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33395 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37544 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35663 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13567 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8381 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12301 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12808 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->