### PR TITLE
generate-serializers.py should support nested conditions

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -49,6 +49,12 @@
 #include "TemplateTest.h"
 #include <Namespace/EmptyConstructorStruct.h>
 #include <Namespace/EmptyConstructorWithIf.h>
+#if !(ENABLE(OUTER_CONDITION))
+#include <Namespace/OtherOuterClass.h>
+#endif
+#if ENABLE(OUTER_CONDITION)
+#include <Namespace/OuterClass.h>
+#endif
 #include <Namespace/ReturnRefClass.h>
 #include <WebCore/FloatBoxExtent.h>
 #include <WebCore/InheritanceGrandchild.h>
@@ -626,6 +632,7 @@ enum class WebCore_TimingFunction_Subclass : IPC::EncodedVariantIndex {
     , SpringTimingFunction
 };
 
+IGNORE_WARNINGS_BEGIN("missing-noreturn")
 void ArgumentCoder<WebCore::TimingFunction>::encode(Encoder& encoder, const WebCore::TimingFunction& instance)
 {
     if (auto* subclass = dynamicDowncast<WebCore::LinearTimingFunction>(instance)) {
@@ -652,6 +659,7 @@ void ArgumentCoder<WebCore::TimingFunction>::encode(Encoder& encoder, const WebC
     }
     ASSERT_NOT_REACHED();
 }
+IGNORE_WARNINGS_END
 
 std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<WebCore::TimingFunction>::decode(Decoder& decoder)
 {
@@ -778,6 +786,7 @@ enum class WebCore_MoveOnlyBaseClass_Subclass : IPC::EncodedVariantIndex {
     MoveOnlyDerivedClass
 };
 
+IGNORE_WARNINGS_BEGIN("missing-noreturn")
 void ArgumentCoder<WebCore::MoveOnlyBaseClass>::encode(Encoder& encoder, WebCore::MoveOnlyBaseClass&& instance)
 {
     if (auto* subclass = dynamicDowncast<WebCore::MoveOnlyDerivedClass>(instance)) {
@@ -787,6 +796,7 @@ void ArgumentCoder<WebCore::MoveOnlyBaseClass>::encode(Encoder& encoder, WebCore
     }
     ASSERT_NOT_REACHED();
 }
+IGNORE_WARNINGS_END
 
 std::optional<WebCore::MoveOnlyBaseClass> ArgumentCoder<WebCore::MoveOnlyBaseClass>::decode(Decoder& decoder)
 {
@@ -1319,6 +1329,64 @@ std::optional<WebKit::RemoteVideoFrameWriteReference> ArgumentCoder<WebKit::Remo
     };
 }
 
+#if ENABLE(OUTER_CONDITION)
+void ArgumentCoder<Namespace::OuterClass>::encode(Encoder& encoder, const Namespace::OuterClass& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.outerValue)>, int>);
+    struct ShouldBeSameSizeAsOuterClass : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<Namespace::OuterClass>, false> {
+        int outerValue;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsOuterClass) == sizeof(Namespace::OuterClass));
+    static_assert(MembersInCorrectOrder < 0
+        , offsetof(Namespace::OuterClass, outerValue)
+    >::value);
+
+    encoder << instance.outerValue;
+}
+
+std::optional<Namespace::OuterClass> ArgumentCoder<Namespace::OuterClass>::decode(Decoder& decoder)
+{
+    auto outerValue = decoder.decode<int>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return {
+        Namespace::OuterClass {
+            WTFMove(*outerValue)
+        }
+    };
+}
+
+#endif
+
+#if !(ENABLE(OUTER_CONDITION))
+void ArgumentCoder<Namespace::OtherOuterClass>::encode(Encoder& encoder, const Namespace::OtherOuterClass& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.outerValue)>, int>);
+    struct ShouldBeSameSizeAsOtherOuterClass : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<Namespace::OtherOuterClass>, false> {
+        int outerValue;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsOtherOuterClass) == sizeof(Namespace::OtherOuterClass));
+    static_assert(MembersInCorrectOrder < 0
+        , offsetof(Namespace::OtherOuterClass, outerValue)
+    >::value);
+
+    encoder << instance.outerValue;
+}
+
+std::optional<Namespace::OtherOuterClass> ArgumentCoder<Namespace::OtherOuterClass>::decode(Decoder& decoder)
+{
+    auto outerValue = decoder.decode<int>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return {
+        Namespace::OtherOuterClass {
+            WTFMove(*outerValue)
+        }
+    };
+}
+
+#endif
+
 } // namespace IPC
 
 namespace WTF {
@@ -1384,7 +1452,7 @@ template<> bool isValidOptionSet<EnumNamespace2::OptionSetEnumType>(OptionSet<En
 #if ENABLE(OPTION_SET_SECOND_VALUE)
         | static_cast<uint8_t>(EnumNamespace2::OptionSetEnumType::OptionSetSecondValue)
 #endif
-#if !ENABLE(OPTION_SET_SECOND_VALUE)
+#if !(ENABLE(OPTION_SET_SECOND_VALUE))
         | static_cast<uint8_t>(EnumNamespace2::OptionSetEnumType::OptionSetSecondValueElse)
 #endif
         | static_cast<uint8_t>(EnumNamespace2::OptionSetEnumType::OptionSetThirdValue)
@@ -1431,6 +1499,24 @@ template<> bool isValidOptionSet<OptionSetEnumAllCondition>(OptionSet<OptionSetE
         | 0;
     return (value.toRaw() | allValidBitsValue) == allValidBitsValue;
 }
+
+#if (ENABLE(OUTER_CONDITION)) && (ENABLE(INNER_CONDITION))
+template<> bool isValidEnum<EnumNamespace::InnerEnumType, void>(uint8_t value)
+{
+    switch (static_cast<EnumNamespace::InnerEnumType>(value)) {
+    case EnumNamespace::InnerEnumType::InnerValue:
+#if ENABLE(INNER_INNER_CONDITION)
+    case EnumNamespace::InnerEnumType::InnerInnerValue:
+#endif
+#if !(ENABLE(INNER_INNER_CONDITION))
+    case EnumNamespace::InnerEnumType::OtherInnerInnerValue:
+#endif
+        return true;
+    default:
+        return false;
+    }
+}
+#endif
 
 } // namespace WTF
 

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -36,6 +36,12 @@ enum class BoolEnumType : bool;
 #if ENABLE(UINT16_ENUM)
 enum class EnumType : uint16_t;
 #endif
+#if (ENABLE(OUTER_CONDITION)) && (ENABLE(INNER_CONDITION))
+enum class InnerEnumType : uint8_t;
+#endif
+#if (ENABLE(OUTER_CONDITION)) && (!(ENABLE(INNER_CONDITION)))
+enum class InnerBoolType : bool;
+#endif
 }
 
 namespace JSC {
@@ -51,6 +57,12 @@ class ConditionalCommonClass;
 #endif
 class CommonClass;
 class AnotherCommonClass;
+#if ENABLE(OUTER_CONDITION)
+class OuterClass;
+#endif
+#if !(ENABLE(OUTER_CONDITION))
+class OtherOuterClass;
+#endif
 }
 
 namespace Namespace::Subnamespace {
@@ -343,6 +355,20 @@ template<> struct ArgumentCoder<WebKit::RemoteVideoFrameWriteReference> {
     static std::optional<WebKit::RemoteVideoFrameWriteReference> decode(Decoder&);
 };
 
+#if ENABLE(OUTER_CONDITION)
+template<> struct ArgumentCoder<Namespace::OuterClass> {
+    static void encode(Encoder&, const Namespace::OuterClass&);
+    static std::optional<Namespace::OuterClass> decode(Decoder&);
+};
+#endif
+
+#if !(ENABLE(OUTER_CONDITION))
+template<> struct ArgumentCoder<Namespace::OtherOuterClass> {
+    static void encode(Encoder&, const Namespace::OtherOuterClass&);
+    static std::optional<Namespace::OtherOuterClass> decode(Decoder&);
+};
+#endif
+
 } // namespace IPC
 
 
@@ -355,5 +381,8 @@ template<> bool isValidEnum<EnumNamespace::EnumType, void>(uint16_t);
 template<> bool isValidOptionSet<OptionSetEnumFirstCondition>(OptionSet<OptionSetEnumFirstCondition>);
 template<> bool isValidOptionSet<OptionSetEnumLastCondition>(OptionSet<OptionSetEnumLastCondition>);
 template<> bool isValidOptionSet<OptionSetEnumAllCondition>(OptionSet<OptionSetEnumAllCondition>);
+#if (ENABLE(OUTER_CONDITION)) && (ENABLE(INNER_CONDITION))
+template<> bool isValidEnum<EnumNamespace::InnerEnumType, void>(uint8_t);
+#endif
 
 } // namespace WTF

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -50,6 +50,12 @@
 #include "TemplateTest.h"
 #include <Namespace/EmptyConstructorStruct.h>
 #include <Namespace/EmptyConstructorWithIf.h>
+#if !(ENABLE(OUTER_CONDITION))
+#include <Namespace/OtherOuterClass.h>
+#endif
+#if ENABLE(OUTER_CONDITION)
+#include <Namespace/OuterClass.h>
+#endif
 #include <Namespace/ReturnRefClass.h>
 #include <WebCore/FloatBoxExtent.h>
 #include <WebCore/InheritanceGrandchild.h>
@@ -461,6 +467,18 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                 "pendingReads()"_s
             },
         } },
+        { "Namespace::OuterClass"_s, {
+            {
+                "int"_s,
+                "outerValue"_s
+            },
+        } },
+        { "Namespace::OtherOuterClass"_s, {
+            {
+                "int"_s,
+                "outerValue"_s
+            },
+        } },
         { "WebCore::SharedStringHash"_s, {
             { "uint32_t"_s, "alias"_s }
         } },
@@ -472,7 +490,7 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             { "int"_s, "alias"_s }
         } },
 #endif
-#if !OS(WINDOWS)
+#if !(OS(WINDOWS))
         { "WTF::ProcessID"_s, {
             { "pid_t"_s, "alias"_s }
         } },
@@ -506,7 +524,7 @@ Vector<SerializedEnumInfo> allSerializedEnums()
 #if ENABLE(OPTION_SET_SECOND_VALUE)
             static_cast<uint64_t>(EnumNamespace2::OptionSetEnumType::OptionSetSecondValue),
 #endif
-#if !ENABLE(OPTION_SET_SECOND_VALUE)
+#if !(ENABLE(OPTION_SET_SECOND_VALUE))
             static_cast<uint64_t>(EnumNamespace2::OptionSetEnumType::OptionSetSecondValueElse),
 #endif
             static_cast<uint64_t>(EnumNamespace2::OptionSetEnumType::OptionSetThirdValue),
@@ -536,6 +554,22 @@ Vector<SerializedEnumInfo> allSerializedEnums()
             static_cast<uint64_t>(OptionSetEnumAllCondition::OptionSetThirdValue),
 #endif
         } },
+#if (ENABLE(OUTER_CONDITION)) && (ENABLE(INNER_CONDITION))
+        { "EnumNamespace::InnerEnumType"_s, sizeof(EnumNamespace::InnerEnumType), false, {
+            static_cast<uint64_t>(EnumNamespace::InnerEnumType::InnerValue),
+#if ENABLE(INNER_INNER_CONDITION)
+            static_cast<uint64_t>(EnumNamespace::InnerEnumType::InnerInnerValue),
+#endif
+#if !(ENABLE(INNER_INNER_CONDITION))
+            static_cast<uint64_t>(EnumNamespace::InnerEnumType::OtherInnerInnerValue),
+#endif
+        } },
+#endif
+#if (ENABLE(OUTER_CONDITION)) && (!(ENABLE(INNER_CONDITION)))
+        { "EnumNamespace::InnerBoolType"_s, sizeof(EnumNamespace::InnerBoolType), false, {
+            0, 1
+        } },
+#endif
     };
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -275,7 +275,6 @@ additional_forward_declaration: typedef struct __CFBar * CFBarRef
     SandboxExtensionHandle callFunction()
 }
 
-
 additional_forward_declaration: namespace IPC { template<typename> class ObjectIdentifierReference; }
 additional_forward_declaration: namespace IPC { template<typename> class ObjectIdentifierWriteReference; }
 additional_forward_declaration: namespace WebKit { using RemoteVideoFrameIdentifier = AtomicObjectIdentifier<RemoteVideoFrameIdentifierType>; }
@@ -291,3 +290,27 @@ header: "RemoteVideoFrameIdentifier.h"
     IPC::ObjectIdentifierReference<WebKit::RemoteVideoFrameIdentifier> reference();
     uint64_t pendingReads();
 };
+
+#if ENABLE(OUTER_CONDITION)
+class Namespace::OuterClass {
+    int outerValue;
+};
+
+#if ENABLE(INNER_CONDITION)
+enum class EnumNamespace::InnerEnumType : uint8_t {
+    InnerValue,
+#if ENABLE(INNER_INNER_CONDITION)
+    InnerInnerValue,
+#else
+    OtherInnerInnerValue,
+#endif
+}
+#else
+enum class EnumNamespace::InnerBoolType : bool
+#endif
+
+#else
+class Namespace::OtherOuterClass {
+    int outerValue;
+};
+#endif


### PR DESCRIPTION
#### 4ad01b4b62e7120bfc5bf78f62b5946884e2743a
<pre>
generate-serializers.py should support nested conditions
<a href="https://bugs.webkit.org/show_bug.cgi?id=268519">https://bugs.webkit.org/show_bug.cgi?id=268519</a>
<a href="https://rdar.apple.com/122056394">rdar://122056394</a>

Reviewed by Brady Eidson and Alex Christensen.

generate-serializers.py does not currently support nested conditions,
not because of a lack of intention, but just because there hasn&apos;t been a
need. However, with the proposed changes for <a href="https://webkit.org/b/267428">https://webkit.org/b/267428</a>,
the watchOS/tvOS/GTK ports fail to compile because several Apple Pay
enablement conditions are being stacked when declaring data types in
WebCoreArgumentCodersCocoa.serialization.in.

This patch addresses the issue by introducing support for nested
conditions in the serializer generation script. It does so by imbibing
the parse_serialized_types method with the concept of a stack of
conditions, pushing to the stack (or negating the top entry) when an IF
or ELSE is seen, respectively, and only popping from the stack when an
ENDIF is seen. The script now keeps an aggregated condition expression
by walking through the condition stack and logically concatenating
conditions.

* Source/WebKit/Scripts/generate-serializers.py:
(ConditionStackEntry):
(ConditionStackEntry.__init__):
(ConditionStackEntry.expression):
(generate_condition_expression):
(parse_serialized_types):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::OuterClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::OuterClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::OtherOuterClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::OtherOuterClass&gt;::decode):
(WTF::isValidOptionSet&lt;EnumNamespace2::OptionSetEnumType&gt;):
(WTF::void&gt;):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
(WebKit::allSerializedEnums):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:

Canonical link: <a href="https://commits.webkit.org/274233@main">https://commits.webkit.org/274233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90ec5f85a7bb30dfed466a39c155eeec84b77c15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40846 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34059 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32301 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14548 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12663 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/38194 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12645 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42124 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34851 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38484 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13225 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36682 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14780 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8627 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13635 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14243 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->