### PR TITLE
[WGSL] shader,validation,const_assert,const_assert:* is failing

### DIFF
--- a/Source/WebGPU/WGSL/AST/AST.h
+++ b/Source/WebGPU/WGSL/AST/AST.h
@@ -41,6 +41,8 @@
 #include "ASTCallStatement.h"
 #include "ASTCompoundAssignmentStatement.h"
 #include "ASTCompoundStatement.h"
+#include "ASTConstAssert.h"
+#include "ASTConstAssertStatement.h"
 #include "ASTConstAttribute.h"
 #include "ASTContinueStatement.h"
 #include "ASTDecrementIncrementStatement.h"

--- a/Source/WebGPU/WGSL/AST/ASTConstAssert.h
+++ b/Source/WebGPU/WGSL/AST/ASTConstAssert.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ASTBuilder.h"
+#include "ASTDeclaration.h"
+
+namespace WGSL::AST {
+
+class ConstAssert final : public Declaration {
+    WGSL_AST_BUILDER_NODE(ConstAssert);
+
+public:
+    using Ref = std::reference_wrapper<ConstAssert>;
+
+    NodeKind kind() const override;
+    Expression& test() { return m_test.get(); }
+
+    Identifier& name() override { RELEASE_ASSERT_NOT_REACHED(); }
+
+private:
+    ConstAssert(SourceSpan span, AST::Expression::Ref&& test)
+        : Declaration(span)
+        , m_test(test)
+    { }
+
+    AST::Expression::Ref m_test;
+};
+
+} // namespace WGSL::AST
+
+SPECIALIZE_TYPE_TRAITS_WGSL_AST(ConstAssert)

--- a/Source/WebGPU/WGSL/AST/ASTConstAssertStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTConstAssertStatement.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ASTBuilder.h"
+#include "ASTConstAssert.h"
+#include "ASTStatement.h"
+
+namespace WGSL::AST {
+
+class ConstAssertStatement final : public Statement {
+    WGSL_AST_BUILDER_NODE(ConstAssertStatement);
+
+public:
+    NodeKind kind() const override;
+    ConstAssert& assertion() { return m_assertion.get(); }
+
+private:
+    ConstAssertStatement(SourceSpan span, AST::ConstAssert::Ref&& assertion)
+        : Statement(span)
+        , m_assertion(WTFMove(assertion))
+    { }
+
+    AST::ConstAssert::Ref m_assertion;
+};
+
+} // namespace WGSL::AST
+
+SPECIALIZE_TYPE_TRAITS_WGSL_AST(ConstAssertStatement)

--- a/Source/WebGPU/WGSL/AST/ASTForward.h
+++ b/Source/WebGPU/WGSL/AST/ASTForward.h
@@ -31,6 +31,7 @@ class Directive;
 class DiagnosticDirective;
 
 class Declaration;
+class ConstAssert;
 
 class Attribute;
 class AlignAttribute;
@@ -77,6 +78,7 @@ class BreakStatement;
 class CallStatement;
 class CompoundAssignmentStatement;
 class CompoundStatement;
+class ConstAssertStatement;
 class ContinueStatement;
 class DecrementIncrementStatement;
 class DiscardStatement;

--- a/Source/WebGPU/WGSL/AST/ASTNode.h
+++ b/Source/WebGPU/WGSL/AST/ASTNode.h
@@ -50,6 +50,7 @@ enum class NodeKind : uint8_t {
     StageAttribute,
     WorkgroupSizeAttribute,
 
+    ConstAssert,
     Directive,
     DiagnosticDirective,
 
@@ -86,6 +87,7 @@ enum class NodeKind : uint8_t {
     CallStatement,
     CompoundAssignmentStatement,
     CompoundStatement,
+    ConstAssertStatement,
     ContinueStatement,
     DecrementIncrementStatement,
     DiscardStatement,

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -85,6 +85,9 @@ void Visitor::visit(AST::Declaration& declaration)
     case AST::NodeKind::TypeAlias:
         checkErrorAndVisit(downcast<AST::TypeAlias>(declaration));
         break;
+    case AST::NodeKind::ConstAssert:
+        checkErrorAndVisit(downcast<AST::ConstAssert>(declaration));
+        break;
     default:
         ASSERT_NOT_REACHED("Unhandled Declaration");
     }
@@ -93,6 +96,11 @@ void Visitor::visit(AST::Declaration& declaration)
 void Visitor::visit(AST::TypeAlias& alias)
 {
     visit(alias.type());
+}
+
+void Visitor::visit(AST::ConstAssert& assertion)
+{
+    visit(assertion.test());
 }
 
 // Attribute
@@ -400,6 +408,9 @@ void Visitor::visit(Statement& statement)
     case AST::NodeKind::CompoundStatement:
         checkErrorAndVisit(downcast<AST::CompoundStatement>(statement));
         break;
+    case AST::NodeKind::ConstAssertStatement:
+        checkErrorAndVisit(downcast<AST::ConstAssertStatement>(statement));
+        break;
     case AST::NodeKind::ContinueStatement:
         checkErrorAndVisit(downcast<AST::ContinueStatement>(statement));
         break;
@@ -466,6 +477,11 @@ void Visitor::visit(CompoundStatement& compoundStatement)
 {
     for (auto& statement : compoundStatement.statements())
         checkErrorAndVisit(statement);
+}
+
+void Visitor::visit(AST::ConstAssertStatement& statement)
+{
+    checkErrorAndVisit(statement.assertion());
 }
 
 void Visitor::visit(AST::ContinueStatement&)

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -54,6 +54,7 @@ public:
     virtual void visit(AST::Variable&);
     virtual void visit(AST::Structure&);
     virtual void visit(AST::TypeAlias&);
+    virtual void visit(AST::ConstAssert&);
 
     // Attribute
     virtual void visit(AST::Attribute&);
@@ -102,6 +103,7 @@ public:
     virtual void visit(AST::CallStatement&);
     virtual void visit(AST::CompoundAssignmentStatement&);
     virtual void visit(AST::CompoundStatement&);
+    virtual void visit(AST::ConstAssertStatement&);
     virtual void visit(AST::ContinueStatement&);
     virtual void visit(AST::DecrementIncrementStatement&);
     virtual void visit(AST::DiscardStatement&);

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -574,6 +574,9 @@ Result<AST::Declaration::Ref> Parser<Lexer>::parseDeclaration()
     } else if (current().type == TokenType::KeywordAlias) {
         PARSE(alias, TypeAlias);
         return { alias };
+    } else if (current().type ==  TokenType::KeywordConstAssert) {
+        PARSE(assert, ConstAssert);
+        return { assert };
     }
 
     PARSE(attributes, Attributes);
@@ -596,6 +599,15 @@ Result<AST::Declaration::Ref> Parser<Lexer>::parseDeclaration()
     default:
         FAIL("Trying to parse a GlobalDecl, expected 'const', 'fn', 'override', 'struct' or 'var'."_s);
     }
+}
+
+template<typename Lexer>
+Result<AST::ConstAssert::Ref> Parser<Lexer>::parseConstAssert()
+{
+    START_PARSE();
+    CONSUME_TYPE(KeywordConstAssert);
+    PARSE(test, Expression);
+    RETURN_ARENA_NODE(ConstAssert, WTFMove(test));
 }
 
 template<typename Lexer>
@@ -1169,6 +1181,10 @@ Result<AST::Statement::Ref> Parser<Lexer>::parseStatement()
         PARSE(rhs, Expression);
         CONSUME_TYPE(Semicolon);
         RETURN_ARENA_NODE(PhonyAssignmentStatement, WTFMove(rhs));
+    }
+    case TokenType::KeywordConstAssert: {
+        PARSE(assert, ConstAssert);
+        RETURN_ARENA_NODE(ConstAssertStatement, WTFMove(assert));
     }
     default:
         FAIL("Not a valid statement"_s);

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -27,6 +27,7 @@
 
 #include "ASTAttribute.h"
 #include "ASTBuilder.h"
+#include "ASTConstAssert.h"
 #include "ASTExpression.h"
 #include "ASTForward.h"
 #include "ASTFunction.h"
@@ -66,6 +67,7 @@ public:
     Result<void> parseEnableDirective();
     Result<void> parseRequireDirective();
     Result<AST::Declaration::Ref> parseDeclaration();
+    Result<AST::ConstAssert::Ref> parseConstAssert();
     Result<AST::Attribute::List> parseAttributes();
     Result<AST::Attribute::Ref> parseAttribute();
     Result<AST::Structure::Ref> parseStructure(AST::Attribute::List&&);

--- a/Source/WebGPU/WGSL/tests/invalid/const-assert.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/const-assert.wgsl
@@ -1,0 +1,65 @@
+// RUN: %not %wgslc | %check
+
+// CHECK-L: const assertion condition must be a bool, got '<AbstractInt>'
+const_assert(1);
+
+// CHECK-L: unresolved identifier 'undefined'
+const_assert(undefined);
+
+// CHECK-L: cannot use type 'vec2' as value
+const_assert(vec2);
+
+// CHECK-L: cannot use type 'i32' as value
+const_assert(i32);
+
+// CHECK-L: unresolved identifier 'sqrt'
+const_assert(sqrt);
+
+// CHECK-L: const assertion failed
+const_assert(1 > 2);
+
+const x = 1;
+const y = 2;
+
+// CHECK-L: const assertion failed
+const_assert(x > y);
+
+var<private> z = 3;
+
+// CHECK-L: const assertion requires a const-expression
+const_assert(x > z);
+
+fn f()
+{
+    // CHECK-L: const assertion condition must be a bool, got '<AbstractInt>'
+    const_assert(1);
+
+    // CHECK-L: unresolved identifier 'undefined'
+    const_assert(undefined);
+
+    // CHECK-L: cannot use type 'vec2' as value
+    const_assert(vec2);
+
+    // CHECK-L: cannot use type 'i32' as value
+    const_assert(i32);
+
+    // CHECK-L: unresolved identifier 'sqrt'
+    const_assert(sqrt);
+
+    // CHECK-L: const assertion failed
+    const_assert(1 > 2);
+
+    const x = 1;
+    const y = 2;
+
+    // CHECK-L: const assertion failed
+    const_assert(x > y);
+
+    let z = 3;
+
+    // CHECK-L: const assertion requires a const-expression
+    const_assert(x > z);
+}
+
+// CHECK-L: cannot use function 'f' as value
+const_assert(f);

--- a/Source/WebGPU/WGSL/tests/valid/const-assert.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/const-assert.wgsl
@@ -1,0 +1,26 @@
+// RUN: %wgslc
+
+const_assert(true);
+const_assert(!false);
+
+const t = true;
+const_assert(t);
+
+const f = false;
+const_assert(!false);
+
+const_assert(all(vec2(true)));
+
+fn main()
+{
+    const_assert(true);
+    const_assert(!false);
+
+    const t = true;
+    const_assert(t);
+
+    const f = false;
+    const_assert(!false);
+
+    const_assert(all(vec2(true)));
+}

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -155,6 +155,8 @@
 		979240C029753B2A0050EA2C /* PhaseTimer.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240BC29753B2A0050EA2C /* PhaseTimer.h */; };
 		979240C829769AC00050EA2C /* EntryPointRewriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240C629769AC00050EA2C /* EntryPointRewriter.h */; };
 		979240C929769AC00050EA2C /* EntryPointRewriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240C729769AC00050EA2C /* EntryPointRewriter.cpp */; };
+		9797BA442B6D5BA70020F22E /* ASTConstAssertStatement.h in Headers */ = {isa = PBXBuildFile; fileRef = 9797BA422B6D5BA60020F22E /* ASTConstAssertStatement.h */; };
+		9797BA452B6D5BA70020F22E /* ASTConstAssert.h in Headers */ = {isa = PBXBuildFile; fileRef = 9797BA432B6D5BA60020F22E /* ASTConstAssert.h */; };
 		979EDBB12A826B2800B4B7D0 /* GlobalSorting.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979EDBAF2A826B2800B4B7D0 /* GlobalSorting.cpp */; };
 		979EDBB22A826B2800B4B7D0 /* GlobalSorting.h in Headers */ = {isa = PBXBuildFile; fileRef = 979EDBB02A826B2800B4B7D0 /* GlobalSorting.h */; };
 		97A448A12AE3544800A4E147 /* AttributeValidator.h in Headers */ = {isa = PBXBuildFile; fileRef = 97A4489F2AE3544800A4E147 /* AttributeValidator.h */; };
@@ -445,6 +447,8 @@
 		979240BC29753B2A0050EA2C /* PhaseTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PhaseTimer.h; sourceTree = "<group>"; };
 		979240C629769AC00050EA2C /* EntryPointRewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EntryPointRewriter.h; sourceTree = "<group>"; };
 		979240C729769AC00050EA2C /* EntryPointRewriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EntryPointRewriter.cpp; sourceTree = "<group>"; };
+		9797BA422B6D5BA60020F22E /* ASTConstAssertStatement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTConstAssertStatement.h; sourceTree = "<group>"; };
+		9797BA432B6D5BA60020F22E /* ASTConstAssert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTConstAssert.h; sourceTree = "<group>"; };
 		979EDBAF2A826B2800B4B7D0 /* GlobalSorting.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GlobalSorting.cpp; sourceTree = "<group>"; };
 		979EDBB02A826B2800B4B7D0 /* GlobalSorting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GlobalSorting.h; sourceTree = "<group>"; };
 		97A4489F2AE3544800A4E147 /* AttributeValidator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AttributeValidator.h; sourceTree = "<group>"; };
@@ -719,6 +723,8 @@
 				97A448A52AE3546700A4E147 /* ASTCallStatement.h */,
 				3A12AEA328FCE94C00C1B975 /* ASTCompoundAssignmentStatement.h */,
 				33EA187A27BC230E00A1DD52 /* ASTCompoundStatement.h */,
+				9797BA432B6D5BA60020F22E /* ASTConstAssert.h */,
+				9797BA422B6D5BA60020F22E /* ASTConstAssertStatement.h */,
 				3A12AE9E28FCE94B00C1B975 /* ASTConstAttribute.h */,
 				3A12AEA228FCE94C00C1B975 /* ASTContinueStatement.h */,
 				3AD0D2302988D3C10080D728 /* ASTDeclaration.h */,
@@ -838,6 +844,8 @@
 				97A448A82AE3546700A4E147 /* ASTCallStatement.h in Headers */,
 				3A12AEBD28FCE94C00C1B975 /* ASTCompoundAssignmentStatement.h in Headers */,
 				33EA187B27BC230E00A1DD52 /* ASTCompoundStatement.h in Headers */,
+				9797BA452B6D5BA70020F22E /* ASTConstAssert.h in Headers */,
+				9797BA442B6D5BA70020F22E /* ASTConstAssertStatement.h in Headers */,
 				3A12AEB828FCE94C00C1B975 /* ASTConstAttribute.h in Headers */,
 				3A12AEBC28FCE94C00C1B975 /* ASTContinueStatement.h in Headers */,
 				3AD0D2332988D3C10080D728 /* ASTDeclaration.h in Headers */,


### PR DESCRIPTION
#### caf4dfc46d78f96ac1960fa9b816a784d4c75c5f
<pre>
[WGSL] shader,validation,const_assert,const_assert:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=268640">https://bugs.webkit.org/show_bug.cgi?id=268640</a>
<a href="https://rdar.apple.com/122194238">rdar://122194238</a>

Reviewed by Mike Wyrzykowski.

Add support for const_expr statements and top-level declarations.

* Source/WebGPU/WGSL/AST/AST.h:
* Source/WebGPU/WGSL/AST/ASTConstAssert.h: Added.
* Source/WebGPU/WGSL/AST/ASTConstAssertStatement.h: Added.
* Source/WebGPU/WGSL/AST/ASTForward.h:
* Source/WebGPU/WGSL/AST/ASTNode.h:
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.h:
* Source/WebGPU/WGSL/GlobalSorting.cpp:
(WGSL::Graph::addNode):
(WGSL::Graph::addEdge):
(WGSL::reorder):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseDeclaration):
(WGSL::Parser&lt;Lexer&gt;::parseConstAssert):
(WGSL::Parser&lt;Lexer&gt;::parseStatement):
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/const-assert.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/const-assert.wgsl: Added.
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/274093@main">https://commits.webkit.org/274093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c4d5a639fedc6e9448f42a24f3dea5fa8cc529d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39805 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40067 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33446 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13590 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31837 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12060 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12030 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41331 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33934 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34025 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37923 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12599 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36086 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14047 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8503 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13360 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->