### PR TITLE
Increase LayoutTestFinder test coverage

### DIFF
--- a/Tools/Scripts/webkitpy/common/system/filesystem.py
+++ b/Tools/Scripts/webkitpy/common/system/filesystem.py
@@ -47,8 +47,9 @@ class FileSystem(object):
 
     Unless otherwise noted, all paths are allowed to be either absolute
     or relative."""
-    sep = os.sep
-    pardir = os.pardir
+    def __init__(self):
+        self.sep = os.sep
+        self.pardir = os.pardir
 
     def abspath(self, path):
         # FIXME: This gross hack is needed while we transition from Cygwin to native Windows, because we
@@ -269,7 +270,7 @@ class FileSystem(object):
     def relpath(self, path, start='.'):
         return os.path.relpath(path, start)
 
-    def remove(self, path, osremove=os.remove):
+    def remove(self, path, osremove=None):
         """On Windows, if a process was recently killed and it held on to a
         file, the OS will hold on to the file for a short while.  This makes
         attempts to delete the file fail.  To work around that, this method
@@ -278,6 +279,9 @@ class FileSystem(object):
             WinOSError = WindowsError
         except NameError:
             WinOSError = OSError
+
+        if osremove is None:
+            osremove = os.remove
 
         retry_timeout_sec = 3.0
         sleep_interval = 0.1

--- a/Tools/Scripts/webkitpy/layout_tests/models/test.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test.py
@@ -41,10 +41,10 @@ class Test(object):
     expected_checksum_path = attr.ib(default=None, type=str)
     expected_audio_path = attr.ib(default=None, type=str)
     reference_files = attr.ib(default=None, type=list)
-    is_http_test = attr.ib(default=None, type=bool)
-    is_websocket_test = attr.ib(default=None, type=bool)
-    is_wpt_test = attr.ib(default=None, type=bool)
-    is_wpt_crash_test = attr.ib(default=None, type=bool)
+    is_http_test = attr.ib(default=False, type=bool)
+    is_websocket_test = attr.ib(default=False, type=bool)
+    is_wpt_test = attr.ib(default=False, type=bool)
+    is_wpt_crash_test = attr.ib(default=False, type=bool)
 
     @property
     def needs_http_server(self):

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -524,7 +524,7 @@ class Port(object):
         text = string_utils.decode(self._filesystem.read_binary_file(baseline_path), target_type=str)
         return text.replace("\r\n", "\n")
 
-    _supported_reference_extensions = set(['.html', '.xml', '.xhtml', '.htm', '.svg', '.xht'])
+    _supported_reference_extensions = ('.html', '.xml', '.xhtml', '.htm', '.svg', '.xht')
 
     def reference_files(self, test_name, device_type=None):
         """Return a list of expectation (== or !=) and filename pairs"""

--- a/Tools/Scripts/webkitpy/port/test.py
+++ b/Tools/Scripts/webkitpy/port/test.py
@@ -107,8 +107,8 @@ class TestList(object):
 #
 # These numbers may need to be updated whenever we add or delete tests.
 #
-TOTAL_TESTS = 84
-TOTAL_SKIPS = 11
+TOTAL_TESTS = 88
+TOTAL_SKIPS = 12
 TOTAL_RETRIES = 13
 
 UNEXPECTED_PASSES = 6
@@ -245,6 +245,10 @@ layer at (0,0) size 800x34
     tests.add('platform/test-mac-leopard/http/test.html')
     tests.add('platform/test-win-7sp0/http/test.html')
 
+    tests.add('overridden/test.html')
+    tests.add('platform/test-mac-leopard/overridden/test.html')
+    tests.add('platform/test-win-7sp0/overridden/test.html')
+
     # For --no-http tests, test that platform specific HTTP tests are properly skipped.
     tests.add('platform/test-snow-leopard/http/test.html')
     tests.add('platform/test-snow-leopard/websocket/test.html')
@@ -269,6 +273,8 @@ layer at (0,0) size 800x34
     tests.add('imported/w3c/web-platform-tests/some/new.html',
         expected_text=None, actual_text='ok', actual_image=None, actual_checksum=None)
     tests.add('imported/w3c/web-platform-tests/some/test-pass-crash.html',
+        expected_text=None, actual_text='some output', actual_image=None, actual_checksum=None, is_wpt_crash_test=True)
+    tests.add('imported/w3c/web-platform-tests/some/test-pass-crash.tentative.html',
         expected_text=None, actual_text='some output', actual_image=None, actual_checksum=None, is_wpt_crash_test=True)
     tests.add('imported/w3c/web-platform-tests/some/test-timeout-crash.html',
         expected_text=None, actual_text=None, actual_image=None, actual_checksum=None, timeout=True, is_wpt_crash_test=True)


### PR DESCRIPTION
#### 24f491ae94894b6c52376c9efb9b76ee817c5a9b
<pre>
Increase LayoutTestFinder test coverage
<a href="https://bugs.webkit.org/show_bug.cgi?id=268524">https://bugs.webkit.org/show_bug.cgi?id=268524</a>

Reviewed by Jonathan Bedard.

As part of bug 220421, rewriting LayoutTestFinder, many new tests have
been written. However, these can stand on their own as a useful increase
in test coverage.

With this, a `with_expectations` argument is added to
LayoutTestFinder.find_tests which fully populates the Test object,
similar to the new implementation. This is not enabled by default as it
is very slow, having to read each directory many times.

This also makes some minor changes to ensure the tests reliably pass, at
least on non-Windows platforms. (Some of the LayoutTestFinder tests
already fail on Windows; these new tests continue to demonstrate
differences, which are almost all bugs in our current implementation.)

* Tools/Scripts/webkitpy/common/system/filesystem.py:
(FileSystem.__init__): Avoid storing os.sep/os.pardir at import time, so that pyfakefs can rewrite them.
(FileSystem.remove): Ditto, but os.remove.
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py:
(LayoutTestFinder.find_tests): Add a with_expectations keyword argument that fully populates the Test object.
(LayoutTestFinder.find_tests_by_path): Ditto.
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy_unittest.py:
(LayoutTestFinderTests.setUp):
(LayoutTestFinderTests.test_supported_test_extensions):
(LayoutTestFinderTests.test_includes_other_platforms_fallback):
(LayoutTestFinderTests.test_find_platform):
(LayoutTestFinderTests.test_find_platform_self):
(LayoutTestFinderTests.test_find_overridden):
(LayoutTestFinderTests):
(LayoutTestFinderTests.test_find_overridden_default):
(LayoutTestFinderTests.test_find_overridden_platform_self):
(LayoutTestFinderTests.test_find_overridden_platform_other):
* Tools/Scripts/webkitpy/layout_tests/models/test.py:
(Test): Fix defaults to be the correct types.
* Tools/Scripts/webkitpy/port/base.py:
(Port): Use a tuple, rather than a set, to give consistent enumeration order over _supported_reference_extensions.
* Tools/Scripts/webkitpy/port/test.py:

Canonical link: <a href="https://commits.webkit.org/273913@main">https://commits.webkit.org/273913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/537a0c8cdafbafbb460474b7e3c92d469910ec60

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37031 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39613 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33095 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31611 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11718 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/37114 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11769 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/32944 "Found 2 new test failures: fast/images/avif-as-image.html, fast/images/avif-heif-container-as-image.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40868 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33588 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37633 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35766 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12417 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4813 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12951 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->