### PR TITLE
Non-unified build fixes, early February 2024 edition

### DIFF
--- a/Source/WebCore/dom/EventTargetConcrete.cpp
+++ b/Source/WebCore/dom/EventTargetConcrete.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "EventTargetConcrete.h"
 
+#include "ContextDestructionObserverInlines.h"
+
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(EventTargetConcrete);

--- a/Source/WebCore/fileapi/FileReader.cpp
+++ b/Source/WebCore/fileapi/FileReader.cpp
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "FileReader.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "DOMException.h"
 #include "EventLoop.h"
 #include "EventNames.h"

--- a/Source/WebCore/html/VoidCallback.h
+++ b/Source/WebCore/html/VoidCallback.h
@@ -27,6 +27,7 @@
 
 #include "ActiveDOMCallback.h"
 #include "CallbackResult.h"
+#include "ContextDestructionObserverInlines.h"
 #include <wtf/RefCounted.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
@@ -29,7 +29,7 @@
 #include "CachedResourceLoader.h"
 #include "CrossOriginAccessControl.h"
 #include "DefaultResourceLoadPriority.h"
-#include "Document.h"
+#include "DocumentInlines.h"
 #include "MediaQueryEvaluator.h"
 #include "MediaQueryParser.h"
 #include "NodeRenderStyle.h"

--- a/Source/WebCore/html/track/VideoTrackList.cpp
+++ b/Source/WebCore/html/track/VideoTrackList.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(VIDEO)
 
+#include "ContextDestructionObserverInlines.h"
 #include "ScriptExecutionContext.h"
 #include "VideoTrack.h"
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h
@@ -28,6 +28,7 @@
 #include "FormattingConstraints.h"
 #include "InlineDisplayContent.h"
 #include "InlineItem.h"
+#include "LineLayoutResult.h"
 #include <wtf/IsoMalloc.h>
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -40,7 +40,7 @@
 #include "ContainerNode.h"
 #include "CrossOriginAccessControl.h"
 #include "DefaultResourceLoadPriority.h"
-#include "Document.h"
+#include "DocumentInlines.h"
 #include "FetchRequestDestination.h"
 #include "FrameLoader.h"
 #include "HTMLSrcsetParser.h"

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -33,7 +33,7 @@
 #include "CachedResourceLoader.h"
 #include "CachedResourceRequest.h"
 #include "CrossOriginAccessControl.h"
-#include "Document.h"
+#include "DocumentInlines.h"
 #include "Element.h"
 #include "FrameDestructionObserverInlines.h"
 #include "InspectorInstrumentation.h"

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -38,7 +38,7 @@
 #include "CachedResourceRequest.h"
 #include "ContentRuleListResults.h"
 #include "ContentSecurityPolicy.h"
-#include "Document.h"
+#include "DocumentInlines.h"
 #include "FrameLoader.h"
 #include "HTTPHeaderValues.h"
 #include "InspectorInstrumentation.h"

--- a/Source/WebCore/loader/TextTrackLoader.cpp
+++ b/Source/WebCore/loader/TextTrackLoader.cpp
@@ -34,7 +34,7 @@
 #include "CachedResourceRequest.h"
 #include "CachedTextTrack.h"
 #include "CrossOriginAccessControl.h"
-#include "Document.h"
+#include "DocumentInlines.h"
 #include "HTMLMediaElement.h"
 #include "HTMLTrackElement.h"
 #include "InspectorInstrumentation.h"

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -44,6 +44,7 @@
 #include "ContentExtensionRule.h"
 #include "ContentRuleListResults.h"
 #include "ContentSecurityPolicy.h"
+#include "CookieJar.h"
 #include "CrossOriginAccessControl.h"
 #include "CustomHeaderFields.h"
 #include "DateComponents.h"

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -33,7 +33,7 @@
 #include "Gradient.h"
 #include "ReferencedSVGResources.h"
 #include "RenderLayer.h"
-#include "RenderSVGResourceMarker.h"
+#include "RenderSVGResourceMarkerInlines.h"
 #include "RenderSVGShapeInlines.h"
 #include "RenderStyleInlines.h"
 #include "SVGMarkerElement.h"

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -23,8 +23,10 @@
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
 #include "ElementChildIteratorInlines.h"
 #include "RenderLayer.h"
+#include "RenderSVGModelObjectInlines.h"
 #include "RenderSVGResourcePatternInlines.h"
 #include "RenderSVGShape.h"
+#include "SVGElementTypeHelpers.h"
 #include "SVGFitToViewBox.h"
 #include "SVGRenderStyle.h"
 #include "SVGRenderingContext.h"

--- a/Source/WebCore/style/StylePendingResources.cpp
+++ b/Source/WebCore/style/StylePendingResources.cpp
@@ -31,7 +31,7 @@
 #include "ContentData.h"
 #include "CursorData.h"
 #include "CursorList.h"
-#include "Document.h"
+#include "DocumentInlines.h"
 #include "FillLayer.h"
 #include "RenderStyleInlines.h"
 #include "SVGURIReference.h"

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -31,6 +31,7 @@
 
 #include "CSSStyleSheet.h"
 #include "CascadeLevel.h"
+#include "DocumentInlines.h"
 #include "ExtensionStyleSheets.h"
 #include "FrameLoader.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/style/StyleSheetContentsCache.cpp
+++ b/Source/WebCore/style/StyleSheetContentsCache.cpp
@@ -23,8 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
 #include "config.h"
 #include "StyleSheetContentsCache.h"
 

--- a/Source/WebCore/style/StyleSheetContentsCache.h
+++ b/Source/WebCore/style/StyleSheetContentsCache.h
@@ -27,6 +27,7 @@
 
 #include "CSSParserContext.h"
 #include <wtf/HashMap.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/svg/SVGTitleElement.cpp
+++ b/Source/WebCore/svg/SVGTitleElement.cpp
@@ -23,7 +23,7 @@
 #include "SVGTitleElement.h"
 
 #include "Document.h"
-#include "SVGNames.h"
+#include "SVGElementTypeHelpers.h"
 #include "SVGSVGElement.h"
 #include <wtf/IsoMallocInlines.h>
 

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "XMLHttpRequestProgressEventThrottle.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "EventTarget.h"

--- a/Source/WebCore/xml/XMLHttpRequestUpload.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestUpload.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "XMLHttpRequestUpload.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
 #include "WebCoreOpaqueRoot.h"
 #include "XMLHttpRequestProgressEvent.h"

--- a/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
+++ b/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
@@ -24,7 +24,7 @@
 #if ENABLE(XSLT)
 
 #include "CachedResourceLoader.h"
-#include "Document.h"
+#include "DocumentInlines.h"
 #include "FrameDestructionObserverInlines.h"
 #include "LocalFrame.h"
 #include "Page.h"

--- a/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
+++ b/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
@@ -27,7 +27,7 @@
 #include "XSLTProcessor.h"
 
 #include "CachedResourceLoader.h"
-#include "Document.h"
+#include "DocumentInlines.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "LocalFrame.h"

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -602,7 +602,7 @@ void GPUProcess::processIsStartingToCaptureAudio(GPUConnectionToWebProcess& proc
 #endif
 
 #if ENABLE(VIDEO)
-void GPUProcess::requestBitmapImageForCurrentTime(WebCore::ProcessIdentifier processIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&)>&& completion)
+void GPUProcess::requestBitmapImageForCurrentTime(WebCore::ProcessIdentifier processIdentifier, WebCore::MediaPlayerIdentifier playerIdentifier, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&& completion)
 {
     auto iterator = m_webProcessConnections.find(processIdentifier);
     if (iterator == m_webProcessConnections.end()) {

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -96,7 +96,7 @@ void RemoteImageBuffer::getPixelBuffer(WebCore::PixelBufferFormat destinationFor
     completionHandler();
 }
 
-void RemoteImageBuffer::getPixelBufferWithNewMemory(SharedMemory::Handle&& handle, WebCore::PixelBufferFormat destinationFormat, WebCore::IntRect srcRect, CompletionHandler<void()>&& completionHandler)
+void RemoteImageBuffer::getPixelBufferWithNewMemory(WebCore::SharedMemory::Handle&& handle, WebCore::PixelBufferFormat destinationFormat, WebCore::IntRect srcRect, CompletionHandler<void()>&& completionHandler)
 {
     assertIsCurrent(workQueue());
     m_backend->setSharedMemoryForGetPixelBuffer(nullptr);
@@ -112,19 +112,19 @@ void RemoteImageBuffer::putPixelBuffer(Ref<WebCore::PixelBuffer> pixelBuffer, We
     m_imageBuffer->putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat);
 }
 
-void RemoteImageBuffer::getShareableBitmap(WebCore::PreserveResolution preserveResolution, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&)>&& completionHandler)
+void RemoteImageBuffer::getShareableBitmap(WebCore::PreserveResolution preserveResolution, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    std::optional<ShareableBitmap::Handle> handle = [&]() -> std::optional<ShareableBitmap::Handle> {
+    std::optional<WebCore::ShareableBitmap::Handle> handle = [&]() -> std::optional<WebCore::ShareableBitmap::Handle> {
         auto backendSize = m_imageBuffer->backendSize();
         auto logicalSize = m_imageBuffer->logicalSize();
         auto resultSize = preserveResolution == WebCore::PreserveResolution::Yes ? backendSize : m_imageBuffer->truncatedLogicalSize();
-        auto bitmap = ShareableBitmap::create({ resultSize, m_imageBuffer->colorSpace() });
+        auto bitmap = WebCore::ShareableBitmap::create({ resultSize, m_imageBuffer->colorSpace() });
         if (!bitmap)
             return std::nullopt;
         auto handle = bitmap->createHandle();
         if (m_backend->resourceOwner())
-            handle->setOwnershipOfMemory(m_backend->resourceOwner(), MemoryLedger::Graphics);
+            handle->setOwnershipOfMemory(m_backend->resourceOwner(), WebCore::MemoryLedger::Graphics);
         auto context = bitmap->createGraphicsContext();
         if (!context)
             return std::nullopt;
@@ -134,20 +134,20 @@ void RemoteImageBuffer::getShareableBitmap(WebCore::PreserveResolution preserveR
     completionHandler(WTFMove(handle));
 }
 
-void RemoteImageBuffer::filteredNativeImage(Ref<WebCore::Filter> filter, CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&)>&& completionHandler)
+void RemoteImageBuffer::filteredNativeImage(Ref<WebCore::Filter> filter, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    std::optional<ShareableBitmap::Handle> handle = [&]() -> std::optional<ShareableBitmap::Handle> {
+    std::optional<WebCore::ShareableBitmap::Handle> handle = [&]() -> std::optional<WebCore::ShareableBitmap::Handle> {
         auto image = m_imageBuffer->filteredNativeImage(filter);
         if (!image)
             return std::nullopt;
         auto imageSize = image->size();
-        auto bitmap = ShareableBitmap::create({ imageSize, m_imageBuffer->colorSpace() });
+        auto bitmap = WebCore::ShareableBitmap::create({ imageSize, m_imageBuffer->colorSpace() });
         if (!bitmap)
             return std::nullopt;
         auto handle = bitmap->createHandle();
         if (m_backend->resourceOwner())
-            handle->setOwnershipOfMemory(m_backend->resourceOwner(), MemoryLedger::Graphics);
+            handle->setOwnershipOfMemory(m_backend->resourceOwner(), WebCore::MemoryLedger::Graphics);
         auto context = bitmap->createGraphicsContext();
         if (!context)
             return std::nullopt;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/PlatformMediaResourceLoader.h>
 #include <WebCore/ResourceRequest.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/WorkQueue.h>
 

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp
@@ -37,7 +37,6 @@
 #include <wtf/NativePromise.h>
 
 namespace WebKit {
-using namespace WebCore::DOMCacheEngine;
 
 WebCacheStorageConnection::WebCacheStorageConnection(WebCacheStorageProvider& provider)
     : m_provider(provider)
@@ -57,7 +56,7 @@ IPC::Connection& WebCacheStorageConnection::connection()
 auto WebCacheStorageConnection::open(const WebCore::ClientOrigin& origin, const String& cacheName) -> Ref<OpenPromise>
 {
     return connection().sendWithPromisedReply(Messages::NetworkStorageManager::CacheStorageOpenCache(origin, cacheName))->whenSettled(RunLoop::current(), [](auto&& result) {
-        return result ? OpenPromise::createAndSettle(WTFMove(result.value())) : OpenPromise::createAndReject(DOMCacheEngine::Error::Internal);
+        return result ? OpenPromise::createAndSettle(WTFMove(result.value())) : OpenPromise::createAndReject(WebCore::DOMCacheEngine::Error::Internal);
     });
 }
 
@@ -81,7 +80,7 @@ void WebCacheStorageConnection::batchDeleteOperation(WebCore::DOMCacheIdentifier
     connection().sendWithAsyncReply(Messages::NetworkStorageManager::CacheStorageRemoveRecords(cacheIdentifier, request, options), WTFMove(callback));
 }
 
-void WebCacheStorageConnection::batchPutOperation(WebCore::DOMCacheIdentifier cacheIdentifier, Vector<CrossThreadRecord>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
+void WebCacheStorageConnection::batchPutOperation(WebCore::DOMCacheIdentifier cacheIdentifier, Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&& records, WebCore::DOMCacheEngine::RecordIdentifiersCallback&& callback)
 {
     connection().sendWithAsyncReply(Messages::NetworkStorageManager::CacheStoragePutRecords(cacheIdentifier, WTFMove(records)), WTFMove(callback));
 }
@@ -110,7 +109,7 @@ void WebCacheStorageConnection::unlockStorage(const WebCore::ClientOrigin& origi
         connection().send(Messages::NetworkStorageManager::UnlockCacheStorage { origin }, 0);
 }
 
-void WebCacheStorageConnection::clearMemoryRepresentation(const WebCore::ClientOrigin& origin, CompletionCallback&& callback)
+void WebCacheStorageConnection::clearMemoryRepresentation(const WebCore::ClientOrigin& origin, WebCore::DOMCacheEngine::CompletionCallback&& callback)
 {
     connection().sendWithAsyncReply(Messages::NetworkStorageManager::CacheStorageClearMemoryRepresentation { origin }, WTFMove(callback));
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.h
@@ -33,23 +33,23 @@
 namespace WebKit {
 class RemoteResourceCacheProxy;
 
-class RemoteNativeImageBackendProxy final : public NativeImageBackend {
+class RemoteNativeImageBackendProxy final : public WebCore::NativeImageBackend {
 public:
-    static std::unique_ptr<RemoteNativeImageBackendProxy> create(NativeImage&);
+    static std::unique_ptr<RemoteNativeImageBackendProxy> create(WebCore::NativeImage&);
     ~RemoteNativeImageBackendProxy() final;
 
-    const PlatformImagePtr& platformImage() const final;
-    IntSize size() const final;
+    const WebCore::PlatformImagePtr& platformImage() const final;
+    WebCore::IntSize size() const final;
     bool hasAlpha() const final;
-    DestinationColorSpace colorSpace() const final;
+    WebCore::DestinationColorSpace colorSpace() const final;
     bool isRemoteNativeImageBackendProxy() const final;
 
     std::optional<WebCore::ShareableBitmap::Handle> createHandle();
 private:
-    RemoteNativeImageBackendProxy(Ref<WebCore::ShareableBitmap>, PlatformImagePtr);
+    RemoteNativeImageBackendProxy(Ref<WebCore::ShareableBitmap>, WebCore::PlatformImagePtr);
 
     Ref<WebCore::ShareableBitmap> m_bitmap;
-    PlatformImageNativeImageBackend m_platformBackend;
+    WebCore::PlatformImageNativeImageBackend m_platformBackend;
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.cpp
@@ -77,7 +77,7 @@ void RemoteMediaResourceProxy::dataReceived(WebCore::PlatformMediaResource&, con
     m_connection->sendWithAsyncReply(Messages::RemoteMediaResourceManager::DataReceived(m_id, IPC::SharedBufferReference { buffer }), [] (auto&& bufferHandle) {
         // Take ownership of shared memory and mark it as media-related memory.
         if (bufferHandle)
-            bufferHandle->takeOwnershipOfMemory(MemoryLedger::Media);
+            bufferHandle->takeOwnershipOfMemory(WebCore::MemoryLedger::Media);
     }, 0);
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
@@ -81,7 +81,7 @@ RemoteVideoFrameProxy::RemoteVideoFrameProxy(IPC::Connection& connection, Remote
 }
 
 RemoteVideoFrameProxy::RemoteVideoFrameProxy(CloneConstructor, RemoteVideoFrameProxy& baseVideoFrame)
-    : VideoFrame(baseVideoFrame.presentationTime(), baseVideoFrame.isMirrored(), baseVideoFrame.rotation(), PlatformVideoColorSpace { baseVideoFrame.colorSpace() })
+    : VideoFrame(baseVideoFrame.presentationTime(), baseVideoFrame.isMirrored(), baseVideoFrame.rotation(), WebCore::PlatformVideoColorSpace { baseVideoFrame.colorSpace() })
     , m_baseVideoFrame(&baseVideoFrame)
     , m_size(baseVideoFrame.m_size)
     , m_pixelFormat(baseVideoFrame.m_pixelFormat)
@@ -141,7 +141,7 @@ CVPixelBufferRef RemoteVideoFrameProxy::pixelBuffer() const
 }
 #endif
 
-Ref<VideoFrame> RemoteVideoFrameProxy::clone()
+Ref<WebCore::VideoFrame> RemoteVideoFrameProxy::clone()
 {
     return adoptRef(*new RemoteVideoFrameProxy(cloneConstructor, *this));
 }


### PR DESCRIPTION
#### 91c1a5ef6fbb412d867b06761133dfded7e286a5
<pre>
Non-unified build fixes, early February 2024 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=268592">https://bugs.webkit.org/show_bug.cgi?id=268592</a>

Unreviewed non-unified build fix.

* Source/WebCore/dom/EventTargetConcrete.cpp:
* Source/WebCore/fileapi/FileReader.cpp:
* Source/WebCore/html/VoidCallback.h:
* Source/WebCore/html/parser/HTMLResourcePreloader.cpp:
* Source/WebCore/html/track/VideoTrackList.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h:
* Source/WebCore/loader/LinkLoader.cpp:
* Source/WebCore/loader/MediaResourceLoader.cpp:
* Source/WebCore/loader/PingLoader.cpp:
* Source/WebCore/loader/TextTrackLoader.cpp:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
* Source/WebCore/style/StylePendingResources.cpp:
* Source/WebCore/style/StyleScopeRuleSets.cpp:
* Source/WebCore/style/StyleSheetContentsCache.cpp:
* Source/WebCore/style/StyleSheetContentsCache.h:
* Source/WebCore/svg/SVGTitleElement.cpp:
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp:
* Source/WebCore/xml/XMLHttpRequestUpload.cpp:
* Source/WebCore/xml/XSLStyleSheetLibxslt.cpp:
* Source/WebCore/xml/XSLTProcessorLibxslt.cpp:
* Source/WebKit/GPUProcess/GPUProcess.cpp:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
* Source/WebKit/GPUProcess/media/RemoteMediaResourceLoader.h:
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
* Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaResourceProxy.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp:

Canonical link: <a href="https://commits.webkit.org/274008@main">https://commits.webkit.org/274008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/106a82a498ed774c027fc5c93709d4ce16dcfe72

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40066 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13589 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13841 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12062 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/33610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41330 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33928 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37922 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12598 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36085 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8451 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->