### PR TITLE
Build fix for arm64 builds

### DIFF
--- a/Source/JavaScriptCore/assembler/FastJITPermissions.h
+++ b/Source/JavaScriptCore/assembler/FastJITPermissions.h
@@ -35,7 +35,26 @@
 #include <wtf/Platform.h>
 
 #if USE(INLINE_JIT_PERMISSIONS_API)
+// This is a temporary workaround to fix a build error, see rdar://121990409
+#ifdef __arm64e__
 #include <BrowserEngineCore/BEMemory.h>
+#elif USE(APPLE_INTERNAL_SDK)
+#include <os/thread_self_restrict.h> 
+inline
+void be_memory_inline_jit_restrict_rwx_to_rw_with_witness(void)
+{
+    os_thread_self_restrict_rwx_to_rw();
+}
+
+inline
+void be_memory_inline_jit_restrict_rwx_to_rx_with_witness(void)
+{
+    os_thread_self_restrict_rwx_to_rx();
+}
+#else
+inline void be_memory_inline_jit_restrict_rwx_to_rw_with_witness(void) { }
+inline void be_memory_inline_jit_restrict_rwx_to_rx_with_witness(void) { }
+#endif
 #elif USE(PTHREAD_JIT_PERMISSIONS_API)
 #include <pthread.h>
 #elif USE(APPLE_INTERNAL_SDK)


### PR DESCRIPTION
#### d21e6f3910e86f0b5553cb891594141c65d4049a
<pre>
Build fix for arm64 builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=268467">https://bugs.webkit.org/show_bug.cgi?id=268467</a>
<a href="https://rdar.apple.com/122018269">rdar://122018269</a>

Reviewed by Mark Lam and Yusuke Suzuki.

* Source/JavaScriptCore/assembler/FastJITPermissions.h:
(be_memory_inline_jit_restrict_rwx_to_rw_with_witness):
(be_memory_inline_jit_restrict_rwx_to_rx_with_witness):

Canonical link: <a href="https://commits.webkit.org/273843@main">https://commits.webkit.org/273843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/259cc86e689596d09de5add3fa8788aeb4ff5b88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36846 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39486 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32998 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12896 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32559 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/11650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40736 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/30887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33429 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/33190 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37562 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/36680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11936 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35687 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13593 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/43406 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12327 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4772 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12838 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->