### PR TITLE
[WGSL] Compiler passes have incorrect scoping

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTScopedVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTScopedVisitor.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "AST.h"
+#include "ASTVisitor.h"
+#include "ContextProvider.h"
+
+namespace WGSL::AST {
+
+template<typename T>
+class ScopedVisitor : public Visitor, public ContextProvider<T> {
+protected:
+    using ContextProvider = ContextProvider<T>;
+    using ContextScope = typename ContextProvider::ContextScope;
+
+public:
+    using Visitor::visit;
+
+    void visit(Function&) override;
+    void visit(CompoundStatement&) override;
+    void visit(ForStatement&) override;
+    void visit(LoopStatement&) override;
+};
+
+} // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTScopedVisitorInlines.h
+++ b/Source/WebGPU/WGSL/AST/ASTScopedVisitorInlines.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ASTScopedVisitor.h"
+#include "ContextProviderInlines.h"
+
+namespace WGSL::AST {
+
+template<typename T>
+void ScopedVisitor<T>::visit(Function& function)
+{
+    ContextScope functionScope(this);
+    Visitor::visit(function);
+}
+
+template<typename T>
+void ScopedVisitor<T>::visit(CompoundStatement& statement)
+{
+    ContextScope blockScope(this);
+    Visitor::visit(statement);
+}
+
+template<typename T>
+void ScopedVisitor<T>::visit(ForStatement& statement)
+{
+    ContextScope forScope(this);
+    Visitor::visit(statement);
+}
+
+template<typename T>
+void ScopedVisitor<T>::visit(LoopStatement& loopStatement)
+{
+    ContextScope loopScope(this);
+    for (auto& attribute : loopStatement.attributes())
+        checkErrorAndVisit(attribute);
+    for (auto& statement : loopStatement.body())
+        checkErrorAndVisit(statement);
+    if (auto& continuing = loopStatement.continuing()) {
+        ContextScope continuingScope(this);
+        checkErrorAndVisit(*continuing);
+    }
+}
+
+} // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -504,7 +504,7 @@ void Visitor::visit(AST::LoopStatement& loopStatement)
         checkErrorAndVisit(attribute);
     for (auto& statement : loopStatement.body())
         checkErrorAndVisit(statement);
-    if (auto continuing = loopStatement.continuing())
+    if (auto& continuing = loopStatement.continuing())
         checkErrorAndVisit(*continuing);
 }
 

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -173,6 +173,8 @@
 		97E21C972A2512F7009CEB0E /* ConstantValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97E21C942A2512F7009CEB0E /* ConstantValue.cpp */; };
 		97E21C982A2512F7009CEB0E /* ConstantValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 97E21C952A2512F7009CEB0E /* ConstantValue.h */; };
 		97E21C992A2512F7009CEB0E /* ConstantFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = 97E21C962A2512F7009CEB0E /* ConstantFunctions.h */; };
+		97E709522B6ACCB50080E489 /* ASTScopedVisitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 97E709502B6ACCB50080E489 /* ASTScopedVisitor.h */; };
+		97E709552B6AD0030080E489 /* ASTScopedVisitorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 97E709542B6AD0030080E489 /* ASTScopedVisitorInlines.h */; };
 		97F547B8298055D90011D79A /* GlobalVariableRewriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97F547B6298055D90011D79A /* GlobalVariableRewriter.cpp */; };
 		97F547B9298055D90011D79A /* GlobalVariableRewriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 97F547B7298055D90011D79A /* GlobalVariableRewriter.h */; };
 		97FA1A8E29C086230052D650 /* wgslc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97FA1A8729C085A60052D650 /* wgslc.cpp */; };
@@ -460,6 +462,8 @@
 		97E21C942A2512F7009CEB0E /* ConstantValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConstantValue.cpp; sourceTree = "<group>"; };
 		97E21C952A2512F7009CEB0E /* ConstantValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConstantValue.h; sourceTree = "<group>"; };
 		97E21C962A2512F7009CEB0E /* ConstantFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConstantFunctions.h; sourceTree = "<group>"; };
+		97E709502B6ACCB50080E489 /* ASTScopedVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTScopedVisitor.h; sourceTree = "<group>"; };
+		97E709542B6AD0030080E489 /* ASTScopedVisitorInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTScopedVisitorInlines.h; sourceTree = "<group>"; };
 		97F547B6298055D90011D79A /* GlobalVariableRewriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GlobalVariableRewriter.cpp; sourceTree = "<group>"; };
 		97F547B7298055D90011D79A /* GlobalVariableRewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GlobalVariableRewriter.h; sourceTree = "<group>"; };
 		97FA1A7F29C085740052D650 /* wgslc */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = wgslc; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -751,6 +755,8 @@
 				3A9D029F298390A000888A75 /* ASTPointerDereference.h */,
 				97099ABF2AA60D58003B41F8 /* ASTReferenceTypeExpression.h */,
 				33EA187D27BC249000A1DD52 /* ASTReturnStatement.h */,
+				97E709502B6ACCB50080E489 /* ASTScopedVisitor.h */,
+				97E709542B6AD0030080E489 /* ASTScopedVisitorInlines.h */,
 				3A12AECE28FCFC5500C1B975 /* ASTSigned32Literal.h */,
 				3A12AEA128FCE94B00C1B975 /* ASTSizeAttribute.h */,
 				3A12AE9928FCE94B00C1B975 /* ASTStageAttribute.h */,
@@ -867,6 +873,8 @@
 				3A9D02A0298390A000888A75 /* ASTPointerDereference.h in Headers */,
 				97099AC22AA60D58003B41F8 /* ASTReferenceTypeExpression.h in Headers */,
 				33EA187E27BC249000A1DD52 /* ASTReturnStatement.h in Headers */,
+				97E709522B6ACCB50080E489 /* ASTScopedVisitor.h in Headers */,
+				97E709552B6AD0030080E489 /* ASTScopedVisitorInlines.h in Headers */,
 				3A12AED428FCFC5600C1B975 /* ASTSigned32Literal.h in Headers */,
 				3A12AEBB28FCE94C00C1B975 /* ASTSizeAttribute.h in Headers */,
 				3A12AEB328FCE94C00C1B975 /* ASTStageAttribute.h in Headers */,


### PR DESCRIPTION
#### a8e15be46cf742a7fd2a0067bbf6405ddee5e7b9
<pre>
[WGSL] Compiler passes have incorrect scoping
<a href="https://bugs.webkit.org/show_bug.cgi?id=268490">https://bugs.webkit.org/show_bug.cgi?id=268490</a>
<a href="https://rdar.apple.com/121527200">rdar://121527200</a>

Reviewed by Mike Wyrzykowski.

Not all classes that relied on the ContextProvider to track values while visiting
the AST provided overrides for all the nodes that had introduce a scope. That
resulted in incorrect scope tracking (e.g. the variables introduced in a for loop
might leak or similar). Move some of that logic into a new helper class, ScopedVisitor,
and updated all the subclasses of ContextProvider to use it instead of the base Visitor.

* Source/WebGPU/WGSL/AST/ASTScopedVisitor.h: Added.
* Source/WebGPU/WGSL/AST/ASTScopedVisitorInlines.h: Added.
(WGSL::AST::ScopedVisitor&lt;T&gt;::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/GlobalSorting.cpp:
(WGSL::GraphBuilder::GraphBuilder::visit):
(WGSL::GraphBuilder::visit): Deleted.
(WGSL::GraphBuilder::GraphBuilder): Deleted.
(WGSL::GraphBuilder::introduceVariable): Deleted.
(WGSL::GraphBuilder::readVariable const): Deleted.
(WGSL::reorder): Deleted.
(WGSL::reorderGlobals): Deleted.
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::run):
(WGSL::NameManglerVisitor::visit):
(WGSL::NameManglerVisitor::visitVariableDeclaration):
* Source/WebGPU/WGSL/PointerRewriter.cpp:
(WGSL::PointerRewriter::PointerRewriter):
(WGSL::PointerRewriter::run):
(WGSL::PointerRewriter::rewrite):
(WGSL::PointerRewriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::bindingKindToString):
(WGSL::TypeChecker::check):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::visitAttributes):
(WGSL::TypeChecker::infer):
(WGSL::TypeChecker::resolve):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/273993@main">https://commits.webkit.org/273993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bba118ef4262196e24771877d13b7ed151e7f095

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37224 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39793 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33207 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31688 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37787 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11844 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11833 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41051 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33826 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37746 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35889 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13793 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8440 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12532 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->