### PR TITLE
[iOS 17.4] Blink crashes on launch due to an unrecognized selector on WKExtendedTextInputTraits

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h
+++ b/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h
@@ -41,7 +41,9 @@
 @property (nonatomic) UITextSpellCheckingType spellCheckingType;
 @property (nonatomic) UITextSmartQuotesType smartQuotesType;
 @property (nonatomic) UITextSmartDashesType smartDashesType;
+#if HAVE(INLINE_PREDICTIONS)
 @property (nonatomic) UITextInlinePredictionType inlinePredictionType;
+#endif
 @property (nonatomic) UIKeyboardType keyboardType;
 @property (nonatomic) UIKeyboardAppearance keyboardAppearance;
 @property (nonatomic) UIReturnKeyType returnKeyType;
@@ -53,6 +55,9 @@
 @property (nonatomic) BOOL typingAdaptationDisabled;
 #endif
 @property (nonatomic, copy) UITextContentType textContentType;
+@property (nonatomic, copy) UITextInputPasswordRules *passwordRules;
+@property (nonatomic) UITextSmartInsertDeleteType smartInsertDeleteType;
+@property (nonatomic) BOOL enablesReturnKeyAutomatically;
 
 @property (nonatomic, strong) UIColor *insertionPointColor;
 #if USE(BROWSERENGINEKIT)

--- a/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm
+++ b/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm
@@ -35,6 +35,29 @@
     RetainPtr<UIColor> _insertionPointColor;
     RetainPtr<UIColor> _selectionHandleColor;
     RetainPtr<UIColor> _selectionHighlightColor;
+    RetainPtr<UITextInputPasswordRules> _passwordRules;
+}
+
+- (instancetype)init
+{
+    if (!(self = [super init]))
+        return nil;
+
+#if USE(BROWSERENGINEKIT)
+    self.typingAdaptationEnabled = YES;
+#endif
+    self.autocapitalizationType = UITextAutocapitalizationTypeSentences;
+    return self;
+}
+
+- (void)setPasswordRules:(UITextInputPasswordRules *)rules
+{
+    _passwordRules = adoptNS(rules.copy);
+}
+
+- (UITextInputPasswordRules *)passwordRules
+{
+    return adoptNS([_passwordRules copy]).autorelease();
 }
 
 - (void)setTextContentType:(UITextContentType)type
@@ -44,7 +67,7 @@
 
 - (UITextContentType)textContentType
 {
-    return _textContentType.get();
+    return adoptNS([_textContentType copy]).autorelease();
 }
 
 - (void)setInsertionPointColor:(UIColor *)color

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -1335,6 +1335,32 @@ TEST(KeyboardInputTests, DeviceEIDAndIMEIAutoFill)
 
 #endif // HAVE(ESIM_AUTOFILL_SYSTEM_SUPPORT)
 
+TEST(KeyboardInputTests, ImplementAllOptionalTextInputTraits)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400)]);
+    auto traits = [webView effectiveTextInputTraits];
+    EXPECT_EQ(traits.autocapitalizationType, UITextAutocapitalizationTypeSentences);
+    EXPECT_EQ(traits.spellCheckingType, UITextSpellCheckingTypeDefault);
+    EXPECT_EQ(traits.smartQuotesType, UITextSmartQuotesTypeDefault);
+    EXPECT_EQ(traits.smartDashesType, UITextSmartDashesTypeDefault);
+    EXPECT_EQ(traits.smartInsertDeleteType, UITextSmartInsertDeleteTypeDefault);
+    EXPECT_EQ(traits.keyboardType, UIKeyboardTypeDefault);
+    EXPECT_EQ(traits.keyboardAppearance, UIKeyboardAppearanceDefault);
+    EXPECT_EQ(traits.returnKeyType, UIReturnKeyDefault);
+    EXPECT_FALSE(traits.enablesReturnKeyAutomatically);
+    EXPECT_FALSE(traits.secureTextEntry);
+    EXPECT_NULL(traits.textContentType);
+    EXPECT_NULL(traits.passwordRules);
+#if USE(BROWSERENGINEKIT)
+    auto extendedTraits = [webView extendedTextInputTraits];
+    EXPECT_FALSE(extendedTraits.singleLineDocument);
+    EXPECT_TRUE(extendedTraits.typingAdaptationEnabled);
+    EXPECT_NULL(extendedTraits.insertionPointColor);
+    EXPECT_NULL(extendedTraits.selectionHandleColor);
+    EXPECT_NULL(extendedTraits.selectionHighlightColor);
+#endif
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 674f7d1c60a7a5d386ffb4fc8e40621ecd5e0dc4
<pre>
[iOS 17.4] Blink crashes on launch due to an unrecognized selector on WKExtendedTextInputTraits
<a href="https://bugs.webkit.org/show_bug.cgi?id=268667">https://bugs.webkit.org/show_bug.cgi?id=268667</a>
<a href="https://rdar.apple.com/122025854">rdar://122025854</a>

Reviewed by Tim Horton.

Maintain binary compatibility with third party apps that reach into `WKContentView`&apos;s internal text
input traits object, and expect it to implement all the API methods on `UITextInputTraits`. This was
previously the case when async text input was disabled, because the internal text input traits would
be a concrete `UITextInputTraits` instance which implements all of the optional properties (as well
as all the properties on `UITextInputTraits_Private`).

We lost this when implementing our own `WKExtendedTextInputTraits` that implements the new
`BEExtendedTextInputTraits` protocol from BrowserEngineKit, since this new class only implements
the properties that we internally set in WebKit, along with the new extended traits.

We should instead ensure binary compatibility when using `WKExtendedTextInputTraits` by (at least)
implementing all of the optional properties on `UITextInputTraits` and `WKExtendedTextInputTraits`,
and ensuring that they have default values that mostly* match the default values described in
`&lt;UIKit/UITextInputTraits.h&gt;`.

Test: KeyboardInputTests.ImplementAllOptionalTextInputTraits

* Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h:
* Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm:
(-[WKExtendedTextInputTraits init]):
(-[WKExtendedTextInputTraits setPasswordRules:]):
(-[WKExtendedTextInputTraits passwordRules]):
(-[WKExtendedTextInputTraits textContentType]):
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:

Add a test that sanity checks all public properties on our text input traits and verifies that the
default values are consistent with UIKit/BrowserEngineKit documentation.

*   Note that this test intentionally leaves out `inlinePredictionType` and `autocorrectionType`,
    since those both have default values in WebKit that are `no`. It&apos;s unclear if this is
    intentional, but I&apos;m leaving this behavior intact for now.

Canonical link: <a href="https://commits.webkit.org/274035@main">https://commits.webkit.org/274035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/241cb4608900a9977f8bdc5293b6945a58bcdf9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40170 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33507 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/38958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13681 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38205 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/32971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12146 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41431 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/37978 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12670 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36147 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8470 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13070 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->