### PR TITLE
[Navigation] Initial implementations of traversal methods

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6882,7 +6882,6 @@ imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/opaque-o
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/opaque-origin-data-url.html [ Pass ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-from-initial-about-blank-gc.html [ Pass ]
 imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-cross-document.html [ Pass ]
-imported/w3c/web-platform-tests/navigation-api/scroll-behavior/after-transition-intercept-handler-modifies.html [ Pass ]
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-on-synthetic-event.html [ Pass ]
 imported/w3c/web-platform-tests/navigation-api/scroll-behavior/scroll-without-intercept.html [ Pass ]
 imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/same-document-away-and-back-location-api.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-expected.txt
@@ -1,3 +1,5 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: Invalid URL
+CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: Invalid URL
 
 
 PASS currententrychange does not fire when navigating away from the initial about:blank

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-back-forward-cross-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-back-forward-cross-doc-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT currententrychange does not fire for cross-document navigation.back() and navigation.forward() Test timed out
+FAIL currententrychange does not fire for cross-document navigation.back() and navigation.forward() assert_equals: expected 2 but got 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-cross-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-cross-doc-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT currententrychange does not fire for cross-document navigation.navigate() Test timed out
+PASS currententrychange does not fire for cross-document navigation.navigate()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-replace-cross-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-replace-cross-doc-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT currententrychange does not fire for cross-document navigation.navigate() with replace Test timed out
+PASS currententrychange does not fire for cross-document navigation.navigate() with replace
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-reload-cross-doc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-reload-cross-doc-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT currententrychange does not fire for cross-document navigation.reload() Test timed out
+PASS currententrychange does not fire for cross-document navigation.reload()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-cross-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-cross-origin-expected.txt
@@ -39,6 +39,7 @@ cors
 credential-management
 css
 custom-elements
+custom-state-pseudo-class
 density-size-correction
 deprecation-reporting
 docs
@@ -78,9 +79,11 @@ media-capabilities
 media-playback-quality
 media-source
 mediacapture-fromelement
+mediacapture-insertable-streams
 mediacapture-record
 mediacapture-streams
 mediasession
+merchant-validation
 mimesniff
 mixed-content
 mst-content-hint
@@ -123,6 +126,7 @@ subresource-integrity
 svg
 tools
 touch-events
+trusted-types
 uievents
 upgrade-insecure-requests
 url

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-from-initial-about-blank-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-from-initial-about-blank-expected.txt
@@ -1,3 +1,5 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: Invalid URL
+CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: Invalid URL
 
 
 Harness Error (TIMEOUT), message = null

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-from-initial-about-blank-gc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-from-initial-about-blank-gc-expected.txt
@@ -1,3 +1,5 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: Invalid URL
+CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: Invalid URL
 
 
 PASS navigate() from <iframe> with src="" but still on initial about:blank doesn't cause a crash on GC

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-from-initial-about-blank-src-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-from-initial-about-blank-src-expected.txt
@@ -1,4 +1,6 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: Invalid URL
+CONSOLE MESSAGE: Unhandled Promise Rejection: SyntaxError: Invalid URL
 
 
-FAIL navigate() from <iframe> with src="" but still on initial about:blank works null is not an object (evaluating 'i.contentWindow.navigation.currentEntry.url')
+FAIL navigate() from <iframe> with src="" but still on initial about:blank works assert_equals: expected "/common/blank.html" but got "/navigation-api/navigation-methods/navigate-from-initial-about-blank-src.html"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-navigation-timing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-navigation-timing-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT reload() appears as a reload to navigation timing APIs Test timed out
+PASS reload() appears as a reload to navigation timing APIs
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-current-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/traverseTo-current-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL traverseTo() with current key promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'navigation.currentEntry.key')"
+PASS traverseTo() with current key
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-cross-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-cross-document-expected.txt
@@ -1,8 +1,6 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT cross-document reload() must leave transition null Test timed out
-NOTRUN cross-document navigate() must leave transition null
-NOTRUN cross-document back() must leave transition null
+PASS cross-document reload() must leave transition null
+PASS cross-document navigate() must leave transition null
+PASS cross-document back() must leave transition null
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-reload-with-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-reload-with-intercept-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL dispose events are not fired when doing a same-document reload using navigation.reload() and intercept() promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'navigation.currentEntry.ondispose = t.unreached_func("dispose must not happen for reloads")')"
+PASS dispose events are not fired when doing a same-document reload using navigation.reload() and intercept()
 

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "DOMPromiseProxy.h"
 #include "EventTarget.h"
 #include "JSDOMPromise.h"
 #include "LocalDOMWindowProperty.h"
@@ -84,7 +83,7 @@ public:
 
     void initializeEntries(const Ref<HistoryItem>& currentItem, Vector<Ref<HistoryItem>> &items);
 
-    Result navigate(const String& url, NavigateOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
+    Result navigate(ScriptExecutionContext&, const String& url, NavigateOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
     Result reload(ReloadOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
@@ -103,6 +102,8 @@ private:
     void derefEventTarget() final { deref(); }
 
     bool hasEntriesAndEventsDisabled() const;
+    Result performTraversal(NavigationHistoryEntry&, Ref<DeferredPromise> committed, Ref<DeferredPromise> finished);
+    std::optional<Ref<NavigationHistoryEntry>> findEntryByKey(const String& key);
 
     std::optional<size_t> m_currentEntryIndex;
     RefPtr<NavigationTransition> m_transition;

--- a/Source/WebCore/page/Navigation.idl
+++ b/Source/WebCore/page/Navigation.idl
@@ -11,7 +11,7 @@
   readonly attribute boolean canGoBack;
   readonly attribute boolean canGoForward;
 
-  [ReturnsPromisePair] NavigationResult navigate(USVString url, optional NavigationNavigateOptions options = {});
+  [ReturnsPromisePair,CallWith=CurrentScriptExecutionContext] NavigationResult navigate(USVString url, optional NavigationNavigateOptions options = {});
   [ReturnsPromisePair] NavigationResult reload(optional NavigationReloadOptions options = {});
 
   [ReturnsPromisePair] NavigationResult traverseTo(DOMString key, optional NavigationOptions options = {});


### PR DESCRIPTION
#### a0dd312f71c532a17e69e5703543708c7af68ba9
<pre>
[Navigation] Initial implementations of traversal methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=268465">https://bugs.webkit.org/show_bug.cgi?id=268465</a>

Reviewed by Alex Christensen.

This is the very beginnings of the traversal methods.

This implements a lot of the error handling but does not
fully implement traversal, only doing basic manual
traversals which can be useful for testing.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigate-from-initial-about-blank-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-cross-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-from-initial-about-blank-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-from-initial-about-blank-gc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-from-initial-about-blank-src-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/reload-navigation-timing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/transition-cross-document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-reload-with-intercept-expected.txt:
* Source/WebCore/page/Navigation.cpp:
(WebCore::createEarlyErrorResult):
(WebCore::Navigation::reload):
(WebCore::Navigation::navigate):
(WebCore::Navigation::performTraversal):
(WebCore::Navigation::findEntryByKey):
(WebCore::Navigation::traverseTo):
(WebCore::Navigation::back):
(WebCore::Navigation::forward):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/Navigation.idl:

Canonical link: <a href="https://commits.webkit.org/275054@main">https://commits.webkit.org/275054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b696706e67e4300c47e815992de67a382115c9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42165 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35530 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41936 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33085 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34295 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13612 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13620 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43442 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36012 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39370 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37636 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16048 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9137 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16097 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15705 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->