### PR TITLE
[CMake] Centralize ShareableBitmapCairo.cpp build

### DIFF
--- a/Source/WebCore/PlatformPlayStation.cmake
+++ b/Source/WebCore/PlatformPlayStation.cmake
@@ -8,7 +8,6 @@ include(platform/TextureMapper.cmake)
 list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
     ${WEBCORE_DIR}/platform
     ${WEBCORE_DIR}/platform/generic
-    ${WEBCORE_DIR}/platform/graphics/cairo
     ${WEBCORE_DIR}/platform/graphics/egl
     ${WEBCORE_DIR}/platform/graphics/opengl
     ${WEBCORE_DIR}/platform/graphics/libwpe
@@ -42,8 +41,6 @@ list(APPEND WebCore_SOURCES
     platform/generic/KeyedEncoderGeneric.cpp
 
     platform/graphics/PlatformDisplay.cpp
-
-    platform/graphics/cairo/ShareableBitmapCairo.cpp
 
     platform/graphics/egl/GLContext.cpp
     platform/graphics/egl/GLContextLibWPE.cpp

--- a/Source/WebCore/PlatformWin.cmake
+++ b/Source/WebCore/PlatformWin.cmake
@@ -14,7 +14,6 @@ endif ()
 list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/accessibility/win"
     "${WEBCORE_DIR}/page/win"
-    "${WEBCORE_DIR}/platform/graphics/cairo"
     "${WEBCORE_DIR}/platform/graphics/egl"
     "${WEBCORE_DIR}/platform/graphics/opengl"
     "${WEBCORE_DIR}/platform/graphics/opentype"
@@ -53,8 +52,6 @@ list(APPEND WebCore_SOURCES
     platform/graphics/PlatformDisplay.cpp
 
     platform/graphics/angle/PlatformDisplayANGLE.cpp
-
-    platform/graphics/cairo/ShareableBitmapCairo.cpp
 
     platform/graphics/egl/GLContext.cpp
 

--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -70,8 +70,6 @@ platform/graphics/PlatformDisplay.cpp @no-unify
 
 platform/graphics/angle/PlatformDisplayANGLE.cpp @no-unify
 
-platform/graphics/cairo/ShareableBitmapCairo.cpp
-
 platform/graphics/egl/GLContext.cpp @no-unify
 platform/graphics/egl/PlatformDisplaySurfaceless.cpp @no-unify
 

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -68,8 +68,6 @@ platform/graphics/PlatformDisplay.cpp @no-unify
 
 platform/graphics/angle/PlatformDisplayANGLE.cpp @no-unify
 
-platform/graphics/cairo/ShareableBitmapCairo.cpp
-
 platform/graphics/wpe/SystemFontDatabaseWPE.cpp
 
 platform/graphics/egl/GLContext.cpp @no-unify

--- a/Source/WebCore/platform/SourcesCairo.txt
+++ b/Source/WebCore/platform/SourcesCairo.txt
@@ -21,13 +21,13 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-platform/graphics/cairo/CairoUtilities.cpp @no-unify
 platform/graphics/cairo/CairoOperations.cpp
+platform/graphics/cairo/CairoUtilities.cpp @no-unify
 platform/graphics/cairo/FloatRectCairo.cpp
 platform/graphics/cairo/FontCairo.cpp
 platform/graphics/cairo/GradientCairo.cpp
-platform/graphics/cairo/GraphicsContextGLCairo.cpp
 platform/graphics/cairo/GraphicsContextCairo.cpp
+platform/graphics/cairo/GraphicsContextGLCairo.cpp
 platform/graphics/cairo/ImageBufferCairoBackend.cpp
 platform/graphics/cairo/ImageBufferCairoImageSurfaceBackend.cpp
 platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp
@@ -37,3 +37,4 @@ platform/graphics/cairo/NativeImageCairo.cpp
 platform/graphics/cairo/PathCairo.cpp
 platform/graphics/cairo/PatternCairo.cpp
 platform/graphics/cairo/RefPtrCairo.cpp
+platform/graphics/cairo/ShareableBitmapCairo.cpp


### PR DESCRIPTION
#### 72a37094553f4d862bd524136db05f761ad462cf
<pre>
[CMake] Centralize ShareableBitmapCairo.cpp build
<a href="https://bugs.webkit.org/show_bug.cgi?id=268648">https://bugs.webkit.org/show_bug.cgi?id=268648</a>

Reviewed by Chris Dumez.

Clean up CMake changes in 273995@main so they&apos;re in `Cairo.cmake`
instead of individual port definitions.

* Source/WebCore/PlatformPlayStation.cmake:
* Source/WebCore/PlatformWin.cmake:
* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/platform/SourcesCairo.txt:

Canonical link: <a href="https://commits.webkit.org/274026@main">https://commits.webkit.org/274026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89a7079877c88a608b26b09bcd5e49410cdaeabc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40079 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33453 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13602 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31842 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38119 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13850 "Found 1 new test failure: media/video-ended-does-not-hold-sleep-assertion.html (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12067 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41344 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33939 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37931 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12609 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10163 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36095 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8463 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13013 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13366 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->