### PR TITLE
Ruby 3.2 removed File.exists?

### DIFF
--- a/Tools/Scripts/check-for-inappropriate-macros-in-external-headers
+++ b/Tools/Scripts/check-for-inappropriate-macros-in-external-headers
@@ -45,7 +45,7 @@ def framework_headers_for_path(framework, path)
   full_path = File.join Dir.pwd, framework, $is_shallow_bundle ? "" : "Versions/A/", path
   if File.directory? full_path
     Dir.glob "#{full_path}/**/*.h"
-  elsif File.exists? full_path
+  elsif File.exist? full_path
     [full_path]
   else
     print_error "path '#{full_path}' for argument '#{path}' does not exist."

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -2501,10 +2501,10 @@ def prepareBundle
             # Check for and copy JavaScriptCore.dll and WTF.dll for dynamic builds
             javaScriptCoreDLLPath = File.join(originalJSCDir, "JavaScriptCore.dll")
             wtfDLLPath = File.join(originalJSCDir, "WTF.dll")
-            if (File.exists?(javaScriptCoreDLLPath))
+            if (File.exist?(javaScriptCoreDLLPath))
                 source = source + [javaScriptCoreDLLPath]
             end
-            if (File.exists?(wtfDLLPath))
+            if (File.exist?(wtfDLLPath))
                 source = source + [wtfDLLPath]
             end
 

--- a/Tools/Scripts/run-testmem
+++ b/Tools/Scripts/run-testmem
@@ -109,7 +109,7 @@ end
 
 def getTestmemPath
     path = Pathname.new(getBuildDirectory).join("testmem").to_s
-    if !File.exists?(path) && !$dryRun
+    if !File.exist?(path) && !$dryRun
         puts "Error: no testmem binary found in <build>/Release"
         exit 1
     end

--- a/Tools/Scripts/webkitruby/jsc-stress-test-writer-playstation.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test-writer-playstation.rb
@@ -166,7 +166,7 @@ def diffErrorHandler(expectedFilename)
         outp.puts "    print " + prefixString("out", plan.name) + "\n"
         outp.puts "    print " + prefixString("\"ERROR: Unexpected exit code \#{status}\\n\"", plan.name) + "\n"
         outp.puts "    " + plan.failCommand
-        outp.puts "elsif File.exists?(\"../#{Shellwords.shellescape(expectedFilename)}\")\n"
+        outp.puts "elsif File.exist?(\"../#{Shellwords.shellescape(expectedFilename)}\")\n"
         outp.puts getDiff("../#{Shellwords.shellescape(expectedFilename)}", outputFilename)
         outp.puts "    if isDifferent\n"
         outp.puts "        print " + prefixString("\"DIFF FAILURE!\\n\"", plan.name) + "\n"

--- a/Tools/Scripts/webkitruby/jsc-stress-test-writer-ruby.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test-writer-ruby.rb
@@ -166,7 +166,7 @@ def diffErrorHandler(expectedFilename)
         outp.puts "    print " + prefixString("out", plan.name) + "\n"
         outp.puts "    print " + prefixString("\"ERROR: Unexpected exit code \#{status.exitstatus}\\n\"", plan.name) + "\n"
         outp.puts "    " + plan.failCommand
-        outp.puts "elsif File.exists?(\"../#{Shellwords.shellescape(expectedFilename)}\")\n"
+        outp.puts "elsif File.exist?(\"../#{Shellwords.shellescape(expectedFilename)}\")\n"
         outp.puts getDiff("../#{Shellwords.shellescape(expectedFilename)}", outputFilename)
         outp.puts "    if isDifferent\n"
         outp.puts "        print " + prefixString("\"DIFF FAILURE!\\n\"", plan.name) + "\n"


### PR DESCRIPTION
#### 3b4f0c1d94b591c4c4de50f8213d910cfaaa307e
<pre>
Ruby 3.2 removed File.exists?
<a href="https://bugs.webkit.org/show_bug.cgi?id=268604">https://bugs.webkit.org/show_bug.cgi?id=268604</a>

Reviewed by Ross Kirsling.

`File.exists?` was deprecated since Ruby 2.1. And, Ruby 3.2 finally
removed File.exists? Use `File.exist?` instead.

* Tools/Scripts/check-for-inappropriate-macros-in-external-headers:
* Tools/Scripts/run-jsc-stress-tests:
* Tools/Scripts/run-testmem:
* Tools/Scripts/webkitruby/jsc-stress-test-writer-playstation.rb:
* Tools/Scripts/webkitruby/jsc-stress-test-writer-ruby.rb:

Canonical link: <a href="https://commits.webkit.org/274040@main">https://commits.webkit.org/274040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22ff5f690f8fca1db7a40cdb7c55439b66a21407

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39950 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33349 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31771 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11957 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41213 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/31238 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33940 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37836 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/37108 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12508 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10076 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/35993 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13981 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/44010 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8475 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12919 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9022 "Found 155 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout, jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout-no-llint, stress/array-flatmap.js.dfg-eager-no-cjit-validate, wasm.yaml/wasm/gc/any.js.default-wasm, wasm.yaml/wasm/gc/any.js.wasm-bbq, wasm.yaml/wasm/gc/any.js.wasm-collect-continuously, wasm.yaml/wasm/gc/any.js.wasm-eager, wasm.yaml/wasm/gc/any.js.wasm-eager-jettison ... (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13296 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->