### PR TITLE
REGRESSION (Safari 17): Named at-rule container skipped when container named in a :host selector

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-name-tree-scoped-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-name-tree-scoped-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Outer scope query should not match container-name set by :host rule in shadow tree
 PASS Outer scope query should not match container-name set by ::slotted rule in shadow tree
+PASS Inner scope query should match container-name set by :host rule in shadow tree
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-name-tree-scoped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-name-tree-scoped.html
@@ -52,6 +52,21 @@
       #t2 { color: red; }
     }
   </style>
+
+  <div id="container-name-host-inner-container-rule">
+    <div id="t3host">
+      <template shadowrootmode="open">
+        <style>
+          :host { container-name: foo; }
+          #t3 { color: red; }
+          @container foo (width > 0px) {
+            #t3 { color: green; }
+          }
+        </style>
+        <div id="t3"></div>
+      </template>
+    </div>
+  </div>
 </div>
 
 <script>
@@ -69,5 +84,9 @@
   test(() => {
     assert_equals(getComputedStyle(t2).color, green);
   }, "Outer scope query should not match container-name set by ::slotted rule in shadow tree");
+
+  test(() => {
+    assert_equals(getComputedStyle(t3host.shadowRoot.querySelector('#t3')).color, green);
+  }, "Inner scope query should match container-name set by :host rule in shadow tree");
 
 </script>


### PR DESCRIPTION
#### 14e1048a543f74f0bad414db694db43a7116c644
<pre>
REGRESSION (Safari 17): Named at-rule container skipped when container named in a :host selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=267046">https://bugs.webkit.org/show_bug.cgi?id=267046</a>
<a href="https://rdar.apple.com/120428386">rdar://120428386</a>

Reviewed by Alan Baradlay.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-name-tree-scoped-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-name-tree-scoped.html:
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
(WebCore::Style::ContainerQueryEvaluator::selectContainer):

A container query should be allowed to match a host element with container name that defined by :host rule in the same shadow tree as the query.

Canonical link: <a href="https://commits.webkit.org/273987@main">https://commits.webkit.org/273987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb0f03ffd4bec07442f837b16db1e0175d815899

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/39979 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33375 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13492 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31786 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13772 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/11982 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/11966 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41242 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33960 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37861 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36019 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/13996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/32920 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8437 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/12937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->