### PR TITLE
<ruby> children should have white-space:nowrap

### DIFF
--- a/LayoutTests/fast/ruby/implicit-base-child-nowrap-expected.html
+++ b/LayoutTests/fast/ruby/implicit-base-child-nowrap-expected.html
@@ -1,0 +1,17 @@
+<style>
+div {
+  border: solid 1px black;
+  width: 200px;
+  font-size: 20px;
+  font-family: Monospace;
+}
+rt {
+ font-size: 5px;
+}
+span {
+    white-space: nowrap;
+}
+</style>
+PASS if base does not wrap
+<div>before ruby <ruby><span>b a s e</span><rt>annotation</rt></ruby> after ruby</div>
+<div>before ruby <ruby>b a s e<rt>annotation</rt></ruby> after ruby</div>

--- a/LayoutTests/fast/ruby/implicit-base-child-nowrap.html
+++ b/LayoutTests/fast/ruby/implicit-base-child-nowrap.html
@@ -1,0 +1,14 @@
+<style>
+div {
+  border: solid 1px black;
+  width: 200px;
+  font-size: 20px;
+  font-family: Monospace;
+}
+rt {
+ font-size: 5px;
+}
+</style>
+PASS if base does not wrap
+<div>before ruby <ruby><span>b a s e</span><rt>annotation</rt></ruby> after ruby</div>
+<div>before ruby <ruby>b a s e<rt>annotation</rt></ruby> after ruby</div>

--- a/Source/WebCore/css/ruby.css
+++ b/Source/WebCore/css/ruby.css
@@ -5,5 +5,8 @@ ruby {
 }
 ruby > rt {
     display: ruby-text;
+}
+/* Avoid wrapping children of implicit ruby bases. We don't support <rb> or <rbc>, avoid giving them any behaviors. */
+ruby > :not(rb, rbc, ruby) {
     white-space: nowrap;
 }


### PR DESCRIPTION
#### d96647d9709657c02a36a2334bd8c30f6149e646
<pre>
&lt;ruby&gt; children should have white-space:nowrap
<a href="https://bugs.webkit.org/show_bug.cgi?id=268475">https://bugs.webkit.org/show_bug.cgi?id=268475</a>
<a href="https://rdar.apple.com/121202426">rdar://121202426</a>

Reviewed by Alan Baradlay.

We may end up wrapping inside anonymous ruby base because while the base
has &apos;white-space:nowrap&apos; the content doesn&apos;t necessarily have it.

* LayoutTests/fast/ruby/implicit-base-child-nowrap-expected.html: Added.
* LayoutTests/fast/ruby/implicit-base-child-nowrap.html: Added.
* Source/WebCore/css/ruby.css:
(ruby &gt; rt):
(ruby &gt; :not(rb, rbc)):

Set nowrap for any direct ruby children (except for unsupported ruby elements to avoid behavior changes for them).

Canonical link: <a href="https://commits.webkit.org/273852@main">https://commits.webkit.org/273852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac128cbb0cb35a3bcdb70673e7da6870198cdcea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39511 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12926 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37438 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/13352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/11658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/32870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40761 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/33452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33212 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9764 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/35704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32563 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8352 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12863 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->