### PR TITLE
REGRESSION(268028@main): Graphics artifacts when scrolling Heroku app

### DIFF
--- a/LayoutTests/compositing/shared-backing/overflow-scroll/composite-via-negative-z-descendants-interrupts-sequence-expected.html
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/composite-via-negative-z-descendants-interrupts-sequence-expected.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+  <head>
+    <style>
+        #scroll-container {
+            overflow-y: scroll;
+            height: 500px;
+            width: 500px;
+            border: 1px solid black;
+        }
+
+        .container {
+            position: relative;
+            z-index: 0;
+            background-color: silver; /* This obscures .child when the bug occurs */
+            height: 500px;
+        }
+
+        .child {
+            position: relative;
+            width: 500px;
+            z-index: 0;
+            height: 200px;
+            background-color: green;
+        }
+
+        .outer-trigger, .mid-trigger, .inner-trigger {
+            position: relative;
+            top: 20px;
+            left: 10px;
+            height: 30px;
+            width: 50px;
+            z-index: 1;
+            background-color: orange;
+        }
+        
+        .content {
+            background-color: green;
+            height: 400px;
+        }
+    </style>
+  </head>
+  <body>
+    <div id="scroll-container">
+        <div class="container">
+
+            <div class="child">
+            </div>
+
+            <div class="outer-trigger">
+                <div class="mid-trigger">
+                    <div class="inner-trigger"></div>
+                </div>
+            </div>
+        </div>
+        <div style="height: 600px;"></div>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/composite-via-negative-z-descendants-interrupts-sequence.html
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/composite-via-negative-z-descendants-interrupts-sequence.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+  <head>
+    <style>
+        #scroll-container {
+            overflow-y: scroll;
+            height: 500px;
+            width: 500px;
+            border: 1px solid black;
+        }
+
+        .container {
+            position: relative;
+            z-index: 0;
+            background-color: silver; /* This obscures .child when the bug occurs */
+            height: 500px;
+        }
+
+        .child {
+            position: relative;
+            width: 500px;
+            z-index: 0;
+            height: 200px;
+            background-color: green;
+        }
+
+        .outer-trigger, .mid-trigger, .inner-trigger {
+            position: relative;
+            top: 20px;
+            left: 10px;
+            height: 30px;
+            width: 50px;
+            z-index: -1;
+            background-color: orange;
+        }
+        
+        .content {
+            background-color: green;
+            height: 400px;
+        }
+    </style>
+  </head>
+  <body>
+    <div id="scroll-container">
+        <div class="container">
+
+            <div class="child">
+            </div>
+
+            <div class="outer-trigger">
+                <div class="mid-trigger">
+                    <div class="inner-trigger"></div>
+                </div>
+            </div>
+        </div>
+        <div style="height: 600px;"></div>
+    </div>
+  </body>
+</html>

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/zero-sized-fixed-interrupts-sharing-sequence-expected.txt
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/zero-sized-fixed-interrupts-sharing-sequence-expected.txt
@@ -1,0 +1,74 @@
+Hover here to see the bug
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 5
+        (GraphicsLayer
+          (position 8.00 80.00)
+          (bounds 602.00 502.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 585.00 500.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=1 height=1)
+                  (anchor 0.00 0.00)
+                  (bounds 585.00 620.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 10.00 10.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 9.00 81.00)
+          (bounds 585.00 500.00)
+          (children 1
+            (GraphicsLayer
+              (children 1
+                (GraphicsLayer
+                  (position 20.00 320.00)
+                  (bounds 500.00 150.00)
+                  (contentsOpaque 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 9.00 81.00)
+          (bounds 600.00 500.00)
+          (children 1
+            (GraphicsLayer
+              (position 585.00 0.00)
+              (bounds 15.00 500.00)
+              (drawsContent 1)
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 10.00 10.00)
+          (bounds 220.00 40.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/zero-sized-fixed-interrupts-sharing-sequence.html
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/zero-sized-fixed-interrupts-sharing-sequence.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+    <style>
+        .outer.scroller {
+            margin-top: 80px;
+            width: 600px;
+            height: 500px;
+        }
+
+        .scroller {
+            overflow-y: scroll;
+            border: 1px solid black;
+        }
+
+        .animator {
+            position: absolute;
+            z-index: 2;
+            top: 10px;
+            left: 10px;
+            height: 20px;
+            width: 200px;
+            padding: 10px;
+            background-color: gray;
+            color: white;
+            transition: opacity 20s;
+        }
+    
+        .animator:hover {
+            opacity: 0.7;
+        }
+    
+        .relative {
+            position: relative;
+            z-index: 1;
+            margin: 20px;
+            height: 150px;
+            width: 500px;
+            background-color: green;
+        }
+
+        .fixed {
+            position: fixed;
+            top: 10px;
+            left: 10px;
+            /* This is invisible */
+        }
+    
+        .spacer {
+            height: 120px;
+            width: 10px;
+            background-color: #eee;
+            margin: 10px;
+        }
+    </style>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        window.addEventListener('load', () => {
+            if (window.internals)
+                document.getElementById('layers').textContent = internals.layerTreeAsText(document);
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="outer scroller">
+        <div class="animator">
+            Hover here to see the bug
+        </div>
+        <div class="spacer"></div>
+        <div class="relative">
+            <div class="fixed"></div>
+        </div>
+        <div class="relative"></div>
+        <div class="spacer"></div>
+    </div>
+<pre id="layers"></pre>
+</body>

--- a/LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/zero-sized-fixed-interrupts-sharing-sequence-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/zero-sized-fixed-interrupts-sharing-sequence-expected.txt
@@ -1,0 +1,63 @@
+Hover here to see the bug
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 4
+        (GraphicsLayer
+          (position 8.00 80.00)
+          (bounds 602.00 502.00)
+          (drawsContent 1)
+          (children 1
+            (GraphicsLayer
+              (offsetFromRenderer width=1 height=1)
+              (position 1.00 1.00)
+              (bounds 600.00 500.00)
+              (children 1
+                (GraphicsLayer
+                  (offsetFromRenderer width=1 height=1)
+                  (anchor 0.00 0.00)
+                  (bounds 600.00 620.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 10.00 10.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 9.00 81.00)
+          (bounds 600.00 500.00)
+          (children 1
+            (GraphicsLayer
+              (children 1
+                (GraphicsLayer
+                  (position 20.00 320.00)
+                  (bounds 500.00 150.00)
+                  (contentsOpaque 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 10.00 10.00)
+          (bounds 220.00 40.00)
+          (contentsOpaque 1)
+          (drawsContent 1)
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1619,7 +1619,7 @@ void RenderLayerCompositor::updateBackingSharingAfterDescendantTraversal(Backing
     layer.backing()->clearBackingSharingLayers();
     LOG_WITH_STREAM(Compositing, stream << TextStream::Repeat(depth * 2, ' ') << " - is composited; maybe ending existing backing sequence with candidates " << sharingState.backingProviderCandidates() << " stacking context " << sharingState.backingSharingStackingContext());
 
-    if (preDescendantProviderStartLayer && preDescendantProviderStartLayer != sharingState.firstProviderCandidateLayer())
+    if (preDescendantProviderStartLayer && preDescendantProviderStartLayer == sharingState.firstProviderCandidateLayer())
         sharingState.endBackingSharingSequence(layer);
 }
 


### PR DESCRIPTION
#### 4b1ca4f3add8483f04957886f45626e1e9b28a80
<pre>
REGRESSION(268028@main): Graphics artifacts when scrolling Heroku app
<a href="https://bugs.webkit.org/show_bug.cgi?id=266926">https://bugs.webkit.org/show_bug.cgi?id=266926</a>
<a href="https://rdar.apple.com/120373474">rdar://120373474</a>

Reviewed by Alan Baradlay.

Backing sharing is used to reduce memory use by allowing multiple RenderLayers (normally siblings),
which share the same stacking context ancestor, to render into the same compositing layer. This has
to be done in a way that preserves back-to-front paint order. The common case where this kicks in is
a non-stacking context overflow:scroll with position:relative descendants.

A backing sharing sequence (a set of layers painting into the same shared backing) has to be interrupted
when a layer becomes composited in order to preserve paint order. 268028@main inadvertently changed the
condition used to end a backing sharing sequence, breaking rendering with various content configurations.

Restore the condition to the previous state, which is to end the sequence if the the provider layer
is the same one we had before traversing into descendant layers.

Add two tests which detect the behavior change.

* LayoutTests/compositing/shared-backing/overflow-scroll/composite-via-negative-z-descendants-interrupts-sequence-expected.html: Added.
* LayoutTests/compositing/shared-backing/overflow-scroll/composite-via-negative-z-descendants-interrupts-sequence.html: Added.
* LayoutTests/compositing/shared-backing/overflow-scroll/zero-sized-fixed-interrupts-sharing-sequence-expected.txt: Added.
* LayoutTests/compositing/shared-backing/overflow-scroll/zero-sized-fixed-interrupts-sharing-sequence.html: Added.
* LayoutTests/platform/ios-wk2/compositing/shared-backing/overflow-scroll/zero-sized-fixed-interrupts-sharing-sequence-expected.txt: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateBackingSharingAfterDescendantTraversal):

Canonical link: <a href="https://commits.webkit.org/273999@main">https://commits.webkit.org/273999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29aaa8b43f7514ada52ce11ca0924237e342f823

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39940 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33341 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13448 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31765 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11950 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11935 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41203 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33825 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33924 "Found 1 new test failure: http/tests/webgpu/webgpu/api/operation/rendering/stencil.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37830 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35986 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13975 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32882 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8442 "Found 1 new test failure: http/tests/webgpu/webgpu/api/operation/rendering/stencil.html (failure)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12912 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4870 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13291 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->