### PR TITLE
[ews-build.webkit.org] Provide links to S3 uploads

### DIFF
--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -4621,11 +4621,8 @@ class TestGenerateS3URL(BuildStepMixinAdditions, unittest.TestCase):
     def tearDown(self):
         return self.tearDownBuildStep()
 
-    def configureStep(self):
-        self.setupStep(GenerateS3URL())
-        self.setProperty('fullPlatform', 'mac-highsierra')
-        self.setProperty('configuration', 'release')
-        self.setProperty('architecture', 'x86_64')
+    def configureStep(self, identifier='mac-highsierra-x86_64-release'):
+        self.setupStep(GenerateS3URL(identifier))
         self.setProperty('change_id', '1234')
 
     def disabled_test_success(self):
@@ -4644,9 +4641,7 @@ class TestGenerateS3URL(BuildStepMixinAdditions, unittest.TestCase):
             return self.runStep()
 
     def test_failure(self):
-        self.configureStep()
-        self.setProperty('fullPlatform', 'ios-simulator-16')
-        self.setProperty('configuration', 'debug')
+        self.configureStep('ios-simulator-16-x86_64-debug')
         self.expectLocalCommands(
             ExpectMasterShellCommand(command=['python3',
                                               '../Shared/generate-s3-url',
@@ -4737,9 +4732,8 @@ class TestUploadFileToS3(BuildStepMixinAdditions, unittest.TestCase):
         return self.tearDownBuildStep()
 
     def configureStep(self):
-        self.setupStep(UploadFileToS3())
+        self.setupStep(UploadFileToS3('WebKitBuild/release.zip'))
         self.build.s3url = 'https://test-s3-url'
-        self.setProperty('configuration', 'release')
 
     def test_success(self):
         self.configureStep()


### PR DESCRIPTION
#### b3b7144bd152111660f81e9aecb76b0a4a8642ab
<pre>
[ews-build.webkit.org] Provide links to S3 uploads
<a href="https://bugs.webkit.org/show_bug.cgi?id=268666">https://bugs.webkit.org/show_bug.cgi?id=268666</a>
<a href="https://rdar.apple.com/122208350">rdar://122208350</a>

Reviewed by Aakash Jain.

Have UploadFileToS3 annotate a previous step with a link to the uploaded archive.

* Tools/CISupport/ews-build/steps.py:
(CompileWebKit.evaluateCommand): Pass link information to UploadFileToS3.
(UploadFileToS3.__init__): Parameterize file path and link construction.
(UploadFileToS3.getLastBuildStepByName):
(UploadFileToS3.run): If upload is successful, extract archive link written by GenerateS3URL
and add a link to a previous step.
(GenerateS3URL.__init__): Parmeterize S3 identifier.
(GenerateS3URL.run): Compute URL of uploaded archive and save for GenerateS3URL.
* Tools/CISupport/ews-build/steps_unittest.py:
(TestGenerateS3URL.configureStep):
(TestGenerateS3URL.test_failure):
(TestUploadFileToS3.configureStep):

Canonical link: <a href="https://commits.webkit.org/274111@main">https://commits.webkit.org/274111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81cb029c24311efe1d25acd169d81de9a0b7660a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40466 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33742 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39253 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14132 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32064 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38495 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14178 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12374 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12333 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33908 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41738 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34404 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38197 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12916 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36377 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/37968 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4920 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->