### PR TITLE
[Navigation] Implement canGoForward/canGoBackward

### DIFF
--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -44,6 +44,28 @@ Navigation::Navigation(ScriptExecutionContext* context, LocalDOMWindow& window)
 {
 }
 
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-cangoback
+bool Navigation::canGoBack() const
+{
+    if (hasEntriesAndEventsDisabled())
+        return false;
+    ASSERT(m_currentEntryIndex);
+    if (!*m_currentEntryIndex)
+        return false;
+    return true;
+}
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-cangoforward
+bool Navigation::canGoForward() const
+{
+    if (hasEntriesAndEventsDisabled())
+        return false;
+    ASSERT(m_currentEntryIndex);
+    if (*m_currentEntryIndex == m_entries.size() - 1)
+        return false;
+    return true;
+}
+
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#initialize-the-navigation-api-entries-for-a-new-document
 void Navigation::initializeEntries(const Ref<HistoryItem>& currentItem, Vector<Ref<HistoryItem>>& items)
 {
@@ -62,8 +84,8 @@ const Vector<Ref<NavigationHistoryEntry>>& Navigation::entries() const
 
 NavigationHistoryEntry* Navigation::currentEntry() const
 {
-    if (!hasEntriesAndEventsDisabled() && m_currentEntryIndex > -1)
-        return m_entries.at(m_currentEntryIndex).ptr();
+    if (!hasEntriesAndEventsDisabled() && m_currentEntryIndex)
+        return m_entries.at(*m_currentEntryIndex).ptr();
     return nullptr;
 }
 

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -79,8 +79,8 @@ public:
     NavigationHistoryEntry* currentEntry() const;
     RefPtr<NavigationTransition> transition() { return m_transition; };
 
-    bool canGoBack() const { return m_canGoBack; };
-    bool canGoForward() const { return m_canGoForward; };
+    bool canGoBack() const;
+    bool canGoForward() const;
 
     void initializeEntries(const Ref<HistoryItem>& currentItem, Vector<Ref<HistoryItem>> &items);
 
@@ -104,10 +104,8 @@ private:
 
     bool hasEntriesAndEventsDisabled() const;
 
-    int m_currentEntryIndex { -1 };
+    std::optional<size_t> m_currentEntryIndex;
     RefPtr<NavigationTransition> m_transition;
-    bool m_canGoBack { false };
-    bool m_canGoForward { false };
     Vector<Ref<NavigationHistoryEntry>> m_entries;
 };
 


### PR DESCRIPTION
#### 1ddf79a30220e5397021a067a8d6e17455a0281b
<pre>
[Navigation] Implement canGoForward/canGoBackward
<a href="https://bugs.webkit.org/show_bug.cgi?id=268454">https://bugs.webkit.org/show_bug.cgi?id=268454</a>

Reviewed by Anne van Kesteren.

Implement canGoForward/canGoBackward as specified here:
<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-cangoback">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-cangoback</a>
<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-cangoforward">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-cangoforward</a>

This PR also makes m_currentEntryIndex a std::optional, this is more convenient as
it avoids signed/unsigned confusion/casting.

* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::canGoBack const):
(WebCore::Navigation::canGoForward const):
(WebCore::Navigation::currentEntry const):
* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/274542@main">https://commits.webkit.org/274542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5db76a24621b9c75d06c8252744f0b8206da0d36

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41718 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34961 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32793 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13273 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13258 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42995 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35592 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39058 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13996 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11550 "Found 1 new test failure: media/track/track-in-band-chapters-invalid-client-crash.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37290 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15602 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8811 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15088 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->