### PR TITLE
[ews-build.webkit.org] Use UAT S3 bucket on UAT EWS instance

### DIFF
--- a/Tools/CISupport/Shared/generate-s3-url
+++ b/Tools/CISupport/Shared/generate-s3-url
@@ -1,11 +1,20 @@
 #!/usr/bin/env python3
 import argparse
 import boto3
+import os
+import socket
 
 from botocore.config import Config
 
-S3_DEFAULT_BUCKET = 'archives.webkit.org'
-S3_EWS_BUCKET = 'ews-archives.webkit.org'
+custom_suffix = ''
+hostname = socket.gethostname().strip()
+if 'dev' in hostname:
+    custom_suffix = '-dev'
+if 'uat' in hostname:
+    custom_suffix = '-uat'
+
+S3_DEFAULT_BUCKET = f'archives.webkit{custom_suffix}.org'
+S3_EWS_BUCKET = f'ews-archives.webkit{custom_suffix}.org'
 
 def generateS3URL(bucket, identifier, revision):
     key = '/'.join([identifier, revision + '.zip'])

--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -37,12 +37,20 @@ if sys.version_info < (3, 5):
     print('ERROR: Please use Python 3. This code is not compatible with Python 2.')
     sys.exit(1)
 
+CURRENT_HOSTNAME = socket.gethostname().strip()
+
+custom_suffix = ''
+if 'dev' in CURRENT_HOSTNAME:
+    custom_suffix = '-dev'
+if 'uat' in CURRENT_HOSTNAME:
+    custom_suffix = '-uat'
+
 BUILD_WEBKIT_HOSTNAME = 'build.webkit.org'
 COMMITS_INFO_URL = 'https://commits.webkit.org/'
-CURRENT_HOSTNAME = socket.gethostname().strip()
 RESULTS_WEBKIT_URL = 'https://results.webkit.org'
 RESULTS_SERVER_API_KEY = 'RESULTS_SERVER_API_KEY'
 S3URL = 'https://s3-us-west-2.amazonaws.com/'
+S3_BUCKET = f'archives.webkit{custom_suffix}.org'
 WithProperties = properties.WithProperties
 Interpolate = properties.Interpolate
 THRESHOLD_FOR_EXCESSIVE_LOGS = 1000000
@@ -559,9 +567,11 @@ class UploadMinifiedBuiltProduct(UploadBuiltProduct):
 
 
 class DownloadBuiltProduct(shell.ShellCommandNewStyle):
-    command = ["python3", "Tools/CISupport/download-built-product",
+    command = [
+        "python3", "Tools/CISupport/download-built-product",
         WithProperties("--platform=%(platform)s"), WithProperties("--%(configuration)s"),
-        WithProperties(S3URL + "archives.webkit.org/%(fullPlatform)s-%(architecture)s-%(configuration)s/%(archive_revision)s.zip")]
+        WithProperties(S3URL + S3_BUCKET + "/%(fullPlatform)s-%(architecture)s-%(configuration)s/%(archive_revision)s.zip"),
+    ]
     name = "download-built-product"
     description = ["downloading built product"]
     descriptionDone = ["downloaded built product"]

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -49,7 +49,7 @@ from .steps import (AddReviewerToCommitMessage, AddMergeLabelsToPRs, AnalyzeAPIT
                    CleanBuild, CleanUpGitIndexLock, CleanGitRepo, CleanWorkingDirectory, CompileJSC, CommitPatch, CompileJSCWithoutChange,
                    CompileWebKit, CompileWebKitWithoutChange, ConfigureBuild, ConfigureBuild, Contributors, DetermineLabelOwner,
                    DetermineLandedIdentifier, DownloadBuiltProduct, DownloadBuiltProductFromMaster,
-                   EWS_BUILD_HOSTNAME, ExtractBuiltProduct, ExtractTestResults,
+                   EWS_BUILD_HOSTNAMES, ExtractBuiltProduct, ExtractTestResults,
                    FetchBranches, FindModifiedLayoutTests, GitHub, GitHubMixin, GenerateS3URL,
                    InstallBuiltProduct, InstallGtkDependencies, InstallWpeDependencies, InstallHooks,
                    KillOldProcesses, PrintConfiguration, PushCommitToWebKitRepo, PushPullRequestBranch, RemoveAndAddLabels, ReRunAPITests, ReRunWebKitPerlTests, RetrievePRDataFromLabel,
@@ -2488,14 +2488,14 @@ class TestRunWebKitTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase
                                  '--builder-name', 'iOS-13-Simulator-WK2-Tests-EWS',
                                  '--build-number', '123',
                                  '--buildbot-worker', 'ews126',
-                                 '--buildbot-master', EWS_BUILD_HOSTNAME,
+                                 '--buildbot-master', EWS_BUILD_HOSTNAMES[0],
                                  '--report', 'https://results.webkit.org/'],
                         env={'RESULTS_SERVER_API_KEY': 'test-api-key'},
                         )
             + 0,
         )
         self.expectOutcome(result=SUCCESS, state_string='layout-tests')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
     def test_run_subtest_tests_success(self):
@@ -2522,7 +2522,7 @@ class TestRunWebKitTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase
                                  '--builder-name', 'iOS-13-Simulator-WK2-Tests-EWS',
                                  '--build-number', '123',
                                  '--buildbot-worker', 'ews126',
-                                 '--buildbot-master', EWS_BUILD_HOSTNAME,
+                                 '--buildbot-master', EWS_BUILD_HOSTNAMES[0],
                                  '--report', 'https://results.webkit.org/',
                                  '--skipped=always',
                                  'test1.html', 'test2.html', 'test3.html', 'test4.html', 'test5.html'],
@@ -2531,7 +2531,7 @@ class TestRunWebKitTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase
             + 0,
         )
         self.expectOutcome(result=SUCCESS, state_string='layout-tests')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
     def test_run_subtest_tests_removes_skipped_that_fails(self):
@@ -2558,7 +2558,7 @@ class TestRunWebKitTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase
                                  '--builder-name', 'iOS-13-Simulator-WK2-Tests-EWS',
                                  '--build-number', '123',
                                  '--buildbot-worker', 'ews126',
-                                 '--buildbot-master', EWS_BUILD_HOSTNAME,
+                                 '--buildbot-master', EWS_BUILD_HOSTNAMES[0],
                                  '--report', 'https://results.webkit.org/',
                                  '--skipped=always',
                                  'test-was-skipped-patch-removed-expectation-but-still-fails.html'],
@@ -2567,7 +2567,7 @@ class TestRunWebKitTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase
             + 0,
         )
         self.expectOutcome(result=SUCCESS, state_string='layout-tests')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
     def test_run_subtest_tests_fail(self):
@@ -2594,7 +2594,7 @@ class TestRunWebKitTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase
                                  '--builder-name', 'iOS-13-Simulator-WK2-Tests-EWS',
                                  '--build-number', '123',
                                  '--buildbot-worker', 'ews126',
-                                 '--buildbot-master', EWS_BUILD_HOSTNAME,
+                                 '--buildbot-master', EWS_BUILD_HOSTNAMES[0],
                                  '--report', 'https://results.webkit.org/',
                                  '--skipped=always',
                                  'test-fails-withpatch1.html', 'test-fails-withpatch2.html', 'test-pre-existent-failure1.html', 'test-pre-existent-failure2.html'],
@@ -2604,7 +2604,7 @@ class TestRunWebKitTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase
             + 2,
         )
         self.expectOutcome(result=FAILURE, state_string='layout-tests (failure)')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
     def test_run_subtest_tests_limit_exceeded(self):
@@ -2632,14 +2632,14 @@ class TestRunWebKitTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase
                                  '--builder-name', 'iOS-13-Simulator-WK2-Tests-EWS',
                                  '--build-number', '123',
                                  '--buildbot-worker', 'ews126',
-                                 '--buildbot-master', EWS_BUILD_HOSTNAME,
+                                 '--buildbot-master', EWS_BUILD_HOSTNAMES[0],
                                  '--report', 'https://results.webkit.org/'],
                         env={'RESULTS_SERVER_API_KEY': 'test-api-key'},
                         )
             + 0,
         )
         self.expectOutcome(result=SUCCESS, state_string='layout-tests')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
     def test_failure(self):
@@ -2664,7 +2664,7 @@ class TestRunWebKitTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase
                                  '--builder-name', 'iOS-13-Simulator-WK2-Tests-EWS',
                                  '--build-number', '123',
                                  '--buildbot-worker', 'ews126',
-                                 '--buildbot-master', EWS_BUILD_HOSTNAME,
+                                 '--buildbot-master', EWS_BUILD_HOSTNAMES[0],
                                  '--report', 'https://results.webkit.org/'],
                         env={'RESULTS_SERVER_API_KEY': 'test-api-key'}
                         )
@@ -2672,7 +2672,7 @@ class TestRunWebKitTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase
             + 2,
         )
         self.expectOutcome(result=FAILURE, state_string='layout-tests (failure)')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
 
@@ -4459,7 +4459,7 @@ class TestDownloadBuiltProduct(BuildStepMixinAdditions, unittest.TestCase):
             + 0,
         )
         self.expectOutcome(result=SUCCESS, state_string='Downloaded built product')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
     def test_failure(self):
@@ -4477,7 +4477,7 @@ class TestDownloadBuiltProduct(BuildStepMixinAdditions, unittest.TestCase):
             + 2,
         )
         self.expectOutcome(result=FAILURE, state_string='Failed to download built product from S3')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
     def test_deployment_skipped(self):
@@ -4640,7 +4640,7 @@ class TestGenerateS3URL(BuildStepMixinAdditions, unittest.TestCase):
             + 0,
         )
         self.expectOutcome(result=SUCCESS, state_string='Generated S3 URL')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
     def test_failure(self):
@@ -4658,7 +4658,7 @@ class TestGenerateS3URL(BuildStepMixinAdditions, unittest.TestCase):
         self.expectOutcome(result=FAILURE, state_string='Failed to generate S3 URL')
 
         try:
-            with current_hostname(EWS_BUILD_HOSTNAME), open(os.devnull, 'w') as null:
+            with current_hostname(EWS_BUILD_HOSTNAMES[0]), open(os.devnull, 'w') as null:
                 sys.stdout = null
                 return self.runStep()
         finally:
@@ -4695,7 +4695,7 @@ class TestTransferToS3(BuildStepMixinAdditions, unittest.TestCase):
             + 0,
         )
         self.expectOutcome(result=SUCCESS, state_string='Transferred archive to S3')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
     def test_failure(self):
@@ -4714,7 +4714,7 @@ class TestTransferToS3(BuildStepMixinAdditions, unittest.TestCase):
             + 2,
         )
         self.expectOutcome(result=FAILURE, state_string='Failed to transfer archive to S3')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
     def test_skipped(self):
@@ -4755,7 +4755,7 @@ class TestUploadFileToS3(BuildStepMixinAdditions, unittest.TestCase):
             + 0,
         )
         self.expectOutcome(result=SUCCESS, state_string='Uploaded archive to S3')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
     def test_failure(self):
@@ -4773,7 +4773,7 @@ exit 1''')
             + 2,
         )
         self.expectOutcome(result=FAILURE, state_string='Failed to upload archive to S3. Please inform an admin.')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
     def test_skipped(self):
@@ -6541,7 +6541,7 @@ class TestPushCommitToWebKitRepo(BuildStepMixinAdditions, unittest.TestCase):
             0,
         )
         self.expectOutcome(result=SUCCESS, state_string='')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             rc = self.runStep()
         self.assertEqual(self.getProperty('landed_hash'), 'b94dc426b331')
         return rc
@@ -6561,7 +6561,7 @@ class TestPushCommitToWebKitRepo(BuildStepMixinAdditions, unittest.TestCase):
             2,
         )
         self.expectOutcome(result=FAILURE, state_string='Failed to push commit to Webkit repository')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             rc = self.runStep()
         self.assertEqual(self.getProperty('retry_count'), 1)
         self.assertEqual(self.getProperty('landed_hash'), None)
@@ -6582,7 +6582,7 @@ class TestPushCommitToWebKitRepo(BuildStepMixinAdditions, unittest.TestCase):
             2,
         )
         self.expectOutcome(result=FAILURE, state_string='Failed to push commit to Webkit repository')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             rc = self.runStep()
         self.assertEqual(self.getProperty('build_finish_summary'), 'Failed to commit to WebKit repository')
         self.assertEqual(self.getProperty('comment_text'), 'commit-queue failed to commit attachment 2345 to WebKit repository. To retry, please set cq+ flag again.')
@@ -6603,7 +6603,7 @@ class TestPushCommitToWebKitRepo(BuildStepMixinAdditions, unittest.TestCase):
             2,
         )
         self.expectOutcome(result=FAILURE, state_string='Failed to push commit to Webkit repository')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             rc = self.runStep()
         self.assertEqual(self.getProperty('build_finish_summary'), 'Failed to commit to WebKit repository')
         self.assertEqual(self.getProperty('comment_text'), 'merge-queue failed to commit PR to repository. To retry, remove any blocking labels and re-apply merge-queue label')
@@ -6712,7 +6712,7 @@ class TestDetermineLandedIdentifier(BuildStepMixinAdditions, unittest.TestCase):
                 0,
             )
             self.expectOutcome(result=SUCCESS, state_string='Identifier: 220797@main')
-            with current_hostname(EWS_BUILD_HOSTNAME):
+            with current_hostname(EWS_BUILD_HOSTNAMES[0]):
                 yield self.runStep()
 
         self.assertEqual(self.getProperty('comment_text'), 'Committed 220797@main (14dbf1155cf5): <https://commits.webkit.org/220797@main>\n\nReviewed commits have been landed. Closing PR #1234 and removing active labels.')
@@ -6734,7 +6734,7 @@ class TestDetermineLandedIdentifier(BuildStepMixinAdditions, unittest.TestCase):
                 0,
             )
             self.expectOutcome(result=SUCCESS, state_string='Identifier: 249903@main')
-            with current_hostname(EWS_BUILD_HOSTNAME):
+            with current_hostname(EWS_BUILD_HOSTNAMES[0]):
                 yield self.runStep()
 
         self.assertEqual(self.getProperty('comment_text'), 'Test gardening commit 249903@main (5dc27962b4c5): <https://commits.webkit.org/249903@main>\n\nReviewed commits have been landed. Closing PR #1234 and removing active labels.')
@@ -6755,7 +6755,7 @@ class TestDetermineLandedIdentifier(BuildStepMixinAdditions, unittest.TestCase):
                 1,
             )
             self.expectOutcome(result=SUCCESS, state_string='Identifier: 220797@main')
-            with current_hostname(EWS_BUILD_HOSTNAME):
+            with current_hostname(EWS_BUILD_HOSTNAMES[0]):
                 yield self.runStep()
 
         self.assertEqual(self.getProperty('comment_text'), 'Committed 220797@main (5dc27962b4c5): <https://commits.webkit.org/220797@main>\n\nReviewed commits have been landed. Closing PR #1234 and removing active labels.')
@@ -6776,7 +6776,7 @@ class TestDetermineLandedIdentifier(BuildStepMixinAdditions, unittest.TestCase):
                 1,
             )
             self.expectOutcome(result=FAILURE, state_string='Failed to determine identifier')
-            with current_hostname(EWS_BUILD_HOSTNAME):
+            with current_hostname(EWS_BUILD_HOSTNAMES[0]):
                 yield self.runStep()
 
         self.assertEqual(self.getProperty('comment_text'), 'Committed ? (5dc27962b4c5): <https://commits.webkit.org/5dc27962b4c5>\n\nReviewed commits have been landed. Closing PR #1234 and removing active labels.')
@@ -6797,7 +6797,7 @@ class TestDetermineLandedIdentifier(BuildStepMixinAdditions, unittest.TestCase):
                 1,
             )
             self.expectOutcome(result=SUCCESS, state_string='Identifier: 220797@main')
-            with current_hostname(EWS_BUILD_HOSTNAME):
+            with current_hostname(EWS_BUILD_HOSTNAMES[0]):
                 yield self.runStep()
 
         self.assertEqual(self.getProperty('comment_text'), 'Committed 220797@main (5dc27962b4c5): <https://commits.webkit.org/220797@main>\n\nAll reviewed patches have been landed. Closing bug and clearing flags on attachment 1234.')
@@ -6818,7 +6818,7 @@ class TestDetermineLandedIdentifier(BuildStepMixinAdditions, unittest.TestCase):
                 1,
             )
             self.expectOutcome(result=FAILURE, state_string='Failed to determine identifier')
-            with current_hostname(EWS_BUILD_HOSTNAME):
+            with current_hostname(EWS_BUILD_HOSTNAMES[0]):
                 yield self.runStep()
 
         self.assertEqual(self.getProperty('comment_text'), 'Committed ? (5dc27962b4c5): <https://commits.webkit.org/5dc27962b4c5>\n\nAll reviewed patches have been landed. Closing bug and clearing flags on attachment 1234.')
@@ -8307,7 +8307,7 @@ class TestPushPullRequestBranch(BuildStepMixinAdditions, unittest.TestCase):
             + ExpectShell.log('stdio', stdout='To https://github.com/Contributor/WebKit.git\n37b7da95723b...9e2cb83b07b6 eng/pull-request-branch -> eng/pull-request-branch (forced update)\n'),
         )
         self.expectOutcome(result=SUCCESS, state_string='Pushed to pull request branch')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
     def test_failure(self):
@@ -8326,7 +8326,7 @@ class TestPushPullRequestBranch(BuildStepMixinAdditions, unittest.TestCase):
             + ExpectShell.log('stdio', stdout="fatal: could not read Username for 'https://github.com': Device not configured\n"),
         )
         self.expectOutcome(result=FAILURE, state_string='Failed to push to pull request branch')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
 
@@ -8404,7 +8404,7 @@ Date:   Tue Mar 29 16:04:35 2022 -0700
 '''),
         )
         self.expectOutcome(result=SUCCESS, state_string='Updated pull request')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             rc = self.runStep()
             self.assertEqual(self.getProperty('bug_id'), '238553')
             self.assertEqual(self.getProperty('is_test_gardening'), False)
@@ -8463,7 +8463,7 @@ Date:   Thu Apr 21 00:25:03 2022 +0000
 '''),
         )
         self.expectOutcome(result=SUCCESS, state_string='Updated pull request')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             rc = yield self.runStep()
             self.assertEqual(self.getProperty('bug_id'), '239577')
             self.assertEqual(self.getProperty('is_test_gardening'), True)
@@ -8505,7 +8505,7 @@ Date:   Tue Mar 29 16:04:35 2022 -0700
 '''),
         )
         self.expectOutcome(result=FAILURE, state_string='Failed to update pull request')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             rc = yield self.runStep()
             self.assertEqual(self.getProperty('bug_id'), '238553')
             self.assertEqual(self.getProperty('is_test_gardening'), False)
@@ -8664,7 +8664,7 @@ Date:   Tue Mar 29 16:04:35 2023 -0700
 '''),
         )
         self.expectOutcome(result=SUCCESS, state_string='Updated pull request')
-        with current_hostname(EWS_BUILD_HOSTNAME):
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             rc = self.runStep()
             self.assertEqual(self.getProperty('bug_id'), '248615')
             self.assertEqual(self.getProperty('is_test_gardening'), False)


### PR DESCRIPTION
#### 4d11473e60a2a083c8e0be6b5f088c004e3f900f
<pre>
[ews-build.webkit.org] Use UAT S3 bucket on UAT EWS instance
<a href="https://bugs.webkit.org/show_bug.cgi?id=268663">https://bugs.webkit.org/show_bug.cgi?id=268663</a>
<a href="https://rdar.apple.com/122207451">rdar://122207451</a>

Reviewed by Aakash Jain.

* Tools/CISupport/Shared/generate-s3-url: Include instance suffix in S3 bucket.
* Tools/CISupport/build-webkit-org/steps.py:
(DownloadBuiltProduct): Parameterize S3 bucket.
* Tools/CISupport/ews-build/steps.py:
(SetCommitQueueMinusFlagOnPatch.run): Allow for multiple production hostnames.
(BlockPullRequest.run): Ditto.
(RemoveLabelsFromPullRequest.doStepIf): Ditto.
(LeaveComment.doStepIf): Ditto.
(CompileWebKit.evaluateCommand): Upload to S3 on the UAT instance.
(UploadFileToS3.doStepIf): Do step on the UAT instance.
(GenerateS3URL.doStepIf): Ditto.
(TransferToS3.doStepIf): Ditto.
(DownloadBuiltProduct): Parameterize S3 bucket.
(DownloadBuiltProduct.start): Download via S3 on UAT instance.
(PushCommitToWebKitRepo.doStepIf): Allow for multiple production hostnames.
(PushPullRequestBranch.doStepIf): Ditto.
(UpdatePullRequest.doStepIf): Ditto.
* Tools/CISupport/ews-build/steps_unittest.py: Handle multiple production hostnames.

Canonical link: <a href="https://commits.webkit.org/274105@main">https://commits.webkit.org/274105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b94c3106466bb45ec11c80982ea878c7318d7b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37904 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40447 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14112 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38476 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/14171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12361 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/33888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41719 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/34397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/12903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36364 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/37949 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4918 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->