### PR TITLE
Backtrace print methods should be able to change stack depth at runtime

### DIFF
--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -234,6 +234,8 @@ WTF_EXPORT_PRIVATE bool WTFWillLogWithLevel(WTFLogChannel*, WTFLogLevel);
 
 WTF_EXPORT_PRIVATE NEVER_INLINE void WTFGetBacktrace(void** stack, int* size);
 WTF_EXPORT_PRIVATE void WTFReportBacktraceWithPrefix(const char*);
+WTF_EXPORT_PRIVATE void WTFReportBacktraceWithStackDepth(int);
+WTF_EXPORT_PRIVATE void WTFReportBacktraceWithPrefixAndStackDepth(const char*, int);
 WTF_EXPORT_PRIVATE void WTFReportBacktrace(void);
 #ifdef __cplusplus
 WTF_EXPORT_PRIVATE void WTFReportBacktraceWithPrefixAndPrintStream(WTF::PrintStream&, const char*);


### PR DESCRIPTION
#### 314032f5abcd40ed3f6e2178ded683ae2706a5ce
<pre>
Backtrace print methods should be able to change stack depth at runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=268686">https://bugs.webkit.org/show_bug.cgi?id=268686</a>
<a href="https://rdar.apple.com/122229849">rdar://122229849</a>

Reviewed by Tim Horton.

Currently, developers can change the stack depth printed by the
WTFReportBacktrace family of functions statically, but this also causes
a lot of rebuilding, which can be time consuming.

Instead, this patch provides two variants to the backtrace reporter
methods that take the desired stack depth as an argument, allowing
developers to reflect these changes at runtime (and not take compile
time hits). Namely, these functions are WTFReportBacktraceWithStackDepth
and WTFReportBacktraceWithPrefixAndStackDepth.

This patch also takes the liberty to pull out the framesToShow and
framesToSkip variables into translation unit constants within
Assertions.cpp, promoting better variable hygiene.

* Source/WTF/wtf/Assertions.cpp:
* Source/WTF/wtf/Assertions.h:

Canonical link: <a href="https://commits.webkit.org/274110@main">https://commits.webkit.org/274110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/141cd308e38ce1a22e32979e905299d989035f60

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40245 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33545 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31908 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12202 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12122 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41504 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/31437 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34072 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38024 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/37410 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36197 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14140 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/44317 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8513 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13111 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9061 "Found 158 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout, jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout-no-cjit, jsc-layout-tests.yaml/js/script-tests/regress-150580.js.layout-no-llint, stress/array-flatmap.js.dfg-eager, stress/array-flatmap.js.dfg-eager-no-cjit-validate, wasm.yaml/wasm/gc/any.js.default-wasm, wasm.yaml/wasm/gc/any.js.wasm-bbq, wasm.yaml/wasm/gc/any.js.wasm-collect-continuously, wasm.yaml/wasm/gc/any.js.wasm-eager ... (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->