### PR TITLE
WebCodecs AV1 codec string validation is buggy

### DIFF
--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
@@ -167,10 +167,11 @@ static bool validateCodecString(VideoCodecType codecType, const String& codecStr
         ASSERT(codecString.startsWith("vp09.0"_s));
         return true;
     case VideoCodecType::AV1:
-        if (codecString.startsWith("av01."_s) && codecString.length() > 7)
+        ASSERT(codecString.startsWith("av01."_s));
+        if (!codecString.startsWith("av01."_s) || codecString.length() < 7)
             return false;
         auto profile = codecString[5];
-        return profile == '0' || profile == '1' || profile == '2';
+        return (profile == '0' || profile == '1' || profile == '2') && codecString[6] == '.';
     }
     ASSERT_NOT_REACHED();
     return true;


### PR DESCRIPTION
#### f3073fb3636d3912a7ab1d50200191ac1e570e8f
<pre>
WebCodecs AV1 codec string validation is buggy
<a href="https://rdar.apple.com/122084515">rdar://122084515</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=268538">https://bugs.webkit.org/show_bug.cgi?id=268538</a>

Reviewed by Eric Carlson.

We just validate the profile so just need to ensure it is there.
We fix the length check and add a &apos;.&apos; check.

Covered by AV1 test running on devices with AV1 decoders.

* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::validateCodecString):

Canonical link: <a href="https://commits.webkit.org/274089@main">https://commits.webkit.org/274089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12ec936c78474253b44d986e9ec81128e9d2989d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39705 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33150 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31652 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32703 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11787 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11868 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40961 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33750 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33816 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37692 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35833 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13742 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8498 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12473 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->