### PR TITLE
[LBSE] Code cleanup after implementing all but one resource

### DIFF
--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -191,7 +191,6 @@ ReferencedSVGResources::SVGElementIdentifierAndTagPairs ReferencedSVGResources::
         }
     }
 
-    // FIXME: [LBSE] Implement support for patterns
     if (svgStyle.fillPaintType() >= SVGPaintType::URINone) {
         auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(svgStyle.fillPaintUri(), document);
         if (!resourceID.isEmpty())

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
@@ -97,6 +97,13 @@ void RenderSVGBlock::absoluteQuads(Vector<FloatQuad>& quads, bool* wasFixed) con
 
 void RenderSVGBlock::willBeDestroyed()
 {
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+    if (document().settings().layerBasedSVGEngineEnabled()) {
+        RenderBlockFlow::willBeDestroyed();
+        return;
+    }
+#endif
+
     SVGResourcesCache::clientDestroyed(*this);
     RenderBlockFlow::willBeDestroyed();
 }
@@ -104,10 +111,13 @@ void RenderSVGBlock::willBeDestroyed()
 void RenderSVGBlock::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (diff == StyleDifference::Layout && !document().settings().layerBasedSVGEngineEnabled())
-#else
-    if (diff == StyleDifference::Layout)
+    if (document().settings().layerBasedSVGEngineEnabled()) {
+        RenderBlockFlow::styleDidChange(diff, oldStyle);
+        return;
+    }
 #endif
+
+    if (diff == StyleDifference::Layout)
         setNeedsBoundariesUpdate();
     RenderBlockFlow::styleDidChange(diff, oldStyle);
     SVGResourcesCache::clientStyleChanged(*this, diff, oldStyle, style());

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
@@ -36,9 +36,6 @@
 #include "RenderView.h"
 #include "SVGContainerLayout.h"
 #include "SVGLayerTransformUpdater.h"
-#include "SVGRenderingContext.h"
-#include "SVGResources.h"
-#include "SVGResourcesCache.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/SetForScope.h>
 #include <wtf/StackStats.h>
@@ -79,10 +76,6 @@ void RenderSVGContainer::layout()
         SetForScope trackTransformChanges(m_didTransformToRootUpdate, transformUpdater.layerTransformChanged() || SVGContainerLayout::transformToRootChanged(parent()));
         layoutChildren();
     }
-
-    // Invalidate all resources of this client if our layout changed.
-    if (everHadLayout() && needsLayout())
-        SVGResourcesCache::clientLayoutChanged(*this);
 
     repainter.repaintAfterLayout();
     clearNeedsLayout();

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
@@ -27,7 +27,6 @@
 #include "GraphicsContext.h"
 #include "HitTestResult.h"
 #include "LayoutRepainter.h"
-#include "LegacyRenderSVGResource.h"
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderLayer.h"
 #include "RenderObject.h"
@@ -36,8 +35,6 @@
 #include "SVGElementTypeHelpers.h"
 #include "SVGForeignObjectElement.h"
 #include "SVGRenderSupport.h"
-#include "SVGRenderingContext.h"
-#include "SVGResourcesCache.h"
 #include "TransformState.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/StackStats.h>
@@ -107,16 +104,11 @@ void RenderSVGForeignObject::layout()
     auto height = useForeignObjectElement.height().value(lengthContext);
     m_viewport = { x, y, width, height };
 
-    bool layoutChanged = everHadLayout() && selfNeedsLayout();
     RenderSVGBlock::layout();
     ASSERT(!needsLayout());
 
     setLocation(enclosingLayoutRect(m_viewport).location());
     updateLayerTransform();
-
-    // Invalidate all resources of this client if our layout changed.
-    if (layoutChanged)
-        SVGResourcesCache::clientLayoutChanged(*this);
 
     repainter.repaintAfterLayout();
 }

--- a/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
@@ -27,7 +27,6 @@
 #include "SVGElementTypeHelpers.h"
 #include "SVGGradientElement.h"
 #include "SVGNames.h"
-#include "SVGResourcesCache.h"
 #include "SVGStopElement.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/StackStats.h>

--- a/Source/WebCore/rendering/svg/RenderSVGInline.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.cpp
@@ -152,6 +152,13 @@ void RenderSVGInline::absoluteQuads(Vector<FloatQuad>& quads, bool* wasFixed) co
 
 void RenderSVGInline::willBeDestroyed()
 {
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+    if (document().settings().layerBasedSVGEngineEnabled()) {
+        RenderInline::willBeDestroyed();
+        return;
+    }
+#endif
+
     SVGResourcesCache::clientDestroyed(*this);
     RenderInline::willBeDestroyed();
 }
@@ -159,13 +166,14 @@ void RenderSVGInline::willBeDestroyed()
 void RenderSVGInline::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (!document().settings().layerBasedSVGEngineEnabled() && diff == StyleDifference::Layout)
-        setNeedsBoundariesUpdate();
-#else
-    if (diff == StyleDifference::Layout)
-        setNeedsBoundariesUpdate();
+    if (document().settings().layerBasedSVGEngineEnabled()) {
+        RenderInline::styleDidChange(diff, oldStyle);
+        return;
+    }
 #endif
 
+    if (diff == StyleDifference::Layout)
+        setNeedsBoundariesUpdate();
     RenderInline::styleDidChange(diff, oldStyle);
     SVGResourcesCache::clientStyleChanged(*this, diff, oldStyle, style());
 }

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2009, Google Inc. All rights reserved.
- * Copyright (C) 2020, 2021, 2022 Igalia S.L.
+ * Copyright (C) 2020, 2021, 2022, 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -33,7 +33,6 @@
 #include "RenderSVGModelObject.h"
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-#include "LegacyRenderSVGResource.h"
 #include "RenderElementInlines.h"
 #include "RenderGeometryMap.h"
 #include "RenderLayer.h"
@@ -48,7 +47,6 @@
 #include "SVGLocatable.h"
 #include "SVGNames.h"
 #include "SVGPathData.h"
-#include "SVGResourcesCache.h"
 #include "SVGUseElement.h"
 #include "TransformState.h"
 #include <wtf/IsoMallocInlines.h>
@@ -148,12 +146,6 @@ void RenderSVGModelObject::absoluteQuads(Vector<FloatQuad>& quads, bool* wasFixe
     quads.append(localToAbsoluteQuad(FloatRect { { }, m_layoutRect.size() }, UseTransforms, wasFixed));
 }
 
-void RenderSVGModelObject::willBeDestroyed()
-{
-    SVGResourcesCache::clientDestroyed(*this);
-    RenderLayerModelObject::willBeDestroyed();
-}
-
 void RenderSVGModelObject::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
     RenderLayerModelObject::styleDidChange(diff, oldStyle);
@@ -164,8 +156,6 @@ void RenderSVGModelObject::styleDidChange(StyleDifference diff, const RenderStyl
     bool hasSVGMask = false;
     if (hasSVGMask && hasLayer() && style().visibility() != Visibility::Visible)
         layer()->setHasVisibleContent();
-
-    SVGResourcesCache::clientStyleChanged(*this, diff, oldStyle, style());
 }
 
 void RenderSVGModelObject::mapAbsoluteToLocalPoint(OptionSet<MapCoordinatesMode> mode, TransformState& transformState) const

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.h
@@ -86,7 +86,6 @@ protected:
     RenderSVGModelObject(Type, Document&, RenderStyle&&, OptionSet<SVGModelObjectFlag> = { });
     RenderSVGModelObject(Type, SVGElement&, RenderStyle&&, OptionSet<SVGModelObjectFlag> = { });
 
-    void willBeDestroyed() override;
     void updateFromStyle() override;
 
     RepaintRects localRectsForRepaint(RepaintOutlineBounds) const override;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -3,7 +3,7 @@
  * Copyright (C) 2004, 2005, 2006, 2007, 2008 Rob Buis <buis@kde.org>
  * Copyright (C) Research In Motion Limited 2009-2010. All rights reserved.
  * Copyright (C) 2011 Dirk Schulze <krit@webkit.org>
- * Copyright (C) 2021, 2022, 2023 Igalia S.L.
+ * Copyright (C) 2021, 2022, 2023, 2024 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -30,29 +30,18 @@
 #include "FrameView.h"
 #include "HitTestRequest.h"
 #include "HitTestResult.h"
-#include "IntRect.h"
-#include "Logging.h"
 #include "ReferencedSVGResources.h"
-#include "RenderElementInlines.h"
-#include "RenderLayer.h"
 #include "RenderLayerInlines.h"
 #include "RenderSVGResourceClipperInlines.h"
 #include "RenderSVGText.h"
 #include "RenderStyle.h"
 #include "RenderView.h"
 #include "SVGClipPathElement.h"
-#include "SVGContainerLayout.h"
 #include "SVGElementTypeHelpers.h"
-#include "SVGNames.h"
-#include "SVGPathData.h"
 #include "SVGRenderStyle.h"
-#include "SVGRenderingContext.h"
-#include "SVGResources.h"
-#include "SVGResourcesCache.h"
 #include "SVGUseElement.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/SetForScope.h>
-#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
@@ -34,12 +34,8 @@
 #include "RenderLayerInlines.h"
 #include "RenderSVGModelObjectInlines.h"
 #include "RenderSVGResourceMarkerInlines.h"
-#include "SVGContainerLayout.h"
 #include "SVGLengthContext.h"
 #include "SVGRenderStyle.h"
-#include "SVGRenderingContext.h"
-#include "SVGResources.h"
-#include "SVGResourcesCache.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
@@ -35,9 +35,6 @@
 #include "SVGContainerLayout.h"
 #include "SVGLengthContext.h"
 #include "SVGRenderStyle.h"
-#include "SVGRenderingContext.h"
-#include "SVGResources.h"
-#include "SVGResourcesCache.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -29,7 +29,6 @@
 #include "SVGElementTypeHelpers.h"
 #include "SVGFitToViewBox.h"
 #include "SVGRenderStyle.h"
-#include "SVGRenderingContext.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -30,7 +30,6 @@
 
 namespace WebCore {
 
-class LegacyRenderSVGResourceContainer;
 class RenderSVGViewportContainer;
 class SVGSVGElement;
 
@@ -57,10 +56,6 @@ public:
     void setContainerSize(const IntSize& containerSize) { m_containerSize = containerSize; }
 
     bool hasRelativeDimensions() const final;
-
-    // The flag is cleared at the beginning of each layout() pass. Elements then call this
-    // method during layout when they are invalidated by a filter.
-    static void addResourceForClientInvalidation(LegacyRenderSVGResourceContainer*);
 
     bool shouldApplyViewportClip() const;
 
@@ -95,10 +90,6 @@ private:
 
     void willBeDestroyed() final;
 
-    void insertedIntoTree(IsInternalMove) final;
-    void willBeRemovedFromTree(IsInternalMove) final;
-
-    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) final;
     void updateFromStyle() final;
     bool needsHasSVGTransformFlags() const final;
     void updateLayerTransform() final;
@@ -125,7 +116,6 @@ private:
     FloatRect m_objectBoundingBox;
     FloatRect m_objectBoundingBoxWithoutTransformations;
     mutable Markable<FloatRect, FloatRect::MarkableTraits> m_strokeBoundingBox;
-    SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer> m_resourcesNeedingToInvalidateClients;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -44,9 +44,6 @@
 #include "RenderView.h"
 #include "SVGPaintServerHandling.h"
 #include "SVGPathData.h"
-#include "SVGRenderingContext.h"
-#include "SVGResources.h"
-#include "SVGResourcesCache.h"
 #include "SVGURIReference.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/StackStats.h>
@@ -144,8 +141,6 @@ void RenderSVGShape::layout()
 
     LayoutRepainter repainter(*this, checkForRepaintDuringLayout(), RepaintOutlineBounds::No);
     if (m_needsShapeUpdate) {
-        // FIXME: [LBSE] Upstream SVGLengthContext changes
-        // graphicsElement().updateLengthContext();
         updateShapeFromElement();
 
         m_needsShapeUpdate = false;
@@ -153,10 +148,6 @@ void RenderSVGShape::layout()
     }
 
     updateLayerTransform();
-
-    // Invalidate all resources of this client if our layout changed.
-    if (everHadLayout() && selfNeedsLayout())
-        SVGResourcesCache::clientLayoutChanged(*this);
 
     repainter.repaintAfterLayout();
     clearNeedsLayout();

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -319,9 +319,6 @@ void RenderSVGText::layout()
 
     LayoutRepainter repainter(*this, isLayerBasedSVGEngineEnabled() ? checkForRepaintDuringLayout() : SVGRenderSupport::checkForSVGRepaintDuringLayout(*this));
 
-    // FIXME: [LBSE] Upstream SVGLengthContext changes
-    // textElement().updateLengthContext();
-
     bool updateCachedBoundariesInParents = false;
     auto previousReferenceBoxRect = transformReferenceBoxRect();
 
@@ -415,6 +412,7 @@ void RenderSVGText::layout()
     if (isLayerBasedSVGEngineEnabled()) {
         updateLayerTransform();
         updateCachedBoundariesInParents = false; // No longer needed for LBSE.
+        layoutChanged = false; // No longer needed for LBSE.
     } else {
         if (m_needsTransformUpdate) {
             if (previousReferenceBoxRect != transformReferenceBoxRect())

--- a/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
+++ b/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
@@ -41,9 +41,6 @@
 #include "RenderSVGTransformableContainer.h"
 #include "RenderSVGViewportContainer.h"
 #include "SVGRenderSupport.h"
-#include "SVGRenderingContext.h"
-#include "SVGResources.h"
-#include "SVGResourcesCache.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
@@ -110,8 +110,9 @@ static bool hasResourcesRequiringRemovalOnClientLayoutChange(SVGResources& resou
 void SVGResourcesCache::clientLayoutChanged(RenderElement& renderer)
 {
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
+    // Verify that LBSE does not make use of SVGResourcesCache.
     if (renderer.document().settings().layerBasedSVGEngineEnabled())
-        return;
+        RELEASE_ASSERT_NOT_REACHED();
 #endif
 
     auto* resources = SVGResourcesCache::cachedResourcesForRenderer(renderer);
@@ -131,12 +132,13 @@ static inline bool rendererCanHaveResources(RenderObject& renderer)
 
 void SVGResourcesCache::clientStyleChanged(RenderElement& renderer, StyleDifference diff, const RenderStyle* oldStyle, const RenderStyle& newStyle)
 {
-    ASSERT(!renderer.element() || renderer.element()->isSVGElement());
-
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
+    // Verify that LBSE does not make use of SVGResourcesCache.
     if (renderer.document().settings().layerBasedSVGEngineEnabled())
-        return;
+        RELEASE_ASSERT_NOT_REACHED();
 #endif
+
+    ASSERT(!renderer.element() || renderer.element()->isSVGElement());
 
     if (!renderer.parent())
         return;
@@ -199,13 +201,14 @@ void SVGResourcesCache::clientStyleChanged(RenderElement& renderer, StyleDiffere
 
 void SVGResourcesCache::clientWasAddedToTree(RenderObject& renderer)
 {
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+    // Verify that LBSE does not make use of SVGResourcesCache.
+    if (renderer.document().settings().layerBasedSVGEngineEnabled())
+        RELEASE_ASSERT_NOT_REACHED();
+#endif
+
     if (renderer.isAnonymous())
         return;
-
-#if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (renderer.document().settings().layerBasedSVGEngineEnabled())
-        return;
-#endif
 
     LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidation(renderer, false);
 
@@ -217,13 +220,15 @@ void SVGResourcesCache::clientWasAddedToTree(RenderObject& renderer)
 
 void SVGResourcesCache::clientWillBeRemovedFromTree(RenderObject& renderer)
 {
-    if (renderer.isAnonymous())
-        return;
-
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
+    // While LBSE does not make use of SVGResourcesCache, we might get here after switching from legacy to LBSE
+    // and destructing the legacy tree -- when LBSE is already activated - don't assert here that this is not reached.
     if (renderer.document().settings().layerBasedSVGEngineEnabled())
         return;
 #endif
+
+    if (renderer.isAnonymous())
+        return;
 
     LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidation(renderer, false);
 
@@ -236,6 +241,8 @@ void SVGResourcesCache::clientWillBeRemovedFromTree(RenderObject& renderer)
 void SVGResourcesCache::clientDestroyed(RenderElement& renderer)
 {
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
+    // While LBSE does not make use of SVGResourcesCache, we might get here after switching from legacy to LBSE
+    // and destructing the legacy tree -- when LBSE is already activated - don't assert here that this is not reached.
     if (renderer.document().settings().layerBasedSVGEngineEnabled())
         return;
 #endif
@@ -249,6 +256,8 @@ void SVGResourcesCache::clientDestroyed(RenderElement& renderer)
 void SVGResourcesCache::resourceDestroyed(LegacyRenderSVGResourceContainer& resource)
 {
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
+    // While LBSE does not make use of SVGResourcesCache, we might get here after switching from legacy to LBSE
+    // and destructing the legacy tree -- when LBSE is already activated - don't assert here that this is not reached.
     if (resource.document().settings().layerBasedSVGEngineEnabled())
         return;
 #endif

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -51,7 +51,6 @@
 #include "RenderRuby.h"
 #include "RenderRubyBase.h"
 #include "RenderRubyRun.h"
-#include "RenderSVGContainer.h"
 #include "RenderSVGInline.h"
 #include "RenderSVGRoot.h"
 #include "RenderSVGText.h"
@@ -281,13 +280,6 @@ void RenderTreeBuilder::attachInternal(RenderElement& parent, RenderPtr<RenderOb
         return;
     }
 
-#if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (auto* container = dynamicDowncast<RenderSVGContainer>(parent)) {
-        svgBuilder().attach(*container, WTFMove(child), beforeChild);
-        return;
-    }
-#endif
-
     if (auto* container = dynamicDowncast<LegacyRenderSVGContainer>(parent)) {
         svgBuilder().attach(*container, WTFMove(child), beforeChild);
         return;
@@ -396,18 +388,8 @@ RenderPtr<RenderObject> RenderTreeBuilder::detach(RenderElement& parent, RenderO
     if (auto* svgInline = dynamicDowncast<RenderSVGInline>(parent))
         return svgBuilder().detach(*svgInline, child);
 
-#if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (is<RenderSVGContainer>(parent))
-        return svgBuilder().detach(downcast<RenderSVGContainer>(parent), child);
-#endif
-
     if (auto* container = dynamicDowncast<LegacyRenderSVGContainer>(parent))
         return svgBuilder().detach(*container, child);
-
-#if ENABLE(LAYER_BASED_SVG_ENGINE)
-    if (auto* svgRoot = dynamicDowncast<RenderSVGRoot>(parent))
-        return svgBuilder().detach(*svgRoot, child);
-#endif
 
     if (auto* svgRoot = dynamicDowncast<LegacyRenderSVGRoot>(parent))
         return svgBuilder().detach(*svgRoot, child);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderSVG.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderSVG.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -52,15 +53,6 @@ void RenderTreeBuilder::SVG::attach(LegacyRenderSVGRoot& parent, RenderPtr<Rende
     SVGResourcesCache::clientWasAddedToTree(childToAdd);
 }
 
-#if ENABLE(LAYER_BASED_SVG_ENGINE)
-void RenderTreeBuilder::SVG::attach(RenderSVGContainer& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild)
-{
-    auto& childToAdd = *child;
-    m_builder.attachToRenderElement(parent, WTFMove(child), beforeChild);
-    SVGResourcesCache::clientWasAddedToTree(childToAdd);
-}
-#endif
-
 void RenderTreeBuilder::SVG::attach(LegacyRenderSVGContainer& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild)
 {
     auto& childToAdd = *child;
@@ -72,7 +64,13 @@ void RenderTreeBuilder::SVG::attach(RenderSVGInline& parent, RenderPtr<RenderObj
 {
     auto& childToAdd = *child;
     m_builder.inlineBuilder().attach(parent, WTFMove(child), beforeChild);
+
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+    if (!childToAdd.document().settings().layerBasedSVGEngineEnabled())
+        SVGResourcesCache::clientWasAddedToTree(childToAdd);
+#else
     SVGResourcesCache::clientWasAddedToTree(childToAdd);
+#endif
 
     if (auto* textAncestor = RenderSVGText::locateRenderSVGTextAncestor(parent))
         textAncestor->subtreeChildWasAdded(&childToAdd);
@@ -81,10 +79,7 @@ void RenderTreeBuilder::SVG::attach(RenderSVGInline& parent, RenderPtr<RenderObj
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
 void RenderTreeBuilder::SVG::attach(RenderSVGRoot& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild)
 {
-    auto& childToAdd = *child;
     m_builder.attachToRenderElement(findOrCreateParentForChild(parent), WTFMove(child), beforeChild);
-
-    SVGResourcesCache::clientWasAddedToTree(childToAdd);
 }
 #endif
 
@@ -93,7 +88,13 @@ void RenderTreeBuilder::SVG::attach(RenderSVGText& parent, RenderPtr<RenderObjec
     auto& childToAdd = *child;
     m_builder.blockFlowBuilder().attach(parent, WTFMove(child), beforeChild);
 
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+    if (!childToAdd.document().settings().layerBasedSVGEngineEnabled())
+        SVGResourcesCache::clientWasAddedToTree(childToAdd);
+#else
     SVGResourcesCache::clientWasAddedToTree(childToAdd);
+#endif
+
     parent.subtreeChildWasAdded(&childToAdd);
 }
 
@@ -105,7 +106,12 @@ RenderPtr<RenderObject> RenderTreeBuilder::SVG::detach(LegacyRenderSVGRoot& pare
 
 RenderPtr<RenderObject> RenderTreeBuilder::SVG::detach(RenderSVGText& parent, RenderObject& child)
 {
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+    if (!child.document().settings().layerBasedSVGEngineEnabled())
+        SVGResourcesCache::clientWillBeRemovedFromTree(child);
+#else
     SVGResourcesCache::clientWillBeRemovedFromTree(child);
+#endif
 
     Vector<SVGTextLayoutAttributes*, 2> affectedAttributes;
     parent.subtreeChildWillBeRemoved(&child, affectedAttributes);
@@ -116,7 +122,12 @@ RenderPtr<RenderObject> RenderTreeBuilder::SVG::detach(RenderSVGText& parent, Re
 
 RenderPtr<RenderObject> RenderTreeBuilder::SVG::detach(RenderSVGInline& parent, RenderObject& child)
 {
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+    if (!child.document().settings().layerBasedSVGEngineEnabled())
+        SVGResourcesCache::clientWillBeRemovedFromTree(child);
+#else
     SVGResourcesCache::clientWillBeRemovedFromTree(child);
+#endif
 
     auto* textAncestor = RenderSVGText::locateRenderSVGTextAncestor(parent);
     if (!textAncestor)
@@ -129,27 +140,11 @@ RenderPtr<RenderObject> RenderTreeBuilder::SVG::detach(RenderSVGInline& parent, 
     return takenChild;
 }
 
-#if ENABLE(LAYER_BASED_SVG_ENGINE)
-RenderPtr<RenderObject> RenderTreeBuilder::SVG::detach(RenderSVGContainer& parent, RenderObject& child)
-{
-    SVGResourcesCache::clientWillBeRemovedFromTree(child);
-    return m_builder.detachFromRenderElement(parent, child);
-}
-#endif
-
 RenderPtr<RenderObject> RenderTreeBuilder::SVG::detach(LegacyRenderSVGContainer& parent, RenderObject& child)
 {
     SVGResourcesCache::clientWillBeRemovedFromTree(child);
     return m_builder.detachFromRenderElement(parent, child);
 }
-
-#if ENABLE(LAYER_BASED_SVG_ENGINE)
-RenderPtr<RenderObject> RenderTreeBuilder::SVG::detach(RenderSVGRoot& parent, RenderObject& child)
-{
-    SVGResourcesCache::clientWillBeRemovedFromTree(child);
-    return m_builder.detachFromRenderElement(parent, child);
-}
-#endif
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
 RenderSVGViewportContainer& RenderTreeBuilder::SVG::findOrCreateParentForChild(RenderSVGRoot& parent)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderSVG.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderSVG.h
@@ -44,20 +44,16 @@ public:
 
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
     void updateAfterDescendants(RenderSVGRoot&);
-
-    void attach(RenderSVGRoot& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
-    void attach(RenderSVGContainer& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
 #endif
+
     void attach(LegacyRenderSVGRoot& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
     void attach(LegacyRenderSVGContainer& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
     void attach(RenderSVGInline& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
-
     void attach(RenderSVGText& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
-
 #if ENABLE(LAYER_BASED_SVG_ENGINE)
-    RenderPtr<RenderObject> detach(RenderSVGRoot& parent, RenderObject& child) WARN_UNUSED_RETURN;
-    RenderPtr<RenderObject> detach(RenderSVGContainer& parent, RenderObject& child) WARN_UNUSED_RETURN;
+    void attach(RenderSVGRoot& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
 #endif
+
     RenderPtr<RenderObject> detach(LegacyRenderSVGRoot& parent, RenderObject& child) WARN_UNUSED_RETURN;
     RenderPtr<RenderObject> detach(LegacyRenderSVGContainer& parent, RenderObject& child) WARN_UNUSED_RETURN;
     RenderPtr<RenderObject> detach(RenderSVGInline& parent, RenderObject& child) WARN_UNUSED_RETURN;


### PR DESCRIPTION
#### a3c7518b1394db37cb46e4c00c9272d382eacb2f
<pre>
[LBSE] Code cleanup after implementing all but one resource
<a href="https://bugs.webkit.org/show_bug.cgi?id=268615">https://bugs.webkit.org/show_bug.cgi?id=268615</a>

Reviewed by Rob Buis.

Remove all usage of SVGRenderingContext.h / SVGResources.h / SVGResourcesCache.h, that
is legacy-only code, from LBSE. Turn all static methods in SVGResourcesCache to release
assertion, to make sure none of these methods is called from LBSE.

Covered by existing tests.

* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::ReferencedSVGResources::referencedSVGResourceIDs):
* Source/WebCore/rendering/svg/RenderSVGBlock.cpp:
(WebCore::RenderSVGBlock::willBeDestroyed):
(WebCore::RenderSVGBlock::styleDidChange):
* Source/WebCore/rendering/svg/RenderSVGContainer.cpp:
(WebCore::RenderSVGContainer::layout):
* Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp:
(WebCore::RenderSVGForeignObject::layout):
* Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp:
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::layout):
(WebCore::RenderSVGImage::imageChanged):
* Source/WebCore/rendering/svg/RenderSVGInline.cpp:
(WebCore::RenderSVGInline::willBeDestroyed):
(WebCore::RenderSVGInline::styleDidChange):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::styleDidChange):
(WebCore::RenderSVGModelObject::willBeDestroyed): Deleted.
* Source/WebCore/rendering/svg/RenderSVGModelObject.h:
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::layout):
(WebCore::RenderSVGRoot::layoutChildren):
(WebCore::RenderSVGRoot::paintObject):
(WebCore::RenderSVGRoot::willBeDestroyed):
(WebCore::RenderSVGRoot::insertedIntoTree): Deleted.
(WebCore::RenderSVGRoot::willBeRemovedFromTree): Deleted.
(WebCore::RenderSVGRoot::styleDidChange): Deleted.
(WebCore::RenderSVGRoot::addResourceForClientInvalidation): Deleted.
* Source/WebCore/rendering/svg/RenderSVGRoot.h:
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::layout):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::layout):
* Source/WebCore/rendering/svg/SVGContainerLayout.cpp:
* Source/WebCore/rendering/svg/SVGResourcesCache.cpp:
(WebCore::SVGResourcesCache::clientLayoutChanged):
(WebCore::SVGResourcesCache::clientStyleChanged):
(WebCore::SVGResourcesCache::clientWasAddedToTree):
(WebCore::SVGResourcesCache::clientWillBeRemovedFromTree):
(WebCore::SVGResourcesCache::clientDestroyed):
(WebCore::SVGResourcesCache::resourceDestroyed):
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::attachInternal):
(WebCore::RenderTreeBuilder::detach):
* Source/WebCore/rendering/updating/RenderTreeBuilderSVG.cpp:
(WebCore::RenderTreeBuilder::SVG::attach):
(WebCore::RenderTreeBuilder::SVG::detach):
* Source/WebCore/rendering/updating/RenderTreeBuilderSVG.h:

Canonical link: <a href="https://commits.webkit.org/274053@main">https://commits.webkit.org/274053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2c6eb3923c24fcef24d63228b3e73b7a0700d9f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40280 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33579 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13847 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31937 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13989 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12232 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12158 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41539 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34132 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38053 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12759 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10311 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36228 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14173 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8481 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13143 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->