### PR TITLE
[SVG2] getPointAtLength should throw exception when in non-rendered document for SVGPathElement

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-03-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-03-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL When SVGGeometryElement.getPointAtLength is called with an element that is not in the document, either succeed or throw exception with SVGPathElement assert_throws_dom: function "function() { pathElement.getPointAtLength(700) }" did not throw
+PASS When SVGGeometryElement.getPointAtLength is called with an element that is not in the document, either succeed or throw exception with SVGPathElement
 PASS When SVGGeometryElement.getPointAtLength is called with an element that is not in the document, either succeed or throw exception with SVGRectElement
 PASS When SVGGeometryElement.getPointAtLength is called with an element that is not in the document, either succeed or throw exception with SVGCircleElement
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt
@@ -1,15 +1,15 @@
 
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: default
-PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none and inline style assert_approx_equals: expected 50 +/- 0.00001 but got 0
+FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none The current element is a non-rendered element.
+FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, path with display: none and inline style The current element is a non-rendered element.
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, rect with display: default
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, rect with display: none The object is in an invalid state.
+FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, rect with display: none The current element is a non-rendered element.
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, circle with display: default
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, circle with display: none The object is in an invalid state.
+FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, circle with display: none The current element is a non-rendered element.
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, polygon with display: default
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, polygon with display: none The object is in an invalid state.
+FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, polygon with display: none The current element is a non-rendered element.
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, polyline with display: default
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, polyline with display: none The object is in an invalid state.
+FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, polyline with display: none The current element is a non-rendered element.
 PASS SVGGeometryElement.getPointAtLength: 'display' and a valid path, ellipse with display: default
-FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, ellipse with display: none The object is in an invalid state.
+FAIL SVGGeometryElement.getPointAtLength: 'display' and a valid path, ellipse with display: none The current element is a non-rendered element.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-05-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-05-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, path with display: default and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw
-FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, path with display: none and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw
+PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, path with display: none and an empty path
 FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, rect with display: default and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw
 PASS SVGGeometryElement.getPointAtLength: 'display' and empty path, rect with display: none and an empty path
 FAIL SVGGeometryElement.getPointAtLength: 'display' and empty path, circle with display: default and an empty path assert_throws_dom: function "function() { element.getPointAtLength(300); }" did not throw

--- a/LayoutTests/svg/dom/SVGPolygonElement-baseVal-list-removal-crash.html
+++ b/LayoutTests/svg/dom/SVGPolygonElement-baseVal-list-removal-crash.html
@@ -6,8 +6,8 @@ if (window.testRunner)
 
 function go() {
     var oSVGPolygon = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
-    var oSVGPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
-    var oSVGPoint1 = oSVGPath.getPointAtLength(0);
+    var svgRoot = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    var oSVGPoint1 = svgRoot.createSVGPoint();
     oSVGPolygon.points.initialize(oSVGPoint1);
     oSVGPolygon.points.removeItem(-9223372036854775802);
     alert("Accessing old oSVGPoint1.x: " + oSVGPoint1.x);

--- a/LayoutTests/svg/dom/path-pointAtLength-expected.txt
+++ b/LayoutTests/svg/dom/path-pointAtLength-expected.txt
@@ -3,10 +3,10 @@ This tests getPointAtLength of SVG path.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS pointAtLengthOfPath('M0,20 L400,20 L640,20') is '(640, 20)'
-PASS pointAtLengthOfPath('M0,20 L400,20 L640,20 z') is '(580, 20)'
-PASS pointAtLengthOfPath('M0,20 L400,20 z M 320,20 L640,20') is '(100, 20)'
-PASS pointAtLengthOfPath('M0,20 L20,40') is '(20, 40)'
+PASS pointAtLengthOfPath('M0,20 L400,20 L640,20') threw exception InvalidStateError: The current element is a non-rendered element..
+PASS pointAtLengthOfPath('M0,20 L400,20 L640,20 z') threw exception InvalidStateError: The current element is a non-rendered element..
+PASS pointAtLengthOfPath('M0,20 L400,20 z M 320,20 L640,20') threw exception InvalidStateError: The current element is a non-rendered element..
+PASS pointAtLengthOfPath('M0,20 L20,40') threw exception InvalidStateError: The current element is a non-rendered element..
 PASS pathElement.getPointAtLength(Math.NaN) threw exception TypeError: The provided value is non-finite.
 PASS pathElement.getPointAtLength() threw exception TypeError: Not enough arguments.
 PASS pathElement.getPointAtLength(Math.Infinity) threw exception TypeError: The provided value is non-finite.

--- a/LayoutTests/svg/dom/path-pointAtLength.html
+++ b/LayoutTests/svg/dom/path-pointAtLength.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
@@ -18,10 +18,10 @@ function pointAtLengthOfPath(string) {
     return "(" + Math.round(point.x) + ", " + Math.round(point.y) + ")";
 }
 
-shouldBe("pointAtLengthOfPath('M0,20 L400,20 L640,20')", "'(640, 20)'");
-shouldBe("pointAtLengthOfPath('M0,20 L400,20 L640,20 z')", "'(580, 20)'");
-shouldBe("pointAtLengthOfPath('M0,20 L400,20 z M 320,20 L640,20')", "'(100, 20)'");
-shouldBe("pointAtLengthOfPath('M0,20 L20,40')", "'(20, 40)'");
+shouldThrow("pointAtLengthOfPath('M0,20 L400,20 L640,20')");
+shouldThrow("pointAtLengthOfPath('M0,20 L400,20 L640,20 z')");
+shouldThrow("pointAtLengthOfPath('M0,20 L400,20 z M 320,20 L640,20')");
+shouldThrow("pointAtLengthOfPath('M0,20 L20,40')");
 shouldThrow("pathElement.getPointAtLength(Math.NaN)");
 shouldThrow("pathElement.getPointAtLength()");
 shouldThrow("pathElement.getPointAtLength(Math.Infinity)");
@@ -29,6 +29,5 @@ shouldThrow("pathElement.getPointAtLength('abc')");
 
 var successfullyParsed = true;
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/svg/SVGGeometryElement.cpp
+++ b/Source/WebCore/svg/SVGGeometryElement.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2018 Adobe Systems Incorporated. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -73,10 +73,9 @@ ExceptionOr<Ref<SVGPoint>> SVGGeometryElement::getPointAtLength(float distance) 
     distance = clampTo<float>(distance, 0, getTotalLength());
 
     auto* renderer = this->renderer();
-
     // Spec: If current element is a non-rendered element, throw an InvalidStateError.
     if (!renderer)
-        return Exception { ExceptionCode::InvalidStateError };
+        return Exception { ExceptionCode::InvalidStateError, "The current element is a non-rendered element."_s };
 
     // Spec: Return a newly created, detached SVGPoint object.
     if (auto* renderSVGShape = dynamicDowncast<LegacyRenderSVGShape>(renderer))

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2006, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -180,8 +180,14 @@ float SVGPathElement::getTotalLength() const
 
 ExceptionOr<Ref<SVGPoint>> SVGPathElement::getPointAtLength(float distance) const
 {
+    document().updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+
     // Spec: Clamp distance to [0, length].
     distance = clampTo<float>(distance, 0, getTotalLength());
+
+    // Spec: If current element is a non-rendered element, throw an InvalidStateError.
+    if (!renderer())
+        return Exception { ExceptionCode::InvalidStateError, "The current element is a non-rendered element."_s };
 
     // Spec: Return a newly created, detached SVGPoint object.
     return SVGPoint::create(getPointAtLengthOfSVGPathByteStream(pathByteStream(), distance));


### PR DESCRIPTION
#### 9f2facf9ef6db9cf652f3e8729ce4e5cc3b90e26
<pre>
[SVG2] getPointAtLength should throw exception when in non-rendered document for SVGPathElement

<a href="https://bugs.webkit.org/show_bug.cgi?id=264876">https://bugs.webkit.org/show_bug.cgi?id=264876</a>
<a href="https://rdar.apple.com/problem/118720630">rdar://problem/118720630</a>

Reviewed by Said Abou-Hallawa.

This patch aligns WebKit with Gecko / Firefox, Blink / Chromium and Web-Specification [1]:

[1] <a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGGeometryElement">https://svgwg.org/svg2-draft/types.html#InterfaceSVGGeometryElement</a>

NOTE: SVGPathElement interface with SVGGeometryElement.

This patch aligns WebKit to throw exception in case of document being non-rendered element.

&quot;If current element is a non-rendered element, and the UA is not able to compute the total length
of the path, then throw an InvalidStateError.&quot;

I took the opportunity to add meaningful error to `SVGGeometryElement` as well and add check for
content-visibility to SVGPathElement.

* Source/WebCore/svg/SVGGeometryElement.cpp:
(SVGGeometryElement::getPointAtLength): Added meaningful message
* Source/WebCore/svg/SVGPathElement.cpp:
(SVGPathElement::getPointAtLength): Aligned with &apos;SVGGeometryElement&apos;
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-03-expected.txt: Rebaselined
* LayoutTests/svg/dom/SVGPolygonElement-baseVal-list-removal-crash.html: Rebaselined
* LayoutTests/svg/dom/path-pointAtLength.html: Ditto
* LayoutTests/svg/dom/path-pointAtLength-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-04-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.getPointAtLength-05-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/274308@main">https://commits.webkit.org/274308@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8200f0c82ae58abe633f8d863f02f7a0f2f2cd99

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41079 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34221 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14818 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32406 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33532 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12792 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12776 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42355 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38603 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36809 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/33689 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8672 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13851 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14458 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->