### PR TITLE
[UnifiedPDF] UnifiedPDFPlugin should handle the "selectAll" editing command

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -136,8 +136,12 @@ private:
     bool handleMouseLeaveEvent(const WebMouseEvent&) override;
     bool handleContextMenuEvent(const WebMouseEvent&) override;
     bool handleKeyboardEvent(const WebKeyboardEvent&) override;
+
+    // Editing commands
     bool handleEditingCommand(const String& commandName, const String& argument) override;
     bool isEditingCommandEnabled(const String& commandName) override;
+    bool forwardEditingCommandToEditor(const String& commandName, const String& argument) const;
+    void selectAll();
 
     enum class ContextMenuItemTag : uint8_t {
         OpenWithPreview,

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1197,12 +1197,15 @@ bool UnifiedPDFPlugin::handleKeyboardEvent(const WebKeyboardEvent&)
     return false;
 }
 
+#pragma mark Editing Commands
+
 bool UnifiedPDFPlugin::handleEditingCommand(const String& commandName, const String& argument)
 {
-    if (!m_frame || !m_frame->coreLocalFrame())
-        return false;
-    if (commandName == "ScrollPageBackward"_s || commandName == "ScrollPageForward"_s) {
-        m_frame->coreLocalFrame()->checkedEditor()->command(commandName).execute(argument);
+    if (commandName == "ScrollPageBackward"_s || commandName == "ScrollPageForward"_s)
+        return forwardEditingCommandToEditor(commandName, argument);
+
+    if (commandName == "selectAll"_s) {
+        selectAll();
         return true;
     }
     return false;
@@ -1212,7 +1215,21 @@ bool UnifiedPDFPlugin::isEditingCommandEnabled(const String& commandName)
 {
     if (commandName == "ScrollPageBackward"_s || commandName == "ScrollPageForward"_s)
         return true;
+    if (commandName == "selectAll"_s)
+        return true;
     return false;
+}
+
+bool UnifiedPDFPlugin::forwardEditingCommandToEditor(const String& commandName, const String& argument) const
+{
+    if (!m_frame || !m_frame->coreLocalFrame())
+        return false;
+    return m_frame->coreLocalFrame()->checkedEditor()->command(commandName).execute(argument);
+}
+
+void UnifiedPDFPlugin::selectAll()
+{
+    setCurrentSelection([m_pdfDocument selectionForEntireDocument]);
 }
 
 #pragma mark Selections


### PR DESCRIPTION
#### 1a2dfd4eb52baf164e5bab30cf957e0596812571
<pre>
[UnifiedPDF] UnifiedPDFPlugin should handle the &quot;selectAll&quot; editing command
<a href="https://bugs.webkit.org/show_bug.cgi?id=268689">https://bugs.webkit.org/show_bug.cgi?id=268689</a>
<a href="https://rdar.apple.com/122230652">rdar://122230652</a>

Reviewed by Simon Fraser.

Following the added support for selection tracking in 274032@main, it is
trivial for the UnifiedPDFPlugin to handle the &quot;selectAll&quot; editing
command.

The plugin does so by simply querying PDFDocument for a selection
representing text for the entire document, and then overriding the
currently tracked selection.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::handleKeyboardEvent):
(WebKit::UnifiedPDFPlugin::handleEditingCommand):
(WebKit::UnifiedPDFPlugin::isEditingCommandEnabled):
(WebKit::UnifiedPDFPlugin::forwardEditingCommandToEditor const):
(WebKit::UnifiedPDFPlugin::selectAll):

Canonical link: <a href="https://commits.webkit.org/274056@main">https://commits.webkit.org/274056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eef69972d5fb3d46ac155115fff047c8cb6a09b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40283 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33582 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13852 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/13995 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12236 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12164 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41542 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34138 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38056 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12762 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36231 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14175 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8483 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13145 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->