### PR TITLE
Test that _automap_to_major_version works with a single version

### DIFF
--- a/Tools/Scripts/webkitpy/common/version_name_map_unittest.py
+++ b/Tools/Scripts/webkitpy/common/version_name_map_unittest.py
@@ -75,3 +75,19 @@ class VersionMapTestCase(unittest.TestCase):
         self.assertEqual('iOS 11', map.to_name(version=Version(11), platform='ios'))
         self.assertEqual('iOS 10', map.to_name(version=Version(10), platform='ios'))
         self.assertEqual('iOS 10', map.to_name(version=Version(10, 3), platform='ios'))
+
+    def test__automap_to_major_version(self):
+        r = VersionNameMap._automap_to_major_version("iOS")
+        self.assertEqual({"iOS 1": Version(1)}, r)
+
+        r = VersionNameMap._automap_to_major_version(
+            "iOS", minimum=Version(1), maximum=Version(1)
+        )
+        self.assertEqual({"iOS 1": Version(1)}, r)
+
+        r = VersionNameMap._automap_to_major_version(
+            "iOS", minimum=Version(1), maximum=Version(3)
+        )
+        self.assertEqual(
+            {"iOS 1": Version(1), "iOS 2": Version(2), "iOS 3": Version(3)}, r
+        )


### PR DESCRIPTION
#### 4479cfaf055493f7ff9c56620286fccdacc70e76
<pre>
Test that _automap_to_major_version works with a single version
<a href="https://bugs.webkit.org/show_bug.cgi?id=268657">https://bugs.webkit.org/show_bug.cgi?id=268657</a>

Reviewed by Jonathan Bedard.

Jonathan claimed it didn&apos;t work. I wrote a test to fix this and it
passed. So let&apos;s keep the test.

* Tools/Scripts/webkitpy/common/version_name_map_unittest.py:
(VersionMapTestCase.test__automap_to_major_version):

Canonical link: <a href="https://commits.webkit.org/274147@main">https://commits.webkit.org/274147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b4422e142e9de29f92ffe787ebd37b1d73cfe4b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40101 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33464 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31851 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12081 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/37605 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33621 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41366 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37950 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36117 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14063 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13025 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4940 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13376 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->