### PR TITLE
[UnifiedPDF] Refactor annotation tracking logic into its own class.

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -41,6 +41,18 @@ namespace WebKit {
 struct PDFContextMenu;
 class WebFrame;
 class WebMouseEvent;
+enum class WebEventType : uint8_t;
+enum class WebMouseEventButton : int8_t;
+
+class AnnotationTrackingState {
+public:
+    void startAnnotationTracking(RetainPtr<PDFAnnotation>&&, const WebEventType&, const WebMouseEventButton&);
+    void finishAnnotationTracking(const WebEventType&, const WebMouseEventButton&);
+    const PDFAnnotation* trackedAnnotation() const { return m_trackedAnnotation.get(); }
+private:
+    void handleMouseDraggedOffTrackedAnnotation();
+    RetainPtr<PDFAnnotation> m_trackedAnnotation;
+};
 
 enum class WebEventModifier : uint8_t;
 
@@ -63,9 +75,6 @@ public:
 
     CGRect pluginBoundsForAnnotation(RetainPtr<PDFAnnotation>&) const final;
     void setActiveAnnotation(RetainPtr<PDFAnnotation>&&) final;
-    void startAnnotationTracking(RetainPtr<PDFAnnotation>&&);
-    void finishAnnotationTracking();
-    void handleMouseDraggedOffTrackedAnnotation();
     void focusNextAnnotation() final;
     void focusPreviousAnnotation() final;
 
@@ -267,7 +276,7 @@ private:
     float m_scaleFactor { 1 };
     bool m_inMagnificationGesture { false };
 
-    RetainPtr<PDFAnnotation> m_trackedAnnotation;
+    AnnotationTrackingState m_annotationTrackingState;
 
     struct SelectionTrackingData {
         bool shouldExtendCurrentSelection { false };


### PR DESCRIPTION
#### 81962dc8143b9e02da51e61edd07e9c8761454ad
<pre>
[UnifiedPDF] Refactor annotation tracking logic into its own class.
<a href="https://bugs.webkit.org/show_bug.cgi?id=268670">https://bugs.webkit.org/show_bug.cgi?id=268670</a>
<a href="https://rdar.apple.com/problem/122211531">rdar://problem/122211531</a>

Reviewed by Simon Fraser and Tim Horton.

Instead of haphazardly modifying and keeping track of the logic needed
to track annotations through mouse events, we can refactor this logic
into its own class and make the rest of the UnifiedPDFPlugin logic
simpler. Whenever we need to actually modify any annotation tracking
state, the calling code will do so by using startAnnotationTracking or
finishAnnotationTracking. The state will be modified by taking into
consideration the type of annotation, the mouse event type, and mouse
event button.

The annotation that is being tracked can be accessed via
trackedAnnotation(). If any other state needs to be kept and queried
in the future (e.g. state that helps know if annotation is being
hovered that I plan on adding), it can be done by adding extra fields
to this class.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
(WebKit::AnnotationTrackingState::trackedAnnotation const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::handleMouseEvent):
(WebKit::AnnotationTrackingState::startAnnotationTracking):
(WebKit::AnnotationTrackingState::finishAnnotationTracking):
(WebKit::AnnotationTrackingState::handleMouseDraggedOffTrackedAnnotation):
(WebKit::UnifiedPDFPlugin::startAnnotationTracking): Deleted.
(WebKit::UnifiedPDFPlugin::finishAnnotationTracking): Deleted.
(WebKit::UnifiedPDFPlugin::handleMouseDraggedOffTrackedAnnotation): Deleted.

Canonical link: <a href="https://commits.webkit.org/274095@main">https://commits.webkit.org/274095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5c0c438ea92e0921eed236667ede5f8129afb51

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16734 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40369 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33654 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32004 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12307 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12255 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41629 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34298 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34297 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38128 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36307 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14340 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8502 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13250 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->