### PR TITLE
Rename `Cloneable` to `Clonable` to align with Web Specification wording

### DIFF
--- a/LayoutTests/fast/shadow-dom/clonable-shadow-root-expected.txt
+++ b/LayoutTests/fast/shadow-dom/clonable-shadow-root-expected.txt
@@ -1,8 +1,8 @@
 
-PASS ShadowRoot in "open" mode is not cloneable by default
-PASS ShadowRoot in "closed" mode is not cloneable by default
-PASS ShadowRoot in "open" mode is cloneable if cloneable flag is set
-PASS ShadowRoot in "closed" mode is cloneable if cloneable flag is set
+PASS ShadowRoot in "open" mode is not clonable by default
+PASS ShadowRoot in "closed" mode is not clonable by default
+PASS ShadowRoot in "open" mode is clonable if clonable flag is set
+PASS ShadowRoot in "closed" mode is clonable if clonable flag is set
 PASS Cloning ShadowRoot in "open" mode clones shadow root mode
 PASS Cloning ShadowRoot in "closed" mode clones shadow root mode
 PASS Cloning ShadowRoot in "open" mode clones delegatesFocus flag set to true

--- a/LayoutTests/fast/shadow-dom/clonable-shadow-root.html
+++ b/LayoutTests/fast/shadow-dom/clonable-shadow-root.html
@@ -12,14 +12,14 @@ function testShadowRootIsNotCloneableByDefault(mode) {
     test(() => {
         const host = document.createElement('div');
         const shadowRoot = host.attachShadow({mode});
-        assert_false(shadowRoot.cloneable);
+        assert_false(shadowRoot.clonable);
 
         const clonedHost = host.cloneNode(true);
         assert_true(!!clonedHost.attachShadow({mode}));
         assert_throws_dom('NotSupportedError', () => {
             shadowRoot.cloneNode(true);
         });
-    }, `ShadowRoot in "${mode}" mode is not cloneable by default`);
+    }, `ShadowRoot in "${mode}" mode is not clonable by default`);
 }
 
 testShadowRootIsNotCloneableByDefault('open');
@@ -28,15 +28,15 @@ testShadowRootIsNotCloneableByDefault('closed');
 function testShadowRootIsCloneable(mode) {
     test(() => {
         const host = document.createElement('div');
-        const shadowRoot = host.attachShadow({mode, cloneable: true});
-        assert_true(shadowRoot.cloneable);
+        const shadowRoot = host.attachShadow({mode, clonable: true});
+        assert_true(shadowRoot.clonable);
 
         const clonedHost = host.cloneNode(true);
         assert_throws_dom('NotSupportedError', () => {
             clonedHost.attachShadow({mode});
         });
         assert_equals(!!clonedHost.shadowRoot, mode == 'open');
-    }, `ShadowRoot in "${mode}" mode is cloneable if cloneable flag is set`);
+    }, `ShadowRoot in "${mode}" mode is clonable if clonable flag is set`);
 }
 
 testShadowRootIsCloneable('open');
@@ -45,8 +45,8 @@ testShadowRootIsCloneable('closed');
 function testShadowRootClonesShadowRootMode(mode) {
     test(() => {
         const host = document.createElement('div');
-        const shadowRoot = host.attachShadow({mode, cloneable: true});
-        assert_true(shadowRoot.cloneable);
+        const shadowRoot = host.attachShadow({mode, clonable: true});
+        assert_true(shadowRoot.clonable);
         const clonedHost = host.cloneNode(true);
         assert_equals(!!clonedHost.shadowRoot, mode == 'open');
     }, `Cloning ShadowRoot in "${mode}" mode clones shadow root mode`);
@@ -58,8 +58,8 @@ window.didFocusInputElement = false;
 function testShadowRootClonesDelegatesFocus(mode, delegatesFocus) {
     test(() => {
         const host = document.createElement('div');
-        const shadowRoot = host.attachShadow({mode, cloneable: true, delegatesFocus});
-        assert_true(shadowRoot.cloneable);
+        const shadowRoot = host.attachShadow({mode, clonable: true, delegatesFocus});
+        assert_true(shadowRoot.clonable);
         shadowRoot.innerHTML = '<input onfocus="window.didFocusInputElement = true">';
 
         const clonedHost = host.cloneNode(true);
@@ -82,8 +82,8 @@ function testShadowRootClonesSlotAssignment(mode) {
     test(() => {
         const host = document.createElement('span');
         host.innerHTML = '<div style="width: 100px; height: 100px; display: inline-block;"></div>';
-        const shadowRoot = host.attachShadow({mode, cloneable: true, slotAssignment: 'manual'});
-        assert_true(shadowRoot.cloneable);
+        const shadowRoot = host.attachShadow({mode, clonable: true, slotAssignment: 'manual'});
+        assert_true(shadowRoot.clonable);
         shadowRoot.innerHTML = '<slot></slot>';
         const clonedHost = host.cloneNode(true);
         if (mode == 'open')
@@ -96,8 +96,8 @@ function testShadowRootClonesSlotAssignment(mode) {
     test(() => {
         const host = document.createElement('span');
         host.innerHTML = '<div style="width: 100px; height: 100px; display: inline-block;"></div>';
-        const shadowRoot = host.attachShadow({mode, cloneable: true, slotAssignment: 'named'});
-        assert_true(shadowRoot.cloneable);
+        const shadowRoot = host.attachShadow({mode, clonable: true, slotAssignment: 'named'});
+        assert_true(shadowRoot.clonable);
         shadowRoot.innerHTML = '<slot></slot>';
         const clonedHost = host.cloneNode(true);
         if (mode == 'open')
@@ -114,8 +114,8 @@ testShadowRootClonesSlotAssignment('closed');
 function testShadowRootClonesShadowDescendants(mode) {
     test(() => {
         const host = document.createElement('span');
-        const shadowRoot = host.attachShadow({mode, cloneable: true});
-        assert_true(shadowRoot.cloneable);
+        const shadowRoot = host.attachShadow({mode, clonable: true});
+        assert_true(shadowRoot.clonable);
         shadowRoot.innerHTML = '<div style="width: 100px; height: 100px; display: inline-block;"><div></div></div>';
         const clonedHost = host.cloneNode(true);
         if (mode == 'open')

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -584,7 +584,7 @@ Ref<Node> Element::cloneNodeInternal(Document& targetDocument, CloningOperation 
 void Element::cloneShadowTreeIfPossible(Element& newHost)
 {
     RefPtr oldShadowRoot = this->shadowRoot();
-    if (!oldShadowRoot || !oldShadowRoot->isCloneable())
+    if (!oldShadowRoot || !oldShadowRoot->isClonable())
         return;
 
     Ref clonedShadowRoot = [&] {
@@ -2961,7 +2961,7 @@ ExceptionOr<ShadowRoot&> Element::attachShadow(const ShadowRootInit& init)
         return Exception { ExceptionCode::TypeError };
     Ref shadow = ShadowRoot::create(document(), init.mode, init.slotAssignment,
         init.delegatesFocus ? ShadowRoot::DelegatesFocus::Yes : ShadowRoot::DelegatesFocus::No,
-        init.cloneable ? ShadowRoot::Cloneable::Yes : ShadowRoot::Cloneable::No,
+        init.clonable ? ShadowRoot::Clonable::Yes : ShadowRoot::Clonable::No,
         isPrecustomizedOrDefinedCustomElement() ? ShadowRoot::AvailableToElementInternals::Yes : ShadowRoot::AvailableToElementInternals::No);
     addShadowRoot(shadow.copyRef());
     return shadow.get();
@@ -2969,7 +2969,7 @@ ExceptionOr<ShadowRoot&> Element::attachShadow(const ShadowRootInit& init)
 
 ExceptionOr<ShadowRoot&> Element::attachDeclarativeShadow(ShadowRootMode mode, bool delegatesFocus)
 {
-    auto exceptionOrShadowRoot = attachShadow({ mode, delegatesFocus, /* cloneable */ true });
+    auto exceptionOrShadowRoot = attachShadow({ mode, delegatesFocus, /* clonable */ true });
     if (exceptionOrShadowRoot.hasException())
         return exceptionOrShadowRoot.releaseException();
     Ref shadowRoot = exceptionOrShadowRoot.releaseReturnValue();

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -602,7 +602,7 @@ ExceptionOr<RefPtr<Node>> processAncestorsAndTheirSiblings(Range::ActionType act
     for (auto& ancestor : ancestors) {
         if (action == Range::Extract || action == Range::Clone) {
             if (auto shadowRoot = dynamicDowncast<ShadowRoot>(ancestor.get())) {
-                if (!shadowRoot->isCloneable())
+                if (!shadowRoot->isClonable())
                     continue;
             }
             Ref clonedAncestor = ancestor->cloneNode(false); // Might have been removed already during mutation event.

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -63,11 +63,11 @@ static_assert(sizeof(ShadowRoot) == sizeof(SameSizeAsShadowRoot), "shadowroot sh
 static_assert(sizeof(WeakPtr<Element, WeakPtrImplWithEventTargetData>) == sizeof(void*), "WeakPtr should be same size as raw pointer");
 #endif
 
-ShadowRoot::ShadowRoot(Document& document, ShadowRootMode mode, SlotAssignmentMode assignmentMode, DelegatesFocus delegatesFocus, Cloneable cloneable, AvailableToElementInternals availableToElementInternals)
+ShadowRoot::ShadowRoot(Document& document, ShadowRootMode mode, SlotAssignmentMode assignmentMode, DelegatesFocus delegatesFocus, Clonable clonable, AvailableToElementInternals availableToElementInternals)
     : DocumentFragment(document, TypeFlag::IsShadowRoot)
     , TreeScope(*this, document)
     , m_delegatesFocus(delegatesFocus == DelegatesFocus::Yes)
-    , m_isCloneable(cloneable == Cloneable::Yes)
+    , m_isClonable(clonable == Clonable::Yes)
     , m_availableToElementInternals(availableToElementInternals == AvailableToElementInternals::Yes)
     , m_mode(mode)
     , m_slotAssignmentMode(assignmentMode)
@@ -241,7 +241,7 @@ Ref<Node> ShadowRoot::cloneNodeInternal(Document& targetDocument, CloningOperati
     switch (type) {
     case CloningOperation::SelfWithTemplateContent:
         return create(targetDocument, m_mode, m_slotAssignmentMode, m_delegatesFocus ? DelegatesFocus::Yes : DelegatesFocus::No,
-            m_isCloneable ? Cloneable::Yes : Cloneable::No, m_availableToElementInternals ? AvailableToElementInternals::Yes : AvailableToElementInternals::No);
+            m_isClonable ? Clonable::Yes : Clonable::No, m_availableToElementInternals ? AvailableToElementInternals::Yes : AvailableToElementInternals::No);
     case CloningOperation::OnlySelf:
     case CloningOperation::Everything:
         break;

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -51,13 +51,13 @@ class ShadowRoot final : public CanMakeCheckedPtr, public DocumentFragment, publ
 public:
 
     enum class DelegatesFocus : bool { No, Yes };
-    enum class Cloneable : bool { No, Yes };
+    enum class Clonable : bool { No, Yes };
     enum class AvailableToElementInternals : bool { No, Yes };
 
     static Ref<ShadowRoot> create(Document& document, ShadowRootMode type, SlotAssignmentMode assignmentMode = SlotAssignmentMode::Named,
-        DelegatesFocus delegatesFocus = DelegatesFocus::No, Cloneable cloneable = Cloneable::No, AvailableToElementInternals availableToElementInternals = AvailableToElementInternals::No)
+        DelegatesFocus delegatesFocus = DelegatesFocus::No, Clonable clonable = Clonable::No, AvailableToElementInternals availableToElementInternals = AvailableToElementInternals::No)
     {
-        return adoptRef(*new ShadowRoot(document, type, assignmentMode, delegatesFocus, cloneable, availableToElementInternals));
+        return adoptRef(*new ShadowRoot(document, type, assignmentMode, delegatesFocus, clonable, availableToElementInternals));
     }
 
     static Ref<ShadowRoot> create(Document& document, std::unique_ptr<SlotAssignment>&& assignment)
@@ -88,7 +88,7 @@ public:
     bool containsFocusedElement() const { return m_containsFocusedElement; }
     void setContainsFocusedElement(bool flag) { m_containsFocusedElement = flag; }
 
-    bool isCloneable() const { return m_isCloneable; }
+    bool isClonable() const { return m_isClonable; }
 
     bool isAvailableToElementInternals() const { return m_availableToElementInternals; }
     void setIsAvailableToElementInternals(bool flag) { m_availableToElementInternals = flag; }
@@ -147,7 +147,7 @@ public:
     Vector<RefPtr<WebAnimation>> getAnimations();
 
 private:
-    ShadowRoot(Document&, ShadowRootMode, SlotAssignmentMode, DelegatesFocus, Cloneable, AvailableToElementInternals);
+    ShadowRoot(Document&, ShadowRootMode, SlotAssignmentMode, DelegatesFocus, Clonable, AvailableToElementInternals);
     ShadowRoot(Document&, std::unique_ptr<SlotAssignment>&&);
 
     bool childTypeAllowed(NodeType) const override;
@@ -161,7 +161,7 @@ private:
 
     bool m_hasBegunDeletingDetachedChildren : 1 { false };
     bool m_delegatesFocus : 1 { false };
-    bool m_isCloneable : 1 { false };
+    bool m_isClonable : 1 { false };
     bool m_containsFocusedElement : 1 { false };
     bool m_availableToElementInternals : 1 { false };
     bool m_isDeclarativeShadowRoot : 1 { false };

--- a/Source/WebCore/dom/ShadowRoot.idl
+++ b/Source/WebCore/dom/ShadowRoot.idl
@@ -23,6 +23,8 @@
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// https://dom.spec.whatwg.org/#interface-shadowroot
+
 [
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
@@ -31,7 +33,7 @@
     readonly attribute ShadowRootMode mode;
     readonly attribute boolean delegatesFocus;
     [ImplementedAs=slotAssignmentMode, EnabledBySetting=ImperativeSlotAPIEnabled] readonly attribute SlotAssignmentMode slotAssignment;
-    [ImplementedAs=isCloneable, EnabledBySetting=DeclarativeShadowRootsEnabled] readonly attribute boolean cloneable;
+    [ImplementedAs=isClonable, EnabledBySetting=DeclarativeShadowRootsEnabled] readonly attribute boolean clonable;
     readonly attribute Element host;
     attribute EventHandler onslotchange;
 };

--- a/Source/WebCore/dom/ShadowRootInit.h
+++ b/Source/WebCore/dom/ShadowRootInit.h
@@ -33,7 +33,7 @@ namespace WebCore {
 struct ShadowRootInit {
     ShadowRootMode mode;
     bool delegatesFocus { false };
-    bool cloneable { false };
+    bool clonable { false };
     SlotAssignmentMode slotAssignment { SlotAssignmentMode::Named };
 };
 

--- a/Source/WebCore/dom/ShadowRootInit.idl
+++ b/Source/WebCore/dom/ShadowRootInit.idl
@@ -23,9 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://dom.spec.whatwg.org/#dictdef-shadowrootinit
+
 dictionary ShadowRootInit {
     required ShadowRootMode mode;
     boolean delegatesFocus = false;
-    [EnabledBySetting=DeclarativeShadowRootsEnabled] boolean cloneable = false;
+    [EnabledBySetting=DeclarativeShadowRootsEnabled] boolean clonable = false;
     [EnabledBySetting=ImperativeSlotAPIEnabled] SlotAssignmentMode slotAssignment = "named";
 };


### PR DESCRIPTION
#### 55c8a567ee56cf6f488c2a1d6a7675088204bea7
<pre>
Rename `Cloneable` to `Clonable` to align with Web Specification wording

<a href="https://bugs.webkit.org/show_bug.cgi?id=267634">https://bugs.webkit.org/show_bug.cgi?id=267634</a>
<a href="https://rdar.apple.com/problem/121516711">rdar://problem/121516711</a>

Reviewed by Ryosuke Niwa.

This patch is just rename of `cloneable` to `clonable` as per web-specification [1]:

[1] <a href="https://dom.spec.whatwg.org/#shadowroot-clonable">https://dom.spec.whatwg.org/#shadowroot-clonable</a>

* Source/WebCore/dom/ShadowRoot.cpp:
(ShadowRoot::ShadowRoot):
(ShadowRoot::cloneNodeInternal):
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/ShadowRoot.idl:
* Source/WebCore/dom/ShadowRootInit.h:
* LayoutTests/fast/shadow-dom/clonable-shadow-root.html: Renamed from
LayoutTests/fast/shadow-dom/cloneable-shadow-root.html and rebaselined
* LayoutTests/fast/shadow-dom/clonable-shadow-root-expected.txt: Renamed from
LayoutTests/fast/shadow-dom/cloneable-shadow-root-expected.txt and rebaselined

Canonical link: <a href="https://commits.webkit.org/274063@main">https://commits.webkit.org/274063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/506b792841ee6b3da449f896f7d6eec81d2c4746

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40315 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33602 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39102 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31958 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33062 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12259 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12189 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSynchronizationSource-senderCaptureTimeOffset.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41574 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34173 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34191 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38080 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36255 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14197 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13165 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4896 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13508 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->