### PR TITLE
[WTF] Adopt adaptive string searching

### DIFF
--- a/JSTests/stress/string-index-of-pathological.js
+++ b/JSTests/stress/string-index-of-pathological.js
@@ -1,0 +1,14 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+shouldBe("Hello World".indexOf(""), 0);
+shouldBe("Hello".indexOf("Hello World"), -1);
+shouldBe(("Hello World".repeat(10000) + "Hello World2").indexOf("Hello World2"), 110000);
+shouldBe(("Hello World".repeat(10000) + "Hello World2".repeat(10000)).indexOf("Hello World2".repeat(10000)), 110000);
+
+shouldBe("こんにちわ世界".indexOf(""), 0);
+shouldBe("こんにちわ".indexOf("こんにちわ世界"), -1);
+shouldBe(("こんにちわ世界".repeat(10000) + "Hello World2").indexOf("Hello World2"), 70000);
+shouldBe(("こんにちわ世界".repeat(10000) + "Hello World2".repeat(10000)).indexOf("Hello World2".repeat(10000)), 70000);

--- a/JSTests/stress/v8-string-indexof-1.js
+++ b/JSTests/stress/v8-string-indexof-1.js
@@ -1,0 +1,311 @@
+// Copyright 2008 the V8 project authors. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Google Inc. nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Flags: --allow-natives-syntax
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+var s = "test test test";
+
+assertEquals(0, s.indexOf("t"));
+assertEquals(3, s.indexOf("t", 1));
+assertEquals(5, s.indexOf("t", 4));
+assertEquals(5, s.indexOf("t", 4.1));
+assertEquals(0, s.indexOf("t", 0));
+assertEquals(0, s.indexOf("t", -1));
+assertEquals(0, s.indexOf("t", -1));
+assertEquals(0, s.indexOf("t", -1.1));
+assertEquals(0, s.indexOf("t", -1073741825));
+assertEquals(1, s.indexOf("e"));
+assertEquals(2, s.indexOf("s"));
+
+assertEquals(5, s.indexOf("test", 4));
+assertEquals(5, s.indexOf("test", 5));
+assertEquals(10, s.indexOf("test", 6));
+assertEquals(10, s.indexOf("test", 6.0));
+assertEquals(0, s.indexOf("test", 0));
+assertEquals(0, s.indexOf("test", 0.0));
+assertEquals(0, s.indexOf("test", -1));
+assertEquals(-1, s.indexOf("not found", -1));
+assertEquals(0, s.indexOf("test", -1.0));
+assertEquals(0, s.indexOf("test", -1073741825));
+assertEquals(0, s.indexOf("test"));
+assertEquals(-1, s.indexOf("notpresent"));
+assertEquals(-1, s.indexOf());
+
+for (var i = 0; i < s.length+10; i++) {
+  var expected = i < s.length ? i : s.length;
+  assertEquals(expected, s.indexOf("", i));
+}
+
+var reString = "asdf[a-z]+(asdf)?";
+
+assertEquals(4, reString.indexOf("[a-z]+"));
+assertEquals(10, reString.indexOf("(asdf)?"));
+
+assertEquals(1, String.prototype.indexOf.length);
+
+// Random greek letters
+var twoByteString = "\u039a\u0391\u03a3\u03a3\u0395";
+
+// Test single char pattern
+assertEquals(0, twoByteString.indexOf("\u039a"), "Lamda");
+assertEquals(1, twoByteString.indexOf("\u0391"), "Alpha");
+assertEquals(2, twoByteString.indexOf("\u03a3"), "First Sigma");
+assertEquals(3, twoByteString.indexOf("\u03a3",3), "Second Sigma");
+assertEquals(4, twoByteString.indexOf("\u0395"), "Epsilon");
+assertEquals(-1, twoByteString.indexOf("\u0392"), "Not beta");
+
+// Test multi-char pattern
+assertEquals(0, twoByteString.indexOf("\u039a\u0391"), "lambda Alpha");
+assertEquals(1, twoByteString.indexOf("\u0391\u03a3"), "Alpha Sigma");
+assertEquals(2, twoByteString.indexOf("\u03a3\u03a3"), "Sigma Sigma");
+assertEquals(3, twoByteString.indexOf("\u03a3\u0395"), "Sigma Epsilon");
+
+assertEquals(-1, twoByteString.indexOf("\u0391\u03a3\u0395"),
+    "Not Alpha Sigma Epsilon");
+
+//single char pattern
+assertEquals(4, twoByteString.indexOf("\u0395"));
+
+// test string with alignment traps
+var alignmentString = "\u1122\u2211\u2222\uFF00\u00FF\u00FF";
+assertEquals(2, alignmentString.indexOf("\u2222"));
+assertEquals(4, alignmentString.indexOf("\u00FF\u00FF"));
+
+var longAlignmentString = "\uFF00" + "\u00FF".repeat(10);
+assertEquals(1,
+    longAlignmentString.indexOf("\u00FF".repeat(10)));
+
+// test string with first character match at the end
+var boundsString = "112233";
+assertEquals(-1, boundsString.indexOf("334455"));
+assertEquals(-1, boundsString.indexOf("334455".repeat(10)));
+
+// Test complex string indexOf algorithms. Only trigger for long strings.
+
+// Long string that isn't a simple repeat of a shorter string.
+var long = "A";
+for(var i = 66; i < 76; i++) {  // from 'B' to 'K'
+  long =  long + String.fromCharCode(i) + long;
+}
+
+// pattern of 15 chars, repeated every 16 chars in long
+var pattern = "ABACABADABACABA";
+for(var i = 0; i < long.length - pattern.length; i+= 7) {
+  var index = long.indexOf(pattern, i);
+  assertEquals((i + 15) & ~0xf, index, "Long ABACABA...-string at index " + i);
+}
+assertEquals(510, long.indexOf("AJABACA"), "Long AJABACA, First J");
+assertEquals(1534, long.indexOf("AJABACA", 511), "Long AJABACA, Second J");
+
+pattern = "JABACABADABACABA";
+assertEquals(511, long.indexOf(pattern), "Long JABACABA..., First J");
+assertEquals(1535, long.indexOf(pattern, 512), "Long JABACABA..., Second J");
+
+
+// Search for a non-ASCII string in a pure ASCII string.
+var asciiString = "arglebargleglopglyfarglebargleglopglyfarglebargleglopglyf";
+assertEquals(-1, asciiString.indexOf("\x2061"));
+
+
+// Search in string containing many non-ASCII chars.
+var allCodePoints = [];
+for (var i = 0; i < 65536; i++) allCodePoints[i] = i;
+var allCharsString = String.fromCharCode.apply(String, allCodePoints);
+// Search for string long enough to trigger complex search with ASCII pattern
+// and UC16 subject.
+assertEquals(-1, allCharsString.indexOf("notfound"));
+
+// Find substrings.
+var lengths = [1, 4, 15];  // Single char, simple and complex.
+var indices = [0x5, 0x65, 0x85, 0x105, 0x205, 0x285, 0x2005, 0x2085, 0xfff0];
+for (var lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
+  var length = lengths[lengthIndex];
+  for (var i = 0; i < indices.length; i++) {
+    var index = indices[i];
+    var pattern = allCharsString.substring(index, index + length);
+    assertEquals(index, allCharsString.indexOf(pattern));
+  }
+}
+
+(function nonStringReceivers() {
+  let indexOf = String.prototype.indexOf;
+  assertThrows(() => indexOf.call(null), TypeError);
+  assertThrows(() => indexOf.call(undefined), TypeError);
+
+  assertEquals(-1, indexOf.call(1));
+  assertEquals(0, indexOf.call(1, "1"));
+
+  assertEquals(-1, indexOf.call(1.2));
+  assertEquals(0, indexOf.call(1.2, "1"));
+  assertEquals(1, indexOf.call(1.2, "."));
+  assertEquals(2, indexOf.call(1.2, "2"));
+  assertEquals(-1, indexOf.call(1.2, "1", 2));
+
+  assertEquals(-1, indexOf.call({}));
+  assertEquals(0, indexOf.call({}, "[object Object]"));
+  assertEquals(-1, indexOf.call({}, "[object", 1));
+
+  assertEquals(-1, indexOf.call([]));
+  assertEquals(0, indexOf.call([1,2], "1,2"));
+
+  assertEquals(-1, indexOf.call(this));
+})();
+
+(function nonStringSearchString() {
+
+  assertEquals(-1, "".indexOf(1));
+  assertEquals(2, "_0123".indexOf(1));
+
+  assertEquals(-1, "".indexOf(1.2));
+  assertEquals(1, "01.2".indexOf(1.2));
+  assertEquals(1, "01.2".indexOf(1.2, 1));
+  assertEquals(-1, "01.2".indexOf(1.2, 2));
+
+  assertEquals(-1, "".indexOf(null));
+  assertEquals(0, "null".indexOf(null));
+
+  assertEquals(-1, "".indexOf(undefined));
+  assertEquals(1, "_undefined_".indexOf(undefined));
+
+  assertEquals(0, "".indexOf([]));
+  assertEquals(0, "123".indexOf([]));
+  assertEquals(2, "1,2,3".indexOf([2,3]));
+
+  assertEquals(-1, "".indexOf({}));
+  assertEquals(-1, "".indexOf(this));
+})();
+
+(function nonStringPosition() {
+  assertEquals(0, "aba".indexOf("a", false));
+  assertEquals(2, "aba".indexOf("a", true));
+  assertEquals(2, "aba".indexOf("a", "1"));
+  assertEquals(2, "aba".indexOf("a", "1.00000"));
+  assertEquals(2, "aba".indexOf("a", "2.00000"));
+  assertEquals(-1, "aba".indexOf("a", "3.00000"));
+})();
+
+(function optimize() {
+  function f() {
+    return 'abc'.indexOf('a');
+  }
+  // %PrepareFunctionForOptimization(f);
+  assertEquals(0, f());
+  assertEquals(0, f());
+  assertEquals(0, f());
+  // %OptimizeFunctionOnNextCall(f);
+  assertEquals(0, f());
+
+  function f2() {
+    return 'abc'.indexOf('a', 1);
+  }
+  // %PrepareFunctionForOptimization(f2);
+  assertEquals(-1, f2());
+  assertEquals(-1, f2());
+  assertEquals(-1, f2());
+  // %OptimizeFunctionOnNextCall(f2);
+  assertEquals(-1, f2());
+
+  function f3() {
+    return 'abc'.indexOf('a');
+  }
+  // %PrepareFunctionForOptimization(f3);
+  assertEquals(0, f3());
+  assertEquals(0, f3());
+  assertEquals(0, f3());
+  // %OptimizeFunctionOnNextCall(f3);
+  assertEquals(0, f3());
+
+  function f4() {
+    return 'abcbc'.indexOf('bc', 2);
+  }
+  // %PrepareFunctionForOptimization(f4);
+  assertEquals(3, f4());
+  assertEquals(3, f4());
+  assertEquals(3, f4());
+  // %OptimizeFunctionOnNextCall(f4);
+  assertEquals(3, f4());
+
+  function f5() {
+    return 'abcbc'.indexOf('b', -1);
+  }
+  // %PrepareFunctionForOptimization(f5);
+  assertEquals(1, f5());
+  assertEquals(1, f5());
+  assertEquals(1, f5());
+  // %OptimizeFunctionOnNextCall(f5);
+  assertEquals(1, f5());
+
+  function f6() {
+    return 'abcbc'.indexOf('b', -10737418);
+  }
+  // %PrepareFunctionForOptimization(f6);
+  assertEquals(1, f6());
+  assertEquals(1, f6());
+  assertEquals(1, f6());
+  // %OptimizeFunctionOnNextCall(f6);
+  assertEquals(1, f6());
+})();
+
+(function optimizeOSR() {
+  function f() {
+    var result;
+    for (var i = 0; i < 100000; i++) {
+      result = 'abc'.indexOf('a');
+    }
+    return result;
+  }
+  assertEquals(0, f());
+
+  function f2() {
+    var result;
+    for (var i = 0; i < 100000; i++) {
+      result = 'abc'.indexOf('a', 1);
+    }
+    return result;
+  }
+  assertEquals(-1, f2());
+
+  function f3() {
+    var result;
+    for (var i = 0; i < 100000; i++) {
+      result = 'abc'.indexOf('a');
+    }
+    return result;
+  }
+  assertEquals(0, f3());
+
+  function f4() {
+    var result;
+    for (var i = 0; i < 100000; i++) {
+      result = 'abcbc'.indexOf('bc', 2);
+    }
+    return result;
+  }
+  assertEquals(3, f4());
+})();

--- a/JSTests/stress/v8-string-indexof-2.js
+++ b/JSTests/stress/v8-string-indexof-2.js
@@ -1,0 +1,70 @@
+// Copyright 2008 the V8 project authors. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Google Inc. nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+var lipsum = "lorem ipsum per se esse fugiendum. itaque aiunt hanc quasi "
+    + "naturalem atque insitam in animis nostris inesse notionem, ut "
+    + "alterum esse appetendum, alterum aspernandum sentiamus. Alii autem,"
+    + " quibus ego assentior, cum a philosophis compluribus permulta "
+    + "dicantur, cur nec voluptas in bonis sit numeranda nec in malis "
+    + "dolor, non existimant oportere nimium nos causae confidere, sed et"
+    + " argumentandum et accurate disserendum et rationibus conquisitis de"
+    + " voluptate et dolore disputandum putant.\n"
+    + "Sed ut perspiciatis, unde omnis iste natus error sit voluptatem "
+    + "accusantium doloremque laudantium, totam rem aperiam eaque ipsa,"
+    + "quae ab illo inventore veritatis et quasi architecto beatae vitae "
+    + "dicta sunt, explicabo. nemo enim ipsam voluptatem, quia voluptas"
+    + "sit, aspernatur aut odit aut fugit, sed quia consequuntur magni"
+    + " dolores eos, qui ratione voluptatem sequi nesciunt, neque porro"
+    + " quisquam est, qui dolorem ipsum, quia dolor sit, amet, "
+    + "consectetur, adipisci velit, sed quia non numquam eius modi"
+    + " tempora incidunt, ut labore et dolore magnam aliquam quaerat "
+    + "voluptatem. ut enim ad minima veniam, quis nostrum exercitationem "
+    + "ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi "
+    + "consequatur? quis autem vel eum iure reprehenderit, qui in ea "
+    + "voluptate velit esse, quam nihil molestiae consequatur, vel illum, "
+    + "qui dolorem eum fugiat, quo voluptas nulla pariatur?\n";
+
+assertEquals(893, lipsum.indexOf("lorem ipsum, quia dolor sit, amet"),
+        "Lipsum");
+// test a lot of substrings of differing length and start-position.
+for(var i = 0; i < lipsum.length; i += 3) {
+  for(var len = 1; i + len < lipsum.length; len += 7) {
+    var substring = lipsum.substring(i, i + len);
+    var index = -1;
+    do {
+      index = lipsum.indexOf(substring, index + 1);
+      assertTrue(index != -1,
+                 "Lipsum substring " + i + ".." + (i + len-1) + " not found");
+      assertEquals(lipsum.substring(index, index + len), substring,
+          "Wrong lipsum substring found: " + i + ".." + (i + len - 1) + "/" +
+              index + ".." + (index + len - 1));
+    } while (index >= 0 && index < i);
+    assertEquals(i, index, "Lipsum match at " + i + ".." + (i + len - 1));
+  }
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -2608,7 +2608,7 @@ JSC_DEFINE_JIT_OPERATION(operationStringReplaceStringEmptyString, JSString*, (JS
     String search = searchCell->value(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    size_t matchStart = string.find(search);
+    size_t matchStart = StringView(string).find(vm.adaptiveStringSearcherTables(), StringView(search));
     if (matchStart == notFound)
         return stringCell;
 
@@ -2808,7 +2808,7 @@ JSC_DEFINE_JIT_OPERATION(operationStringIndexOf, UCPUStrictInt32, (JSGlobalObjec
     auto otherViewWithString = argument->viewWithUnderlyingString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    size_t result = thisViewWithString.view.find(otherViewWithString.view);
+    size_t result = thisViewWithString.view.find(vm.adaptiveStringSearcherTables(), otherViewWithString.view);
     if (result == notFound)
         return toUCPUStrictInt32(-1);
     return toUCPUStrictInt32(result);
@@ -2853,7 +2853,7 @@ JSC_DEFINE_JIT_OPERATION(operationStringIndexOfWithIndex, UCPUStrictInt32, (JSGl
     if (static_cast<unsigned>(length) < otherViewWithString.view.length() + pos)
         return toUCPUStrictInt32(-1);
 
-    size_t result = thisViewWithString.view.find(otherViewWithString.view, pos);
+    size_t result = thisViewWithString.view.find(vm.adaptiveStringSearcherTables(), otherViewWithString.view, pos);
     if (result == notFound)
         return toUCPUStrictInt32(-1);
     return toUCPUStrictInt32(result);

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1105,7 +1105,7 @@ static EncodedJSValue stringIndexOfImpl(JSGlobalObject* globalObject, CallFrame*
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     auto otherViewWithString = otherJSString->viewWithUnderlyingString(globalObject);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
-    size_t result = thisViewWithString.view.find(otherViewWithString.view, pos);
+    size_t result = thisViewWithString.view.find(vm.adaptiveStringSearcherTables(), otherViewWithString.view, pos);
     if (result == notFound)
         return JSValue::encode(jsNumber(-1));
     return JSValue::encode(jsNumber(result));
@@ -1378,7 +1378,7 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplitFast, (JSGlobalObject* globalObject
         //   b. If e is failure, then let q = q+1.
         //   c. Else, e is an integer index <= s.
         size_t position = 0;
-        while ((matchPosition = stringImpl->find(separatorImpl, position)) != notFound) {
+        while ((matchPosition = StringView(stringImpl).find(vm.adaptiveStringSearcherTables(), StringView(separatorImpl), position)) != notFound) {
             // 1. Let T be a String value equal to the substring of S consisting of the characters at positions p (inclusive)
             //    through q (exclusive).
             // 2. Call CreateDataProperty(A, ToString(lengthA), T).
@@ -1810,7 +1810,7 @@ static EncodedJSValue stringIncludesImpl(JSGlobalObject* globalObject, VM& vm, S
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
     }
 
-    return JSValue::encode(jsBoolean(stringToSearchIn.find(searchString, start) != notFound));
+    return JSValue::encode(jsBoolean(StringView(stringToSearchIn).find(vm.adaptiveStringSearcherTables(), StringView(searchString), start) != notFound));
 }
 
 JSC_DEFINE_HOST_FUNCTION(stringProtoFuncIncludes, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -205,7 +205,7 @@ ALWAYS_INLINE JSString* stringReplaceStringString(JSGlobalObject* globalObject, 
         matchStart = table->find(string, search);
     else {
         UNUSED_PARAM(table);
-        matchStart = string.find(search);
+        matchStart = StringView(string).find(vm.adaptiveStringSearcherTables(), StringView(search));
     }
     if (matchStart == notFound)
         return stringCell;
@@ -263,7 +263,7 @@ inline JSString* replaceUsingStringSearch(VM& vm, JSGlobalObject* globalObject, 
             RELEASE_AND_RETURN(scope, (stringReplaceStringString<StringReplaceSubstitutions::Yes, StringReplaceUseTable::No, BoyerMooreHorspoolTable<uint8_t>>(globalObject, jsString, WTFMove(string), WTFMove(searchString), WTFMove(replaceString), nullptr)));
     }
 
-    size_t matchStart = string.find(searchString);
+    size_t matchStart = StringView(string).find(vm.adaptiveStringSearcherTables(), StringView(searchString));
     if (matchStart == notFound)
         return jsString;
 
@@ -320,7 +320,7 @@ inline JSString* replaceUsingStringSearch(VM& vm, JSGlobalObject* globalObject, 
         endOfLastMatch = matchEnd;
         if (mode == StringReplaceMode::Single)
             break;
-        matchStart = string.find(searchString, !searchStringLength ? endOfLastMatch + 1 : endOfLastMatch);
+        matchStart = StringView(string).find(vm.adaptiveStringSearcherTables(), StringView(searchString), !searchStringLength ? endOfLastMatch + 1 : endOfLastMatch);
     } while (matchStart != notFound);
 
     if (UNLIKELY(!sourceRanges.tryConstructAndAppend(endOfLastMatch, string.length()))) {

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -256,6 +256,10 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
             ref.set(makeUniqueRef<HeapProfiler>(vm));
         });
 
+        m_stringSearcherTables.initLater([](VM&, auto& ref) {
+            ref.set(makeUniqueRef<AdaptiveStringSearcherTables>());
+        });
+
         m_watchdog.initLater([](VM& vm, auto& ref) {
             ref.set(adoptRef(*new Watchdog(&vm)));
             vm.ensureTerminationException();

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -77,6 +77,7 @@
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/UniqueArray.h>
+#include <wtf/text/AdaptiveStringSearcher.h>
 #include <wtf/text/SymbolImpl.h>
 #include <wtf/text/SymbolRegistry.h>
 
@@ -325,6 +326,8 @@ public:
 
     HeapProfiler* heapProfiler() { return m_heapProfiler.getIfExists(); }
     HeapProfiler& ensureHeapProfiler() { return m_heapProfiler.get(*this); }
+
+    AdaptiveStringSearcherTables& adaptiveStringSearcherTables() { return m_stringSearcherTables.get(*this); }
 
     bool isAnalyzingHeap() const { return m_activeHeapAnalyzer; }
     HeapAnalyzer* activeHeapAnalyzer() const { return m_activeHeapAnalyzer; }
@@ -1116,6 +1119,7 @@ private:
     VMTraps m_traps;
     LazyRef<VM, Watchdog> m_watchdog;
     LazyUniqueRef<VM, HeapProfiler> m_heapProfiler;
+    LazyUniqueRef<VM, AdaptiveStringSearcherTables> m_stringSearcherTables;
 #if ENABLE(SAMPLING_PROFILER)
     RefPtr<SamplingProfiler> m_samplingProfiler;
 #endif

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -831,6 +831,7 @@
 		E36BA9DE29E275DB00300057 /* WTFProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E36BA9DC29E275DB00300057 /* WTFProcess.cpp */; };
 		E36BA9DF29E275DB00300057 /* WTFProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = E36BA9DD29E275DB00300057 /* WTFProcess.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E37E96542702AD0B00E1C36A /* ApproximateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E37E96522702AD0700E1C36A /* ApproximateTime.cpp */; };
+		E383AAC92B6C730B00058E60 /* AdaptiveStringSearcher.h in Headers */ = {isa = PBXBuildFile; fileRef = E383AAC82B6C730B00058E60 /* AdaptiveStringSearcher.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E388886F20C9095100E632BC /* WorkerPool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E388886D20C9095100E632BC /* WorkerPool.cpp */; };
 		E38C41281EB4E0680042957D /* CPUTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38C41261EB4E0680042957D /* CPUTime.cpp */; };
 		E38D6E271F5522E300A75CC4 /* StringBuilderJSON.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38D6E261F5522E300A75CC4 /* StringBuilderJSON.cpp */; };
@@ -1769,6 +1770,7 @@
 		E37E96532702AD0700E1C36A /* ApproximateTime.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ApproximateTime.h; sourceTree = "<group>"; };
 		E38020DB2401C0930037CA9E /* CompactRefPtrTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompactRefPtrTuple.h; sourceTree = "<group>"; };
 		E3831F922703101A00EF5EB3 /* GenericTimeMixin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GenericTimeMixin.h; sourceTree = "<group>"; };
+		E383AAC82B6C730B00058E60 /* AdaptiveStringSearcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AdaptiveStringSearcher.h; sourceTree = "<group>"; };
 		E388886D20C9095100E632BC /* WorkerPool.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WorkerPool.cpp; sourceTree = "<group>"; };
 		E388886E20C9095100E632BC /* WorkerPool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WorkerPool.h; sourceTree = "<group>"; };
 		E38C41261EB4E0680042957D /* CPUTime.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CPUTime.cpp; sourceTree = "<group>"; };
@@ -2526,6 +2528,7 @@
 				A5BA15F61824359E00A82E69 /* cf */,
 				A5BA15F11824339F00A82E69 /* cocoa */,
 				1C181C881D307AB800F5FA16 /* icu */,
+				E383AAC82B6C730B00058E60 /* AdaptiveStringSearcher.h */,
 				A8A4731C151A825B004123FF /* ASCIIFastPath.h */,
 				C6F050790D9C432A99085E75 /* ASCIILiteral.cpp */,
 				382029E246C84B0099FD6764 /* ASCIILiteral.h */,
@@ -3021,6 +3024,7 @@
 			files = (
 				FE6997E129D241630078B9C6 /* AbortWithReasonSPI.h in Headers */,
 				E3B8E6032961EA7600A8AEE3 /* AccessibleAddress.h in Headers */,
+				E383AAC92B6C730B00058E60 /* AdaptiveStringSearcher.h in Headers */,
 				DD3DC8FA27A4BF8E007E5B61 /* AggregateLogger.h in Headers */,
 				DD3DC96027A4BF8E007E5B61 /* Algorithms.h in Headers */,
 				DD3DC99627A4BF8E007E5B61 /* AnsiColors.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -392,6 +392,7 @@ set(WTF_PUBLIC_HEADERS
 
     text/ASCIIFastPath.h
     text/ASCIILiteral.h
+    text/AdaptiveStringSearcher.h
     text/AtomString.h
     text/AtomStringHash.h
     text/AtomStringImpl.h

--- a/Source/WTF/wtf/text/ASCIIFastPath.h
+++ b/Source/WTF/wtf/text/ASCIIFastPath.h
@@ -67,6 +67,13 @@ template<> struct NonASCIIMask<8, LChar> {
     static inline uint64_t value() { return 0x8080808080808080ULL; }
 };
 
+template<size_t size, typename CharacterType> struct NonLatin1Mask;
+template<> struct NonLatin1Mask<4, UChar> {
+    static inline uint32_t value() { return 0xFF00FF00U; }
+};
+template<> struct NonLatin1Mask<8, UChar> {
+    static inline uint64_t value() { return 0xFF00FF00FF00FF00ULL; }
+};
 
 template<typename CharacterType>
 inline bool containsOnlyASCII(MachineWord word)
@@ -104,6 +111,42 @@ inline bool charactersAreAllASCII(const CharacterType* characters, size_t length
 
     MachineWord nonASCIIBitMask = NonASCIIMask<sizeof(MachineWord), CharacterType>::value();
     return !(allCharBits & nonASCIIBitMask);
+}
+
+// Note: This function assume the input is likely all Latin1, and
+// does not leave early if it is not the case.
+template<typename CharacterType>
+inline bool charactersAreAllLatin1(const CharacterType* characters, size_t length)
+{
+    if constexpr (sizeof(CharacterType) == 1)
+        return true;
+    else {
+        MachineWord allCharBits = 0;
+        const CharacterType* end = characters + length;
+
+        // Prologue: align the input.
+        while (!isAlignedToMachineWord(characters) && characters != end) {
+            allCharBits |= *characters;
+            ++characters;
+        }
+
+        // Compare the values of CPU word size.
+        const CharacterType* wordEnd = alignToMachineWord(end);
+        const size_t loopIncrement = sizeof(MachineWord) / sizeof(CharacterType);
+        while (characters < wordEnd) {
+            allCharBits |= *(reinterpret_cast_ptr<const MachineWord*>(characters));
+            characters += loopIncrement;
+        }
+
+        // Process the remaining bytes.
+        while (characters != end) {
+            allCharBits |= *characters;
+            ++characters;
+        }
+
+        MachineWord nonLatin1BitMask = NonLatin1Mask<sizeof(MachineWord), CharacterType>::value();
+        return !(allCharBits & nonLatin1BitMask);
+    }
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/AdaptiveStringSearcher.h
+++ b/Source/WTF/wtf/text/AdaptiveStringSearcher.h
@@ -1,0 +1,561 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2011 the V8 project authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <limits>
+#include <wtf/text/StringCommon.h>
+#include <wtf/text/StringView.h>
+
+namespace WTF {
+
+//---------------------------------------------------------------------
+// String Search object.
+//---------------------------------------------------------------------
+
+// Class holding constants and methods that apply to all string search variants,
+// independently of subject and pattern char size.
+class AdaptiveStringSearcherBase {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    // Cap on the maximal shift in the Boyer-Moore implementation. By setting a
+    // limit, we can fix the size of tables. For a needle longer than this limit,
+    // search will not be optimal, since we only build tables for a suffix
+    // of the string, but it is a safe approximation.
+    static constexpr int bmMaxShift = 250;
+
+    // Reduce alphabet to this size.
+    // One of the tables used by Boyer-Moore and Boyer-Moore-Horspool has size
+    // proportional to the input alphabet. We reduce the alphabet size by
+    // equating input characters modulo a smaller alphabet size. This gives
+    // a potentially less efficient searching, but is a safe approximation.
+    // For needles using only characters in the same Unicode 256-code point page,
+    // there is no search speed degradation.
+    static constexpr int latin1AlphabetSize = 256;
+    static constexpr int ucharAlphabetSize = 256;
+
+    // Bad-char shift table stored in the state. It's length is the alphabet size.
+    // For patterns below this length, the skip length of Boyer-Moore is too short
+    // to compensate for the algorithmic overhead compared to simple brute force.
+    static constexpr int bmMinPatternLength = 7;
+
+    static constexpr bool exceedsOneByte(LChar) { return false; }
+    static constexpr bool exceedsOneByte(UChar c) { return c > 0xff; }
+
+    template <typename T, typename U>
+    static inline T alignDown(T value, U alignment)
+    {
+        return reinterpret_cast<T>((reinterpret_cast<uintptr_t>(value) & ~(alignment - 1)));
+    }
+
+    static constexpr uint8_t getHighestValueByte(LChar character) { return character; }
+
+    static constexpr uint8_t getHighestValueByte(UChar character)
+    {
+        return std::max<unsigned>(static_cast<uint8_t>(character & 0xFF), static_cast<uint8_t>(character >> 8));
+    }
+
+    template <typename PatternChar, typename SubjectChar>
+    static inline int findFirstCharacter(std::span<const PatternChar> pattern, std::span<const SubjectChar> subject, int index)
+    {
+        const auto* subjectPtr = subject.data();
+        const PatternChar patternFirstChar = pattern[0];
+        const int maxN = (subject.size() - pattern.size() + 1);
+
+        if (sizeof(SubjectChar) == 2 && !patternFirstChar) {
+            // Special-case looking for the 0 char in other than one-byte strings.
+            // memchr mostly fails in this case due to every other byte being 0 in text
+            // that is mostly ascii characters.
+            for (int i = index; i < maxN; ++i) {
+                if (!subjectPtr[i])
+                    return i;
+            }
+            return -1;
+        }
+        const uint8_t searchByte = getHighestValueByte(patternFirstChar);
+        const SubjectChar searchChar = static_cast<SubjectChar>(patternFirstChar);
+        int pos = index;
+        do {
+            ASSERT(maxN - pos >= 0);
+            const SubjectChar* charPos = reinterpret_cast<const SubjectChar*>(memchr(subjectPtr + pos, searchByte, (maxN - pos) * sizeof(SubjectChar)));
+            if (charPos == nullptr)
+                return -1;
+            charPos = alignDown(charPos, sizeof(SubjectChar));
+            pos = static_cast<int>(charPos - subjectPtr);
+            if (subjectPtr[pos] == searchChar)
+                return pos;
+        } while (++pos < maxN);
+
+        return -1;
+    }
+};
+
+class AdaptiveStringSearcherTables {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    int* badCharShiftTable() { return m_badCharShiftTable.data(); }
+    int* goodSuffixShiftTable() { return m_goodSuffixShiftTable.data(); }
+    int* suffixTable() { return m_suffixTable.data(); }
+
+private:
+    std::array<int, AdaptiveStringSearcherBase::ucharAlphabetSize> m_badCharShiftTable { };
+    std::array<int, AdaptiveStringSearcherBase::bmMaxShift> m_goodSuffixShiftTable { };
+    std::array<int, AdaptiveStringSearcherBase::bmMaxShift + 1> m_suffixTable { };
+};
+
+template <typename PatternChar, typename SubjectChar>
+class AdaptiveStringSearcher : private AdaptiveStringSearcherBase {
+public:
+    AdaptiveStringSearcher(AdaptiveStringSearcherTables& tables, std::span<const PatternChar> pattern)
+        : m_tables(tables)
+        , m_pattern(pattern)
+        , m_start(std::max<int>(0, pattern.size() - bmMaxShift))
+    {
+        if (sizeof(PatternChar) > sizeof(SubjectChar)) {
+            if (!charactersAreAllLatin1(m_pattern.data(), m_pattern.size())) {
+                m_strategy = &failSearch;
+                return;
+            }
+        }
+        int patternLength = m_pattern.size();
+        if (patternLength < bmMinPatternLength) {
+            if (patternLength == 1) {
+                m_strategy = &singleCharSearch;
+                return;
+            }
+            m_strategy = &linearSearch;
+            return;
+        }
+        m_strategy = &initialSearch;
+    }
+
+    int search(std::span<const SubjectChar> subject, int index)
+    {
+        return m_strategy(*this, subject, index);
+    }
+
+    static constexpr int alphabetSize()
+    {
+        if constexpr (sizeof(PatternChar) == 1) {
+            // Latin1 needle.
+            return latin1AlphabetSize;
+        } else {
+            ASSERT_UNDER_CONSTEXPR_CONTEXT(sizeof(PatternChar) == 2);
+            // UC16 needle.
+            return ucharAlphabetSize;
+        }
+    }
+
+private:
+    using SearchFunction = int (*)(AdaptiveStringSearcher<PatternChar, SubjectChar>&, std::span<const SubjectChar>, int);
+
+    static int failSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>&, std::span<const SubjectChar>, int)
+    {
+        return -1;
+    }
+
+    static int singleCharSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>&, std::span<const SubjectChar>, int startIndex);
+
+    static int linearSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>&, std::span<const SubjectChar>, int startIndex);
+
+    static int initialSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>&, std::span<const SubjectChar>, int startIndex);
+
+    static int boyerMooreHorspoolSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>&, std::span<const SubjectChar>, int startIndex);
+
+    static int boyerMooreSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>&, std::span<const SubjectChar>, int startIndex);
+
+    void populateBoyerMooreHorspoolTable();
+
+    void populateBoyerMooreTable();
+
+    static inline int charOccurrence(int* badCharOccurrence, SubjectChar charCode)
+    {
+        if constexpr (sizeof(SubjectChar) == 1)
+            return badCharOccurrence[static_cast<int>(charCode)];
+
+        if constexpr (sizeof(PatternChar) == 1) {
+            if (exceedsOneByte(charCode))
+                return -1;
+            return badCharOccurrence[static_cast<unsigned>(charCode)];
+        }
+        // Both pattern and subject are UC16. Reduce character to equivalence
+        // class.
+        int equivClass = charCode % ucharAlphabetSize;
+        return badCharOccurrence[equivClass];
+    }
+
+    // The following tables are shared by all searches.
+    // TODO(lrn): Introduce a way for a pattern to keep its tables
+    // between searches (e.g., for an Atom RegExp).
+
+    // Store for the BoyerMoore(Horspool) bad char shift table.
+    // Return a table covering the last bmMaxShift+1 positions of
+    // pattern.
+    int* badCharTable() { return m_tables.badCharShiftTable(); }
+
+    // Store for the BoyerMoore good suffix shift table.
+    int* goodSuffixShiftTable()
+    {
+        // Return biased pointer that maps the range  [m_start..m_pattern.size()
+        // to the kGoodSuffixShiftTable array.
+        return m_tables.goodSuffixShiftTable() - m_start;
+    }
+
+    // Table used temporarily while building the BoyerMoore good suffix
+    // shift table.
+    int* suffixTable()
+    {
+        // Return biased pointer that maps the range  [m_start..m_pattern.size()
+        // to the kSuffixTable array.
+        return m_tables.suffixTable() - m_start;
+    }
+
+    AdaptiveStringSearcherTables& m_tables;
+    // The pattern to search for.
+    std::span<const PatternChar> m_pattern;
+    // Pointer to implementation of the search.
+    SearchFunction m_strategy;
+    // Cache value of max(0, pattern_size() - bmMaxShift)
+    int m_start;
+};
+
+//---------------------------------------------------------------------
+// Single Character Pattern Search Strategy
+//---------------------------------------------------------------------
+
+template <typename PatternChar, typename SubjectChar>
+int AdaptiveStringSearcher<PatternChar, SubjectChar>::singleCharSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>& search, std::span<const SubjectChar> subject, int index)
+{
+    ASSERT(search.m_pattern.size() == 1);
+    PatternChar patternFirstChar = search.m_pattern[0];
+    if constexpr (sizeof(PatternChar) > sizeof(SubjectChar)) {
+        if (exceedsOneByte(patternFirstChar))
+            return -1;
+    }
+    return findFirstCharacter(search.m_pattern, subject, index);
+}
+
+//---------------------------------------------------------------------
+// Linear Search Strategy
+//---------------------------------------------------------------------
+
+// Simple linear search for short patterns. Never bails out.
+template <typename PatternChar, typename SubjectChar>
+int AdaptiveStringSearcher<PatternChar, SubjectChar>::linearSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>& search, std::span<const SubjectChar> subject, int index)
+{
+    auto charCompare = [](const PatternChar* pattern, const SubjectChar* subject, int length) ALWAYS_INLINE_LAMBDA {
+        ASSERT(length > 0);
+        int pos = 0;
+        do {
+            if (pattern[pos] != subject[pos])
+                return false;
+            pos++;
+        } while (pos < length);
+        return true;
+    };
+
+    std::span<const PatternChar> pattern = search.m_pattern;
+    ASSERT(pattern.size() > 1);
+    int patternLength = pattern.size();
+    int i = index;
+    int n = subject.size() - patternLength;
+    while (i <= n) {
+        i = findFirstCharacter(pattern, subject, i);
+        if (i == -1)
+            return -1;
+        ASSERT(i <= n);
+        i++;
+        // Loop extracted to separate function to allow using return to do
+        // a deeper break.
+        if (charCompare(pattern.data() + 1, subject.data() + i, patternLength - 1))
+            return i - 1;
+    }
+    return -1;
+}
+
+//---------------------------------------------------------------------
+// Boyer-Moore string search
+//---------------------------------------------------------------------
+
+template <typename PatternChar, typename SubjectChar>
+int AdaptiveStringSearcher<PatternChar, SubjectChar>::boyerMooreSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>& search, std::span<const SubjectChar> subject, int startIndex)
+{
+    std::span<const PatternChar> pattern = search.m_pattern;
+    const auto* subjectPtr = subject.data();
+    const auto* patternPtr = pattern.data();
+    int subjectLength = subject.size();
+    int patternLength = pattern.size();
+    // Only preprocess at most bmMaxShift last characters of pattern.
+    int start = search.m_start;
+
+    int* badCharOccurrence = search.badCharTable();
+    int* goodSuffixShift = search.goodSuffixShiftTable();
+
+    PatternChar lastChar = patternPtr[patternLength - 1];
+    int index = startIndex;
+    // Continue search from i.
+    while (index <= subjectLength - patternLength) {
+        int j = patternLength - 1;
+        int c;
+        while (lastChar != (c = subjectPtr[index + j])) {
+            int shift = j - charOccurrence(badCharOccurrence, c);
+            index += shift;
+            if (index > subjectLength - patternLength)
+                return -1;
+        }
+        while (j >= 0 && patternPtr[j] == (c = subjectPtr[index + j]))
+            j--;
+        if (j < 0)
+            return index;
+        if (j < start) {
+            // we have matched more than our tables allow us to be smart about.
+            // Fall back on BMH shift.
+            index += patternLength - 1 - charOccurrence(badCharOccurrence, static_cast<SubjectChar>(lastChar));
+        } else {
+            int gsShift = goodSuffixShift[j + 1];
+            int bcOcc = charOccurrence(badCharOccurrence, c);
+            int shift = j - bcOcc;
+            if (gsShift > shift)
+                shift = gsShift;
+            index += shift;
+        }
+    }
+
+    return -1;
+}
+
+template <typename PatternChar, typename SubjectChar>
+void AdaptiveStringSearcher<PatternChar, SubjectChar>::populateBoyerMooreTable()
+{
+    const auto* patternPtr = m_pattern.data();
+    int patternLength = m_pattern.size();
+    // Only look at the last bmMaxShift characters of pattern (from m_start
+    // to patternLength).
+    int start = m_start;
+    int length = patternLength - start;
+
+    // Biased tables so that we can use pattern indices as table indices,
+    // even if we only cover the part of the pattern from offset start.
+    int* shiftTable = goodSuffixShiftTable();
+    int* suffixTable = this->suffixTable();
+
+    // Initialize table.
+    for (int i = start; i < patternLength; i++)
+        shiftTable[i] = length;
+    shiftTable[patternLength] = 1;
+    suffixTable[patternLength] = patternLength + 1;
+
+    if (patternLength <= start)
+        return;
+
+    // Find suffixes.
+    PatternChar lastChar = patternPtr[patternLength - 1];
+    int suffix = patternLength + 1;
+    {
+        int i = patternLength;
+        while (i > start) {
+            PatternChar c = patternPtr[i - 1];
+            while (suffix <= patternLength && c != patternPtr[suffix - 1]) {
+                if (shiftTable[suffix] == length)
+                    shiftTable[suffix] = suffix - i;
+                suffix = suffixTable[suffix];
+            }
+            suffixTable[--i] = --suffix;
+            if (suffix == patternLength) {
+                // No suffix to extend, so we check against lastChar only.
+                while ((i > start) && (patternPtr[i - 1] != lastChar)) {
+                    if (shiftTable[patternLength] == length)
+                        shiftTable[patternLength] = patternLength - i;
+                    suffixTable[--i] = patternLength;
+                }
+                if (i > start)
+                    suffixTable[--i] = --suffix;
+            }
+        }
+    }
+    // Build shift table using suffixes.
+    if (suffix < patternLength) {
+        for (int i = start; i <= patternLength; i++) {
+            if (shiftTable[i] == length)
+                shiftTable[i] = suffix - start;
+            if (i == suffix)
+                suffix = suffixTable[suffix];
+        }
+    }
+}
+
+//---------------------------------------------------------------------
+// Boyer-Moore-Horspool string search.
+//---------------------------------------------------------------------
+
+template <typename PatternChar, typename SubjectChar>
+int AdaptiveStringSearcher<PatternChar, SubjectChar>::boyerMooreHorspoolSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>& search, std::span<const SubjectChar> subject, int startIndex)
+{
+    std::span<const PatternChar> pattern = search.m_pattern;
+    const auto* subjectPtr = subject.data();
+    const auto* patternPtr = pattern.data();
+    int subjectLength = subject.size();
+    int patternLength = pattern.size();
+    int* charOccurrences = search.badCharTable();
+    int badness = -patternLength;
+
+    // How bad we are doing without a good-suffix table.
+    PatternChar lastChar = patternPtr[patternLength - 1];
+    int lastCharShift = patternLength - 1 - charOccurrence(charOccurrences, static_cast<SubjectChar>(lastChar));
+    // Perform search
+    int index = startIndex; // No matches found prior to this index.
+    while (index <= subjectLength - patternLength) {
+        int j = patternLength - 1;
+        int subjectChar;
+        while (lastChar != (subjectChar = subjectPtr[index + j])) {
+            int bcOcc = charOccurrence(charOccurrences, subjectChar);
+            int shift = j - bcOcc;
+            index += shift;
+            badness += 1 - shift; // at most zero, so badness cannot increase.
+            if (index > subjectLength - patternLength)
+                return -1;
+        }
+        j--;
+        while (j >= 0 && patternPtr[j] == (subjectPtr[index + j]))
+            j--;
+        if (j < 0)
+            return index;
+
+        index += lastCharShift;
+        // Badness increases by the number of characters we have
+        // checked, and decreases by the number of characters we
+        // can skip by shifting. It's a measure of how we are doing
+        // compared to reading each character exactly once.
+        badness += (patternLength - j) - lastCharShift;
+        if (badness > 0) {
+            search.populateBoyerMooreTable();
+            search.m_strategy = &boyerMooreSearch;
+            return boyerMooreSearch(search, subject, index);
+        }
+    }
+    return -1;
+}
+
+template <typename PatternChar, typename SubjectChar>
+void AdaptiveStringSearcher<PatternChar, SubjectChar>::populateBoyerMooreHorspoolTable()
+{
+    int patternLength = m_pattern.size();
+
+    int* badCharOccurrence = badCharTable();
+
+    // Only preprocess at most bmMaxShift last characters of pattern.
+    int start = m_start;
+    // Run forwards to populate badCharTable, so that *last* instance
+    // of character equivalence class is the one registered.
+    // Notice: Doesn't include the last character.
+    int tableSize = alphabetSize();
+    if (!start) // All patterns less than bmMaxShift in length.
+        memset(badCharOccurrence, -1, tableSize * sizeof(*badCharOccurrence));
+    else {
+        for (int i = 0; i < tableSize; i++)
+            badCharOccurrence[i] = start - 1;
+    }
+    const auto* patternPtr = m_pattern.data();
+    for (int i = start; i < patternLength - 1; i++) {
+        PatternChar c = patternPtr[i];
+        int bucket = (sizeof(PatternChar) == 1) ? c : c % alphabetSize();
+        badCharOccurrence[bucket] = i;
+    }
+}
+
+//---------------------------------------------------------------------
+// Linear string search with bailout to BMH.
+//---------------------------------------------------------------------
+
+// Simple linear search for short patterns, which bails out if the string
+// isn't found very early in the subject. Upgrades to BoyerMooreHorspool.
+template <typename PatternChar, typename SubjectChar>
+int AdaptiveStringSearcher<PatternChar, SubjectChar>::initialSearch(AdaptiveStringSearcher<PatternChar, SubjectChar>& search, std::span<const SubjectChar> subject, int index)
+{
+    std::span<const PatternChar> pattern = search.m_pattern;
+    const auto* subjectPtr = subject.data();
+    const auto* patternPtr = pattern.data();
+    int patternLength = pattern.size();
+    // Badness is a count of how much work we have done. When we have
+    // done enough work we decide it's probably worth switching to a better
+    // algorithm.
+    int badness = -10 - (patternLength << 2);
+
+    // We know our pattern is at least 2 characters, we cache the first so
+    // the common case of the first character not matching is faster.
+    for (int i = index, n = subject.size() - patternLength; i <= n; i++) {
+        badness++;
+        if (badness <= 0) {
+            i = findFirstCharacter(pattern, subject, i);
+            if (i == -1)
+                return -1;
+            ASSERT(i <= n);
+            int j = 1;
+            do {
+                if (patternPtr[j] != subjectPtr[i + j])
+                    break;
+                j++;
+            } while (j < patternLength);
+            if (j == patternLength)
+                return i;
+            badness += j;
+        } else {
+            search.populateBoyerMooreHorspoolTable();
+            search.m_strategy = &boyerMooreHorspoolSearch;
+            return boyerMooreHorspoolSearch(search, subject, i);
+        }
+    }
+    return -1;
+}
+
+// Perform a a single stand-alone search.
+// If searching multiple times for the same pattern, a search
+// object should be constructed once and the Search function then called
+// for each search.
+template <typename SubjectChar, typename PatternChar>
+int searchString(AdaptiveStringSearcherTables& tables, std::span<const SubjectChar> subject, std::span<const PatternChar> pattern, int startIndex)
+{
+    AdaptiveStringSearcher<PatternChar, SubjectChar> search(tables, pattern);
+    return search.search(subject, startIndex);
+}
+
+// A wrapper function around SearchString that wraps raw pointers to the subject
+// and pattern as vectors before calling SearchString. Used from the
+// StringIndexOf builtin.
+template <typename SubjectChar, typename PatternChar>
+intptr_t searchStringRaw(AdaptiveStringSearcherTables& tables, const SubjectChar* subjectPtr, int subjectLength, const PatternChar* patternPtr, int patternLength, int startIndex)
+{
+    std::span<const SubjectChar> subject(subjectPtr, subjectLength);
+    std::span<const PatternChar> pattern(patternPtr, patternLength);
+    return searchString(tables, subject, pattern, startIndex);
+}
+
+} // namespace WTF
+
+using WTF::AdaptiveStringSearcher;
+using WTF::AdaptiveStringSearcherTables;
+using WTF::searchString;
+using WTF::searchStringRaw;

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <wtf/ASCIICType.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
+#include <wtf/text/AdaptiveStringSearcher.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/TextBreakIterator.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
@@ -107,6 +108,31 @@ CString StringView::utf8(ConversionMode mode) const
 size_t StringView::find(StringView matchString, unsigned start) const
 {
     return findCommon(*this, matchString, start);
+}
+
+size_t StringView::find(AdaptiveStringSearcherTables& tables, StringView matchString, unsigned start) const
+{
+    unsigned subjectLength = length();
+    unsigned matchLength = matchString.length();
+
+    if (start > subjectLength)
+        return notFound;
+
+    if (!matchLength)
+        return start;
+
+    if (UNLIKELY(subjectLength > INT32_MAX || matchLength > INT32_MAX))
+        return find(matchString, start);
+
+    if (is8Bit()) {
+        if (matchString.is8Bit())
+            return searchStringRaw(tables, characters8(), length(), matchString.characters8(), matchString.length(), start);
+        return searchStringRaw(tables, characters8(), length(), matchString.characters16(), matchString.length(), start);
+    }
+
+    if (matchString.is8Bit())
+        return searchStringRaw(tables, characters16(), length(), matchString.characters8(), matchString.length(), start);
+    return searchStringRaw(tables, characters16(), length(), matchString.characters16(), matchString.length(), start);
 }
 
 size_t StringView::find(const LChar* match, unsigned matchLength, unsigned start) const

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -48,6 +48,8 @@ OBJC_CLASS NSString;
 
 namespace WTF {
 
+class AdaptiveStringSearcherTables;
+
 // StringView is a non-owning reference to a string, similar to the proposed std::string_view.
 
 class StringView final {
@@ -160,6 +162,7 @@ public:
     size_t find(CodeUnitMatchFunction&&, unsigned start = 0) const;
     ALWAYS_INLINE size_t find(ASCIILiteral literal, unsigned start = 0) const { return find(literal.characters8(), literal.length(), start); }
     WTF_EXPORT_PRIVATE size_t find(StringView, unsigned start = 0) const;
+    WTF_EXPORT_PRIVATE size_t find(AdaptiveStringSearcherTables&, StringView, unsigned start = 0) const;
 
     size_t reverseFind(UChar, unsigned index = std::numeric_limits<unsigned>::max()) const;
     ALWAYS_INLINE size_t reverseFind(ASCIILiteral literal, unsigned start = std::numeric_limits<unsigned>::max()) const { return reverseFind(literal.characters8(), literal.length(), start); }


### PR DESCRIPTION
#### 802150baed8ddc888da813f8a5c076de17e152a3
<pre>
[WTF] Adopt adaptive string searching
<a href="https://bugs.webkit.org/show_bug.cgi?id=268635">https://bugs.webkit.org/show_bug.cgi?id=268635</a>
<a href="https://rdar.apple.com/121082299">rdar://121082299</a>

Reviewed by Mark Lam.

This patch adopts V8&apos;s StringSearch class. We tailor it to our use and name it AdaptiveStringSearcher.
We add `StringView::find(AdaptiveStringSearcherTables&amp;, ...)` function which uses `AdaptiveStringSearcher`,
when the table is attached. In this way, we can use this function even without JSC VM for example.

The mechanism of this class is that, it requires additional space for large table (AdaptiveStringSearcherTables).
And it *adaptively* switches string searching algorithm: linearSearch -&gt; boyerMooreHorspoolSearch -&gt; boyerMooreSearch.
The reason is that the latter requires more costly preprocess to populate table data. For very simple case, linearSearch suffice,
but for more complex cases, the preprocess gets paid, and boyerMooreHorspoolSearch / boyerMooreSearch works better for performance.

* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::stringIndexOfImpl):
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::stringIncludesImpl):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::stringReplaceStringString):
(JSC::replaceUsingStringSearch):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::adaptiveStringSearcherTables):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/text/ASCIIFastPath.h:
(WTF::charactersAreAllLatin1):
* Source/WTF/wtf/text/AdaptiveStringSearcher.h: Added.
(WTF::AdaptiveStringSearcherBase::exceedsOneByte):
(WTF::AdaptiveStringSearcherBase::alignDown):
(WTF::AdaptiveStringSearcherBase::getHighestValueByte):
(WTF::AdaptiveStringSearcherBase::findFirstCharacter):
(WTF::AdaptiveStringSearcherTables::badCharShiftTable):
(WTF::AdaptiveStringSearcherTables::goodSuffixShiftTable):
(WTF::AdaptiveStringSearcherTables::suffixTable):
(WTF::AdaptiveStringSearcher::AdaptiveStringSearcher):
(WTF::AdaptiveStringSearcher::search):
(WTF::AdaptiveStringSearcher::alphabetSize):
(WTF::AdaptiveStringSearcher::failSearch):
(WTF::AdaptiveStringSearcher::charOccurrence):
(WTF::AdaptiveStringSearcher::badCharTable):
(WTF::AdaptiveStringSearcher::goodSuffixShiftTable):
(WTF::AdaptiveStringSearcher::suffixTable):
(WTF::SubjectChar&gt;::singleCharSearch):
(WTF::SubjectChar&gt;::linearSearch):
(WTF::SubjectChar&gt;::boyerMooreSearch):
(WTF::SubjectChar&gt;::populateBoyerMooreTable):
(WTF::SubjectChar&gt;::boyerMooreHorspoolSearch):
(WTF::SubjectChar&gt;::populateBoyerMooreHorspoolTable):
(WTF::SubjectChar&gt;::initialSearch):
(WTF::searchString):
(WTF::searchStringRaw):
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::find const):
* Source/WTF/wtf/text/StringView.h:

Canonical link: <a href="https://commits.webkit.org/274033@main">https://commits.webkit.org/274033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9391326e1eccb88b5f9d94779cea9ad22ef1e0c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16477 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40122 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33474 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13638 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31863 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13879 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12106 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12059 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41385 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/31347 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33972 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34048 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37968 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/37288 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10178 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36136 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14073 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/44188 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13037 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9047 "Found 157 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout, jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout-no-llint, stress/array-flatmap.js.dfg-eager-no-cjit-validate, wasm.yaml/wasm/gc/any.js.default-wasm, wasm.yaml/wasm/gc/any.js.wasm-bbq, wasm.yaml/wasm/gc/any.js.wasm-collect-continuously, wasm.yaml/wasm/gc/any.js.wasm-eager, wasm.yaml/wasm/gc/any.js.wasm-eager-jettison ... (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4885 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13386 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->