### PR TITLE
Adopt API for layer hosting

### DIFF
--- a/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
+++ b/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
@@ -38,7 +38,9 @@
 #import <wtf/MachSendRight.h>
 
 #if USE(EXTENSIONKIT)
-#import "ExtensionKitSoftLink.h"
+#import <BrowserEngineKit/BELayerHierarchy.h>
+#import <BrowserEngineKit/BELayerHierarchyHandle.h>
+#import <BrowserEngineKit/BELayerHierarchyHostingTransactionCoordinator.h>
 #endif
 
 namespace WebKit {
@@ -108,13 +110,13 @@ void RemoteMediaPlayerProxy::setVideoLayerSizeFenced(const WebCore::FloatSize& s
     ALWAYS_LOG(LOGIDENTIFIER, size.width(), "x", size.height());
 
 #if USE(EXTENSIONKIT)
-    RetainPtr<_SEHostingUpdateCoordinator> hostingUpdateCoordinator;
+    RetainPtr<BELayerHierarchyHostingTransactionCoordinator> hostingUpdateCoordinator;
 #endif
 
     if (m_inlineLayerHostingContext) {
 #if USE(EXTENSIONKIT)
         hostingUpdateCoordinator = LayerHostingContext::createHostingUpdateCoordinator(machSendRight.sendRight());
-        [hostingUpdateCoordinator addHostable:m_inlineLayerHostingContext->hostable().get()];
+        [hostingUpdateCoordinator addLayerHierarchy:m_inlineLayerHostingContext->hostable().get()];
 #else
         m_inlineLayerHostingContext->setFencePort(machSendRight.sendRight());
 #endif

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.h
@@ -34,9 +34,9 @@ OBJC_CLASS CALayer;
 OBJC_CLASS CAContext;
 
 #if USE(EXTENSIONKIT)
-OBJC_CLASS _SEHostable;
-OBJC_CLASS _SEHostingHandle;
-OBJC_CLASS _SEHostingUpdateCoordinator;
+OBJC_CLASS BELayerHierarchy;
+OBJC_CLASS BELayerHierarchyHandle;
+OBJC_CLASS BELayerHierarchyHostingTransactionCoordinator;
 #endif
 
 namespace WTF {
@@ -114,10 +114,10 @@ public:
 
 #if USE(EXTENSIONKIT)
     OSObjectPtr<xpc_object_t> xpcRepresentation() const;
-    RetainPtr<_SEHostable> hostable() const { return m_hostable; }
+    RetainPtr<BELayerHierarchy> hostable() const { return m_hostable; }
 
-    static RetainPtr<_SEHostingHandle> createHostingHandle(uint64_t pid, uint64_t contextID);
-    static RetainPtr<_SEHostingUpdateCoordinator> createHostingUpdateCoordinator(mach_port_t sendRight);
+    static RetainPtr<BELayerHierarchyHandle> createHostingHandle(uint64_t pid, uint64_t contextID);
+    static RetainPtr<BELayerHierarchyHostingTransactionCoordinator> createHostingUpdateCoordinator(mach_port_t sendRight);
 #endif
 
 private:
@@ -128,7 +128,7 @@ private:
     LayerHostingContextID m_cachedContextID;
     RetainPtr<CAContext> m_context;
 #if USE(EXTENSIONKIT)
-    RetainPtr<_SEHostable> m_hostable;
+    RetainPtr<BELayerHierarchy> m_hostable;
 #endif
 };
 

--- a/Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h
@@ -30,6 +30,23 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+#if __has_include(<BrowserEngineKit/BELayerHierarchy_Private.h>)
+#import <BrowserEngineKit/BELayerHierarchy_Private.h>
+#else
+#import <BrowserEngineKit/BELayerHierarchy.h>
+@class CAContext;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BELayerHierarchy ()
++ (nullable BELayerHierarchy *)layerHierarchyWithOptions:(NSDictionary *)options error:(NSError **)error NS_REFINED_FOR_SWIFT;
+- (instancetype)initWithContext:(CAContext *)context;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif
+
 #if __has_include(<ServiceExtensions/ServiceExtensions_Private.h>)
 #import <ServiceExtensions/ServiceExtensions_Private.h>
 #else
@@ -114,29 +131,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)assertionWithDomain:(NSString *)domain name:(NSString *)name environmentIdentifier:(NSString *)environmentIdentifier;
 + (instancetype)assertionWithDomain:(NSString *)domain name:(NSString *)name environmentIdentifier:(NSString *)environmentIdentifier willInvalidate:(void (^)())willInvalidateBlock didInvalidate:(void (^)())didInvalidateBlock;
 @property (nonatomic, readonly) NSString *mediaEnvironment;
-@end
-
-@interface _SEHostingHandle: NSObject
--(instancetype)initFromXPCRepresentation:(xpc_object_t)xpcRepresentation;
--(xpc_object_t)xpcRepresentation;
-@end
-
-@interface _SEHostable: NSObject
-+(_SEHostable*)createHostableWithOptions:(NSDictionary*)dict error:(NSError**)error;
-@property (nonatomic, readonly) _SEHostingHandle* handle;
-@property (nonatomic, strong) CALayer *layer;
-@end
-
-@interface _SEHostingView: UIView
-@property (nonatomic, retain) _SEHostingHandle* handle;
-@end
-
-@interface _SEHostingUpdateCoordinator : NSObject
--(instancetype)initFromXPCRepresentation:(xpc_object_t)xpcRepresentation;
--(xpc_object_t)xpcRepresentation;
--(void)addHostable:(_SEHostable*)hostable;
--(void)addHostingView:(_SEHostingView*)hostingView;
--(void)commit;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### ecb45081cdfb08277d4b4556360954e12dd1ec1e
<pre>
Adopt API for layer hosting
<a href="https://bugs.webkit.org/show_bug.cgi?id=268562">https://bugs.webkit.org/show_bug.cgi?id=268562</a>
<a href="https://rdar.apple.com/121747472">rdar://121747472</a>

Reviewed by Brent Fulgham.

Adopt BrowserEngineKit API for layer hosting. This is also a speculative fix for a crash seen when
calling [_SEHostingView setHandle:], since the forward declared handle property was incorrectly
declared. This is possibly fixed in this patch by using the proper system headers instead of
using an incorrect property declaration.

* Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm:
(WebKit::RemoteMediaPlayerProxy::setVideoLayerSizeFenced):
* Source/WebKit/Platform/cocoa/LayerHostingContext.h:
(WebKit::LayerHostingContext::hostable const):
* Source/WebKit/Platform/cocoa/LayerHostingContext.mm:
(WebKit::LayerHostingContext::createForExternalHostingProcess):
(WebKit::LayerHostingContext::xpcRepresentation const):
(WebKit::LayerHostingContext::createHostingUpdateCoordinator):
(WebKit::LayerHostingContext::createHostingHandle):
* Source/WebKit/Platform/spi/Cocoa/ExtensionKitSPI.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::createLayerHostViewWithID):
(WebKit::VideoPresentationManagerProxy::setVideoLayerFrame):

Canonical link: <a href="https://commits.webkit.org/273950@main">https://commits.webkit.org/273950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17c830d4c123f40f21379dd9740692f822296db9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/37333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/16218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/39605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/18814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/13368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/39868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/37898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/18814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/39605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/18814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/39605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/41131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/18814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/39605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/41131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/12452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/13368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/41131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/39605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4828 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->