### PR TITLE
[UnifiedPDF] Add support for scaling to "Actual Size"

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h
@@ -406,6 +406,8 @@ CGError CGSRegisterNotifyProc(CGSNotifyProcPtr, CGSNotificationType, void* arg);
 size_t CGDisplayModeGetPixelsWide(CGDisplayModeRef);
 size_t CGDisplayModeGetPixelsHigh(CGDisplayModeRef);
 
+CGSize CGDisplayScreenSize(CGDirectDisplayID);
+
 typedef int32_t CGSDisplayID;
 CGSDisplayID CGSMainDisplayID(void);
 

--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -106,7 +106,7 @@ struct ScreenData;
 WEBCORE_EXPORT ScreenProperties collectScreenProperties();
 WEBCORE_EXPORT void setScreenProperties(const ScreenProperties&);
 const ScreenProperties& getScreenProperties();
-const ScreenData* screenData(PlatformDisplayID screendisplayID);
+WEBCORE_EXPORT const ScreenData* screenData(PlatformDisplayID screendisplayID);
 WEBCORE_EXPORT PlatformDisplayID primaryScreenDisplayID();
     
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -45,10 +45,12 @@ struct ScreenData {
     bool screenHasInvertedColors { false };
     bool screenSupportsHighDynamicRange { false };
 #if PLATFORM(MAC)
+    FloatSize screenSize; // In millimeters.
     bool screenIsMonochrome { false };
     uint32_t displayMask { 0 };
     PlatformGPUID gpuID { 0 };
     DynamicRangeMode preferredDynamicRangeMode { DynamicRangeMode::Standard };
+    WEBCORE_EXPORT double screenDPI() const;
 #endif
 #if PLATFORM(GTK)
     IntSize screenSize; // In millimeters.

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -166,6 +166,7 @@ ScreenProperties collectScreenProperties()
         if (screenData.displayMask)
             screenData.gpuID = gpuIDForDisplayMask(screenData.displayMask);
 
+        screenData.screenSize = FloatSize { CGDisplayScreenSize(displayID) };
         screenData.scaleFactor = screen.backingScaleFactor;
         screenData.screenSupportsHighDynamicRange = screenSupportsHighDynamicRange(displayID, screenData.preferredDynamicRangeMode);
 
@@ -436,6 +437,12 @@ FloatRect safeScreenFrame(NSScreen* screen)
     return frame;
 }
 
+double ScreenData::screenDPI() const
+{
+    constexpr double mmPerInch = 25.4;
+    auto screenWidthInches = screenSize.width() / mmPerInch;
+    return screenRect.width() / screenWidthInches;
+}
 
 } // namespace WebCore
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2235,6 +2235,7 @@ header: <WebCore/ScreenProperties.h>
     bool screenHasInvertedColors;
     bool screenSupportsHighDynamicRange;
 #if PLATFORM(MAC)
+    WebCore::FloatSize screenSize;
     bool screenIsMonochrome;
     uint32_t displayMask;
     WebCore::PlatformGPUID gpuID;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -70,6 +70,7 @@ public:
     void focusPreviousAnnotation() final;
 
     void attemptToUnlockPDF(const String& password) final;
+
 private:
     explicit UnifiedPDFPlugin(WebCore::HTMLPlugInElement&);
     bool isUnifiedPDFPlugin() const override { return true; }
@@ -80,6 +81,8 @@ private:
     void teardown() override;
 
     void installPDFDocument() override;
+
+    float scaleForActualSize() const;
 
     CGFloat scaleFactor() const override;
     CGSize contentSizeRespectingZoom() const final;


### PR DESCRIPTION
#### 36b3983cdb3ffbf14af36378f00937c7f1ec92aa
<pre>
[UnifiedPDF] Add support for scaling to &quot;Actual Size&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=268665">https://bugs.webkit.org/show_bug.cgi?id=268665</a>
<a href="https://rdar.apple.com/122208262">rdar://122208262</a>

Reviewed by Tim Horton.

Make it possible to display a PDF at &quot;Actual Size&quot;, which results in the UnifiedPDFPlugin
choosing a scale that makes the PDF page size match physical screen inches.

To do this we need the screen DPI plumbed through from ScreenData (this will be
read in the UI Process, and fed to the Web Process via ScreenProperties).

Then we read the size of the first PDF page in points, convert to inches using the fixed
72DPI resolution that PDFs assume, and then scale via screenDPI.

* Source/WebCore/PAL/pal/spi/cg/CoreGraphicsSPI.h:
* Source/WebCore/platform/PlatformScreen.h:
* Source/WebCore/platform/ScreenProperties.h:
* Source/WebCore/platform/mac/PlatformScreenMac.mm:
(WebCore::collectScreenProperties):
(WebCore::ScreenData::screenDPI const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::scaleForActualSize const):
(WebKit::UnifiedPDFPlugin::performContextMenuAction):

Canonical link: <a href="https://commits.webkit.org/274039@main">https://commits.webkit.org/274039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e33861b280d7830fbf5cf3a6ebb0ec04bbc8fcc0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40146 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33489 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38933 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31874 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38180 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13891 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12128 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12071 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41407 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33986 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34063 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37967 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12652 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10189 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36135 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14088 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8474 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13052 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->