### PR TITLE
updateRelativeLengthsInformation exhibits O(n^2) in SVGElement::insertedIntoAncestor

### DIFF
--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -58,7 +58,7 @@ public:
 
     String title() const override;
     virtual bool supportsMarkers() const { return false; }
-    bool hasRelativeLengths() const { return !m_elementsWithRelativeLengths.isEmptyIgnoringNullReferences(); }
+    bool hasRelativeLengths() const { return m_selfHasRelativeLengths || !m_childElementsWithRelativeLengths.isEmptyIgnoringNullReferences(); }
     virtual bool needsPendingResourceHandling() const { return true; }
     bool instanceUpdatesBlocked() const;
     void setInstanceUpdatesBlocked(bool);
@@ -190,8 +190,8 @@ protected:
     void removedFromAncestor(RemovalType, ContainerNode&) override;
     void childrenChanged(const ChildChange&) override;
     virtual bool selfHasRelativeLengths() const { return false; }
-    void updateRelativeLengthsInformation() { updateRelativeLengthsInformation(selfHasRelativeLengths(), *this); }
-    void updateRelativeLengthsInformation(bool hasRelativeLengths, SVGElement&);
+    void updateRelativeLengthsInformation();
+    void updateRelativeLengthsInformationForChild(bool hasRelativeLengths, SVGElement&);
 
     void willRecalcStyle(Style::Change) override;
 
@@ -209,7 +209,10 @@ private:
 
     std::unique_ptr<SVGElementRareData> m_svgRareData;
 
-    WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData> m_elementsWithRelativeLengths;
+    WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData> m_childElementsWithRelativeLengths;
+    bool m_hasRegisteredWithParentForRelativeLengths { false };
+    bool m_selfHasRelativeLengths { false };
+    bool m_hasInitializedRelativeLengthsState { false };
 
     std::unique_ptr<SVGPropertyAnimatorFactory> m_propertyAnimatorFactory;
 


### PR DESCRIPTION
#### 5a5af81309ac3798f83128299fca8e17bbe9e988
<pre>
updateRelativeLengthsInformation exhibits O(n^2) in SVGElement::insertedIntoAncestor
<a href="https://bugs.webkit.org/show_bug.cgi?id=268522">https://bugs.webkit.org/show_bug.cgi?id=268522</a>

Reviewed by Cameron McCormack.

When SVGElement::updateRelativeLengthsInformation() gets called in SVGElement::insertedIntoAncestor,
it traverses inclusive ancestors to update whether an SVGElement contains a child element or &quot;this&quot;
element which uses relative lengths. Because SVGElement::insertedIntoAncestor gets called on each
descendent of an inserted subtree, this results in O(n^2) behavior.

This PR rectifies this situation by avoiding ancestor traversal when we&apos;ve already registered itself
to the parent. For this, this PR introduces SVGElement::m_hasRegisteredWithParentForRelativeLengths,
which remembers whether the element is registered in parent element&apos;s m_elementsWithRelativeLengths,
which is now renamed to m_childElementsWithRelativeLengths for clarity.

In addition, this PR introduces two more boolean member variables to SVGElement:
m_selfHasRelativeLengths, which is a cache for the selfHasRelativeLengths() virtual function call,
and m_hasInitializedRelativeLengthsState, which is initialized to false and set to true whenever
updateRelativeLengthsInformation is called to update m_selfHasRelativeLengths. When this flag is false,
the next invocation of SVGElement::insertedIntoAncestor will call updateRelativeLengthsInformation(),
which updates m_selfHasRelativeLengths and notifies its ancestor SVG elements.

* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::removedFromAncestor): Remove this element from old parent&apos;s
m_childElementWithRelativeLengths set if this element was removed from the parent.
removedFromAncestor can be called in other scenarios where an ancestor got removed from its parent
and we don&apos;t do anything in those cases as this element&apos;s parent did not change in such cases.
(WebCore::SVGElement::svgAttributeChanged): Set m_hasInitializedRelativeLengthsState to false so
that updateRelativeLengthsInformation() will be called next time this element is inserted to a tree.
(WebCore::SVGElement::insertedIntoAncestor): Call
(WebCore::SVGElement::updateRelativeLengthsInformation): Moved from .h file. Now updates
m_hasInitializedRelativeLengthsState and m_selfHasRelativeLengths before updating flags on this
element&apos;s ancestor SVG elements.
(WebCore::SVGElement::updateRelativeLengthsInformationForChild): Renamed from
updateRelativeLengthsInformation and added a debug assert that second argument&apos;s parent node is
&quot;this&quot; element, or we&apos;re dealing with an element that had been removed from this subtree.

* Source/WebCore/svg/SVGElement.h:
(WebCore::SVGElement::updateRelativeLengthsInformation): Moved to .cpp file.
(WebCore::SVGElement::hasRelativeLengths const):

Canonical link: <a href="https://commits.webkit.org/273936@main">https://commits.webkit.org/273936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2ce36db840d58d9672dae8b5c3fbbe1a3f2ecd6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39631 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33108 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38340 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18506 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13093 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31622 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11740 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11749 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40887 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33563 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33502 "layout-tests (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37646 "Found 1 new test failure: fast/repaint/animation-after-layer-scroll.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35780 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13700 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12430 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4821 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12964 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->