### PR TITLE
Add `::first-line` UA stylesheet rules similar to `::placeholder`

### DIFF
--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -823,6 +823,13 @@ textarea {
     writing-mode: inherit !important;
 }
 
+/* https://drafts.csswg.org/css-pseudo-4/#first-line-styling */
+::first-line {
+    direction: inherit !important;
+    text-orientation: inherit !important;
+    writing-mode: inherit !important;
+}
+
 input::placeholder {
     white-space: pre;
     word-wrap: normal;


### PR DESCRIPTION
<pre>
Add `::first-line` UA stylesheet rules similar to `::placeholder`
<a href="https://bugs.webkit.org/show_bug.cgi?id=268481">https://bugs.webkit.org/show_bug.cgi?id=268481</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Web-Specification [1]:

[1] <a href="https://drafts.csswg.org/css-pseudo-4/#first-line-styling">https://drafts.csswg.org/css-pseudo-4/#first-line-styling</a>

In 254416@main, we added 'user agent' stylesheet rules for `placeholder` based on web-specification
stemming from `first-line` pseudo element that they should apply to `placeholder` but never added
originally for `first-line`. This patch adds them as stated below in web-specification:

> User agents may apply other properties as well except for the following excluded properties:
- writing-mode
- direction
- text-orientation

This leads to two progression of WPT tests in CSS2 directory but since we don't import it in WebKit,
find the test names with directory below:

> css/CSS2/selectors/first-line-inherit-002.xht
> css/CSS2/selectors/first-line-inherit-003.xht

* Source/WebCore/css/html.css:
(::first-line):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a5d7df998f059280a833c6dd99e83a7810c61cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39624 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33101 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38333 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13086 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31617 "Found 102 new test failures: css2.1/20110323/floats-wrap-top-below-bfc-001l.htm, css2.1/20110323/floats-wrap-top-below-bfc-001r.htm, css2.1/20110323/floats-wrap-top-below-bfc-002l.htm, css2.1/20110323/floats-wrap-top-below-bfc-002r.htm, css2.1/20110323/floats-wrap-top-below-bfc-003l.htm, css2.1/20110323/floats-wrap-top-below-bfc-003r.htm, css2.1/20110323/floats-wrap-top-below-inline-002l.htm, css2.1/20110323/floats-wrap-top-below-inline-002r.htm, css2.1/20110323/floats-wrap-top-below-inline-003l.htm, css2.1/20110323/floats-wrap-top-below-inline-003r.htm ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37604 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13451 "Found 60 new test failures: compositing/scrolling/async-overflow-scrolling/toggle-visibility-on-scroller.html, compositing/updates/animation-non-composited.html, css2.1/20110323/floats-wrap-top-below-bfc-001l.htm, css2.1/20110323/floats-wrap-top-below-bfc-001r.htm, css2.1/20110323/floats-wrap-top-below-bfc-002l.htm, css2.1/20110323/floats-wrap-top-below-bfc-002r.htm, css2.1/20110323/floats-wrap-top-below-bfc-003l.htm, css2.1/20110323/floats-wrap-top-below-bfc-003r.htm, css2.1/20110323/floats-wrap-top-below-inline-002l.htm, css2.1/20110323/floats-wrap-top-below-inline-002r.htm ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11725 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11741 "Found 60 new test failures: imported/w3c/web-platform-tests/IndexedDB/idbfactory-open-opaque-origin.html, imported/w3c/web-platform-tests/content-security-policy/worker-src/shared-child.sub.html, imported/w3c/web-platform-tests/content-security-policy/worker-src/shared-fallback.sub.html, imported/w3c/web-platform-tests/content-security-policy/worker-src/shared-list.sub.html, imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-video.html, imported/w3c/web-platform-tests/css/css-backgrounds/linear-gradient-currentcolor-first-line.html, imported/w3c/web-platform-tests/css/css-break/block-in-inline-000.html, imported/w3c/web-platform-tests/css/css-break/block-in-inline-001.html, imported/w3c/web-platform-tests/css/css-break/block-in-inline-002.html, imported/w3c/web-platform-tests/css/css-break/block-in-inline-003.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33089 "Found 60 new test failures: css2.1/20110323/floats-wrap-top-below-bfc-001l.htm, css2.1/20110323/floats-wrap-top-below-bfc-001r.htm, css2.1/20110323/floats-wrap-top-below-bfc-002l.htm, css2.1/20110323/floats-wrap-top-below-bfc-002r.htm, css2.1/20110323/floats-wrap-top-below-bfc-003l.htm, css2.1/20110323/floats-wrap-top-below-bfc-003r.htm, css2.1/20110323/floats-wrap-top-below-inline-002l.htm, css2.1/20110323/floats-wrap-top-below-inline-002r.htm, css2.1/20110323/floats-wrap-top-below-inline-003l.htm, css2.1/20110323/floats-wrap-top-below-inline-003r.htm ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40880 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33554 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33486 "layout-tests (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37638 "Found 119 new test failures: css2.1/20110323/floats-wrap-top-below-bfc-001l.htm, css2.1/20110323/floats-wrap-top-below-bfc-001r.htm, css2.1/20110323/floats-wrap-top-below-bfc-002l.htm, css2.1/20110323/floats-wrap-top-below-bfc-002r.htm, css2.1/20110323/floats-wrap-top-below-bfc-003l.htm, css2.1/20110323/floats-wrap-top-below-bfc-003r.htm, css2.1/20110323/floats-wrap-top-below-inline-002l.htm, css2.1/20110323/floats-wrap-top-below-inline-002r.htm, css2.1/20110323/floats-wrap-top-below-inline-003l.htm, css2.1/20110323/floats-wrap-top-below-inline-003r.htm ... (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12050 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9852 "Found 60 new test failures: compositing/repaint/copy-forward-dirty-region-purged.html, compositing/repaint/copy-forward-dirty-region.html, compositing/updates/animation-non-composited.html, css2.1/20110323/floats-wrap-top-below-bfc-001l.htm, css2.1/20110323/floats-wrap-top-below-bfc-001r.htm, css2.1/20110323/floats-wrap-top-below-bfc-002l.htm, css2.1/20110323/floats-wrap-top-below-bfc-002r.htm, css2.1/20110323/floats-wrap-top-below-bfc-003l.htm, css2.1/20110323/floats-wrap-top-below-bfc-003r.htm, css2.1/20110323/floats-wrap-top-below-inline-002l.htm ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35772 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13693 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12423 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12957 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->