### PR TITLE
Move more Local/RemoteDOMWindow functions to DOMWindow

### DIFF
--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -139,4 +139,42 @@ WebCoreOpaqueRoot root(DOMWindow* window)
     return WebCoreOpaqueRoot { window };
 }
 
+WindowProxy* DOMWindow::opener() const
+{
+    RefPtr frame = this->frame();
+    if (!frame)
+        return nullptr;
+
+    RefPtr openerFrame = frame->opener();
+    if (!openerFrame)
+        return nullptr;
+
+    return &openerFrame->windowProxy();
+}
+
+WindowProxy* DOMWindow::top() const
+{
+    RefPtr frame = this->frame();
+    if (!frame)
+        return nullptr;
+
+    if (!frame->page())
+        return nullptr;
+
+    return &frame->tree().top().windowProxy();
+}
+
+WindowProxy* DOMWindow::parent() const
+{
+    RefPtr frame = this->frame();
+    if (!frame)
+        return nullptr;
+
+    RefPtr parentFrame = frame->tree().parent();
+    if (parentFrame)
+        return &parentFrame->windowProxy();
+
+    return &frame->windowProxy();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -40,6 +40,7 @@ class Location;
 class PageConsoleClient;
 class SecurityOrigin;
 class WebCoreOpaqueRoot;
+class WindowProxy;
 enum class SetLocationLocking : bool { LockHistoryBasedOnGestureState, LockHistoryAndBackForwardList };
 
 class DOMWindow : public RefCounted<DOMWindow>, public EventTarget {
@@ -67,6 +68,11 @@ public:
 
     PageConsoleClient* console() const;
     CheckedPtr<PageConsoleClient> checkedConsole() const;
+
+    WindowProxy* opener() const;
+
+    WindowProxy* top() const;
+    WindowProxy* parent() const;
 
 protected:
     explicit DOMWindow(GlobalWindowIdentifier&&);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1462,49 +1462,10 @@ void LocalDOMWindow::setStatus(const String& string)
     m_status = string;
 }
 
-WindowProxy* LocalDOMWindow::opener() const
-{
-    // FIXME: <rdar://118263278> Move LocalDOMWindow::opener and RemoteDOMWindow::opener to DOMWindow.
-    RefPtr frame = this->frame();
-    if (!frame)
-        return nullptr;
-
-    RefPtr openerFrame = frame->loader().opener();
-    if (!openerFrame)
-        return nullptr;
-
-    return &openerFrame->windowProxy();
-}
-
 void LocalDOMWindow::disownOpener()
 {
     if (RefPtr frame = this->frame())
         frame->checkedLoader()->setOpener(nullptr);
-}
-
-WindowProxy* LocalDOMWindow::parent() const
-{
-    RefPtr frame = this->frame();
-    if (!frame)
-        return nullptr;
-
-    RefPtr parentFrame = frame->tree().parent();
-    if (parentFrame)
-        return &parentFrame->windowProxy();
-
-    return &frame->windowProxy();
-}
-
-WindowProxy* LocalDOMWindow::top() const
-{
-    RefPtr frame = this->frame();
-    if (!frame)
-        return nullptr;
-
-    if (!frame->page())
-        return nullptr;
-
-    return &frame->tree().top().windowProxy();
 }
 
 String LocalDOMWindow::origin() const

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -225,10 +225,7 @@ public:
     String status() const;
     void setStatus(const String&);
 
-    WindowProxy* opener() const;
     void disownOpener();
-    WindowProxy* parent() const;
-    WindowProxy* top() const;
 
     String origin() const;
     SecurityOrigin* securityOrigin() const;

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -93,42 +93,10 @@ unsigned RemoteDOMWindow::length() const
     return m_frame->tree().childCount();
 }
 
-WindowProxy* RemoteDOMWindow::top() const
-{
-    if (!m_frame)
-        return nullptr;
-
-    return &m_frame->tree().top().windowProxy();
-}
-
-WindowProxy* RemoteDOMWindow::opener() const
-{
-    if (!m_frame)
-        return nullptr;
-
-    RefPtr openerFrame = m_frame->opener();
-    if (!openerFrame)
-        return nullptr;
-
-    return &openerFrame->windowProxy();
-}
-
 void RemoteDOMWindow::setOpener(WindowProxy*)
 {
     // FIXME: <rdar://118263373> Implement.
     // JSLocalDOMWindow::setOpener has some security checks. Are they needed here?
-}
-
-WindowProxy* RemoteDOMWindow::parent() const
-{
-    if (!m_frame)
-        return nullptr;
-
-    RefPtr parent = m_frame->tree().parent();
-    if (!parent)
-        return nullptr;
-
-    return &parent->windowProxy();
 }
 
 ExceptionOr<void> RemoteDOMWindow::postMessage(JSC::JSGlobalObject& lexicalGlobalObject, LocalDOMWindow& incumbentWindow, JSC::JSValue message, WindowPostMessageOptions&& options)

--- a/Source/WebCore/page/RemoteDOMWindow.h
+++ b/Source/WebCore/page/RemoteDOMWindow.h
@@ -63,10 +63,7 @@ public:
     void focus(LocalDOMWindow& incumbentWindow);
     void blur();
     unsigned length() const;
-    WindowProxy* top() const;
-    WindowProxy* opener() const;
     void setOpener(WindowProxy*);
-    WindowProxy* parent() const;
     void frameDetached();
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, LocalDOMWindow& incumbentWindow, JSC::JSValue message, WindowPostMessageOptions&&);
     ExceptionOr<void> postMessage(JSC::JSGlobalObject& globalObject, LocalDOMWindow& incumbentWindow, JSC::JSValue message, String&& targetOrigin, Vector<JSC::Strong<JSC::JSObject>>&& transfer)


### PR DESCRIPTION
#### 8b99375ed38cff1aa03e2c6423c242af1b1669ff
<pre>
Move more Local/RemoteDOMWindow functions to DOMWindow
<a href="https://bugs.webkit.org/show_bug.cgi?id=268564">https://bugs.webkit.org/show_bug.cgi?id=268564</a>
<a href="https://rdar.apple.com/122117399">rdar://122117399</a>

Reviewed by Tim Nguyen and Alex Christensen.

* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::opener const):
(WebCore::DOMWindow::top const):
(WebCore::DOMWindow::parent const):
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::opener const): Deleted.
(WebCore::LocalDOMWindow::parent const): Deleted.
(WebCore::LocalDOMWindow::top const): Deleted.
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::top const): Deleted.
(WebCore::RemoteDOMWindow::opener const): Deleted.
(WebCore::RemoteDOMWindow::parent const): Deleted.
* Source/WebCore/page/RemoteDOMWindow.h:

Canonical link: <a href="https://commits.webkit.org/273964@main">https://commits.webkit.org/273964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3aaa85411790aecea95b6a87e777f1af2a32d99

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39823 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33233 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38570 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31710 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37831 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11870 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11853 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33414 "layout-tests (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41083 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/31136 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33732 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33848 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37768 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10008 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35912 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13825 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12558 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4845 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->