### PR TITLE
WebExtensionControllerProxy ASSERT in WebProcess when loading a page.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -38,22 +38,22 @@ namespace WebKit {
 
 using namespace WebCore;
 
-static HashMap<WebExtensionContextIdentifier, WeakPtr<WebExtensionContext>>& webExtensionContexts()
+static HashMap<WebExtensionContextIdentifier, WeakRef<WebExtensionContext>>& webExtensionContexts()
 {
-    static NeverDestroyed<HashMap<WebExtensionContextIdentifier, WeakPtr<WebExtensionContext>>> contexts;
+    static NeverDestroyed<HashMap<WebExtensionContextIdentifier, WeakRef<WebExtensionContext>>> contexts;
     return contexts;
 }
 
 WebExtensionContext* WebExtensionContext::get(WebExtensionContextIdentifier identifier)
 {
-    return webExtensionContexts().get(identifier).get();
+    return webExtensionContexts().get(identifier);
 }
 
 WebExtensionContext::WebExtensionContext()
     : m_identifier(WebExtensionContextIdentifier::generate())
 {
-    ASSERT(!webExtensionContexts().contains(m_identifier));
-    webExtensionContexts().add(m_identifier, this);
+    ASSERT(!get(m_identifier));
+    webExtensionContexts().add(m_identifier, *this);
 }
 
 WebExtensionContextParameters WebExtensionContext::parameters() const

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -39,23 +39,23 @@ namespace WebKit {
 
 constexpr auto freshlyCreatedTimeout = 5_s;
 
-static HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionController>>& webExtensionControllers()
+static HashMap<WebExtensionControllerIdentifier, WeakRef<WebExtensionController>>& webExtensionControllers()
 {
-    static MainThreadNeverDestroyed<HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionController>>> controllers;
+    static MainThreadNeverDestroyed<HashMap<WebExtensionControllerIdentifier, WeakRef<WebExtensionController>>> controllers;
     return controllers;
 }
 
 WebExtensionController* WebExtensionController::get(WebExtensionControllerIdentifier identifier)
 {
-    return webExtensionControllers().get(identifier).get();
+    return webExtensionControllers().get(identifier);
 }
 
 WebExtensionController::WebExtensionController(Ref<WebExtensionControllerConfiguration> configuration)
     : m_configuration(configuration)
     , m_identifier(WebExtensionControllerIdentifier::generate())
 {
-    ASSERT(!webExtensionControllers().contains(m_identifier));
-    webExtensionControllers().add(m_identifier, this);
+    ASSERT(!get(m_identifier));
+    webExtensionControllers().add(m_identifier, *this);
 
     // A freshly created extension controller will be used to determine if the startup event
     // should be fired for any loaded extensions during a brief time window. Start a timer

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp
@@ -39,15 +39,15 @@ namespace WebKit {
 
 using namespace WebCore;
 
-static HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionControllerProxy>>& webExtensionControllerProxies()
+static HashMap<WebExtensionControllerIdentifier, WeakRef<WebExtensionControllerProxy>>& webExtensionControllerProxies()
 {
-    static MainThreadNeverDestroyed<HashMap<WebExtensionControllerIdentifier, WeakPtr<WebExtensionControllerProxy>>> controllers;
+    static MainThreadNeverDestroyed<HashMap<WebExtensionControllerIdentifier, WeakRef<WebExtensionControllerProxy>>> controllers;
     return controllers;
 }
 
 RefPtr<WebExtensionControllerProxy> WebExtensionControllerProxy::get(WebExtensionControllerIdentifier identifier)
 {
-    return webExtensionControllerProxies().get(identifier).get();
+    return webExtensionControllerProxies().get(identifier);
 }
 
 Ref<WebExtensionControllerProxy> WebExtensionControllerProxy::getOrCreate(const WebExtensionControllerParameters& parameters, WebPage* newPage)
@@ -57,37 +57,37 @@ Ref<WebExtensionControllerProxy> WebExtensionControllerProxy::getOrCreate(const 
         WebExtensionContextProxyBaseURLMap baseURLMap;
 
         for (auto& contextParameters : parameters.contextParameters) {
-            auto context = WebExtensionContextProxy::getOrCreate(contextParameters, newPage);
+            Ref context = WebExtensionContextProxy::getOrCreate(contextParameters, newPage);
             baseURLMap.add(contextParameters.baseURL.protocolHostAndPort(), context);
             contexts.add(context);
         }
 
-        controller.m_extensionContexts.swap(contexts);
-        controller.m_extensionContextBaseURLMap.swap(baseURLMap);
+        controller.m_extensionContexts = WTFMove(contexts);
+        controller.m_extensionContextBaseURLMap = WTFMove(baseURLMap);
     };
 
-    if (auto controller = webExtensionControllerProxies().get(parameters.identifier)) {
+    if (RefPtr controller = get(parameters.identifier)) {
         updateProperties(*controller);
         return *controller;
     }
 
-    auto result = adoptRef(new WebExtensionControllerProxy(parameters));
-    updateProperties(*result);
-    return result.releaseNonNull();
+    Ref result = adoptRef(*new WebExtensionControllerProxy(parameters));
+    updateProperties(result);
+    return result;
 }
 
 WebExtensionControllerProxy::WebExtensionControllerProxy(const WebExtensionControllerParameters& parameters)
     : m_identifier(parameters.identifier)
 {
-    ASSERT(!webExtensionControllerProxies().contains(m_identifier));
-    webExtensionControllerProxies().add(m_identifier, this);
+    ASSERT(!get(m_identifier));
+    webExtensionControllerProxies().add(m_identifier, *this);
 
     WebProcess::singleton().addMessageReceiver(Messages::WebExtensionControllerProxy::messageReceiverName(), m_identifier, *this);
 }
 
 WebExtensionControllerProxy::~WebExtensionControllerProxy()
 {
-    WebProcess::singleton().removeMessageReceiver(Messages::WebExtensionControllerProxy::messageReceiverName(), m_identifier);
+    WebProcess::singleton().removeMessageReceiver(*this);
 }
 
 void WebExtensionControllerProxy::load(const WebExtensionContextParameters& contextParameters)


### PR DESCRIPTION
#### ead1bd233aac711efb8547ff8bcf6043cbf99af8
<pre>
WebExtensionControllerProxy ASSERT in WebProcess when loading a page.
<a href="https://webkit.org/b/268511">https://webkit.org/b/268511</a>
<a href="https://rdar.apple.com/problem/122051926">rdar://problem/122051926</a>

Reviewed by Jeff Miller.

The check for HashMap `contains()` ASSERTs return `true`, even though the WeakPtr is
null. Check if the pointer is null instead of just contained in the map.

Change the `WeakPtr` to be `WeakRef`, to better signal that the map should be
only non-null references. Also be explicit about the smart pointers.

* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::webExtensionContexts):
(WebKit::WebExtensionContext::get):
(WebKit::WebExtensionContext::WebExtensionContext):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::webExtensionControllers):
(WebKit::WebExtensionController::get):
(WebKit::WebExtensionController::WebExtensionController):
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::webExtensionContextProxies):
(WebKit::WebExtensionContextProxy::get):
(WebKit::WebExtensionContextProxy::WebExtensionContextProxy):
(WebKit::WebExtensionContextProxy::~WebExtensionContextProxy):
(WebKit::WebExtensionContextProxy::getOrCreate):
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.cpp:
(WebKit::webExtensionControllerProxies):
(WebKit::WebExtensionControllerProxy::get):
(WebKit::WebExtensionControllerProxy::getOrCreate):
(WebKit::WebExtensionControllerProxy::WebExtensionControllerProxy):
(WebKit::WebExtensionControllerProxy::~WebExtensionControllerProxy):

Canonical link: <a href="https://commits.webkit.org/273880@main">https://commits.webkit.org/273880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14943ee0ba9766816ecdfe0453003ea477cd46b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39308 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39587 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13030 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37545 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13417 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11702 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40838 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33520 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33271 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12017 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/9824 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/35745 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4797 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/12930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->