### PR TITLE
Draws to unused 2D contexts may consume excessive amount of memory on Cocoa

### DIFF
--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -152,13 +152,11 @@ void CanvasCaptureMediaStreamTrack::Source::canvasResized(CanvasBase& canvas)
     setSize(IntSize(m_canvas->width(), m_canvas->height()));
 }
 
-void CanvasCaptureMediaStreamTrack::Source::canvasChanged(CanvasBase& canvas, const std::optional<FloatRect>&)
+void CanvasCaptureMediaStreamTrack::Source::canvasChanged(CanvasBase&, const FloatRect&)
 {
-    ASSERT_UNUSED(canvas, m_canvas == &canvas);
-#if ENABLE(WEBGL)
-    if (m_canvas->renderingContext() && m_canvas->renderingContext()->needsPreparationForDisplay() && m_canvas->hasObserver(m_canvas->document()))
+    // If canvas needs preparation, the capture will be scheduled once document prepares the canvas.
+    if (m_canvas->needsPreparationForDisplay())
         return;
-#endif
     scheduleCaptureCanvas();
 }
 

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.h
@@ -67,7 +67,7 @@ private:
         Source(HTMLCanvasElement&, std::optional<double>&&);
 
         // CanvasObserver overrides.
-        void canvasChanged(CanvasBase&, const std::optional<FloatRect>&) final;
+        void canvasChanged(CanvasBase&, const FloatRect&) final;
         void canvasResized(CanvasBase&) final;
         void canvasDestroyed(CanvasBase&) final;
 

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
@@ -93,7 +93,7 @@ private:
     static IntSize computeNativeWebGLFramebufferResolution();
     static IntSize computeRecommendedWebGLFramebufferResolution();
 
-    void canvasChanged(CanvasBase&, const std::optional<FloatRect>&) final { };
+    void canvasChanged(CanvasBase&, const FloatRect&) final { };
     void canvasResized(CanvasBase&) final;
     void canvasDestroyed(CanvasBase&) final { };
     Ref<WebXRSession> m_session;

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -171,7 +171,7 @@ bool CanvasBase::hasObserver(CanvasObserver& observer) const
     return m_observers.contains(observer);
 }
 
-void CanvasBase::notifyObserversCanvasChanged(const std::optional<FloatRect>& rect)
+void CanvasBase::notifyObserversCanvasChanged(const FloatRect& rect)
 {
     for (auto& observer : m_observers)
         observer.canvasChanged(*this, rect);
@@ -179,13 +179,16 @@ void CanvasBase::notifyObserversCanvasChanged(const std::optional<FloatRect>& re
 
 void CanvasBase::didDraw(const std::optional<FloatRect>& rect, ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)
 {
+    addCanvasNeedingPreparationForDisplayOrFlush();
+    IntRect dirtyRect { { }, size() };
+    if (rect)
+        dirtyRect.intersect(enclosingIntRect(*rect));
+    notifyObserversCanvasChanged(dirtyRect);
+
     // FIXME: We should exclude rects with ShouldApplyPostProcessingToDirtyRect::No
     if (shouldInjectNoiseBeforeReadback()) {
         if (shouldApplyPostProcessingToDirtyRect == ShouldApplyPostProcessingToDirtyRect::Yes) {
-            if (rect)
-                m_canvasNoiseInjection.updateDirtyRect(intersection(enclosingIntRect(*rect), { { }, size() }));
-            else
-                m_canvasNoiseInjection.updateDirtyRect({ { }, size() });
+            m_canvasNoiseInjection.updateDirtyRect(dirtyRect);
         } else if (!rect)
             m_canvasNoiseInjection.clearDirtyRect();
     }
@@ -354,6 +357,20 @@ void CanvasBase::recordLastFillText(const String& text)
     if (!shouldInjectNoiseBeforeReadback())
         return;
     m_lastFillText = text;
+}
+
+void CanvasBase::addCanvasNeedingPreparationForDisplayOrFlush()
+{
+    if (auto* document = dynamicDowncast<Document>(scriptExecutionContext()))
+        document->addCanvasNeedingPreparationForDisplayOrFlush(*this);
+    // FIXME: WorkerGlobalContext does not have prepare phase yet.
+}
+
+void CanvasBase::removeCanvasNeedingPreparationForDisplayOrFlush()
+{
+    if (auto* document = dynamicDowncast<Document>(scriptExecutionContext()))
+        document->removeCanvasNeedingPreparationForDisplayOrFlush(*this);
+    // FIXME: WorkerGlobalContext does not have prepare phase yet.
 }
 
 bool CanvasBase::postProcessPixelBufferResults(Ref<PixelBuffer>&& pixelBuffer) const

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -100,7 +100,7 @@ public:
     void addObserver(CanvasObserver&);
     void removeObserver(CanvasObserver&);
     bool hasObserver(CanvasObserver&) const;
-    void notifyObserversCanvasChanged(const std::optional<FloatRect>&);
+    void notifyObserversCanvasChanged(const FloatRect&);
     void notifyObserversCanvasResized();
     void notifyObserversCanvasDestroyed(); // Must be called in destruction before clearing m_context.
     void addDisplayBufferObserver(CanvasDisplayBufferObserver&);
@@ -113,6 +113,7 @@ public:
     virtual GraphicsContext* drawingContext() const;
     virtual GraphicsContext* existingDrawingContext() const;
 
+    // !rect means caller knows the full canvas is invalidated previously.
     void didDraw(const std::optional<FloatRect>& rect) { return didDraw(rect, ShouldApplyPostProcessingToDirtyRect::Yes); }
     virtual void didDraw(const std::optional<FloatRect>&, ShouldApplyPostProcessingToDirtyRect);
 
@@ -149,11 +150,14 @@ protected:
 
     RefPtr<ImageBuffer> allocateImageBuffer() const;
     String lastFillText() const { return m_lastFillText; }
+    void addCanvasNeedingPreparationForDisplayOrFlush();
+    void removeCanvasNeedingPreparationForDisplayOrFlush();
 
 private:
     bool shouldInjectNoiseBeforeReadback() const;
     virtual void createImageBuffer() const { }
     bool shouldAccelerate(uint64_t area) const;
+
 
     mutable IntSize m_size;
     mutable Lock m_imageBufferAssignmentLock;

--- a/Source/WebCore/html/CanvasObserver.h
+++ b/Source/WebCore/html/CanvasObserver.h
@@ -38,7 +38,7 @@ public:
 
     virtual bool isStyleCanvasImage() const { return false; }
 
-    virtual void canvasChanged(CanvasBase&, const std::optional<FloatRect>& changedRect) = 0;
+    virtual void canvasChanged(CanvasBase&, const FloatRect& changedRect) = 0;
     virtual void canvasResized(CanvasBase&) = 0;
     virtual void canvasDestroyed(CanvasBase&) = 0;
 };

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -147,7 +147,7 @@ HTMLCanvasElement::~HTMLCanvasElement()
     // downcasts the CanvasBase object to HTMLCanvasElement. That invokes virtual methods, which should be
     // avoided in destructors, but works as long as it's done before HTMLCanvasElement destructs completely.
     notifyObserversCanvasDestroyed();
-    document().clearCanvasPreparation(*this);
+    removeCanvasNeedingPreparationForDisplayOrFlush();
 
     m_context = nullptr; // Ensure this goes away before the ImageBuffer.
     setImageBuffer(nullptr);
@@ -435,10 +435,6 @@ WebGLRenderingContextBase* HTMLCanvasElement::createContextWebGL(WebGLVersion ty
     // adapter when there is an active immersive device.
     m_context = WebGLRenderingContextBase::create(*this, attrs, type);
     if (m_context) {
-        // This new context needs to be observed by the Document, in order
-        // for it to be correctly preparedForRendering before it is composited.
-        addObserver(document());
-
         // Need to make sure a RenderLayer and compositing layer get created for the Canvas.
         invalidateStyleAndLayerComposition();
         if (renderBox())
@@ -482,6 +478,7 @@ ImageBitmapRenderingContext* HTMLCanvasElement::createContextBitmapRenderer(cons
     ASSERT(!m_context);
 
     m_context = ImageBitmapRenderingContext::create(*this, WTFMove(settings));
+    downcast<ImageBitmapRenderingContext>(m_context.get())->transferFromImageBitmap(nullptr);
 
 #if USE(IOSURFACE_CANVAS_BACKING_STORE)
     // Need to make sure a RenderLayer and compositing layer get created for the Canvas.
@@ -515,10 +512,6 @@ GPUCanvasContext* HTMLCanvasElement::createContextWebGPU(const String& type, GPU
     m_context = GPUCanvasContext::create(*this, *gpu);
 
     if (m_context) {
-        // Adds the current document as an observer, so that the document calls prepareForDisplay
-        // when the canvas changes.
-        addObserver(document());
-
         // Need to make sure a RenderLayer and compositing layer get created for the Canvas.
         invalidateStyleAndLayerComposition();
     }
@@ -544,34 +537,30 @@ GPUCanvasContext* HTMLCanvasElement::getContextWebGPU(const String& type, GPU* g
 
 void HTMLCanvasElement::didDraw(const std::optional<FloatRect>& rect, ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)
 {
-    CanvasBase::didDraw(rect, shouldApplyPostProcessingToDirtyRect);
-
     clearCopiedImage();
-    
-    if (!rect) {
-        notifyObserversCanvasChanged(std::nullopt);
-        return;
-    }
-
-    auto dirtyRect = rect.value();
+    auto adjustedRect = rect;
     if (CheckedPtr renderer = renderBox()) {
-        FloatRect destRect;
-        if (CheckedPtr renderReplaced = dynamicDowncast<RenderReplaced>(*renderer))
-            destRect = renderReplaced->replacedContentRect();
-        else
-            destRect = renderer->contentBoxRect();
+        if (isGPUBased() && renderer->hasAcceleratedCompositing())
+            renderer->contentChanged(CanvasPixelsChanged);
+        else if (adjustedRect) {
+            FloatRect destRect;
+            if (CheckedPtr renderReplaced = dynamicDowncast<RenderReplaced>(*renderer))
+                destRect = renderReplaced->replacedContentRect();
+            else
+                destRect = renderer->contentBoxRect();
 
-        // Inflate dirty rect to cover antialiasing on image buffers.
-        if (drawingContext() && drawingContext()->shouldAntialias())
-            dirtyRect.inflate(1);
+            // Inflate dirty rect to cover antialiasing on image buffers.
+            if (drawingContext() && drawingContext()->shouldAntialias())
+                adjustedRect->inflate(1);
 
-        FloatRect r = mapRect(dirtyRect, FloatRect(0, 0, size().width(), size().height()), destRect);
-        r.intersect(destRect);
+            FloatRect r = mapRect(*adjustedRect, FloatRect { { }, size() }, destRect);
+            r.intersect(destRect);
 
-        if (!r.isEmpty())
-            renderer->repaintRectangle(enclosingIntRect(r));
+            if (!r.isEmpty())
+                renderer->repaintRectangle(enclosingIntRect(r));
+        }
     }
-    notifyObserversCanvasChanged(dirtyRect);
+    CanvasBase::didDraw(adjustedRect, shouldApplyPostProcessingToDirtyRect);
 }
 
 void HTMLCanvasElement::reset()
@@ -676,11 +665,6 @@ void HTMLCanvasElement::setSurfaceSize(const IntSize& size)
     m_hasCreatedImageBuffer = false;
     setImageBuffer(nullptr);
     clearCopiedImage();
-
-    if (!needsPreparationForDisplay()) {
-        document().clearCanvasPreparation(*this);
-        removeObserver(document());
-    }
 }
 
 static String toEncodingMimeType(const String& mimeType)
@@ -890,9 +874,6 @@ void HTMLCanvasElement::createImageBuffer() const
         const_cast<HTMLCanvasElement*>(this)->invalidateStyleAndLayerComposition();
     }
 #endif
-
-    if (m_context && buffer() && buffer()->prefersPreparationForDisplay())
-        const_cast<HTMLCanvasElement*>(this)->addObserver(document());
 }
 
 void HTMLCanvasElement::setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&& buffer)
@@ -975,37 +956,9 @@ void HTMLCanvasElement::eventListenersDidChange()
 
 void HTMLCanvasElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
 {
-    if (needsPreparationForDisplay()) {
-        oldDocument.clearCanvasPreparation(*this);
-        removeObserver(oldDocument);
-        addObserver(newDocument);
-    }
-
+    oldDocument.removeCanvasNeedingPreparationForDisplayOrFlush(*this);
+    newDocument.addCanvasNeedingPreparationForDisplayOrFlush(*this);
     HTMLElement::didMoveToNewDocument(oldDocument, newDocument);
-}
-
-Node::InsertedIntoAncestorResult HTMLCanvasElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
-{
-    if (needsPreparationForDisplay() && insertionType.connectedToDocument) {
-        auto& document = parentOfInsertedTree.document();
-        addObserver(document);
-        // Drawing commands may have been issued to the canvas before now, so we need to
-        // tell the document if we need preparation.
-        if (m_context && m_context->compositingResultsNeedUpdating())
-            document.canvasChanged(*this, FloatRect { });
-    }
-
-    return HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
-}
-
-void HTMLCanvasElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
-{
-    if (needsPreparationForDisplay() && removalType.disconnectedFromDocument) {
-        oldParentOfRemovedTree.document().clearCanvasPreparation(*this);
-        removeObserver(oldParentOfRemovedTree.document());
-    }
-
-    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
 }
 
 bool HTMLCanvasElement::needsPreparationForDisplay()

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -183,8 +183,6 @@ private:
     ScriptExecutionContext* canvasBaseScriptExecutionContext() const final { return HTMLElement::scriptExecutionContext(); }
 
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
-    Node::InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
-    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
 
     std::unique_ptr<CanvasRenderingContext> m_context;
     mutable RefPtr<Image> m_copiedImage; // FIXME: This is temporary for platforms that have to copy the image buffer to render (and for CSSCanvasValue).

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -97,6 +97,12 @@ public:
     bool hasActiveInspectorCanvasCallTracer() const { return m_hasActiveInspectorCanvasCallTracer; }
     void setHasActiveInspectorCanvasCallTracer(bool hasActiveInspectorCanvasCallTracer) { m_hasActiveInspectorCanvasCallTracer = hasActiveInspectorCanvasCallTracer; }
 
+    // Returns true if there are pending deferred operations that might consume memory.
+    virtual bool hasDeferredOperations() const { return false; }
+
+    // Called periodically if needsFlush() was true when canvas change happened.
+    virtual void flushDeferredOperations() { }
+
     virtual bool compositingResultsNeedUpdating() const { return false; }
     virtual bool needsPreparationForDisplay() const { return false; }
     // Swaps the current drawing buffer to display buffer.

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -438,6 +438,9 @@ private:
 
     bool isAccelerated() const override;
 
+    bool hasDeferredOperations() const final;
+    void flushDeferredOperations() final;
+
     bool hasInvertibleTransform() const final { return state().hasInvertibleTransform; }
 
     // The relationship between FontCascade and CanvasRenderingContext2D::FontProxy must hold certain invariants.
@@ -457,6 +460,7 @@ private:
     bool m_usesCSSCompatibilityParseMode;
     mutable std::variant<CachedContentsTransparent, CachedContentsUnknown, CachedContentsImageData> m_cachedContents;
     CanvasRenderingContext2DSettings m_settings;
+    bool m_hasDeferredOperations { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.cpp
@@ -43,13 +43,10 @@ HTMLCanvasElement* GPUBasedCanvasRenderingContext::htmlCanvas() const
     return dynamicDowncast<HTMLCanvasElement>(canvasBase());
 }
 
-void GPUBasedCanvasRenderingContext::notifyCanvasContentChanged()
+void GPUBasedCanvasRenderingContext::markCanvasChanged()
 {
-    if (htmlCanvas()) {
-        RenderBox* renderBox = htmlCanvas()->renderBox();
-        if (renderBox && renderBox->hasAcceleratedCompositing())
-            renderBox->contentChanged(CanvasChanged);
-    }
+    auto& canvas = canvasBase();
+    canvas.didDraw(FloatRect { { }, canvas.size() }, ShouldApplyPostProcessingToDirtyRect::No);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
@@ -45,7 +45,7 @@ protected:
     explicit GPUBasedCanvasRenderingContext(CanvasBase&);
 
     HTMLCanvasElement* htmlCanvas() const;
-    void notifyCanvasContentChanged();
+    void markCanvasChanged();
 };
     
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -274,33 +274,8 @@ void GPUCanvasContextCocoa::prepareForDisplay()
 void GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers()
 {
     m_compositingResultsNeedsUpdating = true;
-
-    bool canvasIsDirty = false;
-
-    auto canvas = htmlOrOffscreenCanvas();
-    CanvasBase *canvasBase = nullptr;
-    WTF::switchOn(canvas, [&](RefPtr<HTMLCanvasElement>& htmlCanvas) {
-        auto* renderBox = htmlCanvas->renderBox();
-        canvasBase = htmlCanvas.get();
-        if (isAccelerated() && renderBox && renderBox->hasAcceleratedCompositing()) {
-            canvasIsDirty = true;
-            htmlCanvas->clearCopiedImage();
-            renderBox->contentChanged(CanvasChanged);
-        }
-    }, [&](RefPtr<OffscreenCanvas>& offscreenCanvas) {
-        canvasBase = offscreenCanvas.get();
-    });
-
-    if (!canvasIsDirty)
-        this->canvasBase().didDraw({ });
-
-    if (!isAccelerated())
-        return;
-
-    if (!canvasBase)
-        return;
-
-    canvasBase->notifyObserversCanvasChanged({ });
+    markCanvasChanged();
 }
+
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
@@ -50,7 +50,6 @@ ImageBitmapRenderingContext::ImageBitmapRenderingContext(CanvasBase& canvas, Ima
     : CanvasRenderingContext(canvas)
     , m_settings(WTFMove(settings))
 {
-    setOutputBitmap(nullptr);
 }
 
 ImageBitmapRenderingContext::~ImageBitmapRenderingContext() = default;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -696,23 +696,8 @@ void WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver(WebGLR
         return;
 
     m_compositingResultsNeedUpdating = true;
-
-    if (auto* canvas = htmlCanvas()) {
-        if (isAccelerated()) {
-            canvas->notifyObserversCanvasChanged({ });
-            RenderBox* renderBox = canvas->renderBox();
-            if (renderBox && renderBox->hasAcceleratedCompositing()) {
-                m_canvasBufferContents = std::nullopt;
-                canvas->clearCopiedImage();
-                renderBox->contentChanged(CanvasPixelsChanged);
-            }
-        }
-    }
-
-    if (m_canvasBufferContents.has_value()) {
-        m_canvasBufferContents = std::nullopt;
-        canvasBase().didDraw(FloatRect(FloatPoint(0, 0), clampedCanvasSize()), ShouldApplyPostProcessingToDirtyRect::No);
-    }
+    m_canvasBufferContents = std::nullopt;
+    markCanvasChanged();
 }
 
 bool WebGLRenderingContextBase::clearIfComposited(WebGLRenderingContextBase::CallerType caller, GCGLbitfield mask)
@@ -5374,7 +5359,11 @@ void WebGLRenderingContextBase::maybeRestoreContext()
             canvasBase().dispatchEvent(WebGLContextEvent::create(eventNames().webglcontextrestoredEvent, Event::CanBubble::No, Event::IsCancelable::Yes, emptyString()));
             // Notify the render layer to reconfigure the structure of the backing. This causes the backing to
             // start using the new layer contents display delegate from the new context.
-            notifyCanvasContentChanged();
+            if (auto* htmlCanvas = this->htmlCanvas()) {
+                RenderBox* renderBox = htmlCanvas->renderBox();
+                if (renderBox && renderBox->hasAcceleratedCompositing())
+                    renderBox->contentChanged(CanvasChanged);
+            }
             return;
         }
         // Remove the possible objects added during the initialization.

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -377,7 +377,7 @@ void InspectorCanvasAgent::didChangeCanvasMemory(CanvasRenderingContext& context
     m_frontendDispatcher->canvasMemoryChanged(inspectorCanvas->identifier(), inspectorCanvas->canvasContext().canvasBase().memoryCost());
 }
 
-void InspectorCanvasAgent::canvasChanged(CanvasBase& canvasBase, const std::optional<FloatRect>&)
+void InspectorCanvasAgent::canvasChanged(CanvasBase& canvasBase, const FloatRect&)
 {
     auto* context = canvasBase.renderingContext();
     if (!context)

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
@@ -83,7 +83,7 @@ public:
 #endif // ENABLE(WEBGL)
 
     // CanvasObserver
-    void canvasChanged(CanvasBase&, const std::optional<FloatRect>&) final;
+    void canvasChanged(CanvasBase&, const FloatRect&) final;
     void canvasResized(CanvasBase&) final { }
     void canvasDestroyed(CanvasBase&) final;
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2007,10 +2007,10 @@ void Page::doAfterUpdateRendering()
 
     DebugPageOverlays::doAfterUpdateRendering(*this);
 
-    m_renderingUpdateRemainingSteps.last().remove(RenderingUpdateStep::PrepareCanvasesForDisplay);
+    m_renderingUpdateRemainingSteps.last().remove(RenderingUpdateStep::PrepareCanvasesForDisplayOrFlush);
 
     forEachDocument([] (Document& document) {
-        document.prepareCanvasesForDisplayIfNeeded();
+        document.prepareCanvasesForDisplayOrFlushIfNeeded();
     });
 
     if (localMainFrame) {
@@ -4297,7 +4297,7 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, RenderingUpdateStep step)
     case RenderingUpdateStep::ScrollingTreeUpdate: ts << "ScrollingTreeUpdate"; break;
 #endif
     case RenderingUpdateStep::VideoFrameCallbacks: ts << "VideoFrameCallbacks"; break;
-    case RenderingUpdateStep::PrepareCanvasesForDisplay: ts << "PrepareCanvasesForDisplay"; break;
+    case RenderingUpdateStep::PrepareCanvasesForDisplayOrFlush: ts << "PrepareCanvasesForDisplayOrFlush"; break;
     case RenderingUpdateStep::CaretAnimation: ts << "CaretAnimation"; break;
     case RenderingUpdateStep::FocusFixup: ts << "FocusFixup"; break;
     case RenderingUpdateStep::UpdateValidationMessagePositions: ts << "UpdateValidationMessagePositions"; break;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -232,7 +232,7 @@ enum class RenderingUpdateStep : uint32_t {
 #endif
     FlushAutofocusCandidates        = 1 << 16,
     VideoFrameCallbacks             = 1 << 17,
-    PrepareCanvasesForDisplay       = 1 << 18,
+    PrepareCanvasesForDisplayOrFlush = 1 << 18,
     CaretAnimation                  = 1 << 19,
     FocusFixup                      = 1 << 20,
     UpdateValidationMessagePositions= 1 << 21,
@@ -266,7 +266,7 @@ constexpr OptionSet<RenderingUpdateStep> updateRenderingSteps = {
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     RenderingUpdateStep::AccessibilityRegionUpdate,
 #endif
-    RenderingUpdateStep::PrepareCanvasesForDisplay,
+    RenderingUpdateStep::PrepareCanvasesForDisplayOrFlush,
     RenderingUpdateStep::CaretAnimation,
     RenderingUpdateStep::UpdateContentRelevancy,
     RenderingUpdateStep::PerformPendingViewTransitions,

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -261,7 +261,7 @@ void ImageBuffer::flushDrawingContext()
 
 bool ImageBuffer::flushDrawingContextAsync()
 {
-    // This function is only really useful for the Remote subclass, where the prefersPreparationForDisplay() == true.
+    // This function is only really useful for the Remote subclass.
     flushDrawingContext();
     return true;
 }

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -130,7 +130,6 @@ public:
 
     WEBCORE_EXPORT virtual GraphicsContext& context() const;
 
-    virtual bool prefersPreparationForDisplay() { return false; }
     WEBCORE_EXPORT virtual void flushDrawingContext();
     WEBCORE_EXPORT virtual bool flushDrawingContextAsync();
 

--- a/Source/WebCore/rendering/style/StyleCanvasImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCanvasImage.cpp
@@ -109,15 +109,12 @@ void StyleCanvasImage::didRemoveClient(RenderElement& renderer)
         InspectorInstrumentation::didChangeCSSCanvasClientNodes(*element);
 }
 
-void StyleCanvasImage::canvasChanged(CanvasBase& canvasBase, const std::optional<FloatRect>& changedRect)
+void StyleCanvasImage::canvasChanged(CanvasBase& canvasBase, const FloatRect& changedRect)
 {
     ASSERT_UNUSED(canvasBase, is<HTMLCanvasElement>(canvasBase));
     ASSERT_UNUSED(canvasBase, m_element == &downcast<HTMLCanvasElement>(canvasBase));
 
-    if (!changedRect)
-        return;
-
-    auto imageChangeRect = enclosingIntRect(changedRect.value());
+    auto imageChangeRect = enclosingIntRect(changedRect);
     for (auto entry : clients()) {
         auto& client = entry.key;
         client.imageChanged(static_cast<WrappedImagePtr>(this), &imageChangeRect);

--- a/Source/WebCore/rendering/style/StyleCanvasImage.h
+++ b/Source/WebCore/rendering/style/StyleCanvasImage.h
@@ -62,7 +62,7 @@ private:
 
     // CanvasObserver.
     bool isStyleCanvasImage() const final { return true; }
-    void canvasChanged(CanvasBase&, const std::optional<FloatRect>& changedRect) final;
+    void canvasChanged(CanvasBase&, const FloatRect&) final;
     void canvasResized(CanvasBase&) final;
     void canvasDestroyed(CanvasBase&) final;
 


### PR DESCRIPTION
#### da9744107a306e658c6874a688488457e6cdc47a
<pre>
Draws to unused 2D contexts may consume excessive amount of memory on Cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=268608">https://bugs.webkit.org/show_bug.cgi?id=268608</a>
<a href="https://rdar.apple.com/117708049">rdar://117708049</a>

Reviewed by Simon Fraser.

Accelerated CG applies a drawn operation only once a specific draw
operation limit is hit, if the result is needed as a source to other
draw or on explicit flush. If the operations are not implicitly or
explicitly flushed, the draws are retained in the draw queue.

This causes memory leaks in cases where modifiable surfaces are used as
sources for draws and and then subsequently the the surfaces are
modified. The modifications force copy-on-write for the surfaces that
have pending references in other draw queues.

This can be triggered by drawing a canvas A to a 2D context B
and then never using the result, subsequently modifying A.

Fix by adding a list of flushed CanvasRenderingContexts to Document.
Any 2D context modified during any JS callstack will be put to the
flush list.

Flush the contexts during rendering update, PrepareCanvases phase.
Rename the rendering update PrepareCanvasesForDisplay phase
PrepareCanvases phase, and do both.

PrepareCanvases phase of Document now does two things:
  - flushes deferred operations
  - prepares for display

Currently only Document manages the canvas preparation.
This works for OffscreenCanvas and HTMLCanvasElement in Web main run
loop.

WorkerGlobalContext is not implemented in this patch.
In future, PrepareCanvases phase of WorkerGlobalContext will do
the flush operations, but not the prepares for display. OffscreenCanvas
does not have the prepare for display, as it&apos;s not displaying.

* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp:
(WebCore::CanvasCaptureMediaStreamTrack::Source::canvasChanged):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::prepareCanvasesIfNeeded):
(WebCore::Document::updateCanvasPreparationForDisplayOrFlush):
(WebCore::Document::removeCanvasPreparationForDisplayOrFlush):
(WebCore::Document::prepareCanvasesForDisplayIfNeeded): Deleted.
(WebCore::Document::clearCanvasPreparation): Deleted.
(WebCore::Document::canvasChanged): Deleted.
(WebCore::Document::canvasDestroyed): Deleted.
* Source/WebCore/dom/Document.h:

Remove Document CanvasObserver interface. The interface was making
the actual logic harder than needed and did not abstract anything, as
the clearCanvasPreparation was a non-interface method anyway.

The object which does the prepare (Document, WorkerGlobalContext), is
always statically known at call site. Thus the call site does not need
to jump thorough the canvasChanged hoop.

* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::~HTMLCanvasElement):
(WebCore::HTMLCanvasElement::createContext2d):
(WebCore::HTMLCanvasElement::createContextWebGL):
(WebCore::HTMLCanvasElement::createContextWebGPU):
(WebCore::HTMLCanvasElement::didDraw):
(WebCore::HTMLCanvasElement::setSurfaceSize):
(WebCore::HTMLCanvasElement::createImageBuffer const):
(WebCore::HTMLCanvasElement::didMoveToNewDocument):
(WebCore::HTMLCanvasElement::insertedIntoAncestor): Deleted.
(WebCore::HTMLCanvasElement::removedFromAncestor): Deleted.

Remove redundant insertedIntoAncestor, removedFromAncestor handlers.
These are called when the element is still in the same document, but
detached from the tree. This does not cause any changes to the
prepare list, as canvases need to be prepared regardless whether
they&apos;re attached or detached.

WebGL still will not prepareForDisplay if it&apos;s not in tree, unless
it has been captured by media stream.

* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::~OffscreenCanvas):
(WebCore::OffscreenCanvas::didDraw):
(WebCore::OffscreenCanvas::updateCanvasPreparation):
(WebCore::OffscreenCanvas::removeCanvasPreparation):
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::hasDeferredOperations const):
(WebCore::CanvasRenderingContext::flushDeferredOperations):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::hasDeferredOperations const):
(WebCore::CanvasRenderingContext2DBase::flushDeferredOperations):
(WebCore::CanvasRenderingContext2DBase::didDraw):
(WebCore::CanvasRenderingContext2DBase::needsPreparationForDisplay const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::doAfterUpdateRendering):
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::flushDrawingContextAsync):
* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::ImageBuffer::prefersPreparationForDisplay): Deleted.

Remove unused ImageBuffer::prefersPreparationForDisplay.

Canonical link: <a href="https://commits.webkit.org/274164@main">https://commits.webkit.org/274164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a94f213a1b35c3f4238ed32c618e980959523ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40597 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33842 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40071 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14284 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32140 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12493 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41872 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34578 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38311 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10681 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36503 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14574 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8543 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13438 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14024 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->