### PR TITLE
Every Timer objects wastes 7 bytes for padding

### DIFF
--- a/Source/WebCore/platform/ThreadTimers.h
+++ b/Source/WebCore/platform/ThreadTimers.h
@@ -27,6 +27,7 @@
 #ifndef ThreadTimers_h
 #define ThreadTimers_h
 
+#include <wtf/IsoMalloc.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/RefCounted.h>
@@ -75,6 +76,9 @@ private:
 };
 
 struct ThreadTimerHeapItem : ThreadSafeRefCounted<ThreadTimerHeapItem> {
+    WTF_MAKE_ISO_ALLOCATED(ThreadTimerHeapItem);
+    WTF_ALLOW_STRUCT_COMPACT_POINTERS;
+
     static RefPtr<ThreadTimerHeapItem> create(TimerBase&, MonotonicTime, unsigned);
 
     bool hasTimer() const { return m_timer; }

--- a/Source/WebCore/platform/Timer.h
+++ b/Source/WebCore/platform/Timer.h
@@ -66,7 +66,7 @@ public:
     inline void stop();
     inline bool isActive() const;
 
-    MonotonicTime nextFireTime() const { return m_heapItem ? m_heapItem->time : MonotonicTime { }; }
+    MonotonicTime nextFireTime() const { return m_heapItemWithBitfields.pointer() ? m_heapItemWithBitfields.pointer()->time : MonotonicTime { }; }
     WEBCORE_EXPORT Seconds nextFireInterval() const;
     Seconds nextUnalignedFireInterval() const;
     Seconds repeatInterval() const { return m_repeatInterval; }
@@ -74,15 +74,24 @@ public:
     void setTimerAlignment(TimerAlignment& alignment) { m_alignment = alignment; }
     TimerAlignment* timerAlignment() { return m_alignment.get(); }
 
-    bool hasReachedMaxNestingLevel() const { return m_hasReachedMaxNestingLevel; }
-    void setHasReachedMaxNestingLevel(bool value) { m_hasReachedMaxNestingLevel = value; }
+    bool hasReachedMaxNestingLevel() const { return bitfields().hasReachedMaxNestingLevel; }
+    void setHasReachedMaxNestingLevel(bool);
 
-    void augmentFireInterval(Seconds delta) { setNextFireTime(m_heapItem->time + delta); }
+    void augmentFireInterval(Seconds delta) { setNextFireTime(m_heapItemWithBitfields.pointer()->time + delta); }
     void augmentRepeatInterval(Seconds delta) { augmentFireInterval(delta); m_repeatInterval += delta; }
 
     void didChangeAlignmentInterval();
 
     WEBCORE_EXPORT static void fireTimersInNestedEventLoop();
+
+protected:
+    struct TimerBitfields {
+        uint8_t hasReachedMaxNestingLevel : 1 { false };
+        uint8_t shouldRestartWhenTimerFires : 1 { false }; // DeferrableOneShotTimer
+    };
+
+    TimerBitfields bitfields() const { return bitwise_cast<TimerBitfields>(m_heapItemWithBitfields.type()); }
+    void setBitfields(const TimerBitfields& bitfields) { return m_heapItemWithBitfields.setType(bitwise_cast<uint8_t>(bitfields)); }
 
 private:
     virtual void fired() = 0;
@@ -94,7 +103,7 @@ private:
 
     void setNextFireTime(MonotonicTime);
 
-    bool inHeap() const { return m_heapItem && m_heapItem->isInHeap(); }
+    bool inHeap() const { return m_heapItemWithBitfields.pointer() && m_heapItemWithBitfields.pointer()->isInHeap(); }
 
     bool hasValidHeapPosition() const;
     void updateHeapIfNeeded(MonotonicTime oldTime);
@@ -111,16 +120,14 @@ private:
     WeakPtr<TimerAlignment> m_alignment;
     MonotonicTime m_unalignedNextFireTime; // m_nextFireTime not considering alignment interval
     Seconds m_repeatInterval; // 0 if not repeating
-    bool m_hasReachedMaxNestingLevel { false };
 
-    RefPtr<ThreadTimerHeapItem> m_heapItem;
+    CompactRefPtrTuple<ThreadTimerHeapItem, uint8_t> m_heapItemWithBitfields;
     Ref<Thread> m_thread { Thread::current() };
 
     friend class ThreadTimers;
     friend class TimerHeapLessThanFunction;
     friend class TimerHeapReference;
 };
-
 
 class Timer : public TimerBase {
     WTF_MAKE_FAST_ALLOCATED;
@@ -157,7 +164,7 @@ private:
 
 inline void TimerBase::stop()
 {
-    if (m_heapItem)
+    if (m_heapItemWithBitfields.pointer())
         stopSlowCase();
 }
 
@@ -172,6 +179,13 @@ inline bool TimerBase::isActive() const
     return static_cast<bool>(nextFireTime());
 }
 
+inline void TimerBase::setHasReachedMaxNestingLevel(bool value)
+{
+    auto values = bitfields();
+    values.hasReachedMaxNestingLevel = value;
+    setBitfields(values);
+}
+
 class DeferrableOneShotTimer : protected TimerBase {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -184,7 +198,6 @@ public:
     DeferrableOneShotTimer(Function<void()>&& function, Seconds delay)
         : m_function(WTFMove(function))
         , m_delay(delay)
-        , m_shouldRestartWhenTimerFires(false)
     {
     }
 
@@ -195,7 +208,7 @@ public:
         // can be quite expensive.
 
         if (isActive()) {
-            m_shouldRestartWhenTimerFires = true;
+            setShouldRestartWhenTimerFires(true);
             return;
         }
         startOneShot(m_delay);
@@ -203,7 +216,7 @@ public:
 
     void stop()
     {
-        m_shouldRestartWhenTimerFires = false;
+        setShouldRestartWhenTimerFires(false);
         TimerBase::stop();
     }
 
@@ -212,8 +225,8 @@ public:
 private:
     void fired() override
     {
-        if (m_shouldRestartWhenTimerFires) {
-            m_shouldRestartWhenTimerFires = false;
+        if (bitfields().shouldRestartWhenTimerFires) {
+            setShouldRestartWhenTimerFires(false);
             startOneShot(m_delay);
             return;
         }
@@ -221,10 +234,16 @@ private:
         m_function();
     }
 
+    void setShouldRestartWhenTimerFires(bool value)
+    {
+        auto values = bitfields();
+        values.shouldRestartWhenTimerFires = value;
+        setBitfields(values);
+    }
+
     Function<void()> m_function;
 
     Seconds m_delay;
-    bool m_shouldRestartWhenTimerFires;
 };
 
 }


### PR DESCRIPTION
#### c2eedea2d5307cb97dfadde9f990ce1ab625d2f5
<pre>
Every Timer objects wastes 7 bytes for padding
<a href="https://bugs.webkit.org/show_bug.cgi?id=268703">https://bugs.webkit.org/show_bug.cgi?id=268703</a>

Reviewed by Darin Adler.

Use a CompactRefPtrTuple to avoid 7-byte padding at the end of each Timer object.
Also use iso-heap for ThreadTimerHeapItem since this object historically had bad
memory management bugs.

* Source/WebCore/platform/ThreadTimers.h:
* Source/WebCore/platform/Timer.cpp:
(WebCore::TimerHeapLessThanFunction::compare):
(WebCore::SameSizeAsTimer::~SameSizeAsTimer):
(WebCore::TimerBase::~TimerBase):
(WebCore::TimerBase::nextFireInterval const):
(WebCore::TimerBase::checkHeapIndex const):
(WebCore::TimerBase::heapDecreaseKey):
(WebCore::TimerBase::heapDelete):
(WebCore::TimerBase::heapDeleteMin):
(WebCore::TimerBase::heapInsert):
(WebCore::TimerBase::heapPop):
(WebCore::TimerBase::heapPopMin):
(WebCore::TimerBase::hasValidHeapPosition const):
(WebCore::TimerBase::updateHeapIfNeeded):
(WebCore::TimerBase::setNextFireTime):
* Source/WebCore/platform/Timer.h:
(WebCore::TimerBase::nextFireTime const):
(WebCore::TimerBase::hasReachedMaxNestingLevel const):
(WebCore::TimerBase::augmentFireInterval):
(WebCore::TimerBase::bitfields const):
(WebCore::TimerBase::setBitfields):
(WebCore::TimerBase::inHeap const):
(WebCore::TimerBase::stop):
(WebCore::TimerBase::setHasReachedMaxNestingLevel):
(WebCore::DeferrableOneShotTimer::DeferrableOneShotTimer):
(WebCore::DeferrableOneShotTimer::restart):
(WebCore::DeferrableOneShotTimer::stop):
(WebCore::DeferrableOneShotTimer::setShouldRestartWhenTimerFires):

Canonical link: <a href="https://commits.webkit.org/274077@main">https://commits.webkit.org/274077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b2c9dff180fe88236cb3ed5f5dca15ed5099c5d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40327 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33613 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31968 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14043 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33078 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12271 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41587 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34201 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34207 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38093 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12796 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36268 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14208 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13176 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4904 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13519 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->