### PR TITLE
Add a delegate method to let clients opt out of granting activeTab from a user gesture

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
@@ -412,6 +412,16 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  */
 - (void)closeForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
+/*!
+ @abstract Called to determine if permissions should be granted for the tab.
+ @param context The context in which the web extension is running.
+ @return `YES` if permissions should be granted to the tab, `NO` otherwise.
+ @discussion This method allows the app to control granting of permissions on a per-tab basis when triggered by a user
+ gesture. Implementing this method enables the app to dynamically manage `activeTab` permissions based on the tab's
+ current state, the content being accessed, or other custom criteria.
+ */
+- (BOOL)shouldGrantTabPermissionsOnUserGestureForWebExtensionContext:(_WKWebExtensionContext *)context;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1010,9 +1010,9 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
 {
     ASSERT(!permission.isEmpty());
 
-    if (tab && hasPermission(_WKWebExtensionPermissionActiveTab) && hasActiveUserGesture(*tab)) {
-        // An active user gesture grants the "tabs" permission.
-        if (permission == String(_WKWebExtensionPermissionTabs))
+    if (tab && permission == String(_WKWebExtensionPermissionTabs)) {
+        RefPtr temporaryPattern = tab->temporaryPermissionMatchPattern();
+        if (temporaryPattern && temporaryPattern->matchesURL(tab->url()))
             return PermissionState::GrantedExplicitly;
     }
 
@@ -2292,6 +2292,9 @@ void WebExtensionContext::userGesturePerformed(WebExtensionTab& tab)
 
     // Nothing else to do if the extension does not have the activeTab permission.
     if (!hasPermission(_WKWebExtensionPermissionActiveTab))
+        return;
+
+    if (!tab.shouldGrantTabPermissionsOnUserGesture())
         return;
 
     auto currentURL = tab.url();

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -90,6 +90,7 @@ WebExtensionTab::WebExtensionTab(const WebExtensionContext& context, _WKWebExten
     , m_respondsToDeselect([delegate respondsToSelector:@selector(deselectForWebExtensionContext:completionHandler:)])
     , m_respondsToDuplicate([delegate respondsToSelector:@selector(duplicateForWebExtensionContext:withOptions:completionHandler:)])
     , m_respondsToClose([delegate respondsToSelector:@selector(closeForWebExtensionContext:completionHandler:)])
+    , m_respondsToShouldGrantTabPermissionsOnUserGesture([delegate respondsToSelector:@selector(shouldGrantTabPermissionsOnUserGestureForWebExtensionContext:)])
 {
     ASSERT([delegate conformsToProtocol:@protocol(_WKWebExtensionTab)]);
 
@@ -869,6 +870,14 @@ void WebExtensionTab::close(CompletionHandler<void(Error)>&& completionHandler)
 
         completionHandler(std::nullopt);
     }).get()];
+}
+
+bool WebExtensionTab::shouldGrantTabPermissionsOnUserGesture() const
+{
+    if (!isValid() || !m_respondsToShouldGrantTabPermissionsOnUserGesture)
+        return true;
+
+    return [m_delegate shouldGrantTabPermissionsOnUserGestureForWebExtensionContext:m_extensionContext->wrapper()];
 }
 
 WebExtensionTab::WebProcessProxySet WebExtensionTab::processes(WebExtensionEventListenerType type, WebExtensionContentWorldType contentWorldType, MainWebViewOnly mainWebViewOnly) const

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -184,6 +184,8 @@ public:
 
     void close(CompletionHandler<void(Error)>&&);
 
+    bool shouldGrantTabPermissionsOnUserGesture() const;
+
     WebProcessProxySet processes(WebExtensionEventListenerType, WebExtensionContentWorldType, MainWebViewOnly = MainWebViewOnly::Yes) const;
 
 #ifdef __OBJC__
@@ -236,6 +238,7 @@ private:
     bool m_respondsToDeselect : 1 { false };
     bool m_respondsToDuplicate : 1 { false };
     bool m_respondsToClose : 1 { false };
+    bool m_respondsToShouldGrantTabPermissionsOnUserGesture : 1 { false };
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### d3733674e19a6b2a0f181736faefa896f3223a2d
<pre>
Add a delegate method to let clients opt out of granting activeTab from a user gesture
<a href="https://bugs.webkit.org/show_bug.cgi?id=268652">https://bugs.webkit.org/show_bug.cgi?id=268652</a>
<a href="https://rdar.apple.com/122129916">rdar://122129916</a>

Reviewed by Timothy Hatcher.

This PR also fixes a place where checking the permission state wasn&apos;t exactly correct.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::permissionState):
(WebKit::WebExtensionContext::userGesturePerformed):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::WebExtensionTab):
(WebKit::WebExtensionTab::shouldGrantTabPermissionsOnUserGesture const):
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:

Canonical link: <a href="https://commits.webkit.org/274021@main">https://commits.webkit.org/274021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bd5b8817c65232b67d7fa585059f4386a2a3c23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40112 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13630 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13870 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12092 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41376 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/33961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/37957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12631 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/36124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8460 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13032 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->