### PR TITLE
Generate WKSecureCoding for PKPaymentMerchantSession

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
@@ -111,6 +111,7 @@ WTF_EXTERN_C_END
 #import <PassKitCore/PKError_Private.h>
 #import <PassKitCore/PKPassLibrary.h>
 #import <PassKitCore/PKPayment.h>
+#import <PassKitCore/PKPaymentMerchantSession_Private.h>
 #import <PassKitCore/PKPaymentMethod.h>
 #import <PassKitCore/PKPaymentPass.h>
 #import <PassKitCore/PKPaymentSetupConfiguration_WebKit.h>

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -53,6 +53,7 @@ OBJC_CLASS AVOutputContext;
 OBJC_CLASS CNPhoneNumber;
 OBJC_CLASS CNPostalAddress;
 OBJC_CLASS PKContact;
+OBJC_CLASS PKPaymentMerchantSession;
 #endif
 
 namespace IPC {
@@ -87,6 +88,7 @@ enum class NSType : uint8_t {
     CNPhoneNumber,
     CNPostalAddress,
     PKContact,
+    PKPaymentMerchantSession,
 #endif
     Color,
 #if ENABLE(DATA_DETECTION)
@@ -126,6 +128,7 @@ template<> Class getClass<AVOutputContext>();
 template<> Class getClass<CNPhoneNumber>();
 template<> Class getClass<CNPostalAddress>();
 template<> Class getClass<PKContact>();
+template<> Class getClass<PKPaymentMerchantSession>();
 #endif
 
 void encodeObjectWithWrapper(Encoder&, id);

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -297,6 +297,10 @@ template<> Class getClass<PKContact>()
 {
     return PAL::getPKContactClass();
 }
+template<> Class getClass<PKPaymentMerchantSession>()
+{
+    return PAL::getPKPaymentMerchantSessionClass();
+}
 #endif
 
 NSType typeFromObject(id object)
@@ -317,6 +321,8 @@ NSType typeFromObject(id object)
         return NSType::CNPostalAddress;
     if (PAL::isPassKitCoreFrameworkAvailable() && [object isKindOfClass:PAL::getPKContactClass()])
         return NSType::PKContact;
+    if (PAL::isPassKitCoreFrameworkAvailable() && [object isKindOfClass:PAL::getPKPaymentMerchantSessionClass()])
+        return NSType::PKPaymentMerchantSession;
 #endif
     if ([object isKindOfClass:[WebCore::CocoaColor class]])
         return NSType::Color;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -67,6 +67,7 @@ using ObjectValue = std::variant<
     CoreIPCCNPhoneNumber,
     CoreIPCCNPostalAddress,
     CoreIPCPKContact,
+    CoreIPCPKPaymentMerchantSession,
 #endif
     CoreIPCColor,
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -67,6 +67,8 @@ static ObjectValue valueFromID(id object)
         return CoreIPCCNPostalAddress((CNPostalAddress *)object);
     case IPC::NSType::PKContact:
         return CoreIPCPKContact((PKContact *)object);
+    case IPC::NSType::PKPaymentMerchantSession:
+        return CoreIPCPKPaymentMerchantSession((PKPaymentMerchantSession *)object);
 #endif
     case IPC::NSType::Color:
         return CoreIPCColor((WebCore::CocoaColor *)object);

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
@@ -23,6 +23,7 @@
 #if USE(PASSKIT)
 
 webkit_platform_headers: "CoreIPCPassKit.h"
+secure_coding_header: <pal/cocoa/PassKitSoftLink.h>
 
 [CustomHeader, WebKitPlatform] class WebKit::CoreIPCPKContact {
     WebKit::CoreIPCPersonNameComponents m_name;
@@ -30,6 +31,23 @@ webkit_platform_headers: "CoreIPCPassKit.h"
     WebKit::CoreIPCCNPhoneNumber m_phoneNumber;
     WebKit::CoreIPCCNPostalAddress m_postalAddress;
     String m_supplementarySublocality;
+}
+
+[WebKitSecureCodingClass=PAL::getPKPaymentMerchantSessionClass(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKPaymentMerchantSession {
+    merchantIdentifier: String
+    merchantSessionIdentifier: String
+    nonce: String
+    epochTimestamp: Number
+    expiresAt: Number
+    domainName: String
+    displayName: String
+    signature: Data
+    retryNonce: String
+    initiativeContext: String
+    initiative: String
+    ampEnrollmentPinning: Data
+    operationalAnalyticsIdentifier: String
+    signedFields: Array<String>
 }
 
 #endif // USE(PASSKIT)

--- a/Source/WebKit/Shared/Cocoa/WKKeyedCoder.mm
+++ b/Source/WebKit/Shared/Cocoa/WKKeyedCoder.mm
@@ -61,6 +61,9 @@
 
 - (void)encodeObject:(id)object forKey:(NSString *)key
 {
+    if (!object)
+        return;
+
     if (!IPC::isSerializableValue(object)) {
         ASSERT_NOT_REACHED_WITH_MESSAGE("WKKeyedCoder attempt to encode object of unsupported type %s", object_getClassName(object));
         return;
@@ -80,12 +83,29 @@
         return nil;
 
     id object = [m_dictionary objectForKey:key];
-    if (![object isKindOfClass:aClass]) {
+    if (object && ![object isKindOfClass:aClass]) {
         m_failedDecoding = YES;
         return nil;
     }
 
     return object;
+}
+
+- (id)decodeObjectOfClasses:(NSSet<Class> *)classes forKey:(NSString *)key
+{
+    if (m_failedDecoding)
+        return nil;
+
+    id object = [m_dictionary objectForKey:key];
+    if (!object)
+        return nil;
+    for (id aClass in classes) {
+        if ([object isKindOfClass:aClass])
+            return object;
+    }
+
+    m_failedDecoding = YES;
+    return nil;
 }
 
 - (id)decodeObjectForKey:(NSString *)key


### PR DESCRIPTION
#### 46b3cc90a48cfdf8905654650313fb3741fdfc6b
<pre>
Generate WKSecureCoding for PKPaymentMerchantSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=268605">https://bugs.webkit.org/show_bug.cgi?id=268605</a>
<a href="https://rdar.apple.com/122166988">rdar://122166988</a>

Reviewed by Alex Christensen.

* Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h:

* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::getClass&lt;PKPaymentMerchantSession&gt;):
(IPC::typeFromObject):

* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::valueFromID):
* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in:

* Source/WebKit/Shared/Cocoa/WKKeyedCoder.mm:
(-[WKKeyedCoder encodeObject:forKey:]):
(-[WKKeyedCoder decodeObjectOfClass:forKey:]):
(-[WKKeyedCoder decodeObjectOfClasses:forKey:]):

* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/274006@main">https://commits.webkit.org/274006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d9f0ff54bfef7699eb8fae9721f3437ffc0f15a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37473 "14 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39999 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13519 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31801 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38038 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/13835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32878 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12003 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41262 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33920 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37884 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12545 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10119 "Found 1 new test failure: http/tests/webgpu/webgpu/api/operation/rendering/indirect_draw.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36041 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14006 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8450 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12952 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13321 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->