### PR TITLE
Remove non-standard `WheelEvent.initWebKitWheelEvent()`

### DIFF
--- a/LayoutTests/fast/events/wheelevent-delta-overflow-expected.txt
+++ b/LayoutTests/fast/events/wheelevent-delta-overflow-expected.txt
@@ -44,16 +44,6 @@ PASS wheelEvent.wheelDeltaX is -2147483648
 PASS wheelEvent.wheelDeltaY is -2147483648
 PASS wheelEvent.deltaX is 2147483649
 PASS wheelEvent.deltaY is 2147483649
-
-wheelEvent = document.createEvent('wheelevent')
-wheelEvent.initWebKitWheelEvent(-2147483648, -2147483648)
-PASS wheelEvent.deltaX is 2147483648
-PASS wheelEvent.deltaY is 2147483648
-
-wheelEvent = document.createEvent('wheelevent')
-wheelEvent.initWebKitWheelEvent(2147483647, 2147483647)
-PASS wheelEvent.deltaX is -2147483647
-PASS wheelEvent.deltaY is -2147483647
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/events/wheelevent-delta-overflow.html
+++ b/LayoutTests/fast/events/wheelevent-delta-overflow.html
@@ -52,18 +52,6 @@ shouldBe("wheelEvent.wheelDeltaX", "-2147483648");
 shouldBe("wheelEvent.wheelDeltaY", "-2147483648");
 shouldBe("wheelEvent.deltaX", "2147483649");
 shouldBe("wheelEvent.deltaY", "2147483649");
-
-debug("");
-evalAndLog("wheelEvent = document.createEvent('wheelevent')");
-evalAndLog("wheelEvent.initWebKitWheelEvent(-2147483648, -2147483648)");
-shouldBe("wheelEvent.deltaX", "2147483648");
-shouldBe("wheelEvent.deltaY", "2147483648");
-
-debug("");
-evalAndLog("wheelEvent = document.createEvent('wheelevent')");
-evalAndLog("wheelEvent.initWebKitWheelEvent(2147483647, 2147483647)");
-shouldBe("wheelEvent.deltaX", "-2147483647");
-shouldBe("wheelEvent.deltaY", "-2147483647");
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/events/wheelevent-in-scrolling-div-expected.txt
+++ b/LayoutTests/fast/events/wheelevent-in-scrolling-div-expected.txt
@@ -1,6 +1,6 @@
-PASS event.wheelDeltaY is window.expectedScrollTop*-120
-PASS event.wheelDeltaX is window.expectedScrollLeft*-120
-PASS event.wheelDelta is window.expectedScrollTop*-120
+PASS successfullyParsed is true
+
+TEST COMPLETE
 PASS div.scrollTop is window.expectedScrollTop
 PASS div.scrollLeft is window.expectedScrollLeft
 

--- a/LayoutTests/fast/events/wheelevent-in-scrolling-div.html
+++ b/LayoutTests/fast/events/wheelevent-in-scrolling-div.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ ScrollAnimatorEnabled=false ] -->
 <html>
     <head>
-        <script src="../../resources/js-test-pre.js"></script>
+        <script src="../../resources/js-test.js"></script>
         <script>
             var expectedScrollTop = 200;
             var expectedScrollLeft = 100;
@@ -17,9 +17,17 @@
                 if (overflowElement) {
                     overflowElement.addEventListener("wheel", mousewheelHandler, false);
 
-                    var wheelEvent = document.createEvent("WheelEvent");
-                    wheelEvent.initWebKitWheelEvent(-window.expectedScrollLeft, -window.expectedScrollTop, window, 0, 0, 0, 0, false, false, false, false);
-                    overflowElement.dispatchEvent(wheelEvent);
+                    var deltaX = window.expectedScrollLeft;
+                    var deltaY = window.expectedScrollTop;
+
+                    var eventInit = {
+                        deltaX: deltaX,
+                        deltaY: deltaY,
+                        wheelDeltaX: -120 * deltaX,
+                        wheelDeltaY: -120 * deltaY,
+                    };
+                    var event = new WheelEvent("mousewheel", eventInit);
+                    overflowElement.dispatchEvent(event);
                 }
 
                 setTimeout('checkOffsets();', 100);
@@ -38,6 +46,8 @@
             function mousewheelHandler(e)
             {
                 event = e;
+                shouldBe("event.deltaY", "window.expectedScrollTop");
+                shouldBe("event.deltaX", "window.expectedScrollLeft");
                 shouldBe("event.wheelDeltaY", "window.expectedScrollTop*-120");
                 shouldBe("event.wheelDeltaX", "window.expectedScrollLeft*-120");
 

--- a/LayoutTests/fast/forms/resources/common-wheel-event.js
+++ b/LayoutTests/fast/forms/resources/common-wheel-event.js
@@ -1,8 +1,7 @@
 function dispatchWheelEvent(element, deltaX, deltaY)
 {
-    var event = document.createEvent('WheelEvent');
-    var dontCare = 0;
-    event.initWebKitWheelEvent(deltaX, deltaY, document.defaultView, dontCare, dontCare, dontCare, dontCare, false, false, false, false);
+    var eventInit = { deltaX: -deltaX, deltaY: -deltaY };
+    var event = new WheelEvent('mousewheel', eventInit);
     element.dispatchEvent(event);
 }
 

--- a/Source/WebCore/dom/WheelEvent.cpp
+++ b/Source/WebCore/dom/WheelEvent.cpp
@@ -86,23 +86,6 @@ Ref<WheelEvent> WheelEvent::create(const AtomString& type, const Init& initializ
     return adoptRef(*new WheelEvent(type, initializer));
 }
 
-void WheelEvent::initWebKitWheelEvent(int rawDeltaX, int rawDeltaY, RefPtr<WindowProxy>&& view, int screenX, int screenY, int pageX, int pageY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey)
-{
-    if (isBeingDispatched())
-        return;
-    
-    initMouseEvent(eventNames().wheelEvent, true, true, WTFMove(view), 0, screenX, screenY, pageX, pageY, ctrlKey, altKey, shiftKey, metaKey, enumToUnderlyingType(MouseButton::Left), nullptr);
-
-    // Normalize to 120 multiple for compatibility with IE.
-    m_wheelDelta = { rawDeltaX * TickMultiplier, rawDeltaY * TickMultiplier };
-    m_deltaX = wheelDeltaToDelta(rawDeltaX);
-    m_deltaY = wheelDeltaToDelta(rawDeltaY);
-
-    m_deltaMode = DOM_DELTA_PIXEL;
-
-    m_underlyingPlatformEvent = std::nullopt;
-}
-
 EventInterface WheelEvent::eventInterface() const
 {
     return WheelEventInterfaceType;

--- a/Source/WebCore/dom/WheelEvent.h
+++ b/Source/WebCore/dom/WheelEvent.h
@@ -54,8 +54,6 @@ public:
 
     static Ref<WheelEvent> create(const AtomString& type, const Init&);
 
-    WEBCORE_EXPORT void initWebKitWheelEvent(int rawDeltaX, int rawDeltaY, RefPtr<WindowProxy>&&, int screenX, int screenY, int pageX, int pageY, bool ctrlKey, bool altKey, bool shiftKey, bool metaKey);
-
     const std::optional<PlatformWheelEvent>& underlyingPlatformEvent() const { return m_underlyingPlatformEvent; }
 
     double deltaX() const { return m_deltaX; } // Positive when scrolling right.

--- a/Source/WebCore/dom/WheelEvent.idl
+++ b/Source/WebCore/dom/WheelEvent.idl
@@ -42,11 +42,6 @@
     readonly attribute long wheelDelta;
 
     readonly attribute boolean webkitDirectionInvertedFromDevice;
-
-    undefined initWebKitWheelEvent(optional long wheelDeltaX = 0, optional long wheelDeltaY = 0, optional WindowProxy? view = null,
-        optional long screenX = 0, optional long screenY = 0, optional long clientX = 0, optional long clientY = 0,
-        optional boolean ctrlKey = false, optional boolean altKey = false,
-        optional boolean shiftKey = false, optional boolean metaKey = false);
 };
 
 // https://w3c.github.io/uievents/#idl-wheeleventinit

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMWheelEvent.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMWheelEvent.cpp
@@ -130,8 +130,6 @@ void webkit_dom_wheel_event_init_wheel_event(WebKitDOMWheelEvent* self, glong wh
     WebCore::JSMainThreadNullState state;
     g_return_if_fail(WEBKIT_DOM_IS_WHEEL_EVENT(self));
     g_return_if_fail(WEBKIT_DOM_IS_DOM_WINDOW(view));
-    WebCore::WheelEvent* item = WebKit::core(self);
-    item->initWebKitWheelEvent(wheelDeltaX, wheelDeltaY, WebKit::toWindowProxy(view), screenX, screenY, clientX, clientY, ctrlKey, altKey, shiftKey, metaKey);
 }
 
 glong webkit_dom_wheel_event_get_wheel_delta_x(WebKitDOMWheelEvent* self)

--- a/Source/WebKitLegacy/mac/DOM/DOMWheelEvent.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMWheelEvent.mm
@@ -95,8 +95,6 @@
 
 - (void)initWheelEvent:(int)inWheelDeltaX wheelDeltaY:(int)inWheelDeltaY view:(DOMAbstractView *)view screenX:(int)screenX screenY:(int)screenY clientX:(int)clientX clientY:(int)clientY ctrlKey:(BOOL)ctrlKey altKey:(BOOL)altKey shiftKey:(BOOL)shiftKey metaKey:(BOOL)metaKey
 {
-    WebCore::JSMainThreadNullState state;
-    IMPL->initWebKitWheelEvent(inWheelDeltaX, inWheelDeltaY, toWindowProxy(view), screenX, screenY, clientX, clientY, ctrlKey, altKey, shiftKey, metaKey);
 }
 
 @end


### PR DESCRIPTION
#### f50de885e127381197e0bab6e3a0f598161b2758
<pre>
Remove non-standard `WheelEvent.initWebKitWheelEvent()`

<a href="https://bugs.webkit.org/show_bug.cgi?id=267813">https://bugs.webkit.org/show_bug.cgi?id=267813</a>
<a href="https://rdar.apple.com/problem/121733957">rdar://problem/121733957</a>

Reviewed by Ryosuke Niwa.

This patch is to align WebKit with Gecko / Firefox, Blink / Chromium and Web Specification [1]:

[1] <a href="https://w3c.github.io/uievents/#interface-wheelevent">https://w3c.github.io/uievents/#interface-wheelevent</a>

This patch remoes prefixed non-standard API `initWebKitWheelEvent` from WheelEvent, it was
never supported by Gecko and removed by Blink in 2014.

All test changes are merged from below Blink commit:

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=179230

* Source/WebCore/dom/WheelEvent.cpp:
(WheelEvent::initWebKitWheelEvent): Deleted
* Source/WebCore/dom/WheelEvent.h:
* Source/WebCore/dom/WheelEvent.idl:
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMWheelEvent.cpp:
(webkit_dom_wheel_event_init_wheel_event):
* Source/WebKitLegacy/mac/DOM/DOMWheelEvent.mm:
(initWheelEvent):
* LayoutTests/fast/events/wheelevent-in-scrolling-div.html: Rebaselined
* LayoutTests/fast/events/wheelevent-in-scrolling-div-expected.txt: Ditto
* LayoutTests/fast/events/wheelevent-delta-overflow.html: Ditto
* LayoutTests/fast/events/wheelevent-delta-overflow-expected.txt: Ditto
* LayoutTests/fast/forms/resources/common-wheel-event.js: Update Test Script

Canonical link: <a href="https://commits.webkit.org/274069@main">https://commits.webkit.org/274069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9b6161bb081aba5b98929d04826314245973a5b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40316 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33603 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31959 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33065 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12261 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12190 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41575 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34195 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38081 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10355 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36256 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14198 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/33167 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8488 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13166 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13509 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->