### PR TITLE
[UnifiedPDF] pdfLog() is a misnomer since it logs for the incremental loader

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
@@ -110,8 +110,7 @@ private:
     size_t incrementThreadsWaitingOnCallback() { return ++m_threadsWaitingOnCallback; }
     size_t decrementThreadsWaitingOnCallback() { return --m_threadsWaitingOnCallback; }
 
-    void pdfLog(const String&);
-    void verboseLog();
+    void incrementalLoaderLog(const String&);
     void logStreamLoader(WTF::TextStream&, WebCore::NetscapePlugInStreamLoader&);
 #endif
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -291,8 +291,7 @@ protected:
 #endif
 
 #if !LOG_DISABLED
-    void pdfLog(const String&);
-    void verboseLog();
+    void incrementalLoaderLog(const String&);
 #endif
 
     SingleThreadWeakPtr<PluginView> m_view;


### PR DESCRIPTION
#### d8b27a8ef37a2055cc7c96442de22f9ff44ef664
<pre>
[UnifiedPDF] pdfLog() is a misnomer since it logs for the incremental loader
<a href="https://bugs.webkit.org/show_bug.cgi?id=268493">https://bugs.webkit.org/show_bug.cgi?id=268493</a>
<a href="https://rdar.apple.com/122038661">rdar://122038661</a>

Reviewed by Simon Fraser.

pdfLog() can be misleading for a caller since it logs exclusively for
the incremental loader. This patch addresses this ambiguity by renaming
it to incrementalLoaderLog() instead. This method also makes the
verboseLog method a static method in the PDFPluginBase translation unit,
since it only has one caller inside PDFPluginBase::incrementalLoaderLog.

* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::PDFIncrementalLoader::receivedNonLinearizedPDFSentinel):
(WebKit::PDFIncrementalLoader::incrementalPDFStreamDidFinishLoading):
(WebKit::PDFIncrementalLoader::getResourceBytesAtPosition):
(WebKit::PDFIncrementalLoader::streamLoaderDidStart):
(WebKit::PDFIncrementalLoader::forgetStreamLoader):
(WebKit::PDFIncrementalLoader::requestCompleteIfPossible):
(WebKit::PDFIncrementalLoader::requestDidCompleteWithBytes):
(WebKit::PDFIncrementalLoader::requestDidCompleteWithAccumulatedData):
(WebKit::PDFIncrementalLoader::dataProviderGetBytesAtPosition):
(WebKit::PDFIncrementalLoader::dataProviderGetByteRanges):
(WebKit::PDFIncrementalLoader::threadEntry):
(WebKit::PDFIncrementalLoader::incrementalLoaderLog):
(WebKit::PDFIncrementalLoader::pdfLog): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::streamDidReceiveData):
(WebKit::PDFPluginBase::adoptBackgroundThreadDocument):
(WebKit::PDFPluginBase::receivedNonLinearizedPDFSentinel):
(WebKit::verboseLog):
(WebKit::PDFPluginBase::incrementalLoaderLog):
(WebKit::PDFPluginBase::pdfLog): Deleted.
(WebKit::PDFPluginBase::verboseLog): Deleted.

Canonical link: <a href="https://commits.webkit.org/273920@main">https://commits.webkit.org/273920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/397f407ff3f536ba8576774edd46ab83a89b196d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39554 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33052 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/12985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31583 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11680 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11771 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40806 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33590 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37599 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/11993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35751 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13646 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8403 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12374 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12903 "Build is in progress. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->