### PR TITLE
Unreviewed, fix the internal iOS build after 274016@main

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/BrowserEngineKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/BrowserEngineKitSPI.h
@@ -33,11 +33,7 @@
 // Note: SPI usage should be limited to testing purposes and binary compatibility with clients
 // of existing WebKit SPI.
 #import <BrowserEngineKit/BrowserEngineKit_Private.h>
-#endif
-
-@interface BEKeyEntry (Staging_121227027)
-@property (nonatomic, readonly) BEKeyPressState state;
-@end
+#else
 
 @class NSTextAlternatives;
 @class UIKeyEvent;
@@ -67,6 +63,12 @@
 @interface BETextSuggestion ()
 @property (nonatomic, readonly, strong) UITextSuggestion *_uikitTextSuggestion;
 - (instancetype)_initWithUIKitTextSuggestion:(UITextSuggestion *)suggestion;
+@end
+
+#endif
+
+@interface BEKeyEntry (Staging_121227027)
+@property (nonatomic, readonly) BEKeyPressState state;
 @end
 
 #endif // USE(BROWSERENGINEKIT)

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -494,11 +494,15 @@ typedef enum {
 - (UIEventButtonMask)_buttonMask;
 @end
 
+@interface UIKeyEvent : NSObject
+- (instancetype)initWithWebEvent:(WebEvent *)webEvent;
+@end
+
 #endif // USE(APPLE_INTERNAL_SDK)
 
-@class UITextInputArrowKeyHistory;
-
 // Start of UIKit IPI
+
+@class UITextInputArrowKeyHistory;
 
 @interface UITextAutofillSuggestion ()
 + (instancetype)autofillSuggestionWithUsername:(NSString *)username password:(NSString *)password;
@@ -615,11 +619,6 @@ typedef NS_ENUM(NSInteger, NSTextBlockLayer) {
 #endif
 
 #if USE(BROWSERENGINEKIT)
-@interface UIKeyEvent : NSObject
-- (instancetype)initWithWebEvent:(WebEvent *)webEvent;
-@property (nonatomic, readonly) WebEvent *webEvent;
-@end
-
 // FIXME: Replace this with BEResponderEditActions once that's in the SDK.
 @interface UIResponder (Staging_121208689)
 - (void)addShortcut:(id)sender;
@@ -653,6 +652,10 @@ typedef NS_ENUM(NSInteger, NSTextBlockLayer) {
 
 @interface UIApplication (IPI)
 - (UIPressInfo *)_pressInfoForPhysicalKeyboardEvent:(UIPhysicalKeyboardEvent *)physicalKeyboardEvent;
+@end
+
+@interface UIKeyEvent (IPI)
+@property (nonatomic, readonly) WebEvent *webEvent;
 @end
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 3a3309b6c196d58a1dcf568e67f936f7003702fb
<pre>
Unreviewed, fix the internal iOS build after 274016@main

Avoid redeclarations by only declaring BrowserEngineKit SPI methods and properties when using the
non-internal SDK.

* Source/WebCore/PAL/pal/spi/ios/BrowserEngineKitSPI.h:
* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:

Canonical link: <a href="https://commits.webkit.org/274034@main">https://commits.webkit.org/274034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b130841ed4ab0eefd4de75b2908e34381107fbda

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16574 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/39919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40221 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13735 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38250 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/13927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/39919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/12181 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/37673 "Build is in progress. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/39919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41480 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/34032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/39919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12704 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/36178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/39919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13093 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4886 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->