### PR TITLE
Generate Serialization for MediaPlaybackTargetContext.

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlaybackTargetContext.serialization.in
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlaybackTargetContext.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2023-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -22,6 +22,8 @@
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 
+header: <WebCore/MediaPlaybackTargetContext.h>
+
 enum class WebCore::MediaPlaybackTargetContextMockState : uint8_t {
     Unknown,
     OutputDeviceUnavailable,
@@ -31,8 +33,16 @@ enum class WebCore::MediaPlaybackTargetContextMockState : uint8_t {
 enum class WebCore::MediaPlaybackTargetContextType : uint8_t {
     None,
     AVOutputContext,
-    SerializedAVOutputContext,
     Mock,
+};
+
+[Nested] struct WebCore::MediaPlaybackTargetContext::NonPlatformData {
+    String mockDeviceName;
+    WebCore::MediaPlaybackTargetContextMockState mockState;
+}
+
+[CreateUsing=fromIPCData] class WebCore::MediaPlaybackTargetContext {
+    std::optional<std::variant<RetainPtr<AVOutputContext>, WebCore::MediaPlaybackTargetContext::NonPlatformData>> ipcData();
 };
 
 #endif // ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -807,11 +807,6 @@ void RemoteMediaPlayerProxy::setShouldPlayToPlaybackTarget(bool shouldPlay)
 void RemoteMediaPlayerProxy::setWirelessPlaybackTarget(MediaPlaybackTargetContext&& targetContext)
 {
     switch (targetContext.type()) {
-    case MediaPlaybackTargetContext::Type::SerializedAVOutputContext: {
-        if (targetContext.deserializeOutputContext())
-            m_player->setWirelessPlaybackTarget(MediaPlaybackTargetCocoa::create(WTFMove(targetContext)));
-        break;
-    }
     case MediaPlaybackTargetContext::Type::Mock:
 #if PLATFORM(MAC)
         m_player->setWirelessPlaybackTarget(MediaPlaybackTargetMock::create(targetContext.deviceName(), targetContext.mockState()));

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
@@ -116,9 +116,6 @@ void RemoteMediaSessionHelperProxy::activeAudioRouteDidChange(ShouldPause should
 void RemoteMediaSessionHelperProxy::activeVideoRouteDidChange(SupportsAirPlayVideo supportsAirPlayVideo, Ref<WebCore::MediaPlaybackTarget>&& target)
 {
     auto context = target->targetContext();
-    if (!context.serializeOutputContext())
-        return;
-
     m_gpuConnection.connection().send(Messages::RemoteMediaSessionHelper::ActiveVideoRouteDidChange(supportsAirPlayVideo, context), { });
 }
 

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
@@ -78,54 +78,6 @@
 
 namespace IPC {
 
-#if ENABLE(WIRELESS_PLAYBACK_TARGET)
-
-void ArgumentCoder<WebCore::MediaPlaybackTargetContext>::encodePlatformData(Encoder& encoder, const WebCore::MediaPlaybackTargetContext& target)
-{
-    if (target.type() == WebCore::MediaPlaybackTargetContext::Type::AVOutputContext) {
-        if ([PAL::getAVOutputContextClass() conformsToProtocol:@protocol(NSSecureCoding)])
-            encoder << target.outputContext();
-    } else if (target.type() == WebCore::MediaPlaybackTargetContext::Type::SerializedAVOutputContext) {
-        encoder << target.serializedOutputContext();
-        encoder << target.hasActiveRoute();
-    } else
-        ASSERT_NOT_REACHED();
-}
-
-bool ArgumentCoder<WebCore::MediaPlaybackTargetContext>::decodePlatformData(Decoder& decoder, WebCore::MediaPlaybackTargetContext::Type contextType, WebCore::MediaPlaybackTargetContext& target)
-{
-    ASSERT(contextType != WebCore::MediaPlaybackTargetContext::Type::Mock);
-
-    if (contextType == WebCore::MediaPlaybackTargetContext::Type::AVOutputContext) {
-        if (![PAL::getAVOutputContextClass() conformsToProtocol:@protocol(NSSecureCoding)])
-            return false;
-
-        auto outputContext = decoder.decodeWithAllowedClasses<AVOutputContext>();
-        if (!outputContext)
-            return false;
-
-        target = WebCore::MediaPlaybackTargetContext { WTFMove(*outputContext) };
-        return true;
-    }
-
-    if (contextType == WebCore::MediaPlaybackTargetContext::Type::SerializedAVOutputContext) {
-        std::optional<RetainPtr<NSData>> serializedOutputContext = decoder.decode<RetainPtr<NSData>>();
-        if (!serializedOutputContext)
-            return false;
-
-        bool hasActiveRoute;
-        if (!decoder.decode(hasActiveRoute))
-            return false;
-
-        target = WebCore::MediaPlaybackTargetContext { WTFMove(*serializedOutputContext), hasActiveRoute };
-        return true;
-    }
-
-    return false;
-}
-#endif
-
-
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
 
 template<> Class getClass<VKCImageAnalysis>()

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -169,10 +169,6 @@
 #include <WebCore/SelectionGeometry.h>
 #endif // PLATFORM(IOS_FAMILY)
 
-#if ENABLE(WIRELESS_PLAYBACK_TARGET)
-#include <WebCore/MediaPlaybackTargetContext.h>
-#endif
-
 #if ENABLE(MEDIA_STREAM)
 #include <WebCore/CaptureDevice.h>
 #include <WebCore/MediaConstraints.h>
@@ -324,53 +320,6 @@ std::optional<FontPlatformData::Attributes> ArgumentCoder<FontPlatformData::Attr
         return std::nullopt;
 
     return result;
-}
-#endif
-
-#if ENABLE(WIRELESS_PLAYBACK_TARGET)
-void ArgumentCoder<MediaPlaybackTargetContext>::encode(Encoder& encoder, const MediaPlaybackTargetContext& target)
-{
-    bool hasPlatformData = target.encodingRequiresPlatformData();
-    encoder << hasPlatformData;
-
-    MediaPlaybackTargetContext::Type contextType = target.type();
-    encoder << contextType;
-
-    if (target.encodingRequiresPlatformData()) {
-        encodePlatformData(encoder, target);
-        return;
-    }
-
-    ASSERT(contextType == MediaPlaybackTargetContext::Type::Mock);
-    encoder << target.deviceName();
-    encoder << target.mockState();
-}
-
-bool ArgumentCoder<MediaPlaybackTargetContext>::decode(Decoder& decoder, MediaPlaybackTargetContext& target)
-{
-    bool hasPlatformData;
-    if (!decoder.decode(hasPlatformData))
-        return false;
-
-    MediaPlaybackTargetContext::Type contextType;
-    if (!decoder.decode(contextType))
-        return false;
-
-    if (hasPlatformData)
-        return decodePlatformData(decoder, contextType, target);
-
-    ASSERT(contextType == MediaPlaybackTargetContext::Type::Mock);
-    String deviceName;
-    if (!decoder.decode(deviceName))
-        return false;
-
-    MediaPlaybackTargetContext::MockState mockState;
-    if (!decoder.decode(mockState))
-        return false;
-
-    target = MediaPlaybackTargetContext(deviceName, mockState);
-
-    return true;
 }
 #endif
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -60,10 +60,6 @@
 #include <WebCore/CurlProxySettings.h>
 #endif
 
-#if ENABLE(WIRELESS_PLAYBACK_TARGET)
-#include <WebCore/MediaPlaybackTargetContext.h>
-#endif
-
 #if PLATFORM(IOS_FAMILY)
 #include <WebCore/InspectorOverlay.h>
 #endif
@@ -174,15 +170,6 @@ template<> struct ArgumentCoder<WebCore::SoupNetworkProxySettings> {
 template<> struct ArgumentCoder<WebCore::CurlProxySettings> {
     static void encode(Encoder&, const WebCore::CurlProxySettings&);
     static std::optional<WebCore::CurlProxySettings> decode(Decoder&);
-};
-#endif
-
-#if ENABLE(WIRELESS_PLAYBACK_TARGET)
-template<> struct ArgumentCoder<WebCore::MediaPlaybackTargetContext> {
-    static void encode(Encoder&, const WebCore::MediaPlaybackTargetContext&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::MediaPlaybackTargetContext&);
-    static void encodePlatformData(Encoder&, const WebCore::MediaPlaybackTargetContext&);
-    static WARN_UNUSED_RETURN bool decodePlatformData(Decoder&, WebCore::MediaPlaybackTargetContext::Type, WebCore::MediaPlaybackTargetContext&);
 };
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11688,10 +11688,6 @@ void WebPageProxy::Internals::setPlaybackTarget(PlaybackTargetClientContextIdent
         return;
 
     auto context = target->targetContext();
-    ASSERT(context.type() != MediaPlaybackTargetContext::Type::SerializedAVOutputContext);
-    if (page.preferences().useGPUProcessForMediaEnabled())
-        context.serializeOutputContext();
-
     page.send(Messages::WebPage::PlaybackTargetSelected(contextId, context));
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -1035,7 +1035,6 @@ void WebPage::playbackTargetSelected(PlaybackTargetClientContextIdentifier conte
 {
     switch (targetContext.type()) {
     case MediaPlaybackTargetContext::Type::AVOutputContext:
-    case MediaPlaybackTargetContext::Type::SerializedAVOutputContext:
         m_page->setPlaybackTarget(contextId, MediaPlaybackTargetCocoa::create(WTFMove(targetContext)));
         break;
     case MediaPlaybackTargetContext::Type::Mock:


### PR DESCRIPTION
#### f1314fda907d00d4b4f1a88f632f953f5dcd4c32
<pre>
Generate Serialization for MediaPlaybackTargetContext.
<a href="https://bugs.webkit.org/show_bug.cgi?id=268584">https://bugs.webkit.org/show_bug.cgi?id=268584</a>
<a href="https://rdar.apple.com/122137982">rdar://122137982</a>

Reviewed by Chris Dumez.

Generate Serialization for MediaPlaybackTargetContext.
Also removed hand coded NSKU (NSKeyedUnarchiver) encoder and decoder APIs.

* Source/WebCore/platform/graphics/cocoa/MediaPlaybackTargetContext.h:
(WebCore::MediaPlaybackTargetContext::MediaPlaybackTargetContext):
(WebCore::MediaPlaybackTargetContext::encodingRequiresPlatformData const):
(WebCore::MediaPlaybackTargetContext::serializedOutputContext const): Deleted.
* Source/WebCore/platform/graphics/cocoa/MediaPlaybackTargetContext.mm:
(WebCore::MediaPlaybackTargetContext::encodePlatformData const):
(WebCore::MediaPlaybackTargetContext::hasActiveRoute const):
(WebCore::MediaPlaybackTargetContext::serializeOutputContext): Deleted.
(WebCore::MediaPlaybackTargetContext::deserializeOutputContext): Deleted.
* Source/WebCore/platform/graphics/cocoa/MediaPlaybackTargetContext.serialization.in:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::setWirelessPlaybackTarget):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::ArgumentCoder&lt;WebCore::MediaPlaybackTargetContext&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::MediaPlaybackTargetContext&gt;::decodePlatformData): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::Internals::setPlaybackTarget):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::playbackTargetSelected const):

Canonical link: <a href="https://commits.webkit.org/274311@main">https://commits.webkit.org/274311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd4c9ecfe8eb66ddd352d7d03a64343316abb1d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41183 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34305 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40955 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14924 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14832 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12875 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42453 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35131 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38692 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11161 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36897 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15074 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/8670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5041 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14551 "Build is being retried. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | | | 
<!--EWS-Status-Bubble-End-->