### PR TITLE
Implement QP using H265BitstreamParser in RTCVideoEncoderH265.mm

### DIFF
--- a/LayoutTests/webrtc/h265-expected.txt
+++ b/LayoutTests/webrtc/h265-expected.txt
@@ -9,4 +9,5 @@ PASS Ensuring connection state is connected
 PASS Track is enabled, video should not be black
 PASS Track is disabled, video should be black
 PASS Track is enabled, video should not be black 2
+PASS outbound qpSum
 

--- a/LayoutTests/webrtc/h265.html
+++ b/LayoutTests/webrtc/h265.html
@@ -43,6 +43,7 @@ if (hasH265) {
 
     var track;
     var remoteTrack;
+    var sendingConnection;
     var receivingConnection;
     promise_test((test) => {
         return navigator.mediaDevices.getUserMedia({video: {width: 320, height: 240, facingMode: "environment"}}).then((localStream) => {
@@ -50,6 +51,7 @@ if (hasH265) {
                 track = localStream.getVideoTracks()[0];
 
                 createConnections((firstConnection) => {
+                    sendingConnection = firstConnection;
                     firstConnection.addTrack(track, localStream);
                 }, (secondConnection) => {
                     receivingConnection = secondConnection;
@@ -95,6 +97,26 @@ if (hasH265) {
         track.enabled = true;
         return checkVideoBlack(false, canvas2, video);
     }, "Track is enabled, video should not be black 2");
+
+    function getOutboundRTPStats(connection)
+    {
+        return connection.getStats().then((report) => {
+            let stats;
+            report.forEach((statItem) => {
+                if (statItem.type === "outbound-rtp") {
+                    stats = statItem;
+                }
+            });
+            return stats;
+        });
+    }
+
+    promise_test(async (test) => {
+        const stats = await getOutboundRTPStats(sendingConnection);
+        assert_true(!!stats, "outbound-rtp stats should not be null");
+        assert_true(!stats.qpSum || Number.isInteger(stats.qpSum), "outbound qpSum should be an integer");
+        assert_greater_than(stats.qpSum, 0);
+    }, "outbound qpSum");
 }
         </script>
     </body>

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_pps_parser.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_pps_parser.h
@@ -13,6 +13,7 @@
 
 #include "absl/types/optional.h"
 #include "api/array_view.h"
+#include "common_video/h265/h265_sps_parser.h"
 #include "rtc_base/bitstream_reader.h"
 
 namespace rtc {
@@ -35,16 +36,19 @@ class H265PpsParser {
     uint32_t num_extra_slice_header_bits = 0;
     uint32_t num_ref_idx_l0_default_active_minus1 = 0;
     uint32_t num_ref_idx_l1_default_active_minus1 = 0;
-    int32_t pic_init_qp_minus26 = 0;
+    int32_t init_qp_minus26 = 0;
     bool weighted_pred_flag = false;
     bool weighted_bipred_flag = false;
     bool lists_modification_present_flag = false;
-    uint32_t id = 0;
+    uint32_t pps_id = 0;
     uint32_t sps_id = 0;
+    int qp_bd_offset_y = 0;
   };
 
   // Unpack RBSP and parse PPS state from the supplied buffer.
-  static absl::optional<PpsState> ParsePps(const uint8_t* data, size_t length);
+  static absl::optional<PpsState> ParsePps(const uint8_t* data,
+                                           size_t length,
+                                           const H265SpsParser::SpsState*);
 
   static bool ParsePpsIds(const uint8_t* data,
                           size_t length,
@@ -60,7 +64,8 @@ class H265PpsParser {
   // Parse the PPS state, for a bit buffer where RBSP decoding has already been
   // performed.
   static absl::optional<PpsState> ParseInternal(
-      rtc::ArrayView<const uint8_t> buffer);
+      rtc::ArrayView<const uint8_t> buffer,
+      const H265SpsParser::SpsState*);
   static bool ParsePpsIdsInternal(BitstreamReader& reader,
                                   uint32_t& pps_id,
                                   uint32_t& sps_id);

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/h265_vps_sps_pps_tracker.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/h265_vps_sps_pps_tracker.cc
@@ -262,7 +262,7 @@ void H265VpsSpsPpsTracker::InsertVpsSpsPpsNalus(
   absl::optional<H265SpsParser::SpsState> parsed_sps = H265SpsParser::ParseSps(
       sps.data() + kNaluHeaderOffset, sps.size() - kNaluHeaderOffset);
   absl::optional<H265PpsParser::PpsState> parsed_pps = H265PpsParser::ParsePps(
-      pps.data() + kNaluHeaderOffset, pps.size() - kNaluHeaderOffset);
+      pps.data() + kNaluHeaderOffset, pps.size() - kNaluHeaderOffset, nullptr);
 
   if (!parsed_vps) {
     RTC_LOG(LS_WARNING) << "Failed to parse VPS.";
@@ -303,10 +303,10 @@ void H265VpsSpsPpsTracker::InsertVpsSpsPpsNalus(
   uint8_t* pps_data = new uint8_t[pps_info.size];
   memcpy(pps_data, pps.data(), pps_info.size);
   pps_info.data.reset(pps_data);
-  pps_data_[parsed_pps->id] = std::move(pps_info);
+  pps_data_[parsed_pps->pps_id] = std::move(pps_info);
 
   RTC_LOG(LS_INFO) << "Inserted SPS id " << parsed_sps->sps_id << " and PPS id "
-                   << parsed_pps->id << " (referencing SPS "
+                   << parsed_pps->pps_id << " (referencing SPS "
                    << parsed_pps->sps_id << ")";
 }
 

--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
@@ -2277,6 +2277,10 @@
 		419241EE21275AFA00634FCF /* simulcast_rate_allocator.cc in Sources */ = {isa = PBXBuildFile; fileRef = 419241EA21275AFA00634FCF /* simulcast_rate_allocator.cc */; };
 		419241EF21275AFA00634FCF /* simulcast_utility.cc in Sources */ = {isa = PBXBuildFile; fileRef = 419241EB21275AFA00634FCF /* simulcast_utility.cc */; };
 		419241F021275AFA00634FCF /* simulcast_rate_allocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 419241EC21275AFA00634FCF /* simulcast_rate_allocator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4197E3BE2B6AA1E10005C4B8 /* h265_bitstream_parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 4197E3BA2B6AA1E00005C4B8 /* h265_bitstream_parser.h */; };
+		4197E3BF2B6AA1E10005C4B8 /* h265_inline.cc in Sources */ = {isa = PBXBuildFile; fileRef = 4197E3BB2B6AA1E00005C4B8 /* h265_inline.cc */; };
+		4197E3C02B6AA1E10005C4B8 /* h265_bitstream_parser.cc in Sources */ = {isa = PBXBuildFile; fileRef = 4197E3BC2B6AA1E00005C4B8 /* h265_bitstream_parser.cc */; };
+		4197E3C12B6AA1E10005C4B8 /* h265_inline.h in Headers */ = {isa = PBXBuildFile; fileRef = 4197E3BD2B6AA1E00005C4B8 /* h265_inline.h */; };
 		419BA9AD2B15EEF600E0D825 /* vpx_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 419BA9A62B15EEF400E0D825 /* vpx_config.h */; };
 		419BA9AF2B15EEF600E0D825 /* vp8_rtcd.h in Headers */ = {isa = PBXBuildFile; fileRef = 419BA9A82B15EEF500E0D825 /* vp8_rtcd.h */; };
 		419BA9B02B15EEF600E0D825 /* vpx_dsp_rtcd.h in Headers */ = {isa = PBXBuildFile; fileRef = 419BA9A92B15EEF500E0D825 /* vpx_dsp_rtcd.h */; };
@@ -8286,6 +8290,10 @@
 		41953C072152ED6400136625 /* idct8x8_1_add_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = idct8x8_1_add_neon.c; sourceTree = "<group>"; };
 		41953C082152ED6400136625 /* highbd_vpx_convolve_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highbd_vpx_convolve_neon.c; sourceTree = "<group>"; };
 		41953C092152ED6400136625 /* quantize_neon.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = quantize_neon.c; sourceTree = "<group>"; };
+		4197E3BA2B6AA1E00005C4B8 /* h265_bitstream_parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = h265_bitstream_parser.h; sourceTree = "<group>"; };
+		4197E3BB2B6AA1E00005C4B8 /* h265_inline.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = h265_inline.cc; sourceTree = "<group>"; };
+		4197E3BC2B6AA1E00005C4B8 /* h265_bitstream_parser.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = h265_bitstream_parser.cc; sourceTree = "<group>"; };
+		4197E3BD2B6AA1E00005C4B8 /* h265_inline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = h265_inline.h; sourceTree = "<group>"; };
 		419BA9A52B15EEF400E0D825 /* vpx_config.asm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm.asm; path = vpx_config.asm; sourceTree = "<group>"; };
 		419BA9A62B15EEF400E0D825 /* vpx_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vpx_config.h; sourceTree = "<group>"; };
 		419BA9A72B15EEF500E0D825 /* vpx_config.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vpx_config.c; sourceTree = "<group>"; };
@@ -11307,8 +11315,12 @@
 		410091EF242E360800C5EDA2 /* h265 */ = {
 			isa = PBXGroup;
 			children = (
+				4197E3BC2B6AA1E00005C4B8 /* h265_bitstream_parser.cc */,
+				4197E3BA2B6AA1E00005C4B8 /* h265_bitstream_parser.h */,
 				410091F7242E362200C5EDA2 /* h265_common.cc */,
 				410091F5242E362100C5EDA2 /* h265_common.h */,
+				4197E3BB2B6AA1E00005C4B8 /* h265_inline.cc */,
+				4197E3BD2B6AA1E00005C4B8 /* h265_inline.h */,
 				410091F3242E362100C5EDA2 /* h265_pps_parser.cc */,
 				410091F2242E362100C5EDA2 /* h265_pps_parser.h */,
 				410091F0242E362000C5EDA2 /* h265_sps_parser.cc */,
@@ -21794,8 +21806,10 @@
 				41D7291C26651D6B00651A0B /* h264_profile_level_id.h in Headers */,
 				5CD285EB1E6A639F0094FDC8 /* h264_sprop_parameter_sets.h in Headers */,
 				5CDD83DA1E439A6F00621E92 /* h264_sps_pps_tracker.h in Headers */,
+				4197E3BE2B6AA1E10005C4B8 /* h265_bitstream_parser.h in Headers */,
 				410091FD242E362200C5EDA2 /* h265_common.h in Headers */,
 				DD77E1D727F7E55500DC90C0 /* h265_globals.h in Headers */,
+				4197E3C12B6AA1E10005C4B8 /* h265_inline.h in Headers */,
 				DDF30BFF27C5A611006A526F /* h265_pps_parser.h in Headers */,
 				410091F9242E362200C5EDA2 /* h265_sps_parser.h in Headers */,
 				410091FE242E362200C5EDA2 /* h265_vps_parser.h in Headers */,
@@ -25560,7 +25574,9 @@
 				41D7291D26651D6B00651A0B /* h264_profile_level_id.cc in Sources */,
 				5CD285EA1E6A639F0094FDC8 /* h264_sprop_parameter_sets.cc in Sources */,
 				5CDD83D91E439A6F00621E92 /* h264_sps_pps_tracker.cc in Sources */,
+				4197E3C02B6AA1E10005C4B8 /* h265_bitstream_parser.cc in Sources */,
 				410091FF242E362200C5EDA2 /* h265_common.cc in Sources */,
+				4197E3BF2B6AA1E10005C4B8 /* h265_inline.cc in Sources */,
 				41E84BCE24373BDE00D34E41 /* h265_pps_parser.cc in Sources */,
 				41E84BCF24373BE200D34E41 /* h265_sps_parser.cc in Sources */,
 				41E84BD024373BE600D34E41 /* h265_vps_parser.cc in Sources */,


### PR DESCRIPTION
#### 4fb4e5fc89e6891e6db99bda738f6d99d0cd4907
<pre>
Implement QP using H265BitstreamParser in RTCVideoEncoderH265.mm
<a href="https://rdar.apple.com/121400444">rdar://121400444</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=268464">https://bugs.webkit.org/show_bug.cgi?id=268464</a>

Reviewed by David Kilzer.

Update h265 implementation to fix the h265 parser according libwebrtc repo.
Update h265_vps_sps_pps_tracker implementation accordingly.
Use it to get qp of the encoded frame.

* LayoutTests/webrtc/h265-expected.txt:
* LayoutTests/webrtc/h265.html:
* Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_bitstream_parser.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_pps_parser.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_pps_parser.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/video_coding/h265_vps_sps_pps_tracker.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoEncoderH265.mm:
(-[RTCVideoEncoderH265 frameWasEncoded:flags:sampleBuffer:width:height:renderTimeMs:timestamp:rotation:]):
* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/273903@main">https://commits.webkit.org/273903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7af6fcb9d35d4301c02051369e0fbe9b7ab57388

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39674 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33131 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13140 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31638 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11763 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11768 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/33190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40930 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37665 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12081 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35803 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13723 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32684 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8388 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12454 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12987 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->