### PR TITLE
[JSC] Use Data DirectCall in DFG

### DIFF
--- a/Source/JavaScriptCore/jit/JITOperations.h
+++ b/Source/JavaScriptCore/jit/JITOperations.h
@@ -46,6 +46,7 @@ class Butterfly;
 class CallFrame;
 class CallLinkInfo;
 class CodeBlock;
+class DirectCallLinkInfo;
 class JSArray;
 class JSBoundFunction;
 class JSCell;
@@ -308,6 +309,7 @@ JSC_DECLARE_JIT_OPERATION(operationCallDirectEvalStrict, EncodedJSValue, (void*,
 JSC_DECLARE_JIT_OPERATION(operationPolymorphicCall, UCPURegister, (CallFrame*, CallLinkInfo*));
 JSC_DECLARE_JIT_OPERATION(operationVirtualCall, UCPURegister, (CallFrame*, CallLinkInfo*));
 JSC_DECLARE_JIT_OPERATION(operationDefaultCall, UCPURegister, (CallFrame*, CallLinkInfo*));
+JSC_DECLARE_JIT_OPERATION(operationDefaultDirectCall, UCPURegister, (CallFrame*, DirectCallLinkInfo*));
 
 JSC_DECLARE_JIT_OPERATION(operationCompareLess, size_t, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationCompareLessEq, size_t, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));

--- a/Source/JavaScriptCore/llint/LLIntThunks.cpp
+++ b/Source/JavaScriptCore/llint/LLIntThunks.cpp
@@ -344,6 +344,48 @@ MacroAssemblerCodeRef<JSEntryPtrTag> defaultCallThunk()
     return codeRef;
 }
 
+MacroAssemblerCodeRef<JSEntryPtrTag> defaultDirectCallThunk()
+{
+    static LazyNeverDestroyed<MacroAssemblerCodeRef<JSEntryPtrTag>> codeRef;
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [&] {
+        // The callee is in regT0 (for JSVALUE32_64, the tag is in regT1).
+        // The return address is on the stack, or in the link register. We will hence
+        // jump to the callee, or save the return address to the call frame while we
+        // make a C++ function call to the appropriate JIT operation.
+
+        // regT0 => callee
+        // regT1 => tag (32bit)
+        // regT2 => CallLinkInfo*
+
+        CCallHelpers jit;
+
+        jit.emitFunctionPrologue();
+        if (maxFrameExtentForSlowPathCall)
+            jit.addPtr(CCallHelpers::TrustedImm32(-static_cast<int32_t>(maxFrameExtentForSlowPathCall)), CCallHelpers::stackPointerRegister);
+        jit.setupArguments<decltype(operationDefaultDirectCall)>(GPRInfo::regT2);
+        jit.move(CCallHelpers::TrustedImmPtr(tagCFunction<OperationPtrTag>(operationDefaultDirectCall)), GPRInfo::nonArgGPR0);
+        jit.call(GPRInfo::nonArgGPR0, OperationPtrTag);
+        if (maxFrameExtentForSlowPathCall)
+            jit.addPtr(CCallHelpers::TrustedImm32(maxFrameExtentForSlowPathCall), CCallHelpers::stackPointerRegister);
+
+        // This slow call will return the address of one of the following:
+        // 1) Exception throwing thunk.
+        // 2) Host call return value returner thingy.
+        // 3) The function to call.
+        // The second return value GPR will hold a non-zero value for tail calls.
+
+        jit.emitFunctionEpilogue();
+        jit.untagReturnAddress();
+        jit.farJump(GPRInfo::returnValueGPR, JSEntryPtrTag);
+
+        LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::Thunk);
+        codeRef.construct(FINALIZE_CODE(patchBuffer, JSEntryPtrTag, "Default Direct Call thunk"));
+        return;
+    });
+    return codeRef;
+}
+
 MacroAssemblerCodeRef<JSEntryPtrTag> getHostCallReturnValueThunk()
 {
     static LazyNeverDestroyed<MacroAssemblerCodeRef<JSEntryPtrTag>> codeRef;

--- a/Source/JavaScriptCore/llint/LLIntThunks.h
+++ b/Source/JavaScriptCore/llint/LLIntThunks.h
@@ -78,6 +78,7 @@ MacroAssemblerCodeRef<JSEntryPtrTag> evalEntryThunk();
 MacroAssemblerCodeRef<JSEntryPtrTag> programEntryThunk();
 MacroAssemblerCodeRef<JSEntryPtrTag> moduleProgramEntryThunk();
 MacroAssemblerCodeRef<JSEntryPtrTag> defaultCallThunk();
+MacroAssemblerCodeRef<JSEntryPtrTag> defaultDirectCallThunk();
 MacroAssemblerCodeRef<JSEntryPtrTag> getHostCallReturnValueThunk();
 MacroAssemblerCodeRef<JSEntryPtrTag> genericReturnPointThunk(OpcodeSize);
 MacroAssemblerCodeRef<JSEntryPtrTag> fuzzerReturnEarlyFromLoopHintThunk();


### PR DESCRIPTION
#### 1183ba1c6a1fd4f11dc59563c3590bf55c19ebf2
<pre>
[JSC] Use Data DirectCall in DFG
<a href="https://bugs.webkit.org/show_bug.cgi?id=268606">https://bugs.webkit.org/show_bug.cgi?id=268606</a>
<a href="https://rdar.apple.com/122167653">rdar://122167653</a>

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/bytecode/CallLinkInfo.cpp:
(JSC::DirectCallLinkInfo::DirectCallLinkInfo):
(JSC::DirectCallLinkInfo::reset):
(JSC::DirectCallLinkInfo::unlinkOrUpgradeImpl):
(JSC::DirectCallLinkInfo::emitDirectFastPath):
(JSC::DirectCallLinkInfo::emitDirectTailCallFastPath):
* Source/JavaScriptCore/bytecode/CallLinkInfo.h:
(JSC::DirectCallLinkInfo::ownerForSlowPath):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::emitCall):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/jit/JITOperations.h:
* Source/JavaScriptCore/llint/LLIntThunks.cpp:
(JSC::LLInt::defaultDirectCallThunk):
* Source/JavaScriptCore/llint/LLIntThunks.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1183ba1c6a1fd4f11dc59563c3590bf55c19ebf2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37430 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39956 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33354 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31776 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/37995 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11968 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/11953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41219 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/31243 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33843 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33944 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37847 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/37114 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12513 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36005 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/13985 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/44017 "Built successfully") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12924 "Hash 1183ba1c for PR 23728 does not build (failure)") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9027 "Found 3 new JSC stress test failures: wasm.yaml/wasm/gc/bug265742.js.wasm-eager, wasm.yaml/wasm/gc/bug266127.js.wasm-eager, wasm.yaml/wasm/gc/call_ref.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13300 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->