### PR TITLE
Sync `WheelEvent` interface (deltaX, deltaY and deltaZ) with Web-Specification

### DIFF
--- a/Source/WebCore/dom/WheelEvent.idl
+++ b/Source/WebCore/dom/WheelEvent.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006, 2007, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
  * Copyright (C) 2013 Samsung Electronics. All rights reserved.
  *
@@ -19,19 +19,21 @@
  * Boston, MA 02110-1301, USA.
  */
 
+// https://w3c.github.io/uievents/#interface-wheelevent
+
 [
     Exposed=Window
 ] interface WheelEvent : MouseEvent {
-    constructor([AtomString] DOMString type, optional WheelEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional WheelEventInit eventInitDict = {});
 
     // DeltaModeCode
     const unsigned long DOM_DELTA_PIXEL = 0x00;
     const unsigned long DOM_DELTA_LINE = 0x01;
     const unsigned long DOM_DELTA_PAGE = 0x02;
 
-    readonly attribute unrestricted double deltaX;
-    readonly attribute unrestricted double deltaY;
-    readonly attribute unrestricted double deltaZ;
+    readonly attribute double deltaX;
+    readonly attribute double deltaY;
+    readonly attribute double deltaZ;
     readonly attribute unsigned long deltaMode;
 
     // Legacy MouseWheelEvent API replaced by standard WheelEvent API.
@@ -46,6 +48,8 @@
         optional boolean ctrlKey = false, optional boolean altKey = false,
         optional boolean shiftKey = false, optional boolean metaKey = false);
 };
+
+// https://w3c.github.io/uievents/#idl-wheeleventinit
 
 dictionary WheelEventInit : MouseEventInit {
     double deltaX = 0.0;


### PR DESCRIPTION
#### fba982021841293d38a888bc7efd7800a070dd5c
<pre>
Sync `WheelEvent` interface (deltaX, deltaY and deltaZ) with Web-Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=268514">https://bugs.webkit.org/show_bug.cgi?id=268514</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Web-Specification [1]:

[1] <a href="https://w3c.github.io/uievents/#interface-wheelevent">https://w3c.github.io/uievents/#interface-wheelevent</a>

As per web-specification, all delta values should be just &apos;double&apos;, so this remove &apos;unrestricted&apos;.

* Source/WebCore/dom/WheelEvent.idl:

Canonical link: <a href="https://commits.webkit.org/273891@main">https://commits.webkit.org/273891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d174c7ac80efa6be7c0bc648b1c0133b63914618

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/36986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39309 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39588 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33074 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31600 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11727 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11717 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40839 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33519 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37642 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12018 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35746 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13668 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8380 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12396 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12931 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->