### PR TITLE
[JSC] Throw RangeError if Set methods are called on an object with negative "size" property

### DIFF
--- a/JSTests/stress/set-prototype-difference.js
+++ b/JSTests/stress/set-prototype-difference.js
@@ -31,21 +31,28 @@ try {
     // Not an object
     set1.difference(1);
 } catch (e) {
-    if (e != "TypeError: Set.prototype.difference expects the first parameter to be an object")
+    if (e != "TypeError: Set operation expects first argument to be an object")
         throw e;
 }
 
 try {
     set1.difference({ });
 } catch (e) {
-    if (e != "TypeError: Set.prototype.difference expects other.size to be a non-NaN number")
+    if (e != "TypeError: Set operation expects first argument to have non-NaN 'size' property")
         throw e;
 }
 
 try {
     set1.difference({ size: NaN });
 } catch (e) {
-    if (e != "TypeError: Set.prototype.difference expects other.size to be a non-NaN number")
+    if (e != "TypeError: Set operation expects first argument to have non-NaN 'size' property")
+        throw e;
+}
+
+try {
+    set1.difference({ size: -1 });
+} catch (e) {
+    if (e != "RangeError: Set operation expects first argument to have non-negative 'size' property")
         throw e;
 }
 

--- a/JSTests/stress/set-prototype-intersection.js
+++ b/JSTests/stress/set-prototype-intersection.js
@@ -35,21 +35,28 @@ try {
     // Not an object
     set1.intersection(1);
 } catch (e) {
-    if (e != "TypeError: Set.prototype.intersection expects the first parameter to be an object")
+    if (e != "TypeError: Set operation expects first argument to be an object")
         throw e;
 }
 
 try {
     set1.intersection({ });
 } catch (e) {
-    if (e != "TypeError: Set.prototype.intersection expects other.size to be a non-NaN number")
+    if (e != "TypeError: Set operation expects first argument to have non-NaN 'size' property")
         throw e;
 }
 
 try {
     set1.intersection({ size:NaN });
 } catch (e) {
-    if (e != "TypeError: Set.prototype.intersection expects other.size to be a non-NaN number")
+    if (e != "TypeError: Set operation expects first argument to have non-NaN 'size' property")
+        throw e;
+}
+
+try {
+    set1.intersection({ size: -4.5 });
+} catch (e) {
+    if (e != "RangeError: Set operation expects first argument to have non-negative 'size' property")
         throw e;
 }
 

--- a/JSTests/stress/set-prototype-isDisjointfrom.js
+++ b/JSTests/stress/set-prototype-isDisjointfrom.js
@@ -47,21 +47,28 @@ try {
     // Not an object
     set1.isDisjointFrom(1);
 } catch (e) {
-    if (e != "TypeError: Set.prototype.isDisjointFrom expects the first parameter to be an object")
+    if (e != "TypeError: Set operation expects first argument to be an object")
         throw e;
 }
 
 try {
     set1.isDisjointFrom({ });
 } catch (e) {
-    if (e != "TypeError: Set.prototype.isDisjointFrom expects other.size to be a non-NaN number")
+    if (e != "TypeError: Set operation expects first argument to have non-NaN 'size' property")
         throw e;
 }
 
 try {
     set1.isDisjointFrom({ size:NaN });
 } catch (e) {
-    if (e != "TypeError: Set.prototype.isDisjointFrom expects other.size to be a non-NaN number")
+    if (e != "TypeError: Set operation expects first argument to have non-NaN 'size' property")
+        throw e;
+}
+
+try {
+    set1.isDisjointFrom({ size: -30 });
+} catch (e) {
+    if (e != "RangeError: Set operation expects first argument to have non-negative 'size' property")
         throw e;
 }
 

--- a/JSTests/stress/set-prototype-isSubsetOf.js
+++ b/JSTests/stress/set-prototype-isSubsetOf.js
@@ -40,21 +40,28 @@ try {
     // Not an object
     set1.isSubsetOf(1);
 } catch (e) {
-    if (e != "TypeError: Set.prototype.isSubsetOf expects the first parameter to be an object")
+    if (e != "TypeError: Set operation expects first argument to be an object")
         throw e;
 }
 
 try {
     set1.isSubsetOf({ });
 } catch (e) {
-    if (e != "TypeError: Set.prototype.isSubsetOf expects other.size to be a non-NaN number")
+    if (e != "TypeError: Set operation expects first argument to have non-NaN 'size' property")
         throw e;
 }
 
 try {
     set1.isSubsetOf({ size:NaN });
 } catch (e) {
-    if (e != "TypeError: Set.prototype.isSubsetOf expects other.size to be a non-NaN number")
+    if (e != "TypeError: Set operation expects first argument to have non-NaN 'size' property")
+        throw e;
+}
+
+try {
+    set1.isSubsetOf({ size: -3483548834553454.543543354 });
+} catch (e) {
+    if (e != "RangeError: Set operation expects first argument to have non-negative 'size' property")
         throw e;
 }
 

--- a/JSTests/stress/set-prototype-isSupersetOf.js
+++ b/JSTests/stress/set-prototype-isSupersetOf.js
@@ -41,21 +41,28 @@ try {
     // Not an object
     set1.isSupersetOf(1);
 } catch (e) {
-    if (e != "TypeError: Set.prototype.isSupersetOf expects the first parameter to be an object")
+    if (e != "TypeError: Set operation expects first argument to be an object")
         throw e;
 }
 
 try {
     set1.isSupersetOf({ });
 } catch (e) {
-    if (e != "TypeError: Set.prototype.isSupersetOf expects other.size to be a non-NaN number")
+    if (e != "TypeError: Set operation expects first argument to have non-NaN 'size' property")
         throw e;
 }
 
 try {
     set1.isSupersetOf({ size:NaN });
 } catch (e) {
-    if (e != "TypeError: Set.prototype.isSupersetOf expects other.size to be a non-NaN number")
+    if (e != "TypeError: Set operation expects first argument to have non-NaN 'size' property")
+        throw e;
+}
+
+try {
+    set1.isSupersetOf({ size: -34787348578345787853478 });
+} catch (e) {
+    if (e != "RangeError: Set operation expects first argument to have non-negative 'size' property")
         throw e;
 }
 

--- a/JSTests/stress/set-prototype-symmetricDifference.js
+++ b/JSTests/stress/set-prototype-symmetricDifference.js
@@ -33,21 +33,28 @@ try {
     // Not an object
     set1.symmetricDifference(1);
 } catch (e) {
-    if (e != "TypeError: Set.prototype.symmetricDifference expects the first parameter to be an object")
+    if (e != "TypeError: Set operation expects first argument to be an object")
         throw e;
 }
 
 try {
     set1.symmetricDifference({ });
 } catch (e) {
-    if (e != "TypeError: Set.prototype.symmetricDifference expects other.size to be a non-NaN number")
+    if (e != "TypeError: Set operation expects first argument to have non-NaN 'size' property")
         throw e;
 }
 
 try {
     set1.symmetricDifference({ size:NaN });
 } catch (e) {
-    if (e != "TypeError: Set.prototype.symmetricDifference expects other.size to be a non-NaN number")
+    if (e != "TypeError: Set operation expects first argument to have non-NaN 'size' property")
+        throw e;
+}
+
+try {
+    set1.symmetricDifference({ size: -1 });
+} catch (e) {
+    if (e != "RangeError: Set operation expects first argument to have non-negative 'size' property")
         throw e;
 }
 

--- a/JSTests/stress/set-prototype-union.js
+++ b/JSTests/stress/set-prototype-union.js
@@ -30,21 +30,28 @@ try {
     // Not an object
     set1.union(1);
 } catch (e) {
-    if (e != "TypeError: Set.prototype.union expects the first parameter to be an object")
+    if (e != "TypeError: Set operation expects first argument to be an object")
         throw e;
 }
 
 try {
     set1.union({ });
 } catch (e) {
-    if (e != "TypeError: Set.prototype.union expects other.size to be a non-NaN number")
+    if (e != "TypeError: Set operation expects first argument to have non-NaN 'size' property")
         throw e;
 }
 
 try {
     set1.union({ size:NaN });
 } catch (e) {
-    if (e != "TypeError: Set.prototype.union expects other.size to be a non-NaN number")
+    if (e != "TypeError: Set operation expects first argument to have non-NaN 'size' property")
+        throw e;
+}
+
+try {
+    set1.union({ size: -435.2221 });
+} catch (e) {
+    if (e != "RangeError: Set operation expects first argument to have non-negative 'size' property")
         throw e;
 }
 

--- a/Source/JavaScriptCore/builtins/SetPrototype.js
+++ b/Source/JavaScriptCore/builtins/SetPrototype.js
@@ -45,6 +45,25 @@ function forEach(callback /*, thisArg */)
     } while (true);
 }
 
+// https://tc39.es/proposal-set-methods/#sec-getsetrecord (steps 1-7)
+@linkTimeConstant
+@alwaysInline
+function getSetSizeAsInt(other)
+{
+    if (!@isObject(other))
+        @throwTypeError("Set operation expects first argument to be an object");
+
+    var size = @toNumber(other.size);
+    if (size !== size) // is NaN?
+        @throwTypeError("Set operation expects first argument to have non-NaN 'size' property");
+
+    var sizeInt = @toIntegerOrInfinity(size);
+    if (sizeInt < 0)
+        @throwRangeError("Set operation expects first argument to have non-negative 'size' property");
+
+    return sizeInt;
+}
+
 function union(other)
 {
     "use strict";
@@ -53,12 +72,7 @@ function union(other)
         @throwTypeError("Set operation called on non-Set object");
 
     // Get Set Record
-    if (!@isObject(other))
-        @throwTypeError("Set.prototype.union expects the first parameter to be an object");
-    var size = @toNumber(other.size);
-    // size is NaN
-    if (size !== size)
-        @throwTypeError("Set.prototype.union expects other.size to be a non-NaN number");
+    var size = @getSetSizeAsInt(other); // unused but @getSetSizeAsInt call is observable
 
     var has = other.has;
     if (!@isCallable(has))
@@ -88,12 +102,7 @@ function intersection(other)
         @throwTypeError("Set operation called on non-Set object");
 
     // Get Set Record
-    if (!@isObject(other))
-        @throwTypeError("Set.prototype.intersection expects the first parameter to be an object");
-    var size = @toNumber(other.size);
-    // size is NaN
-    if (size !== size)
-        @throwTypeError("Set.prototype.intersection expects other.size to be a non-NaN number");
+    var size = @getSetSizeAsInt(other);
 
     var has = other.has;
     if (!@isCallable(has))
@@ -138,12 +147,7 @@ function difference(other)
         @throwTypeError("Set operation called on non-Set object");
 
     // Get Set Record
-    if (!@isObject(other))
-        @throwTypeError("Set.prototype.difference expects the first parameter to be an object");
-    var size = @toNumber(other.size);
-    // size is NaN
-    if (size !== size)
-        @throwTypeError("Set.prototype.difference expects other.size to be a non-NaN number");
+    var size = @getSetSizeAsInt(other);
 
     var has = other.has;
     if (!@isCallable(has))
@@ -188,12 +192,7 @@ function symmetricDifference(other)
         @throwTypeError("Set operation called on non-Set object");
 
     // Get Set Record
-    if (!@isObject(other))
-        @throwTypeError("Set.prototype.symmetricDifference expects the first parameter to be an object");
-    var size = @toNumber(other.size);
-    // size is NaN
-    if (size !== size)
-        @throwTypeError("Set.prototype.symmetricDifference expects other.size to be a non-NaN number");
+    var size = @getSetSizeAsInt(other); // unused but @getSetSizeAsInt call is observable
 
     var has = other.has;
     if (!@isCallable(has))
@@ -227,12 +226,7 @@ function isSubsetOf(other)
         @throwTypeError("Set operation called on non-Set object");
 
     // Get Set Record
-    if (!@isObject(other))
-        @throwTypeError("Set.prototype.isSubsetOf expects the first parameter to be an object");
-    var size = @toNumber(other.size);
-    // size is NaN
-    if (size !== size)
-        @throwTypeError("Set.prototype.isSubsetOf expects other.size to be a non-NaN number");
+    var size = @getSetSizeAsInt(other);
 
     var has = other.has;
     if (!@isCallable(has))
@@ -267,12 +261,7 @@ function isSupersetOf(other)
         @throwTypeError("Set operation called on non-Set object");
 
     // Get Set Record
-    if (!@isObject(other))
-        @throwTypeError("Set.prototype.isSupersetOf expects the first parameter to be an object");
-    var size = @toNumber(other.size);
-    // size is NaN
-    if (size !== size)
-        @throwTypeError("Set.prototype.isSupersetOf expects other.size to be a non-NaN number");
+    var size = @getSetSizeAsInt(other);
 
     var has = other.has;
     if (!@isCallable(has))
@@ -305,12 +294,7 @@ function isDisjointFrom(other)
         @throwTypeError("Set operation called on non-Set object");
 
     // Get Set Record
-    if (!@isObject(other))
-        @throwTypeError("Set.prototype.isDisjointFrom expects the first parameter to be an object");
-    var size = @toNumber(other.size);
-    // size is NaN
-    if (size !== size)
-        @throwTypeError("Set.prototype.isDisjointFrom expects other.size to be a non-NaN number");
+    var size = @getSetSizeAsInt(other);
 
     var has = other.has;
     if (!@isCallable(has))


### PR DESCRIPTION
#### eeda72823e71a06b3993663328d737332329fc60
<pre>
[JSC] Throw RangeError if Set methods are called on an object with negative &quot;size&quot; property
<a href="https://bugs.webkit.org/show_bug.cgi?id=267494">https://bugs.webkit.org/show_bug.cgi?id=267494</a>
&lt;<a href="https://rdar.apple.com/problem/121310940">rdar://problem/121310940</a>&gt;

Reviewed by Justin Michaud and Yusuke Suzuki.

This change implements steps 6-7 of GetSetRecord [1], ensuring a RangeError is thrown if
result of ToIntegerOrInfinity is negative, and extracts always-inlineable @getSetSizeAsInt().

These methods are at stage 3 of ECMA-262 standardization process, meaning we shouldn&apos;t worry
too much about performance impact.

Aligns JSC with V8, preventing most of newly-added Set methods from returning wrong results
when given an malformed Set-like object.

[1]: <a href="https://tc39.es/proposal-set-methods/#sec-getsetrecord">https://tc39.es/proposal-set-methods/#sec-getsetrecord</a>

* JSTests/stress/set-prototype-difference.js:
* JSTests/stress/set-prototype-intersection.js:
* JSTests/stress/set-prototype-isDisjointfrom.js:
* JSTests/stress/set-prototype-isSubsetOf.js:
* JSTests/stress/set-prototype-isSupersetOf.js:
* JSTests/stress/set-prototype-symmetricDifference.js:
* JSTests/stress/set-prototype-union.js:
* Source/JavaScriptCore/builtins/SetPrototype.js:
(linkTimeConstant.alwaysInline.getSetSizeAsInt):
(isSubsetOf):

Canonical link: <a href="https://commits.webkit.org/274009@main">https://commits.webkit.org/274009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5f89388bbd7b6ae153221bb5f471f99893d1066

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39889 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33309 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18838 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31754 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13684 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11924 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11902 "Passed tests") | [💥 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33463 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41152 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/31196 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33789 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33900 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37809 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/37044 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35973 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13944 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/43944 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12881 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9016 "Found 157 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout, jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout-no-llint, stress/array-flatmap.js.dfg-eager-no-cjit-validate, wasm.yaml/wasm/gc/any.js.default-wasm, wasm.yaml/wasm/gc/any.js.wasm-bbq, wasm.yaml/wasm/gc/any.js.wasm-collect-continuously, wasm.yaml/wasm/gc/any.js.wasm-eager, wasm.yaml/wasm/gc/any.js.wasm-eager-jettison ... (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4874 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->