### PR TITLE
Fire onChanged events for Web Extension Storage API.

### DIFF
--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -108,6 +108,7 @@ NSString *encodeJSONString(id, JSONOptionSet = { }, NSError ** = nullptr);
 NSData *encodeJSONData(id, JSONOptionSet = { }, NSError ** = nullptr);
 
 NSDictionary *dictionaryWithLowercaseKeys(NSDictionary *);
+NSDictionary *dictionaryWithKeys(NSDictionary *, NSArray *keys);
 NSDictionary *mergeDictionaries(NSDictionary *, NSDictionary *);
 NSDictionary *mergeDictionariesAndSetValues(NSDictionary *, NSDictionary *);
 

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -305,6 +305,19 @@ NSDictionary *dictionaryWithLowercaseKeys(NSDictionary *dictionary)
     return [newDictionary copy];
 }
 
+NSDictionary *dictionaryWithKeys(NSDictionary *dictionary, NSArray *keys)
+{
+    if (!dictionary.count || !keys.count)
+        return @{ };
+
+    auto *keysSet = [NSSet setWithArray:keys];
+
+    return filterObjects(dictionary, ^bool(id key, id) {
+        return dictionary[key] && [keysSet containsObject:key];
+    });
+
+}
+
 NSDictionary *mergeDictionaries(NSDictionary *dictionaryA, NSDictionary *dictionaryB)
 {
     if (!dictionaryB.count)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -648,6 +648,7 @@ private:
     void storageRemove(WebPageProxyIdentifier, WebExtensionStorageType, const Vector<String>& keys, CompletionHandler<void(ErrorString)>&&);
     void storageClear(WebPageProxyIdentifier, WebExtensionStorageType, CompletionHandler<void(ErrorString)>&&);
     void storageSetAccessLevel(WebPageProxyIdentifier, WebExtensionStorageType, WebExtensionStorageAccessLevel, CompletionHandler<void(ErrorString)>&&);
+    void fireStorageChangedEventIfNeeded(NSDictionary *oldKeysAndValues, NSDictionary *newKeysAndValues, WebExtensionStorageType);
 
     // Tabs APIs
     void tabsCreate(WebPageProxyIdentifier, const WebExtensionTabParameters&, CompletionHandler<void(std::optional<WebExtensionTabParameters>, WebExtensionTab::Error)>&&);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorage.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorage.h
@@ -50,6 +50,10 @@ public:
     WebExtensionAPIEvent& onChanged();
 
 private:
+    friend class WebExtensionContextProxy;
+
+    WebExtensionAPIStorageArea& storageAreaForType(WebExtensionStorageType);
+
     RefPtr<WebExtensionAPIStorageArea> m_local;
     RefPtr<WebExtensionAPIStorageArea> m_session;
     RefPtr<WebExtensionAPIStorageArea> m_sync;

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -126,6 +126,19 @@ _WKWebExtensionLocalization *WebExtensionContextProxy::parseLocalization(API::Da
     return [[_WKWebExtensionLocalization alloc] initWithLocalizedDictionary:parseJSON(json) uniqueIdentifier:baseURL.host().toString()];
 }
 
+WebCore::DOMWrapperWorld& WebExtensionContextProxy::toDOMWorld(WebExtensionContentWorldType contentWorldType)
+{
+    switch (contentWorldType) {
+    case WebExtensionContentWorldType::Main:
+        return mainWorld();
+    case WebExtensionContentWorldType::ContentScript:
+        return contentScriptWorld();
+    case WebExtensionContentWorldType::Native:
+        ASSERT_NOT_REACHED();
+        return mainWorld();
+    }
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -44,6 +44,7 @@ OBJC_CLASS _WKWebExtensionLocalization;
 namespace WebKit {
 
 class WebExtensionAPINamespace;
+class WebExtensionAPIStorage;
 class WebExtensionMatchPattern;
 class WebFrame;
 
@@ -83,6 +84,8 @@ public:
     bool isSessionStorageAllowedInContentScripts() { return m_isSessionStorageAllowedInContentScripts; }
 
     bool inTestingMode() { return m_testingMode; }
+
+    WebCore::DOMWrapperWorld& toDOMWorld(WebExtensionContentWorldType);
 
     static WebCore::DOMWrapperWorld& mainWorld() { return WebCore::mainThreadNormalWorld(); }
 
@@ -158,6 +161,7 @@ private:
 
     // Storage
     void setStorageAccessLevel(bool);
+    void dispatchStorageChangedEvent(const String& onChangedJSON, WebExtensionStorageType, WebExtensionContentWorldType);
 
     // Tabs
     void dispatchTabsCreatedEvent(const WebExtensionTabParameters&);

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -62,6 +62,7 @@ messages -> WebExtensionContextProxy {
 
     // Storage
     SetStorageAccessLevel(bool allowedInContentScripts)
+    DispatchStorageChangedEvent(String onChangedJSON, WebKit::WebExtensionStorageType storageType, WebKit::WebExtensionContentWorldType contentWorldType)
 
     // Tabs Events
     DispatchTabsCreatedEvent(WebKit::WebExtensionTabParameters tabParameters)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
@@ -317,6 +317,32 @@ TEST(WKWebExtensionAPIStorage, Clear)
     Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
 }
 
+TEST(WKWebExtensionAPIStorage, StorageOnChanged)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"function listener() { browser.test.notifyPass() }",
+        @"await browser?.storage?.onChanged?.addListener(listener)",
+
+        @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
+        @"await browser?.storage?.local?.set(data)",
+    ]);
+
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+}
+
+TEST(WKWebExtensionAPIStorage, StorageAreaOnChanged)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"function listener() { browser.test.notifyPass() }",
+        @"await browser?.storage?.local?.onChanged?.addListener(listener)",
+
+        @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
+        @"await browser?.storage?.local?.set(data)",
+    ]);
+
+    Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### 62c9865813d8e9d50461961249155ac3de478da3
<pre>
Fire onChanged events for Web Extension Storage API.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267965">https://bugs.webkit.org/show_bug.cgi?id=267965</a>
<a href="https://rdar.apple.com/121474442">rdar://121474442</a>

Reviewed by Timothy Hatcher.

This patch fires storage.onChanged and storageArea.onChanged events when new data is added or
old data is removed from storage. The onChanged data sent to the listener only contains data
for key value pairs where the value for that key has changed. If no data has changed, don&apos;t
fire the event.

* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::dictionaryWithKeys):
Helper method that returns a new dictionary based on the one provided, containing the specified keys.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm:
(WebKit::WebExtensionContext::storageSet):
(WebKit::WebExtensionContext::storageRemove):
(WebKit::WebExtensionContext::storageClear):
(WebKit::WebExtensionContext::fireStorageChangedEventIfNeeded):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm:
(WebKit::WebExtensionAPIStorage::storageAreaForType):
(WebKit::WebExtensionContextProxy::dispatchStorageChangedEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorage.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/273942@main">https://commits.webkit.org/273942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1d1b442a49cde2ec630589c33b230c691cc5cd5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/37304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/16197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/39584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/38610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/18789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/13345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/39850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/37869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/18789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/39584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/18789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/39584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/41110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/18789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/39584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/41110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/12238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/13345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/41110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/39584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4824 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->