### PR TITLE
Use a mock git for most of SummarizedResultsTest

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py
@@ -158,11 +158,6 @@ class SummarizedResultsTest(unittest.TestCase):
         summary = summarized_results(self.port, expected=False, passing=False, flaky=False)
         self.assertNotIn('revision', summary)
 
-    def test_git_revision_exists(self):
-        self.port._options.builder_name = 'dummy builder'
-        summary = summarized_results(self.port, expected=False, passing=False, flaky=False)
-        self.assertNotEqual(summary['revision'], '')
-
     def test_git_revision_identifier(self):
         with mocks.local.Git(path='/'), OutputCapture():
             self.port._options.builder_name = 'dummy builder'
@@ -170,29 +165,33 @@ class SummarizedResultsTest(unittest.TestCase):
             self.assertEqual(summary['revision'], '5@main')
 
     def test_summarized_results_wontfix(self):
-        self.port._options.builder_name = 'dummy builder'
-        summary = summarized_results(self.port, expected=False, passing=False, flaky=False)
-        self.assertTrue(summary['tests']['failures']['expected']['hang.html']['wontfix'])
+        with mocks.local.Git(path='/'), OutputCapture():
+            self.port._options.builder_name = 'dummy builder'
+            summary = summarized_results(self.port, expected=False, passing=False, flaky=False)
+            self.assertTrue(summary['tests']['failures']['expected']['hang.html']['wontfix'])
 
     def test_summarized_results_include_passes(self):
-        self.port._options.builder_name = 'dummy builder'
-        summary = summarized_results(self.port, expected=False, passing=True, flaky=False, include_passes=True)
-        self.assertEqual(summary['tests']['passes']['text.html']['expected'], 'PASS')
+        with mocks.local.Git(path='/'), OutputCapture():
+            self.port._options.builder_name = 'dummy builder'
+            summary = summarized_results(self.port, expected=False, passing=True, flaky=False, include_passes=True)
+            self.assertEqual(summary['tests']['passes']['text.html']['expected'], 'PASS')
 
     def test_summarized_results_world_leaks_disabled(self):
-        self.port._options.builder_name = 'dummy builder'
-        summary = summarized_results(self.port, expected=False, passing=True, flaky=False, include_passes=True)
-        self.assertEqual(summary['tests']['failures']['expected']['leak.html']['expected'], 'PASS')
+        with mocks.local.Git(path='/'), OutputCapture():
+            self.port._options.builder_name = 'dummy builder'
+            summary = summarized_results(self.port, expected=False, passing=True, flaky=False, include_passes=True)
+            self.assertEqual(summary['tests']['failures']['expected']['leak.html']['expected'], 'PASS')
 
     def test_summarized_run_metadata(self):
-        self.port._options.builder_name = 'dummy builder'
-        summary = summarized_results(self.port, expected=False, passing=True, flaky=False, include_passes=True)
-        self.assertEqual(summary['port_name'], 'test-mac-leopard')
-        self.assertEqual(
-            summary['test_configuration'],
-            {'version': 'leopard', 'architecture': 'x86', 'build_type': 'release'},
-        )
-        self.assertEqual(
-            summary['baseline_search_path'],
-            ['platform/test-mac-leopard', 'platform/test-mac-snowleopard'],
-        )
+        with mocks.local.Git(path='/'), OutputCapture():
+            self.port._options.builder_name = 'dummy builder'
+            summary = summarized_results(self.port, expected=False, passing=True, flaky=False, include_passes=True)
+            self.assertEqual(summary['port_name'], 'test-mac-leopard')
+            self.assertEqual(
+                summary['test_configuration'],
+                {'version': 'leopard', 'architecture': 'x86', 'build_type': 'release'},
+            )
+            self.assertEqual(
+                summary['baseline_search_path'],
+                ['platform/test-mac-leopard', 'platform/test-mac-snowleopard'],
+            )


### PR DESCRIPTION
#### 7df0ea213a3fa40674ca325726f5ba089d44f7e8
<pre>
Use a mock git for most of SummarizedResultsTest
<a href="https://bugs.webkit.org/show_bug.cgi?id=268510">https://bugs.webkit.org/show_bug.cgi?id=268510</a>

Reviewed by Jonathan Bedard.

None of these tests actually are looking at the output from git
whatsoever, and with many remotes and branches actually querying git can
be slow, so just use a mock git object instead.

Lastly, mark the one test that still uses real git as slow.

* Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py:
(SummarizedResultsTest.test_no_git_revision):
(SummarizedResultsTest.test_summarized_results_wontfix):
(SummarizedResultsTest.test_summarized_results_include_passes):
(SummarizedResultsTest.test_summarized_results_world_leaks_disabled):
(SummarizedResultsTest.test_summarized_run_metadata):
(SummarizedResultsTest.test_git_revision_exists): Deleted.

Canonical link: <a href="https://commits.webkit.org/273948@main">https://commits.webkit.org/273948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5efb5ff3626e576367d16e4315de140d9ea317ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/37327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/16214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/39601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/38633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/18809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/13363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/39865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/37892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/18809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/39601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/37374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/18809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/39601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/41127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/18809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/39601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/41127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/12407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/13363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/41127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/39601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4827 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->