### PR TITLE
[JSC] Redesign DirectCall

### DIFF
--- a/Source/JavaScriptCore/bytecode/CallLinkInfoBase.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfoBase.cpp
@@ -43,6 +43,9 @@ void CallLinkInfoBase::unlinkOrUpgrade(VM& vm, CodeBlock* oldCodeBlock, CodeBloc
     case CallSiteType::PolymorphicCallNode:
         static_cast<PolymorphicCallNode*>(this)->unlinkOrUpgradeImpl(vm, oldCodeBlock, newCodeBlock);
         break;
+    case CallSiteType::DirectCall:
+        static_cast<DirectCallLinkInfo*>(this)->unlinkOrUpgradeImpl(vm, oldCodeBlock, newCodeBlock);
+        break;
 #endif
     case CallSiteType::CachedCall:
         static_cast<CachedCall*>(this)->unlinkOrUpgradeImpl(vm, oldCodeBlock, newCodeBlock);

--- a/Source/JavaScriptCore/bytecode/CallLinkInfoBase.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfoBase.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ArityCheckMode.h"
+#include "CallMode.h"
 #include "JSCPtrTag.h"
 #include <wtf/CodePtr.h>
 #include <wtf/SentinelLinkedList.h>
@@ -58,9 +59,47 @@ public:
         CallLinkInfo,
 #if ENABLE(JIT)
         PolymorphicCallNode,
+        DirectCall,
 #endif
         CachedCall,
     };
+
+    enum CallType : uint8_t {
+        None,
+        Call,
+        CallVarargs,
+        Construct,
+        ConstructVarargs,
+        TailCall,
+        TailCallVarargs,
+        DirectCall,
+        DirectConstruct,
+        DirectTailCall
+    };
+
+    enum class UseDataIC : bool { No, Yes };
+
+    static CallMode callModeFor(CallType callType)
+    {
+        switch (callType) {
+        case Call:
+        case CallVarargs:
+        case DirectCall:
+            return CallMode::Regular;
+        case TailCall:
+        case TailCallVarargs:
+        case DirectTailCall:
+            return CallMode::Tail;
+        case Construct:
+        case ConstructVarargs:
+        case DirectConstruct:
+            return CallMode::Construct;
+        case None:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+
+        RELEASE_ASSERT_NOT_REACHED();
+    }
 
     explicit CallLinkInfoBase(CallSiteType callSiteType)
         : m_callSiteType(callSiteType)

--- a/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkStatus.cpp
@@ -140,10 +140,6 @@ CallLinkStatus CallLinkStatus::computeFor(
 CallLinkStatus CallLinkStatus::computeFromCallLinkInfo(
     const ConcurrentJSLocker&, CallLinkInfo& callLinkInfo)
 {
-    // We cannot tell you anything about direct calls.
-    if (callLinkInfo.isDirect())
-        return CallLinkStatus();
-    
     if (callLinkInfo.clearedByGC() || callLinkInfo.clearedByVirtual())
         return takesSlowPath();
     

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -344,6 +344,8 @@ public:
 
     bool useDataIC() const;
 
+    CodePtr<JSEntryPtrTag> addressForCallConcurrently(ArityCheckMode) const;
+
 #if ENABLE(JIT)
     CodeBlock* replacement();
 

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -2588,17 +2588,16 @@ void InlineCacheCompiler::generateImpl(AccessCase& accessCase)
             // We *always* know that the getter/setter, if non-null, is a cell.
             jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
 #endif
-            auto [slowCase, dispatchLabel] = CallLinkInfo::emitFastPath(jit, callLinkInfo, BaselineJITRegisters::Call::callLinkInfoGPR);
+            auto [slowCase, dispatchLabel] = CallLinkInfo::emitFastPath(jit, callLinkInfo);
             auto doneLocation = jit.label();
 
             if (accessCase.m_type == AccessCase::Getter)
                 jit.setupResults(valueRegs);
             done.append(jit.jump());
 
-            CCallHelpers::Label slowPathStart = jit.label();
             if (!slowCase.empty()) {
                 slowCase.link(&jit);
-                CallLinkInfo::emitSlowPath(vm, jit, callLinkInfo, BaselineJITRegisters::Call::callLinkInfoGPR);
+                CallLinkInfo::emitSlowPath(vm, jit, callLinkInfo);
 
                 if (accessCase.m_type == AccessCase::Getter)
                     jit.setupResults(valueRegs);
@@ -2628,9 +2627,7 @@ void InlineCacheCompiler::generateImpl(AccessCase& accessCase)
             restoreLiveRegistersFromStackForCall(spillState, callHasReturnValue);
 
             jit.addLinkTask([=] (LinkBuffer& linkBuffer) {
-                callLinkInfo->setCodeLocations(
-                    linkBuffer.locationOf<JSInternalPtrTag>(slowPathStart),
-                    linkBuffer.locationOf<JSInternalPtrTag>(doneLocation));
+                callLinkInfo->setCodeLocations(linkBuffer.locationOf<JSInternalPtrTag>(doneLocation));
             });
         } else {
             ASSERT(accessCase.m_type == AccessCase::CustomValueGetter || accessCase.m_type == AccessCase::CustomAccessorGetter || accessCase.m_type == AccessCase::CustomValueSetter || accessCase.m_type == AccessCase::CustomAccessorSetter);
@@ -3331,19 +3328,17 @@ void InlineCacheCompiler::emitProxyObjectAccess(ProxyObjectAccessCase& accessCas
     // We *always* know that the proxy function, if non-null, is a cell.
     jit.move(CCallHelpers::TrustedImm32(JSValue::CellTag), BaselineJITRegisters::Call::calleeJSR.tagGPR());
 #endif
-    auto [slowCase, dispatchLabel] = CallLinkInfo::emitFastPath(jit, callLinkInfo, BaselineJITRegisters::Call::callLinkInfoGPR);
+    auto [slowCase, dispatchLabel] = CallLinkInfo::emitFastPath(jit, callLinkInfo);
     auto doneLocation = jit.label();
 
     if (accessCase.m_type != AccessCase::ProxyObjectStore)
         jit.setupResults(valueRegs);
 
-    auto slowPathStart = jit.label();
     if (!slowCase.empty()) {
         auto done = jit.jump();
 
-        slowPathStart = jit.label();
         slowCase.link(&jit);
-        CallLinkInfo::emitSlowPath(vm, jit, callLinkInfo, BaselineJITRegisters::Call::callLinkInfoGPR);
+        CallLinkInfo::emitSlowPath(vm, jit, callLinkInfo);
 
         if (accessCase.m_type != AccessCase::ProxyObjectStore)
             jit.setupResults(valueRegs);
@@ -3372,9 +3367,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(ProxyObjectAccessCase& accessCas
     restoreLiveRegistersFromStackForCall(spillState, dontRestore);
 
     jit.addLinkTask([=] (LinkBuffer& linkBuffer) {
-        callLinkInfo->setCodeLocations(
-            linkBuffer.locationOf<JSInternalPtrTag>(slowPathStart),
-            linkBuffer.locationOf<JSInternalPtrTag>(doneLocation));
+        callLinkInfo->setCodeLocations(linkBuffer.locationOf<JSInternalPtrTag>(doneLocation));
     });
     succeed();
 }

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -1742,26 +1742,12 @@ void repatchInstanceOf(
         repatchSlowPathCall(codeBlock, stubInfo, operationInstanceOfGaveUp);
 }
 
-void linkDirectCall(
-    CallFrame* callFrame, OptimizingCallLinkInfo& callLinkInfo, CodeBlock* calleeCodeBlock,
-    CodePtr<JSEntryPtrTag> codePtr)
+void linkDirectCall(DirectCallLinkInfo& callLinkInfo, CodeBlock* calleeCodeBlock, CodePtr<JSEntryPtrTag> codePtr)
 {
-    ASSERT(!callLinkInfo.stub());
-    
     // DirectCall is only used from DFG / FTL.
-    CodeBlock* callerCodeBlock = callFrame->codeBlock();
-
-    VM& vm = callerCodeBlock->vm();
-    
-    ASSERT(!callLinkInfo.isLinked());
-    callLinkInfo.setCodeBlock(vm, callerCodeBlock, jsCast<FunctionCodeBlock*>(calleeCodeBlock));
-    if (shouldDumpDisassemblyFor(callerCodeBlock))
-        dataLog("Linking call in ", FullCodeOrigin(callerCodeBlock, callLinkInfo.codeOrigin()), " to ", pointerDump(calleeCodeBlock), ", entrypoint at ", codePtr, "\n");
-
-    callLinkInfo.setDirectCallTarget(jsCast<FunctionCodeBlock*>(calleeCodeBlock), CodeLocationLabel<JSEntryPtrTag>(codePtr));
-
+    callLinkInfo.setCallTarget(jsCast<FunctionCodeBlock*>(calleeCodeBlock), CodeLocationLabel<JSEntryPtrTag>(codePtr));
     if (calleeCodeBlock)
-        calleeCodeBlock->linkIncomingCall(callerCodeBlock, &callLinkInfo);
+        calleeCodeBlock->linkIncomingCall(callLinkInfo.owner(), &callLinkInfo);
 }
 
 void linkPolymorphicCall(VM& vm, JSCell* owner, CallFrame* callFrame, CallLinkInfo& callLinkInfo, CallVariant newVariant)

--- a/Source/JavaScriptCore/bytecode/Repatch.h
+++ b/Source/JavaScriptCore/bytecode/Repatch.h
@@ -31,6 +31,7 @@
 namespace JSC {
 
 class CallLinkInfo;
+class DirectCallLinkInfo;
 class OptimizingCallLinkInfo;
 class StructureStubInfo;
 
@@ -85,7 +86,7 @@ void repatchCheckPrivateBrand(JSGlobalObject*, CodeBlock*, JSObject*, CacheableI
 void repatchSetPrivateBrand(JSGlobalObject*, CodeBlock*, JSObject*, Structure*, CacheableIdentifier, StructureStubInfo&);
 void repatchInstanceOf(JSGlobalObject*, CodeBlock*, JSValue, JSValue prototype, StructureStubInfo&, bool wasFound);
 void linkMonomorphicCall(VM&, JSCell*, CallLinkInfo&, CodeBlock*, JSObject* callee, CodePtr<JSEntryPtrTag>);
-void linkDirectCall(CallFrame*, OptimizingCallLinkInfo&, CodeBlock*, CodePtr<JSEntryPtrTag>);
+void linkDirectCall(DirectCallLinkInfo&, CodeBlock*, CodePtr<JSEntryPtrTag>);
 void linkPolymorphicCall(VM&, JSCell*, CallFrame*, CallLinkInfo&, CallVariant);
 void resetGetBy(CodeBlock*, StructureStubInfo&, GetByKind);
 void resetPutBy(CodeBlock*, StructureStubInfo&, PutByKind);

--- a/Source/JavaScriptCore/bytecode/RepatchInlines.h
+++ b/Source/JavaScriptCore/bytecode/RepatchInlines.h
@@ -130,8 +130,6 @@ ALWAYS_INLINE void* linkFor(VM& vm, JSCell* owner, CallFrame* calleeFrame, CallL
 
     CodeSpecializationKind kind = callLinkInfo->specializationKind();
 
-    RELEASE_ASSERT(!callLinkInfo->isDirect());
-
     JSValue calleeAsValue = calleeFrame->guaranteedJSValueCallee();
     JSCell* calleeAsFunctionCell = getJSFunction(calleeAsValue);
     if (!calleeAsFunctionCell) {
@@ -159,7 +157,6 @@ ALWAYS_INLINE void* linkFor(VM& vm, JSCell* owner, CallFrame* calleeFrame, CallL
                 break;
             }
             case CallLinkInfo::Mode::Virtual:
-            case CallLinkInfo::Mode::LinkedDirect:
                 break;
             }
 
@@ -225,7 +222,6 @@ ALWAYS_INLINE void* linkFor(VM& vm, JSCell* owner, CallFrame* calleeFrame, CallL
         break;
     }
     case CallLinkInfo::Mode::Virtual:
-    case CallLinkInfo::Mode::LinkedDirect:
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGCommonData.h
+++ b/Source/JavaScriptCore/dfg/DFGCommonData.h
@@ -132,6 +132,7 @@ public:
     FixedVector<std::unique_ptr<BoyerMooreHorspoolTable<uint8_t>>> m_stringSearchTable8;
     Bag<StructureStubInfo> m_stubInfos;
     Bag<OptimizingCallLinkInfo> m_callLinkInfos;
+    Bag<DirectCallLinkInfo> m_directCallLinkInfos;
     Yarr::YarrBoyerMooreData m_boyerMooreData;
     
     ScratchBuffer* catchOSREntryBuffer;

--- a/Source/JavaScriptCore/dfg/DFGJITCode.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.h
@@ -77,7 +77,6 @@ struct UnlinkedCallLinkInfo : JSC::UnlinkedCallLinkInfo {
 
     CodeOrigin codeOrigin;
     CallLinkInfo::CallType callType { CallLinkInfo::CallType::None };
-    GPRReg callLinkInfoGPR { InvalidGPRReg };
 };
 
 class LinkerIR {

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.h
@@ -255,7 +255,7 @@ public:
         m_jsCalls.append(JSCallRecord(slowPathStart, doneLocation, info));
     }
     
-    void addJSDirectCall(Label slowPath, OptimizingCallLinkInfo* info)
+    void addJSDirectCall(Label slowPath, DirectCallLinkInfo* info)
     {
         m_jsDirectCalls.append(JSDirectCallRecord(slowPath, info));
     }
@@ -394,7 +394,7 @@ public:
     }
 
     std::tuple<CompileTimeStructureStubInfo, StructureStubInfoIndex> addStructureStubInfo();
-    std::tuple<CompileTimeCallLinkInfo, LinkableConstant> addCallLinkInfo(CodeOrigin, bool isDirect);
+    std::tuple<CompileTimeCallLinkInfo, LinkableConstant> addCallLinkInfo(CodeOrigin);
     LinkerIR::Constant addToConstantPool(LinkerIR::Type, void*);
 
     void appendExceptionHandlingOSRExit(SpeculativeJIT*, ExitKind, unsigned eventStreamIndex, CodeOrigin, HandlerInfo* exceptionHandler, CallSiteIndex, MacroAssembler::JumpList jumpsToFail = MacroAssembler::JumpList());
@@ -442,14 +442,14 @@ protected:
     };
     
     struct JSDirectCallRecord {
-        JSDirectCallRecord(Label slowPath, OptimizingCallLinkInfo* info)
+        JSDirectCallRecord(Label slowPath, DirectCallLinkInfo* info)
             : slowPath(slowPath)
             , info(info)
         {
         }
         
         Label slowPath;
-        OptimizingCallLinkInfo* info;
+        DirectCallLinkInfo* info;
     };
     
     Vector<InlineCacheWrapper<JITGetByIdGenerator>, 4> m_getByIds;

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -38,6 +38,7 @@
 namespace JSC {
 
 class DateInstance;
+class DirectCallLinkInfo;
 class JSBigInt;
 class JSBoundFunction;
 class JSPropertyNameEnumerator;
@@ -367,7 +368,7 @@ JSC_DECLARE_JIT_OPERATION(operationNewRawObject, char*, (VM*, Structure*, int32_
 JSC_DECLARE_JIT_OPERATION(operationNewObjectWithButterfly, JSCell*, (VM*, Structure*, Butterfly*));
 JSC_DECLARE_JIT_OPERATION(operationNewObjectWithButterflyWithIndexingHeaderAndVectorLength, JSCell*, (VM*, Structure*, unsigned length, Butterfly*));
 
-JSC_DECLARE_JIT_OPERATION(operationLinkDirectCall, void, (OptimizingCallLinkInfo*, JSFunction*));
+JSC_DECLARE_JIT_OPERATION(operationLinkDirectCall, void, (DirectCallLinkInfo*, JSFunction*));
 
 JSC_DECLARE_JIT_OPERATION(operationDateGetFullYear, EncodedJSValue, (VM*, DateInstance*));
 JSC_DECLARE_JIT_OPERATION(operationDateGetUTCFullYear, EncodedJSValue, (VM*, DateInstance*));

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -538,6 +538,10 @@ void Plan::reallyAdd(CommonData* commonData)
         ConcurrentJSLocker locker(m_codeBlock->m_lock);
         commonData->recordedStatuses = WTFMove(m_recordedStatuses);
     }
+
+    ASSERT(m_vm->heap.isDeferred());
+    for (auto* callLinkInfo : commonData->m_directCallLinkInfos)
+        callLinkInfo->validateSpeculativeRepatchOnMainThread(*m_vm);
 }
 
 bool Plan::isStillValidOnMainThread()

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -807,6 +807,7 @@ Protocol::ErrorStringOr<void> InspectorDebuggerAgent::addSymbolicBreakpoint(cons
 #if ENABLE(JIT)
     {
         JSC::DeferGCForAWhile deferGC(m_debugger.vm());
+        m_debugger.vm().notifyDebuggerHookInjected();
 
         Vector<JSC::NativeExecutable*> newNativeExecutables;
         {

--- a/Source/JavaScriptCore/jit/JITCall.cpp
+++ b/Source/JavaScriptCore/jit/JITCall.cpp
@@ -202,7 +202,7 @@ bool JIT::compileTailCall(const Op&, BaselineUnlinkedCallLinkInfo*, unsigned)
 template<>
 bool JIT::compileTailCall(const OpTailCall& bytecode, BaselineUnlinkedCallLinkInfo* callLinkInfo, unsigned callLinkInfoIndex)
 {
-    auto [slowPaths, dispatchLabel] = CallLinkInfo::emitTailCallFastPath(*this, callLinkInfo, BaselineJITRegisters::Call::callLinkInfoGPR, scopedLambda<void()>([&] {
+    auto [slowPaths, dispatchLabel] = CallLinkInfo::emitTailCallFastPath(*this, callLinkInfo, scopedLambda<void()>([&] {
         CallFrameShuffleData shuffleData = CallFrameShuffleData::createForBaselineOrLLIntTailCall(bytecode, m_unlinkedCodeBlock->numParameters());
         CallFrameShuffler shuffler { *this, shuffleData };
         shuffler.setCalleeJSValueRegs(BaselineJITRegisters::Call::calleeJSR);
@@ -266,7 +266,7 @@ void JIT::compileOpCall(const JSInstruction* instruction)
         compileTailCall(bytecode, callLinkInfo, callLinkInfoIndex);
     else {
         if constexpr (Op::opcodeID == op_tail_call_varargs || Op::opcodeID == op_tail_call_forward_arguments) {
-            auto [slowPaths, dispatchLabel] = CallLinkInfo::emitTailCallFastPath(*this, callLinkInfo, BaselineJITRegisters::Call::callLinkInfoGPR, scopedLambda<void()>([&] {
+            auto [slowPaths, dispatchLabel] = CallLinkInfo::emitTailCallFastPath(*this, callLinkInfo, scopedLambda<void()>([&] {
                 emitRestoreCalleeSaves();
                 prepareForTailCallSlow(RegisterSet {
                     BaselineJITRegisters::Call::calleeJSR.payloadGPR(),
@@ -281,7 +281,7 @@ void JIT::compileOpCall(const JSInstruction* instruction)
             auto doneLocation = label();
             m_callCompilationInfo[callLinkInfoIndex].doneLocation = doneLocation;
         } else {
-            auto [slowPaths, dispatchLabel] = CallLinkInfo::emitFastPath(*this, callLinkInfo, BaselineJITRegisters::Call::callLinkInfoGPR);
+            auto [slowPaths, dispatchLabel] = CallLinkInfo::emitFastPath(*this, callLinkInfo);
             ASSERT(slowPaths.empty());
             auto doneLocation = label();
             m_callCompilationInfo[callLinkInfoIndex].doneLocation = doneLocation;

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
@@ -2326,7 +2326,7 @@ macro callHelper(opcodeName, opcodeStruct, dispatchAfterCall, valueProfileName, 
     addp CallerFrameAndPCSize, sp
 
     bineq t1, CellTag, .opCallSlow
-    loadp %opcodeStruct%::Metadata::m_callLinkInfo.m_calleeOrCodeBlock[t5], t3
+    loadp %opcodeStruct%::Metadata::m_callLinkInfo.m_callee[t5], t3
     btpz t3, (constexpr CallLinkInfo::polymorphicCalleeMask), .notPolymorphic
     prepareCall(t2, t3, t4, t6, macro(address)
         loadp %opcodeStruct%::Metadata::m_callLinkInfo.u.dataIC.m_codeBlock[t5], t2
@@ -2416,7 +2416,7 @@ macro doCallVarargs(opcodeName, size, get, opcodeStruct, valueProfileName, dstVi
             metadata(t5, t2)
 
             bineq t1, CellTag, .opCallSlow
-            loadp %opcodeStruct%::Metadata::m_callLinkInfo.m_calleeOrCodeBlock[t5], t3
+            loadp %opcodeStruct%::Metadata::m_callLinkInfo.m_callee[t5], t3
             btpz t3, (constexpr CallLinkInfo::polymorphicCalleeMask), .notPolymorphic
             prepareCall(t2, t3, t4, t6, macro(address)
                 loadp %opcodeStruct%::Metadata::m_callLinkInfo.u.dataIC.m_codeBlock[t5], t2

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -2537,7 +2537,7 @@ macro callHelper(opcodeName, opcodeStruct, dispatchAfterCall, valueProfileName, 
     move t3, sp
     addp CallerFrameAndPCSize, sp
 
-    loadp %opcodeStruct%::Metadata::m_callLinkInfo.m_calleeOrCodeBlock[t5], t1
+    loadp %opcodeStruct%::Metadata::m_callLinkInfo.m_callee[t5], t1
     btpz t1, (constexpr CallLinkInfo::polymorphicCalleeMask), .notPolymorphic
     prepareCall(t2, t3, t4, t1, macro(address)
         loadp %opcodeStruct%::Metadata::m_callLinkInfo.u.dataIC.m_codeBlock[t5], t2
@@ -2626,7 +2626,7 @@ macro doCallVarargs(opcodeName, size, get, opcodeStruct, valueProfileName, dstVi
             loadConstantOrVariable(size, t1, t0)
             metadata(t5, t2)
 
-            loadp %opcodeStruct%::Metadata::m_callLinkInfo.m_calleeOrCodeBlock[t5], t1
+            loadp %opcodeStruct%::Metadata::m_callLinkInfo.m_callee[t5], t1
             btpz t1, (constexpr CallLinkInfo::polymorphicCalleeMask), .notPolymorphic
             prepareCall(t2, t3, t4, t1, macro(address)
                 loadp %opcodeStruct%::Metadata::m_callLinkInfo.u.dataIC.m_codeBlock[t5], t2

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -1015,6 +1015,9 @@ public:
     void registerWasmInstance(Wasm::Instance&);
 #endif
 
+    void notifyDebuggerHookInjected() { m_isDebuggerHookInjected = true; }
+    bool isDebuggerHookInjected() const { return m_isDebuggerHookInjected; }
+
 private:
     VM(VMType, HeapType, WTF::RunLoop* = nullptr, bool* success = nullptr);
     static VM*& sharedInstanceInternal();
@@ -1131,6 +1134,7 @@ private:
     bool m_hasTerminationRequest { false };
     bool m_executionForbidden { false };
     bool m_executionForbiddenOnTermination { false };
+    bool m_isDebuggerHookInjected { false };
 
     Lock m_loopHintExecutionCountLock;
     HashMap<const JSInstruction*, std::pair<unsigned, std::unique_ptr<uintptr_t>>> m_loopHintExecutionCounts;


### PR DESCRIPTION
#### ef37e645ce878556343c35bf4c5ec721cd785a96
<pre>
[JSC] Redesign DirectCall
<a href="https://bugs.webkit.org/show_bug.cgi?id=268499">https://bugs.webkit.org/show_bug.cgi?id=268499</a>
<a href="https://rdar.apple.com/122042902">rdar://122042902</a>

Reviewed by Justin Michaud.

This patch redesigns DirectCall. We decouple DirectCallLinkInfo from CallLinkInfo since they are very different mechanism now.
Right now, we continue using repatching DirectCalls since it seems that it is the fastest form from experiments. But instead,

1. For NativeExecutable, we attempt to inline call thunk into DFG / FTL directly and embed call targets / global objects if possible.
   We do not do it when debugger hook is injected (in this case, debugger hook injection once destroys all CodeBlock. So if we do not see this bool flag
   set when compiling, it is fine to continue).
2. For the other cases, we attempt to fill CodeBlock and CodePtr pair speculatively from compiler thread at link time to avoid repatching in the main thread.
   This can avoid repatching in most of cases. And then, in the main thread, we check whether this speculative values are the right ones, and if not, we repatch them.
   Otherwise, we will continue using them. We will chain DirectCallLinkInfo to CodeBlock in the main thread since this is main thread only operation.
3. We repatch to the newer CodeBlock / CodePtr when unlinkOrUpgradeImpl happens to DirectCall.

* Source/JavaScriptCore/bytecode/CallLinkInfo.cpp:
(JSC::CallLinkInfo::doneLocation):
(JSC::CallLinkInfo::setMonomorphicCallee):
(JSC::CallLinkInfo::clearCallee):
(JSC::CallLinkInfo::callee):
(JSC::CallLinkInfo::setLastSeenCallee):
(JSC::CallLinkInfo::lastSeenCallee const):
(JSC::CallLinkInfo::haveLastSeenCallee const):
(JSC::CallLinkInfo::visitWeak):
(JSC::CallLinkInfo::revertCallToStub):
(JSC::CallLinkInfo::reset):
(JSC::CallLinkInfo::setVirtualCall):
(JSC::DirectCallLinkInfo::reset):
(JSC::DirectCallLinkInfo::unlinkOrUpgradeImpl):
(JSC::DirectCallLinkInfo::visitWeak):
(JSC::CallLinkInfo::emitFastPathImpl):
(JSC::CallLinkInfo::emitDataICFastPath):
(JSC::CallLinkInfo::emitTailCallDataICFastPath):
(JSC::CallLinkInfo::setStub):
(JSC::CallLinkInfo::emitSlowPathImpl):
(JSC::CallLinkInfo::emitDataICSlowPath):
(JSC::CallLinkInfo::emitFastPath):
(JSC::CallLinkInfo::emitTailCallFastPath):
(JSC::CallLinkInfo::emitSlowPath):
(JSC::CallLinkInfo::emitTailCallSlowPath):
(JSC::OptimizingCallLinkInfo::emitFastPath):
(JSC::OptimizingCallLinkInfo::emitTailCallFastPath):
(JSC::OptimizingCallLinkInfo::emitSlowPath):
(JSC::OptimizingCallLinkInfo::emitTailCallSlowPath):
(JSC::OptimizingCallLinkInfo::initializeFromDFGUnlinkedCallLinkInfo):
(JSC::DirectCallLinkInfo::emitDirectFastPath):
(JSC::DirectCallLinkInfo::emitDirectTailCallFastPath):
(JSC::DirectCallLinkInfo::initialize):
(JSC::DirectCallLinkInfo::setCallTarget):
(JSC::DirectCallLinkInfo::setMaxArgumentCountIncludingThis):
(JSC::DirectCallLinkInfo::retrieveCallInfo):
(JSC::DirectCallLinkInfo::repatchSpeculatively):
(JSC::DirectCallLinkInfo::validateSpeculativeRepatchOnMainThread):
(JSC::CallLinkInfo::setCodeBlock): Deleted.
(JSC::CallLinkInfo::clearCodeBlock): Deleted.
(JSC::CallLinkInfo::codeBlock): Deleted.
(JSC::CallLinkInfo::clearLastSeenCallee): Deleted.
(JSC::CallLinkInfo::setExecutableDuringCompilation): Deleted.
(JSC::CallLinkInfo::executable): Deleted.
(JSC::OptimizingCallLinkInfo::slowPathStart): Deleted.
(JSC::OptimizingCallLinkInfo::fastPathStart): Deleted.
(JSC::OptimizingCallLinkInfo::emitDirectFastPath): Deleted.
(JSC::OptimizingCallLinkInfo::emitDirectTailCallFastPath): Deleted.
(JSC::OptimizingCallLinkInfo::initializeDirectCall): Deleted.
(JSC::OptimizingCallLinkInfo::setDirectCallTarget): Deleted.
(JSC::OptimizingCallLinkInfo::initializeDirectCallRepatch): Deleted.
(JSC::OptimizingCallLinkInfo::setDirectCallMaxArgumentCountIncludingThis): Deleted.
* Source/JavaScriptCore/bytecode/CallLinkInfo.h:
(JSC::CallLinkInfo::specializationKind const):
(JSC::CallLinkInfo::offsetOfCallee):
(JSC::CallLinkInfo::forEachDependentCell const):
(JSC::CallLinkInfo::callModeFor): Deleted.
(JSC::CallLinkInfo::isDirect): Deleted.
(JSC::CallLinkInfo::isDirect const): Deleted.
(JSC::CallLinkInfo::callLinkInfoGPR const): Deleted.
* Source/JavaScriptCore/bytecode/CallLinkInfoBase.cpp:
(JSC::CallLinkInfoBase::unlinkOrUpgrade):
* Source/JavaScriptCore/bytecode/CallLinkInfoBase.h:
(JSC::CallLinkInfoBase::callModeFor):
* Source/JavaScriptCore/bytecode/CallLinkStatus.cpp:
(JSC::CallLinkStatus::computeFromCallLinkInfo):
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::finalizeJITInlineCaches):
(JSC::CodeBlock::addressForCallConcurrently const):
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::generateImpl):
(JSC::InlineCacheCompiler::emitProxyObjectAccess):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::linkDirectCall):
* Source/JavaScriptCore/bytecode/Repatch.h:
* Source/JavaScriptCore/bytecode/RepatchInlines.h:
(JSC::linkFor):
* Source/JavaScriptCore/dfg/DFGCommonData.h:
* Source/JavaScriptCore/dfg/DFGJITCode.h:
* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
(JSC::DFG::JITCompiler::link):
(JSC::DFG::JITCompiler::addCallLinkInfo):
* Source/JavaScriptCore/dfg/DFGJITCompiler.h:
(JSC::DFG::JITCompiler::addJSDirectCall):
(JSC::DFG::JITCompiler::JSDirectCallRecord::JSDirectCallRecord):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::reallyAdd):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::InspectorDebuggerAgent::addSymbolicBreakpoint):
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::compileTailCall):
(JSC::JIT::compileOpCall):
* Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::notifyDebuggerHookInjected):
(JSC::VM::isDebuggerHookInjected const):
* Source/JavaScriptCore/wasm/js/WasmToJS.cpp:
(JSC::Wasm::wasmToJS):

Canonical link: <a href="https://commits.webkit.org/273947@main">https://commits.webkit.org/273947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d84766a6b101266a9b157cd1e19bc9d4affa6a24

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37258 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39820 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33230 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13304 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13631 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11878 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11855 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/33413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41080 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/31161 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33734 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/33847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37765 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/36965 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12204 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9990 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35908 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13815 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/43839 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12555 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9008 "Found 158 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout, jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout-no-llint, stress/array-flatmap.js.dfg-eager-no-cjit-validate, wasm.yaml/wasm/gc/any.js.default-wasm, wasm.yaml/wasm/gc/any.js.wasm-bbq, wasm.yaml/wasm/gc/any.js.wasm-collect-continuously, wasm.yaml/wasm/gc/any.js.wasm-eager, wasm.yaml/wasm/gc/any.js.wasm-eager-jettison ... (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4825 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->