### PR TITLE
Adopt more smart pointers in WebCore/loader/cache

### DIFF
--- a/Source/WebCore/loader/FontLoadRequest.h
+++ b/Source/WebCore/loader/FontLoadRequest.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "FontTaggedSettings.h"
+#include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
@@ -37,7 +38,7 @@ class FontDescription;
 class FontLoadRequest;
 struct FontSelectionSpecifiedCapabilities;
 
-class FontLoadRequestClient {
+class FontLoadRequestClient : public CanMakeWeakPtr<FontLoadRequestClient> {
 public:
     virtual ~FontLoadRequestClient() = default;
     virtual void fontLoaded(FontLoadRequest&) { }

--- a/Source/WebCore/loader/cache/CachedApplicationManifest.cpp
+++ b/Source/WebCore/loader/cache/CachedApplicationManifest.cpp
@@ -43,9 +43,9 @@ CachedApplicationManifest::CachedApplicationManifest(CachedResourceRequest&& req
 void CachedApplicationManifest::finishLoading(const FragmentedSharedBuffer* data, const NetworkLoadMetrics& metrics)
 {
     if (data) {
-        auto contiguousData = data->makeContiguous();
+        Ref contiguousData = data->makeContiguous();
         setEncodedSize(data->size());
-        m_text = m_decoder->decodeAndFlush(contiguousData->data(), data->size());
+        m_text = protectedDecoder()->decodeAndFlush(contiguousData->data(), data->size());
         m_data = WTFMove(contiguousData);
     } else {
         m_data = nullptr;
@@ -56,12 +56,12 @@ void CachedApplicationManifest::finishLoading(const FragmentedSharedBuffer* data
 
 void CachedApplicationManifest::setEncoding(const String& chs)
 {
-    m_decoder->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
+    protectedDecoder()->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
 }
 
 String CachedApplicationManifest::encoding() const
 {
-    return String::fromLatin1(m_decoder->encoding().name());
+    return String::fromLatin1(protectedDecoder()->encoding().name());
 }
 
 std::optional<ApplicationManifest> CachedApplicationManifest::process(const URL& manifestURL, const URL& documentURL, Document* document)
@@ -71,6 +71,11 @@ std::optional<ApplicationManifest> CachedApplicationManifest::process(const URL&
     if (document)
         return ApplicationManifestParser::parse(*document, *m_text, manifestURL, documentURL);
     return ApplicationManifestParser::parse(*m_text, manifestURL, documentURL);
+}
+
+Ref<TextResourceDecoder> CachedApplicationManifest::protectedDecoder() const
+{
+    return m_decoder;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedApplicationManifest.h
+++ b/Source/WebCore/loader/cache/CachedApplicationManifest.h
@@ -42,10 +42,11 @@ public:
     std::optional<struct ApplicationManifest> process(const URL& manifestURL, const URL& documentURL, Document* = nullptr);
 
 private:
-    void finishLoading(const FragmentedSharedBuffer*, const NetworkLoadMetrics&) override;
-    const TextResourceDecoder* textResourceDecoder() const override { return m_decoder.ptr(); }
-    void setEncoding(const String&) override;
-    String encoding() const override;
+    void finishLoading(const FragmentedSharedBuffer*, const NetworkLoadMetrics&) final;
+    const TextResourceDecoder* textResourceDecoder() const final { return m_decoder.ptr(); }
+    Ref<TextResourceDecoder> protectedDecoder() const;
+    void setEncoding(const String&) final;
+    String encoding() const final;
 
     Ref<TextResourceDecoder> m_decoder;
     std::optional<String> m_text;

--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
@@ -51,8 +51,8 @@ CachedCSSStyleSheet::CachedCSSStyleSheet(CachedResourceRequest&& request, PAL::S
 
 CachedCSSStyleSheet::~CachedCSSStyleSheet()
 {
-    if (m_parsedStyleSheetCache)
-        m_parsedStyleSheetCache->removedFromMemoryCache();
+    if (RefPtr parsedStyleSheetCache = m_parsedStyleSheetCache)
+        parsedStyleSheetCache->removedFromMemoryCache();
 }
 
 void CachedCSSStyleSheet::didAddClient(CachedResourceClient& client)
@@ -69,12 +69,12 @@ void CachedCSSStyleSheet::didAddClient(CachedResourceClient& client)
 
 void CachedCSSStyleSheet::setEncoding(const String& chs)
 {
-    m_decoder->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
+    protectedDecoder()->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
 }
 
 String CachedCSSStyleSheet::encoding() const
 {
-    return String::fromLatin1(m_decoder->encoding().name());
+    return String::fromLatin1(protectedDecoder()->encoding().name());
 }
 
 const String CachedCSSStyleSheet::sheetText(MIMETypeCheckHint mimeTypeCheckHint, bool* hasValidMIMEType, bool* hasHTTPStatusOK) const
@@ -88,8 +88,8 @@ const String CachedCSSStyleSheet::sheetText(MIMETypeCheckHint mimeTypeCheckHint,
     if (!m_decodedSheetText.isNull())
         return m_decodedSheetText;
 
-    // Don't cache the decoded text, regenerating is cheap and it can use quite a bit of memory
-    return m_decoder->decodeAndFlush(m_data->makeContiguous()->data(), m_data->size());
+    // Don't cache the decoded text, regenerating is cheap and it can use quite a bit of memory.
+    return protectedDecoder()->decodeAndFlush(m_data->makeContiguous()->data(), m_data->size());
 }
 
 void CachedCSSStyleSheet::setBodyDataFrom(const CachedResource& resource)
@@ -101,14 +101,14 @@ void CachedCSSStyleSheet::setBodyDataFrom(const CachedResource& resource)
 
     m_decoder = sheet.m_decoder;
     m_decodedSheetText = sheet.m_decodedSheetText;
-    if (sheet.m_parsedStyleSheetCache)
-        saveParsedStyleSheet(*sheet.m_parsedStyleSheetCache);
+    if (RefPtr parsedStyleSheetCache = sheet.m_parsedStyleSheetCache)
+        saveParsedStyleSheet(parsedStyleSheetCache.releaseNonNull());
 }
 
 void CachedCSSStyleSheet::finishLoading(const FragmentedSharedBuffer* data, const NetworkLoadMetrics& metrics)
 {
     if (data) {
-        auto contiguousData = data->makeContiguous();
+        Ref contiguousData = data->makeContiguous();
         setEncodedSize(data->size());
         // Decode the data to find out the encoding and keep the sheet text around during checkNotify()
         m_decodedSheetText = protectedDecoder()->decodeAndFlush(contiguousData->data(), data->size());
@@ -135,7 +135,7 @@ void CachedCSSStyleSheet::checkNotify(const NetworkLoadMetrics&)
 
     CachedResourceClientWalker<CachedStyleSheetClient> walker(*this);
     while (CachedStyleSheetClient* c = walker.next())
-        c->setCSSStyleSheet(m_resourceRequest.url().string(), response().url(), String::fromLatin1(m_decoder->encoding().name()), this);
+        c->setCSSStyleSheet(m_resourceRequest.url().string(), response().url(), String::fromLatin1(protectedDecoder()->encoding().name()), this);
 }
 
 String CachedCSSStyleSheet::responseMIMEType() const
@@ -196,7 +196,7 @@ void CachedCSSStyleSheet::destroyDecodedData()
     if (!m_parsedStyleSheetCache)
         return;
 
-    m_parsedStyleSheetCache->removedFromMemoryCache();
+    Ref { *m_parsedStyleSheetCache }->removedFromMemoryCache();
     m_parsedStyleSheetCache = nullptr;
 
     setDecodedSize(0);
@@ -204,19 +204,20 @@ void CachedCSSStyleSheet::destroyDecodedData()
 
 RefPtr<StyleSheetContents> CachedCSSStyleSheet::restoreParsedStyleSheet(const CSSParserContext& context, CachePolicy cachePolicy, FrameLoader& loader)
 {
-    if (!m_parsedStyleSheetCache)
+    RefPtr parsedStyleSheetCache = m_parsedStyleSheetCache;
+    if (!parsedStyleSheetCache)
         return nullptr;
-    if (!m_parsedStyleSheetCache->subresourcesAllowReuse(cachePolicy, loader)) {
-        m_parsedStyleSheetCache->removedFromMemoryCache();
+    if (!parsedStyleSheetCache->subresourcesAllowReuse(cachePolicy, loader)) {
+        parsedStyleSheetCache->removedFromMemoryCache();
         m_parsedStyleSheetCache = nullptr;
         return nullptr;
     }
 
-    ASSERT(m_parsedStyleSheetCache->isCacheable());
-    ASSERT(m_parsedStyleSheetCache->isInMemoryCache());
+    ASSERT(parsedStyleSheetCache->isCacheable());
+    ASSERT(parsedStyleSheetCache->isInMemoryCache());
 
     // Contexts must be identical so we know we would get the same exact result if we parsed again.
-    if (m_parsedStyleSheetCache->parserContext() != context)
+    if (parsedStyleSheetCache->parserContext() != context)
         return nullptr;
 
     didAccessDecodedData(MonotonicTime::now());
@@ -228,12 +229,12 @@ void CachedCSSStyleSheet::saveParsedStyleSheet(Ref<StyleSheetContents>&& sheet)
 {
     ASSERT(sheet->isCacheable());
 
-    if (m_parsedStyleSheetCache)
-        m_parsedStyleSheetCache->removedFromMemoryCache();
-    m_parsedStyleSheetCache = WTFMove(sheet);
-    m_parsedStyleSheetCache->addedToMemoryCache();
+    if (RefPtr parsedStyleSheetCache = m_parsedStyleSheetCache)
+        parsedStyleSheetCache->removedFromMemoryCache();
+    m_parsedStyleSheetCache = sheet.copyRef();
+    sheet->addedToMemoryCache();
 
-    setDecodedSize(m_parsedStyleSheetCache->estimatedSizeInBytes());
+    setDecodedSize(sheet->estimatedSizeInBytes());
 }
 
 }


### PR DESCRIPTION
#### 2fa29a741ed22b3670e5042d12b7de2aa0b475a6
<pre>
Adopt more smart pointers in WebCore/loader/cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=268468">https://bugs.webkit.org/show_bug.cgi?id=268468</a>

Reviewed by Brent Fulgham.

* Source/WebCore/loader/FontLoadRequest.h:
* Source/WebCore/loader/cache/CachedApplicationManifest.cpp:
(WebCore::CachedApplicationManifest::finishLoading):
(WebCore::CachedApplicationManifest::setEncoding):
(WebCore::CachedApplicationManifest::encoding const):
(WebCore::CachedApplicationManifest::protectedDecoder const):
* Source/WebCore/loader/cache/CachedApplicationManifest.h:
* Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp:
(WebCore::CachedCSSStyleSheet::~CachedCSSStyleSheet):
(WebCore::CachedCSSStyleSheet::setEncoding):
(WebCore::CachedCSSStyleSheet::encoding const):
(WebCore::CachedCSSStyleSheet::sheetText const):
(WebCore::CachedCSSStyleSheet::setBodyDataFrom):
(WebCore::CachedCSSStyleSheet::finishLoading):
(WebCore::CachedCSSStyleSheet::checkNotify):
(WebCore::CachedCSSStyleSheet::destroyDecodedData):
(WebCore::CachedCSSStyleSheet::restoreParsedStyleSheet):
(WebCore::CachedCSSStyleSheet::saveParsedStyleSheet):
* Source/WebCore/loader/cache/CachedFont.cpp:
(WebCore::CachedFont::finishLoading):
(WebCore::CachedFont::setErrorAndDeleteData):
(WebCore::CachedFont::ensureCustomFontData):
(WebCore::CachedFont::platformDataFromCustomData):
* Source/WebCore/loader/cache/CachedFontLoadRequest.h:

Canonical link: <a href="https://commits.webkit.org/273856@main">https://commits.webkit.org/273856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bfeff08b2e20bfd51f3775af99e254633578998

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39473 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32989 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38119 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/18384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12883 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31544 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11630 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11643 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40723 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33415 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33181 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37556 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35676 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13581 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12315 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4780 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12826 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->