### PR TITLE
If testRunner.notifyDone is called in a different site isolated process than testRunner.waitUntilDone, layout test doesn't complete

### DIFF
--- a/LayoutTests/http/tests/site-isolation/notify-done-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/notify-done-expected.txt
@@ -1,0 +1,5 @@
+
+--------
+Frame: '<!--frame2-->'
+--------
+I am a simple document that calls notifyDone when loaded.

--- a/LayoutTests/http/tests/site-isolation/notify-done.html
+++ b/LayoutTests/http/tests/site-isolation/notify-done.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpChildFramesAsText();
+    testRunner.waitUntilDone();
+}
+</script>
+</head>
+<body>
+<p>
+This test passes if it doesn't time out.
+</p>
+<iframe src="http://localhost:8000/site-isolation/resources/frame-notify-done.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/frame-notify-done.html
+++ b/LayoutTests/http/tests/site-isolation/resources/frame-notify-done.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<head>
+<script>
+function loaded()
+{
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+</head>
+<body onload="loaded();">
+I am a simple document that calls notifyDone when loaded.
+</body>

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -768,14 +768,13 @@ void InjectedBundlePage::dump(bool forceRepaint)
     }
     WKBundlePageFlushPendingEditorStateUpdate(m_page);
 
-    WKBundleFrameRef frame = WKBundlePageGetMainFrame(m_page);
-    auto urlRef = adoptWK(WKBundleFrameCopyURL(frame));
-    if (!urlRef)
-        return;
-    String url = toWTFString(adoptWK(WKURLCopyString(urlRef.get())));
-    auto mimeType = adoptWK(WKBundleFrameCopyMIMETypeForResourceWithURL(frame, urlRef.get()));
-    if (url.find("dumpAsText/"_s) != notFound || WKStringIsEqualToUTF8CString(mimeType.get(), "text/plain"))
-        injectedBundle.testRunner()->dumpAsText(false);
+    WKBundleFrameRef mainFrame = WKBundlePageGetMainFrame(m_page);
+    if (auto urlRef = adoptWK(WKBundleFrameCopyURL(mainFrame))) {
+        String url = toWTFString(adoptWK(WKURLCopyString(urlRef.get())));
+        auto mimeType = adoptWK(WKBundleFrameCopyMIMETypeForResourceWithURL(mainFrame, urlRef.get()));
+        if (url.find("dumpAsText/"_s) != notFound || WKStringIsEqualToUTF8CString(mimeType.get(), "text/plain"))
+            injectedBundle.testRunner()->dumpAsText(false);
+    }
 
     StringBuilder stringBuilder;
 
@@ -796,7 +795,7 @@ void InjectedBundlePage::dump(bool forceRepaint)
     case WhatToDump::Audio:
         break;
     case WhatToDump::DOMAsWebArchive:
-        dumpDOMAsWebArchive(frame, stringBuilder);
+        dumpDOMAsWebArchive(mainFrame, stringBuilder);
         break;
     }
 


### PR DESCRIPTION
#### fbc2754daeb5630ce4978233edf2c94a7c763af0
<pre>
If testRunner.notifyDone is called in a different site isolated process than testRunner.waitUntilDone, layout test doesn&apos;t complete
<a href="https://rdar.apple.com/121682316">rdar://121682316</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=268471">https://bugs.webkit.org/show_bug.cgi?id=268471</a>

Reviewed by NOBODY (OOPS!).

Before site isolation both an iframe and parent frame lived in the same
process and so used the same Injected Bundle. Done notifications worked
because even if the child frame was finishing the test it was able to
access a pointer to the main frame and dump appropriately. In site
isolation a cross origin iframe lives in a different process and so does
not have access to the main frame&apos;s pointer.

This change bypasses a main frame check when a frame is wrapping up after a
call to testRunner.notifyDone if it is not in the main frame&apos;s process.
This will allow the frame to send the &quot;Done&quot; notification to the UI
process which can handle notifications to the other web content
processes to finish the test.

* LayoutTests/http/tests/site-isolation/notify-done-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/notify-done.html: Added.
* LayoutTests/http/tests/site-isolation/resources/frame-notify-done.html: Added.
(WTR::InjectedBundlePage::dump):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbc2754daeb5630ce4978233edf2c94a7c763af0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39503 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33009 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31566 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11651 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11661 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40753 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33440 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33200 "Found 6 new test failures: http/tests/site-isolation/basic-iframe-render-output.html, http/tests/site-isolation/basic-iframe.html, http/tests/site-isolation/double-iframe.html, http/tests/site-isolation/draw-after-navigation.html, http/tests/site-isolation/key-events.html, http/tests/site-isolation/selection-focus.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37570 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11947 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9756 "Found 6 new test failures: http/tests/site-isolation/basic-iframe-render-output.html, http/tests/site-isolation/basic-iframe.html, http/tests/site-isolation/double-iframe.html, http/tests/site-isolation/draw-after-navigation.html, http/tests/site-isolation/key-events.html, http/tests/site-isolation/selection-focus.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35719 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32550 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12338 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12855 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->