### PR TITLE
TZone: Implement TZone Allocation on JavaScriptCore Types

### DIFF
--- a/Source/JavaScriptCore/API/tests/testapi.c
+++ b/Source/JavaScriptCore/API/tests/testapi.c
@@ -41,6 +41,9 @@
 #include "JSScriptRefPrivate.h"
 #include "JSStringRefPrivate.h"
 #include "JSWeakPrivate.h"
+#if USE(TZONE_MALLOC)
+#include <_simple.h>
+#endif
 #if !OS(WINDOWS)
 #include <libgen.h>
 #endif
@@ -77,6 +80,10 @@
 
 #if JSC_OBJC_API_ENABLED
 void testObjectiveCAPI(const char*);
+#endif
+
+#if USE(TZONE_MALLOC)
+void WTFTZoneInit(const char*);
 #endif
 
 void configureJSCForTesting(void);
@@ -1430,7 +1437,13 @@ static bool samplingProfilerTest(void)
     return false;
 }
 
-int main(int argc, char* argv[])
+#if USE(TZONE_MALLOC)
+#define TZONE_EXTRA_MAIN_ARGS , const char** envp, const char **darwinEnvp
+#else
+#define TZONE_EXTRA_MAIN_ARGS
+#endif
+
+int main(int argc, char* argv[] TZONE_EXTRA_MAIN_ARGS)
 {
 #if OS(WINDOWS)
     // Cygwin calls SetErrorMode(SEM_FAILCRITICALERRORS), which we will inherit. This is bad for
@@ -1439,6 +1452,11 @@ int main(int argc, char* argv[])
     SetErrorMode(0);
 #endif
 
+#if USE(TZONE_MALLOC)
+    UNUSED_PARAM(envp);
+    const char* boothash = _simple_getenv(darwinEnvp, "executable_boothash");
+    WTFTZoneInit(boothash);
+#endif
     configureJSCForTesting();
 
 #if !OS(WINDOWS)

--- a/Source/JavaScriptCore/API/tests/testapi.cpp
+++ b/Source/JavaScriptCore/API/tests/testapi.cpp
@@ -28,6 +28,7 @@
 #include "APICast.h"
 #include "JSGlobalObjectInlines.h"
 #include "MarkedJSValueRefArray.h"
+#include "RegisterTZoneTypes.h"
 #include <JavaScriptCore/JSContextRefPrivate.h>
 #include <JavaScriptCore/JSObjectRefPrivate.h>
 #include <JavaScriptCore/JavaScript.h>
@@ -35,6 +36,7 @@
 #include <wtf/Expected.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/NumberOfCores.h>
+#include <wtf/TZoneMallocInitialization.h>
 #include <wtf/Vector.h>
 #include <wtf/text/StringCommon.h>
 
@@ -42,6 +44,9 @@
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #endif
 
+#if USE(TZONE_MALLOC)
+extern "C" void WTFTZoneInit(const char *);
+#endif
 extern "C" void configureJSCForTesting();
 extern "C" int testCAPIViaCpp(const char* filter);
 extern "C" void JSSynchronousGarbageCollectForDebugging(JSContextRef);
@@ -741,6 +746,15 @@ void TestAPI::testJSObjectSetOnGlobalObjectSubclassDefinition()
 
     check(JSEvaluateScript(context, propertyName, globalObject, nullptr, 1, nullptr) == newObject, "Setting a property on a custom global object should set the property");
 }
+
+#if USE(TZONE_MALLOC)
+void WTFTZoneInit(const char* seed)
+{
+    WTF_TZONE_INIT(seed);
+    JSC::registerTZoneTypes();
+    WTF_TZONE_REGISTRATION_DONE();
+}
+#endif
 
 void configureJSCForTesting()
 {

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -942,7 +942,7 @@
 		44F93E0E2AE71FBD00FFA37C /* JavaScriptCoreFramework.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44F93E0D2AE71F9F00FFA37C /* JavaScriptCoreFramework.cpp */; };
 		451539B912DC994500EF7AC4 /* Yarr.h in Headers */ = {isa = PBXBuildFile; fileRef = 451539B812DC994500EF7AC4 /* Yarr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4615E46A2B5849F4001D4D53 /* WasmBBQJIT32_64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4615E4672B5833FB001D4D53 /* WasmBBQJIT32_64.cpp */; };
-        4615E46B2B5849F4001D4D53 /* WasmBBQJIT64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4615E4682B5833FB001D4D53 /* WasmBBQJIT64.cpp */; };
+		4615E46B2B5849F4001D4D53 /* WasmBBQJIT64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4615E4682B5833FB001D4D53 /* WasmBBQJIT64.cpp */; };
 		473DA4A4764C45FE871B0485 /* DefinePropertyAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 169948EDE68D4054B01EF797 /* DefinePropertyAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4B1F22F62900BFC700CB5E66 /* Width.h in Headers */ = {isa = PBXBuildFile; fileRef = 4BBA4CD428FF5FE5003EBFC4 /* Width.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4B46940328984FA800512FDF /* MacroAssemblerARM64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEB137561BB11EEE00CD5100 /* MacroAssemblerARM64.cpp */; };
@@ -1242,6 +1242,7 @@
 		641DF80E2890C7D500F9895F /* WasmSIMDOpcodes.h in Headers */ = {isa = PBXBuildFile; fileRef = 641DF80D2890C7D500F9895F /* WasmSIMDOpcodes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		642D20D42B476A250030545E /* WasmSlowPaths.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14AB0C92231747B7000250BC /* WasmSlowPaths.cpp */; };
 		642D20D52B476A2E0030545E /* WasmIPIntSlowPaths.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53091F972ABE1F570076CBC4 /* WasmIPIntSlowPaths.cpp */; };
+		65072B082B6C3DEA0065065C /* RegisterTZoneTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 65072B062B6C3DEA0065065C /* RegisterTZoneTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		6507D29E0E871E5E00D7D896 /* JSTypeInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 6507D2970E871E4A00D7D896 /* JSTypeInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		651122FD14046A4C002B101D /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 932F5BD90822A1C700736975 /* JavaScriptCore.framework */; };
 		651122FE14046A4C002B101D /* libedit.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D5D8AD00E0D0EBE00F9C692 /* libedit.dylib */; };
@@ -1250,7 +1251,6 @@
 		65303D641447B9E100D3F904 /* ParserTokens.h in Headers */ = {isa = PBXBuildFile; fileRef = 65303D631447B9E100D3F904 /* ParserTokens.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		653BC43F26D013A600D8BE20 /* YarrJITRegisters.h in Headers */ = {isa = PBXBuildFile; fileRef = 653BC43E26D013A600D8BE20 /* YarrJITRegisters.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		65570F5A1AA4C3EA009B3C23 /* Regress141275.mm in Sources */ = {isa = PBXBuildFile; fileRef = 65570F591AA4C00A009B3C23 /* Regress141275.mm */; };
-		6571E9822B23F4D0009DF224 /* JITTZoneImpls.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6571E9812B23F4D0009DF224 /* JITTZoneImpls.cpp */; };
 		657CF45919BF6662004ACBF2 /* JSCallee.h in Headers */ = {isa = PBXBuildFile; fileRef = 657CF45719BF6662004ACBF2 /* JSCallee.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		658824AF1E5CFDB000FB7359 /* ConfigFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 658824AE1E5CFDB000FB7359 /* ConfigFile.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		658D3A5619638268003C45D6 /* VMEntryRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = 658D3A5519638268003C45D6 /* VMEntryRecord.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -3963,9 +3963,9 @@
 		451539B812DC994500EF7AC4 /* Yarr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Yarr.h; path = yarr/Yarr.h; sourceTree = "<group>"; };
 		45E12D8806A49B0F00E9DF84 /* jsc.cpp */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.cpp.cpp; path = jsc.cpp; sourceTree = "<group>"; tabWidth = 4; };
 		4615E4662B5833FB001D4D53 /* WasmBBQJIT64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmBBQJIT64.h; sourceTree = "<group>"; };
-        4615E4672B5833FB001D4D53 /* WasmBBQJIT32_64.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmBBQJIT32_64.cpp; sourceTree = "<group>"; };
-        4615E4682B5833FB001D4D53 /* WasmBBQJIT64.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmBBQJIT64.cpp; sourceTree = "<group>"; };
-        4615E4692B5833FC001D4D53 /* WasmBBQJIT32_64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmBBQJIT32_64.h; sourceTree = "<group>"; };
+		4615E4672B5833FB001D4D53 /* WasmBBQJIT32_64.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmBBQJIT32_64.cpp; sourceTree = "<group>"; };
+		4615E4682B5833FB001D4D53 /* WasmBBQJIT64.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmBBQJIT64.cpp; sourceTree = "<group>"; };
+		4615E4692B5833FC001D4D53 /* WasmBBQJIT32_64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmBBQJIT32_64.h; sourceTree = "<group>"; };
 		4B78E098294427D2003C6682 /* B3SIMDValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = B3SIMDValue.cpp; path = b3/B3SIMDValue.cpp; sourceTree = "<group>"; };
 		4B78E099294427D2003C6682 /* B3Const128Value.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = B3Const128Value.h; path = b3/B3Const128Value.h; sourceTree = "<group>"; };
 		4B78E09A294427D2003C6682 /* B3SIMDValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = B3SIMDValue.h; path = b3/B3SIMDValue.h; sourceTree = "<group>"; };
@@ -4356,6 +4356,8 @@
 		62EC9BB41B7EB07C00303AD1 /* CallFrameShuffleData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CallFrameShuffleData.cpp; sourceTree = "<group>"; };
 		62EC9BB51B7EB07C00303AD1 /* CallFrameShuffleData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CallFrameShuffleData.h; sourceTree = "<group>"; };
 		641DF80D2890C7D500F9895F /* WasmSIMDOpcodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmSIMDOpcodes.h; sourceTree = "<group>"; };
+		65072B052B6C3DEA0065065C /* RegisterTZoneTypes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RegisterTZoneTypes.cpp; sourceTree = "<group>"; };
+		65072B062B6C3DEA0065065C /* RegisterTZoneTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RegisterTZoneTypes.h; sourceTree = "<group>"; };
 		6507D2970E871E4A00D7D896 /* JSTypeInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSTypeInfo.h; sourceTree = "<group>"; };
 		651122E5140469BA002B101D /* testRegExp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = testRegExp.cpp; sourceTree = "<group>"; };
 		6511230514046A4C002B101D /* testRegExp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = testRegExp; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -7687,9 +7689,9 @@
 				FED5FA3329A0859C00798A7F /* WasmBBQJIT.cpp */,
 				FED5FA3229A0859C00798A7F /* WasmBBQJIT.h */,
 				4615E4672B5833FB001D4D53 /* WasmBBQJIT32_64.cpp */,
-                4615E4692B5833FC001D4D53 /* WasmBBQJIT32_64.h */,
-                4615E4682B5833FB001D4D53 /* WasmBBQJIT64.cpp */,
-                4615E4662B5833FB001D4D53 /* WasmBBQJIT64.h */,
+				4615E4692B5833FC001D4D53 /* WasmBBQJIT32_64.h */,
+				4615E4682B5833FB001D4D53 /* WasmBBQJIT64.cpp */,
+				4615E4662B5833FB001D4D53 /* WasmBBQJIT64.h */,
 				53CA73071EA533D80076049D /* WasmBBQPlan.cpp */,
 				53CA73081EA533D80076049D /* WasmBBQPlan.h */,
 				AD4B1DF71DF244D70071AE32 /* WasmBinding.cpp */,
@@ -8636,6 +8638,8 @@
 				84925A9A22B30CBA00D1DFFF /* RegExpStringIteratorPrototype.cpp */,
 				84925A9B22B30CBA00D1DFFF /* RegExpStringIteratorPrototype.h */,
 				276B38A22A71D1B600252F4E /* RegExpStringIteratorPrototypeInlines.h */,
+				65072B052B6C3DEA0065065C /* RegisterTZoneTypes.cpp */,
+				65072B062B6C3DEA0065065C /* RegisterTZoneTypes.h */,
 				FE9F3FBA2613C87C0069E89F /* ResourceExhaustion.cpp */,
 				FE9F3FB82613C7880069E89F /* ResourceExhaustion.h */,
 				70B0A9D01A9B66200001306A /* RuntimeFlags.h */,
@@ -11583,6 +11587,7 @@
 				623A37EC1B87A7C000754209 /* RegisterMap.h in Headers */,
 				0FC314121814559100033232 /* RegisterSet.h in Headers */,
 				0FD0E5F01E46BF250006AB08 /* RegisterState.h in Headers */,
+				65072B082B6C3DEA0065065C /* RegisterTZoneTypes.h in Headers */,
 				A57D23EE1891B5540031C7FA /* RegularExpression.h in Headers */,
 				0F7CF94F1DBEEE880098CC12 /* ReleaseHeapAccessScope.h in Headers */,
 				99D6A1161BEAD34D00E25C37 /* RemoteAutomationTarget.h in Headers */,
@@ -13135,7 +13140,7 @@
 				538F15EF268FBBB600D601C4 /* UnifiedSource155.cpp in Sources */,
 				E3C091E929B07D4C00CD6D97 /* WasmBBQJIT.cpp in Sources */,
 				4615E46A2B5849F4001D4D53 /* WasmBBQJIT32_64.cpp in Sources */,
-                4615E46B2B5849F4001D4D53 /* WasmBBQJIT64.cpp in Sources */,
+				4615E46B2B5849F4001D4D53 /* WasmBBQJIT64.cpp in Sources */,
 				642D20D52B476A2E0030545E /* WasmIPIntSlowPaths.cpp in Sources */,
 				642D20D42B476A250030545E /* WasmSlowPaths.cpp in Sources */,
 				E31135C9281B5B0000C1A4A9 /* ZydisFormatterATT.c in Sources */,
@@ -13173,7 +13178,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				44F93E0E2AE71FBD00FFA37C /* JavaScriptCoreFramework.cpp in Sources */,
-				6571E9822B23F4D0009DF224 /* JITTZoneImpls.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1020,6 +1020,7 @@ runtime/RegExpMatchesArray.cpp
 runtime/RegExpObject.cpp
 runtime/RegExpPrototype.cpp
 runtime/RegExpStringIteratorPrototype.cpp
+runtime/RegisterTZoneTypes.cpp
 runtime/ResourceExhaustion.cpp
 runtime/RuntimeTZoneImpls.cpp
 runtime/RuntimeType.cpp

--- a/Source/JavaScriptCore/assembler/testmasm.cpp
+++ b/Source/JavaScriptCore/assembler/testmasm.cpp
@@ -32,6 +32,7 @@
 #include "InitializeThreading.h"
 #include "LinkBuffer.h"
 #include "ProbeContext.h"
+#include "RegisterTZoneTypes.h"
 #include "StackAlignment.h"
 #include <limits>
 #include <wtf/Compiler.h>
@@ -40,6 +41,7 @@
 #include <wtf/Lock.h>
 #include <wtf/NumberOfCores.h>
 #include <wtf/PtrTag.h>
+#include <wtf/TZoneMallocInitialization.h>
 #include <wtf/Threading.h>
 #include <wtf/WTFProcess.h>
 #include <wtf/text/StringCommon.h>
@@ -6305,8 +6307,15 @@ static void run(const char*)
 
 #endif // ENABLE(JIT)
 
-int main(int argc, char** argv)
+int main(int argc, char** argv WTF_TZONE_EXTRA_MAIN_ARGS)
 {
+#if USE(TZONE_MALLOC)
+    const char* boothash = _simple_getenv(darwinEnvp, "executable_boothash");
+    WTF_TZONE_INIT(boothash);
+    JSC::registerTZoneTypes();
+    WTF_TZONE_REGISTRATION_DONE();
+#endif
+
     const char* filter = nullptr;
     switch (argc) {
     case 1:

--- a/Source/JavaScriptCore/b3/air/testair.cpp
+++ b/Source/JavaScriptCore/b3/air/testair.cpp
@@ -41,12 +41,14 @@
 #include "Options.h"
 #include "ProbeContext.h"
 #include "PureNaN.h"
+#include "RegisterTZoneTypes.h"
 #include <regex>
 #include <string>
 #include <wtf/DataLog.h>
 #include <wtf/Lock.h>
 #include <wtf/NumberOfCores.h>
 #include <wtf/StdMap.h>
+#include <wtf/TZoneMallocInitialization.h>
 #include <wtf/Threading.h>
 #include <wtf/WTFProcess.h>
 #include <wtf/text/StringCommon.h>
@@ -2776,8 +2778,15 @@ static void run(const char*)
 
 #endif // ENABLE(B3_JIT)
 
-int main(int argc, char** argv)
+int main(int argc, char** argv WTF_TZONE_EXTRA_MAIN_ARGS)
 {
+#if USE(TZONE_MALLOC)
+    const char* boothash = _simple_getenv(darwinEnvp, "executable_boothash");
+    WTF_TZONE_INIT(boothash);
+    JSC::registerTZoneTypes();
+    WTF_TZONE_REGISTRATION_DONE();
+#endif
+
     const char* filter = nullptr;
     switch (argc) {
     case 1:

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -78,6 +78,7 @@
 #include <wtf/Lock.h>
 #include <wtf/NumberOfCores.h>
 #include <wtf/StdList.h>
+#include <wtf/TZoneMallocInitialization.h>
 #include <wtf/Threading.h>
 #include <wtf/WTFProcess.h>
 #include <wtf/text/StringCommon.h>

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -26,6 +26,9 @@
 #include "config.h"
 #include "testb3.h"
 
+#include "RegisterTZoneTypes.h"
+#include <wtf/TZoneMallocInitialization.h>
+
 #if ENABLE(B3_JIT) && !CPU(ARM)
 
 Lock crashLock;
@@ -935,8 +938,15 @@ extern const JSC::JITOperationAnnotation startOfJITOperationsInTestB3 __asm("sec
 extern const JSC::JITOperationAnnotation endOfJITOperationsInTestB3 __asm("section$end$__DATA_CONST$__jsc_ops");
 #endif
 
-int main(int argc, char** argv)
+int main(int argc, char** argv WTF_TZONE_EXTRA_MAIN_ARGS)
 {
+#if USE(TZONE_MALLOC)
+    const char* boothash = _simple_getenv(darwinEnvp, "executable_boothash");
+    WTF_TZONE_INIT(boothash);
+    JSC::registerTZoneTypes();
+    WTF_TZONE_REGISTRATION_DONE();
+#endif
+
     TestConfig config;
     for (int i = 1; i < argc; i++) {
         if (!strcmp(argv[i], "-filter")) {

--- a/Source/JavaScriptCore/dfg/testdfg.cpp
+++ b/Source/JavaScriptCore/dfg/testdfg.cpp
@@ -29,7 +29,10 @@
 // The above are needed before DFGAbstractValue.h
 #include "DFGAbstractValue.h"
 #include "InitializeThreading.h"
+#include "RegisterTZoneTypes.h"
 #include <wtf/DataLog.h>
+#include <wtf/TZoneMallocInitialization.h>
+#include <wtf/Threading.h>
 #include <wtf/WTFProcess.h>
 #include <wtf/text/StringCommon.h>
 
@@ -98,8 +101,15 @@ static void run(const char*)
 
 #endif // ENABLE(DFG_JIT)
 
-int main(int argc, char** argv)
+int main(int argc, char** argv WTF_TZONE_EXTRA_MAIN_ARGS)
 {
+#if USE(TZONE_MALLOC)
+    const char* boothash = _simple_getenv(darwinEnvp, "executable_boothash");
+    WTF_TZONE_INIT(boothash);
+    JSC::registerTZoneTypes();
+    WTF_TZONE_REGISTRATION_DONE();
+#endif
+
     const char* filter = nullptr;
     switch (argc) {
     case 1:

--- a/Source/JavaScriptCore/jit/JITOpaqueByproducts.h
+++ b/Source/JavaScriptCore/jit/JITOpaqueByproducts.h
@@ -36,7 +36,7 @@ namespace JSC {
 
 class OpaqueByproducts {
     WTF_MAKE_NONCOPYABLE(OpaqueByproducts)
-    WTF_MAKE_TZONE_ALLOCATED(OpaqueByproducts);
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(OpaqueByproducts, JS_EXPORT_PRIVATE);
 public:
     OpaqueByproducts();
     JS_EXPORT_PRIVATE ~OpaqueByproducts();

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -70,6 +70,7 @@
 #include "ObjectConstructor.h"
 #include "ParserError.h"
 #include "ProfilerDatabase.h"
+#include "RegisterTZoneTypes.h"
 #include "ReleaseHeapAccessScope.h"
 #include "SamplingProfiler.h"
 #include "SideDataRepository.h"
@@ -100,6 +101,7 @@
 #include <wtf/SafeStrerror.h>
 #include <wtf/Scope.h>
 #include <wtf/StringPrintStream.h>
+#include <wtf/TZoneMallocInitialization.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
 #include <wtf/WTFProcess.h>
@@ -3404,7 +3406,7 @@ static void startTimeoutThreadIfNeeded(VM& vm)
     startTimeoutTimer(timeoutDuration);
 }
 
-int main(int argc, char** argv)
+int main(int argc, char** argv WTF_TZONE_EXTRA_MAIN_ARGS)
 {
 #if OS(DARWIN) && CPU(ARM_THUMB2)
     // Enabled IEEE754 denormal support.
@@ -3412,6 +3414,11 @@ int main(int argc, char** argv)
     fegetenv( &env );
     env.__fpscr &= ~0x01000000u;
     fesetenv( &env );
+#endif
+
+#if USE(TZONE_MALLOC)
+    const char* boothash = _simple_getenv(darwinEnvp, "executable_boothash");
+    WTF_TZONE_INIT(boothash);
 #endif
 
 #if OS(DARWIN) && PLATFORM(MAC)
@@ -4236,12 +4243,22 @@ extern const JITOperationAnnotation startOfJITOperationsInShell __asm("section$s
 extern const JITOperationAnnotation endOfJITOperationsInShell __asm("section$end$__DATA_CONST$__jsc_ops");
 #endif
 
+#if USE(TZONE_MALLOC)
+extern const bmalloc::api::TZoneAnnotation startOfTZoneTypesInShell __asm("section$start$__DATA_CONST$__tzone_descs");
+extern const bmalloc::api::TZoneAnnotation endOfTZoneTypesInShell __asm("section$end$__DATA_CONST$__tzone_descs");
+#endif
+
 int jscmain(int argc, char** argv)
 {
     // Need to override and enable restricted options before we start parsing options below.
     JSC::Config::enableRestrictedOptions();
 
     WTF::initializeMainThread();
+#if USE(TZONE_MALLOC)
+    WTF_TZONE_REGISTER_TYPES(&startOfTZoneTypesInShell, &endOfTZoneTypesInShell);
+    JSC::registerTZoneTypes();
+    WTF_TZONE_REGISTRATION_DONE();
+#endif
 
     // Note that the options parsing can affect VM creation, and thus
     // comes first.

--- a/Source/JavaScriptCore/runtime/RegisterTZoneTypes.cpp
+++ b/Source/JavaScriptCore/runtime/RegisterTZoneTypes.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RegisterTZoneTypes.h"
+
+#include <wtf/TZoneMalloc.h>
+
+namespace JSC {
+
+#if USE(TZONE_MALLOC)
+extern const bmalloc::api::TZoneAnnotation startOfTZoneTypes __asm("section$start$__DATA_CONST$__tzone_descs");
+extern const bmalloc::api::TZoneAnnotation endOfTZoneTypes __asm("section$end$__DATA_CONST$__tzone_descs");
+
+void registerTZoneTypes()
+{
+    WTF_TZONE_REGISTER_TYPES(&startOfTZoneTypes, &endOfTZoneTypes);
+}
+#endif
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/RegisterTZoneTypes.h
+++ b/Source/JavaScriptCore/runtime/RegisterTZoneTypes.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSExportMacros.h"
+
+namespace JSC {
+
+#if USE(TZONE_MALLOC)
+JS_EXPORT_PRIVATE void registerTZoneTypes();
+#endif
+
+} // namespace JSC

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -277,6 +277,7 @@ private:
 #if ENABLE(WEBASSEMBLY_OMGJIT)
 
 class OMGCallee final : public OptimizingJITCallee {
+    WTF_MAKE_TZONE_ALLOCATED(OMGCallee);
 public:
     static Ref<OMGCallee> create(size_t index, std::pair<const Name*, RefPtr<NameSection>>&& name)
     {

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		6311592628989A55006A9A12 /* LibraryPathDiagnostics.h in Headers */ = {isa = PBXBuildFile; fileRef = 6311592428989A55006A9A12 /* LibraryPathDiagnostics.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		6311592728989A55006A9A12 /* LibraryPathDiagnostics.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6311592528989A55006A9A12 /* LibraryPathDiagnostics.mm */; };
 		63F9BED42898D96400371416 /* CFPrivSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 63F9BED32898D96400371416 /* CFPrivSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		65072B162B6D7FAA0065065C /* TZoneMallocInitialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 65072B152B6D7FAA0065065C /* TZoneMallocInitialization.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		70A993FE1AD7151300FA615B /* SymbolRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70A993FC1AD7151300FA615B /* SymbolRegistry.cpp */; };
 		70ECA60D1B02426800449739 /* AtomStringImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70ECA60A1B02426800449739 /* AtomStringImpl.cpp */; };
 		7A05093F1FB9DCC500B33FB8 /* JSONValues.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A05093E1FB9DCC500B33FB8 /* JSONValues.cpp */; };
@@ -1231,6 +1232,7 @@
 		6311592428989A55006A9A12 /* LibraryPathDiagnostics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LibraryPathDiagnostics.h; sourceTree = "<group>"; };
 		6311592528989A55006A9A12 /* LibraryPathDiagnostics.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LibraryPathDiagnostics.mm; sourceTree = "<group>"; };
 		63F9BED32898D96400371416 /* CFPrivSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CFPrivSPI.h; sourceTree = "<group>"; };
+		65072B152B6D7FAA0065065C /* TZoneMallocInitialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TZoneMallocInitialization.h; sourceTree = "<group>"; };
 		70A993FC1AD7151300FA615B /* SymbolRegistry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SymbolRegistry.cpp; sourceTree = "<group>"; };
 		70A993FD1AD7151300FA615B /* SymbolRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SymbolRegistry.h; sourceTree = "<group>"; };
 		70ECA60A1B02426800449739 /* AtomStringImpl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AtomStringImpl.cpp; sourceTree = "<group>"; };
@@ -2428,6 +2430,7 @@
 				83FBA93119DF459700F30ADB /* TypeCasts.h */,
 				5164042E2AB1D4DD0042B1C3 /* TypeTraits.h */,
 				FE03831B2ABC04F700A576A2 /* TZoneMalloc.h */,
+				65072B152B6D7FAA0065065C /* TZoneMallocInitialization.h */,
 				FE03831A2ABC04F700A576A2 /* TZoneMallocInlines.h */,
 				E360C7642127B85B00C90F0E /* UnalignedAccess.h */,
 				E360C7652127B85C00C90F0E /* Unexpected.h */,
@@ -3464,6 +3467,7 @@
 				DDF306FD27C086CC006A526F /* TypeCastsCocoa.h in Headers */,
 				5164042F2AB1D4DD0042B1C3 /* TypeTraits.h in Headers */,
 				FE03831D2ABC04F700A576A2 /* TZoneMalloc.h in Headers */,
+				65072B162B6D7FAA0065065C /* TZoneMallocInitialization.h in Headers */,
 				FE03831C2ABC04F700A576A2 /* TZoneMallocInlines.h in Headers */,
 				DD3DC8C927A4BF8E007E5B61 /* UnalignedAccess.h in Headers */,
 				DD3DC86A27A4BF8E007E5B61 /* Unexpected.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -294,6 +294,7 @@ set(WTF_PUBLIC_HEADERS
     SystemMalloc.h
     SystemTracing.h
     TZoneMalloc.h
+    TZoneMallocInitialization.h
     TZoneMallocInlines.h
     TaggedArrayStoragePtr.h
     ThreadAssertions.h

--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -323,7 +323,7 @@
 #endif
 
 #if !defined(USE_TZONE_MALLOC)
-#if CPU(ARM64)
+#if CPU(ARM64) && OS(DARWIN)
 // Only MacroAssemblerARM64 is known to build.
 // Building with TZONE_MALLOC currently disabled for all platforms.
 #define USE_TZONE_MALLOC 0

--- a/Source/WTF/wtf/TZoneMallocInitialization.h
+++ b/Source/WTF/wtf/TZoneMallocInitialization.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,32 +25,25 @@
 
 #pragma once
 
-#include <wtf/ForbidHeapAllocation.h>
 #include <wtf/Platform.h>
 
 #if USE(SYSTEM_MALLOC) || !USE(TZONE_MALLOC)
 
-#include <wtf/FastMalloc.h>
-
-#define WTF_TZONE_REGISTER_TYPES(begin, end)
-#define WTF_MAKE_TZONE_ALLOCATED(name) WTF_MAKE_FAST_ALLOCATED
-#define WTF_MAKE_TZONE_ALLOCATED_EXPORT(name, exportMacro) WTF_MAKE_FAST_ALLOCATED
-#define WTF_MAKE_TZONE_NONALLOCATABLE(name) WTF_FORBID_HEAP_ALLOCATION
+#define WTF_TZONE_EXTRA_MAIN_ARGS
+#define WTF_TZONE_INIT(seed)
+#define WTF_TZONE_REGISTRATION_DONE()
 
 #else
 
-#include <bmalloc/TZoneHeap.h>
+#include <_simple.h>
+#include <bmalloc/TZoneHeapManager.h>
 
 #if !BUSE(TZONE)
 #error "TZones enabled in WTF, but not enabled in bmalloc"
 #endif
 
-#define WTF_NOEXPORT
-
-#define WTF_TZONE_REGISTER_TYPES(begin, end) BTZONE_REGISTER_TYPES((const bmalloc_type*)begin, (const bmalloc_type*)end)
-#define WTF_MAKE_TZONE_ALLOCATED(name) MAKE_BTZONE_MALLOCED(name, WTF_NOEXPORT)
-#define WTF_MAKE_TZONE_ALLOCATED_EXPORT(name, exportMacro) MAKE_BTZONE_MALLOCED(name, exportMacro)
-#define WTF_MAKE_TZONE_NONALLOCATABLE(name) WTF_FORBID_HEAP_ALLOCATION
+#define WTF_TZONE_EXTRA_MAIN_ARGS , [[maybe_unused]] const char**, [[maybe_unused]] const char** darwinEnvp
+#define WTF_TZONE_INIT(seed) BTZONE_INIT(seed)
+#define WTF_TZONE_REGISTRATION_DONE() BTZONE_REGISTRATION_DONE()
 
 #endif
-

--- a/Source/WTF/wtf/TZoneMallocInlines.h
+++ b/Source/WTF/wtf/TZoneMallocInlines.h
@@ -31,21 +31,25 @@
 
 #include <wtf/FastMalloc.h>
 
-#define WTF_MAKE_TZONE_ALLOCATED_INLINE(name) WTF_MAKE_FAST_ALLOCATED
-#define WTF_MAKE_TZONE_ALLOCATED_IMPL(name) struct WTFIsoMallocSemicolonifier##name { }
-#define WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(name, type) struct WTFIsoMallocSemicolonifier##name { }
-#define WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(name) struct WTFIsoMallocSemicolonifier##name { }
-#define WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED_TEMPLATE(name, type) struct WTFIsoMallocSemicolonifier##name { }
+#define WTF_MAKE_TZONE_ALLOCATED_INLINE(typeName) WTF_MAKE_FAST_ALLOCATED
+#define WTF_MAKE_TZONE_ALLOCATED_IMPL(typeName) struct WTFIsoMallocSemicolonifier##typeName { }
+#define WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(typeName, type) struct WTFIsoMallocSemicolonifier##typeName { }
+#define WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(typeName) struct WTFIsoMallocSemicolonifier##typeName { }
+#define WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED_TEMPLATE(typeName, type) struct WTFIsoMallocSemicolonifier##typeName { }
 
 #else
 
 #include <bmalloc/TZoneHeapInlines.h>
 
-#define WTF_MAKE_TZONE_ALLOCATED_INLINE(name) MAKE_BTZONE_MALLOCED_INLINE(name)
-#define WTF_MAKE_TZONE_ALLOCATED_IMPL(name) MAKE_BTZONE_MALLOCED_IMPL(name)
-#define WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(name, type) MAKE_BTZONE_MALLOCED_IMPL_NESTED(name, type)
-#define WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(name) MAKE_BTZONE_MALLOCED_IMPL_TEMPLATE(name)
-#define WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED_TEMPLATE(name, type) MAKE_BTZONE_MALLOCED_IMPL_NESTED_TEMPLATE(name, type)
+#if !BUSE(TZONE)
+#error "TZones enabled in WTF, but not enabled in bmalloc"
+#endif
+
+#define WTF_MAKE_TZONE_ALLOCATED_INLINE(typeName) MAKE_BTZONE_MALLOCED_INLINE(typeName)
+#define WTF_MAKE_TZONE_ALLOCATED_IMPL(type) MAKE_BTZONE_MALLOCED_IMPL(type)
+#define WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED(typeName, type) MAKE_BTZONE_MALLOCED_IMPL_NESTED(typeName, type)
+#define WTF_MAKE_TZONE_ALLOCATED_IMPL_TEMPLATE(typeName) MAKE_BTZONE_MALLOCED_IMPL_TEMPLATE(typeName)
+#define WTF_MAKE_TZONE_ALLOCATED_IMPL_NESTED_TEMPLATE(typeName, type) MAKE_BTZONE_MALLOCED_IMPL_NESTED_TEMPLATE(typeName, type)
 
 #endif
 

--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -36,6 +36,8 @@ set(bmalloc_SOURCES
     bmalloc/ObjectTypeTable.cpp
     bmalloc/PerProcess.cpp
     bmalloc/Scavenger.cpp
+    bmalloc/TZoneHeap.cpp
+    bmalloc/TZoneHeapManager.cpp
     bmalloc/bmalloc.cpp
 
     libpas/src/libpas/bmalloc_heap.c
@@ -284,6 +286,9 @@ set(bmalloc_PUBLIC_HEADERS
     bmalloc/SmallPage.h
     bmalloc/StaticPerProcess.h
     bmalloc/StdLibExtras.h
+    bmalloc/TZoneHeap.h
+    bmalloc/TZoneHeapInlines.h
+    bmalloc/TZoneHeapManager.h
     bmalloc/VMAllocate.h
     bmalloc/Vector.h
     bmalloc/Zone.h

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -136,8 +136,10 @@
 		4426E2801C838EE0008EB042 /* Logging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4426E27E1C838EE0008EB042 /* Logging.cpp */; };
 		4426E2811C838EE0008EB042 /* Logging.h in Headers */ = {isa = PBXBuildFile; fileRef = 4426E27F1C838EE0008EB042 /* Logging.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		52F47249210BA30200B730BB /* MemoryStatusSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 52F47248210BA2F500B730BB /* MemoryStatusSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		65072AE72B6195B90065065C /* TZoneHeapManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65072AE52B6195B90065065C /* TZoneHeapManager.cpp */; };
 		6599C5CC1EC3F15900A2F7BB /* AvailableMemory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6599C5CA1EC3F15900A2F7BB /* AvailableMemory.cpp */; };
 		6599C5CD1EC3F15900A2F7BB /* AvailableMemory.h in Headers */ = {isa = PBXBuildFile; fileRef = 6599C5CB1EC3F15900A2F7BB /* AvailableMemory.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		65FE739D2B79E09800C5CDAF /* TZoneHeapManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 65072AE62B6195B90065065C /* TZoneHeapManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7939885B2076EEB60074A2E7 /* BulkDecommit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7939885A2076EEB50074A2E7 /* BulkDecommit.h */; };
 		795AB3C7206E0D340074FE76 /* PhysicalPageMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 795AB3C6206E0D250074FE76 /* PhysicalPageMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7C571F0122388B840077A3C7 /* StdLibExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C571F0022388B840077A3C7 /* StdLibExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1353,6 +1355,8 @@
 		4426E27E1C838EE0008EB042 /* Logging.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Logging.cpp; path = bmalloc/Logging.cpp; sourceTree = "<group>"; };
 		4426E27F1C838EE0008EB042 /* Logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Logging.h; path = bmalloc/Logging.h; sourceTree = "<group>"; };
 		52F47248210BA2F500B730BB /* MemoryStatusSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MemoryStatusSPI.h; path = bmalloc/darwin/MemoryStatusSPI.h; sourceTree = "<group>"; };
+		65072AE52B6195B90065065C /* TZoneHeapManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TZoneHeapManager.cpp; path = bmalloc/TZoneHeapManager.cpp; sourceTree = "<group>"; };
+		65072AE62B6195B90065065C /* TZoneHeapManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TZoneHeapManager.h; path = bmalloc/TZoneHeapManager.h; sourceTree = "<group>"; };
 		6599C5CA1EC3F15900A2F7BB /* AvailableMemory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AvailableMemory.cpp; path = bmalloc/AvailableMemory.cpp; sourceTree = "<group>"; };
 		6599C5CB1EC3F15900A2F7BB /* AvailableMemory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AvailableMemory.h; path = bmalloc/AvailableMemory.h; sourceTree = "<group>"; };
 		7939885A2076EEB50074A2E7 /* BulkDecommit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BulkDecommit.h; path = bmalloc/BulkDecommit.h; sourceTree = "<group>"; };
@@ -1486,6 +1490,8 @@
 				FE03831F2ABC0E9F00A576A2 /* TZoneHeap.cpp */,
 				FE03831E2ABC0E9F00A576A2 /* TZoneHeap.h */,
 				FE0383222ABC988C00A576A2 /* TZoneHeapInlines.h */,
+				65072AE52B6195B90065065C /* TZoneHeapManager.cpp */,
+				65072AE62B6195B90065065C /* TZoneHeapManager.h */,
 			);
 			name = iso;
 			sourceTree = "<group>";
@@ -2298,6 +2304,7 @@
 				7C571F0122388B840077A3C7 /* StdLibExtras.h in Headers */,
 				FE0383202ABC0E9F00A576A2 /* TZoneHeap.h in Headers */,
 				FE0383232ABC988C00A576A2 /* TZoneHeapInlines.h in Headers */,
+				65FE739D2B79E09800C5CDAF /* TZoneHeapManager.h in Headers */,
 				14DD78CE18F48D7500950799 /* valgrind.h in Headers */,
 				14DD78CF18F48D7500950702 /* Vector.h in Headers */,
 				14DD78D018F48D7500950702 /* VMAllocate.h in Headers */,
@@ -2854,6 +2861,7 @@
 				AD14AD2A202529C700890E3B /* ProcessCheck.mm in Sources */,
 				0F5BF1521F22E1570029D91D /* Scavenger.cpp in Sources */,
 				FE0383212ABC0E9F00A576A2 /* TZoneHeap.cpp in Sources */,
+				65072AE72B6195B90065065C /* TZoneHeapManager.cpp in Sources */,
 				1440AFCD1A9527AF00837FAA /* Zone.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -391,3 +391,9 @@
 #define BENABLE_MALLOC_SIZE 0
 #define BENABLE_MALLOC_GOOD_SIZE 0
 #endif
+
+#if BUSE(LIBPAS) && BOS(DARWIN) && BCPU(ARM64)
+#define BUSE_TZONE 0
+#else
+#define BUSE_TZONE 0
+#endif

--- a/Source/bmalloc/bmalloc/TZoneHeap.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeap.cpp
@@ -25,7 +25,7 @@
 
 #include "TZoneHeap.h"
 
-#if BUSE(LIBPAS)
+#if BUSE(TZONE)
 
 #include "IsoMallocFallback.h"
 #include "bmalloc_heap_inlines.h"
@@ -72,5 +72,5 @@ void tzoneDeallocate(void* ptr)
 
 } } // namespace bmalloc::api
 
-#endif // BUSE(LIBPAS)
+#endif // BUSE(TZONE)
 

--- a/Source/bmalloc/bmalloc/TZoneHeapInlines.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapInlines.h
@@ -26,6 +26,9 @@
 #pragma once
 
 #include "BPlatform.h"
+
+#if BUSE(TZONE)
+
 #include "DeferredDecommitInlines.h"
 #include "DeferredTriggerInlines.h"
 #include "EligibilityResultInlines.h"
@@ -116,11 +119,11 @@ auto TZoneHeap<Type>::impl() -> IsoHeapImpl<Config>&
 
 // This is most appropraite for template classes.
 
-#define MAKE_BTZONE_MALLOCED_INLINE(isoType) \
+#define MAKE_BTZONE_MALLOCED_INLINE(tzoneType) \
 public: \
-    static ::bmalloc::api::TZoneHeap<isoType>& btzoneHeap() \
+    static ::bmalloc::api::TZoneHeap<tzoneType>& btzoneHeap() \
     { \
-        static ::bmalloc::api::TZoneHeap<isoType> heap("WebKit_"#isoType); \
+        static ::bmalloc::api::TZoneHeap<tzoneType> heap("WebKit_"#tzoneType); \
         return heap; \
     } \
     \
@@ -129,7 +132,7 @@ public: \
     \
     void* operator new(size_t size) \
     { \
-        RELEASE_BASSERT(size == sizeof(isoType)); \
+        RELEASE_BASSERT(size == sizeof(tzoneType)); \
         return btzoneHeap().allocate(); \
     } \
     \
@@ -153,115 +156,116 @@ public: \
     \
     using webkitFastMalloced = int; \
 private: \
-    using __makeBtzoneMallocedInlineMacroSemicolonifier BunusedTypeAlias = int
+    using __makeBtzoneMallocedInlineMacroSemicolonifier BUNUSED_TYPE_ALIAS = int
 
-#define MAKE_BTZONE_MALLOCED_IMPL(isoType) \
-::bmalloc::api::TZoneHeap<isoType>& isoType::btzoneHeap() \
+#define MAKE_BTZONE_MALLOCED_IMPL(tzoneType) \
+::bmalloc::api::TZoneHeap<tzoneType>& tzoneType::btzoneHeap() \
 { \
-    static ::bmalloc::api::TZoneHeap<isoType> heap("WebKit "#isoType); \
+    static ::bmalloc::api::TZoneHeap<tzoneType> heap("WebKit "#tzoneType); \
     return heap; \
 } \
 \
-void* isoType::operator new(size_t size) \
+void* tzoneType::operator new(size_t size) \
 { \
-    RELEASE_BASSERT(size == sizeof(isoType)); \
+    RELEASE_BASSERT(size == sizeof(tzoneType)); \
     return btzoneHeap().allocate(); \
 } \
 \
-void isoType::operator delete(void* p) \
+void tzoneType::operator delete(void* p) \
 { \
     btzoneHeap().deallocate(p); \
 } \
 \
-void isoType::freeAfterDestruction(void* p) \
+void tzoneType::freeAfterDestruction(void* p) \
 { \
     btzoneHeap().deallocate(p); \
 } \
 \
-struct MakeBtzoneMallocedImplMacroSemicolonifier##isoType { }
+struct MakeBtzoneMallocedImplMacroSemicolonifier##tzoneType { }
 
-#define MAKE_BTZONE_MALLOCED_IMPL_NESTED(isoTypeName, isoType) \
-::bmalloc::api::TZoneHeap<isoType>& isoType::btzoneHeap() \
+#define MAKE_BTZONE_MALLOCED_IMPL_NESTED(tzoneTypeName, tzoneType) \
+::bmalloc::api::TZoneHeap<tzoneType>& tzoneType::btzoneHeap() \
 { \
-    static ::bmalloc::api::TZoneHeap<isoType> heap("WebKit "#isoType); \
+    static ::bmalloc::api::TZoneHeap<tzoneType> heap("WebKit "#tzoneType); \
     return heap; \
 } \
 \
-void* isoType::operator new(size_t size) \
+void* tzoneType::operator new(size_t size) \
 { \
-    RELEASE_BASSERT(size == sizeof(isoType)); \
+    RELEASE_BASSERT(size == sizeof(tzoneType)); \
     return btzoneHeap().allocate(); \
 } \
 \
-void isoType::operator delete(void* p) \
+void tzoneType::operator delete(void* p) \
 { \
     btzoneHeap().deallocate(p); \
 } \
 \
-void isoType::freeAfterDestruction(void* p) \
+void tzoneType::freeAfterDestruction(void* p) \
 { \
     btzoneHeap().deallocate(p); \
 } \
 \
-struct MakeBtzoneMallocedImplMacroSemicolonifier##isoTypeName { }
+struct MakeBtzoneMallocedImplMacroSemicolonifier##tzoneTypeName { }
 
-#define MAKE_BTZONE_MALLOCED_IMPL_TEMPLATE(isoType) \
+#define MAKE_BTZONE_MALLOCED_IMPL_TEMPLATE(tzoneType) \
 template<> \
-::bmalloc::api::TZoneHeap<isoType>& isoType::btzoneHeap() \
+::bmalloc::api::TZoneHeap<tzoneType>& tzoneType::btzoneHeap() \
 { \
-    static ::bmalloc::api::TZoneHeap<isoType> heap("WebKit_"#isoType); \
-    return heap; \
-} \
-\
-template<> \
-void* isoType::operator new(size_t size) \
-{ \
-    RELEASE_BASSERT(size == sizeof(isoType)); \
-    return btzoneHeap().allocate(); \
-} \
-\
-template<> \
-void isoType::operator delete(void* p) \
-{ \
-    btzoneHeap().deallocate(p); \
-} \
-\
-template<> \
-void isoType::freeAfterDestruction(void* p) \
-{ \
-    btzoneHeap().deallocate(p); \
-} \
-\
-struct MakeBtzoneMallocedImplMacroSemicolonifier##isoType { }
-
-#define MAKE_BTZONE_MALLOCED_IMPL_NESTED_TEMPLATE(isoTypeName, isoType) \
-template<> \
-::bmalloc::api::TZoneHeap<isoType>& isoType::btzoneHeap() \
-{ \
-    static ::bmalloc::api::TZoneHeap<isoType> heap("WebKit "#isoType); \
+    static ::bmalloc::api::TZoneHeap<tzoneType> heap("WebKit_"#tzoneType); \
     return heap; \
 } \
 \
 template<> \
-void* isoType::operator new(size_t size) \
+void* tzoneType::operator new(size_t size) \
 { \
-    RELEASE_BASSERT(size == sizeof(isoType)); \
+    RELEASE_BASSERT(size == sizeof(tzoneType)); \
     return btzoneHeap().allocate(); \
 } \
 \
 template<> \
-void isoType::operator delete(void* p) \
+void tzoneType::operator delete(void* p) \
 { \
     btzoneHeap().deallocate(p); \
 } \
 \
 template<> \
-void isoType::freeAfterDestruction(void* p) \
+void tzoneType::freeAfterDestruction(void* p) \
 { \
     btzoneHeap().deallocate(p); \
 } \
 \
-struct MakeBtzoneMallocedImplMacroSemicolonifier##isoTypeName { }
+struct MakeBtzoneMallocedImplMacroSemicolonifier##tzoneType { }
+
+#define MAKE_BTZONE_MALLOCED_IMPL_NESTED_TEMPLATE(tzoneTypeName, tzoneType) \
+template<> \
+::bmalloc::api::TZoneHeap<tzoneType>& tzoneType::btzoneHeap() \
+{ \
+    static ::bmalloc::api::TZoneHeap<tzoneType> heap("WebKit "#tzoneType); \
+    return heap; \
+} \
+\
+template<> \
+void* tzoneType::operator new(size_t size) \
+{ \
+    RELEASE_BASSERT(size == sizeof(tzoneType)); \
+    return btzoneHeap().allocate(); \
+} \
+\
+template<> \
+void tzoneType::operator delete(void* p) \
+{ \
+    btzoneHeap().deallocate(p); \
+} \
+\
+template<> \
+void tzoneType::freeAfterDestruction(void* p) \
+{ \
+    btzoneHeap().deallocate(p); \
+} \
+\
+struct MakeBtzoneMallocedImplMacroSemicolonifier##tzoneTypeName { }
 
 } } // namespace bmalloc::api
 
+#endif // BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "TZoneHeapManager.h"
+
+#if BUSE(TZONE)
+
+#include "Sizes.h"
+#include "VMAllocate.h"
+#include "bmalloc.h"
+#include "bmalloc_heap_inlines.h"
+
+namespace bmalloc { namespace api {
+
+static constexpr bool verbose = false;
+
+TZoneHeapManager* TZoneHeapManager::theTZoneHeapManager = nullptr;
+
+static const char base64Chars[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+static const unsigned SizeBase64Size = 3;
+static const unsigned AlignmentBase64Size = 1;
+static const unsigned IndexSize = 2;
+static const unsigned typeNameLen = 12;
+
+typedef union {
+    struct {
+        char prefix[3];
+        char sizeBase64[SizeBase64Size];
+        char underscore1;
+        char alignmentBase64[AlignmentBase64Size];
+        char underscore2;
+        char index[IndexSize];
+        char terminatingNull;
+    } nameTemplate;
+    char string[typeNameLen];
+} TypeNameTemplate;
+
+static_assert(sizeof(TypeNameTemplate) == typeNameLen);
+
+static TypeNameTemplate typeNameTemplate;
+
+void TZoneHeapManager::init(const char* seed)
+{
+    RELEASE_BASSERT(m_state == TZoneHeapManager::Uninitialized);
+
+    if (verbose)
+        fprintf(stderr, "TZoneHeapManager(seed: %s)\n", seed ? seed : "<null>");
+
+    if (seed && seed[0]) {
+        // Convert seed string to hex values.
+        enum { HighNibble, LowNibble } currentNibble = HighNibble;
+        unsigned char currentByte = 0;
+        for (unsigned i = 0; i < CC_SHA1_DIGEST_LENGTH * 2 && seed[i]; ++i) {
+            char currentChar = seed[i];
+            unsigned char nibble = currentChar >= '0' && currentChar <= '9' ? currentChar - '0' : (((currentChar |= 0x20) >= 'a' && currentChar <= 'f') ? 10 + currentChar - 'a' : 0);
+            if (currentNibble == HighNibble) {
+                currentByte = nibble << 4;
+                currentNibble = LowNibble;
+            } else {
+                currentByte |= nibble;
+                m_tzoneKey.seed[i >> 1] = currentByte;
+                currentNibble = HighNibble;
+            }
+        }
+    } else {
+        const unsigned char defaultSeed[CC_SHA1_DIGEST_LENGTH] = { "DefaultSeed\x12\x34\x56\x78\x9a\xbc\xde\xf0" };
+        memcpy(m_tzoneKey.seed, defaultSeed, CC_SHA1_DIGEST_LENGTH);
+    }
+
+    m_state = TZoneHeapManager::Seeded;
+}
+
+void TZoneHeapManager::initTypenameTemplate()
+{
+    typeNameTemplate.nameTemplate.prefix[0] = 'T';
+    typeNameTemplate.nameTemplate.prefix[1] = 'Z';
+    typeNameTemplate.nameTemplate.prefix[2] = '_';
+    typeNameTemplate.nameTemplate.underscore1 = '_';
+    typeNameTemplate.nameTemplate.underscore2 = '_';
+    typeNameTemplate.nameTemplate.terminatingNull = '\0';
+}
+
+void TZoneHeapManager::registerTZoneTypes(const bmalloc_type* begin, const bmalloc_type* end)
+{
+    RELEASE_BASSERT(m_state == TZoneHeapManager::Seeded || m_state == TZoneHeapManager::RegisteringTypes);
+
+    m_state = TZoneHeapManager::RegisteringTypes;
+
+    for (const auto* current = begin; current != end; ++current) {
+        registeredTypeCount++;
+        SizeAndAlign typeSizeAlign = SizeAndAlign(current);
+        unsigned count = 1;
+        if (m_typeCountBySizeAndAlignment.contains(typeSizeAlign)) {
+            count = m_typeCountBySizeAndAlignment.get(typeSizeAlign);
+            ++count;
+        } else
+            m_typeSizes.push(typeSizeAlign);
+
+        m_typeCountBySizeAndAlignment.set(typeSizeAlign, count);
+    }
+}
+
+static char* nameForType(UniqueLockHolder&, unsigned typeSize, unsigned alignment, unsigned index)
+{
+    for (unsigned i = 0; i < SizeBase64Size; ++i) {
+        typeNameTemplate.nameTemplate.sizeBase64[SizeBase64Size - i - 1] = base64Chars[typeSize % 64];
+        typeSize <<= 6;
+    }
+
+    for (unsigned i = 0; i < AlignmentBase64Size; ++i) {
+        typeNameTemplate.nameTemplate.alignmentBase64[AlignmentBase64Size - i - 1] = base64Chars[alignment % 64];
+        alignment <<= 6;
+    }
+
+    for (unsigned i = 0; i < IndexSize; ++i) {
+        typeNameTemplate.nameTemplate.index[IndexSize - i - 1] = '0' + index % 10;
+        index /= 10;
+    }
+
+    return &typeNameTemplate.string[0];
+}
+
+static char* nameForTypeUpdateIndex(UniqueLockHolder&, unsigned index)
+{
+    for (unsigned i = 0; i < IndexSize; ++i) {
+        typeNameTemplate.nameTemplate.index[IndexSize - i - 1] = '0' + index % 10;
+        index /= 10;
+    }
+
+    return &typeNameTemplate.string[0];
+}
+
+void TZoneHeapManager::closeRegistration()
+{
+    static_assert(!(sizeof(TZoneBucket) % sizeof(void*)));
+    static_assert(!(sizeof(TZoneTypeBuckets) % sizeof(void*)));
+
+    RELEASE_BASSERT(m_state == TZoneHeapManager::Seeded || m_state == TZoneHeapManager::RegisteringTypes);
+
+    if (verbose) {
+        auto typeSizesEnd = m_typeSizes.end();
+
+        Vector<unsigned> bucketCountHistogram;
+
+        bucketCountHistogram.grow(6);
+
+        for (auto iter = m_typeSizes.begin(); iter < typeSizesEnd; iter++) {
+            SizeAndAlign typeSizeAlign = *iter;
+            auto typeCount = m_typeCountBySizeAndAlignment.get(typeSizeAlign);
+            auto bucketCount = bucketCountForTypeCount(typeCount);
+
+            bucketCountHistogram[bucketCount] = bucketCountHistogram[bucketCount] + 1;
+            if (typeCount > largestSizeClassCount) {
+                largestSizeClassCount = typeCount;
+                largestSizeClass = typeSizeAlign;
+            }
+        }
+
+        fprintf(stderr, "TZoneHeapManager configured: registered types: %u  size classes: %zu\n", registeredTypeCount, m_typeSizes.size());
+        fprintf(stderr, "    most populated size class:  size: %u  alignment %u  type count: %u\n", largestSizeClass.size(), largestSizeClass.alignment(), largestSizeClassCount);
+        fprintf(stderr, "    size class bucket histogram:");
+        for (unsigned i = 1; i <= 5; ++i)
+            fprintf(stderr, " count %u: %u", i, bucketCountHistogram[i]);
+        fprintf(stderr, "\n");
+    }
+
+    m_state = TZoneHeapManager::TypesRegistered;
+}
+
+void TZoneHeapManager::ensureInstance()
+{
+    static std::once_flag onceFlag;
+    std::call_once(
+        onceFlag,
+        [] {
+            theTZoneHeapManager = new TZoneHeapManager();
+        }
+    );
+};
+
+TZoneHeapManager::TZoneTypeBuckets* TZoneHeapManager::populateBucketsForSizeClass(UniqueLockHolder& lock, SizeAndAlign typeSizeAlign)
+{
+    BASSERT(!m_heapRefsBySizeAndAlignment.contains(typeSizeAlign));
+
+    auto typeCount = m_typeCountBySizeAndAlignment.get(typeSizeAlign);
+    auto bucketCount = bucketCountForTypeCount(typeCount);
+
+    TZoneTypeBuckets* buckets = static_cast<TZoneTypeBuckets*>(zeroedMalloc(SIZE_TZONE_TYPE_BUCKETS(bucketCount)));
+
+    buckets->numberOfBuckets = bucketCount;
+
+    for (unsigned i = 0; i < bucketCount; ++i) {
+        char* typeName = !i ? nameForType(lock, typeSizeAlign.size(), typeSizeAlign.alignment(), i) : nameForTypeUpdateIndex(lock, i);
+        memcpy(buckets->buckets[i].typeName, typeName, typeNameLen);
+        buckets->buckets[i].type.size = typeSizeAlign.size();
+        buckets->buckets[i].type.alignment = typeSizeAlign.alignment();
+        buckets->buckets[i].type.name = buckets->buckets[i].typeName;
+        buckets->buckets[i].heapref.type = (const pas_heap_type*)(&buckets->buckets[i].type);
+    }
+
+    m_heapRefsBySizeAndAlignment.set(typeSizeAlign, buckets);
+
+    return buckets;
+}
+
+
+pas_heap_ref* TZoneHeapManager::heapRefForTZoneType(bmalloc_type* classType)
+{
+    RELEASE_BASSERT(m_state == TZoneHeapManager::TypesRegistered);
+
+    UniqueLockHolder lock(mutex());
+
+    SizeAndAlign typeSizeAlign = SizeAndAlign(classType);
+
+    TZoneTypeBuckets* bucketsForSize = nullptr;
+
+    if (m_heapRefsBySizeAndAlignment.contains(typeSizeAlign))
+        bucketsForSize = m_heapRefsBySizeAndAlignment.get(typeSizeAlign);
+    else
+        bucketsForSize = populateBucketsForSizeClass(lock, typeSizeAlign);
+
+    unsigned bucket = tzoneBucketForKey(lock, classType, bucketsForSize->numberOfBuckets);
+
+    return &bucketsForSize->buckets[bucket].heapref;
+}
+
+} } // namespace bmalloc::api
+
+#endif // BUSE(TZONE)

--- a/Source/bmalloc/bmalloc/TZoneHeapManager.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.h
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "BExport.h"
+#include "BPlatform.h"
+
+#if BUSE(TZONE)
+
+#include "IsoConfig.h"
+#include "Map.h"
+#include "Mutex.h"
+#include <CommonCrypto/CommonDigest.h>
+#include <mutex>
+
+#if BUSE(LIBPAS)
+#include "bmalloc_heap_ref.h"
+
+namespace bmalloc { namespace api {
+
+class TZoneHeapManager {
+    enum State {
+        Uninitialized,
+        Seeded,
+        RegisteringTypes,
+        TypesRegistered
+    };
+
+    static const unsigned typeNameLen = 12;
+
+    typedef uint64_t SHA256ResultAsUnsigned[CC_SHA256_DIGEST_LENGTH / sizeof(uint64_t)];
+    static_assert(!(CC_SHA256_DIGEST_LENGTH % sizeof(uint64_t)));
+
+    struct TZoneHeapRandomizeKey {
+        unsigned char seed[CC_SHA1_DIGEST_LENGTH];
+        bmalloc_type* classType;
+        unsigned sizeOfType;
+        unsigned alignmentOfType;
+    };
+
+    struct TZoneBucket {
+        bmalloc_type type;
+        pas_heap_ref heapref;
+        char typeName[typeNameLen];
+    };
+
+    struct TZoneTypeBuckets {
+        unsigned numberOfBuckets;
+        unsigned unusedSpaceFiller;
+        TZoneBucket buckets[0];
+    };
+
+#define SIZE_TZONE_TYPE_BUCKETS(count) (sizeof(struct TZoneTypeBuckets) + count * sizeof(TZoneBucket))
+
+    struct SizeAndAlign {
+        SizeAndAlign()
+        {
+            m_value.key = 0;
+        }
+
+        SizeAndAlign(unsigned size, unsigned alignment)
+        {
+            m_value.u.size = size;
+            m_value.u.alignment = alignment;
+        }
+
+        SizeAndAlign(const bmalloc_type* type)
+        {
+            m_value.u.size = type->size;
+            m_value.u.alignment = type->alignment;
+        }
+
+        inline unsigned size() const { return m_value.u.size; }
+        inline unsigned alignment() const { return m_value.u.alignment; }
+        inline unsigned long key() const { return m_value.key; }
+
+        static unsigned long hash(SizeAndAlign value)
+        {
+            return value.key() >> 4;
+        }
+
+        bool operator==(const SizeAndAlign& other) const
+        {
+            return key() == other.key();
+        }
+
+        operator bool() const
+        {
+            return !!key();
+        }
+
+        union {
+            struct {
+                unsigned alignment;
+                unsigned size;
+            } u;
+            unsigned long key;
+        } m_value;
+    };
+
+protected:
+    TZoneHeapManager()
+        : m_state(TZoneHeapManager::Uninitialized)
+    {
+        initTypenameTemplate();
+    }
+
+public:
+    TZoneHeapManager(TZoneHeapManager &other) = delete;
+    void operator=(const TZoneHeapManager &) = delete;
+
+    BEXPORT void init(const char* seed);
+
+    BINLINE static TZoneHeapManager& getInstance()
+    {
+        if (!theTZoneHeapManager)
+            ensureInstance();
+        BASSERT(theTZoneHeapManager);
+        return *theTZoneHeapManager;
+    }
+
+    BEXPORT void registerTZoneTypes(const bmalloc_type* start, const bmalloc_type* end);
+    BEXPORT void closeRegistration();
+    BEXPORT pas_heap_ref* heapRefForTZoneType(bmalloc_type* classType);
+
+private:
+    BEXPORT static void ensureInstance();
+
+    void initTypenameTemplate();
+
+    BINLINE Mutex& mutex() { return m_mutex; }
+
+    BINLINE unsigned bucketCountForTypeCount(unsigned typeCount)
+    {
+        BASSERT(typeCount);
+
+        // Returns number of buckets for the typeCount.
+        // The goal here is to have a sufficient number of buckets to to provide enough randomness without an adverse impact on memory use.
+        if (typeCount == 1)
+            return 1;
+        if (typeCount <= 4)
+            return 2;
+        if (typeCount <= 9)
+            return 3;
+        if (typeCount <= 19)
+            return 4;
+
+        return 5;
+    }
+
+    BINLINE unsigned tzoneBucketForKey(UniqueLockHolder&, bmalloc_type* type, unsigned bucketCountForSize)
+    {
+        SHA256ResultAsUnsigned sha256Result;
+
+        m_tzoneKey.classType = type;
+        m_tzoneKey.sizeOfType = type->size;
+        m_tzoneKey.alignmentOfType = type->alignment;
+
+        (void)CC_SHA256(&m_tzoneKey, sizeof(TZoneHeapRandomizeKey), (unsigned char*)&sha256Result);
+
+        return sha256Result[3] % bucketCountForSize;
+    }
+
+    TZoneTypeBuckets* populateBucketsForSizeClass(UniqueLockHolder&, SizeAndAlign);
+
+    BEXPORT static TZoneHeapManager* theTZoneHeapManager;
+
+    TZoneHeapManager::State m_state;
+    Mutex m_mutex;
+    unsigned registeredTypeCount { 0 };
+    unsigned largestSizeClassCount { 0 };
+    TZoneHeapRandomizeKey m_tzoneKey;
+    SizeAndAlign largestSizeClass;
+    Map<SizeAndAlign, unsigned, SizeAndAlign> m_typeCountBySizeAndAlignment;
+    Vector<SizeAndAlign> m_typeSizes;
+    Map<SizeAndAlign, TZoneTypeBuckets*, SizeAndAlign> m_heapRefsBySizeAndAlignment;
+};
+
+#define BTZONE_INIT(seed) bmalloc::api::TZoneHeapManager::getInstance().init(seed)
+#define BTZONE_REGISTER_TYPES(begin, end) bmalloc::api::TZoneHeapManager::getInstance().registerTZoneTypes(begin, end)
+#define BTZONE_REGISTRATION_DONE() bmalloc::api::TZoneHeapManager::getInstance().closeRegistration()
+
+} } // namespace bmalloc::api
+
+#else // BUSE(LIBPAS) -> so !BUSE(LIBPAS)
+
+#define BTZONE_INIT(seed)
+#define BTZONE_REGISTER_TYPES(begin, end)
+#define BTZONE_REGISTRATION_DONE()
+
+#endif // BUSE(LIBPAS) -> so end of !BUSE(LIBPAS)
+
+#endif // BUSE(TZONE)

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -63,6 +63,7 @@
 #import <JavaScriptCore/InitializeThreading.h>
 #import <JavaScriptCore/JSCConfig.h>
 #import <JavaScriptCore/Options.h>
+#import <JavaScriptCore/RegisterTZoneTypes.h>
 #import <JavaScriptCore/TestRunnerUtils.h>
 #import <WebCore/LogInitialization.h>
 #import <WebCore/NetworkStorageSession.h>
@@ -101,6 +102,7 @@
 #import <wtf/OSObjectPtr.h>
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/TZoneMallocInitialization.h>
 #import <wtf/Threading.h>
 #import <wtf/UniqueArray.h>
 #import <wtf/WTFProcess.h>
@@ -1311,6 +1313,12 @@ void atexitFunction()
 
 int DumpRenderTreeMain(int argc, const char *argv[])
 {
+#if USE(TZONE_MALLOC)
+    WTF_TZONE_INIT(nullptr);
+    JSC::registerTZoneTypes();
+    WTF_TZONE_REGISTRATION_DONE();
+#endif
+
     atexit(atexitFunction);
 
     WTF::setProcessPrivileges(allPrivileges());


### PR DESCRIPTION
#### 40f96223908c9f08584300adf79bc50a855116cc
<pre>
TZone: Implement TZone Allocation on JavaScriptCore Types
<a href="https://bugs.webkit.org/show_bug.cgi?id=268673">https://bugs.webkit.org/show_bug.cgi?id=268673</a>
<a href="https://rdar.apple.com/122213822">rdar://122213822</a>

Reviewed by Keith Miller.

This patch implements TZone selection in bmalloc through the newly added TZoneHeapManager class.
The macro that defines a TZone allocated type puts the type name, type size and type aligment in a static bmalloc_type.
That static object is now placed in a newly added __DATA_CONST$__tzone_descs section.  At startup time, each dylib / framework
will register their types by passing this new section&apos;s start and end location to the TZoneHeapManager::registerTZoneTypes() method.
When allocating a type for the first time, TZoneHeapManager will allocate if needed for all buckets for the same size and alignment.
Then the manager will compute which of those bucket to use the current type.  This is computed by a process start up seed and the
size and type.

The JavaScript types have been annotated and all JavaScript tests run.  DumpRenderTree has been modified as well.

This patch has TZone allocation turned off via BUSE_TZONE in bmalloc/BPlatform.h and USE_TZONE_MALLOC in wtc/PlatformUse.h
The BUSE_TZONE macro was added to work around a linker bug where unused exported functions end up being eliminated.

* Source/JavaScriptCore/API/tests/testapi.c:
(main):
* Source/JavaScriptCore/API/tests/testapi.cpp:
(WTFTZoneInit):
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/assembler/testmasm.cpp:
(main):
* Source/JavaScriptCore/b3/air/testair.cpp:
(main):
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(main):
* Source/JavaScriptCore/dfg/testdfg.cpp:
(main):
* Source/JavaScriptCore/jit/JITOpaqueByproducts.h:
* Source/JavaScriptCore/jsc.cpp:
(main):
(jscmain):
* Source/JavaScriptCore/runtime/RegisterTZoneTypes.cpp: Added.
(JSC::registerTZoneTypes):
* Source/JavaScriptCore/runtime/RegisterTZoneTypes.h: Added.
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/PlatformUse.h:
* Source/WTF/wtf/TZoneMalloc.h:
* Source/WTF/wtf/TZoneMallocInitialization.h: Copied from Source/WTF/wtf/TZoneMalloc.h.
* Source/WTF/wtf/TZoneMallocInlines.h:
* Source/bmalloc/CMakeLists.txt:
* Source/bmalloc/bmalloc.xcodeproj/project.pbxproj:
* Source/bmalloc/bmalloc/BPlatform.h:
* Source/bmalloc/bmalloc/Map.h:
(bmalloc::Map::contains):
* Source/bmalloc/bmalloc/TZoneHeap.cpp:
* Source/bmalloc/bmalloc/TZoneHeap.h:
(bmalloc::api::roundUpToMulipleOf8):
(bmalloc::api::TZoneHeap::provideHeap):
* Source/bmalloc/bmalloc/TZoneHeapInlines.h:
* Source/bmalloc/bmalloc/TZoneHeapManager.cpp: Added.
(bmalloc::api::TZoneHeapManager::init):
(bmalloc::api::TZoneHeapManager::initTypenameTemplate):
(bmalloc::api::TZoneHeapManager::registerTZoneTypes):
(bmalloc::api::nameForType):
(bmalloc::api::nameForTypeUpdateIndex):
(bmalloc::api::TZoneHeapManager::closeRegistration):
(bmalloc::api::TZoneHeapManager::ensureInstance):
(bmalloc::api::TZoneHeapManager::populateBucketsForSizeClass):
(bmalloc::api::TZoneHeapManager::heapRefForTZoneType):
* Source/bmalloc/bmalloc/TZoneHeapManager.h: Added.
(bmalloc::api::TZoneHeapManager::SizeAndAlign::SizeAndAlign):
(bmalloc::api::TZoneHeapManager::SizeAndAlign::size const):
(bmalloc::api::TZoneHeapManager::SizeAndAlign::alignment const):
(bmalloc::api::TZoneHeapManager::SizeAndAlign::key const):
(bmalloc::api::TZoneHeapManager::SizeAndAlign::hash):
(bmalloc::api::TZoneHeapManager::SizeAndAlign::operator== const):
(bmalloc::api::TZoneHeapManager::SizeAndAlign::operator bool const):
(bmalloc::api::TZoneHeapManager::TZoneHeapManager):
(bmalloc::api::TZoneHeapManager::getInstance):
(bmalloc::api::TZoneHeapManager::mutex):
(bmalloc::api::TZoneHeapManager::bucketCountForTypeCount):
(bmalloc::api::TZoneHeapManager::tzoneBucketForKey):
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(DumpRenderTreeMain):

Canonical link: <a href="https://commits.webkit.org/274606@main">https://commits.webkit.org/274606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/531be2ec74e23690bfad29366baa50e05cceddb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39525 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42059 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35425 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41831 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15833 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34220 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13539 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43337 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/32978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35885 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35501 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39300 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/39151 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11816 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15943 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/46157 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8855 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15991 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9414 "Found 3 new JSC binary failures: testair, testapi, testmasm, Found 21593 new JSC stress test failures: ChakraCore.yaml/ChakraCore/test/Array/array_indexOf.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_lastindexof.js.default, ChakraCore.yaml/ChakraCore/test/Array/array_sort3.js.default, ChakraCore.yaml/ChakraCore/test/Array/concat1.js.default, ChakraCore.yaml/ChakraCore/test/Array/join2.js.default, ChakraCore.yaml/ChakraCore/test/Array/memop_alias.js.default, ChakraCore.yaml/ChakraCore/test/Array/protoLookup.js.default, ChakraCore.yaml/ChakraCore/test/Array/push2.js.default, ChakraCore.yaml/ChakraCore/test/Array/shift_unshift.js.default, ChakraCore.yaml/ChakraCore/test/Array/sparsearray.js.default ... (failure)") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15600 "Build is in progress. Recent messages:") | | | 
<!--EWS-Status-Bubble-End-->