### PR TITLE
[Site Isolation][iOS] Do not recreate hosting layer when hosting identifier has no change

### DIFF
--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1312,6 +1312,9 @@ void GraphicsLayerCA::setContentsToPlatformLayer(PlatformLayer* platformLayer, C
 
 void GraphicsLayerCA::setContentsToPlatformLayerHost(LayerHostingContextIdentifier identifier)
 {
+    if (m_contentsLayer && m_contentsLayer->hostingContextIdentifier() == identifier)
+        return;
+
     m_contentsLayer = createPlatformCALayerHost(identifier, this);
     m_contentsLayerPurpose = GraphicsLayer::ContentsLayerPurpose::Host;
     m_contentsDisplayDelegate = nullptr;

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -101,6 +101,7 @@ public:
     virtual ~PlatformCALayer();
 
     PlatformLayerIdentifier layerID() const { return m_layerID; }
+    virtual std::optional<WebCore::LayerHostingContextIdentifier> hostingContextIdentifier() const { return std::nullopt; }
 
     enum class Type : uint8_t {
         Cocoa,

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteHost.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteHost.h
@@ -33,6 +33,7 @@ class PlatformCALayerRemoteHost final : public PlatformCALayerRemote {
     friend class PlatformCALayerRemote;
 public:
     static Ref<PlatformCALayerRemote> create(WebCore::LayerHostingContextIdentifier, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
+    std::optional<WebCore::LayerHostingContextIdentifier> hostingContextIdentifier() const final { return m_identifier; }
 
 private:
     PlatformCALayerRemoteHost(WebCore::LayerHostingContextIdentifier, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);


### PR DESCRIPTION
#### 9692297b2f37a9eb1dba6401b6781f33ddb7a1f4
<pre>
[Site Isolation][iOS] Do not recreate hosting layer when hosting identifier has no change
<a href="https://bugs.webkit.org/show_bug.cgi?id=268642">https://bugs.webkit.org/show_bug.cgi?id=268642</a>
<a href="https://rdar.apple.com/122195472">rdar://122195472</a>

Reviewed by Alex Christensen.

When running site isolation tests, I noticed there were many PlatformCALayers created even though the frame tree did
not change. I found that GraphicsLayerCA resets its m_contentsLayer every time RenderLayerBacking::updateConfiguration
is invoked. This is unnecessary as the new contents layer has the same configuration as the old one when hosting
identifier does not change.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::setContentsToPlatformLayerHost):
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteHost.h:

Canonical link: <a href="https://commits.webkit.org/274028@main">https://commits.webkit.org/274028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/854eb6276c140525baf1dca6b2429e1e7fb0ba41

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37533 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40059 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33443 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13582 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31833 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38098 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/13897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12053 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41323 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/33993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37920 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36083 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14044 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8467 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/12998 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13357 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->