### PR TITLE
Web Inspector: Audit tab align the scope bars

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
@@ -32,6 +32,7 @@
     --scope-bar-background-color-default: unset;
     --scope-bar-background-opacity-default: var(--glyph-opacity);
     --scope-bar-border-color-default: unset;
+    --scope-bar-text-align-default: right;
 }
 
 .scope-bar > li {
@@ -43,7 +44,6 @@
     font-size: 11px;
     line-height: 11px;
     color: var(--scope-bar-text-color);
-    text-align: center;
 
     --scope-bar-margin: var(--scope-bar-margin-override, var(--scope-bar-margin-default));
     --scope-bar-padding: var(--scope-bar-padding-override, var(--scope-bar-padding-default));
@@ -51,6 +51,7 @@
     --scope-bar-background-color: var(--scope-bar-background-color-override, var(--scope-bar-background-color-default));
     --scope-bar-background-opacity: var(--scope-bar-background-opacity-override, var(--scope-bar-background-opacity-default));
     --scope-bar-border-color: var(--scope-bar-border-color-override, var(--scope-bar-border-color-default));
+    --scope-bar-text-align: var(--scope-bar-text-align-override, var(--scope-bar-text-align-default));
 }
 
 .scope-bar > li::after {


### PR DESCRIPTION
#### 776f1348c1a4afca785f5a127096e3e83ccd6675
<pre>
Web Inspector: Audit tab align the scope bars
<a href="https://bugs.webkit.org/show_bug.cgi?id=268321">https://bugs.webkit.org/show_bug.cgi?id=268321</a>

Reviewed by NOBODY (OOPS!).

Align scope bars in the audit tab.
Add --scope-bar-text-align-default and set to right in ScopeBar.css
Add --scope-bar-text-align-override.

* Source/WebInspectorUI/UserInterface/Views/ScopeBar.css:
(.scope-bar):
(.scope-bar &gt; li):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/776f1348c1a4afca785f5a127096e3e83ccd6675

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41252 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34374 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32501 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12912 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12890 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42528 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35174 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34899 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38723 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11192 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36931 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15143 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/14841 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14624 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->