### PR TITLE
Deadlock under ~PluginView() with PDFPlugin.

### DIFF
--- a/LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction-expected.txt
+++ b/LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not timeout.
+
+

--- a/LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction.html
+++ b/LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction.html
@@ -1,0 +1,17 @@
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+  onload = async () => {
+    let iframe0 = document.createElement('iframe');
+    iframe0.src = 'data:application/pdf,x';
+    document.body.append(iframe0);
+
+    await caches.has('a');
+    await caches.has('a');
+
+    $vm.print('before');
+    iframe0.remove();
+    $vm.print('after');
+  };
+</script>
+<p>This test passes if it does not timeout.</p>

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
@@ -31,6 +31,7 @@
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Threading.h>
+#include <wtf/threads/BinarySemaphore.h>
 
 OBJC_CLASS PDFDocument;
 
@@ -118,6 +119,7 @@ private:
 
     RetainPtr<PDFDocument> m_backgroundThreadDocument;
     RefPtr<Thread> m_pdfThread;
+    BinarySemaphore m_dataSemaphore;
 
     Ref<PDFPluginStreamLoaderClient> m_streamLoaderClient;
 


### PR DESCRIPTION
#### 89a06fec3aed7311462e7614afa571d3babf4aef
<pre>
Deadlock under ~PluginView() with PDFPlugin.
<a href="https://rdar.apple.com/108489643">rdar://108489643</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=268536">https://bugs.webkit.org/show_bug.cgi?id=268536</a>

Reviewed by Simon Fraser.

dataProviderGetBytesAtPosition might be invoked recursively from CG, and it highly increased the possiblity when the main runloop is destructing the PDFPlugin,
while the another main runloop is dispatched from dataProviderGetBytesAtPosition and does not get chance to signal semaphore as it is waiting current runloop to finish,
that causes deadlock. This change is to stop dispatch main runloop when document finshed loading and signal the semaphore before main thread calling waitForCompletion for m_pdfThread.

* LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction-expected.txt: Added.
* LayoutTests/compositing/plugins/pdf/pdf-plugin-hang-during-destruction.html: Added.
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::PDFIncrementalLoader::clear):
(WebKit::PDFIncrementalLoader::dataProviderGetBytesAtPosition):

Canonical link: <a href="https://commits.webkit.org/273988@main">https://commits.webkit.org/273988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d446096aa0d34b59d9ac481a3e040b520e8feda

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39692 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33145 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31648 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11777 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40948 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33608 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37678 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35819 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13737 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32695 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12468 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4861 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->