### PR TITLE
[GTK] Check window focus with gtk_window_is_active()

### DIFF
--- a/Source/WebKit/UIProcess/Gamepad/gtk/UIGamepadProviderGtk.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/gtk/UIGamepadProviderGtk.cpp
@@ -76,8 +76,8 @@ WebPageProxy* UIGamepadProvider::platformWebPageProxyForGamepadInput()
             continue;
 
 #if USE(GTK4)
-        GtkWidget* window = GTK_WIDGET(iter->data);
-        if (!gtk_widget_has_focus(window))
+        GtkWindow* window = GTK_WINDOW(iter->data);
+        if (!gtk_window_is_active(window))
             continue;
 #else
         GtkWindow* window = GTK_WINDOW(iter->data);


### PR DESCRIPTION
#### 7ca356b2f1bfd368d4b5e9896efeb3072d24c793
<pre>
[GTK] Check window focus with gtk_window_is_active()
<a href="https://bugs.webkit.org/show_bug.cgi?id=258264">https://bugs.webkit.org/show_bug.cgi?id=258264</a>

Reviewed by Michael Catanzaro.

In GTK3, gtk_widget_has_focus() called on a GtkWindow has the semantics
of &quot;does this window receive input&quot;. This semantic is not preserved in
GTK4; instead, gtk_window_is_active() is what yields the same results.

By using gtk_widget_has_focus() in UIGamepadProviderGtk, it always
returned false, and prevented gamepad detection from properly working.
Switch that to gtk_window_is_active().

* Source/WebKit/UIProcess/Gamepad/gtk/UIGamepadProviderGtk.cpp:
(WebKit::UIGamepadProvider::platformWebPageProxyForGamepadInput):

Canonical link: <a href="https://commits.webkit.org/273882@main">https://commits.webkit.org/273882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3180c7657ff103cd9657bd840475d6f53a62f222

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39501 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33007 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31573 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11662 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11659 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40751 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33438 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33208 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37569 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35725 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13602 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8375 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->