### PR TITLE
Make option+drag scrolling to the left work when origin is on the right

### DIFF
--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -195,6 +195,14 @@ void ScrollableArea::scrollToPositionWithAnimation(const FloatPoint& position, c
     setCurrentScrollType(previousScrollType);
 }
 
+void ScrollableArea::scrollToPositionWithoutAnimation(ScrollbarOrientation orientation, float position)
+{
+    if (orientation == ScrollbarOrientation::Horizontal)
+        scrollToPositionWithoutAnimation(FloatPoint(position, scrollAnimator().currentPosition().y()));
+    else
+        scrollToPositionWithoutAnimation(FloatPoint(scrollAnimator().currentPosition().x(), position));
+}
+
 void ScrollableArea::scrollToOffsetWithoutAnimation(const FloatPoint& offset, ScrollClamping clamping)
 {
     LOG_WITH_STREAM(Scrolling, stream << "ScrollableArea " << this << " scrollToOffsetWithoutAnimation " << offset);

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -82,6 +82,7 @@ public:
     WEBCORE_EXPORT bool scroll(ScrollDirection, ScrollGranularity, unsigned stepCount = 1);
     WEBCORE_EXPORT void scrollToPositionWithAnimation(const FloatPoint&, const ScrollPositionChangeOptions& options = ScrollPositionChangeOptions::createProgrammatic());
     WEBCORE_EXPORT void scrollToPositionWithoutAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
+    WEBCORE_EXPORT void scrollToPositionWithoutAnimation(ScrollbarOrientation, float position);
 
     WEBCORE_EXPORT void scrollToOffsetWithoutAnimation(const FloatPoint&, ScrollClamping = ScrollClamping::Clamped);
     WEBCORE_EXPORT void scrollToOffsetWithoutAnimation(ScrollbarOrientation, float offset);

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -286,7 +286,7 @@ void Scrollbar::moveThumb(int pos, bool draggingDocument)
             destinationPosition = std::min(destinationPosition + delta, maximum());
         else if (delta < 0)
             destinationPosition = std::max(destinationPosition + delta, 0);
-        m_scrollableArea.scrollToOffsetWithoutAnimation(m_orientation, destinationPosition);
+        m_scrollableArea.scrollToPositionWithoutAnimation(m_orientation, destinationPosition);
         m_documentDragPos = pos;
         return;
     }


### PR DESCRIPTION
#### 5c7681b9f93ddf18d02f3c7831d73b44aa8b65ac
<pre>
Make scrolling to the left work when origin is on the right
<a href="https://bugs.webkit.org/show_bug.cgi?id=250207">https://bugs.webkit.org/show_bug.cgi?id=250207</a>
<a href="https://rdar.apple.com/104223915">rdar://104223915</a>

Reviewed by NOBODY (OOPS!).

Scrollbar::moveThumb uses scroll positions (not offsets), but called
scrollToOffset instead of scrollToPosition, breaking scrolling to the
left of the origin.

* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::scrollToPositionWithoutAnimation): Implement new scrollToPosition method.
* Source/WebCore/platform/ScrollableArea.h: Add corresponding scrollToPosition method.
* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::moveThumb): Switch from scrollToOffset to scrollToPosition.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c7681b9f93ddf18d02f3c7831d73b44aa8b65ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39916 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33330 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31759 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11932 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11959 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41179 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33849 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33916 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37823 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35972 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13965 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12902 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->