### PR TITLE
Multiple queues experiencing sporadic 0.01% ImageOnlyFailures.

### DIFF
--- a/LayoutTests/compositing/device-pixel-image-buffer-hidpi.html
+++ b/LayoutTests/compositing/device-pixel-image-buffer-hidpi.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>

--- a/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html
+++ b/LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
 <style>
   body {
     width: 1000px;

--- a/LayoutTests/compositing/transitions/transform-on-large-layer.html
+++ b/LayoutTests/compositing/transitions/transform-on-large-layer.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>Animating transform on large tiled layer.</title>
     <style type="text/css">
         #box {

--- a/LayoutTests/css3/blending/blend-mode-accelerated-parent-overflow-hidden.html
+++ b/LayoutTests/css3/blending/blend-mode-accelerated-parent-overflow-hidden.html
@@ -1,4 +1,7 @@
 <!DOCTYPE HTML>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 
 <link rel="stylesheet" href="resources/blending-style.css">
 

--- a/LayoutTests/css3/blending/blend-mode-clip-accelerated-blending-child.html
+++ b/LayoutTests/css3/blending/blend-mode-clip-accelerated-blending-child.html
@@ -1,4 +1,7 @@
 <!DOCTYPE HTML>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <link rel="stylesheet" href="resources/blending-style.css">
 
 <p>This test checks that blending works if the isolating layer has overflow hidden and the blending layer is accelerated.<br />

--- a/LayoutTests/css3/blending/blend-mode-clip-accelerated-blending-double.html
+++ b/LayoutTests/css3/blending/blend-mode-clip-accelerated-blending-double.html
@@ -1,4 +1,7 @@
 <!DOCTYPE HTML>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 
 <link rel="stylesheet" href="resources/blending-style.css">
 <style>

--- a/LayoutTests/css3/blending/blend-mode-clip-accelerated-blending-with-siblings.html
+++ b/LayoutTests/css3/blending/blend-mode-clip-accelerated-blending-with-siblings.html
@@ -1,4 +1,7 @@
 <!DOCTYPE HTML>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 
 <link rel="stylesheet" href="resources/blending-style.css">
 <style>

--- a/LayoutTests/css3/blending/blend-mode-clip-accelerated-transformed-blending.html
+++ b/LayoutTests/css3/blending/blend-mode-clip-accelerated-transformed-blending.html
@@ -1,4 +1,7 @@
 <!DOCTYPE HTML>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 
 <link rel="stylesheet" href="resources/blending-style.css">
 <style>

--- a/LayoutTests/css3/blending/blend-mode-clip-rect-accelerated-blending.html
+++ b/LayoutTests/css3/blending/blend-mode-clip-rect-accelerated-blending.html
@@ -1,4 +1,7 @@
 <!DOCTYPE HTML>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 
 <link rel="stylesheet" href="resources/blending-style.css">
 <style>

--- a/LayoutTests/fast/canvas/canvas-color-space-display-p3.html
+++ b/LayoutTests/fast/canvas/canvas-color-space-display-p3.html
@@ -1,6 +1,9 @@
 <style>
     .ref { background-color: #009900; width: 100px; height: 50px; margin-bottom: 0; }
 </style>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <body>
     <p>This test passes if the square below looks to be all one color</p>
     <div class="ref"> </div>

--- a/LayoutTests/fast/canvas/putImageData-multiple.html
+++ b/LayoutTests/fast/canvas/putImageData-multiple.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
 </head>
 <body>
 This test makes sure that putImageData() isn't affected by subsequent changes to the ImageData. The test passes if you see a green square below.

--- a/LayoutTests/fast/canvas/webgl/match-page-color-space-p3.html
+++ b/LayoutTests/fast/canvas/webgl/match-page-color-space-p3.html
@@ -61,6 +61,9 @@ function run() {
 
 window.addEventListener("load", run, false);
 </script>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <body>
 <p>The boxes below should all be uniform in color. Any difference is likely to be extremely subtle.</p>
 <div class="box" style="background-color: red"></div>

--- a/LayoutTests/fast/clip/hidpi-background-clip-with-text-fill-color.html
+++ b/LayoutTests/fast/clip/hidpi-background-clip-with-text-fill-color.html
@@ -1,3 +1,6 @@
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <style>
 .container {
   transform: translateZ(0);

--- a/LayoutTests/fast/css-grid-layout/grid-element-shrink-to-fit.html
+++ b/LayoutTests/fast/css-grid-layout/grid-element-shrink-to-fit.html
@@ -42,6 +42,9 @@
     height: 100px;
 }
 </style>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <body>
 
 <p>This test checks that the shrink-to-fit behavior is applied to out-of-flow positioned elements.</p>

--- a/LayoutTests/fast/images/decode-static-image-resolve.html
+++ b/LayoutTests/fast/images/decode-static-image-resolve.html
@@ -5,6 +5,9 @@
         background-color: red;
     }
 </style>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <body>
     <p>This tests resolving the decode() promise when loading and decoding a static image succeeds.</p>
     <canvas></canvas>

--- a/LayoutTests/fast/images/image-orientation-none-canvas.html
+++ b/LayoutTests/fast/images/image-orientation-none-canvas.html
@@ -27,6 +27,9 @@
     if (window.internals)
         internals.settings.setCanvasUsesAcceleratedDrawing(false);
 </script>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <body>
     <b>CanvasRenderingContext2D.drawImage() should ignore the image's EXIF orientation if its style image-orientation is set to "none".</b>
     <br>

--- a/LayoutTests/fast/images/svg-mask-in-canvas.html
+++ b/LayoutTests/fast/images/svg-mask-in-canvas.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
 </head>
 <body>
 <p>This test passes if you see a black rectangle with a green border below.</p>

--- a/LayoutTests/fast/overflow/containing-block-and-overflow-hidden.html
+++ b/LayoutTests/fast/overflow/containing-block-and-overflow-hidden.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <style>
     div {
         display: inline-block;

--- a/LayoutTests/http/tests/canvas/color-fonts/text-sbix.html
+++ b/LayoutTests/http/tests/canvas/color-fonts/text-sbix.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
 <style>
 @font-face {
     font-family: "WebFont";

--- a/LayoutTests/imported/blink/fast/multicol/composited-layer-single-fragment.html
+++ b/LayoutTests/imported/blink/fast/multicol/composited-layer-single-fragment.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <style>
 .multicol {
     width: 60px;

--- a/LayoutTests/imported/blink/svg/canvas/canvas-draw-pattern-size.html
+++ b/LayoutTests/imported/blink/svg/canvas/canvas-draw-pattern-size.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
 <style>
     canvas {
         image-rendering: pixelated;

--- a/LayoutTests/imported/blink/transforms/inline-transform-and-clipping-roots.html
+++ b/LayoutTests/imported/blink/transforms/inline-transform-and-clipping-roots.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 Test that clipping is properly calculated when inline transforms cause a clipping root with a different position to be used. The green box should be visible.
 <div style="transform: translateZ(0)"></div>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip/clip-absolute-positioned-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip/clip-absolute-positioned-002.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Masking: Test clip property and rect function on div with position: fixed</title>
     <link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip/clip-not-absolute-positioned-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip/clip-not-absolute-positioned-003.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Masking: Test clip property and rect function on not absolutely positioned div - 3</title>
     <link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com">
     <link rel="help" href="http://www.w3.org/TR/css-masking-1/#clipping-paths">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip/clip-transform-order.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip/clip-transform-order.html
@@ -1,4 +1,7 @@
 <!doctype html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <title>Clips should be applied before transforms</title>
 <link rel="help" href="https://drafts.fxtf.org/css-masking-1/#placement">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1524966">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/3d-rendering-context-and-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/3d-rendering-context-and-inline.html
@@ -1,4 +1,7 @@
 <!DOCTYPE HTML>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <title>CSS Test (Transforms): 3D Rendering Context following DOM Tree (inlines)</title>
 <link rel="author" title="L. David Baron" href="https://dbaron.org/">
 <link rel="author" title="Google" href="http://www.google.com/">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-002.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <title>backface visibility: hidden self-transform</title>
 <link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">
 <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-004.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <title>backface visibility: hidden creates containing block and stacking context when participating in a 3D rendering context</title>
 <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
 <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-005.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <title>backface visibility: hidden creates containing block and stacking context when transformed</title>
 <link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
 <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-rotate-2d-3d-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-rotate-2d-3d-001.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Transforms Test: 2D rotation with 3D rotation</title>
     <link rel="author" title="Philip Rogers" href="mailto:pdr@google.com">
     <link rel="reviewer" title="Dirk Schulze" href="mailto:dschulze@adobe.com" /> <!-- 2012-06-16 -->

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotate3d-X-negative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotate3d-X-negative.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <meta charset="utf-8">
     <title>CSS Transforms Test: rotate3d on div element</title>
     <link rel="author" title="Intel" href="http://www.intel.com">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotate3d-X-positive.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotate3d-X-positive.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <meta charset="utf-8">
     <title>CSS Transforms Test: rotate3d on div element</title>
     <link rel="author" title="Intel" href="http://www.intel.com">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotate3d-Y-negative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotate3d-Y-negative.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <meta charset="utf-8">
     <title>CSS Transforms Test: rotate3d on div element</title>
     <link rel="author" title="Intel" href="http://www.intel.com">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotate3d-Y-positive.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotate3d-Y-positive.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <meta charset="utf-8">
     <title>CSS Transforms Test: rotate3d on div element</title>
     <link rel="author" title="Intel" href="http://www.intel.com">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotateX-negative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotateX-negative.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <meta charset="utf-8">
     <title>CSS Transforms Test: rotateX on div element</title>
     <link rel="author" title="Intel" href="http://www.intel.com">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotateX-positive.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotateX-positive.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <meta charset="utf-8">
     <title>CSS Transforms Test: rotateX on div element</title>
     <link rel="author" title="Intel" href="http://www.intel.com">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotateY-negative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotateY-negative.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <meta charset="utf-8">
     <title>CSS Transforms Test: rotateY on div element</title>
     <link rel="author" title="Intel" href="http://www.intel.com">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotateY-positive.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotateY-positive.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <meta charset="utf-8">
     <title>CSS Transforms Test: rotateY on div element</title>
     <link rel="author" title="Intel" href="http://www.intel.com">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-transform-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-transform-style.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <meta charset="utf-8">
     <title>CSS Transforms Test: rotateY with transform-style on nested elements</title>
     <link rel="author" title="Intel" href="http://www.intel.com">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css3-transform-perspective.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css3-transform-perspective.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
   <title>CSS Test: rotateX 90 degrees with perspective make it invisible</title>
   <link rel="author" title="caoqixing" href="mailto:robin.webkit@gmail.com" />
   <link rel="reviewer" title="Dayang Shen" href="mailto:shendayang@baidu.com" /> <!-- 2013-09-03 -->

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css3-transform-rotateY.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css3-transform-rotateY.html
@@ -1,6 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Transforms Test: transform property with rotateY function</title>
     <link rel="author" title="Noah Lu" href="mailto:codedancerhua@gmail.com" />
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property" />

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/fractional-scale-gradient-bg-obscure-red-bg.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/fractional-scale-gradient-bg-obscure-red-bg.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-8427" />
+</head>
 <link rel="help" href="https://crbug.com/1330509">
 <link rel="match" href="fractional-scale-gradient-bg-obscure-red-bg-ref.html">
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-origin-x.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-origin-x.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Transforms Test: perspective property</title>
     <link rel="author" title="Francisca Gil" href="mailto:pancha0.0@gmail.com">
     <link rel="reviewer" title="Apple Inc." href="http://www.apple.com">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-origin-xy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-origin-xy.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Transforms Test: perspective property</title>
     <link rel="author" title="Francisca Gil" href="mailto:pancha0.0@gmail.com">
     <link rel="reviewer" title="Apple Inc." href="http://www.apple.com">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-translateZ-0.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-translateZ-0.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Transforms Test: perspective property</title>
     <link rel="author" title="Andres Ugarte" href="mailto:anduga@gmail.com">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#perspective-property">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-translateZ-negative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-translateZ-negative.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Transforms Test: perspective property</title>
     <link rel="author" title="Andres Ugarte" href="mailto:anduga@gmail.com">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#perspective-property">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-translateZ-positive.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-translateZ-positive.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Transforms Test: perspective property</title>
     <link rel="author" title="Andres Ugarte" href="mailto:anduga@gmail.com">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#perspective-property">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/rotateY.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/rotateY.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Transforms Test: transform property with rotateY</title>
     <link rel="author" title="Zou Rui" href="mailto:zrxldl@gmail.com">
     <link rel="reviewer" title="Dayang Shen" href="mailto:shendayang@baidu.com"> <!-- 2013-09-05 -->

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform-table-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform-table-006.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Test (Transforms): Table Without Preserve-3D 1</title>
     <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#transform-style-property">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform-table-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform-table-007.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Test (Transforms): Table Without Preserve-3D 2</title>
     <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#transform-style-property">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform-table-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform-table-008.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Test (Transforms): Table Without Preserve-3D 3</title>
     <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#transform-style-property">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-012.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-012.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Test (Transforms): 90-Degree Rotations Without Preserve-3D</title>
     <link rel="author" title="Matt Woodrow" href="mailto:mwoodrow@mozilla.com">
     <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform3d-scale-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform3d-scale-004.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Test (Transforms): scale3d(2, 2, 0)</title>
     <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#three-d-transform-functions">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transformed-preserve-3d-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transformed-preserve-3d-1.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
   <title>CSS Transforms API Test: transform preserve-3d</title>
   <link rel="author" title="loveky" href="mailto:ylzcylx@gmail.com">
   <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transformed-rotateX-3.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transformed-rotateX-3.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Transforms API Test: transform rotateX</title>
     <link rel="author" title="loveky" href="mailto:ylzcylx@gmail.com">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transformed-rotateY-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transformed-rotateY-1.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+  <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Transforms API Test: transform rotateY</title>
     <link rel="author" title="loveky" href="mailto:ylzcylx@gmail.com">
     <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transforms-rotateY-degree-60.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transforms-rotateY-degree-60.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Transforms Test: transform property with rotate function and one parameter</title>
     <link rel="author" title="Ji Kai" href="mailto:7jikai@gmail.com">
     <link rel="reviewer" title="Dayang Shen" href="mailto:shendayang@baidu.com"> <!-- 2013-09-04 -->

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-containing-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-containing-block.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <meta charset="utf-8">
 <title>backdrop-filter: Forms a containing block for fixed/absolute</title>
 <link rel="author" href="mailto:masonf@chromium.org">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-drop-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-drop-shadow.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
     <title>CSS Filters Animation: Drop Shadow</title>
     <link rel="author" title="Gunther Brunner" href="mailto:takeshimiya@gmail.com">
     <link rel="reviewer" title="Dirk Schulze" href="mailto:dschulze@adobe.com">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/compositing/canvas_compositing_globalcompositeoperation_001.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/compositing/canvas_compositing_globalcompositeoperation_001.htm
@@ -1,6 +1,7 @@
 <!doctype HTML>
 <html>
     <head>
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
         <title>HTML5 Canvas Test:  globalCompositeOperation "destination-over"</title>
         <link rel="match" href="canvas_compositing_globalcompositeoperation_001-ref.htm">
         <link rel="author" title="Microsoft" href="http://www.microsoft.com" />

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap-flipped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap-flipped.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <link rel="match" href="imageBitmapRendering-transferFromImageBitmap-flipped-expected.html" />
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <body>
   <p>Test whether the imageOrientation "flipY" works when creating an ImageBitmap from the ImageData of a canvas, and then transfered to an ImageBitmapRenderingContext.</p>
   <canvas id="canvas" width="300" height="300"></canvas>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap-webgl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap-webgl.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <link rel="match" href="imageBitmapRendering-transferFromImageBitmap-webgl-expected.html" />
 
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <body>
   <p>
     Test creating an ImageBitmap from the transferToImageBitmap of a webgl OffscreenCanvas, and then

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <link rel="match" href="imageBitmapRendering-transferFromImageBitmap-expected.html" />
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <body>
   <p>Test whether the imageOrientation "from-image" works when creating an ImageBitmap from the ImageData of a canvas, and then transfered to an ImageBitmapRenderingContext.</p>
   <canvas id="canvas" width="300" height="300"></canvas>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/line-styles/canvas_linestyles_linecap_001.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/line-styles/canvas_linestyles_linecap_001.htm
@@ -1,6 +1,7 @@
 <!doctype HTML>
 <html>
     <head>
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
         <title>HTML5 Canvas Test: "square" lineCap</title>
         <link rel="match" href="canvas_linestyles_linecap_001-ref.htm">
         <link rel="author" title="Microsoft" href="http://www.microsoft.com" />

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/the-canvas-state/canvas_state_restore_001.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/the-canvas-state/canvas_state_restore_001.htm
@@ -1,6 +1,7 @@
 <!doctype HTML>
 <html>
     <head>
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
         <title>HTML5 Canvas Test: restore() pops top entry in drawing state stack</title>
         <link rel="match" href="canvas_state_restore_001-ref.htm">
         <link rel="author" title="Microsoft" href="http://www.microsoft.com" />

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/transformations/canvas_transformations_scale_001.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/transformations/canvas_transformations_scale_001.htm
@@ -2,6 +2,7 @@
 
 <html>
     <head>
+    <meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
         <title>HTML5 Canvas Test: scale() transformation</title>
         <link rel="match" href="canvas_transformations_scale_001-ref.htm">
         <link rel="author" title="Microsoft" href="http://www.microsoft.com" />

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-stacking-order.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-stacking-order.html
@@ -61,6 +61,9 @@ dialog {
     z-index: -1000;  /* z-index has no effect. */
 }
 </style>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <body>
 Test for dialog::backdrop stacking order. The test passes if there are 6
 boxes enclosed in each other, becoming increasingly smaller and brighter

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-generated-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-generated-content.html
@@ -49,6 +49,9 @@ dialog::backdrop::after {
     background: red;
 }
 </style>
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <body>
 Test for a modal dialog with ::before, ::after, and ::backdrop. The test passes
 if there are two green boxes, one with the texts "::before" and "::after" in it.

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-display-none.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-display-none.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
 <link rel="match" href="top-layer-display-none-ref.html">
 <link rel="help" href="https://fullscreen.spec.whatwg.org/#new-stacking-layer">
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-nesting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-nesting.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
 <link rel="match" href="top-layer-nesting-ref.html">
 <link rel="help" href="https://fullscreen.spec.whatwg.org/#new-stacking-layer">
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-stacking-dynamic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-stacking-dynamic.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
 <link rel="match" href="top-layer-stacking-dynamic-ref.html">
 <link rel="help" href="https://fullscreen.spec.whatwg.org/#new-stacking-layer">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-dialog-element">

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/infinite-duration-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/infinite-duration-animation.html
@@ -32,6 +32,9 @@
   }
 </style>
 
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <body>
   <div id="box-1"></div>
   <div id="box-2"></div>

--- a/LayoutTests/svg/as-image/img-with-svg-resource-in-dom-and-drawImage.html
+++ b/LayoutTests/svg/as-image/img-with-svg-resource-in-dom-and-drawImage.html
@@ -1,3 +1,6 @@
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <body>
 <p>This test shows a <code>&lt;canvas></code> element in which we draw the SVG image with the source rectangle set to fit the green rectangle from the SVG image and the destination rectangle as the bounds of the canvas element. In this example, the source <code>&lt;img></code> is in the DOM and is explicitly sized.</p>
 <script type="text/javascript">

--- a/LayoutTests/svg/as-image/img-with-svg-resource-in-dom-no-size-and-drawImage.html
+++ b/LayoutTests/svg/as-image/img-with-svg-resource-in-dom-no-size-and-drawImage.html
@@ -1,3 +1,6 @@
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <body>
 <p>This test shows a <code>&lt;canvas></code> element in which we draw the SVG image with the source rectangle set to fit the green rectangle from the SVG image and the destination rectangle as the bounds of the canvas element. In this example, the source <code>&lt;img></code> is in the DOM and is not explicitly sized.</p>
 <script type="text/javascript">

--- a/LayoutTests/svg/as-image/img-with-svg-resource-not-in-dom-and-drawImage.html
+++ b/LayoutTests/svg/as-image/img-with-svg-resource-not-in-dom-and-drawImage.html
@@ -1,3 +1,6 @@
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <body>
 <p>This test shows a <code>&lt;canvas></code> element in which we draw the SVG image with the source rectangle set to fit the green rectangle from the SVG image and the destination rectangle as the bounds of the canvas element. In this example, the source <code>&lt;img></code> is not in the DOM and is explicitly sized.</p>
 <script type="text/javascript">

--- a/LayoutTests/svg/as-image/img-with-svg-resource-not-in-dom-no-size-and-drawImage.html
+++ b/LayoutTests/svg/as-image/img-with-svg-resource-not-in-dom-no-size-and-drawImage.html
@@ -1,3 +1,6 @@
+<head>
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-1" />
+</head>
 <body>
 <p>This test shows a <code>&lt;canvas></code> element in which we draw the SVG image with the source rectangle set to fit the green rectangle from the SVG image and the destination rectangle as the bounds of the canvas element. In this example, the source <code>&lt;img></code> is not in the DOM and is not explicitly sized.</p>
 <script type="text/javascript">


### PR DESCRIPTION
#### 9d4ed892ddb57e05d2f61bc2f0c2a14ca0206e0a
<pre>
Multiple queues experiencing sporadic 0.01% ImageOnlyFailures.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267869">https://bugs.webkit.org/show_bug.cgi?id=267869</a>
<a href="https://rdar.apple.com/121384093">rdar://121384093</a>

Reviewed by Simon Fraser.

Add pixel tolerance.

* LayoutTests/compositing/device-pixel-image-buffer-hidpi.html:
* LayoutTests/compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html:
* LayoutTests/compositing/transitions/transform-on-large-layer.html:
* LayoutTests/css3/blending/blend-mode-accelerated-parent-overflow-hidden.html:
* LayoutTests/css3/blending/blend-mode-clip-accelerated-blending-child.html:
* LayoutTests/css3/blending/blend-mode-clip-accelerated-blending-double.html:
* LayoutTests/css3/blending/blend-mode-clip-accelerated-blending-with-siblings.html:
* LayoutTests/css3/blending/blend-mode-clip-accelerated-transformed-blending.html:
* LayoutTests/css3/blending/blend-mode-clip-rect-accelerated-blending.html:
* LayoutTests/fast/canvas/canvas-color-space-display-p3.html:
* LayoutTests/fast/canvas/putImageData-multiple.html:
* LayoutTests/fast/canvas/webgl/match-page-color-space-p3.html:
* LayoutTests/fast/clip/hidpi-background-clip-with-text-fill-color.html:
* LayoutTests/fast/css-grid-layout/grid-element-shrink-to-fit.html:
* LayoutTests/fast/images/decode-static-image-resolve.html:
* LayoutTests/fast/images/image-orientation-none-canvas.html:
* LayoutTests/fast/images/svg-mask-in-canvas.html:
* LayoutTests/fast/overflow/containing-block-and-overflow-hidden.html:
* LayoutTests/http/tests/canvas/color-fonts/text-sbix.html:
* LayoutTests/imported/blink/fast/multicol/composited-layer-single-fragment.html:
* LayoutTests/imported/blink/svg/canvas/canvas-draw-pattern-size.html:
* LayoutTests/imported/blink/transforms/inline-transform-and-clipping-roots.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip/clip-absolute-positioned-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip/clip-not-absolute-positioned-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip/clip-transform-order.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/3d-rendering-context-and-inline.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-004.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/backface-visibility-hidden-005.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-rotate-2d-3d-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotate3d-X-negative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotate3d-X-positive.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotate3d-Y-negative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotate3d-Y-positive.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotateX-negative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotateX-positive.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotateY-negative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-rotateY-positive.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css-transform-3d-transform-style.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css3-transform-perspective.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/css3-transform-rotateY.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/fractional-scale-gradient-bg-obscure-red-bg.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-origin-x.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-origin-xy.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-translateZ-0.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-translateZ-negative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/perspective-translateZ-positive.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/rotateY.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform-table-006.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform-table-007.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform-table-008.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-012.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform3d-scale-004.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transformed-preserve-3d-1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transformed-rotateX-3.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transformed-rotateY-1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transforms-rotateY-degree-60.html:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-containing-block.html:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-drop-shadow.html:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/compositing/canvas_compositing_globalcompositeoperation_001.htm:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap-flipped.html:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap-webgl.html:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap.html:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/line-styles/canvas_linestyles_linecap_001.htm:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/the-canvas-state/canvas_state_restore_001.htm:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/transformations/canvas_transformations_scale_001.htm:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/backdrop-stacking-order.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/modal-dialog-generated-content.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-display-none.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-nesting.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/top-layer-stacking-dynamic.html:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/timing-model/animations/infinite-duration-animation.html:
* LayoutTests/svg/as-image/img-with-svg-resource-in-dom-and-drawImage.html:
* LayoutTests/svg/as-image/img-with-svg-resource-in-dom-no-size-and-drawImage.html:
* LayoutTests/svg/as-image/img-with-svg-resource-not-in-dom-and-drawImage.html:
* LayoutTests/svg/as-image/img-with-svg-resource-not-in-dom-no-size-and-drawImage.html:

Canonical link: <a href="https://commits.webkit.org/273975@main">https://commits.webkit.org/273975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec63b49686e1caa40df8b62b1e4c333fa449e3bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39932 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13440 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13731 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11943 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41195 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/33823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/33923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37828 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/12499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35983 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32879 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8431 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->