### PR TITLE
Adopt more smart pointers in WebCore/loader/cache

### DIFF
--- a/Source/WebCore/loader/cache/CachedResourceHandle.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceHandle.cpp
@@ -61,6 +61,11 @@ CachedResourceHandleBase::~CachedResourceHandleBase()
         m_resource->unregisterHandle(this);
 }
 
+CachedResource* CachedResourceHandleBase::get() const
+{
+    return m_resource.get();
+}
+
 void CachedResourceHandleBase::setResource(CachedResource* resource)
 {
     if (resource == m_resource)

--- a/Source/WebCore/loader/cache/CachedResourceHandle.h
+++ b/Source/WebCore/loader/cache/CachedResourceHandle.h
@@ -26,42 +26,40 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class CachedResource;
 
-class WEBCORE_EXPORT CachedResourceHandleBase {
+class CachedResourceHandleBase {
 public:
-    ~CachedResourceHandleBase();
+    WEBCORE_EXPORT ~CachedResourceHandleBase();
 
-    CachedResource* get() const { return m_resource; }
+    WEBCORE_EXPORT CachedResource* get() const;
     
     bool operator!() const { return !m_resource; }
-    
-    // This conversion operator allows implicit conversion to bool but not to other integer types.
-    typedef CachedResource* CachedResourceHandleBase::*UnspecifiedBoolType;
-    operator UnspecifiedBoolType() const { return m_resource ? &CachedResourceHandleBase::m_resource : 0; }
+    operator bool() const { return !!m_resource; }
 
 protected:
-    CachedResourceHandleBase();
-    explicit CachedResourceHandleBase(CachedResource*);
-    explicit CachedResourceHandleBase(CachedResource&);
-    CachedResourceHandleBase(const CachedResourceHandleBase&);
+    WEBCORE_EXPORT CachedResourceHandleBase();
+    WEBCORE_EXPORT explicit CachedResourceHandleBase(CachedResource*);
+    WEBCORE_EXPORT explicit CachedResourceHandleBase(CachedResource&);
+    WEBCORE_EXPORT CachedResourceHandleBase(const CachedResourceHandleBase&);
 
-    void setResource(CachedResource*);
+    WEBCORE_EXPORT void setResource(CachedResource*);
     
 private:
     CachedResourceHandleBase& operator=(const CachedResourceHandleBase&) { return *this; } 
     
     friend class CachedResource;
 
-    CachedResource* m_resource;
+    WeakPtr<CachedResource> m_resource;
 };
     
 template <class R> class CachedResourceHandle : public CachedResourceHandleBase {
 public: 
-    CachedResourceHandle() { }
+    CachedResourceHandle() = default;
     CachedResourceHandle(R& res) : CachedResourceHandleBase(res) { }
     CachedResourceHandle(R* res) : CachedResourceHandleBase(res) { }
     CachedResourceHandle(const CachedResourceHandle<R>& o) : CachedResourceHandleBase(o) { }

--- a/Source/WebCore/loader/cache/CachedSVGDocument.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGDocument.cpp
@@ -45,20 +45,25 @@ CachedSVGDocument::~CachedSVGDocument() = default;
 
 void CachedSVGDocument::setEncoding(const String& chs)
 {
-    m_decoder->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
+    protectedDecoder()->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
 }
 
 String CachedSVGDocument::encoding() const
 {
-    return String::fromLatin1(m_decoder->encoding().name());
+    return String::fromLatin1(protectedDecoder()->encoding().name());
+}
+
+RefPtr<TextResourceDecoder> CachedSVGDocument::protectedDecoder() const
+{
+    return m_decoder;
 }
 
 void CachedSVGDocument::finishLoading(const FragmentedSharedBuffer* data, const NetworkLoadMetrics& metrics)
 {
     if (data) {
         // We don't need to create a new frame because the new document belongs to the parent UseElement.
-        auto document = SVGDocument::create(nullptr, m_settings, response().url());
-        document->setMarkupUnsafe(m_decoder->decodeAndFlush(data->makeContiguous()->data(), data->size()), { ParserContentPolicy::AllowDeclarativeShadowRoots });
+        Ref document = SVGDocument::create(nullptr, m_settings.copyRef(), response().url());
+        document->setMarkupUnsafe(protectedDecoder()->decodeAndFlush(data->makeContiguous()->data(), data->size()), { ParserContentPolicy::AllowDeclarativeShadowRoots });
         m_document = WTFMove(document);
     }
     CachedResource::finishLoading(data, metrics);

--- a/Source/WebCore/loader/cache/CachedSVGDocument.h
+++ b/Source/WebCore/loader/cache/CachedSVGDocument.h
@@ -43,6 +43,7 @@ private:
     void setEncoding(const String&) override;
     String encoding() const override;
     const TextResourceDecoder* textResourceDecoder() const override { return m_decoder.get(); }
+    RefPtr<TextResourceDecoder> protectedDecoder() const;
     void finishLoading(const FragmentedSharedBuffer*, const NetworkLoadMetrics&) override;
 
     RefPtr<SVGDocument> m_document;

--- a/Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp
@@ -36,15 +36,13 @@ namespace WebCore {
 
 CachedSVGDocumentReference::CachedSVGDocumentReference(const String& url)
     : m_url(url)
-    , m_document(nullptr)
-    , m_loadRequested(false)
 {
 }
 
 CachedSVGDocumentReference::~CachedSVGDocumentReference()
 {
-    if (m_document)
-        m_document->removeClient(*this);
+    if (CachedResourceHandle document = m_document)
+        document->removeClient(*this);
 }
 
 void CachedSVGDocumentReference::load(CachedResourceLoader& loader, const ResourceLoaderOptions& options)
@@ -57,8 +55,8 @@ void CachedSVGDocumentReference::load(CachedResourceLoader& loader, const Resour
     CachedResourceRequest request(ResourceRequest(loader.document()->completeURL(m_url)), fetchOptions);
     request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
     m_document = loader.requestSVGDocument(WTFMove(request)).value_or(nullptr);
-    if (m_document)
-        m_document->addClient(*this);
+    if (CachedResourceHandle document = m_document)
+        document->addClient(*this);
 
     m_loadRequested = true;
 }

--- a/Source/WebCore/loader/cache/CachedSVGDocumentReference.h
+++ b/Source/WebCore/loader/cache/CachedSVGDocumentReference.h
@@ -50,7 +50,7 @@ public:
 private:
     String m_url;
     CachedResourceHandle<CachedSVGDocument> m_document;
-    bool m_loadRequested;
+    bool m_loadRequested { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedSVGFont.h
+++ b/Source/WebCore/loader/cache/CachedSVGFont.h
@@ -51,7 +51,7 @@ private:
 
     RefPtr<SharedBuffer> m_convertedFont;
     RefPtr<SVGDocument> m_externalSVGDocument;
-    SVGFontElement* m_externalSVGFontElement;
+    WeakPtr<SVGFontElement, WeakPtrImplWithEventTargetData> m_externalSVGFontElement;
     const Ref<const Settings> m_settings;
 };
 

--- a/Source/WebCore/loader/cache/CachedScript.cpp
+++ b/Source/WebCore/loader/cache/CachedScript.cpp
@@ -43,14 +43,19 @@ CachedScript::CachedScript(CachedResourceRequest&& request, PAL::SessionID sessi
 
 CachedScript::~CachedScript() = default;
 
+RefPtr<TextResourceDecoder> CachedScript::protectedDecoder() const
+{
+    return m_decoder;
+}
+
 void CachedScript::setEncoding(const String& chs)
 {
-    m_decoder->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
+    protectedDecoder()->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
 }
 
 String CachedScript::encoding() const
 {
-    return String::fromLatin1(m_decoder->encoding().name());
+    return String::fromLatin1(protectedDecoder()->encoding().name());
 }
 
 StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
@@ -58,14 +63,14 @@ StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
     if (!m_data)
         return emptyString();
 
-    if (!m_data->isContiguous())
-        m_data = m_data->makeContiguous();
+    if (RefPtr data = m_data; !data->isContiguous())
+        m_data = data->makeContiguous();
 
-    auto& contiguousData = downcast<SharedBuffer>(*m_data);
+    Ref contiguousData = downcast<SharedBuffer>(*m_data);
     if (m_decodingState == NeverDecoded
         && PAL::TextEncoding(encoding()).isByteBasedEncoding()
-        && m_data->size()
-        && charactersAreAllASCII(contiguousData.data(), m_data->size())) {
+        && contiguousData->size()
+        && charactersAreAllASCII(contiguousData->data(), contiguousData->size())) {
 
         m_decodingState = DataAndDecodedStringHaveSameBytes;
 
@@ -73,23 +78,23 @@ StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
         setDecodedSize(0);
         stopDecodedDataDeletionTimer();
 
-        m_scriptHash = StringHasher::computeHashAndMaskTop8Bits(contiguousData.data(), m_data->size());
+        m_scriptHash = StringHasher::computeHashAndMaskTop8Bits(contiguousData->data(), contiguousData->size());
     }
 
     if (m_decodingState == DataAndDecodedStringHaveSameBytes)
-        return { contiguousData.data(), static_cast<unsigned>(m_data->size()) };
+        return { contiguousData->data(), static_cast<unsigned>(contiguousData->size()) };
 
     bool shouldForceRedecoding = m_wasForceDecodedAsUTF8 != (shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes);
     if (!m_script || shouldForceRedecoding) {
         if (shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes) {
-            auto forceUTF8Decoder = TextResourceDecoder::create("text/javascript"_s, PAL::UTF8Encoding());
+            Ref forceUTF8Decoder = TextResourceDecoder::create("text/javascript"_s, PAL::UTF8Encoding());
             forceUTF8Decoder->setAlwaysUseUTF8();
-            m_script = forceUTF8Decoder->decodeAndFlush(contiguousData.data(), encodedSize());
+            m_script = forceUTF8Decoder->decodeAndFlush(contiguousData->data(), encodedSize());
         } else
-            m_script = m_decoder->decodeAndFlush(contiguousData.data(), encodedSize());
+            m_script = m_decoder->decodeAndFlush(contiguousData->data(), encodedSize());
         if (m_decodingState == NeverDecoded || shouldForceRedecoding)
-            m_scriptHash = m_script.impl()->hash();
-        ASSERT(!m_scriptHash || m_scriptHash == m_script.impl()->hash());
+            m_scriptHash = m_script.hash();
+        ASSERT(!m_scriptHash || m_scriptHash == m_script.hash());
         m_decodingState = DataAndDecodedStringHaveDifferentBytes;
         m_wasForceDecodedAsUTF8 = shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes;
         setDecodedSize(m_script.sizeInBytes());

--- a/Source/WebCore/loader/cache/CachedScript.h
+++ b/Source/WebCore/loader/cache/CachedScript.h
@@ -48,6 +48,7 @@ private:
     void setEncoding(const String&) final;
     String encoding() const final;
     const TextResourceDecoder* textResourceDecoder() const final { return m_decoder.get(); }
+    RefPtr<TextResourceDecoder> protectedDecoder() const;
     void finishLoading(const FragmentedSharedBuffer*, const NetworkLoadMetrics&) final;
 
     void destroyDecodedData() final;

--- a/Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp
@@ -44,6 +44,11 @@ CachedXSLStyleSheet::CachedXSLStyleSheet(CachedResourceRequest&& request, PAL::S
 
 CachedXSLStyleSheet::~CachedXSLStyleSheet() = default;
 
+RefPtr<TextResourceDecoder> CachedXSLStyleSheet::protectedDecoder() const
+{
+    return m_decoder;
+}
+
 void CachedXSLStyleSheet::didAddClient(CachedResourceClient& client)
 {
     ASSERT(client.resourceClientType() == CachedStyleSheetClient::expectedType());
@@ -53,20 +58,20 @@ void CachedXSLStyleSheet::didAddClient(CachedResourceClient& client)
 
 void CachedXSLStyleSheet::setEncoding(const String& chs)
 {
-    m_decoder->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
+    protectedDecoder()->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
 }
 
 String CachedXSLStyleSheet::encoding() const
 {
-    return String::fromLatin1(m_decoder->encoding().name());
+    return String::fromLatin1(protectedDecoder()->encoding().name());
 }
 
 void CachedXSLStyleSheet::finishLoading(const FragmentedSharedBuffer* data, const NetworkLoadMetrics& metrics)
 {
     if (data) {
-        auto contiguousData = data->makeContiguous();
+        Ref contiguousData = data->makeContiguous();
         setEncodedSize(data->size());
-        m_sheet = m_decoder->decodeAndFlush(contiguousData->data(), encodedSize());
+        m_sheet = protectedDecoder()->decodeAndFlush(contiguousData->data(), encodedSize());
         m_data = WTFMove(contiguousData);
     } else {
         m_data = nullptr;

--- a/Source/WebCore/loader/cache/CachedXSLStyleSheet.h
+++ b/Source/WebCore/loader/cache/CachedXSLStyleSheet.h
@@ -47,6 +47,7 @@ private:
     void setEncoding(const String&) final;
     String encoding() const final;
     const TextResourceDecoder* textResourceDecoder() const final { return m_decoder.get(); }
+    RefPtr<TextResourceDecoder> protectedDecoder() const;
     void finishLoading(const FragmentedSharedBuffer*, const NetworkLoadMetrics&) final;
 
     String m_sheet;

--- a/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
+++ b/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
@@ -55,7 +55,7 @@ bool KeepaliveRequestTracker::tryRegisterRequest(CachedResource& resource)
 void KeepaliveRequestTracker::registerRequest(CachedResource& resource)
 {
     ASSERT(resource.options().keepAlive);
-    auto body = resource.resourceRequest().httpBody();
+    RefPtr body = resource.resourceRequest().httpBody();
     if (!body)
         return;
     ASSERT(!m_inflightKeepaliveRequests.contains(&resource));


### PR DESCRIPTION
#### 147a51dd33fed9c55ccd87138a5b0788bd44b7e3
<pre>
Adopt more smart pointers in WebCore/loader/cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=268706">https://bugs.webkit.org/show_bug.cgi?id=268706</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/loader/cache/CachedResourceHandle.cpp:
(WebCore::CachedResourceHandleBase::get const):
* Source/WebCore/loader/cache/CachedResourceHandle.h:
* Source/WebCore/loader/cache/CachedSVGDocument.cpp:
(WebCore::CachedSVGDocument::setEncoding):
(WebCore::CachedSVGDocument::encoding const):
(WebCore::CachedSVGDocument::protectedDecoder const):
(WebCore::CachedSVGDocument::finishLoading):
* Source/WebCore/loader/cache/CachedSVGDocument.h:
* Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp:
(WebCore::CachedSVGDocumentReference::CachedSVGDocumentReference):
(WebCore::CachedSVGDocumentReference::~CachedSVGDocumentReference):
(WebCore::CachedSVGDocumentReference::load):
* Source/WebCore/loader/cache/CachedSVGDocumentReference.h:
* Source/WebCore/loader/cache/CachedSVGFont.cpp:
(WebCore::CachedSVGFont::CachedSVGFont):
(WebCore::CachedSVGFont::ensureCustomFontData):
(WebCore::CachedSVGFont::maybeInitializeExternalSVGFontElement):
* Source/WebCore/loader/cache/CachedSVGFont.h:
* Source/WebCore/loader/cache/CachedScript.cpp:
(WebCore::CachedScript::protectedDecoder const):
(WebCore::CachedScript::setEncoding):
(WebCore::CachedScript::encoding const):
(WebCore::CachedScript::script):
* Source/WebCore/loader/cache/CachedScript.h:
* Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp:
(WebCore::CachedXSLStyleSheet::protectedDecoder const):
(WebCore::CachedXSLStyleSheet::setEncoding):
(WebCore::CachedXSLStyleSheet::encoding const):
(WebCore::CachedXSLStyleSheet::finishLoading):
* Source/WebCore/loader/cache/CachedXSLStyleSheet.h:
* Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp:
(WebCore::KeepaliveRequestTracker::registerRequest):
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::revalidationSucceeded):
(WebCore::MemoryCache::resourceForRequest):
(WebCore::MemoryCache::forEachSessionResource):
(WebCore::MemoryCache::pruneLiveResourcesToSize):
(WebCore::MemoryCache::pruneDeadResourcesToSize):
(WebCore::MemoryCache::removeResourcesWithOrigin):
(WebCore::MemoryCache::removeResourcesWithOrigins):
(WebCore::MemoryCache::removeRequestFromSessionCaches):
(WebCore::MemoryCache::setDisabled):

Canonical link: <a href="https://commits.webkit.org/274071@main">https://commits.webkit.org/274071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/baa620fd7746e1f29a4498bf872ec8ffb63ce4c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40319 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33606 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31961 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12264 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41579 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34184 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38086 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12789 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36261 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14201 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13169 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4902 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13512 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->