### PR TITLE
[iOS 17.4] Crash in -[WKScrollingNodeScrollViewDelegate actingParentScrollViewForScrollView:]

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h
@@ -30,6 +30,7 @@
 #import <WebCore/ScrollingCoordinator.h>
 #import <WebCore/ScrollingTreeScrollingNode.h>
 #import <WebCore/ScrollingTreeScrollingNodeDelegate.h>
+#import <wtf/WeakPtr.h>
 
 @class CALayer;
 @class UIScrollView;
@@ -49,7 +50,7 @@ class ScrollingTreeScrollingNode;
 
 namespace WebKit {
 
-class ScrollingTreeScrollingNodeDelegateIOS final : public WebCore::ScrollingTreeScrollingNodeDelegate {
+class ScrollingTreeScrollingNodeDelegateIOS final : public WebCore::ScrollingTreeScrollingNodeDelegate, public CanMakeWeakPtr<ScrollingTreeScrollingNodeDelegateIOS> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     
@@ -105,12 +106,12 @@ private:
 } // namespace WebKit
 
 @interface WKScrollingNodeScrollViewDelegate : NSObject <WKBEScrollViewDelegate> {
-    WebKit::ScrollingTreeScrollingNodeDelegateIOS* _scrollingTreeNodeDelegate;
+    WeakPtr<WebKit::ScrollingTreeScrollingNodeDelegateIOS> _scrollingTreeNodeDelegate;
 }
 
 @property (nonatomic, getter=_isInUserInteraction) BOOL inUserInteraction;
 
-- (instancetype)initWithScrollingTreeNodeDelegate:(WebKit::ScrollingTreeScrollingNodeDelegateIOS*)delegate;
+- (instancetype)initWithScrollingTreeNodeDelegate:(WebKit::ScrollingTreeScrollingNodeDelegateIOS&)delegate;
 
 @end
 


### PR DESCRIPTION
#### d29efacb92f373cc441bef208b6705670c800ddc
<pre>
[iOS 17.4] Crash in -[WKScrollingNodeScrollViewDelegate actingParentScrollViewForScrollView:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=268492">https://bugs.webkit.org/show_bug.cgi?id=268492</a>
<a href="https://rdar.apple.com/122041538">rdar://122041538</a>

Reviewed by Tim Horton.

This is a speculative fix for crashes underneath `-actingParentScrollViewForScrollView:`, due to
accessing (what is presumably) an invalid `ScrollingTreeScrollingNodeDelegateIOS` pointer. I wasn&apos;t
able to discover repro steps for this crash; however, from source inspection, it&apos;s unsafe for
`WKScrollingNodeScrollViewDelegate` to hold a raw pointer to `ScrollingTreeScrollingNodeDelegateIOS`,
since the ObjC delegate may outlive its C++ counterpart if anything (in system frameworks like
UIKit, or in WebKit itself) retains or autoreleases the ObjC delegate.

To fix this, we turn the raw `ScrollingTreeScrollingNodeDelegateIOS*` into a `WeakPtr`, and then
bail upon detecting a null `ScrollingTreeScrollingNodeDelegateIOS` delegate in various scroll view
delegate method implementations in `WKScrollingNodeScrollViewDelegate`.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(-[WKScrollingNodeScrollViewDelegate initWithScrollingTreeNodeDelegate:]):

Also, make this initializer take a reference instead of a pointer, to make it clear that this can
only be initialized with a non-null `ScrollingTreeScrollingNodeDelegateIOS`.

(-[WKScrollingNodeScrollViewDelegate scrollViewDidScroll:]):
(-[WKScrollingNodeScrollViewDelegate scrollViewWillBeginDragging:]):
(-[WKScrollingNodeScrollViewDelegate scrollViewWillEndDragging:withVelocity:targetContentOffset:]):
(-[WKScrollingNodeScrollViewDelegate scrollViewDidEndDragging:willDecelerate:]):
(-[WKScrollingNodeScrollViewDelegate scrollViewDidEndDecelerating:]):
(-[WKScrollingNodeScrollViewDelegate scrollViewDidEndScrollingAnimation:]):
(-[WKScrollingNodeScrollViewDelegate cancelPointersForGestureRecognizer:]):
(-[WKScrollingNodeScrollViewDelegate axesToPreventScrollingForPanGestureInScrollView:]):
(-[WKScrollingNodeScrollViewDelegate parentScrollViewForScrollView:]):
(-[WKScrollingNodeScrollViewDelegate scrollView:handleScrollUpdate:completion:]):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren):

Canonical link: <a href="https://commits.webkit.org/273946@main">https://commits.webkit.org/273946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74134812d6c63bcf328de38d7926366bb8918936

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/15957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39628 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33105 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31619 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13523 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32657 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11728 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11785 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40884 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33621 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33490 "layout-tests (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37643 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35776 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13697 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8420 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12427 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/12961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->