### PR TITLE
REGRESSION (273805@main): [ iOS macOS  Debug ] TestWTF.JSONValue.MemoryCost is a consistent failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
@@ -672,28 +672,28 @@ TEST(JSONValue, MemoryCost)
         Ref<JSON::Value> value = JSON::Value::null();
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 24U);
+        EXPECT_LE(memoryCost, 32U);
     }
 
     {
         Ref<JSON::Value> value = JSON::Value::create(true);
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 24U);
+        EXPECT_LE(memoryCost, 32U);
     }
 
     {
         Ref<JSON::Value> value = JSON::Value::create(1.0);
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 24U);
+        EXPECT_LE(memoryCost, 32U);
     }
 
     {
         Ref<JSON::Value> value = JSON::Value::create(1);
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 24U);
+        EXPECT_LE(memoryCost, 32U);
     }
 
     {
@@ -701,9 +701,9 @@ TEST(JSONValue, MemoryCost)
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
 #if HAVE(36BIT_ADDRESS)
-        EXPECT_LE(memoryCost, 60U);
+        EXPECT_LE(memoryCost, 68U);
 #else
-        EXPECT_LE(memoryCost, 52U);
+        EXPECT_LE(memoryCost, 60U);
 #endif
     }
 
@@ -712,9 +712,9 @@ TEST(JSONValue, MemoryCost)
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
 #if HAVE(36BIT_ADDRESS)
-        EXPECT_LE(memoryCost, 56U);
+        EXPECT_LE(memoryCost, 64U);
 #else
-        EXPECT_LE(memoryCost, 48U);
+        EXPECT_LE(memoryCost, 56U);
 #endif
     }
 
@@ -722,7 +722,7 @@ TEST(JSONValue, MemoryCost)
         Ref<JSON::Value> value = JSON::Value::create(String());
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 24U);
+        EXPECT_LE(memoryCost, 32U);
     }
 
     {
@@ -746,14 +746,14 @@ TEST(JSONValue, MemoryCost)
         value->setValue("test"_s, JSON::Value::null());
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 92U);
+        EXPECT_LE(memoryCost, 108U);
     }
 
     {
         Ref<JSON::Object> value = JSON::Object::create();
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 64U);
+        EXPECT_LE(memoryCost, 72U);
     }
 
     {
@@ -781,14 +781,14 @@ TEST(JSONValue, MemoryCost)
         value->pushValue(JSON::Value::null());
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 64U);
+        EXPECT_LE(memoryCost, 80U);
     }
 
     {
         Ref<JSON::Array> value = JSON::Array::create();
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 40U);
+        EXPECT_LE(memoryCost, 48U);
     }
 
     {


### PR DESCRIPTION
#### 0a279cde8508141b68f0cc0a8d99fee71d6b40ee
<pre>
REGRESSION (273805@main): [ iOS macOS  Debug ] TestWTF.JSONValue.MemoryCost is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=268483">https://bugs.webkit.org/show_bug.cgi?id=268483</a>
<a href="https://rdar.apple.com/122029223">rdar://122029223</a>

Unreviewed, adjust JSONValues memoryCost function for debug build (because
of RefCounted&apos;s additional fields in 273805@main).

* Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/273860@main">https://commits.webkit.org/273860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5b0a03e368fa7118f3f605c516ca491b8db73df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39535 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12965 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11667 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40787 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33461 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33220 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11976 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9779 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/35714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8357 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->