### PR TITLE
Add target for h265_bitstream_parser_fuzzer

### DIFF
--- a/Source/ThirdParty/libwebrtc/Configurations/h265_bitstream_parser_fuzzer.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/h265_bitstream_parser_fuzzer.xcconfig
@@ -1,0 +1,26 @@
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "Base-libwebrtc.xcconfig"
+
+WARNING_CFLAGS = $(inherited) -Wno-shorten-64-to-32;

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_bitstream_parser.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_bitstream_parser.cc
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 
 #include <cstdint>
+#include <limits>
 #include <vector>
 
 #include "common_video/h265/h265_common.h"
@@ -129,6 +130,8 @@ H265BitstreamParser::Result H265BitstreamParser::ParseNonParameterSetNalu(
 
     uint32_t slice_segment_address_bits =
         H265::Log2Ceiling(pic_height_in_ctbs_y * pic_width_in_ctbs_y);
+    TRUE_OR_RETURN(slice_segment_address_bits !=
+                   std::numeric_limits<uint32_t>::max());
     slice_reader.ConsumeBits(slice_segment_address_bits);
   }
 

--- a/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 			dependencies = (
 				4469C10E2B5F24DA00E32E5A /* PBXTargetDependency */,
 				44D88ACE2AF0495A005C956E /* PBXTargetDependency */,
+				44D8D11C2B6AFBCF00B3CF91 /* PBXTargetDependency */,
 				44D88AE32AF04AE4005C956E /* PBXTargetDependency */,
 				449467D32AE05DD200A9FED0 /* PBXTargetDependency */,
 				449467BF2AE05CA800A9FED0 /* PBXTargetDependency */,
@@ -3295,6 +3296,9 @@
 		44D88AD82AF04AA1005C956E /* webrtc_fuzzer_main.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44ABBE952AC64023006B44DD /* webrtc_fuzzer_main.cc */; };
 		44D88ADA2AF04AA1005C956E /* libwebrtc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FB39D0D11200F0E300088E69 /* libwebrtc.dylib */; };
 		44D88AE12AF04AC4005C956E /* h265_depacketizer_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44D88AE02AF04AC3005C956E /* h265_depacketizer_fuzzer.cc */; };
+		44D8D1122B6AFBA900B3CF91 /* webrtc_fuzzer_main.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44ABBE952AC64023006B44DD /* webrtc_fuzzer_main.cc */; };
+		44D8D1142B6AFBA900B3CF91 /* libwebrtc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FB39D0D11200F0E300088E69 /* libwebrtc.dylib */; };
+		44D8D11A2B6AFBC100B3CF91 /* h265_bitstream_parser_fuzzer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44D8D10B2B6AFB9A00B3CF91 /* h265_bitstream_parser_fuzzer.cc */; };
 		44E751672AC738D200828AC4 /* fake_audio_capture_module.cc in Sources */ = {isa = PBXBuildFile; fileRef = 44E7515E2AC738D100828AC4 /* fake_audio_capture_module.cc */; };
 		44E751722AC7396300828AC4 /* fake_audio_capture_module.h in Headers */ = {isa = PBXBuildFile; fileRef = 44E751662AC738D200828AC4 /* fake_audio_capture_module.h */; };
 		44E7517D2AC73B2000828AC4 /* integration_test_helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 44E751742AC73B2000828AC4 /* integration_test_helpers.h */; };
@@ -5522,6 +5526,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 44D88AD12AF04AA1005C956E;
 			remoteInfo = h265_depacketizer_fuzzer;
+		};
+		44D8D10E2B6AFBA900B3CF91 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FB39D0D01200F0E300088E69;
+			remoteInfo = libwebrtc;
+		};
+		44D8D11B2B6AFBCF00B3CF91 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = FB39D0701200ED9200088E69 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 44D8D10C2B6AFBA900B3CF91;
+			remoteInfo = h265_bitstream_parser_fuzzer;
 		};
 		44E7509B2AC726A600828AC4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -9447,6 +9465,9 @@
 		44D88ACF2AF049A1005C956E /* h264_depacketizer_fuzzer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = h264_depacketizer_fuzzer.cc; sourceTree = "<group>"; };
 		44D88ADF2AF04AA1005C956E /* h265_depacketizer_fuzzer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = h265_depacketizer_fuzzer; sourceTree = BUILT_PRODUCTS_DIR; };
 		44D88AE02AF04AC3005C956E /* h265_depacketizer_fuzzer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = h265_depacketizer_fuzzer.cc; sourceTree = "<group>"; };
+		44D8D10B2B6AFB9A00B3CF91 /* h265_bitstream_parser_fuzzer.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = h265_bitstream_parser_fuzzer.cc; sourceTree = "<group>"; };
+		44D8D1192B6AFBA900B3CF91 /* h265_bitstream_parser_fuzzer */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = h265_bitstream_parser_fuzzer; sourceTree = BUILT_PRODUCTS_DIR; };
+		44D8D11D2B6AFBFD00B3CF91 /* h265_bitstream_parser_fuzzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = h265_bitstream_parser_fuzzer.xcconfig; sourceTree = "<group>"; };
 		44E7515E2AC738D100828AC4 /* fake_audio_capture_module.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_audio_capture_module.cc; sourceTree = "<group>"; };
 		44E751662AC738D200828AC4 /* fake_audio_capture_module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_audio_capture_module.h; sourceTree = "<group>"; };
 		44E751742AC73B2000828AC4 /* integration_test_helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = integration_test_helpers.h; sourceTree = "<group>"; };
@@ -11244,6 +11265,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				44D88ADA2AF04AA1005C956E /* libwebrtc.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44D8D1132B6AFBA900B3CF91 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44D8D1142B6AFBA900B3CF91 /* libwebrtc.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -16607,6 +16636,7 @@
 				441380CC2AE06BC200C928CB /* fuzz_data_helper.h */,
 				4469C10F2B5F255500E32E5A /* h264_bitstream_parser_fuzzer.cc */,
 				44D88ACF2AF049A1005C956E /* h264_depacketizer_fuzzer.cc */,
+				44D8D10B2B6AFB9A00B3CF91 /* h265_bitstream_parser_fuzzer.cc */,
 				44D88AE02AF04AC3005C956E /* h265_depacketizer_fuzzer.cc */,
 				449467C02AE05D6B00A9FED0 /* rtp_depacketizer_av1_assemble_frame_fuzzer.cc */,
 				449467D02AE05DBF00A9FED0 /* rtp_packetizer_av1_fuzzer.cc */,
@@ -19874,6 +19904,7 @@
 				5D7C59C71208C68B001C873E /* DebugRelease.xcconfig */,
 				4469C1272B5F2AE900E32E5A /* h264_bitstream_parser_fuzzer.xcconfig */,
 				448A76AD2AF054F400C0A67C /* h264_depacketizer_fuzzer.xcconfig */,
+				44D8D11D2B6AFBFD00B3CF91 /* h265_bitstream_parser_fuzzer.xcconfig */,
 				448A76AE2AF064FE00C0A67C /* h265_depacketizer_fuzzer.xcconfig */,
 				DDF30D0B27C5C01A006A526F /* libabsl.xcconfig */,
 				DDEBB11E24C0189600ADBD44 /* libaom.xcconfig */,
@@ -20392,6 +20423,7 @@
 				4460B8A82B155B2E00392062 /* vp9_depacketizer_fuzzer */,
 				4460B8B72B155B4E00392062 /* vp8_qp_parser_fuzzer */,
 				4460B8C62B155B6A00392062 /* vp9_qp_parser_fuzzer */,
+				44D8D1192B6AFBA900B3CF91 /* h265_bitstream_parser_fuzzer */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -20608,6 +20640,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		44D88AC02AF04946005C956E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44D8D10F2B6AFBA900B3CF91 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -23417,6 +23456,24 @@
 			productReference = 44D88ADF2AF04AA1005C956E /* h265_depacketizer_fuzzer */;
 			productType = "com.apple.product-type.tool";
 		};
+		44D8D10C2B6AFBA900B3CF91 /* h265_bitstream_parser_fuzzer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 44D8D1152B6AFBA900B3CF91 /* Build configuration list for PBXNativeTarget "h265_bitstream_parser_fuzzer" */;
+			buildPhases = (
+				44D8D10F2B6AFBA900B3CF91 /* Headers */,
+				44D8D1102B6AFBA900B3CF91 /* Sources */,
+				44D8D1132B6AFBA900B3CF91 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				44D8D10D2B6AFBA900B3CF91 /* PBXTargetDependency */,
+			);
+			name = h265_bitstream_parser_fuzzer;
+			productName = h265_bitstream_parser_fuzzer;
+			productReference = 44D8D1192B6AFBA900B3CF91 /* h265_bitstream_parser_fuzzer */;
+			productType = "com.apple.product-type.tool";
+		};
 		5C08848B1E4A97E300403995 /* srtp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5C0884CD1E4A97E300403995 /* Build configuration list for PBXNativeTarget "srtp" */;
@@ -23643,6 +23700,7 @@
 				449CF1592ADEDE8500F22CAF /* Fuzzers (libwebrtc) */,
 				4469C0FF2B5F24C500E32E5A /* h264_bitstream_parser_fuzzer */,
 				44D88ABD2AF04946005C956E /* h264_depacketizer_fuzzer */,
+				44D8D10C2B6AFBA900B3CF91 /* h265_bitstream_parser_fuzzer */,
 				44D88AD12AF04AA1005C956E /* h265_depacketizer_fuzzer */,
 				449467C22AE05DA200A9FED0 /* rtp_depacketizer_av1_assemble_frame_fuzzer */,
 				449467A22AE05C9600A9FED0 /* rtp_packetizer_av1_fuzzer */,
@@ -24329,6 +24387,15 @@
 			files = (
 				44D88AE12AF04AC4005C956E /* h265_depacketizer_fuzzer.cc in Sources */,
 				44D88AD82AF04AA1005C956E /* webrtc_fuzzer_main.cc in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44D8D1102B6AFBA900B3CF91 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44D8D11A2B6AFBC100B3CF91 /* h265_bitstream_parser_fuzzer.cc in Sources */,
+				44D8D1122B6AFBA900B3CF91 /* webrtc_fuzzer_main.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -26518,6 +26585,16 @@
 			target = 44D88AD12AF04AA1005C956E /* h265_depacketizer_fuzzer */;
 			targetProxy = 44D88AE22AF04AE4005C956E /* PBXContainerItemProxy */;
 		};
+		44D8D10D2B6AFBA900B3CF91 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FB39D0D01200F0E300088E69 /* libwebrtc */;
+			targetProxy = 44D8D10E2B6AFBA900B3CF91 /* PBXContainerItemProxy */;
+		};
+		44D8D11C2B6AFBCF00B3CF91 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 44D8D10C2B6AFBA900B3CF91 /* h265_bitstream_parser_fuzzer */;
+			targetProxy = 44D8D11B2B6AFBCF00B3CF91 /* PBXContainerItemProxy */;
+		};
 		44E7509C2AC726A600828AC4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = FB39D0D01200F0E300088E69 /* libwebrtc */;
@@ -26956,6 +27033,30 @@
 			};
 			name = Production;
 		};
+		44D8D1162B6AFBA900B3CF91 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44D8D11D2B6AFBFD00B3CF91 /* h265_bitstream_parser_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		44D8D1172B6AFBA900B3CF91 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44D8D11D2B6AFBFD00B3CF91 /* h265_bitstream_parser_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		44D8D1182B6AFBA900B3CF91 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44D8D11D2B6AFBFD00B3CF91 /* h265_bitstream_parser_fuzzer.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Production;
+		};
 		5C0884CE1E4A97E300403995 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5C0884891E4A978C00403995 /* libsrtp.xcconfig */;
@@ -27330,6 +27431,16 @@
 				44D88ADC2AF04AA1005C956E /* Debug */,
 				44D88ADD2AF04AA1005C956E /* Release */,
 				44D88ADE2AF04AA1005C956E /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		44D8D1152B6AFBA900B3CF91 /* Build configuration list for PBXNativeTarget "h265_bitstream_parser_fuzzer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				44D8D1162B6AFBA900B3CF91 /* Debug */,
+				44D8D1172B6AFBA900B3CF91 /* Release */,
+				44D8D1182B6AFBA900B3CF91 /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;


### PR DESCRIPTION
#### 23f0a41a51e3596141076d7d81883edea91e2acb
<pre>
Add target for h265_bitstream_parser_fuzzer
<a href="https://bugs.webkit.org/show_bug.cgi?id=268504">https://bugs.webkit.org/show_bug.cgi?id=268504</a>
&lt;<a href="https://rdar.apple.com/122044505">rdar://122044505</a>&gt;

Reviewed by Youenn Fablet.

Also merge this upstream fuzzer fix:

  h265_bitstream_parser_fuzzer: Unexpected-exit in rtc::webrtc_checks_impl::WriteFatalLog
  &lt;<a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1513102">https://bugs.chromium.org/p/chromium/issues/detail?id=1513102</a>&gt;
  a9ef127f6f0cbf2fe8f293fbc255a8f7b4f8c842

* Source/ThirdParty/libwebrtc/Configurations/h265_bitstream_parser_fuzzer.xcconfig: Add.
* Source/ThirdParty/libwebrtc/Source/webrtc/common_video/h265/h265_bitstream_parser.cc:
- Merge upstream fix.
* Source/ThirdParty/libwebrtc/libwebrtc.xcodeproj/project.pbxproj:
(Fuzzers (libwebrtc)):
- Add h265_bitstream_parser_fuzzer to target dependencies.
(h265_bitstream_parser_fuzzer): Add target.

Canonical link: <a href="https://commits.webkit.org/273908@main">https://commits.webkit.org/273908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1988c6689f10a0930090b81225a2ded6b4b05b6c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39612 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33094 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31612 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32646 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11719 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11734 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/33364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40867 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33545 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37631 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35763 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13686 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12416 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4811 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12950 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->