### PR TITLE
Adopt new MarketplaceKit API

### DIFF
--- a/Source/WebKit/WebKitSwift/MarketplaceKit/MarketplaceKitWrapper.swift
+++ b/Source/WebKit/WebKitSwift/MarketplaceKit/MarketplaceKitWrapper.swift
@@ -36,10 +36,13 @@ public final class MarketplaceKitWrapper : NSObject {
     @objc
     @available(iOS 17.4, *)
     public static func requestAppInstallation(topOrigin: URL, url: URL) {
-        let metadata = LinkMetadata(referrer: topOrigin, url: url)
         Task { @MainActor in
             do {
-                try await AppLibrary.current.requestAppInstallation(with: metadata)
+#if canImport(MarketplaceKit, _version: "1.4.77.2")
+                try await AppLibrary.current.requestAppInstallationFromBrowser(for: url, referrer: topOrigin)
+#else
+                try await AppLibrary.current.requestAppInstallation(with: LinkMetadata(referrer: topOrigin, url: url))
+#endif
                 logger.debug("WKMarketplaceKit.requestAppInstallation with top origin \(topOrigin, privacy: .sensitive) for \(url, privacy: .sensitive) succeeded")
             } catch {
                 logger.error("WKMarketplaceKit.requestAppInstallation with top origin \(topOrigin, privacy: .sensitive) for \(url, privacy: .sensitive) failed: \(error, privacy: .public)")


### PR DESCRIPTION
#### 075fc974c8e598ac8f7c1cee014afc9456e0a094
<pre>
Adopt new MarketplaceKit API
<a href="https://bugs.webkit.org/show_bug.cgi?id=268478">https://bugs.webkit.org/show_bug.cgi?id=268478</a>
<a href="https://rdar.apple.com/122022027">rdar://122022027</a>

Reviewed by Brent Fulgham.

MarketplaceKit renamed their requestAppInstallation API and we need to adopt the new version of it.

* Source/WebKit/WebKitSwift/MarketplaceKit/MarketplaceKitWrapper.swift:
(MarketplaceKitWrapper.requestAppInstallation(_:url:)):

Canonical link: <a href="https://commits.webkit.org/273850@main">https://commits.webkit.org/273850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a54b8e5cdde1dc5eebb476261456a01e3f6c81a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39490 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33000 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12900 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11643 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11652 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40740 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33430 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33193 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9749 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/35696 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13595 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8354 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12329 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12842 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->