### PR TITLE
CrashTracer: com.apple.WebKit.WebContent at WebCore: WebCore::Document::addTopLayerElement

### DIFF
--- a/LayoutTests/fullscreen/fullscreen-add-disconnected-to-top-layer-expected.txt
+++ b/LayoutTests/fullscreen/fullscreen-add-disconnected-to-top-layer-expected.txt
@@ -1,0 +1,5 @@
+Click to run test manually
+Test passes if there is no crash
+
+END OF TEST
+

--- a/LayoutTests/fullscreen/fullscreen-add-disconnected-to-top-layer.html
+++ b/LayoutTests/fullscreen/fullscreen-add-disconnected-to-top-layer.html
@@ -1,0 +1,18 @@
+<button id="button">Click to run test manually</button>
+<p>Test passes if there is no crash</p>
+<div id="target">To be fullscreened</div>
+<script src="full-screen-test.js"></script>
+<script>
+    function test() {
+        target.requestFullscreen();
+        requestAnimationFrame(() => {
+            target.remove();
+            endTest();
+        });
+    }
+    button.onclick = test;
+    onload = () => {
+        if (window.internals)
+            runWithKeyDown(test);
+    }
+</script>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9565,7 +9565,7 @@ void Document::keyframesRuleDidChange(const String& name)
 
 void Document::addTopLayerElement(Element& element)
 {
-    RELEASE_ASSERT(&element.document() == this && element.isConnected() && !element.isInTopLayer());
+    RELEASE_ASSERT(&element.document() == this && !element.isInTopLayer());
     auto result = m_topLayerElements.add(element);
     RELEASE_ASSERT(result.isNewEntry);
     if (auto* candidatePopover = dynamicDowncast<HTMLElement>(element); candidatePopover && candidatePopover->popoverState() == PopoverState::Auto) {


### PR DESCRIPTION
#### de15933efb3df90ef3af89e73f48847471f22700
<pre>
CrashTracer: com.apple.WebKit.WebContent at WebCore: WebCore::Document::addTopLayerElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=268434">https://bugs.webkit.org/show_bug.cgi?id=268434</a>
<a href="https://rdar.apple.com/117975912">rdar://117975912</a>

Reviewed by Chris Dumez.

The release assertion here is bogus, the top layer is a DOM construct that is used for various DOM algorithms, not just a rendering one.

Things in the top layer are not required to be rendered.

* LayoutTests/fullscreen/fullscreen-add-disconnected-to-top-layer-expected.txt: Added.
* LayoutTests/fullscreen/fullscreen-add-disconnected-to-top-layer.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::addTopLayerElement):

Canonical link: <a href="https://commits.webkit.org/273885@main">https://commits.webkit.org/273885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cc645e5fda38eab14340ba39617c1258a133361

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39576 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33066 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13017 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31592 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32624 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11691 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11711 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40826 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33508 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37611 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12010 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35739 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13660 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32613 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12388 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4799 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12923 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->