### PR TITLE
Displayed datalist dropdown is out of sync with datalist options elements after DOM update

### DIFF
--- a/LayoutTests/fast/forms/datalist/datalist-textinput-dynamically-add-options-expected.txt
+++ b/LayoutTests/fast/forms/datalist/datalist-textinput-dynamically-add-options-expected.txt
@@ -1,0 +1,5 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS isShowingDataListSuggestions is false
+

--- a/LayoutTests/fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown-expected.txt
+++ b/LayoutTests/fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown-expected.txt
@@ -1,0 +1,6 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS input.value became 'A'
+PASS isShowingDataListSuggestions is true
+

--- a/LayoutTests/fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html
+++ b/LayoutTests/fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+input {
+    width: 300px;
+    height: 50px;
+}
+body {
+    margin: 0;
+}
+</style>
+</head>
+<body>
+
+<input id="fruit" list="fruits" type="text" onInput="addOptions()"/>
+<datalist id="fruits">
+</datalist>
+
+<script>
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+function addOptions() {
+  let options = "";
+  options += "<option value='Apple'>\n";
+  options += "<option value='Orange'>\n";
+  options += "<option value='Pear'>\n";
+  document.getElementById('fruits').innerHTML = options;
+}
+
+function waitForDataListSuggestionsToChangeVisibility(visible)
+{
+    return new Promise(async resolve => {
+        while (visible != await UIHelper.isShowingDataListSuggestions())
+            continue;
+        resolve();
+    });
+}
+
+(async () => {
+    input = document.getElementById("fruit");
+
+    await UIHelper.activateElementAndWaitForInputSession(input);
+    await UIHelper.typeCharacter("A");
+
+    await waitForDataListSuggestionsToChangeVisibility(true);
+
+    await new Promise(resolve => shouldBecomeEqual("input.value", "'A'", resolve));
+
+    isShowingDataListSuggestions = await UIHelper.isShowingDataListSuggestions();
+    shouldBeTrue("isShowingDataListSuggestions");
+
+    testRunner.notifyDone();
+})();
+
+</script>
+
+</body>
+</html>

--- a/LayoutTests/fast/forms/datalist/datalist-textinput-dynamically-add-options.html
+++ b/LayoutTests/fast/forms/datalist/datalist-textinput-dynamically-add-options.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+input {
+    width: 300px;
+    height: 50px;
+}
+body {
+    margin: 0;
+}
+</style>
+</head>
+<body>
+
+<input id="fruit" list="fruits" type="text"/>
+<datalist id="fruits">
+</datalist>
+
+<script>
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+function addOptions() {
+  let options = "";
+  options += "<option value='Apple'>\n";
+  options += "<option value='Orange'>\n";
+  options += "<option value='Pear'>\n";
+  document.getElementById('fruits').innerHTML = options;
+}
+
+(async () => {
+    addOptions();
+
+    isShowingDataListSuggestions = await UIHelper.isShowingDataListSuggestions();
+    shouldBeFalse("isShowingDataListSuggestions");
+
+    testRunner.notifyDone();
+})();
+
+</script>
+
+</body>
+</html>

--- a/Source/WebCore/html/DataListSuggestionInformation.h
+++ b/Source/WebCore/html/DataListSuggestionInformation.h
@@ -37,6 +37,7 @@ enum class DataListSuggestionActivationType : uint8_t {
     ControlClicked,
     IndicatorClicked,
     TextChanged,
+    DataListMayHaveChanged,
 };
 
 struct DataListSuggestion {

--- a/Source/WebCore/html/HTMLDataListElement.cpp
+++ b/Source/WebCore/html/HTMLDataListElement.cpp
@@ -75,6 +75,12 @@ Ref<HTMLCollection> HTMLDataListElement::options()
     return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::DataListOptions>::traversalType>>(*this, CollectionType::DataListOptions);
 }
 
+void HTMLDataListElement::childrenChanged(const ChildChange& change)
+{
+    if (change.source == ChildChange::Source::API)
+        optionElementChildrenChanged();
+}
+
 void HTMLDataListElement::optionElementChildrenChanged()
 {
     if (auto& id = getIdAttribute(); !id.isEmpty()) {

--- a/Source/WebCore/html/HTMLDataListElement.h
+++ b/Source/WebCore/html/HTMLDataListElement.h
@@ -57,6 +57,8 @@ public:
 private:
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 
+    void childrenChanged(const ChildChange&) final;
+
     HTMLDataListElement(const QualifiedName&, Document&);
 };
 

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -918,6 +918,8 @@ void TextFieldInputType::dataListMayHaveChanged()
     if (!element())
         return;
     m_dataListDropdownIndicator->setInlineStyleProperty(CSSPropertyDisplay, element()->list() ? CSSValueBlock : CSSValueNone, true);
+    if (element()->list() && element()->focused())
+        displaySuggestions(DataListSuggestionActivationType::DataListMayHaveChanged);
 }
 
 HTMLElement* TextFieldInputType::dataListButtonElement() const
@@ -1001,7 +1003,7 @@ void TextFieldInputType::displaySuggestions(DataListSuggestionActivationType typ
     if (element()->isDisabledFormControl() || !element()->renderer())
         return;
 
-    if (!UserGestureIndicator::processingUserGesture() && type != DataListSuggestionActivationType::TextChanged)
+    if (!UserGestureIndicator::processingUserGesture() && !(type == DataListSuggestionActivationType::TextChanged || type == DataListSuggestionActivationType::DataListMayHaveChanged))
         return;
 
     if (!m_suggestionPicker && suggestions().size() > 0)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2321,6 +2321,7 @@ header: <WebCore/DataListSuggestionInformation.h>
     ControlClicked,
     IndicatorClicked,
     TextChanged,
+    DataListMayHaveChanged,
 };
 
 header: <WebCore/DataListSuggestionInformation.h>

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -464,7 +464,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     [self _updateTextSuggestions];
 
-    if (![UIKeyboard isInHardwareKeyboardMode] && activationType != WebCore::DataListSuggestionActivationType::IndicatorClicked)
+    if (![UIKeyboard isInHardwareKeyboardMode] && !(activationType == WebCore::DataListSuggestionActivationType::IndicatorClicked || activationType == WebCore::DataListSuggestionActivationType::DataListMayHaveChanged))
         return;
 
     [self _showSuggestions];


### PR DESCRIPTION
#### ba02cc6aade5caa1ddecb92778f6bfe82d5bef25
<pre>
Displayed datalist dropdown is out of sync with datalist options elements after DOM update
<a href="https://bugs.webkit.org/show_bug.cgi?id=201121">https://bugs.webkit.org/show_bug.cgi?id=201121</a>

Reviewed by Aditya Keerthi.

Adding datalist dropdown items by dynamically inserting options to the datalist on keydown/input change
was not taking effect right away. To fix this, detect datalist DOM changes through HTMLDataListElement::childrenChanged
and notify the corresponding input. This will eventually land in TextFieldInputType::dataListMayHaveChanged which
now ends with trying to display the suggestions if the input is focused.

Note that here a new DataListSuggestionActivationType value DataListMayHaveChanged is added to distinguish from
current usages (text changed, indicator/control clicked).

* LayoutTests/fast/forms/datalist/datalist-textinput-dynamically-add-options-expected.txt: Added.
* LayoutTests/fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown-expected.txt: Added.
* LayoutTests/fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html: Added.
* LayoutTests/fast/forms/datalist/datalist-textinput-dynamically-add-options.html: Added.
* Source/WebCore/html/DataListSuggestionInformation.h:
* Source/WebCore/html/HTMLDataListElement.cpp:
(WebCore::HTMLDataListElement::childrenChanged):
* Source/WebCore/html/HTMLDataListElement.h:
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::dataListMayHaveChanged):
(WebCore::TextFieldInputType::displaySuggestions):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm:
(-[WKDataListSuggestionsDropdown _displayWithActivationType:]):

Canonical link: <a href="https://commits.webkit.org/274608@main">https://commits.webkit.org/274608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92239574f9173faad8d87fe9caf3693d777f471d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41428 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32597 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13033 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12990 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42705 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34986 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38834 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37047 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/33935 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8858 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/14977 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14801 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->