### PR TITLE
[Site Isolation] Connect scrolling trees from main process and iframe process

### DIFF
--- a/LayoutTests/http/tests/site-isolation/scrolling/basic-scrolling-tree-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/scrolling/basic-scrolling-tree-expected.txt
@@ -1,0 +1,36 @@
+Verifies scrolling tree for simple page.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+(scrolling tree
+  (frame scrolling node
+    (scrollable area size width=800 height=600)
+    (total content size width=800 height=600)
+    (last committed scroll position (0,0))
+    (scrollable area parameters
+      (horizontal scroll elasticity 2)
+      (vertical scroll elasticity 2)
+      (horizontal scrollbar mode 0)
+      (vertical scrollbar mode 0))
+    (layout viewport (0,0) width=800 height=600)
+    (min layoutViewport origin (0,0))
+    (max layoutViewport origin (0,0))
+    (behavior for fixed 1)
+    (frame hosting node
+      (has hosting context identifier )
+      (frame scrolling node
+        (scrollable area size width=800 height=600)
+        (total content size width=800 height=600)
+        (last committed scroll position (0,0))
+        (scrollable area parameters
+          (horizontal scroll elasticity 0)
+          (vertical scroll elasticity 0)
+          (horizontal scrollbar mode 0)
+          (vertical scrollbar mode 0))
+        (layout viewport (0,0) width=800 height=600)
+        (min layoutViewport origin (0,0))
+        (max layoutViewport origin (0,0))
+        (behavior for fixed 1)))))
+

--- a/LayoutTests/http/tests/site-isolation/scrolling/basic-scrolling-tree.html
+++ b/LayoutTests/http/tests/site-isolation/scrolling/basic-scrolling-tree.html
@@ -1,0 +1,25 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<body>
+    <pre id="scrollingTree"></pre>
+</body>
+<script>
+description("Verifies scrolling tree for simple page.");
+jsTestIsAsync = true;
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();            
+}
+
+window.addEventListener('load', async () => {
+    if (!window.internals)
+        return
+
+    document.getElementById('scrollingTree').innerText = await UIHelper.getScrollingTree();
+    if (window.testRunner)
+        testRunner.notifyDone();
+}, false);
+</script>
+<iframe width="300" height="300" src="http://localhost:8000/site-isolation/scrolling/resources/empty-iframe.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/scrolling/resources/overflow-scroll-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/scrolling/resources/overflow-scroll-iframe.html
@@ -1,0 +1,25 @@
+<style>
+    body {
+        height: 1000px;
+    }
+    .scroller {
+        position: absolute;
+        top: 10px;
+        left: 10px;
+        height: 50px;
+        width: 50px;
+        padding: 5px;
+        overflow: scroll;
+        background-color: green;
+    }
+    .content {
+        width: 200%;
+        height: 300%;
+    }
+    
+</style>
+<body>
+    <div class="scroller">
+        <div class="content">Loreum ipsum dolor</div>
+    </div>
+</body>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4584,6 +4584,8 @@ webkit.org/b/257904 http/tests/site-isolation/draw-after-navigation.html [ Skip 
 webkit.org/b/257904 http/tests/site-isolation/selection-focus.html [ Skip ]
 webkit.org/b/257904 http/tests/site-isolation/basic-iframe-render-output.html [ Failure Timeout Pass ]
 
+webkit.org/b/269550 http/tests/site-isolation/scrolling/basic-scrolling-tree.html [ Skip ]
+
 # This test can't be enabled on iOS until EventSenderProxyIOS::keyDown() is implemented.
 http/tests/site-isolation/key-events.html [ Skip ]
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1992,6 +1992,8 @@ webkit.org/b/268836 [ Monterey+ Debug ] loader/stateobjects/pushstate-size-ifram
 [ Monterey+ Release ] imported/w3c/web-platform-tests/preload/preload-in-data-doc.html [ Pass ImageOnlyFailure ]
 [ Monterey+ Release ] fast/speechrecognition/start-recognition-after-denied-gum.html [ Pass Timeout ]
 
+webkit.org/b/269639 http/tests/site-isolation/window-properties.html [ Skip ]
+
 #webkit.org/b/269301  (2X imported/w3c/web-platform-tests/webcodecs/videoFrame (layout-tests) are constant failures)
 [ Monterey+ x86_64 ] imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any.html [ Failure ]
 [ Monterey+ x86_64 ] imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any.worker.html [ Failure ]

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -801,6 +801,9 @@ void AsyncScrollingCoordinator::scrollableAreaScrollbarLayerDidChange(Scrollable
 ScrollingNodeID AsyncScrollingCoordinator::createNode(ScrollingNodeType nodeType, ScrollingNodeID newNodeID)
 {
     LOG_WITH_STREAM(ScrollingTree, stream << "AsyncScrollingCoordinator::createNode " << nodeType << " node " << newNodeID);
+    // TODO: rdar://123052250 Need a better way to fix scrolling tree in iframe process
+    if ((!m_scrollingStateTree->rootStateNode() && nodeType == ScrollingNodeType::Subframe) || (m_scrollingStateTree->rootStateNode() && m_scrollingStateTree->rootStateNode()->scrollingNodeID() == newNodeID))
+        return m_scrollingStateTree->insertNode(nodeType, newNodeID, { }, 0);
     return m_scrollingStateTree->createUnparentedNode(nodeType, newNodeID);
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -442,4 +442,9 @@ String ScrollingCoordinator::synchronousScrollingReasonsAsText() const
     return String();
 }
 
+FrameIdentifier ScrollingCoordinator::mainFrameIdentifier() const
+{
+    return m_page->mainFrame().frameID();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "EventTrackingRegions.h"
+#include "FrameIdentifier.h"
 #include "LayerHostingContextIdentifier.h"
 #include "LayoutRect.h"
 #include "PlatformWheelEvent.h"
@@ -211,6 +212,7 @@ public:
     WEBCORE_EXPORT virtual void setMouseIsOverScrollbar(Scrollbar*, bool) { }
     WEBCORE_EXPORT virtual void setScrollbarEnabled(Scrollbar&) { }
     WEBCORE_EXPORT virtual void setLayerHostingContextIdentifierForFrameHostingNode(ScrollingNodeID, std::optional<LayerHostingContextIdentifier>) { }
+    FrameIdentifier mainFrameIdentifier() const;
 
 protected:
     explicit ScrollingCoordinator(Page*);

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
@@ -60,6 +60,7 @@ static void nodeWasReattachedRecursive(ScrollingStateNode& node)
 
 ScrollingStateTree::ScrollingStateTree(AsyncScrollingCoordinator* scrollingCoordinator)
     : m_scrollingCoordinator(scrollingCoordinator)
+    , m_rootFrameIdentifier(FrameIdentifier { })
 {
 }
 
@@ -220,12 +221,12 @@ ScrollingNodeID ScrollingStateTree::insertNode(ScrollingNodeType nodeType, Scrol
 
     RefPtr<ScrollingStateNode> newNode;
     if (!parentID) {
-        RELEASE_ASSERT(nodeType == ScrollingNodeType::MainFrame);
+        RELEASE_ASSERT(nodeType == ScrollingNodeType::MainFrame || nodeType == ScrollingNodeType::Subframe);
         ASSERT(!childIndex || childIndex == notFound);
         // If we're resetting the root node, we should clear the HashMap and destroy the current children.
         clear();
 
-        setRootStateNode(ScrollingStateFrameScrollingNode::create(*this, ScrollingNodeType::MainFrame, newNodeID));
+        setRootStateNode(ScrollingStateFrameScrollingNode::create(*this, nodeType, newNodeID));
         newNode = rootStateNode();
         m_hasNewRootStateNode = true;
     } else {

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -93,6 +93,8 @@ public:
     }
 
     String scrollingStateTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior>) const;
+    FrameIdentifier rootFrameIdentifier() const { return m_rootFrameIdentifier; }
+    void setRootFrameIdentifier(FrameIdentifier frameID) { m_rootFrameIdentifier = frameID; }
 
 private:
     ScrollingStateTree(bool hasNewRootStateNode, bool hasChangedProperties, RefPtr<ScrollingStateFrameScrollingNode>&&);
@@ -111,6 +113,8 @@ private:
     void traverse(const ScrollingStateNode&, const Function<void(const ScrollingStateNode&)>&) const;
 
     ThreadSafeWeakPtr<AsyncScrollingCoordinator> m_scrollingCoordinator;
+    FrameIdentifier m_rootFrameIdentifier;
+
     // Contains all the nodes we know about (those in the m_rootStateNode tree, and in m_unparentedNodes subtrees).
     StateNodeMap m_stateNodeMap;
     // Owns roots of unparented subtrees.

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp
@@ -60,6 +60,29 @@ bool ScrollingTreeFrameHostingNode::commitStateBeforeChildren(const ScrollingSta
     return true;
 }
 
+void ScrollingTreeFrameHostingNode::setLayerHostingContextIdentifier(std::optional<LayerHostingContextIdentifier> identifier)
+{
+    if (m_hostingContext != identifier)
+        removeHostedChildren();
+    m_hostingContext = identifier;
+    if (m_hostingContext)
+        scrollingTree().addScrollingNodeToHostedSubtreeMap(*m_hostingContext, *this);
+}
+
+void ScrollingTreeFrameHostingNode::removeHostedChildren()
+{
+    auto hostedChildren = std::exchange(m_hostedChildren, { });
+    for (auto& children : hostedChildren)
+        scrollingTree().removeNode(children->scrollingNodeID());
+}
+
+void ScrollingTreeFrameHostingNode::willBeDestroyed()
+{
+    if (m_hostingContext)
+        scrollingTree().removeFrameHostingNode(*m_hostingContext);
+    removeHostedChildren();
+}
+
 void ScrollingTreeFrameHostingNode::applyLayerPositions()
 {
 }
@@ -67,8 +90,12 @@ void ScrollingTreeFrameHostingNode::applyLayerPositions()
 void ScrollingTreeFrameHostingNode::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
 {
     ts << "frame hosting node";
-    if (auto hostingContextIdentifier = m_hostingContext)
-        ts.dumpProperty("hosting context identifier", *m_hostingContext);
+    if (auto hostingContextIdentifier = m_hostingContext) {
+        if (behavior & ScrollingStateTreeAsTextBehavior::IncludeNodeIDs)
+            ts.dumpProperty("hosting context identifier", *m_hostingContext);
+        else
+            ts.dumpProperty("has hosting context identifier", "");
+    }
     ScrollingTreeNode::dumpProperties(ts, behavior);
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h
@@ -39,7 +39,12 @@ public:
     virtual ~ScrollingTreeFrameHostingNode();
 
     std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() const { return m_hostingContext; }
-    void setLayerHostingContextIdentifier(std::optional<LayerHostingContextIdentifier> identifier) { m_hostingContext = identifier; }
+    void setLayerHostingContextIdentifier(std::optional<LayerHostingContextIdentifier>);
+    bool isRootOfHostedSubtree() const final { return (bool)m_hostingContext; }
+
+    void willBeDestroyed() override;
+    void addHostedChild(RefPtr<ScrollingTreeNode> node) { m_hostedChildren.add(node); }
+    void removeHostedChildren();
 
 private:
     ScrollingTreeFrameHostingNode(ScrollingTree&, ScrollingNodeID);
@@ -50,6 +55,7 @@ private:
     WEBCORE_EXPORT void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 
     std::optional<LayerHostingContextIdentifier> m_hostingContext;
+    HashSet<RefPtr<ScrollingTreeNode>> m_hostedChildren;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollingTreeNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeNode.h
@@ -89,10 +89,15 @@ public:
     void removeChild(ScrollingTreeNode&);
     void removeAllChildren();
 
+    virtual bool isRootOfHostedSubtree() const { return false; }
+
     WEBCORE_EXPORT RefPtr<ScrollingTreeFrameScrollingNode> enclosingFrameNodeIncludingSelf();
     WEBCORE_EXPORT RefPtr<ScrollingTreeScrollingNode> enclosingScrollingNodeIncludingSelf();
 
     WEBCORE_EXPORT void dump(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const;
+
+    FrameIdentifier frameIdentifier() const { return m_parentFrameIdentifier; }
+    void setFrameIdentifier(FrameIdentifier frameID) { m_parentFrameIdentifier = frameID; }
 
 protected:
     ScrollingTreeNode(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);
@@ -109,6 +114,7 @@ private:
 
     const ScrollingNodeType m_nodeType;
     const ScrollingNodeID m_nodeID;
+    FrameIdentifier m_parentFrameIdentifier;
 
     ThreadSafeWeakPtr<ScrollingTreeNode> m_parent;
 };

--- a/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
@@ -65,6 +65,7 @@ void ThreadedScrollingCoordinator::commitTreeStateIfNeeded()
     LOG_WITH_STREAM(ScrollingTree, stream << "ThreadedScrollingCoordinator::commitTreeState: state tree " << scrollingStateTreeAsText(debugScrollingStateTreeAsTextBehaviors));
 
     auto stateTree = scrollingStateTree()->commit(LayerRepresentation::PlatformLayerRepresentation);
+    stateTree->setRootFrameIdentifier(page()->mainFrame().frameID());
     scrollingTree()->commitTreeState(WTFMove(stateTree));
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -49,9 +49,10 @@ using namespace WebCore;
 
 RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction() = default;
 
-RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(std::unique_ptr<WebCore::ScrollingStateTree>&& scrollingStateTree, bool clearScrollLatching, FromDeserialization fromDeserialization)
+RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction(std::unique_ptr<WebCore::ScrollingStateTree>&& scrollingStateTree, bool clearScrollLatching, WebCore::FrameIdentifier frameID, FromDeserialization fromDeserialization)
     : m_scrollingStateTree(WTFMove(scrollingStateTree))
     , m_clearScrollLatching(clearScrollLatching)
+    , m_rootFrameID(frameID)
 {
     if (!m_scrollingStateTree)
         m_scrollingStateTree = makeUnique<WebCore::ScrollingStateTree>();

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(UI_SIDE_COMPOSITING)
 
+#include <WebCore/FrameIdentifier.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -39,13 +40,16 @@ class RemoteScrollingCoordinatorTransaction {
 public:
     enum class FromDeserialization : bool { No, Yes };
     RemoteScrollingCoordinatorTransaction();
-    RemoteScrollingCoordinatorTransaction(std::unique_ptr<WebCore::ScrollingStateTree>&&, bool, FromDeserialization = FromDeserialization::Yes);
+    RemoteScrollingCoordinatorTransaction(std::unique_ptr<WebCore::ScrollingStateTree>&&, bool, WebCore::FrameIdentifier = { }, FromDeserialization = FromDeserialization::Yes);
     RemoteScrollingCoordinatorTransaction(RemoteScrollingCoordinatorTransaction&&);
     RemoteScrollingCoordinatorTransaction& operator=(RemoteScrollingCoordinatorTransaction&&);
     ~RemoteScrollingCoordinatorTransaction();
 
     std::unique_ptr<WebCore::ScrollingStateTree>& scrollingStateTree() { return m_scrollingStateTree; }
     const std::unique_ptr<WebCore::ScrollingStateTree>& scrollingStateTree() const { return m_scrollingStateTree; }
+
+    WebCore::FrameIdentifier rootFrameIdentifier() const { return m_rootFrameID; }
+    void setFrameIdentifier(WebCore::FrameIdentifier identifier) { m_rootFrameID = identifier; }
 
     bool clearScrollLatching() const { return m_clearScrollLatching; }
 
@@ -60,6 +64,9 @@ private:
     // Data encoded here should be "imperative" (valid just for one transaction). Stateful things should live on scrolling tree nodes.
     // Maybe RequestedScrollData should move here.
     bool m_clearScrollLatching { false };
+
+    // Frame Identifier for the root frame of this transaction
+    WebCore::FrameIdentifier m_rootFrameID;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
@@ -25,6 +25,7 @@ headers: <WebCore/ScrollingStateTree.h> <WebCore/ScrollingStateFrameScrollingNod
 class WebKit::RemoteScrollingCoordinatorTransaction {
     std::unique_ptr<WebCore::ScrollingStateTree> scrollingStateTree()
     bool clearScrollLatching()
+    WebCore::FrameIdentifier rootFrameIdentifier()
 }
 
 [CreateUsing=createAfterReconstruction] class WebCore::ScrollingStateTree {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -289,9 +289,13 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
         }
 
 #if ENABLE(ASYNC_SCROLLING)
-        // FIXME: Making scrolling trees work with site isolation.
-        if (layerTreeTransaction.isMainFrameProcessTransaction())
-            requestedScroll = webPageProxy->scrollingCoordinatorProxy()->commitScrollingTreeState(scrollingTreeTransaction);
+#if PLATFORM(IOS_FAMILY)
+        if (!layerTreeTransaction.isMainFrameProcessTransaction()) {
+            // TODO: rdar://123104203 Making scrolling trees work with site isolation on iOS.
+            return;
+        }
+#endif
+        requestedScroll = webPageProxy->scrollingCoordinatorProxy()->commitScrollingTreeState(scrollingTreeTransaction, layerTreeTransaction.remoteContextHostedIdentifier());
 #endif
     };
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -81,7 +81,7 @@ const RemoteLayerTreeHost* RemoteScrollingCoordinatorProxy::layerTreeHost() cons
     return &remoteDrawingArea.remoteLayerTreeHost();
 }
 
-std::optional<RequestedScrollData> RemoteScrollingCoordinatorProxy::commitScrollingTreeState(const RemoteScrollingCoordinatorTransaction& transaction)
+std::optional<RequestedScrollData> RemoteScrollingCoordinatorProxy::commitScrollingTreeState(const RemoteScrollingCoordinatorTransaction& transaction, std::optional<LayerHostingContextIdentifier> identifier)
 {
     m_requestedScroll = { };
 
@@ -93,9 +93,12 @@ std::optional<RequestedScrollData> RemoteScrollingCoordinatorProxy::commitScroll
         return { };
     }
 
+    stateTree->setRootFrameIdentifier(transaction.rootFrameIdentifier());
+
     ASSERT(stateTree);
     connectStateNodeLayers(*stateTree, *layerTreeHost);
-    bool succeeded = m_scrollingTree->commitTreeState(WTFMove(stateTree));
+    bool succeeded = m_scrollingTree->commitTreeState(WTFMove(stateTree), identifier);
+
     MESSAGE_CHECK_WITH_RETURN_VALUE(succeeded, std::nullopt);
 
     establishLayerTreeScrollingRelations(*layerTreeHost);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -108,7 +108,7 @@ public:
     const RemoteLayerTreeHost* layerTreeHost() const;
     WebPageProxy& webPageProxy() const { return m_webPageProxy; }
 
-    std::optional<WebCore::RequestedScrollData> commitScrollingTreeState(const RemoteScrollingCoordinatorTransaction&);
+    std::optional<WebCore::RequestedScrollData> commitScrollingTreeState(const RemoteScrollingCoordinatorTransaction&, std::optional<WebCore::LayerHostingContextIdentifier> = std::nullopt);
 
     bool hasFixedOrSticky() const { return m_scrollingTree->hasFixedOrSticky(); }
     bool hasScrollableMainFrame() const;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -390,6 +390,7 @@ void RemoteLayerTreeDrawingArea::updateRendering()
 #if ENABLE(ASYNC_SCROLLING)
         if (webPage->scrollingCoordinator())
             scrollingTransaction = downcast<RemoteScrollingCoordinator>(*webPage->scrollingCoordinator()).buildTransaction();
+        scrollingTransaction.setFrameIdentifier(rootLayer.frameID);
 #endif
 
         return { WTFMove(layerTransaction), WTFMove(scrollingTransaction) };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -110,6 +110,7 @@ RemoteScrollingCoordinatorTransaction RemoteScrollingCoordinator::buildTransacti
     return {
         scrollingStateTree()->commit(LayerRepresentation::PlatformLayerIDRepresentation),
         std::exchange(m_clearScrollLatchingInNextTransaction, false),
+        { },
         RemoteScrollingCoordinatorTransaction::FromDeserialization::No
     };
 }


### PR DESCRIPTION
#### e7e9773f128b368bf877a9f1481917a7350e9b05
<pre>
[Site Isolation] Connect scrolling trees from main process and iframe process
<a href="https://bugs.webkit.org/show_bug.cgi?id=268591">https://bugs.webkit.org/show_bug.cgi?id=268591</a>
<a href="https://rdar.apple.com/122145583">rdar://122145583</a>

Reviewed by Simon Fraser.

This is part 2 of splitting up <a href="https://github.com/WebKit/WebKit/pull/23242">https://github.com/WebKit/WebKit/pull/23242</a>
This connects the scrolling node marked with the hosting id with the root
of a transaction marked with the same id. Since the scrolling state tree
only includes state changes, we need to keep track of all state trees committed
with a host id if we haven&apos;t received a commit with the corresponding host id
in the tree.

* LayoutTests/http/tests/site-isolation/scrolling/basic-scrolling-tree-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/scrolling/basic-scrolling-tree.html: Added.
* LayoutTests/http/tests/site-isolation/scrolling/resources/empty-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/scrolling/resources/overflow-scroll-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/scrolling/scrolling-tree-iframe-overflow-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/scrolling/scrolling-tree-iframe-overflow.html: Added.
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::createNode):
* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
(WebCore::ScrollingCoordinator::mainFrameIdentifier const):
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(WebCore::ScrollingStateTree::ScrollingStateTree):
(WebCore::ScrollingStateTree::insertNode):
* Source/WebCore/page/scrolling/ScrollingStateTree.h:
(WebCore::ScrollingStateTree::frameIdentifier const):
(WebCore::ScrollingStateTree::setFrameIdentifier):
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::removeNode):
(WebCore::ScrollingTree::commitTreeState):
(WebCore::ScrollingTree::updateTreeFromStateNodeRecursive):
(WebCore::ScrollingTree::removeAllNodes):
(WebCore::ScrollingTree::addScrollingNodeToHostedSubtreeMap):
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::isScrollingSynchronizedWithMainThread):
(WebCore::ScrollingTree::treeLock):
(WebCore::ScrollingTree::propagateSynchronousScrollingReasons):
(WebCore::ScrollingTree::WTF_REQUIRES_LOCK): Deleted.
(WebCore::ScrollingTree::WTF_RETURNS_LOCK): Deleted.
* Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.cpp:
(WebCore::ScrollingTreeFrameHostingNode::setLayerHostingContextIdentifier):
(WebCore::ScrollingTreeFrameHostingNode::removeHostedChildren):
(WebCore::ScrollingTreeFrameHostingNode::willBeDestroyed):
(WebCore::ScrollingTreeFrameHostingNode::dumpProperties const):
* Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h:
(WebCore::ScrollingTreeFrameHostingNode::addHostedChild):
(WebCore::ScrollingTreeFrameHostingNode::setLayerHostingContextIdentifier): Deleted.
* Source/WebCore/page/scrolling/ScrollingTreeNode.cpp:
(WebCore::ScrollingTreeNode::dumpProperties const):
* Source/WebCore/page/scrolling/ScrollingTreeNode.h:
(WebCore::ScrollingTreeNode::isRootOfHostedSubtree const):
(WebCore::ScrollingTreeNode::frameIdentifier const):
(WebCore::ScrollingTreeNode::setFrameIdentifier):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::dumpProperties const):
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::waitForEventToBeProcessedByMainThread):
(WebCore::ThreadedScrollingTree::waitForRenderingUpdateCompletionOrTimeout):
* Source/WebCore/page/scrolling/ThreadedScrollingTree.h:
(WebCore::ThreadedScrollingTree::treeLock):
(WebCore::ThreadedScrollingTree::WTF_RETURNS_LOCK): Deleted.
(WebCore::ThreadedScrollingTree::WTF_GUARDED_BY_LOCK): Deleted.
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeMac.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(WebKit::RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h:
(WebKit::RemoteScrollingCoordinatorTransaction::RemoteScrollingCoordinatorTransaction):
(WebKit::RemoteScrollingCoordinatorTransaction::frameIdentifier const):
(WebKit::RemoteScrollingCoordinatorTransaction::setFrameIdentifier):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::commitScrollingTreeState):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
(WebKit::RemoteScrollingTree::WTF_GUARDED_BY_LOCK): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::waitForEventDefaultHandlingCompletion):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::buildTransaction):

Canonical link: <a href="https://commits.webkit.org/274918@main">https://commits.webkit.org/274918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff892d1a2753aa3cac2883d2d90743f1ae10b65d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40366 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42911 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36455 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33485 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14066 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44189 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/36587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36091 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39831 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15181 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38105 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/16800 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/35051 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/16849 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5347 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16444 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->