### PR TITLE
Generate Serialization for ObjectIdentifierReadReference

### DIFF
--- a/Source/WebKit/Platform/IPC/ObjectIdentifierReference.serialization.in
+++ b/Source/WebKit/Platform/IPC/ObjectIdentifierReference.serialization.in
@@ -23,6 +23,7 @@
 
 additional_forward_declaration: namespace IPC { template<typename> class ObjectIdentifierReference; }
 additional_forward_declaration: namespace IPC { template<typename> class ObjectIdentifierWriteReference; }
+additional_forward_declaration: namespace IPC { template<typename> struct ObjectIdentifierReadReference; }
 additional_forward_declaration: namespace WebCore { using RenderingResourceIdentifier = AtomicObjectIdentifier<RenderingResourceIdentifierType>; }
 additional_forward_declaration: namespace WebKit { using RemoteVideoFrameIdentifier = AtomicObjectIdentifier<RemoteVideoFrameIdentifierType>; }
 additional_forward_declaration: namespace WebKit { using RemoteSerializedImageBufferIdentifier = WebCore::RenderingResourceIdentifier; }
@@ -40,6 +41,11 @@ header: "RemoteVideoFrameIdentifier.h"
     uint64_t pendingReads();
 };
 
+header: "RemoteVideoFrameIdentifier.h"
+[Alias=class IPC::ObjectIdentifierReadReference<RemoteVideoFrameIdentifier>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias WebKit::RemoteVideoFrameReadReference {
+    IPC::ObjectIdentifierReference<WebKit::RemoteVideoFrameIdentifier> reference();
+};
+
 header: "RemoteSerializedImageBufferIdentifier.h"
 [Alias=class IPC::ObjectIdentifierReference<RemoteSerializedImageBufferIdentifier>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias WebKit::RemoteSerializedImageBufferReference {
     WebKit::RemoteSerializedImageBufferIdentifier identifier();
@@ -52,6 +58,11 @@ header: "RemoteSerializedImageBufferIdentifier.h"
     uint64_t pendingReads();
 };
 
+header: "RemoteSerializedImageBufferIdentifier.h"
+[Alias=class IPC::ObjectIdentifierReadReference<RemoteSerializedImageBufferIdentifier>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias WebKit::RemoteSerializedImageBufferReadReference {
+    IPC::ObjectIdentifierReference<WebKit::RemoteSerializedImageBufferIdentifier> reference();
+};
+
 header: "ThreadSafeObjectHeap.h"
 [Alias=class IPC::ObjectIdentifierReference<TestedObjectIdentifier>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias TestWebKitAPI::TestedObjectReference {
     TestWebKitAPI::TestedObjectIdentifier identifier();
@@ -62,4 +73,9 @@ header: "ThreadSafeObjectHeap.h"
 [Alias=class IPC::ObjectIdentifierWriteReference<TestedObjectIdentifier>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias TestWebKitAPI::TestedObjectWriteReference {
     IPC::ObjectIdentifierReference<TestWebKitAPI::TestedObjectIdentifier> reference();
     uint64_t pendingReads();
+};
+
+header: "ThreadSafeObjectHeap.h"
+[Alias=class IPC::ObjectIdentifierReadReference<TestedObjectIdentifier>, AdditionalEncoder=StreamConnectionEncoder, CustomHeader] alias TestWebKitAPI::TestedObjectReadReference {
+    IPC::ObjectIdentifierReference<TestWebKitAPI::TestedObjectIdentifier> reference();
 };

--- a/Source/WebKit/Platform/IPC/ObjectIdentifierReferenceTracker.h
+++ b/Source/WebKit/Platform/IPC/ObjectIdentifierReferenceTracker.h
@@ -77,19 +77,6 @@ public:
     uint64_t version() const { return m_reference.version(); }
     Reference reference() const { return m_reference; }
 
-    template<typename Encoder> void encode(Encoder& encoder) const
-    {
-        encoder << m_reference;
-    }
-    template<typename Decoder> static std::optional<ObjectIdentifierReadReference> decode(Decoder& decoder)
-    {
-        std::optional<Reference> reference;
-        decoder >> reference;
-        if (!decoder.isValid())
-            return std::nullopt;
-        return ObjectIdentifierReadReference { WTFMove(*reference) };
-    }
-
 private:
     Reference m_reference;
 };


### PR DESCRIPTION
#### 29eeaffe3de46d4c072decbcacb10f99ffffb925
<pre>
Generate Serialization for ObjectIdentifierReadReference
<a href="https://bugs.webkit.org/show_bug.cgi?id=268546">https://bugs.webkit.org/show_bug.cgi?id=268546</a>
<a href="https://rdar.apple.com/122089980">rdar://122089980</a>

Reviewed by Alex Christensen and Brady Eidson.

Added code to Generate IPC Serialization for ObjectIdentifierReadReference

* Source/WebKit/Platform/IPC/ObjectIdentifierReference.serialization.in:
* Source/WebKit/Platform/IPC/ObjectIdentifierReferenceTracker.h:
(IPC::ObjectIdentifierReadReference::encode const): Deleted.
(IPC::ObjectIdentifierReadReference::decode): Deleted.

Canonical link: <a href="https://commits.webkit.org/273984@main">https://commits.webkit.org/273984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92c81555d2e0dedaf016a3fd1c4d86a951c0904d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39827 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33268 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31715 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32771 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11875 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11863 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41087 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33743 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33851 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37770 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12211 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/9993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35914 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13906 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8435 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12562 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->