### PR TITLE
Ghostery throws exception trying to use storageArea.set().

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.h
@@ -69,7 +69,7 @@ size_t storageSizeOf(NSString *);
 size_t storageSizeOf(NSDictionary<NSString *, NSString *> *);
 
 /// Returns true if the size of any item in the dictionary exceeds the given quota.
-bool anyItemsExceedQuota(NSDictionary *, size_t quota);
+bool anyItemsExceedQuota(NSDictionary *, size_t quota, NSString **outKeyWithError = nullptr);
 
 } // namespace WebKit
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm
@@ -387,16 +387,24 @@ size_t storageSizeOf(NSDictionary<NSString *, NSString *> *keysAndValues)
     return storageSize;
 }
 
-bool anyItemsExceedQuota(NSDictionary *items, size_t quota)
+bool anyItemsExceedQuota(NSDictionary *items, size_t quota, NSString **outKeyWithError)
 {
-    __block BOOL itemExceededQuota = NO;
+    __block bool itemExceededQuota;
+    __block NSString *keyWithError;
+
     [items enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, BOOL *stop) {
         size_t sizeOfCurrentItem = storageSizeOf(key) + storageSizeOf(value);
         if (sizeOfCurrentItem > quota) {
-            itemExceededQuota = YES;
+            itemExceededQuota = true;
+            keyWithError = key;
             *stop = YES;
         }
     }];
+
+    ASSERT(!itemExceededQuota || (itemExceededQuota && keyWithError));
+
+    if (outKeyWithError)
+        *outKeyWithError = keyWithError;
 
     return itemExceededQuota;
 }

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
@@ -121,6 +121,11 @@ enum class NullValuePolicy : bool {
     Allowed,
 };
 
+enum class ValuePolicy : bool {
+    Recursive,
+    StopAtTopLevel,
+};
+
 inline RefPtr<WebFrame> toWebFrame(JSContextRef context)
 {
     ASSERT(context);
@@ -167,7 +172,7 @@ RefPtr<WebExtensionCallbackHandler> toJSCallbackHandler(JSContextRef, JSValueRef
 
 id toNSObject(JSContextRef, JSValueRef, Class containingObjectsOfClass = Nil);
 NSString *toNSString(JSContextRef, JSValueRef, NullStringPolicy = NullStringPolicy::NullAndUndefinedAsNullString);
-NSDictionary *toNSDictionary(JSContextRef, JSValueRef, NullValuePolicy = NullValuePolicy::NotAllowed);
+NSDictionary *toNSDictionary(JSContextRef, JSValueRef, NullValuePolicy = NullValuePolicy::NotAllowed, ValuePolicy = ValuePolicy::Recursive);
 
 inline NSArray *toNSArray(JSContextRef context, JSValueRef value, Class containingObjectsOfClass = NSObject.class)
 {

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -1343,6 +1343,7 @@ sub _platformTypeConstructor
 
     if ($idlTypeName eq "any") {
         return "serializeJSObject(context, $argumentName, exception)" if $signature->extendedAttributes->{"Serialization"} && $signature->extendedAttributes->{"Serialization"} eq "JSON";
+        return "toNSDictionary(context, $argumentName, NullValuePolicy::Allowed, ValuePolicy::StopAtTopLevel)" if $signature->extendedAttributes->{"NSDictionary"} && $signature->extendedAttributes->{"NSDictionary"} eq "StopAtTopLevel";
         return "toNSDictionary(context, $argumentName, NullValuePolicy::Allowed)" if $signature->extendedAttributes->{"NSDictionary"} && $signature->extendedAttributes->{"NSDictionary"} eq "NullAllowed";
         return "toNSDictionary(context, $argumentName, NullValuePolicy::NotAllowed)" if $signature->extendedAttributes->{"NSDictionary"};
         return "toNSArray(context, $argumentName, $arrayType.class)" if $signature->extendedAttributes->{"NSArray"} && $arrayType;

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl
@@ -31,7 +31,7 @@
 
     [RaisesException] void get([Optional, NSObject, DOMString] any items, [Optional, CallbackHandler] function callback);
     [RaisesException] void getBytesInUse([Optional, NSObject, DOMString] any keys, [Optional, CallbackHandler] function callback);
-    [RaisesException] void set([NSDictionary] any items, [Optional, CallbackHandler] function callback);
+    [RaisesException] void set([NSDictionary=StopAtTopLevel] any items, [Optional, CallbackHandler] function callback);
     [RaisesException] void remove([NSObject] any keys, [Optional, CallbackHandler] function callback);
     [NeedsPage] void clear([Optional, CallbackHandler] function callback);
 


### PR DESCRIPTION
#### 944eaf18a9d63ee99bcbb6ad1fb93f8b3d210cae
<pre>
Ghostery throws exception trying to use storageArea.set().
<a href="https://webkit.org/b/268565">https://webkit.org/b/268565</a>
<a href="https://rdar.apple.com/problem/122118152">rdar://problem/122118152</a>

Reviewed by Jeff Miller.

We need to use JavaScript&apos;s native JSON encoder for storage, since extensions like Ghostery
use toJSON() functions on custom objects to set data in storage.

Teach the code generator how to convert only the top-level keys of a dictionary while
having all the values be JSValue. This allows for the convenience of a dictionary for
the keys, and true values for conversion with JavaScript&apos;s JSON stringifier.

* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::encodeJSONString): Use JSValue&apos;s _toJSONString when it is a JSValue.
(WebKit::encodeJSONData): Ditto.
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.h:
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.mm:
(WebKit::anyItemsExceedQuota): Added keyWithError out param for better error logging.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::set): Record JSON/quota errors per key for debugging ease.
* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
(WebKit::toNSDictionary): Added ValuePolicy key to stop at top-level.
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h:
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_platformTypeConstructor): Added support for NSDictionary=StopAtTopLevel attribute.
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIStorageArea.idl:
(set): Use NSDictionary=StopAtTopLevel for items.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm:
(TestWebKitAPI::TEST): Added new test, and also test quota and null.

Canonical link: <a href="https://commits.webkit.org/273949@main">https://commits.webkit.org/273949@main</a>
</pre>
