### PR TITLE
RemoteImageBufferSetProxy::didPrepareForDisplay can be blocked by other main thread task.

### DIFF
--- a/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.cpp
@@ -150,4 +150,14 @@ Connection& StreamClientConnection::connectionForTesting()
     return m_connection.get();
 }
 
+void StreamClientConnection::addWorkQueueMessageReceiver(ReceiverName name, WorkQueue& workQueue, WorkQueueMessageReceiver& receiver, uint64_t destinationID)
+{
+    m_connection->addWorkQueueMessageReceiver(name, workQueue, receiver, destinationID);
+}
+
+void StreamClientConnection::removeWorkQueueMessageReceiver(ReceiverName name, uint64_t destinationID)
+{
+    m_connection->removeWorkQueueMessageReceiver(name, destinationID);
+}
+
 }

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -89,6 +89,9 @@ public:
     Error waitForAndDispatchImmediately(ObjectIdentifierGeneric<U, V> destinationID, Timeout, OptionSet<WaitForOption> = { });
     template<typename> Error waitForAsyncReplyAndDispatchImmediately(AsyncReplyID, Timeout);
 
+    void addWorkQueueMessageReceiver(ReceiverName, WorkQueue&, WorkQueueMessageReceiver&, uint64_t destinationID = 0);
+    void removeWorkQueueMessageReceiver(ReceiverName, uint64_t destinationID = 0);
+
     StreamClientConnectionBuffer& bufferForTesting();
     Connection& connectionForTesting();
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h
@@ -35,6 +35,7 @@ class RemoteImageBufferSetProxy;
 class RemoteLayerWithRemoteRenderingBackingStore : public RemoteLayerBackingStore {
 public:
     RemoteLayerWithRemoteRenderingBackingStore(PlatformCALayerRemote*);
+    ~RemoteLayerWithRemoteRenderingBackingStore();
 
     bool isRemoteLayerWithRemoteRenderingBackingStore() const final { return true; }
     ProcessModel processModel() const final { return ProcessModel::Remote; }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
@@ -50,6 +50,12 @@ RemoteLayerWithRemoteRenderingBackingStore::RemoteLayerWithRemoteRenderingBackin
     m_bufferSet = collection->layerTreeContext().ensureRemoteRenderingBackendProxy().createRemoteImageBufferSet();
 }
 
+RemoteLayerWithRemoteRenderingBackingStore::~RemoteLayerWithRemoteRenderingBackingStore()
+{
+    if (m_bufferSet)
+        m_bufferSet->close();
+}
+
 bool RemoteLayerWithRemoteRenderingBackingStore::hasFrontBuffer() const
 {
     return m_contentsBufferHandle || !m_cleared;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.messages.in
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.messages.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-messages -> RemoteImageBufferSetProxy NotRefCounted  {
+messages -> RemoteImageBufferSetProxy {
 #if PLATFORM(COCOA)
     DidPrepareForDisplay(struct WebKit::ImageBufferSetPrepareBufferForDisplayOutputData outputData, WebKit::RenderingUpdateID renderingUpdateID)
 #endif

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -70,6 +70,7 @@ std::unique_ptr<RemoteRenderingBackendProxy> RemoteRenderingBackendProxy::create
 RemoteRenderingBackendProxy::RemoteRenderingBackendProxy(const RemoteRenderingBackendCreationParameters& parameters, SerialFunctionDispatcher& dispatcher)
     : m_parameters(parameters)
     , m_dispatcher(dispatcher)
+    , m_queue(WorkQueue::create("RemoteRenderingBackendProxy", WorkQueue::QOS::UserInteractive))
 {
 }
 
@@ -141,7 +142,6 @@ void RemoteRenderingBackendProxy::didClose(IPC::Connection&)
         bufferSet.value->remoteBufferSetWasDestroyed();
         send(Messages::RemoteRenderingBackend::CreateRemoteImageBufferSet(bufferSet.value->identifier(), bufferSet.value->displayListResourceIdentifier()));
     }
-    m_bufferSetsInDisplay.clear();
 }
 
 void RemoteRenderingBackendProxy::disconnectGPUProcess()
@@ -378,9 +378,6 @@ Vector<SwapBuffersDisplayRequirement> RemoteRenderingBackendProxy::prepareImageB
         perLayerData.bufferSet->clearVolatilityUntilAfter(m_currentVolatilityRequest);
         perLayerData.bufferSet->willPrepareForDisplay();
 
-        auto addResult = m_bufferSetsInDisplay.add(perLayerData.bufferSet->identifier(), perLayerData.bufferSet);
-        ASSERT_UNUSED(addResult, addResult.isNewEntry);
-
         return ImageBufferSetPrepareBufferForDisplayInputData {
             perLayerData.bufferSet->identifier(),
             perLayerData.dirtyRegion,
@@ -408,12 +405,6 @@ Vector<SwapBuffersDisplayRequirement> RemoteRenderingBackendProxy::prepareImageB
             displayRequirement = SwapBuffersDisplayRequirement::NeedsNormalDisplay;
     }
     return result;
-}
-
-void RemoteRenderingBackendProxy::didPrepareForDisplay(RemoteImageBufferSetProxy& bufferSet)
-{
-    bool success = m_bufferSetsInDisplay.remove(bufferSet.identifier());
-    ASSERT_UNUSED(success, success);
 }
 #endif
 
@@ -470,13 +461,6 @@ bool RemoteRenderingBackendProxy::dispatchMessage(IPC::Connection& connection, I
         if (imageBuffer)
             imageBuffer->didReceiveMessage(connection, decoder);
         // Messages to already removed instances are ok.
-        return true;
-    }
-    if (decoder.messageReceiverName() == Messages::RemoteImageBufferSetProxy::messageReceiverName()) {
-        RefPtr bufferSet = m_bufferSetsInDisplay.get(RemoteImageBufferSetIdentifier { decoder.destinationID() });
-        ASSERT(bufferSet);
-        if (bufferSet)
-            bufferSet->didReceiveMessage(connection, decoder);
         return true;
     }
     return false;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -51,6 +51,7 @@
 #include <wtf/Deque.h>
 #include <wtf/HashMap.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/WorkQueue.h>
 
 namespace WebCore {
 
@@ -138,7 +139,6 @@ public:
 
 #if PLATFORM(COCOA)
     Vector<SwapBuffersDisplayRequirement> prepareImageBufferSetsForDisplay(Vector<LayerPrepareBuffersData>&&);
-    void didPrepareForDisplay(RemoteImageBufferSetProxy&);
 #endif
 
     void finalizeRenderingUpdate();
@@ -159,6 +159,7 @@ public:
     IPC::Connection* connection() { return m_connection.get(); }
 
     SerialFunctionDispatcher& dispatcher() { return m_dispatcher; }
+    Ref<WorkQueue> workQueue() { return m_queue; }
 
     static constexpr Seconds defaultTimeout = 15_s;
 private:
@@ -200,8 +201,8 @@ private:
     MarkSurfacesAsVolatileRequestIdentifier m_currentVolatilityRequest;
     HashMap<MarkSurfacesAsVolatileRequestIdentifier, CompletionHandler<void(bool)>> m_markAsVolatileRequests;
     HashMap<RemoteImageBufferSetIdentifier, WeakPtr<RemoteImageBufferSetProxy>> m_bufferSets;
-    HashMap<RemoteImageBufferSetIdentifier, RefPtr<RemoteImageBufferSetProxy>> m_bufferSetsInDisplay;
     SerialFunctionDispatcher& m_dispatcher;
+    Ref<WorkQueue> m_queue;
 
     RenderingUpdateID m_renderingUpdateID;
     RenderingUpdateID m_didRenderingUpdateID;


### PR DESCRIPTION
#### 4beae41dc6154ad2687f21a5fd87d09039e0d2af
<pre>
RemoteImageBufferSetProxy::didPrepareForDisplay can be blocked by other main thread task.
<a href="https://bugs.webkit.org/show_bug.cgi?id=268506">https://bugs.webkit.org/show_bug.cgi?id=268506</a>
&lt;<a href="https://rdar.apple.com/121664924">rdar://121664924</a>&gt;

Reviewed by Kimmo Kinnunen.

This message is received on the main thread, and blocks submission of the previous layer tree transaction.

It can be delayed by other work on the main thread, for arbitrary periods of time.

This changes makes it be delivered it to a WorkQueue instead to prevent this blocking.

* Source/WebKit/Platform/IPC/StreamClientConnection.cpp:
(IPC::StreamClientConnection::addWorkQueueMessageReceiver):
(IPC::StreamClientConnection::removeWorkQueueMessageReceiver):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::~RemoteLayerWithRemoteRenderingBackingStore):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxyFlushFence::create):
(WebKit::RemoteImageBufferSetProxyFlushFence::~RemoteImageBufferSetProxyFlushFence):
(WebKit::RemoteImageBufferSetProxyFlushFence::waitFor):
(WebKit::RemoteImageBufferSetProxyFlushFence::tryTakeEvent):
(WebKit::RemoteImageBufferSetProxyFlushFence::setWaitingForSignal):
(WebKit::RemoteImageBufferSetProxy::didPrepareForDisplay):
(WebKit::RemoteImageBufferSetProxy::shutdown):
(WebKit::RemoteImageBufferSetProxy::doShutdown):
(WebKit::RemoteImageBufferSetProxy::createFlushFence):
(WebKit::RemoteImageBufferSetProxy::flushFrontBufferAsync):
(WebKit::RemoteImageBufferSetProxy::willPrepareForDisplay):
(WebKit::RemoteImageBufferSetProxy::remoteBufferSetWasDestroyed):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h:
(WebKit::RemoteImageBufferSetProxy::WTF_GUARDED_BY_LOCK):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::RemoteRenderingBackendProxy):
(WebKit::RemoteRenderingBackendProxy::didClose):
(WebKit::RemoteRenderingBackendProxy::prepareImageBufferSetsForDisplay):
(WebKit::RemoteRenderingBackendProxy::dispatchMessage):
(WebKit::RemoteRenderingBackendProxy::didPrepareForDisplay): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
(WebKit::RemoteRenderingBackendProxy::workQueue):

Canonical link: <a href="https://commits.webkit.org/274047@main">https://commits.webkit.org/274047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/835ce55df47be7323eed93816070da5ef18973de

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40234 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33534 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31901 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12192 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12123 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41493 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34073 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38014 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10225 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36183 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14131 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8478 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13102 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13444 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->