### PR TITLE
REGRESSION(ExtensionKit): Video stops playing on mlb.com when entering PiP

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -511,6 +511,7 @@ UIProcess/ios/WKTextSelectionRect.mm
 UIProcess/ios/WKUSDPreviewView.mm
 UIProcess/ios/WKVelocityTrackingScrollView.mm
 UIProcess/ios/WKVideoView.mm
+UIProcess/ios/WKVisibilityPropagationView.mm
 UIProcess/ios/WKWebEvent.mm
 UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
 

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -80,6 +80,7 @@ OBJC_CLASS NSSet;
 OBJC_CLASS NSTextAlternatives;
 OBJC_CLASS UIGestureRecognizer;
 OBJC_CLASS UIScrollView;
+OBJC_CLASS UIView;
 OBJC_CLASS WKBaseScrollView;
 OBJC_CLASS WKBEScrollViewScrollUpdate;
 OBJC_CLASS _WKRemoteObjectRegistry;
@@ -371,7 +372,10 @@ public:
 #if ENABLE(GPU_PROCESS)
     virtual void didCreateContextInGPUProcessForVisibilityPropagation(LayerHostingContextID) { }
 #endif
+#if USE(EXTENSIONKIT)
+    virtual UIView *createVisibilityPropagationView() { return nullptr; }
 #endif
+#endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 #if ENABLE(GPU_PROCESS)
     virtual void gpuProcessDidFinishLaunching() { }

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -82,6 +82,9 @@ private:
 #if ENABLE(GPU_PROCESS)
     void didCreateContextInGPUProcessForVisibilityPropagation(LayerHostingContextID) override;
 #endif // ENABLE(GPU_PROCESS)
+#if USE(EXTENSIONKIT)
+    UIView *createVisibilityPropagationView() override;
+#endif
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -51,6 +51,7 @@
 #import "WKGeolocationProviderIOS.h"
 #import "WKPasswordView.h"
 #import "WKProcessPoolInternal.h"
+#import "WKVisibilityPropagationView.h"
 #import "WKWebViewConfigurationInternal.h"
 #import "WKWebViewContentProviderRegistry.h"
 #import "WKWebViewIOS.h"
@@ -229,6 +230,13 @@ void PageClientImpl::didCreateContextInGPUProcessForVisibilityPropagation(LayerH
     [contentView() _gpuProcessDidCreateContextForVisibilityPropagation];
 }
 #endif // ENABLE(GPU_PROCESS)
+
+#if USE(EXTENSIONKIT)
+UIView *PageClientImpl::createVisibilityPropagationView()
+{
+    return [contentView() _createVisibilityPropagationView];
+}
+#endif
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/ios/WKContentView.h
+++ b/Source/WebKit/UIProcess/ios/WKContentView.h
@@ -108,6 +108,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if ENABLE(GPU_PROCESS)
 - (void)_gpuProcessDidCreateContextForVisibilityPropagation;
 #endif // ENABLE(GPU_PROCESS)
+#if USE(EXTENSIONKIT)
+- (UIView *)_createVisibilityPropagationView;
+#endif
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
 - (void)_setAcceleratedCompositingRootView:(UIView *)rootView;

--- a/Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.h
+++ b/Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if HAVE(VISIBILITY_PROPAGATION_VIEW) && USE(EXTENSIONKIT)
+
+#import <UIKit/UIKit.h>
+
+namespace WebKit {
+class AuxiliaryProcessProxy;
+}
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKVisibilityPropagationView : UIView
+
+- (void)propagateVisibilityToProcess:(WebKit::AuxiliaryProcessProxy&)process;
+- (void)stopPropagatingVisibilityToProcess:(WebKit::AuxiliaryProcessProxy&)process;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // HAVE(VISIBILITY_PROPAGATION_VIEW) && USE(EXTENSIONKIT)

--- a/Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.mm
+++ b/Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.mm
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKVisibilityPropagationView.h"
+
+#if HAVE(VISIBILITY_PROPAGATION_VIEW) && USE(EXTENSIONKIT)
+
+#import "AuxiliaryProcessProxy.h"
+#import "ExtensionKitSPI.h"
+#import "Logging.h"
+#import <wtf/RetainPtr.h>
+#import <wtf/WeakPtr.h>
+
+namespace WebKit {
+using ProcessAndInteractionPair = std::pair<WeakPtr<AuxiliaryProcessProxy>, RetainPtr<id<UIInteraction>>>;
+}
+
+@implementation WKVisibilityPropagationView {
+    Vector<WebKit::ProcessAndInteractionPair> _processesAndInteractions;
+}
+
+- (void)propagateVisibilityToProcess:(WebKit::AuxiliaryProcessProxy&)process
+{
+    if ([self _containsInteractionForProcess:process])
+        return;
+
+    RetainPtr extensionProcess = process.extensionProcess();
+    SEL selector = NSSelectorFromString(@"createVisibilityPropagationInteraction");
+    if (![extensionProcess respondsToSelector:selector])
+        return;
+
+    id<UIInteraction> visibilityPropagationInteraction = [extensionProcess performSelector:selector];
+    if (!visibilityPropagationInteraction)
+        return;
+
+    [self addInteraction:visibilityPropagationInteraction];
+
+    RELEASE_LOG(Process, "Created visibility propagation interaction %p for process with PID=%d", visibilityPropagationInteraction, process.processID());
+
+    auto processAndInteraction = std::make_pair(WeakPtr(process), visibilityPropagationInteraction);
+    _processesAndInteractions.append(WTFMove(processAndInteraction));
+}
+
+- (void)stopPropagatingVisibilityToProcess:(WebKit::AuxiliaryProcessProxy&)process
+{
+    _processesAndInteractions.removeAllMatching([&](auto& processAndInteraction) {
+        auto existingProcess = processAndInteraction.first.get();
+        if (existingProcess && existingProcess != &process)
+            return false;
+
+        RELEASE_LOG(Process, "Removing visibility propagation interaction %p", processAndInteraction.second.get());
+
+        [self removeInteraction:processAndInteraction.second.get()];
+        return true;
+    });
+}
+
+- (BOOL)_containsInteractionForProcess:(WebKit::AuxiliaryProcessProxy&)process
+{
+    return _processesAndInteractions.containsIf([&](auto& processAndInteraction) {
+        return processAndInteraction.first.get() == &process;
+    });
+}
+
+@end
+
+#endif // HAVE(VISIBILITY_PROPAGATION_VIEW) && USE(EXTENSIONKIT)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -109,6 +109,7 @@
 #import <WebCore/PlatformScreen.h>
 #import <WebCore/PlaybackSessionInterfaceMac.h>
 #import <WebCore/PromisedAttachmentInfo.h>
+#import <WebCore/ShareableBitmap.h>
 #import <WebCore/TextAlternativeWithRange.h>
 #import <WebCore/TextRecognitionResult.h>
 #import <WebCore/TextUndoInsertionMarkupMac.h>
@@ -1125,6 +1126,8 @@ static void* imageOverlayObservationContext = &imageOverlayObservationContext;
 #endif // ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
 
 namespace WebKit {
+
+using namespace WebCore;
 
 static NSTrackingAreaOptions trackingAreaOptions()
 {

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1883,6 +1883,7 @@
 		A181A79821ACC74B0059A316 /* WebKitAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = A181A79721ACAC610059A316 /* WebKitAdditions.mm */; };
 		A182D5B51BE6BD250087A7CC /* AccessibilityIOS.h in Headers */ = {isa = PBXBuildFile; fileRef = A182D5B31BE6BD250087A7CC /* AccessibilityIOS.h */; };
 		A183494224EF467800BDC9A8 /* SharedBufferReference.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CC5DB9121488E16006CB8A8 /* SharedBufferReference.h */; };
+		A188D2E52B6B0F4E00E65A08 /* WKVisibilityPropagationView.h in Headers */ = {isa = PBXBuildFile; fileRef = A188D2E22B6B0F4E00E65A08 /* WKVisibilityPropagationView.h */; };
 		A19DD3C01D07D16800AC823B /* _WKWebViewPrintFormatterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = A19DD3BF1D07D16800AC823B /* _WKWebViewPrintFormatterInternal.h */; };
 		A1A4FE5A18DCE9FA00B5EA8A /* _WKDownload.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A4FE5718DCE9FA00B5EA8A /* _WKDownload.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1A4FE5C18DCE9FA00B5EA8A /* _WKDownloadInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A4FE5918DCE9FA00B5EA8A /* _WKDownloadInternal.h */; };
@@ -6829,6 +6830,8 @@
 		A181A79721ACAC610059A316 /* WebKitAdditions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebKitAdditions.mm; sourceTree = "<group>"; };
 		A182D5B21BE6BD250087A7CC /* AccessibilityIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AccessibilityIOS.mm; sourceTree = "<group>"; };
 		A182D5B31BE6BD250087A7CC /* AccessibilityIOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccessibilityIOS.h; sourceTree = "<group>"; };
+		A188D2E22B6B0F4E00E65A08 /* WKVisibilityPropagationView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKVisibilityPropagationView.h; path = ios/WKVisibilityPropagationView.h; sourceTree = "<group>"; };
+		A188D2E32B6B0F4E00E65A08 /* WKVisibilityPropagationView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKVisibilityPropagationView.mm; path = ios/WKVisibilityPropagationView.mm; sourceTree = "<group>"; };
 		A19DD3BF1D07D16800AC823B /* _WKWebViewPrintFormatterInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebViewPrintFormatterInternal.h; sourceTree = "<group>"; };
 		A1A4FE5718DCE9FA00B5EA8A /* _WKDownload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKDownload.h; sourceTree = "<group>"; };
 		A1A4FE5818DCE9FA00B5EA8A /* _WKDownload.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKDownload.mm; sourceTree = "<group>"; };
@@ -10655,6 +10658,8 @@
 				F4DD79EF2AD59BA6000C6821 /* WKVelocityTrackingScrollView.mm */,
 				CDB96AD32AB379C9007A90D3 /* WKVideoView.h */,
 				CDB96AD42AB379CA007A90D3 /* WKVideoView.mm */,
+				A188D2E22B6B0F4E00E65A08 /* WKVisibilityPropagationView.h */,
+				A188D2E32B6B0F4E00E65A08 /* WKVisibilityPropagationView.mm */,
 				2D1E8221216FFF5000A15265 /* WKWebEvent.h */,
 				2D1E8222216FFF5100A15265 /* WKWebEvent.mm */,
 				463010012984778C00715DB1 /* WKWebGeolocationPolicyDecider.h */,
@@ -16860,6 +16865,7 @@
 				BC8699B7116AADAA002A925B /* WKViewInternal.h in Headers */,
 				2D28A4971AF965A100F190C9 /* WKViewLayoutStrategy.h in Headers */,
 				BFA6179F12F0B99D0033E0CA /* WKViewPrivate.h in Headers */,
+				A188D2E52B6B0F4E00E65A08 /* WKVisibilityPropagationView.h in Headers */,
 				5136E516236A62110074FD5D /* WKWebArchive.h in Headers */,
 				5136E514236A60DC0074FD5D /* WKWebArchiveRef.h in Headers */,
 				C5E1AFEB16B20B7E006CC1F2 /* WKWebArchiveResource.h in Headers */,


### PR DESCRIPTION
#### 7223f04262f101f416e31198f62ca743ea803cdc
<pre>
REGRESSION(ExtensionKit): Video stops playing on mlb.com when entering PiP
<a href="https://bugs.webkit.org/show_bug.cgi?id=268532">https://bugs.webkit.org/show_bug.cgi?id=268532</a>
<a href="https://rdar.apple.com/121120961">rdar://121120961</a>

Reviewed by Per Arne Vollan.

Prior to managing WebKit auxiliary processes as extensions and enabling media capability grants,
the iOS media system tracked the visibility of the WebKit host process by observing the foreground
status of the app whose PID WebKit provided to AVSystemController via the
AVSystemController_PIDToInheritAppStateFrom SPI. When a PiP window is visible on screen then the
associated app and its WebContent and GPU processes are considered in the foreground and media
playback is allowed by the system.

Once WebKit started managing auxiliary processes as extensions we stopped using AVSystemController
SPIs and relied instead on BrowserEngineKit visibility propagation interactions to propagate
visibility from the host app to the WebContent and GPU extensions. Visibility propagation
interactions were installed on the WKContentView, and so long as the content view was in a visible
scene then the WebContent and GPU extensions would be considered visible by the media system.
However, the PiP window is in a different scene and may be visible at times when the
WKContentView&apos;s scene isn&apos;t. In these cases the WebContent and GPU extensions would not be
considered visible, preventing media playback from continuing in the PiP window while the host app
is in the backround.

Resolved this by encapsulating the logic for creating visibility propagation interactions into a
new UIView subclass (WKVisibilityPropagationView) that is added as a subview of WKContentViews and
WKLayerHostViews (the latter only when in a fullscreen or PiP presentation mode). This ensures that
WebContent and GPU extensions are considered visible whenever either of these views are in a visible
scene. WKContentView keeps a weak set of all WKVisibilityPropagationViews and is responsible for
creating and removing visibility propagation interactions as auxiliary processes launch and exit.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(-[WKLayerHostView visibilityPropagationView]):
(-[WKLayerHostView setVisibilityPropagationView:]):
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
(WebKit::VideoPresentationManagerProxy::didCleanupFullscreen):
(WebKit::VideoPresentationManagerProxy::setVideoLayerFrame):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::createVisibilityPropagationView):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::createVisibilityPropagationView):
* Source/WebKit/UIProcess/ios/WKContentView.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _commonInitializationWithProcessPool:configuration:]):
(-[WKContentView _installVisibilityPropagationViews]):
(-[WKContentView _setupVisibilityPropagationForWebProcess]):
(-[WKContentView _setupVisibilityPropagationForGPUProcess]):
(-[WKContentView _removeVisibilityPropagationViewForWebProcess]):
(-[WKContentView _removeVisibilityPropagationViewForGPUProcess]):
(-[WKContentView _didRelaunchProcess]):
(-[WKContentView _webProcessDidCreateContextForVisibilityPropagation]):
(-[WKContentView _gpuProcessDidCreateContextForVisibilityPropagation]):
(-[WKContentView _createVisibilityPropagationView]):
(-[WKContentView _setupVisibilityPropagationViewForWebProcess]): Deleted.
(-[WKContentView _setupVisibilityPropagationViewForGPUProcess]): Deleted.
* Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.h: Added.
* Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.mm: Added.
(-[WKVisibilityPropagationView propagateVisibilityToProcess:]):
(-[WKVisibilityPropagationView stopPropagatingVisibilityToProcess:]):
(-[WKVisibilityPropagationView _containsInteractionForProcess:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/274037@main">https://commits.webkit.org/274037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d463caf20fb21aa361526911fedc156b62bc197

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40191 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33515 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13702 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38221 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13912 "Found 1 new test failure: media/video-ended-does-not-hold-sleep-assertion.html (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12091 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41450 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34009 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37986 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12679 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36155 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8472 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13079 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->