### PR TITLE
[UnifiedPDF] Text annotations do not have blue background on hover

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -51,9 +51,12 @@ public:
     void startAnnotationTracking(RetainPtr<PDFAnnotation>&&, const WebEventType&, const WebMouseEventButton&);
     void finishAnnotationTracking(const WebEventType&, const WebMouseEventButton&);
     const PDFAnnotation *trackedAnnotation() const { return m_trackedAnnotation.get(); }
+    bool isBeingHovered() const;
 private:
     void handleMouseDraggedOffTrackedAnnotation();
+    void resetAnnotationTrackingState();
     RetainPtr<PDFAnnotation> m_trackedAnnotation;
+    bool m_isBeingHovered { false };
 };
 
 enum class WebEventModifier : uint8_t;
@@ -211,6 +214,7 @@ private:
     bool layerNeedsPlatformContext(const WebCore::GraphicsLayer*) const override { return true; }
 
     void paintPDFContent(WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect);
+    void paintPDFOverlays(WebCore::GraphicsContext&);
     void ensureLayers();
     void updateLayerHierarchy();
 


### PR DESCRIPTION
#### 8147bb3d60a35215dcb9493678a34f1673f9329d
<pre>
[UnifiedPDF] Text annotations do not have blue background on hover
<a href="https://bugs.webkit.org/show_bug.cgi?id=268497">https://bugs.webkit.org/show_bug.cgi?id=268497</a>
<a href="https://rdar.apple.com/problem/122041412">rdar://problem/122041412</a>

Reviewed by Tim Horton.

In order to display the blue rectangle that appears when a mouse cursor
is over a text annotation we must first start keeping track of that
in AnnotationTrackingState. We can simply add a new field there that
keepts track of this and can be queried later on when we need to check
if we need to paint it over the text annotation field.

startAnnotationTracking will set this field if the mouse event type
is a mouse move and no mouse button was pressed. This bit will get
reset when the client determines the mouse has moved off the text
annotation and calls finishAnnotationTracking().

If the mouse cursor is hovering over a text annotation and the left
mouse button is clicked to bring up the HTML input, then the blue
rectangle should still appear after the text has been inputted and if
the cursor did not move off the annotation. If the cursor moves off
the annotation then the blue rectangle should not appear the text has
been inputted even if it is brought back on top of the cursor while the
HTML input is up.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
(WebKit::AnnotationTrackingState::trackedAnnotation const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::paintPDFContent):
(WebKit::textAnnotationHoverColor):
(WebKit::UnifiedPDFPlugin::paintPDFOverlays):
(WebKit::UnifiedPDFPlugin::handleMouseEvent):
(WebKit::AnnotationTrackingState::startAnnotationTracking):
(WebKit::AnnotationTrackingState::finishAnnotationTracking):
(WebKit::AnnotationTrackingState::handleMouseDraggedOffTrackedAnnotation):
(WebKit::AnnotationTrackingState::isBeingHovered const):
(WebKit::AnnotationTrackingState::resetAnnotationTrackingState):

Canonical link: <a href="https://commits.webkit.org/274272@main">https://commits.webkit.org/274272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1ecb4aa780db4156d9e351c613a57df18056afc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41048 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34192 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14786 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32382 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12763 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42324 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34973 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38585 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11040 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36789 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14955 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8644 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14427 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->