### PR TITLE
Use dynamicDowncast<> for ScriptElement

### DIFF
--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -613,11 +613,11 @@ bool isScriptElement(Element& element)
     return is<HTMLScriptElement>(element) || is<SVGScriptElement>(element);
 }
 
-ScriptElement& downcastScriptElement(Element& element)
+ScriptElement* dynamicDowncastScriptElement(Element& element)
 {
     if (auto* htmlElement = dynamicDowncast<HTMLScriptElement>(element))
-        return *htmlElement;
-    return downcast<SVGScriptElement>(element);
+        return htmlElement;
+    return dynamicDowncast<SVGScriptElement>(element);
 }
 
 }

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -155,6 +155,6 @@ private:
 
 // FIXME: replace with is/downcast<ScriptElement>.
 bool isScriptElement(Element&);
-ScriptElement& downcastScriptElement(Element&);
+ScriptElement* dynamicDowncastScriptElement(Element&);
 
 }


### PR DESCRIPTION
#### 4fe554a8d9ac7bb8c6d2c754ccd252c535d0335f
<pre>
Use dynamicDowncast&lt;&gt; for ScriptElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=268540">https://bugs.webkit.org/show_bug.cgi?id=268540</a>

Reviewed by Chris Dumez.

* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::dynamicDowncastScriptElement):
(WebCore::downcastScriptElement): Deleted.
* Source/WebCore/dom/ScriptElement.h:
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::endElementNs):

Remove an obsolete FIXME while here.

Canonical link: <a href="https://commits.webkit.org/273917@main">https://commits.webkit.org/273917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93b1ab26bb15cdbf5ccb6ceb922a5f6190d97790

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39709 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33152 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31655 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11790 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/40965 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33631 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/33785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37699 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35840 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13744 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8399 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12475 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13008 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->