### PR TITLE
RemoteDOMWindow::close needs same security checks as LocalDOMWindow::close

### DIFF
--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -382,7 +382,6 @@ imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/loc
 imported/w3c/web-platform-tests/html/browsers/origin/cross-origin-objects/cross-origin-objects-function-caching.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/origin/cross-origin-objects/cross-origin-objects-function-length.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/origin/cross-origin-objects/cross-origin-objects-function-name.html [ Skip ]
-imported/w3c/web-platform-tests/html/browsers/the-window-object/closed-attribute.window.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object/navigated-named-objects.window.html [ Skip ]
 
 ###############################################################################

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -37,6 +37,7 @@ class Document;
 class Frame;
 class LocalDOMWindow;
 class Location;
+class PageConsoleClient;
 class SecurityOrigin;
 class WebCoreOpaqueRoot;
 enum class SetLocationLocking : bool { LockHistoryBasedOnGestureState, LockHistoryAndBackForwardList };
@@ -60,6 +61,12 @@ public:
     virtual void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, SetLocationLocking = SetLocationLocking::LockHistoryBasedOnGestureState) = 0;
 
     bool closed() const;
+    WEBCORE_EXPORT void close();
+    void close(Document&);
+    virtual void closePage() = 0;
+
+    PageConsoleClient* console() const;
+    CheckedPtr<PageConsoleClient> checkedConsole() const;
 
 protected:
     explicit DOMWindow(GlobalWindowIdentifier&&);

--- a/Source/WebCore/page/FrameDestructionObserver.cpp
+++ b/Source/WebCore/page/FrameDestructionObserver.cpp
@@ -39,7 +39,6 @@ FrameDestructionObserver::FrameDestructionObserver(LocalFrame* frame)
 FrameDestructionObserver::~FrameDestructionObserver()
 {
     observeFrame(nullptr);
-
 }
 
 void FrameDestructionObserver::observeFrame(LocalFrame* frame)

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -77,7 +77,6 @@ class Navigator;
 class Node;
 class NodeList;
 class Page;
-class PageConsoleClient;
 class Performance;
 class RequestAnimationFrameCallback;
 class RequestIdleCallback;
@@ -189,8 +188,6 @@ public:
     WEBCORE_EXPORT void focus(bool allowFocus = false);
     void focus(LocalDOMWindow& incumbentWindow);
     void blur();
-    WEBCORE_EXPORT void close();
-    void close(Document&);
     void print();
     void stop();
     bool isStopping() const { return m_isStopping; }
@@ -256,9 +253,6 @@ public:
 
     RefPtr<WebKitPoint> webkitConvertPointFromPageToNode(Node*, const WebKitPoint*) const;
     RefPtr<WebKitPoint> webkitConvertPointFromNodeToPage(Node*, const WebKitPoint*) const;
-
-    PageConsoleClient* console() const;
-    CheckedPtr<PageConsoleClient> checkedConsole() const;
 
     void printErrorMessage(const String&) const;
 
@@ -423,6 +417,7 @@ private:
 
     bool isLocalDOMWindow() const final { return true; }
     bool isRemoteDOMWindow() const final { return false; }
+    void closePage() final;
     void eventListenersDidChange() final;
     void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, SetLocationLocking) final;
 

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -59,22 +59,16 @@ WindowProxy* RemoteDOMWindow::self() const
     return &m_frame->windowProxy();
 }
 
-void RemoteDOMWindow::close(Document&)
+void RemoteDOMWindow::closePage()
 {
-    // FIXME: <rdar://117381050> Add security checks here equivalent to LocalDOMWindow::close (both with and without Document& parameter).
-    // Or refactor to share code.
     if (!m_frame)
         return;
+    m_frame->client().closePage();
+}
 
-    if (!m_frame->isMainFrame())
-        return;
-
-    RefPtr page = m_frame->page();
-    if (!page)
-        return;
-
-    page->setIsClosing();
-    m_frame->client().close();
+void RemoteDOMWindow::frameDetached()
+{
+    m_frame = nullptr;
 }
 
 void RemoteDOMWindow::focus(LocalDOMWindow&)

--- a/Source/WebCore/page/RemoteDOMWindow.h
+++ b/Source/WebCore/page/RemoteDOMWindow.h
@@ -60,7 +60,6 @@ public:
 
     // DOM API exposed cross-origin.
     WindowProxy* self() const;
-    void close(Document&);
     void focus(LocalDOMWindow& incumbentWindow);
     void blur();
     unsigned length() const;
@@ -68,6 +67,7 @@ public:
     WindowProxy* opener() const;
     void setOpener(WindowProxy*);
     WindowProxy* parent() const;
+    void frameDetached();
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, LocalDOMWindow& incumbentWindow, JSC::JSValue message, WindowPostMessageOptions&&);
     ExceptionOr<void> postMessage(JSC::JSGlobalObject& globalObject, LocalDOMWindow& incumbentWindow, JSC::JSValue message, String&& targetOrigin, Vector<JSC::Strong<JSC::JSObject>>&& transfer)
     {
@@ -79,6 +79,7 @@ private:
 
     bool isRemoteDOMWindow() const final { return true; }
     bool isLocalDOMWindow() const final { return false; }
+    void closePage() final;
     void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, SetLocationLocking) final;
 
     WeakPtr<RemoteFrame> m_frame;

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -118,6 +118,7 @@ void RemoteFrame::setView(RefPtr<RemoteFrameView>&& view)
 void RemoteFrame::frameDetached()
 {
     m_client->frameDetached();
+    m_window->frameDetached();
 }
 
 String RemoteFrame::renderTreeAsText(size_t baseIndent, OptionSet<RenderAsTextFlag> behavior)

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -47,7 +47,7 @@ public:
     virtual void changeLocation(FrameLoadRequest&&) = 0;
     virtual String renderTreeAsText(size_t baseIndent, OptionSet<RenderAsTextFlag>) = 0;
     virtual void broadcastFrameRemovalToOtherProcesses() = 0;
-    virtual void close() = 0;
+    virtual void closePage() = 0;
     virtual void focus() = 0;
     virtual void unfocus() = 0;
     virtual ~RemoteFrameClient() { }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13584,17 +13584,6 @@ IPC::ConnectionSendSyncResult<M> WebPageProxy::sendSyncToProcessContainingFrame(
     );
 }
 
-void WebPageProxy::closeRemoteFrame(WebCore::FrameIdentifier frameID)
-{
-    RefPtr destinationFrame = WebFrameProxy::webFrame(frameID);
-    if (!destinationFrame || !destinationFrame->isMainFrame())
-        return;
-
-    ASSERT(destinationFrame->page() == this);
-
-    closePage();
-}
-
 void WebPageProxy::focusRemoteFrame(IPC::Connection& connection, WebCore::FrameIdentifier frameID)
 {
     RefPtr destinationFrame = WebFrameProxy::webFrame(frameID);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2927,7 +2927,6 @@ private:
 
     void broadcastFocusedFrameToOtherProcesses(IPC::Connection&, const WebCore::FrameIdentifier&);
 
-    void closeRemoteFrame(WebCore::FrameIdentifier);
     void focusRemoteFrame(IPC::Connection&, WebCore::FrameIdentifier);
     void postMessageToRemote(WebCore::FrameIdentifier source, const String& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, const WebCore::MessageWithMessagePorts&);
     void renderTreeAsText(WebCore::FrameIdentifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>, CompletionHandler<void(String&&)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -627,7 +627,6 @@ messages -> WebPageProxy {
 
     DispatchLoadEventToFrameOwnerElement(WebCore::FrameIdentifier frameID)
 
-    CloseRemoteFrame(WebCore::FrameIdentifier frameID)
     FocusRemoteFrame(WebCore::FrameIdentifier frameID)
     PostMessageToRemote(WebCore::FrameIdentifier source, String sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, struct WebCore::MessageWithMessagePorts message)
     RenderTreeAsText(WebCore::FrameIdentifier identifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior) -> (String renderTreeDump) Synchronous

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -101,11 +101,10 @@ void WebRemoteFrameClient::broadcastFrameRemovalToOtherProcesses()
     WebFrameLoaderClient::broadcastFrameRemovalToOtherProcesses();
 }
 
-void WebRemoteFrameClient::close()
+void WebRemoteFrameClient::closePage()
 {
-    // FIXME: <rdar://117381050> Consider if this needs the same logic as WebChromeClient::closeWindow, or refactor to share code.
     if (auto* page = m_frame->page())
-        page->send(Messages::WebPageProxy::CloseRemoteFrame(m_frame->frameID()));
+        page->sendClose();
 }
 
 void WebRemoteFrameClient::focus()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -49,7 +49,7 @@ private:
     void changeLocation(WebCore::FrameLoadRequest&&) final;
     String renderTreeAsText(size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>) final;
     void broadcastFrameRemovalToOtherProcesses() final;
-    void close() final;
+    void closePage() final;
     void focus() final;
     void unfocus() final;
     void dispatchDecidePolicyForNavigationAction(const WebCore::NavigationAction&, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& redirectResponse, WebCore::FormState*, const String& clientRedirectSourceForHistory, uint64_t navigationID, std::optional<WebCore::HitTestResult>&&, bool hasOpener, WebCore::SandboxFlags, WebCore::PolicyDecisionMode, WebCore::FramePolicyFunction&&) final;


### PR DESCRIPTION
#### 58b0fdf84a3249ec5964ceb9fddf236f2c99b01c
<pre>
RemoteDOMWindow::close needs same security checks as LocalDOMWindow::close
<a href="https://bugs.webkit.org/show_bug.cgi?id=268530">https://bugs.webkit.org/show_bug.cgi?id=268530</a>
<a href="https://rdar.apple.com/117381050">rdar://117381050</a>

Reviewed by Charlie Wolfe.

I moved the checks to DOMWindow and shared them.

I added RemoteDOMWindow::frameDetached so that frame.remove() followed immediately by
frame.contentWindow.closed returns true with a RemoteDOMWindow like it does a LocalDOMWindow
because the frame gets detached.

WebPageProxy::closeRemoteFrame isn&apos;t really needed any more because we already have
checks that the close() call is only coming from a main frame, so it is closing the page.
Just call WebPage::closePage to close the page without having an unneeded code path.

* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::close):
(WebCore::DOMWindow::console const):
(WebCore::DOMWindow::checkedConsole const):
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/FrameDestructionObserver.cpp:
(WebCore::FrameDestructionObserver::~FrameDestructionObserver):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::closePage):
(WebCore::LocalDOMWindow::console const): Deleted.
(WebCore::LocalDOMWindow::checkedConsole const): Deleted.
(WebCore::LocalDOMWindow::close): Deleted.
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::closePage):
(WebCore::RemoteDOMWindow::frameDetached):
(WebCore::RemoteDOMWindow::close): Deleted.
* Source/WebCore/page/RemoteDOMWindow.h:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::frameDetached):
* Source/WebCore/page/RemoteFrameClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::closeRemoteFrame): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::closePage):
(WebKit::WebRemoteFrameClient::close): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h:

Canonical link: <a href="https://commits.webkit.org/273911@main">https://commits.webkit.org/273911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13cfe0f55e4f1de8bca6d507b6a1a18c06b39690

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39743 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13215 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13569 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11812 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/33355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41000 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33664 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12142 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35866 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12498 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4812 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->