### PR TITLE
[WebGPU] RemotePresentationContext::getCurrentTexture does not handle when getCurrentTexture() returns nullptr

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
@@ -72,6 +72,9 @@ void RemotePresentationContext::unconfigure()
 void RemotePresentationContext::getCurrentTexture(WebGPUIdentifier identifier)
 {
     auto texture = m_backing->getCurrentTexture();
+    if (!texture)
+        return;
+
     // We're creating a new resource here, because we don't want the GetCurrentTexture message to be sync.
     // If the message is async, then the WebGPUIdentifier goes from the Web process to the GPU Process, which
     // means the Web Process is going to proceed and interact with the texture as-if it has this identifier.
@@ -80,7 +83,6 @@ void RemotePresentationContext::getCurrentTexture(WebGPUIdentifier identifier)
     // but for now let's just create a new RemoteTexture object with the expected identifier, just for simplicity.
     // The Web Process should already be caching these current textures internally, so it's unlikely that we'll
     // actually run into a problem here.
-    // FIXME: Handle the situation where texture is nullptr.
     auto remoteTexture = RemoteTexture::create(*texture, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap.addObject(identifier, remoteTexture);
 }


### PR DESCRIPTION
#### 8c986e80a9f1cb83e4a58ed27f9ba14e2848d631
<pre>
[WebGPU] RemotePresentationContext::getCurrentTexture does not handle when getCurrentTexture() returns nullptr
<a href="https://bugs.webkit.org/show_bug.cgi?id=268664">https://bugs.webkit.org/show_bug.cgi?id=268664</a>
&lt;radar://122173189&gt;

Reviewed by Tadeu Zagallo.

If getCurrentTexture return null, we shouldn&apos;t dereference it.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp:
(WebKit::RemotePresentationContext::getCurrentTexture):

Canonical link: <a href="https://commits.webkit.org/274231@main">https://commits.webkit.org/274231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf814735369e0a922f71d4bdc94ec984035c6b9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40147 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33490 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31870 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/32954 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12121 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12066 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41408 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/33979 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37963 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36138 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14089 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8628 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13053 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->