### PR TITLE
Remove `MediaPlayer::invalidTime()`

### DIFF
--- a/Source/WebCore/html/MediaController.cpp
+++ b/Source/WebCore/html/MediaController.cpp
@@ -52,7 +52,7 @@ MediaController::MediaController(ScriptExecutionContext& context)
     , m_paused(false)
     , m_defaultPlaybackRate(1)
     , m_volume(1)
-    , m_position(MediaPlayer::invalidTime())
+    , m_position(std::numeric_limits<double>::quiet_NaN())
     , m_muted(false)
     , m_readyState(HAVE_NOTHING)
     , m_playbackState(WAITING)
@@ -141,7 +141,7 @@ double MediaController::currentTime() const
     if (m_mediaElements.isEmpty())
         return 0;
 
-    if (m_position == MediaPlayer::invalidTime()) {
+    if (std::isnan(m_position)) {
         // Some clocks may return times outside the range of [0..duration].
         m_position = std::max<double>(0, std::min(duration(), m_clock->currentTime()));
         m_clearPositionTimer.startOneShot(0_s);
@@ -548,7 +548,7 @@ void MediaController::asyncEventTimerFired()
 
 void MediaController::clearPositionTimerFired()
 {
-    m_position = MediaPlayer::invalidTime();
+    m_position = std::numeric_limits<double>::quiet_NaN();
 }
 
 bool MediaController::hasAudio() const

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -1278,10 +1278,10 @@ std::optional<NowPlayingInfo> MediaElementSession::nowPlayingInfo() const
 
     bool supportsSeeking = m_element.supportsSeeking();
     double rate = 1.0;
-    double duration = supportsSeeking ? m_element.duration() : MediaPlayer::invalidTime();
+    double duration = supportsSeeking ? m_element.duration() : std::numeric_limits<double>::quiet_NaN();
     double currentTime = m_element.currentTime();
     if (!std::isfinite(currentTime) || !supportsSeeking)
-        currentTime = MediaPlayer::invalidTime();
+        currentTime = std::numeric_limits<double>::quiet_NaN();
     auto sourceApplicationIdentifier = m_element.sourceApplicationIdentifier();
 #if PLATFORM(COCOA)
     // FIXME: Eventually, this should be moved into HTMLMediaElement, so all clients

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -417,7 +417,7 @@ void MediaSessionManagerCocoa::setNowPlayingInfo(bool setAsNowPlayingApplication
     CFDictionarySetValue(info.get(), kMRMediaRemoteNowPlayingInfoAlbum, nowPlayingInfo.album.createCFString().get());
     CFDictionarySetValue(info.get(), kMRMediaRemoteNowPlayingInfoTitle, nowPlayingInfo.title.createCFString().get());
 
-    if (std::isfinite(nowPlayingInfo.duration) && nowPlayingInfo.duration != MediaPlayer::invalidTime()) {
+    if (std::isfinite(nowPlayingInfo.duration) && !std::isnan(nowPlayingInfo.duration)) {
         auto cfDuration = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberDoubleType, &nowPlayingInfo.duration));
         CFDictionarySetValue(info.get(), kMRMediaRemoteNowPlayingInfoDuration, cfDuration.get());
     }
@@ -432,7 +432,7 @@ void MediaSessionManagerCocoa::setNowPlayingInfo(bool setAsNowPlayingApplication
     auto cfIdentifier = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberLongLongType, &lastUpdatedNowPlayingInfoUniqueIdentifier));
     CFDictionarySetValue(info.get(), kMRMediaRemoteNowPlayingInfoUniqueIdentifier, cfIdentifier.get());
 
-    if (std::isfinite(nowPlayingInfo.currentTime) && nowPlayingInfo.currentTime != MediaPlayer::invalidTime() && nowPlayingInfo.supportsSeeking) {
+    if (std::isfinite(nowPlayingInfo.currentTime) && !std::isnan(nowPlayingInfo.currentTime) && nowPlayingInfo.supportsSeeking) {
         auto cfCurrentTime = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberDoubleType, &nowPlayingInfo.currentTime));
         CFDictionarySetValue(info.get(), kMRMediaRemoteNowPlayingInfoElapsedTime, cfCurrentTime.get());
     }
@@ -523,13 +523,13 @@ void MediaSessionManagerCocoa::updateNowPlayingInfo()
         m_lastUpdatedNowPlayingTitle = nowPlayingInfo->title;
 
     double duration = nowPlayingInfo->duration;
-    if (std::isfinite(duration) && duration != MediaPlayer::invalidTime())
+    if (std::isfinite(duration) && !std::isnan(duration))
         m_lastUpdatedNowPlayingDuration = duration;
 
     m_lastUpdatedNowPlayingInfoUniqueIdentifier = nowPlayingInfo->uniqueIdentifier;
 
     double currentTime = nowPlayingInfo->currentTime;
-    if (std::isfinite(currentTime) && currentTime != MediaPlayer::invalidTime() && nowPlayingInfo->supportsSeeking)
+    if (std::isfinite(currentTime) && !std::isnan(currentTime) && nowPlayingInfo->supportsSeeking)
         m_lastUpdatedNowPlayingElapsedTime = currentTime;
 
     m_nowPlayingActive = nowPlayingInfo->allowsNowPlayingControlsVisibility;

--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp
@@ -305,13 +305,13 @@ void MediaSessionManagerGLib::updateNowPlayingInfo()
         m_lastUpdatedNowPlayingTitle = nowPlayingInfo->title;
 
     double duration = nowPlayingInfo->duration;
-    if (std::isfinite(duration) && duration != MediaPlayer::invalidTime())
+    if (std::isfinite(duration) && !std::isnan(duration))
         m_lastUpdatedNowPlayingDuration = duration;
 
     m_lastUpdatedNowPlayingInfoUniqueIdentifier = nowPlayingInfo->uniqueIdentifier;
 
     double currentTime = nowPlayingInfo->currentTime;
-    if (std::isfinite(currentTime) && currentTime != MediaPlayer::invalidTime() && nowPlayingInfo->supportsSeeking)
+    if (std::isfinite(currentTime) && !std::isnan(currentTime) && nowPlayingInfo->supportsSeeking)
         m_lastUpdatedNowPlayingElapsedTime = currentTime;
 
     m_nowPlayingActive = nowPlayingInfo->allowsNowPlayingControlsVisibility;

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -426,7 +426,6 @@ public:
     bool seeking() const;
     void seeked(const MediaTime&);
 
-    static double invalidTime() { return -1.0;}
     MediaTime duration() const;
     MediaTime currentTime() const;
 


### PR DESCRIPTION
<pre>
Remove `MediaPlayer::invalidTime()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=268701">https://bugs.webkit.org/show_bug.cgi?id=268701</a>

Reviewed by NOBODY (OOPS!).

Partial Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=188460">https://src.chromium.org/viewvc/blink?view=revision&revision=188460</a>

This patch removes `MediaPlayer::invalidTime()` (literal -1.0) replacing it with
a std::isNan / quiet_NaN() as needed.

* Source/WebCore/platform/graphics/MediaPlayer.h: Remove 'invalidTime'
* Source/WebCore/html/MediaController.cpp:
(MediaController::MediaController):
(MediaController::currentTime):
(MediaController::clearPositionTimerFired):
* Source/WebCore/html/MediaElementSession.cpp:
(MediaElementSession::nowPlayingInfo):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(MediaSessionManagerCocoa::setNowPlayingInfo):
(MediaSessionManagerCocoa::updateNowPlayingInfo):
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp:
(MediaSessionManagerGLib::updateNowPlayingInfo):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dbe21f04c2a62cce7d5bdce1e46787a0f9ef6ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40289 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33586 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13860 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31947 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14000 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12242 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33733 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41548 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34145 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38065 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36240 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14181 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13149 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->