### PR TITLE
Deprecate WKBundlePageFindStringMatches

### DIFF
--- a/LayoutTests/editing/find/cocoa/find-and-replace-adjacent-words.html
+++ b/LayoutTests/editing/find/cocoa/find-and-replace-adjacent-words.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <script src="../../../resources/dump-as-markup.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
 </head>
 <body>
     <div id="editor" contenteditable>appleappleapple</div>
@@ -11,22 +12,30 @@ function reset() {
     editor.textContent = "appleappleapple";
 }
 
+Markup.waitUntilDone();
 Markup.description("Verifies that find and replace can be used to replace adjacent words in an editable area. This test requires WebKitTestRunner.");
 
-testRunner.findStringMatchesInPage("apple", []);
-testRunner.replaceFindMatchesAtIndices([0, 1, 2], "", false);
-Markup.dump("editor", "After replacing 'apple' with an empty string");
+onload = async () => {
+    testRunner.findStringMatchesInPage("apple", []);
+    await UIHelper.ensurePresentationUpdate();
+    testRunner.replaceFindMatchesAtIndices([0, 1, 2], "", false);
+    Markup.dump("editor", "After replacing 'apple' with an empty string");
 
-reset();
+    reset();
 
-testRunner.findStringMatchesInPage("apple", []);
-testRunner.replaceFindMatchesAtIndices([0, 1, 2], "appleapple", false);
-Markup.dump("editor", "After replacing 'apple' with 'appleapple'");
+    testRunner.findStringMatchesInPage("apple", []);
+    await UIHelper.ensurePresentationUpdate();
+    testRunner.replaceFindMatchesAtIndices([0, 1, 2], "appleapple", false);
+    Markup.dump("editor", "After replacing 'apple' with 'appleapple'");
 
-reset();
+    reset();
 
-testRunner.findStringMatchesInPage("apple", []);
-testRunner.replaceFindMatchesAtIndices([0, 1, 2], "APPLE", false);
-Markup.dump("editor", "After replacing 'apple' with 'APPLE'");
+    testRunner.findStringMatchesInPage("apple", []);
+    await UIHelper.ensurePresentationUpdate();
+    testRunner.replaceFindMatchesAtIndices([0, 1, 2], "APPLE", false);
+    Markup.dump("editor", "After replacing 'apple' with 'APPLE'");
+
+    Markup.notifyDone();
+}
 </script>
 </html>

--- a/LayoutTests/editing/find/cocoa/find-and-replace-at-editing-boundary.html
+++ b/LayoutTests/editing/find/cocoa/find-and-replace-at-editing-boundary.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <script src="../../../resources/dump-as-markup.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
 <style>
     p[contenteditable] {
         border: 1px solid red;
@@ -14,9 +15,16 @@
     </div>
 </body>
 <script>
+Markup.waitUntilDone();
 Markup.description("Verifies that find and replace ignores matches that span editing boundaries. This test requires WebKitTestRunner.");
-testRunner.findStringMatchesInPage("apple", []);
-testRunner.replaceFindMatchesAtIndices([0], "pear", false);
-Markup.dump("container", "After replacing 'apple' with 'pear'");
+
+onload = async () => {
+    testRunner.findStringMatchesInPage("apple", []);
+    await UIHelper.ensurePresentationUpdate();
+    testRunner.replaceFindMatchesAtIndices([0], "pear", false);
+    Markup.dump("container", "After replacing 'apple' with 'pear'");
+
+    Markup.notifyDone();
+}
 </script>
 </html>

--- a/LayoutTests/editing/find/cocoa/find-and-replace-basic.html
+++ b/LayoutTests/editing/find/cocoa/find-and-replace-basic.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <script src="../../../resources/dump-as-markup.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
 </head>
 <body>
     <div id="editor" contenteditable>
@@ -10,14 +11,21 @@
     </div>
 </body>
 <script>
+Markup.waitUntilDone();
 Markup.description("Verifies that find and replace can be used to replace words in an editable area. This test requires WebKitTestRunner.");
 
-testRunner.findStringMatchesInPage("orange", []);
-testRunner.replaceFindMatchesAtIndices([0], "apricot", false);
-Markup.dump("editor", "After replacing 'orange' with 'apricot'");
+onload = async () => {
+    testRunner.findStringMatchesInPage("orange", []);
+    await UIHelper.ensurePresentationUpdate();
+    testRunner.replaceFindMatchesAtIndices([0], "apricot", false);
+    Markup.dump("editor", "After replacing 'orange' with 'apricot'");
 
-testRunner.findStringMatchesInPage("banana", []);
-testRunner.replaceFindMatchesAtIndices([0, 1], "watermelon", false);
-Markup.dump("editor", "After replacing 'banana' with 'watermelon'");
+    testRunner.findStringMatchesInPage("banana", []);
+    await UIHelper.ensurePresentationUpdate();
+    testRunner.replaceFindMatchesAtIndices([0, 1], "watermelon", false);
+    Markup.dump("editor", "After replacing 'banana' with 'watermelon'");
+
+    Markup.notifyDone();
+};
 </script>
 </html>

--- a/LayoutTests/editing/find/cocoa/find-and-replace-in-subframes.html
+++ b/LayoutTests/editing/find/cocoa/find-and-replace-in-subframes.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <script src="../../../resources/dump-as-markup.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
 </head>
 <body>
     <div contenteditable id="editor">
@@ -19,12 +20,14 @@
 Markup.waitUntilDone();
 Markup.description("Verifies that find and replace can be used to replace words in different frames on the same page, as well as inside text fields. This test requires WebKitTestRunner.");
 
-addEventListener("load", () => {
+addEventListener("load", async () => {
     testRunner.findStringMatchesInPage("bar", []);
+    await UIHelper.ensurePresentationUpdate();
     testRunner.replaceFindMatchesAtIndices([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], "hello", false);
     Markup.dump("editor", "After replacing 'bar' with 'hello'");
 
     testRunner.findStringMatchesInPage("foo", []);
+    await UIHelper.ensurePresentationUpdate();
     testRunner.replaceFindMatchesAtIndices([0], "world", false);
     Markup.dump("editor", "After replacing the first occurrence of 'foo' with 'world'");
 

--- a/LayoutTests/editing/find/cocoa/find-and-replace-noneditable-matches.html
+++ b/LayoutTests/editing/find/cocoa/find-and-replace-noneditable-matches.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <script src="../../../resources/dump-as-markup.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
 <style>
     *[contenteditable="true"] {
         border: 3px green solid;
@@ -25,9 +26,16 @@
     </div>
 </body>
 <script>
+Markup.waitUntilDone();
 Markup.description("Verifies that find and replace does not change matches in noneditable content. This test requires WebKitTestRunner.");
-testRunner.findStringMatchesInPage("eta", []);
-testRunner.replaceFindMatchesAtIndices([0, 1, 2, 3, 4], "_eta_", false);
-Markup.dump("editor", "After replacing 'eta' with '_eta_'");
+
+onload = async () => {
+    testRunner.findStringMatchesInPage("eta", []);
+    await UIHelper.ensurePresentationUpdate();
+    testRunner.replaceFindMatchesAtIndices([0, 1, 2, 3, 4], "_eta_", false);
+    Markup.dump("editor", "After replacing 'eta' with '_eta_'");
+
+    Markup.notifyDone();
+}
 </script>
 </html>

--- a/LayoutTests/editing/find/cocoa/find-and-replace-replacement-text-input-events.html
+++ b/LayoutTests/editing/find/cocoa/find-and-replace-replacement-text-input-events.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <html>
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+</head>
 <body>
     <p>Verifies that find and replace fires input events of type "insertReplacementText". This test requires WebKitTestRunner.</p>
     <div id="editor" contenteditable>
@@ -35,7 +38,12 @@ field.addEventListener("input", logInputEvent);
 
 if (window.testRunner) {
     testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+onload = async () => {
     testRunner.findStringMatchesInPage("banana", []);
+    await UIHelper.ensurePresentationUpdate();
     testRunner.replaceFindMatchesAtIndices([0, 1, 2], "watermelon", false);
 
     write("---");
@@ -48,6 +56,8 @@ if (window.testRunner) {
     field.focus();
     field.setSelectionRange(0, 0);
     testRunner.replaceFindMatchesAtIndices([], "Guava", false);
+
+    testRunner.notifyDone();
 }
 </script>
 </html>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -495,11 +495,6 @@ bool WKBundlePageFindString(WKBundlePageRef pageRef, WKStringRef target, WKFindO
     return WebKit::toImpl(pageRef)->findStringFromInjectedBundle(WebKit::toWTFString(target), WebKit::toFindOptions(findOptions));
 }
 
-void WKBundlePageFindStringMatches(WKBundlePageRef pageRef, WKStringRef target, WKFindOptions findOptions)
-{
-    WebKit::toImpl(pageRef)->findStringMatchesFromInjectedBundle(WebKit::toWTFString(target), WebKit::toFindOptions(findOptions));
-}
-
 void WKBundlePageReplaceStringMatches(WKBundlePageRef pageRef, WKArrayRef matchIndicesRef, WKStringRef replacementText, bool selectionOnly)
 {
     auto* matchIndices = WebKit::toImpl(matchIndicesRef);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h
@@ -91,7 +91,6 @@ WK_EXPORT bool WKBundlePageHasLocalDataForURL(WKBundlePageRef page, WKURLRef url
 WK_EXPORT bool WKBundlePageCanHandleRequest(WKURLRequestRef request);
 
 WK_EXPORT bool WKBundlePageFindString(WKBundlePageRef page, WKStringRef target, WKFindOptions findOptions);
-WK_EXPORT void WKBundlePageFindStringMatches(WKBundlePageRef page, WKStringRef target, WKFindOptions findOptions);
 WK_EXPORT void WKBundlePageReplaceStringMatches(WKBundlePageRef page, WKArrayRef matchIndices, WKStringRef replacementText, bool selectionOnly);
 
 WK_EXPORT WKImageRef WKBundlePageCreateSnapshotWithOptions(WKBundlePageRef page, WKRect rect, WKSnapshotOptions options);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5324,11 +5324,6 @@ bool WebPage::findStringFromInjectedBundle(const String& target, OptionSet<FindO
     return m_page->findString(target, core(options)).has_value();
 }
 
-void WebPage::findStringMatchesFromInjectedBundle(const String& target, OptionSet<FindOptions> options)
-{
-    findController().findStringMatches(target, options, 0);
-}
-
 void WebPage::replaceStringMatchesFromInjectedBundle(const Vector<uint32_t>& matchIndices, const String& replacementText, bool selectionOnly)
 {
     findController().replaceMatches(matchIndices, replacementText, selectionOnly);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -614,7 +614,6 @@ public:
 #endif
 
     bool findStringFromInjectedBundle(const String&, OptionSet<FindOptions>);
-    void findStringMatchesFromInjectedBundle(const String&, OptionSet<FindOptions>);
     void replaceStringMatchesFromInjectedBundle(const Vector<uint32_t>& matchIndices, const String& replacementText, bool selectionOnly);
 
     void setTextIndicator(const WebCore::TextIndicatorData&);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -351,8 +351,12 @@ bool TestRunner::findString(JSStringRef target, JSValueRef optionsArrayAsValue)
 
 void TestRunner::findStringMatchesInPage(JSStringRef target, JSValueRef optionsArrayAsValue)
 {
-    if (auto options = findOptionsFromArray(optionsArrayAsValue))
-        WKBundlePageFindStringMatches(page(), toWK(target).get(), *options);
+    if (auto options = findOptionsFromArray(optionsArrayAsValue)) {
+        postPageMessage("FindStringMatches", createWKDictionary({
+            { "String", toWK(target) },
+            { "FindOptions", toWK(*options) },
+        }));
+    }
 }
 
 void TestRunner::replaceFindMatchesAtIndices(JSValueRef matchIndicesAsValue, JSStringRef replacementText, bool selectionOnly)

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -890,6 +890,14 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
+    if (WKStringIsEqualToUTF8CString(messageName, "FindStringMatches")) {
+        auto messageBodyDictionary = dictionaryValue(messageBody);
+        auto string = stringValue(messageBodyDictionary, "String");
+        auto findOptions = static_cast<WKFindOptions>(uint64Value(messageBodyDictionary, "FindOptions"));
+        WKPageFindStringMatches(TestController::singleton().mainWebView()->page(), string, findOptions, 0);
+        return;
+    }
+
     ASSERT_NOT_REACHED();
 }
 


### PR DESCRIPTION
#### f8dbeb24802246ee9b34dfac504c27013a215b0b
<pre>
Deprecate WKBundlePageFindStringMatches
<a href="https://bugs.webkit.org/show_bug.cgi?id=268526">https://bugs.webkit.org/show_bug.cgi?id=268526</a>
<a href="https://rdar.apple.com/122063903">rdar://122063903</a>

Reviewed by Alex Christensen.

Also make changes to make WebKitTestRunner to send a message to the UI process to keep existing tests
working.

Layout tests previously using the injected bundle API need to wait for a presentation update because
it will no longer be synchronous.

* LayoutTests/editing/find/cocoa/find-and-replace-adjacent-words.html:
* LayoutTests/editing/find/cocoa/find-and-replace-at-editing-boundary.html:
* LayoutTests/editing/find/cocoa/find-and-replace-basic.html:
* LayoutTests/editing/find/cocoa/find-and-replace-in-subframes.html:
* LayoutTests/editing/find/cocoa/find-and-replace-noneditable-matches.html:
* LayoutTests/editing/find/cocoa/find-and-replace-replacement-text-input-events.html:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageFindStringMatches):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::findStringMatchesFromInjectedBundle): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::findStringMatchesInPage):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/273915@main">https://commits.webkit.org/273915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82af78a8fa9fd8fc7b15d49f91987732ffb1b453

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33139 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31644 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32689 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11773 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11775 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40939 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33600 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37674 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35815 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32694 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12462 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4814 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->