### PR TITLE
"Function could be declared with attribute 'noreturn'" warnings generated in some configurations when building GeneratedSerializers.mm

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -895,6 +895,8 @@ def generate_one_impl(type, template_argument):
     for encoder in type.encoders:
         if type.custom_encoder:
             continue
+        if type.members_are_subclasses:
+            result.append('IGNORE_WARNINGS_BEGIN("missing-noreturn")')
         if type.cf_type is not None:
             result.append('void ArgumentCoder<' + name_with_template + '>::encode(' + encoder + '& encoder, ' + name_with_template + ' instance)')
         elif type.rvalue:
@@ -908,6 +910,8 @@ def generate_one_impl(type, template_argument):
         if type.members_are_subclasses:
             result.append('    ASSERT_NOT_REACHED();')
         result.append('}')
+        if type.members_are_subclasses:
+            result.append('IGNORE_WARNINGS_END')
         result.append('')
     if type.cf_type is not None:
         result.append('std::optional<RetainPtr<' + name_with_template + '>> ArgumentCoder<RetainPtr<' + name_with_template + '>>::decode(Decoder& decoder)')


### PR DESCRIPTION
#### f1fd5543da45033aad082598fca3290af392b7e7
<pre>
&quot;Function could be declared with attribute &apos;noreturn&apos;&quot; warnings generated in some configurations when building GeneratedSerializers.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=268501">https://bugs.webkit.org/show_bug.cgi?id=268501</a>
<a href="https://rdar.apple.com/122043321">rdar://122043321</a>

Reviewed by Elliott Williams.

In configurations where -Wmissing-noreturn is enabled, a warning (promoted to error in engineering
builds) in GeneratedSerializers.mm is emitted when an instance of ArgumentCoder::encode is
generated where each subclass is guarded by a condition that evaluates to false in that particular
build configuration. In that case the only code in the function is an ASSERT_NOT_REACHED(), which
indeed is a case where [[noreturn]] could be used.

Resolved this by ignoring -Wmissing-noreturn when generating ArgumentCoder::encode functions with
subclass members.

* Source/WebKit/Scripts/generate-serializers.py:
(generate_one_impl):

Canonical link: <a href="https://commits.webkit.org/273874@main">https://commits.webkit.org/273874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9991ab50675328da5f18222f6be6025335eaa28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/36950 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/15871 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/39211 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/18402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/12995 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/39560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/37511 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/18402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/39211 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/37053 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/18402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/39211 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/40813 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/18402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/39211 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/40813 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/11999 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/12995 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/40813 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/39211 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/12912 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->