### PR TITLE
Add some tests for CFArrayRef serialization

### DIFF
--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
@@ -122,7 +122,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     // If you're hitting this, it probably means that you've put an NS type inside a CF container.
     // Try round-tripping the container through an NS type instead.
-    ASSERT_NOT_REACHED();
     return CFType::Unknown;
 }
 
@@ -190,8 +189,6 @@ void ArgumentCoder<CFTypeRef>::encode(Encoder& encoder, CFTypeRef typeRef)
     case CFType::Unknown:
         break;
     }
-
-    ASSERT_NOT_REACHED();
 }
 
 template void ArgumentCoder<CFTypeRef>::encode<Encoder>(Encoder&, CFTypeRef);
@@ -341,10 +338,9 @@ void ArgumentCoder<CFArrayRef>::encode(Encoder& encoder, CFArrayRef array)
 
     CFArrayGetValues(array, CFRangeMake(0, size), values.data());
 
-    HashSet<CFIndex> invalidIndices;
+    HashSet<CFIndex, WTF::IntHash<CFIndex>, WTF::UnsignedWithZeroKeyHashTraits<CFIndex>> invalidIndices;
     for (CFIndex i = 0; i < size; ++i) {
         // Ignore values we don't support.
-        ASSERT(typeFromCFTypeRef(values[i]) != CFType::Unknown);
         if (typeFromCFTypeRef(values[i]) == CFType::Unknown)
             invalidIndices.add(i);
     }
@@ -452,8 +448,6 @@ void ArgumentCoder<CFDictionaryRef>::encode(Encoder& encoder, CFDictionaryRef di
         ASSERT(values[i]);
 
         // Ignore keys/values we don't support.
-        ASSERT(typeFromCFTypeRef(keys[i]) != CFType::Unknown);
-        ASSERT(typeFromCFTypeRef(values[i]) != CFType::Unknown);
         if (typeFromCFTypeRef(keys[i]) == CFType::Unknown || typeFromCFTypeRef(values[i]) == CFType::Unknown)
             invalidKeys.add(keys[i]);
     }


### PR DESCRIPTION
#### f3054ac4d2cb5b6348a7612c2366c4ba539df389
<pre>
Add some tests for CFArrayRef serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=268681">https://bugs.webkit.org/show_bug.cgi?id=268681</a>

Reviewed by Brady Eidson.

Also make WebKit not assert when things that were previously untested happen.

* Source/WebKit/Shared/cf/ArgumentCodersCF.cpp:
(IPC::typeFromCFTypeRef):
(IPC::ArgumentCoder&lt;CFTypeRef&gt;::encode):
(IPC::ArgumentCoder&lt;CFArrayRef&gt;::encode):
(IPC::ArgumentCoder&lt;CFDictionaryRef&gt;::encode):
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(secTrustRefsEqual):
(cfHolder):
(operator==):
(operator!=):
(arraysEqual):
(TEST):
(compareSecTrustRefs): Deleted.

Canonical link: <a href="https://commits.webkit.org/274048@main">https://commits.webkit.org/274048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d50197c854ca914e8d2a7e96581828b274afb86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40256 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33556 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13805 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31916 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38283 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/13966 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12210 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12135 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41515 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34098 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38032 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10275 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36204 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14151 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13122 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4890 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13464 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->