### PR TITLE
[WPE] Remove unused WPE platform variables

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
@@ -180,7 +180,9 @@ private:
 
 #if ENABLE(FULLSCREEN_API)
     WebKit::WebFullScreenManagerProxy::FullscreenState m_fullscreenState { WebKit::WebFullScreenManagerProxy::FullscreenState::NotInFullscreen };
+#if ENABLE(WPE_PLATFORM)
     bool m_viewWasAlreadyInFullScreen { false };
+#endif
 #endif
 
     mutable GRefPtr<WebKitWebViewAccessible> m_accessible;

--- a/Tools/WebKitTestRunner/libwpe/EventSenderProxyClientLibWPE.h
+++ b/Tools/WebKitTestRunner/libwpe/EventSenderProxyClientLibWPE.h
@@ -65,7 +65,6 @@ private:
     void prepareAndDispatchTouchEvent(uint32_t, double);
 #endif // ENABLE(TOUCH_EVENTS)
 
-    struct wpe_view_backend* m_backend { nullptr };
     uint32_t m_buttonState { 0 };
 #if ENABLE(TOUCH_EVENTS)
     Vector<struct wpe_input_touch_event_raw> m_touchEvents;


### PR DESCRIPTION
#### d43204ef8d198c79e44bb588cef9782dff95c27d
<pre>
[WPE] Remove unused WPE platform variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=268627">https://bugs.webkit.org/show_bug.cgi?id=268627</a>

Reviewed by Michael Catanzaro.

* Source/WebKit/UIProcess/API/wpe/WPEWebView.h:
m_viewWasAlreadyInFullScreen is used only with ENABLE(WPE_PLATFORM)

* Tools/WebKitTestRunner/libwpe/EventSenderProxyClientLibWPE.h:
m_backend is never used

Canonical link: <a href="https://commits.webkit.org/274041@main">https://commits.webkit.org/274041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/954f83b5df9e8f56a593674a125f2a134eab90c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40016 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33413 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38804 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/18990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13537 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31814 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38055 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13813 "Found 1 new test failure: media/video-ended-does-not-hold-sleep-assertion.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32895 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12019 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12002 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41279 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33896 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/33997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37898 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12562 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36056 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14021 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8476 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12968 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13335 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->