### PR TITLE
[UnifiedPDF] Track text selections on mouse drag

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -42,6 +42,8 @@ struct PDFContextMenu;
 class WebFrame;
 class WebMouseEvent;
 
+enum class WebEventModifier : uint8_t;
+
 class UnifiedPDFPlugin final : public PDFPluginBase, public WebCore::GraphicsLayerClient {
 public:
     static Ref<UnifiedPDFPlugin> create(WebCore::HTMLPlugInElement&);
@@ -154,6 +156,19 @@ private:
     static constexpr int invalidContextMenuItemTag { -1 };
 #endif
 
+    enum class SelectionGranularity : uint8_t {
+        Character,
+        Word,
+        Line,
+    };
+    enum class SelectionCommitReason : bool { SelectionIsNoLongerActive, ReceivedMouseUp };
+
+    SelectionGranularity selectionGranularityForMouseEvent(const WebMouseEvent&) const;
+    void beginTrackingSelection(PDFDocumentLayout::PageIndex, const WebCore::IntPoint& pagePoint, SelectionGranularity, OptionSet<WebEventModifier>);
+    void continueTrackingSelection(PDFDocumentLayout::PageIndex, const WebCore::IntPoint& pagePoint);
+    void setCurrentSelection(RetainPtr<PDFSelection>&&);
+    void commitCurrentSelection(SelectionCommitReason);
+
     String getSelectionString() const override;
     bool existingSelectionContainsPoint(const WebCore::FloatPoint&) const override;
     WebCore::FloatRect rectForSelectionInRootView(PDFSelection *) const override;
@@ -246,6 +261,18 @@ private:
 
     RetainPtr<PDFAnnotation> m_trackedAnnotation;
 
+    struct SelectionTrackingData {
+        bool shouldExtendCurrentSelection { false };
+        bool shouldMakeMarqueeSelection { false };
+        bool isActive { false };
+        SelectionGranularity granularity { SelectionGranularity::Character };
+        PDFDocumentLayout::PageIndex startPageIndex;
+        WebCore::IntPoint startPagePoint;
+        RetainPtr<PDFSelection> selectionToExtendWith;
+        WebCore::IntRect marqueeSelectionRect;
+    };
+    SelectionTrackingData m_selectionTrackingData;
+    RetainPtr<PDFSelection> m_currentSelection;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 85b7b3c02480754c7629094106730e68d9c36c7a
<pre>
[UnifiedPDF] Track text selections on mouse drag
<a href="https://bugs.webkit.org/show_bug.cgi?id=268654">https://bugs.webkit.org/show_bug.cgi?id=268654</a>
<a href="https://rdar.apple.com/122200693">rdar://122200693</a>

Reviewed by Tim Horton.

This patch introduces support for tracking text selections on mouse
drag. It does so by keeping a record of the state of selections in the
plugin, through the currentSelection and selectionTrackingData objects.

Selections are initiated on a left button mousedown, and end when a
corresponding mouseup is received.

We additionally provide support for marquee selections, where a
mouse drag gesture with an active alt-key modifier generates a selection
within the rect dragged by the gesture.

Finally, we also add unimplemented codepaths for tracking selections at
different granularities, which is relevant if the user double clicks or
triple clicks, and for extending selections with shift-click.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::annotationForRootViewPoint const):
(WebKit::UnifiedPDFPlugin::handleMouseEvent):
(WebKit::UnifiedPDFPlugin::selectionGranularityForMouseEvent const):
(WebKit::UnifiedPDFPlugin::beginTrackingSelection):
(WebKit::computeMarqueeSelectionRect):
(WebKit::UnifiedPDFPlugin::continueTrackingSelection):
(WebKit::UnifiedPDFPlugin::setCurrentSelection):
(WebKit::UnifiedPDFPlugin::commitCurrentSelection):
(WebKit::UnifiedPDFPlugin::getSelectionString const):

Canonical link: <a href="https://commits.webkit.org/274032@main">https://commits.webkit.org/274032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53cae5fe11eca85d9ea822cdec0181e4a4f4dcf6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16473 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39849 "Hash 53cae5fe for PR 23776 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40117 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33473 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13635 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31858 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13874 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12096 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12054 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41381 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33965 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34046 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37951 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12635 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10177 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36118 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14072 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8469 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13385 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->