### PR TITLE
Google meet video effects have a low frame rate

### DIFF
--- a/LayoutTests/fast/mediacapturefromelement/CanvasCaptureMediaStream-capture-out-of-DOM-canvas-webgl-expected.txt
+++ b/LayoutTests/fast/mediacapturefromelement/CanvasCaptureMediaStream-capture-out-of-DOM-canvas-webgl-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS check frame of capture canvas is sufficient
+

--- a/LayoutTests/fast/mediacapturefromelement/CanvasCaptureMediaStream-capture-out-of-DOM-canvas-webgl.html
+++ b/LayoutTests/fast/mediacapturefromelement/CanvasCaptureMediaStream-capture-out-of-DOM-canvas-webgl.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Capture canvas to video track framerate</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="../../webrtc/routines.js"></script>
+</head>
+<body>
+    <video id="video" muted autoplay playsInline controls width="200px"></video>
+    <script>
+function drawCanvasTestPatternWebGL(canvas, patternNumber)
+{
+    patternNumber = patternNumber || 0;
+    const gl = canvas.getContext("webgl", { depth: false, stencil: false, antialias: false });
+    gl.enable(gl.SCISSOR_TEST);
+    const boxSize = [ canvas.width, canvas.height ];
+    const boxes = [
+        [0.0, 0.5, 0.5, 1.0],
+        [0.5, 0.5, 1.0, 1.0],
+        [0.5, 0.0, 1.0, 0.5],
+        [0.0, 0.0, 0.5, 0.5],
+    ];
+    const boxColors = Object.values(testColors);
+    for (let n = 0; n < 4; ++n) {
+        const i = (n + patternNumber) % boxes.length;
+        const color = boxColors[i];
+        const box = boxes[n];
+        gl.scissor(box[0] * boxSize[0], box[1] * boxSize[1], box[2] * boxSize[0], box[3] * boxSize[1]);
+        gl.clearColor(color[0] / 255., color[1] / 255, color[2] / 255., color[3] / 255.);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+    }
+}
+
+promise_test(async (t) => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 200;
+    canvas.height = 200;
+
+    let frames = 0;
+    const loop = () => {
+        frames += 1;
+        drawCanvasTestPatternWebGL(canvas, frames);
+        setTimeout(loop, 1000/30);
+    }
+
+    loop();
+
+    const stream = canvas.captureStream();
+    video.srcObject = stream;
+    video.play();
+
+    const frameRate = await computeFrameRate(stream, video);
+
+    // If the test was unable to generate any frames then nothing meaningful can be determined. Our test only makes sense if we have sufficient fps.
+    if (frames <= 10)
+        return;
+
+    // Check that the difference in expected and observed frame rates is < 25%
+    const percentDiff = Math.abs(frameRate - frames) / frames * 100;
+    assert_less_than(percentDiff, 25, `frame rate difference between ${frames} & ${frameRate} is below 25%`);
+}, "check frame of capture canvas is sufficient");
+    </script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1204,6 +1204,8 @@ http/wpt/webcodecs/encoder-task-failing.html [ Pass ]
 # expected to pass again once we update to GStreamer 1.24.
 fast/mediastream/play-newly-added-audio-track.html [ Pass Crash ]
 
+fast/mediacapturefromelement/CanvasCaptureMediaStream-capture-out-of-DOM-canvas-webgl.html [ Pass Failure ]
+
 webkit.org/b/264665 http/wpt/webcodecs/videoFrame-webglCanvasImageSource.html [ Failure ]
 
 webkit.org/b/264666 imported/w3c/web-platform-tests/encrypted-media/clearkey-generate-request-disallowed-input.https.html [ Failure ]

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -699,7 +699,7 @@ void WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver(WebGLR
 
     if (auto* canvas = htmlCanvas()) {
         if (isAccelerated()) {
-            canvas->notifyObserversCanvasChanged(FloatRect(FloatPoint(0, 0), clampedCanvasSize()));
+            canvas->notifyObserversCanvasChanged({ });
             RenderBox* renderBox = canvas->renderBox();
             if (renderBox && renderBox->hasAcceleratedCompositing()) {
                 m_canvasBufferContents = std::nullopt;


### PR DESCRIPTION
#### 52bbfead48be6d9040ca75ef9b911beb89caadd0
<pre>
Google meet video effects have a low frame rate
<a href="https://rdar.apple.com/121257960">rdar://121257960</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=268455">https://bugs.webkit.org/show_bug.cgi?id=268455</a>

Reviewed by Dan Glastonbury and Kimmo Kinnunen.

Document::canvasChanged is only triggering a PrepareCanvasesForDisplay update if it is not given a rect.
WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver was passing the whole canvas rect.
We change it to passing std::nullopt instead.

* LayoutTests/fast/mediacapturefromelement/CanvasCaptureMediaStream-capture-out-of-DOM-canvas-webgl-expected.txt: Added.
* LayoutTests/fast/mediacapturefromelement/CanvasCaptureMediaStream-capture-out-of-DOM-canvas-webgl.html: Added.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver):

Canonical link: <a href="https://commits.webkit.org/273897@main">https://commits.webkit.org/273897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11d5849c78844951db4fda8a76ff836fd11b676e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39688 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13154 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13508 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11775 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/33219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40944 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33604 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/33589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37677 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12095 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35818 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32693 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8383 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12464 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/12997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->