### PR TITLE
[WGSL] Functions should not be used as values

### DIFF
--- a/Source/WebGPU/WGSL/tests/invalid/bitcast.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/bitcast.wgsl
@@ -29,6 +29,12 @@ fn testInvalidConversion()
 
 fn testI32Overflow()
 {
-    // value 4294967295 cannot be represented as 'i32'
+    // CHECK-L: value 4294967295 cannot be represented as 'i32'
     { const x: f32 = bitcast<f32>(4294967295); }
+}
+
+fn testFunctionAsValue()
+{
+    // CHECK-L: cannot use function 'testI32Overflow' as value
+    { const x: f32 = bitcast<f32>(testI32Overflow); }
 }


### PR DESCRIPTION
#### 981e9e4ec22114d6202cb208f34462ddaf965f05
<pre>
[WGSL] Functions should not be used as values
<a href="https://bugs.webkit.org/show_bug.cgi?id=268456">https://bugs.webkit.org/show_bug.cgi?id=268456</a>
<a href="https://rdar.apple.com/121527098">rdar://121527098</a>

Reviewed by Mike Wyrzykowski.

Add a separate binding type for functions, since they can only ever be used in
function calls, so we don&apos;t have to handle it everywhere.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::bindingKindToString):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::bitcast):
(WGSL::TypeChecker::lookupType):
(WGSL::TypeChecker::introduceFunction):
* Source/WebGPU/WGSL/tests/invalid/bitcast.wgsl:

Canonical link: <a href="https://commits.webkit.org/273916@main">https://commits.webkit.org/273916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf9dba44cb6eb1667ec2a4667b51625fd86e430b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36819 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39460 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32980 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31536 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11621 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11628 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40709 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37547 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9728 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35694 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13572 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8392 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12306 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12813 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->