### PR TITLE
[iOS] YouTube does not provide an AirPlay button in fullscreen mode

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -71,6 +71,10 @@
 #include <JavaScriptCore/SourceProvider.h>
 #include <JavaScriptCore/StackVisitor.h>
 
+#if PLATFORM(IOS_FAMILY)
+#include <pal/system/ios/UserInterfaceIdiom.h>
+#endif
+
 #if PLATFORM(COCOA)
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #endif
@@ -423,10 +427,13 @@ bool Quirks::shouldDisableElementFullscreenQuirk() const
     // Twitter.com video embeds have controls that are too tiny and
     // show page behind fullscreen.
     // (Ref: rdar://121473410)
+    // YouTube.com does not provide AirPlay controls in fullscreen
+    // (Ref: rdar://121471373)
     if (!m_shouldDisableElementFullscreen) {
         m_shouldDisableElementFullscreen = isDomain("vimeo.com"_s)
             || isDomain("instagram.com"_s)
-            || isEmbedDomain("twitter.com"_s);
+            || isEmbedDomain("twitter.com"_s)
+            || (PAL::currentUserInterfaceIdiomIsSmallScreen() && (isDomain("youtube.com"_s) || isEmbedDomain("youtube.com"_s)));
     }
 
     return m_shouldDisableElementFullscreen.value();


### PR DESCRIPTION
#### f2404c16679026dbb66715a03149d87b5d6b3cfa
<pre>
[iOS] YouTube does not provide an AirPlay button in fullscreen mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=268634">https://bugs.webkit.org/show_bug.cgi?id=268634</a>
<a href="https://rdar.apple.com/121471373">rdar://121471373</a>

Reviewed by Brent Fulgham and Aditya Keerthi.

Add a quirk to disable the Fullscreen API on YouTube.com (and youtube.com embeds).

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDisableElementFullscreenQuirk const):

Canonical link: <a href="https://commits.webkit.org/274117@main">https://commits.webkit.org/274117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/889c5371d1b31f166b31606107bea949f9225ee3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40113 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33470 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38903 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31856 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38151 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13917 "Found 1 new test failure: media/video-ended-does-not-hold-sleep-assertion.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32939 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12093 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33625 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41377 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34014 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34043 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37947 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12632 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36114 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14069 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8516 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13033 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13382 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->