### PR TITLE
[UnifiedPDF] Drive-by style fixes under WebKit/WebProcess/Plugins/PDF

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -352,8 +352,8 @@ void PDFPluginBase::maybeClearHighLatencyDataProviderFlag()
     if (!m_pdfDocument || !m_documentFinishedLoading)
         return;
 
-    if ([m_pdfDocument.get() respondsToSelector:@selector(setHasHighLatencyDataProvider:)])
-        [m_pdfDocument.get() setHasHighLatencyDataProvider:NO];
+    if ([m_pdfDocument respondsToSelector:@selector(setHasHighLatencyDataProvider:)])
+        [m_pdfDocument setHasHighLatencyDataProvider:NO];
 }
 
 void PDFPluginBase::startByteRangeRequest(NetscapePlugInStreamLoaderClient& streamLoaderClient, uint64_t requestIdentifier, uint64_t position, size_t count)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1039,7 +1039,7 @@ bool UnifiedPDFPlugin::handleMouseEvent(const WebMouseEvent& event)
                     return true;
 
                 if ([annotation isKindOfClass:getPDFAnnotationTextWidgetClass()] || [annotation isKindOfClass:getPDFAnnotationChoiceWidgetClass()]) {
-                    setActiveAnnotation(annotation.get());
+                    setActiveAnnotation(WTFMove(annotation));
                     return true;
                 }
                 if ([annotation isKindOfClass:getPDFAnnotationButtonWidgetClass()]) {
@@ -1260,7 +1260,7 @@ void UnifiedPDFPlugin::continueTrackingSelection(PDFDocumentLayout::PageIndex pa
 
         m_selectionTrackingData.marqueeSelectionRect = computeMarqueeSelectionRect(pagePoint, m_selectionTrackingData.startPagePoint);
         auto page = m_documentLayout.pageAtIndex(pageIndex);
-        return setCurrentSelection([page.get() selectionForRect:m_selectionTrackingData.marqueeSelectionRect]);
+        return setCurrentSelection([page selectionForRect:m_selectionTrackingData.marqueeSelectionRect]);
     }
 
     switch (m_selectionTrackingData.granularity) {
@@ -1363,8 +1363,8 @@ void UnifiedPDFPlugin::zoomOut()
 
 CGRect UnifiedPDFPlugin::pluginBoundsForAnnotation(RetainPtr<PDFAnnotation>& annotation) const
 {
-    auto pageSpaceBounds = IntRect([annotation.get() bounds]);
-    if (auto pageIndex = m_documentLayout.indexForPage([annotation.get() page])) {
+    auto pageSpaceBounds = IntRect([annotation bounds]);
+    if (auto pageIndex = m_documentLayout.indexForPage([annotation page])) {
         auto documentSpacePoint = convertFromPageToDocument({ pageSpaceBounds.x(), pageSpaceBounds.y() }, pageIndex.value());
 
         // The origin of an annotation in page space and document space are opposite


### PR DESCRIPTION
#### 71e4e7e3844641aa59c978c77f47d0ebe4b7785a
<pre>
[UnifiedPDF] Drive-by style fixes under WebKit/WebProcess/Plugins/PDF
<a href="https://bugs.webkit.org/show_bug.cgi?id=268688">https://bugs.webkit.org/show_bug.cgi?id=268688</a>
<a href="https://rdar.apple.com/122230060">rdar://122230060</a>

Reviewed by Wenson Hsieh.

Namely, we prefer `[retainPtr method:]` over `[retainPtr.get() method:]`,
but also, move an annotation to avoid unnecessary ref-churn when calling
UnifiedPDFPlugin::setActiveAnnotation.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::maybeClearHighLatencyDataProviderFlag):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::handleMouseEvent):
(WebKit::UnifiedPDFPlugin::continueTrackingSelection):
(WebKit::UnifiedPDFPlugin::boundsForAnnotation const):

Canonical link: <a href="https://commits.webkit.org/274052@main">https://commits.webkit.org/274052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70173609197c4b05f97d9729349e7f2cf67d67fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40246 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33546 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31909 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12203 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12124 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41505 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34121 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38023 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36196 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14141 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8482 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13112 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13454 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->