### PR TITLE
A scroller whose parent doesn't rubber-band due to overflow:hidden or over scroll behavior should still rubber-band

### DIFF
--- a/LayoutTests/fast/scrolling/mac/rubberband-overflow-with-non-scrollable-root-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/rubberband-overflow-with-non-scrollable-root-expected.txt
@@ -1,0 +1,7 @@
+
+Pulling down in the overflow should rubberband it.
+PASS sawOverflowScrollWithNegativeOffset became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Contents

--- a/LayoutTests/fast/scrolling/mac/rubberband-overflow-with-non-scrollable-root.html
+++ b/LayoutTests/fast/scrolling/mac/rubberband-overflow-with-non-scrollable-root.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 2000px;
+            overflow: hidden;
+        }
+
+        .scroller {
+            height: 300px;
+            width: 300px;
+            border: 1px solid black;
+            padding: 5px;
+            overflow: scroll;
+        }
+        .content {
+            width: 200%;
+            height: 300%;
+        }
+        
+    </style>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        var jsTestIsAsync = true;
+
+        var scroller;
+        var sawOverflowScrollWithNegativeOffset = false;
+
+        async function resetScrollPositions()
+        {
+            scroller.scrollTop = 0;
+            
+            // Wait for scroll events to fire.
+            await UIHelper.renderingUpdate();
+
+            sawOverflowScrollWithNegativeOffset = false;
+        }
+        
+        async function doMouseWheelScroll()
+        {
+            eventSender.mouseMoveTo(150, 200);
+
+            // Pull down.
+            const wheelEventSquence = {
+                "events" : [
+                    {
+                        type : "wheel",
+                        viewX : 150,
+                        viewY : 200,
+                        deltaY : 1,
+                        phase : "began"
+                    },
+                    {
+                        type : "wheel",
+                        deltaY : 10,
+                        phase : "changed"
+                    },
+                    {
+                        type : "wheel",
+                        viewX : 201, // defeat coalescing
+                        deltaY : 10,
+                        phase : "changed"
+                    },
+                    {
+                        type : "wheel",
+                        phase : "ended"
+                    }
+                ]
+            };
+
+            await UIHelper.sendEventStream(wheelEventSquence);
+            await UIHelper.renderingUpdate();
+        }
+        
+        async function scrollTest()
+        {
+            debug('');
+            debug('Pulling down in the overflow should rubberband it.');
+            await resetScrollPositions();
+
+            await doMouseWheelScroll();
+
+            shouldBecomeEqual('sawOverflowScrollWithNegativeOffset', 'true', finishJSTest);
+        }
+
+        window.addEventListener('load', () => {
+            scroller = document.querySelector('.scroller');
+            scroller.addEventListener('scroll', () => {
+                if (scroller.scrollTop < 0)
+                    sawOverflowScrollWithNegativeOffset = true;
+            }, false);
+
+            setTimeout(scrollTest, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="content">Contents</div>
+    </div>
+    <script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/mac/rubberband-overflow-with-overscroll-none-parent-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/rubberband-overflow-with-overscroll-none-parent-expected.txt
@@ -1,0 +1,8 @@
+
+Pulling down in the overflow should rubberband it.
+PASS sawOverflowScrollWithNegativeOffset became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Contents
+

--- a/LayoutTests/fast/scrolling/mac/rubberband-overflow-with-overscroll-none-parent.html
+++ b/LayoutTests/fast/scrolling/mac/rubberband-overflow-with-overscroll-none-parent.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 2000px;
+        }
+
+        .scroller {
+            height: 400px;
+            width: 400px;
+            border: 1px solid black;
+            padding: 5px;
+            overflow: scroll;
+        }
+        
+        .outer.scroller {
+            overscroll-behavior: none;
+        }
+        
+        .scroller .scroller {
+            height: 300px;
+            width: 300px;
+            margin: 20px;
+        }
+
+        .content {
+            width: 200%;
+            height: 300%;
+        }
+        
+        .spacer {
+            width: 10px;
+            height: 100px;
+            background-color: silver;
+        }
+    </style>
+    <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        var jsTestIsAsync = true;
+
+        var scroller;
+        var sawOverflowScrollWithNegativeOffset = false;
+
+        async function resetScrollPositions()
+        {
+            scroller.scrollTop = 0;
+            
+            // Wait for scroll events to fire.
+            await UIHelper.renderingUpdate();
+
+            sawOverflowScrollWithNegativeOffset = false;
+        }
+        
+        async function doMouseWheelScroll()
+        {
+            eventSender.mouseMoveTo(200, 300);
+
+            // Pull down.
+            const wheelEventSquence = {
+                "events" : [
+                    {
+                        type : "wheel",
+                        viewX : 200,
+                        viewY : 300,
+                        deltaY : 1,
+                        phase : "began"
+                    },
+                    {
+                        type : "wheel",
+                        deltaY : 20,
+                        phase : "changed"
+                    },
+                    {
+                        type : "wheel",
+                        viewX : 201, // defeat coalescing
+                        deltaY : 30,
+                        phase : "changed"
+                    },
+                    {
+                        type : "wheel",
+                        phase : "ended"
+                    }
+                ]
+            };
+
+            await UIHelper.sendEventStream(wheelEventSquence);
+            await UIHelper.renderingUpdate();
+        }
+        
+        async function scrollTest()
+        {
+            debug('');
+            debug('Pulling down in the overflow should rubberband it.');
+            await resetScrollPositions();
+
+            await doMouseWheelScroll();
+
+            shouldBecomeEqual('sawOverflowScrollWithNegativeOffset', 'true', finishJSTest);
+        }
+
+        window.addEventListener('load', () => {
+            scroller = document.querySelector('.inner.scroller');
+            scroller.addEventListener('scroll', () => {
+                if (scroller.scrollTop < 0)
+                    sawOverflowScrollWithNegativeOffset = true;
+            }, false);
+
+            setTimeout(scrollTest, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="outer scroller">
+        <div class="spacer"></div>
+        <div class="inner scroller">
+            <div class="content">Contents</div>
+        </div>
+        <div class="spacer"></div>
+    </div>
+    <script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -548,6 +548,19 @@ void ScrollingTree::clearLatchedNode()
     m_latchingController.clearLatchedNode();
 }
 
+RefPtr<ScrollingTreeScrollingNode> ScrollingTree::enclosingScrollingNode(const ScrollingTreeNode& node) const
+{
+    RefPtr parentNode = node.parent();
+    while (parentNode) {
+        if (auto scrollingNode = dynamicDowncast<ScrollingTreeScrollingNode>(parentNode))
+            return scrollingNode;
+
+        parentNode = parentNode->parent();
+    }
+
+    return nullptr;
+}
+
 float ScrollingTree::mainFrameTopContentInset() const
 {
     Locker locker { m_treeStateLock };

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -181,6 +181,9 @@ public:
     std::optional<ScrollingNodeID> latchedNodeID() const;
     WEBCORE_EXPORT void clearLatchedNode();
 
+    // Excludes the argument node.
+    RefPtr<ScrollingTreeScrollingNode> enclosingScrollingNode(const ScrollingTreeNode&) const;
+
     bool hasFixedOrSticky() const { return !!m_fixedOrStickyNodeCount; }
     void fixedOrStickyNodeAdded() { ++m_fixedOrStickyNodeCount; }
     void fixedOrStickyNodeRemoved()

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -135,14 +135,53 @@ bool ScrollingTreeScrollingNode::isLatchedNode() const
     return scrollingTree().latchedNodeID() == scrollingNodeID();
 }
 
-bool ScrollingTreeScrollingNode::shouldRubberBand(const PlatformWheelEvent& wheelEvent, EventTargeting eventTargeting) const
+bool ScrollingTreeScrollingNode::canScrollOrRubberbandWithEvent(const PlatformWheelEvent& wheelEvent) const
 {
-    // We always rubber-band the latched node, or the root node.
-    // The stateless wheel event doesn't trigger rubber-band.
-    // Also rubberband when we should block scroll propagation
-    // at this node, which has overscroll behavior that is not none.
+    if (eventCanScrollContents(wheelEvent))
+        return true;
+
+    if (wheelEvent.delta().width() && allowsHorizontalScrolling() && horizontalScrollElasticity() != ScrollElasticity::None)
+        return true;
+
+    if (wheelEvent.delta().height() && allowsVerticalScrolling() && verticalScrollElasticity() != ScrollElasticity::None)
+        return true;
+
+    return false;
+}
+
+bool ScrollingTreeScrollingNode::mayRubberBand(const PlatformWheelEvent& wheelEvent, EventTargeting eventTargeting) const
+{
+    if (wheelEvent.isNonGestureEvent())
+        return false;
+
+    if (isLatchedNode())
+        return true;
+
+    if (eventTargeting == EventTargeting::NodeOnly)
+        return true;
+
+    auto isRootOrChildOfNonOverscrollingNode = [&]() {
+        if (isRootNode())
+            return true;
+
+        RefPtr enclosingScrollingNode = scrollingTree().enclosingScrollingNode(*this);
+        if (!enclosingScrollingNode)
+            return true;
+
+        if (wheelEvent.shouldConsultDelta() && !enclosingScrollingNode->canScrollOrRubberbandWithEvent(wheelEvent))
+            return true;
+
+        return false;
+    };
+
+    if (isRootOrChildOfNonOverscrollingNode())
+        return true;
+
     auto scrollPropagationInfo = computeScrollPropagation(wheelEvent.delta());
-    return (isLatchedNode() || eventTargeting == EventTargeting::NodeOnly || (isRootNode() && !wheelEvent.isNonGestureEvent()) || ( scrollPropagationInfo.shouldBlockScrollPropagation && scrollPropagationInfo.isHandled && overscrollBehaviorAllowsRubberBand()));
+    if (scrollPropagationInfo.shouldBlockScrollPropagation && scrollPropagationInfo.isHandled && overscrollBehaviorAllowsRubberBand())
+        return true;
+
+    return false;
 }
 
 bool ScrollingTreeScrollingNode::canHandleWheelEvent(const PlatformWheelEvent& wheelEvent, EventTargeting eventTargeting) const
@@ -154,7 +193,7 @@ bool ScrollingTreeScrollingNode::canHandleWheelEvent(const PlatformWheelEvent& w
     if (wheelEvent.phase() == PlatformWheelEventPhase::MayBegin)
         return true;
 
-    if (shouldRubberBand(wheelEvent, eventTargeting))
+    if (mayRubberBand(wheelEvent, eventTargeting))
         return true;
 
     return eventCanScrollContents(wheelEvent);

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -186,8 +186,10 @@ protected:
     PlatformWheelEvent eventForPropagation(const PlatformWheelEvent&) const;
     ScrollPropagationInfo computeScrollPropagation(const FloatSize&) const;
     bool overscrollBehaviorAllowsRubberBand() const { return m_scrollableAreaParameters.horizontalOverscrollBehavior != OverscrollBehavior::None ||  m_scrollableAreaParameters.verticalOverscrollBehavior != OverscrollBehavior::None; }
-    bool shouldRubberBand(const PlatformWheelEvent&, EventTargeting) const;
+    bool mayRubberBand(const PlatformWheelEvent&, EventTargeting) const;
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
+
+    bool canScrollOrRubberbandWithEvent(const PlatformWheelEvent&) const;
 
     std::unique_ptr<ScrollingTreeScrollingNodeDelegate> m_delegate;
 

--- a/Source/WebCore/platform/PlatformWheelEvent.h
+++ b/Source/WebCore/platform/PlatformWheelEvent.h
@@ -156,6 +156,7 @@ public:
 #if ENABLE(ASYNC_SCROLLING)
     bool useLatchedEventElement() const;
     bool isGestureContinuation() const; // The fingers-down part of the gesture excluding momentum.
+    bool shouldConsultDelta() const;
     bool shouldResetLatching() const;
     bool isEndOfMomentumScroll() const;
 #else
@@ -223,6 +224,14 @@ inline bool PlatformWheelEvent::useLatchedEventElement() const
 inline bool PlatformWheelEvent::isGestureContinuation() const
 {
     return m_phase == PlatformWheelEventPhase::Changed;
+}
+
+inline bool PlatformWheelEvent::shouldConsultDelta() const
+{
+    return m_phase == PlatformWheelEventPhase::Began
+        || m_phase == PlatformWheelEventPhase::Changed
+        || m_momentumPhase == PlatformWheelEventPhase::Began
+        || m_momentumPhase == PlatformWheelEventPhase::Changed;
 }
 
 inline bool PlatformWheelEvent::shouldResetLatching() const


### PR DESCRIPTION
#### a5d846af4c992c62455b9d69ac7f9e1fd3bf359d
<pre>
A scroller whose parent doesn&apos;t rubber-band due to overflow:hidden or over scroll behavior should still rubber-band
<a href="https://bugs.webkit.org/show_bug.cgi?id=268682">https://bugs.webkit.org/show_bug.cgi?id=268682</a>
<a href="https://rdar.apple.com/122222568">rdar://122222568</a>

Reviewed by NOBODY (OOPS!).

With nested scrollers, when all scrollers are scrolled to the top, conceptually the root-most scroller that
can rubberband should if the user drags down in the inner-most scroller. Non-root scrollers may prevent
rubberbanding or scroll propagation with `overscroll-behavior`, and the root may prevent scrolling via
`overflow: hidden`.

Fix on the async scrolling code path by changing `ScrollingTreeScrollingNode::shouldRubberBand()`
to check whether the parent scroller can handle the event.

Rename `shouldRubberBand()` to `mayRubberBand()` to reflect the fact that it&apos;s not prescriptive;
it may return true, but rubberbanding may be prevented layer by `overflow:hidden`, for example.

* LayoutTests/fast/scrolling/mac/rubberband-overflow-with-non-scrollable-root-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/rubberband-overflow-with-non-scrollable-root.html: Added.
* LayoutTests/fast/scrolling/mac/rubberband-overflow-with-overscroll-none-parent-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/rubberband-overflow-with-overscroll-none-parent.html: Added.
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::enclosingScrollingNode const):
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::canScrollOrRubberbandWithEvent const):
(WebCore::ScrollingTreeScrollingNode::mayRubberBand const):
(WebCore::ScrollingTreeScrollingNode::canHandleWheelEvent const):
(WebCore::ScrollingTreeScrollingNode::shouldRubberBand const): Deleted.
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/platform/PlatformWheelEvent.h:
(WebCore::PlatformWheelEvent::shouldConsultDelta const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5d846af4c992c62455b9d69ac7f9e1fd3bf359d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40235 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33535 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13750 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31902 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12193 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12107 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41494 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34044 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34104 "Found 2 new test failures: scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe-overscroll-behavior.html, scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38015 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12716 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10224 "Found 2 new test failures: scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe-overscroll-behavior.html, scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36184 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14132 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/33089 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13103 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->