### PR TITLE
Build fix for watchOS and tvOS.

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
@@ -30,15 +30,18 @@
 #import "config.h"
 #import "JSWebExtensionWrapper.h"
 
-#if ENABLE(WK_WEB_EXTENSIONS)
-
 #import "CocoaHelpers.h"
-#import "JSWebExtensionWrappable.h"
 #import "Logging.h"
-#import "WebExtensionAPIRuntime.h"
 #import <JavaScriptCore/JSObjectRef.h>
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+#import "JSWebExtensionWrappable.h"
+#import "WebExtensionAPIRuntime.h"
+#endif
+
 namespace WebKit {
+
+#if ENABLE(WK_WEB_EXTENSIONS)
 
 WebExtensionCallbackHandler::WebExtensionCallbackHandler(JSValue *callbackFunction)
     : m_callbackFunction(JSValueToObject(callbackFunction.context.JSGlobalContextRef, callbackFunction.JSValueRef, nullptr))
@@ -156,6 +159,8 @@ id WebExtensionCallbackHandler::call(id argumentOne, id argumentTwo, id argument
         toJSValueRef(m_globalContext.get(), argumentThree)
     });
 }
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)
 
 id toNSObject(JSContextRef context, JSValueRef valueRef, Class containingObjectsOfClass)
 {
@@ -291,10 +296,7 @@ JSValueRef toJSValueRef(JSContextRef context, NSURL *url, NullOrEmptyString null
     return toJSValueRef(context, url.absoluteURL.absoluteString, nullOrEmptyString);
 }
 
-NSString *toNSString(JSStringRef string)
-{
-    return string ? CFBridgingRelease(JSStringCopyCFString(nullptr, string)) : nil;
-}
+#if ENABLE(WK_WEB_EXTENSIONS)
 
 RefPtr<WebExtensionCallbackHandler> toJSCallbackHandler(JSContextRef context, JSValueRef callbackValue, WebExtensionAPIRuntimeBase& runtime)
 {
@@ -311,6 +313,13 @@ RefPtr<WebExtensionCallbackHandler> toJSCallbackHandler(JSContextRef context, JS
         return nullptr;
 
     return WebExtensionCallbackHandler::create(context, callbackFunction, runtime);
+}
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)
+
+NSString *toNSString(JSStringRef string)
+{
+    return string ? CFBridgingRelease(JSStringCopyCFString(nullptr, string)) : nil;
 }
 
 JSValueRef deserializeJSONString(JSContextRef context, NSString *jsonString)
@@ -339,8 +348,6 @@ NSString *serializeJSObject(JSContextRef context, JSValueRef value, JSValueRef* 
 }
 
 } // namespace WebKit
-
-#endif // ENABLE(WK_WEB_EXTENSIONS)
 
 using namespace WebKit;
 

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h
@@ -50,14 +50,15 @@ OBJC_CLASS NSString;
 
 #endif // JSC_OBJC_API_ENABLED && defined(__OBJC__)
 
-#if ENABLE(WK_WEB_EXTENSIONS)
-
 namespace WebKit {
+
+class WebPage;
+
+#if ENABLE(WK_WEB_EXTENSIONS)
 
 class JSWebExtensionWrappable;
 class WebExtensionAPIRuntimeBase;
 class WebExtensionCallbackHandler;
-class WebPage;
 
 class JSWebExtensionWrapper {
 public:
@@ -103,6 +104,8 @@ private:
     RefPtr<WebExtensionAPIRuntimeBase> m_runtime;
 #endif
 };
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)
 
 enum class NullStringPolicy : uint8_t {
     NoNullString,
@@ -150,6 +153,8 @@ inline JSValueRef toJSValueRefOrJSNull(JSContextRef context, JSValueRef value)
     return value ? value : JSValueMakeNull(context);
 }
 
+#if ENABLE(WK_WEB_EXTENSIONS)
+
 inline JSValueRef toJS(JSContextRef context, JSWebExtensionWrappable* impl)
 {
     return JSWebExtensionWrapper::wrap(context, impl);
@@ -166,6 +171,8 @@ inline Ref<WebExtensionCallbackHandler> toJSErrorCallbackHandler(JSContextRef co
 }
 
 RefPtr<WebExtensionCallbackHandler> toJSCallbackHandler(JSContextRef, JSValueRef callback, WebExtensionAPIRuntimeBase&);
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)
 
 #ifdef __OBJC__
 
@@ -254,5 +261,3 @@ inline bool isDictionary(JSContextRef context, JSValueRef value) { return toJSVa
 #endif // __OBJC__
 
 } // namespace WebKit
-
-#endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### 6dcf6d1fe6e87803062a811cdff5961c2ee0e93c
<pre>
Build fix for watchOS and tvOS.

Unreviewed build fix.

* Source/WebKit/WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm:
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.h:
Move the non-extension code out from behind ENABLE(WK_WEB_EXTENSIONS).

Canonical link: <a href="https://commits.webkit.org/273980@main">https://commits.webkit.org/273980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3136d0a72cfc94de0016eafef4bf03d0d0296e49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39698 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13470 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/39961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/38000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/13760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/39961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41224 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/33847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/33949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/12516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/36006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4858 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->