### PR TITLE
Adopt more smart pointers in CachedRawResource and CachedResource

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2046,6 +2046,11 @@ DocumentLoader* FrameLoader::activeDocumentLoader() const
     return m_documentLoader.get();
 }
 
+RefPtr<DocumentLoader> FrameLoader::protectedActiveDocumentLoader() const
+{
+    return activeDocumentLoader();
+}
+
 bool FrameLoader::isLoading() const
 {
     DocumentLoader* docLoader = activeDocumentLoader();

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -174,6 +174,7 @@ public:
     String outgoingOrigin() const;
 
     WEBCORE_EXPORT DocumentLoader* activeDocumentLoader() const;
+    RefPtr<DocumentLoader> protectedActiveDocumentLoader() const;
     DocumentLoader* documentLoader() const { return m_documentLoader.get(); }
     RefPtr<DocumentLoader> protectedDocumentLoader() const;
     DocumentLoader* policyDocumentLoader() const { return m_policyDocumentLoader.get(); }

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -163,14 +163,14 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
         failBeforeStarting();
         return;
     }
-    LocalFrame& frame = *cachedResourceLoader.frame();
+    Ref frame = *cachedResourceLoader.frame();
 
     // Prevent new loads if we are in the BackForwardCache or being added to the BackForwardCache.
     // We query the top document because new frames may be created in pagehide event handlers
     // and their backForwardCacheState will not reflect the fact that they are about to enter page
     // cache.
-    if (auto* localFrame = dynamicDowncast<LocalFrame>(frame.mainFrame())) {
-        if (auto* topDocument = localFrame->document()) {
+    if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame())) {
+        if (RefPtr topDocument = localFrame->document()) {
             switch (topDocument->backForwardCacheState()) {
             case Document::NotInBackForwardCache:
                 break;
@@ -178,26 +178,26 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
                 // Beacons are allowed to go through in 'pagehide' event handlers.
                 if (m_options.keepAlive || shouldUsePingLoad(type()))
                     break;
-                CACHEDRESOURCE_RELEASE_LOG_WITH_FRAME("load: About to enter back/forward cache", frame);
+                CACHEDRESOURCE_RELEASE_LOG_WITH_FRAME("load: About to enter back/forward cache", frame.get());
                 failBeforeStarting();
                 return;
             case Document::InBackForwardCache:
-                CACHEDRESOURCE_RELEASE_LOG_WITH_FRAME("load: Already in back/forward cache", frame);
+                CACHEDRESOURCE_RELEASE_LOG_WITH_FRAME("load: Already in back/forward cache", frame.get());
                 failBeforeStarting();
                 return;
             }
         }
     }
 
-    FrameLoader& frameLoader = frame.loader();
+    CheckedRef frameLoader = frame->loader();
     if (m_options.securityCheck == SecurityCheckPolicy::DoSecurityCheck && !m_options.keepAlive && !shouldUsePingLoad(type())) {
         while (true) {
-            if (frameLoader.state() == FrameState::Provisional)
-                CACHEDRESOURCE_RELEASE_LOG_WITH_FRAME("load: Failed security check -- state is provisional", frame);
-            else if (!frameLoader.activeDocumentLoader())
-                CACHEDRESOURCE_RELEASE_LOG_WITH_FRAME("load: Failed security check -- not active document", frame);
-            else if (frameLoader.activeDocumentLoader()->isStopping())
-                CACHEDRESOURCE_RELEASE_LOG_WITH_FRAME("load: Failed security check -- active loader is stopping", frame);
+            if (frameLoader->state() == FrameState::Provisional)
+                CACHEDRESOURCE_RELEASE_LOG_WITH_FRAME("load: Failed security check -- state is provisional", frame.get());
+            else if (!frameLoader->activeDocumentLoader())
+                CACHEDRESOURCE_RELEASE_LOG_WITH_FRAME("load: Failed security check -- not active document", frame.get());
+            else if (frameLoader->activeDocumentLoader()->isStopping())
+                CACHEDRESOURCE_RELEASE_LOG_WITH_FRAME("load: Failed security check -- active loader is stopping", frame.get());
             else
                 break;
             failBeforeStarting();
@@ -208,7 +208,7 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
     m_loading = true;
 
     if (isCacheValidator()) {
-        CachedResource* resourceToRevalidate = m_resourceToRevalidate;
+        CachedResourceHandle resourceToRevalidate = m_resourceToRevalidate.get();
         ASSERT(resourceToRevalidate->canUseCacheValidator());
         ASSERT(resourceToRevalidate->isLoaded());
         const String& lastModified = resourceToRevalidate->response().httpHeaderField(HTTPHeaderName::LastModified);
@@ -232,7 +232,7 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
     // So no need for extra fields for MainResource.
     if (type() != Type::MainResource) {
         bool isServiceWorkerNavigationLoad = type() != Type::SVGDocumentResource && m_options.serviceWorkersMode == ServiceWorkersMode::None && (m_options.destination == FetchOptions::Destination::Document || m_options.destination == FetchOptions::Destination::Iframe);
-        frameLoader.updateRequestAndAddExtraFields(m_resourceRequest, IsMainResource::No, FrameLoadType::Standard, ShouldUpdateAppInitiatedValue::Yes, isServiceWorkerNavigationLoad ? FrameLoader::IsServiceWorkerNavigationLoad::Yes : FrameLoader::IsServiceWorkerNavigationLoad::No);
+        frameLoader->updateRequestAndAddExtraFields(m_resourceRequest, IsMainResource::No, FrameLoadType::Standard, ShouldUpdateAppInitiatedValue::Yes, isServiceWorkerNavigationLoad ? FrameLoader::IsServiceWorkerNavigationLoad::Yes : FrameLoader::IsServiceWorkerNavigationLoad::No);
     }
 
     // FIXME: It's unfortunate that the cache layer and below get to know anything about fragment identifiers.
@@ -254,28 +254,28 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
     // FIXME: Deprecate that code path.
     if (m_options.keepAlive && shouldUsePingLoad(type()) && platformStrategies()->loaderStrategy()->usePingLoad()) {
         ASSERT(m_originalRequest);
-        CachedResourceHandle<CachedResource> protectedThis(this);
+        CachedResourceHandle protectedThis { *this };
 
         auto identifier = ResourceLoaderIdentifier::generate();
-        InspectorInstrumentation::willSendRequestOfType(&frame, identifier, frameLoader.activeDocumentLoader(), request, InspectorInstrumentation::LoadType::Beacon);
+        InspectorInstrumentation::willSendRequestOfType(frame.ptr(), identifier, frameLoader->protectedActiveDocumentLoader().get(), request, InspectorInstrumentation::LoadType::Beacon);
 
-        platformStrategies()->loaderStrategy()->startPingLoad(frame, request, m_originalRequest->httpHeaderFields(), m_options, m_options.contentSecurityPolicyImposition, [this, protectedThis = WTFMove(protectedThis), protectedFrame = Ref { frame }, identifier] (const ResourceError& error, const ResourceResponse& response) {
+        platformStrategies()->loaderStrategy()->startPingLoad(frame, request, m_originalRequest->httpHeaderFields(), m_options, m_options.contentSecurityPolicyImposition, [this, protectedThis = WTFMove(protectedThis), frame = Ref { frame }, identifier] (const ResourceError& error, const ResourceResponse& response) {
             if (!response.isNull())
-                InspectorInstrumentation::didReceiveResourceResponse(protectedFrame, identifier, protectedFrame->loader().activeDocumentLoader(), response, nullptr);
+                InspectorInstrumentation::didReceiveResourceResponse(frame, identifier, frame->loader().protectedActiveDocumentLoader().get(), response, nullptr);
             if (!error.isNull()) {
                 setResourceError(error);
                 this->error(LoadError);
-                InspectorInstrumentation::didFailLoading(protectedFrame.ptr(), protectedFrame->loader().activeDocumentLoader(), identifier, error);
+                InspectorInstrumentation::didFailLoading(frame.ptr(), frame->loader().protectedActiveDocumentLoader().get(), identifier, error);
                 return;
             }
             finishLoading(nullptr, { });
             NetworkLoadMetrics emptyMetrics;
-            InspectorInstrumentation::didFinishLoading(protectedFrame.ptr(), protectedFrame->loader().activeDocumentLoader(), identifier, emptyMetrics, nullptr);
+            InspectorInstrumentation::didFinishLoading(frame.ptr(), frame->loader().protectedActiveDocumentLoader().get(), identifier, emptyMetrics, nullptr);
         });
         return;
     }
 
-    platformStrategies()->loaderStrategy()->loadResource(frame, *this, WTFMove(request), m_options, [this, protectedThis = CachedResourceHandle<CachedResource>(this), frameRef = Ref { frame }] (RefPtr<SubresourceLoader>&& loader) {
+    platformStrategies()->loaderStrategy()->loadResource(frame, *this, WTFMove(request), m_options, [this, protectedThis = CachedResourceHandle { *this }, frameRef = Ref { frame }] (RefPtr<SubresourceLoader>&& loader) {
         m_loader = WTFMove(loader);
         if (!m_loader) {
             RELEASE_LOG(Network, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 "] CachedResource::load: Unable to create SubresourceLoader", this, PAGE_ID(frameRef.get()), FRAME_ID(frameRef.get()));
@@ -369,7 +369,7 @@ void CachedResource::cancelLoad()
     if (!isLoading() && !stillNeedsLoad())
         return;
 
-    auto* documentLoader = (m_loader && m_loader->frame()) ? m_loader->frame()->loader().activeDocumentLoader() : nullptr;
+    RefPtr documentLoader = (m_loader && m_loader->frame()) ? m_loader->frame()->loader().activeDocumentLoader() : nullptr;
     if (m_options.keepAlive && (!documentLoader || documentLoader->isStopping())) {
         if (m_response)
             m_response->m_error = { };
@@ -608,8 +608,10 @@ void CachedResource::removeClient(CachedResourceClient& client)
 
 void CachedResource::allClientsRemoved()
 {
-    if (isLinkPreload() && m_loader)
-        m_loader->cancelIfNotFinishing();
+    if (isLinkPreload()) {
+        if (RefPtr loader = m_loader)
+            loader->cancelIfNotFinishing();
+    }
 }
 
 void CachedResource::destroyDecodedDataIfNeeded()
@@ -629,7 +631,7 @@ void CachedResource::decodedDataDeletionTimerFired()
 bool CachedResource::deleteIfPossible()
 {
     if (!canDelete()) {
-        LOG(ResourceLoading, "CachedResource %p deleteIfPossible - can't delete (hasClients %d loader %p preloadCount %u handleCount %u resourceToRevalidate %p proxyResource %p)", this, hasClients(), m_loader.get(), m_preloadCount, m_handleCount, m_resourceToRevalidate, m_proxyResource);
+        LOG(ResourceLoading, "CachedResource %p deleteIfPossible - can't delete (hasClients %d loader %p preloadCount %u handleCount %u resourceToRevalidate %p proxyResource %p)", this, hasClients(), m_loader.get(), m_preloadCount, m_handleCount, m_resourceToRevalidate.get(), m_proxyResource.get());
         return false;
     }
 
@@ -655,8 +657,8 @@ bool CachedResource::deleteIfPossible()
         return true;
     }
 
-    if (m_data)
-        m_data->hintMemoryNotNeededSoon();
+    if (RefPtr data = m_data)
+        data->hintMemoryNotNeededSoon();
 
     return false;
 }
@@ -754,7 +756,7 @@ void CachedResource::setResourceToRevalidate(CachedResource* resource)
 
     LOG(ResourceLoading, "CachedResource %p setResourceToRevalidate %p", this, resource);
 
-    resource->m_proxyResource = this;
+    resource->m_proxyResource = *this;
     m_resourceToRevalidate = resource;
 }
 
@@ -780,12 +782,12 @@ void CachedResource::switchClientsToRevalidatedResource()
     ASSERT(m_resourceToRevalidate->inCache());
     ASSERT(!inCache());
 
-    LOG(ResourceLoading, "CachedResource %p switchClientsToRevalidatedResource %p", this, m_resourceToRevalidate);
+    LOG(ResourceLoading, "CachedResource %p switchClientsToRevalidatedResource %p", this, m_resourceToRevalidate.get());
 
     m_switchingClientsToRevalidatedResource = true;
     for (auto& handle : m_handlesToRevalidate) {
-        handle->m_resource = m_resourceToRevalidate;
-        m_resourceToRevalidate->registerHandle(handle);
+        handle->m_resource = m_resourceToRevalidate.get();
+        protectedResourceToRevalidate()->registerHandle(handle);
         --m_handleCount;
     }
     ASSERT(!m_handleCount);
@@ -809,7 +811,7 @@ void CachedResource::switchClientsToRevalidatedResource()
 
     for (auto& client : clientsToMove) {
         if (client)
-            m_resourceToRevalidate->addClientToSet(*client);
+            protectedResourceToRevalidate()->addClientToSet(*client);
     }
     for (auto& client : clientsToMove) {
         // Calling didAddClient may do anything, including trying to cancel revalidation.
@@ -817,7 +819,7 @@ void CachedResource::switchClientsToRevalidatedResource()
         ASSERT(m_resourceToRevalidate);
         // Calling didAddClient for a client may end up removing another client. In that case it won't be in the set anymore.
         if (client && m_resourceToRevalidate->m_clients.contains(*client))
-            m_resourceToRevalidate->didAddClient(*client);
+            protectedResourceToRevalidate()->didAddClient(*client);
     }
     m_switchingClientsToRevalidatedResource = false;
 }
@@ -904,7 +906,12 @@ bool CachedResource::varyHeaderValuesMatch(const ResourceRequest& request)
     if (m_varyingHeaderValues.isEmpty())
         return true;
 
-    return verifyVaryingRequestHeaders(cookieJar(), m_varyingHeaderValues, request);
+    return verifyVaryingRequestHeaders(protectedCookieJar().get(), m_varyingHeaderValues, request);
+}
+
+CachedResourceHandle<CachedResource> CachedResource::protectedResourceToRevalidate() const
+{
+    return m_resourceToRevalidate.get();
 }
 
 unsigned CachedResource::overheadSize() const
@@ -981,6 +988,11 @@ const ResourceError& CachedResource::resourceError() const
     return m_response->m_error;
 }
 
+RefPtr<const CookieJar> CachedResource::protectedCookieJar() const
+{
+    return m_cookieJar;
+}
+
 bool CachedResource::wasCanceled() const
 {
     return resourceError().isCancellation();
@@ -1023,7 +1035,7 @@ inline void CachedResource::Callback::cancel()
 
 void CachedResource::Callback::timerFired()
 {
-    m_resource.didAddClient(m_client);
+    CachedResourceHandle { m_resource.get() }->didAddClient(m_client);
 }
 
 #if ENABLE(SHAREABLE_RESOURCE)
@@ -1042,7 +1054,7 @@ void CachedResource::tryReplaceEncodedData(SharedBuffer& newBuffer)
     if (*m_data != newBuffer)
         return;
 
-    m_data = Ref { newBuffer };
+    m_data = &newBuffer;
     didReplaceSharedBufferContents();
 }
 


### PR DESCRIPTION
#### f232a5d1d6e79c12e69a9aaa4e145c3523f9a66f
<pre>
Adopt more smart pointers in CachedRawResource and CachedResource
<a href="https://bugs.webkit.org/show_bug.cgi?id=268702">https://bugs.webkit.org/show_bug.cgi?id=268702</a>

Reviewed by Darin Adler.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::protectedActiveDocumentLoader const):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/cache/CachedRawResource.cpp:
(WebCore::CachedRawResource::updateBuffer):
(WebCore::CachedRawResource::finishLoading):
(WebCore::CachedRawResource::notifyClientsDataWasReceived):
(WebCore::CachedRawResource::didAddClient):
(WebCore::CachedRawResource::allClientsRemoved):
(WebCore::CachedRawResource::redirectReceived):
(WebCore::CachedRawResource::responseReceived):
(WebCore::CachedRawResource::setDefersLoading):
(WebCore::CachedRawResource::clear):
(WebCore::CachedRawResource::previewResponseReceived):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::load):
(WebCore::CachedResource::cancelLoad):
(WebCore::CachedResource::allClientsRemoved):
(WebCore::CachedResource::deleteIfPossible):
(WebCore::CachedResource::setResourceToRevalidate):
(WebCore::CachedResource::switchClientsToRevalidatedResource):
(WebCore::CachedResource::varyHeaderValuesMatch):
(WebCore::CachedResource::protectedResourceToRevalidate const):
(WebCore::CachedResource::protectedCookieJar const):
(WebCore::CachedResource::Callback::timerFired):
(WebCore::CachedResource::tryReplaceEncodedData): Deleted.
(WebCore::CachedResource::previewResponseReceived): Deleted.
(WebCore::CachedResource::cryptographicDigest const): Deleted.
* Source/WebCore/loader/cache/CachedResource.h:
(WebCore::CachedResource::isCacheValidator const):
(WebCore::CachedResource::resourceToRevalidate const):
(WebCore::CachedResource::validationInProgress const):

Canonical link: <a href="https://commits.webkit.org/274060@main">https://commits.webkit.org/274060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17102510a2c3aabe037f799527e2c7b6e6a051e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/39993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40292 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33589 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13865 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/31948 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33045 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12243 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12173 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41551 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38062 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36237 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14184 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13152 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4894 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->