### PR TITLE
Adopt more dynamicDowncast<> in XML code

### DIFF
--- a/Source/WebCore/xml/XPathStep.cpp
+++ b/Source/WebCore/xml/XPathStep.cpp
@@ -200,21 +200,22 @@ inline bool nodeMatchesBasicTest(Node& node, Step::Axis axis, const Step::NodeTe
 
             // For other axes, the principal node type is element.
             ASSERT(primaryNodeType(axis) == Node::ELEMENT_NODE);
-            if (!is<Element>(node))
+            auto* element = dynamicDowncast<Element>(node);
+            if (!element)
                 return false;
 
             if (name == starAtom())
                 return namespaceURI.isEmpty() || namespaceURI == node.namespaceURI();
 
             if (node.document().isHTMLDocument()) {
-                if (is<HTMLElement>(node)) {
+                if (is<HTMLElement>(*element)) {
                     // Paths without namespaces should match HTML elements in HTML documents despite those having an XHTML namespace. Names are compared case-insensitively.
-                    return equalIgnoringASCIICase(downcast<HTMLElement>(node).localName(), name) && (namespaceURI.isNull() || namespaceURI == node.namespaceURI());
+                    return equalIgnoringASCIICase(element->localName(), name) && (namespaceURI.isNull() || namespaceURI == node.namespaceURI());
                 }
                 // An expression without any prefix shouldn't match no-namespace nodes (because HTML5 says so).
-                return downcast<Element>(node).hasLocalName(name) && namespaceURI == node.namespaceURI() && !namespaceURI.isNull();
+                return element->hasLocalName(name) && namespaceURI == node.namespaceURI() && !namespaceURI.isNull();
             }
-            return downcast<Element>(node).hasLocalName(name) && namespaceURI == node.namespaceURI();
+            return element->hasLocalName(name) && namespaceURI == node.namespaceURI();
         }
     }
     ASSERT_NOT_REACHED();
@@ -347,10 +348,9 @@ void Step::nodesInAxis(Node& context, NodeSet& nodes) const
             return;
         }
         case AttributeAxis: {
-            if (!is<Element>(context))
+            RefPtr contextElement = dynamicDowncast<Element>(context);
+            if (!contextElement)
                 return;
-
-            Element& contextElement = downcast<Element>(context);
 
             // Avoid lazily creating attribute nodes for attributes that we do not need anyway.
             if (m_nodeTest.m_kind == NodeTest::NameTest && m_nodeTest.m_data != starAtom()) {
@@ -358,9 +358,9 @@ void Step::nodesInAxis(Node& context, NodeSet& nodes) const
                 // We need this branch because getAttributeNodeNS() doesn't do
                 // ignore-case matching even for an HTML element in an HTML document.
                 if (m_nodeTest.m_namespaceURI.isNull())
-                    attr = contextElement.getAttributeNode(m_nodeTest.m_data);
+                    attr = contextElement->getAttributeNode(m_nodeTest.m_data);
                 else
-                    attr = contextElement.getAttributeNodeNS(m_nodeTest.m_namespaceURI, m_nodeTest.m_data);
+                    attr = contextElement->getAttributeNodeNS(m_nodeTest.m_namespaceURI, m_nodeTest.m_data);
                 if (attr && attr->namespaceURI() != XMLNSNames::xmlnsNamespaceURI) { // In XPath land, namespace nodes are not accessible on the attribute axis.
                     if (nodeMatches(*attr, AttributeAxis, m_nodeTest)) // Still need to check merged predicates.
                         nodes.append(WTFMove(attr));
@@ -368,11 +368,11 @@ void Step::nodesInAxis(Node& context, NodeSet& nodes) const
                 return;
             }
             
-            if (!contextElement.hasAttributes())
+            if (!contextElement->hasAttributes())
                 return;
 
-            for (const Attribute& attribute : contextElement.attributesIterator()) {
-                auto attr = contextElement.ensureAttr(attribute.name());
+            for (const Attribute& attribute : contextElement->attributesIterator()) {
+                auto attr = contextElement->ensureAttr(attribute.name());
                 if (nodeMatches(attr.get(), AttributeAxis, m_nodeTest))
                     nodes.append(WTFMove(attr));
             }

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -837,8 +837,8 @@ void XMLDocumentParser::startElementNs(const xmlChar* xmlLocalName, const xmlCha
     if (!m_currentNode) // Synchronous DOM events may have removed the current node.
         return;
 
-    if (is<HTMLTemplateElement>(newElement))
-        pushCurrentNode(&downcast<HTMLTemplateElement>(newElement.get()).content());
+    if (RefPtr templateElement = dynamicDowncast<HTMLTemplateElement>(newElement))
+        pushCurrentNode(&templateElement->content());
     else
         pushCurrentNode(newElement.ptr());
 


### PR DESCRIPTION
#### 0150236f7e5d4ff6e0b871a35ea388973bd05972
<pre>
Adopt more dynamicDowncast&lt;&gt; in XML code
<a href="https://bugs.webkit.org/show_bug.cgi?id=268460">https://bugs.webkit.org/show_bug.cgi?id=268460</a>

Reviewed by Chris Dumez.

* Source/WebCore/xml/XPathFunctions.cpp:
(WebCore::XPath::expandedNameLocalPart):
(WebCore::XPath::expandedName):
(WebCore::XPath::FunLocalName::evaluate const):
(WebCore::XPath::FunName::evaluate const):
(WebCore::XPath::FunLang::evaluate const):
* Source/WebCore/xml/XPathStep.cpp:
(WebCore::XPath::nodeMatchesBasicTest):
(WebCore::XPath::Step::nodesInAxis const):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::startElementNs):

Canonical link: <a href="https://commits.webkit.org/273878@main">https://commits.webkit.org/273878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80d2e9e2e0f72726d81b86792f5ee625de406cdb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39462 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32982 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31547 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37383 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11634 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11676 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32830 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40711 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33448 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37546 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9730 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35665 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13574 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8373 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12308 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->