### PR TITLE
_WKHitTestResult should expose an imageSuggestedFilename property

### DIFF
--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -105,7 +105,7 @@ public:
     WEBCORE_EXPORT String titleDisplayString() const;
     WEBCORE_EXPORT Image* image() const;
     WEBCORE_EXPORT IntRect imageRect() const;
-    bool hasEntireImage() const;
+    WEBCORE_EXPORT bool hasEntireImage() const;
     WEBCORE_EXPORT URL absoluteImageURL() const;
     WEBCORE_EXPORT URL absolutePDFURL() const;
     WEBCORE_EXPORT URL absoluteMediaURL() const;

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h
@@ -52,6 +52,7 @@ WK_CLASS_AVAILABLE(macos(10.12), ios(16.0))
 @property (nonatomic, readonly, copy) NSString *linkLabel;
 @property (nonatomic, readonly, copy) NSString *linkTitle;
 @property (nonatomic, readonly, copy) NSString *linkSuggestedFilename WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, readonly, copy) NSString *imageSuggestedFilename WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, readonly, copy) NSString *lookupText;
 
 @property (nonatomic, readonly, getter=isContentEditable) BOOL contentEditable;

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
@@ -100,6 +100,11 @@ static NSURL *URLFromString(const WTF::String& urlString)
     return _hitTestResult->linkSuggestedFilename();
 }
 
+- (NSString *)imageSuggestedFilename
+{
+    return _hitTestResult->imageSuggestedFilename();
+}
+
 - (NSString *)imageMIMEType
 {
     return _hitTestResult->sourceImageMIMEType();

--- a/Source/WebKit/Shared/WebHitTestResultData.cpp
+++ b/Source/WebKit/Shared/WebHitTestResultData.cpp
@@ -68,6 +68,18 @@ static String linkLocalDataMIMETypeFromHitTestResult(const HitTestResult& hitTes
     return webFrame->mimeTypeForResourceWithURL(hitTestResult.absoluteLinkURL());
 }
 
+static String imageSuggestedFilenameFromHitTestResult(const HitTestResult& hitTestResult)
+{
+    if (!hitTestResult.hasEntireImage())
+        return nullString();
+
+    RefPtr webFrame = webFrameFromHitTestResult(hitTestResult);
+    if (!webFrame)
+        return nullString();
+
+    return webFrame->suggestedFilenameForResourceWithURL(hitTestResult.absoluteImageURL());
+}
+
 WebHitTestResultData::WebHitTestResultData()
 {
 }
@@ -92,12 +104,14 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, c
     , frameInfo(frameInfoDataFromHitTestResult(hitTestResult))
     , toolTipText(toolTipText)
     , hasLocalDataForLinkURL(hitTestResult.hasLocalDataForLinkURL())
+    , hasEntireImage(hitTestResult.hasEntireImage())
 {
     if (auto* scrollbar = hitTestResult.scrollbar())
         isScrollbar = scrollbar->orientation() == ScrollbarOrientation::Horizontal ? IsScrollbar::Horizontal : IsScrollbar::Vertical;
 
     elementType = elementTypeFromHitTestResult(hitTestResult);
     linkLocalDataMIMEType = linkLocalDataMIMETypeFromHitTestResult(hitTestResult);
+    imageSuggestedFilename = imageSuggestedFilenameFromHitTestResult(hitTestResult);
 }
 
 WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, bool includeImage)
@@ -119,12 +133,14 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, b
     , elementType(ElementType::None)
     , frameInfo(frameInfoDataFromHitTestResult(hitTestResult))
     , hasLocalDataForLinkURL(hitTestResult.hasLocalDataForLinkURL())
+    , hasEntireImage(hitTestResult.hasEntireImage())
 {
     if (auto* scrollbar = hitTestResult.scrollbar())
         isScrollbar = scrollbar->orientation() == ScrollbarOrientation::Horizontal ? IsScrollbar::Horizontal : IsScrollbar::Vertical;
 
     elementType = elementTypeFromHitTestResult(hitTestResult);
     linkLocalDataMIMEType = linkLocalDataMIMETypeFromHitTestResult(hitTestResult);
+    imageSuggestedFilename = imageSuggestedFilenameFromHitTestResult(hitTestResult);
 
     if (!includeImage)
         return;
@@ -156,7 +172,7 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, b
     }
 }
 
-WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar& isScrollbar, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, const WebHitTestResultData::ElementType& elementType, std::optional<FrameInfoData>&& frameInfo, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, const String& linkLocalDataMIMEType, bool hasLocalDataForLinkURL,
+WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar& isScrollbar, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, const WebHitTestResultData::ElementType& elementType, std::optional<FrameInfoData>&& frameInfo, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, const String& linkLocalDataMIMEType, bool hasLocalDataForLinkURL, bool hasEntireImage,
 #if PLATFORM(MAC)
     const WebHitTestResultPlatformData& platformData,
 #endif
@@ -168,6 +184,7 @@ WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const
         , linkLabel(linkLabel)
         , linkTitle(linkTitle)
         , linkSuggestedFilename(linkSuggestedFilename)
+        , imageSuggestedFilename(imageSuggestedFilename)
         , isContentEditable(isContentEditable)
         , elementBoundingBox(elementBoundingBox)
         , isScrollbar(isScrollbar)
@@ -185,6 +202,7 @@ WebHitTestResultData::WebHitTestResultData(const String& absoluteImageURL, const
         , sourceImageMIMEType(sourceImageMIMEType)
         , linkLocalDataMIMEType(linkLocalDataMIMEType)
         , hasLocalDataForLinkURL(hasLocalDataForLinkURL)
+        , hasEntireImage(hasEntireImage)
 #if PLATFORM(MAC)
         , platformData(platformData)
 #endif

--- a/Source/WebKit/Shared/WebHitTestResultData.h
+++ b/Source/WebKit/Shared/WebHitTestResultData.h
@@ -77,6 +77,7 @@ struct WebHitTestResultData {
     String linkLabel;
     String linkTitle;
     String linkSuggestedFilename;
+    String imageSuggestedFilename;
     bool isContentEditable;
     WebCore::IntRect elementBoundingBox;
     enum class IsScrollbar : uint8_t { No, Vertical, Horizontal };
@@ -98,6 +99,7 @@ struct WebHitTestResultData {
     String sourceImageMIMEType;
     String linkLocalDataMIMEType;
     bool hasLocalDataForLinkURL;
+    bool hasEntireImage;
 
 #if PLATFORM(MAC)
     WebHitTestResultPlatformData platformData;
@@ -114,7 +116,7 @@ struct WebHitTestResultData {
     WebHitTestResultData& operator=(const WebHitTestResultData&) = default;
     WebHitTestResultData(const WebCore::HitTestResult&, const String& toolTipText);
     WebHitTestResultData(const WebCore::HitTestResult&, bool includeImage);
-    WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar&, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, const WebKit::WebHitTestResultData::ElementType&, std::optional<FrameInfoData>&&, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, const String& linkLocalDataMIMEType, bool hasLocalDataForLinkURL,
+    WebHitTestResultData(const String& absoluteImageURL, const String& absolutePDFURL, const String& absoluteLinkURL, const String& absoluteMediaURL, const String& linkLabel, const String& linkTitle, const String& linkSuggestedFilename, const String& imageSuggestedFilename, bool isContentEditable, const WebCore::IntRect& elementBoundingBox, const WebKit::WebHitTestResultData::IsScrollbar&, bool isSelected, bool isTextNode, bool isOverTextInsideFormControlElement, bool isDownloadableMedia, bool mediaIsInFullscreen, const WebKit::WebHitTestResultData::ElementType&, std::optional<FrameInfoData>&&, const String& lookupText, const String& toolTipText, const String& imageText, std::optional<WebCore::SharedMemory::Handle>&& imageHandle, const RefPtr<WebCore::ShareableBitmap>& imageBitmap, const String& sourceImageMIMEType, const String& linkLocalDataMIMEType, bool hasLocalDataForLinkURL, bool hasEntireImage,
 #if PLATFORM(MAC)
         const WebHitTestResultPlatformData&,
 #endif

--- a/Source/WebKit/Shared/WebHitTestResultData.serialization.in
+++ b/Source/WebKit/Shared/WebHitTestResultData.serialization.in
@@ -42,6 +42,7 @@ struct WebKit::WebHitTestResultData {
     String linkLabel;
     String linkTitle;
     String linkSuggestedFilename;
+    String imageSuggestedFilename;
     bool isContentEditable;
     WebCore::IntRect elementBoundingBox;
     WebKit::WebHitTestResultData::IsScrollbar isScrollbar;
@@ -60,6 +61,7 @@ struct WebKit::WebHitTestResultData {
     String sourceImageMIMEType;
     String linkLocalDataMIMEType;
     bool hasLocalDataForLinkURL;
+    bool hasEntireImage;
 
 #if PLATFORM(MAC)
     WebKit::WebHitTestResultPlatformData platformData;

--- a/Source/WebKit/UIProcess/API/APIHitTestResult.h
+++ b/Source/WebKit/UIProcess/API/APIHitTestResult.h
@@ -58,6 +58,7 @@ public:
     WTF::String linkTitle() const { return m_data.linkTitle; }
     WTF::String linkLocalDataMIMEType() const { return m_data.linkLocalDataMIMEType; }
     WTF::String linkSuggestedFilename() const { return m_data.linkSuggestedFilename; }
+    WTF::String imageSuggestedFilename() const { return m_data.imageSuggestedFilename; }
     WTF::String lookupText() const { return m_data.lookupText; }
     WTF::String sourceImageMIMEType() const { return m_data.sourceImageMIMEType; }
 

--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
@@ -733,6 +733,28 @@ TEST(ContextMenuTests, HitTestResultLinkSuggestedFilename)
     Util::run(&gotProposedMenu);
 }
 
+TEST(ContextMenuTests, HitTestResultImageSuggestedFilename)
+{
+    auto delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotProposedMenu = false;
+    [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
+        EXPECT_TRUE(elementInfo.hasEntireImage);
+        EXPECT_NOT_NULL(elementInfo.hitTestResult);
+        EXPECT_TRUE([elementInfo.hitTestResult.imageSuggestedFilename isEqualToString:@"sunset-in-cupertino-600px.jpg"]);
+        completion(nil);
+        gotProposedMenu = true;
+    }];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView setUIDelegate:delegate.get()];
+    [webView synchronouslyLoadHTMLString:@"<img src='sunset-in-cupertino-600px.jpg'></img>"];
+
+    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
+    Util::run(&gotProposedMenu);
+}
+
 TEST(ContextMenuTests, HitTestResultHasLocalDataForLinkURL)
 {
     auto delegate = adoptNS([[TestUIDelegate alloc] init]);


### PR DESCRIPTION
#### 13769cf1e65593750d931d505723cda7c2e3874d
<pre>
_WKHitTestResult should expose an imageSuggestedFilename property
<a href="https://bugs.webkit.org/show_bug.cgi?id=268588">https://bugs.webkit.org/show_bug.cgi?id=268588</a>
<a href="https://rdar.apple.com/122130871">rdar://122130871</a>

Reviewed by Aditya Keerthi.

Add hasEntireImage and imageSuggestedFilename to WebHitTestResultData (and the underlying plumbing
to support calculating the filename) and expose imageSuggestedFilename via a property on
_WKHitTestResult. hasEntireImage is currently exposed on _WKContextMenuElementInfo, which in
hindsight was probably a mistake, it should be on _WKHitTestResult since that class contains every
other related property, but I&apos;ll address that in a separate patch.

* Source/WebCore/rendering/HitTestResult.h:
Export hasEntireImage() so WebKit can use it.

* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.h:
Added imageSuggestedFilename property.

* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm:
(-[_WKHitTestResult imageSuggestedFilename]):
Added.

* Source/WebKit/Shared/WebHitTestResultData.cpp:
(WebKit::imageSuggestedFilenameFromHitTestResult):
Added, we can only determine the suggested filename if the entire image is available.

(WebKit::WebHitTestResultData::WebHitTestResultData):
Initialize linkLocalDataMIMEType.

* Source/WebKit/Shared/WebHitTestResultData.h:
Added imageSuggestedFilename and hasEntireImage.

* Source/WebKit/Shared/WebHitTestResultData.serialization.in:
Ditto.

* Source/WebKit/UIProcess/API/APIHitTestResult.h:
(API::HitTestResult::imageSuggestedFilename const):
Added.

* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST):
Added HitTestResultImageSuggestedFilename, loads an image and verifies that the
imageSuggestedFilename is the name of the file.

Canonical link: <a href="https://commits.webkit.org/274042@main">https://commits.webkit.org/274042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09ef3ebd37e77ca960577c69e6c768deffaf6e96

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40180 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33510 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13691 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31887 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12151 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12088 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41440 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34087 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37983 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36152 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14109 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8477 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13422 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->