### PR TITLE
REGRESSION (234750@main): [GTK][WPE] preferred language not passed to NetworkProcess if set in WebContext before creating WebView

### DIFF
--- a/Source/WebKit/UIProcess/soup/WebProcessPoolSoup.cpp
+++ b/Source/WebKit/UIProcess/soup/WebProcessPoolSoup.cpp
@@ -29,6 +29,7 @@
 #include "MemoryPressureMonitor.h"
 #include "NetworkProcessCreationParameters.h"
 #include "NetworkProcessMessages.h"
+#include "OverrideLanguages.h"
 #include "WebCoreArgumentCoders.h"
 #include "WebProcessMessages.h"
 #include <wtf/Language.h>
@@ -39,7 +40,7 @@ std::optional<MemoryPressureHandler::Configuration> WebProcessPool::s_networkPro
 
 void WebProcessPool::platformInitializeNetworkProcess(NetworkProcessCreationParameters& parameters)
 {
-    parameters.languages = userPreferredLanguages();
+    parameters.languages = overrideLanguages().isEmpty() ? userPreferredLanguages() : overrideLanguages();
     parameters.memoryPressureHandlerConfiguration = s_networkProcessMemoryPressureHandlerConfiguration;
 
 #if OS(LINUX)


### PR DESCRIPTION
#### f2599adbe88142f918a4302fdde68d4a01ba9e2a
<pre>
REGRESSION (234750@main): [GTK][WPE] preferred language not passed to NetworkProcess if set in WebContext before creating WebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=268479">https://bugs.webkit.org/show_bug.cgi?id=268479</a>

Reviewed by Adrian Perez de Castro.

In GLib ports, since 234750@main, the user preferred language is not
properly passed to the NetworkProcess if it is set in WebContext
before creating the WebView.
This causes a wrong Accept-Language header in HTTP requests sent with libsoup.

The webkit_web_context_set_preferred_languages() API can be called
before passing the WebContext at WebView creation.
Since 234750@main, this function calls the setOverrideLanguages()
WebProcessPool API instead of the overrideUserPreferredLanguages() WTF API.

So WebProcessPool::platformInitializeNetworkProcess() could not get the
real preferred language from the userPreferredLanguages() WTF API.

Instead, the NetworkProcess creation should use the overrideLanguages()
WebProcessPool API, like already done for the WebProcess creation
parameters (see also 226031@main).
Keep userPreferredLanguages() as a fallback to get the default
language from platformLanguage() in WTF::LanguageUnix.

* Source/WebKit/UIProcess/soup/WebProcessPoolSoup.cpp:
(WebKit::WebProcessPool::platformInitializeNetworkProcess):

Canonical link: <a href="https://commits.webkit.org/274011@main">https://commits.webkit.org/274011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/960c5d631727fa1a80d5674871db11e564240376

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40003 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33399 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31806 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12009 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11994 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41266 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33887 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/33989 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37889 "Found 2 new test failures: fast/repaint/animation-after-layer-scroll.html, webrtc/captureCanvas-webrtc-software-h264-baseline.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36046 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14010 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8453 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13325 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->