### PR TITLE
Revert arm64 build fixes

### DIFF
--- a/Source/JavaScriptCore/assembler/FastJITPermissions.h
+++ b/Source/JavaScriptCore/assembler/FastJITPermissions.h
@@ -35,32 +35,7 @@
 #include <wtf/Platform.h>
 
 #if USE(INLINE_JIT_PERMISSIONS_API)
-// This is a temporary workaround to fix a build error, see rdar://121990409
-#ifdef __arm64e__
 #include <BrowserEngineCore/BEMemory.h>
-#elif USE(APPLE_INTERNAL_SDK)
-#include <os/thread_self_restrict.h>
-inline bool be_memory_inline_jit_restrict_with_witness_supported()
-{
-    return !!os_thread_self_restrict_rwx_is_supported();
-}
-
-inline
-void be_memory_inline_jit_restrict_rwx_to_rw_with_witness(void)
-{
-    os_thread_self_restrict_rwx_to_rw();
-}
-
-inline
-void be_memory_inline_jit_restrict_rwx_to_rx_with_witness(void)
-{
-    os_thread_self_restrict_rwx_to_rx();
-}
-#else
-inline bool be_memory_inline_jit_restrict_with_witness_supported() { return false; }
-inline void be_memory_inline_jit_restrict_rwx_to_rw_with_witness(void) { }
-inline void be_memory_inline_jit_restrict_rwx_to_rx_with_witness(void) { }
-#endif
 #elif USE(PTHREAD_JIT_PERMISSIONS_API)
 #include <pthread.h>
 #elif USE(APPLE_INTERNAL_SDK)

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -85,10 +85,8 @@ extern "C" {
 #endif
 
 #if USE(INLINE_JIT_PERMISSIONS_API)
-#ifdef __arm64e__
 #include <wtf/darwin/WeakLinking.h>
 WTF_WEAK_LINK_FORCE_IMPORT(be_memory_inline_jit_restrict_with_witness_supported);
-#endif
 #endif
 
 namespace JSC {
@@ -422,10 +420,8 @@ static ALWAYS_INLINE JITReservation initializeJITPageReservation()
         bool fastJITPermissionsIsSupported = false;
 #if OS(DARWIN) && CPU(ARM64)
 #if USE(INLINE_JIT_PERMISSIONS_API)
-IGNORE_WARNINGS_BEGIN("pointer-bool-conversion")
         fastJITPermissionsIsSupported = (be_memory_inline_jit_restrict_with_witness_supported
             && !!be_memory_inline_jit_restrict_with_witness_supported());
-IGNORE_WARNINGS_END
 #elif USE(PTHREAD_JIT_PERMISSIONS_API)
         fastJITPermissionsIsSupported = !!pthread_jit_write_protect_supported_np();
 #elif USE(APPLE_INTERNAL_SDK)


### PR DESCRIPTION
#### d2ea11d2ec6050d30961ba4b2038c1b6a566b82a
<pre>
Revert arm64 build fixes
<a href="https://bugs.webkit.org/show_bug.cgi?id=268517">https://bugs.webkit.org/show_bug.cgi?id=268517</a>
<a href="https://rdar.apple.com/122018269">rdar://122018269</a>

Unreviewed revert.

Revert &quot;ARM64 Build Fix (part 3)&quot;
This reverts commit 642c3a4c1b5e8d252d0bed6a6d9084a037fed03c.
Revert &quot;Fix ARM64 build (part 2)&quot;
This reverts commit 13ca1d4ad63fa5d8df592a7f45375929781d1c45.
Revert &quot;Build fix for arm64 builds&quot;
This reverts commit d21e6f3910e86f0b5553cb891594141c65d4049a.

We will have a better build fix tomorrow.

* Source/JavaScriptCore/assembler/FastJITPermissions.h:
(be_memory_inline_jit_restrict_with_witness_supported): Deleted.
(be_memory_inline_jit_restrict_rwx_to_rw_with_witness): Deleted.
(be_memory_inline_jit_restrict_rwx_to_rx_with_witness): Deleted.
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::initializeJITPageReservation):

Canonical link: <a href="https://commits.webkit.org/273873@main">https://commits.webkit.org/273873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9fa4982e46c39e6a638924d7e81c6f1e72ead15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/36993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/15913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/39316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/18446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/13038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/39594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/37553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/18446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/39316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/18446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/39316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/40846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/30965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/18446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/39316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/40846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/36714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/12024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/13038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/40846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/39316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/43556 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/8980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4793 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/12937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->