### PR TITLE
[Site Isolation] Mark scrolling tree nodes that are parents of a RemoteFrame

### DIFF
--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -421,6 +421,15 @@ void AsyncScrollingCoordinator::setMouseMovedInContentArea(ScrollableArea& scrol
     stateNode->setMouseMovedInContentArea(state);
 }
 
+void AsyncScrollingCoordinator::setLayerHostingContextIdentifierForFrameHostingNode(ScrollingNodeID scrollingNodeID, std::optional<LayerHostingContextIdentifier> identifier)
+{
+    auto stateNode = dynamicDowncast<ScrollingStateFrameHostingNode>(m_scrollingStateTree->stateNodeForID(scrollingNodeID));
+    ASSERT(stateNode);
+    if (!stateNode)
+        return;
+    stateNode->setLayerHostingContextIdentifier(identifier);
+}
+
 void AsyncScrollingCoordinator::setScrollbarEnabled(Scrollbar& scrollbar)
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -75,6 +75,8 @@ public:
     
     WEBCORE_EXPORT void setMouseIsOverContentArea(ScrollableArea&, bool) override;
     WEBCORE_EXPORT void setMouseMovedInContentArea(ScrollableArea&) override;
+    WEBCORE_EXPORT void setLayerHostingContextIdentifierForFrameHostingNode(ScrollingNodeID, std::optional<LayerHostingContextIdentifier>) override;
+
 
 protected:
     WEBCORE_EXPORT AsyncScrollingCoordinator(Page*);

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "EventTrackingRegions.h"
+#include "LayerHostingContextIdentifier.h"
 #include "LayoutRect.h"
 #include "PlatformWheelEvent.h"
 #include "ScrollSnapOffsetsInfo.h"
@@ -209,6 +210,7 @@ public:
     WEBCORE_EXPORT virtual void setMouseMovedInContentArea(ScrollableArea&) { }
     WEBCORE_EXPORT virtual void setMouseIsOverScrollbar(Scrollbar*, bool) { }
     WEBCORE_EXPORT virtual void setScrollbarEnabled(Scrollbar&) { }
+    WEBCORE_EXPORT virtual void setLayerHostingContextIdentifierForFrameHostingNode(ScrollingNodeID, std::optional<LayerHostingContextIdentifier>) { }
 
 protected:
     explicit ScrollingCoordinator(Page*);

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameHostingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameHostingNode.cpp
@@ -38,13 +38,14 @@ Ref<ScrollingStateFrameHostingNode> ScrollingStateFrameHostingNode::create(Scrol
     return adoptRef(*new ScrollingStateFrameHostingNode(stateTree, nodeID));
 }
 
-Ref<ScrollingStateFrameHostingNode> ScrollingStateFrameHostingNode::create(ScrollingNodeID nodeID, Vector<Ref<ScrollingStateNode>>&& children, OptionSet<ScrollingStateNodeProperty> changedProperties, std::optional<PlatformLayerIdentifier> layerID)
+Ref<ScrollingStateFrameHostingNode> ScrollingStateFrameHostingNode::create(ScrollingNodeID nodeID, Vector<Ref<ScrollingStateNode>>&& children, OptionSet<ScrollingStateNodeProperty> changedProperties, std::optional<PlatformLayerIdentifier> layerID, std::optional<LayerHostingContextIdentifier> identifier)
 {
-    return adoptRef(*new ScrollingStateFrameHostingNode(nodeID, WTFMove(children), changedProperties, layerID));
+    return adoptRef(*new ScrollingStateFrameHostingNode(nodeID, WTFMove(children), changedProperties, layerID, identifier));
 }
 
-ScrollingStateFrameHostingNode::ScrollingStateFrameHostingNode(ScrollingNodeID nodeID, Vector<Ref<ScrollingStateNode>>&& children, OptionSet<ScrollingStateNodeProperty> changedProperties, std::optional<PlatformLayerIdentifier> layerID)
+ScrollingStateFrameHostingNode::ScrollingStateFrameHostingNode(ScrollingNodeID nodeID, Vector<Ref<ScrollingStateNode>>&& children, OptionSet<ScrollingStateNodeProperty> changedProperties, std::optional<PlatformLayerIdentifier> layerID, std::optional<LayerHostingContextIdentifier> identifier)
     : ScrollingStateNode(ScrollingNodeType::FrameHosting, nodeID, WTFMove(children), changedProperties, layerID)
+    , m_hostingContext(identifier)
 {
     ASSERT(isFrameHostingNode());
 }
@@ -57,10 +58,19 @@ ScrollingStateFrameHostingNode::ScrollingStateFrameHostingNode(ScrollingStateTre
 
 ScrollingStateFrameHostingNode::ScrollingStateFrameHostingNode(const ScrollingStateFrameHostingNode& stateNode, ScrollingStateTree& adoptiveTree)
     : ScrollingStateNode(stateNode, adoptiveTree)
+    , m_hostingContext(stateNode.layerHostingContextIdentifier())
 {
 }
 
 ScrollingStateFrameHostingNode::~ScrollingStateFrameHostingNode() = default;
+
+void ScrollingStateFrameHostingNode::setLayerHostingContextIdentifier(const std::optional<LayerHostingContextIdentifier> identifier)
+{
+    if (identifier == m_hostingContext)
+        return;
+    m_hostingContext = identifier;
+    setPropertyChanged(Property::LayerHostingContextIdentifier);
+}
 
 Ref<ScrollingStateNode> ScrollingStateFrameHostingNode::clone(ScrollingStateTree& adoptiveTree)
 {

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameHostingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameHostingNode.h
@@ -36,17 +36,22 @@ class Scrollbar;
 class ScrollingStateFrameHostingNode final : public ScrollingStateNode {
 public:
     WEBCORE_EXPORT static Ref<ScrollingStateFrameHostingNode> create(ScrollingStateTree&, ScrollingNodeID);
-    WEBCORE_EXPORT static Ref<ScrollingStateFrameHostingNode> create(ScrollingNodeID, Vector<Ref<ScrollingStateNode>>&&, OptionSet<ScrollingStateNodeProperty>, std::optional<PlatformLayerIdentifier>);
+    WEBCORE_EXPORT static Ref<ScrollingStateFrameHostingNode> create(ScrollingNodeID, Vector<Ref<ScrollingStateNode>>&&, OptionSet<ScrollingStateNodeProperty>, std::optional<PlatformLayerIdentifier>, std::optional<LayerHostingContextIdentifier>);
     Ref<ScrollingStateNode> clone(ScrollingStateTree&) override;
+
+    std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() const { return m_hostingContext; }
+    void setLayerHostingContextIdentifier(const std::optional<LayerHostingContextIdentifier>);
 
     virtual ~ScrollingStateFrameHostingNode();
 
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 
 private:
-    ScrollingStateFrameHostingNode(ScrollingNodeID, Vector<Ref<ScrollingStateNode>>&&, OptionSet<ScrollingStateNodeProperty>, std::optional<PlatformLayerIdentifier>);
+    ScrollingStateFrameHostingNode(ScrollingNodeID, Vector<Ref<ScrollingStateNode>>&&, OptionSet<ScrollingStateNodeProperty>, std::optional<PlatformLayerIdentifier>, std::optional<LayerHostingContextIdentifier>);
     ScrollingStateFrameHostingNode(ScrollingStateTree&, ScrollingNodeID);
     ScrollingStateFrameHostingNode(const ScrollingStateFrameHostingNode&, ScrollingStateTree&);
+
+    std::optional<LayerHostingContextIdentifier> m_hostingContext;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -265,6 +265,9 @@ enum class ScrollingStateNodeProperty : uint64_t {
     ViewportConstraints                         = 1LLU << 1, // Same value as ScrollableAreaSize, RelatedOverflowScrollingNodes and OverflowScrollingNode
     // ScrollingStateOverflowScrollProxyNode
     OverflowScrollingNode                       = 1LLU << 1, // Same value as ScrollableAreaSize, ViewportConstraints and RelatedOverflowScrollingNodes
+    // ScrollingStateFrameHostingNode
+    LayerHostingContextIdentifier               = 1LLU << 1,
+
 };
 
 class ScrollingStateNode : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ScrollingStateNode> {

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp
@@ -49,8 +49,14 @@ ScrollingTreeFrameHostingNode::ScrollingTreeFrameHostingNode(ScrollingTree& scro
 
 ScrollingTreeFrameHostingNode::~ScrollingTreeFrameHostingNode() = default;
 
-bool ScrollingTreeFrameHostingNode::commitStateBeforeChildren(const ScrollingStateNode&)
+bool ScrollingTreeFrameHostingNode::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
+    if (!is<ScrollingStateFrameHostingNode>(stateNode))
+        return false;
+
+    const auto& state = downcast<ScrollingStateFrameHostingNode>(stateNode);
+    if (state.hasChangedProperty(ScrollingStateNode::Property::LayerHostingContextIdentifier))
+        setLayerHostingContextIdentifier(state.layerHostingContextIdentifier());
     return true;
 }
 
@@ -61,6 +67,8 @@ void ScrollingTreeFrameHostingNode::applyLayerPositions()
 void ScrollingTreeFrameHostingNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
 {
     ts << "frame hosting node";
+    if (auto hostingContextIdentifier = m_hostingContext)
+        ts.dumpProperty("hosting context identifier", *m_hostingContext);
     ScrollingTreeNode::dumpProperties(ts, behavior);
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h
@@ -38,6 +38,9 @@ public:
     WEBCORE_EXPORT static Ref<ScrollingTreeFrameHostingNode> create(ScrollingTree&, ScrollingNodeID);
     virtual ~ScrollingTreeFrameHostingNode();
 
+    std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() const { return m_hostingContext; }
+    void setLayerHostingContextIdentifier(std::optional<LayerHostingContextIdentifier> identifier) { m_hostingContext = identifier; }
+
 private:
     ScrollingTreeFrameHostingNode(ScrollingTree&, ScrollingNodeID);
 
@@ -45,6 +48,8 @@ private:
     void applyLayerPositions() final;
 
     WEBCORE_EXPORT void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
+
+    std::optional<LayerHostingContextIdentifier> m_hostingContext;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3883,6 +3883,10 @@ bool RenderLayerCompositor::isLayerForIFrameWithScrollCoordinatedContents(const 
     if (!renderWidget)
         return false;
 
+    auto* frame = renderWidget->frameOwnerElement().contentFrame();
+    if (frame && is<RemoteFrame>(frame))
+        return renderWidget->hasLayer() && renderWidget->layer()->isComposited();
+
     auto* contentDocument = renderWidget->frameOwnerElement().contentDocument();
     if (!contentDocument)
         return false;
@@ -5267,6 +5271,12 @@ ScrollingNodeID RenderLayerCompositor::updateScrollingNodeForFrameHostingRole(Re
     if (changes & ScrollingNodeChangeFlags::Layer)
         scrollingCoordinator->setNodeLayers(newNodeID, { layer.backing()->graphicsLayer() });
 
+    if (auto* renderWidget = dynamicDowncast<RenderWidget>(layer.renderer())) {
+        if (auto* frame = renderWidget->frameOwnerElement().contentFrame()) {
+            if (is<RemoteFrame>(frame))
+                scrollingCoordinator->setLayerHostingContextIdentifierForFrameHostingNode(newNodeID, dynamicDowncast<RemoteFrame>(frame)->layerHostingContextIdentifier());
+        }
+    }
     return newNodeID;
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
@@ -59,6 +59,7 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     Vector<Ref<WebCore::ScrollingStateNode>> children()
     [OptionalTupleBits] OptionSet<WebCore::ScrollingStateNodeProperty> changedProperties()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::Layer] std::optional<WebCore::PlatformLayerIdentifier> layer().layerIDForEncoding()
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::LayerHostingContextIdentifier] std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier();
 }
 
 [RefCounted] class WebCore::ScrollingStateFrameScrollingNode {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3938,6 +3938,7 @@ header: <WebCore/ScrollingStateNode.h>
     OverflowScrollingNode
     KeyboardScrollData
     OverlayScrollbarsEnabled
+    LayerHostingContextIdentifier
 };
 #endif
 


### PR DESCRIPTION
#### 385c72e3a6462abfbbdbee6b77a344a663ffd74d
<pre>
[Site Isolation] Mark scrolling tree nodes that are parents of a RemoteFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=268518">https://bugs.webkit.org/show_bug.cgi?id=268518</a>
<a href="https://rdar.apple.com/122054689">rdar://122054689</a>

Reviewed by Simon Fraser.

This is part 1 of splitting up <a href="https://github.com/WebKit/WebKit/pull/23242.">https://github.com/WebKit/WebKit/pull/23242.</a> The
purpose of this patch is to mark scrolling tree nodes that have an associated
RemoteFrame, currently using the LayerHostingContextIdentifier. This will later
be used to connect the scrolling tree from the iframe process in the ui process.

* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::didFinishLoadInAnotherProcess):
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::setLayerHostingContextIdentifier):
(WebCore::AsyncScrollingCoordinator::frameViewForScrollingNode const):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
(WebCore::ScrollingCoordinator::isSiteIsolatedTree):
(WebCore::ScrollingCoordinator::setLayerHostingContextIdentifier):
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp:
(WebCore::ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateNode.cpp:
(WebCore::operator&lt;&lt;):
(WebCore::ScrollingStateNode::setLayer):
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
(WebCore::LayerRepresentation::operator PlatformLayer* const):
(WebCore::LayerRepresentation::toRepresentation const):
(WebCore::LayerRepresentation::representation const):
* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.cpp:
(WebCore::ScrollingStateOverflowScrollingNode::ScrollingStateOverflowScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStateOverflowScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.cpp:
(WebCore::ScrollingStatePluginScrollingNode::ScrollingStatePluginScrollingNode):
* Source/WebCore/page/scrolling/ScrollingStatePluginScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.cpp:
(WebCore::ScrollingStateScrollingNode::ScrollingStateScrollingNode):
(WebCore::ScrollingStateScrollingNode::setLayerHostingContextIdentifier):
(WebCore::ScrollingStateScrollingNode::dumpProperties const):
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h:
(WebCore::ScrollingStateScrollingNode::layerHostingContextIdentifier const):
* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(WebCore::ScrollingStateTree::createUnparentedNode):
(WebCore::ScrollingStateTree::insertNode):
* Source/WebCore/page/scrolling/ScrollingStateTree.h:
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/page/scrolling/ScrollingTreeNode.cpp:
(WebCore::ScrollingTreeNode::removeAllChildren):
* Source/WebCore/page/scrolling/ScrollingTreeNode.h:
(WebCore::ScrollingTreeNode::setIsHostedSubtree):
(WebCore::ScrollingTreeNode::isHostedSubtree const):
(WebCore::ScrollingTreeNode::layerHostingContextIdentifier):
(WebCore::ScrollingTreeNode::setlayerHostingContextIdentifier):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::commitStateBeforeChildren):
(WebCore::ScrollingTreeScrollingNode::dumpProperties const):
* Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm:
(scrollingNodeIDForLayer):
(ScrollingTreeMac::scrollingNodeForPoint):

Canonical link: <a href="https://commits.webkit.org/274123@main">https://commits.webkit.org/274123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be84f8ccad4115e7151406f994c7a6f02c880285

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37936 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40480 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33754 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14146 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32077 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33227 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12389 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41753 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34422 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38210 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12928 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10569 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36393 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14502 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8518 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13359 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13954 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->