### PR TITLE
Explicitly invalidate grant for locked files

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -259,6 +259,7 @@ void NetworkProcess::setProxyConfigData(PAL::SessionID sessionID, Vector<std::pa
 #if USE(RUNNINGBOARD) && USE(EXTENSIONKIT)
 bool NetworkProcess::acquireLockedFileGrant()
 {
+    [m_holdingLockedFileGrant invalidateGrant];
     m_holdingLockedFileGrant = [WKProcessExtension.sharedInstance grant:@"com.apple.common" name:@"FinishTaskInterruptable"];
     if (m_holdingLockedFileGrant)
         RELEASE_LOG(Process, "Successfully took assertion on Network process for locked file.");
@@ -272,6 +273,7 @@ void NetworkProcess::invalidateGrant()
     if (!hasAcquiredGrant())
         return;
 
+    [m_holdingLockedFileGrant invalidateGrant];
     m_holdingLockedFileGrant = nil;
 }
 

--- a/Source/WebKit/Shared/Cocoa/WKProcessExtension.h
+++ b/Source/WebKit/Shared/Cocoa/WKProcessExtension.h
@@ -27,6 +27,7 @@
 
 OBJC_EXPORT
 @interface WKGrant : NSObject
+- (void)invalidateGrant;
 @end
 
 OBJC_EXPORT

--- a/Source/WebKit/Shared/Cocoa/WKProcessExtension.mm
+++ b/Source/WebKit/Shared/Cocoa/WKProcessExtension.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 
+#import "Logging.h"
 #if USE(EXTENSIONKIT)
 #import "WKProcessExtension.h"
 
@@ -37,6 +38,10 @@ static RetainPtr<WKProcessExtension>& sharedInstance()
 }
 
 @implementation WKGrant
+- (void)invalidateGrant
+{
+    RELEASE_LOG_FAULT(Process, "-[WKGrant invalidateGrant] should never be called");
+}
 @end
 
 @implementation WKProcessExtension


### PR DESCRIPTION
#### 990d138133d5746825ec0e3e0d0e1236f83acfda
<pre>
Explicitly invalidate grant for locked files
<a href="https://bugs.webkit.org/show_bug.cgi?id=268473">https://bugs.webkit.org/show_bug.cgi?id=268473</a>
<a href="https://rdar.apple.com/121746578">rdar://121746578</a>

Reviewed by Chris Dumez.

Explicitly invalidate grant for locked files in the Networking process. This is a speculative fix for a crash
we&apos;re seeing in the Networking process because it has taken too many assertions. The assertions are currently
being invalidated when the grant object is being destroyed. The grant object is autoreleased, and will
therefore be destroyed in an autorelease pool. The reasoning behind this change is that we should explicitly
invalidate the assertions without relying on when they are being destroyed, since that is outside of WebKit
control. This patch also adds some new logs and faults.

* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::acquireLockedFileGrant):
(WebKit::NetworkProcess::invalidateGrant):
* Source/WebKit/Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.swift:
(Grant.invalidateGrant):
(NetworkingProcessExtension.grant(_:name:)):
(Grant.invalidate): Deleted.
* Source/WebKit/Shared/Cocoa/WKProcessExtension.h:
* Source/WebKit/Shared/Cocoa/WKProcessExtension.mm:
(-[WKGrant invalidateGrant]):

Canonical link: <a href="https://commits.webkit.org/273865@main">https://commits.webkit.org/273865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/636343c227f447f35b0a75ddf64c47fa2cda8d05

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39106 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39479 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/32992 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31546 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32553 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11633 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11645 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40729 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33419 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37558 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35679 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13587 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12321 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4787 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->