### PR TITLE
[GTK][WPE] Detect gamepad button 16

### DIFF
--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
@@ -97,6 +97,8 @@ static ManetteGamepad::StandardGamepadButton toStandardGamepadButton(uint16_t ma
         return ManetteGamepad::StandardGamepadButton::DPadLeft;
     case BTN_DPAD_RIGHT:
         return ManetteGamepad::StandardGamepadButton::DPadRight;
+    case BTN_MODE:
+        return ManetteGamepad::StandardGamepadButton::Mode;
     default:
         break;
     }

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
@@ -64,6 +64,7 @@ public:
         DPadDown,
         DPadLeft,
         DPadRight,
+        Mode,
         Count,
     };
 


### PR DESCRIPTION
#### 37a85d6c3252bc09b873bde4d6ea58ae9cafea69
<pre>
[GTK][WPE] Detect gamepad button 16
<a href="https://bugs.webkit.org/show_bug.cgi?id=268653">https://bugs.webkit.org/show_bug.cgi?id=268653</a>

Reviewed by Michael Catanzaro.

The Gamepad spec lists 17 buttons, starting at zero. The button number
16 is defined as &quot;Center button in center cluster&quot; [1], e.g. the PS
button in a DualShock 4 or 5, or similar ones in other controllers.

The libmanette gamepad backend only lists up to button number 15, which
was what was under the spec when the backend was introduced.

Add the button 16 to the listing as well. Listing is all that is needed
since the rest of the code already detects and maps this button as
expected

[1] <a href="https://www.w3.org/TR/gamepad/#dfn-standard-gamepad">https://www.w3.org/TR/gamepad/#dfn-standard-gamepad</a>

* Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp:
(WebCore::toStandardGamepadButton):
* Source/WebCore/platform/gamepad/manette/ManetteGamepad.h:

Canonical link: <a href="https://commits.webkit.org/274022@main">https://commits.webkit.org/274022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57cbd865f42676c80c9754c681d03f8594e2d238

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40089 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13609 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13854 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12072 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12037 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/33620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41354 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33943 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37935 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12614 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36101 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8461 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13017 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->