### PR TITLE
Sync `InputEvent` and `CompositionEvent` with WebIDL Specification

### DIFF
--- a/Source/WebCore/dom/CompositionEvent.idl
+++ b/Source/WebCore/dom/CompositionEvent.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,20 +23,26 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+// https://w3c.github.io/uievents/#idl-compositionevent
+
 [
     Exposed=Window
 ] interface CompositionEvent : UIEvent {
-    constructor([AtomString] DOMString type, optional CompositionEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional CompositionEventInit eventInitDict = {});
 
-    readonly attribute DOMString data;
+    readonly attribute USVString data;
 
+    // https://w3c.github.io/uievents/#idl-interface-CompositionEvent-initializers
+    // Originally introduced (and deprecated) in this specification
     undefined initCompositionEvent([AtomString] DOMString typeArg,
                               optional boolean canBubbleArg = false,
                               optional boolean cancelableArg = false,
                               optional WindowProxy? viewArg = null,
-                              optional DOMString dataArg = "undefined");
+                              optional DOMString dataArg = "");
 
 };
+
+// https://w3c.github.io/uievents/#idl-compositioneventinit
 
 dictionary CompositionEventInit : UIEventInit {
     DOMString data = "";

--- a/Source/WebCore/dom/InputEvent.idl
+++ b/Source/WebCore/dom/InputEvent.idl
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2016 Apple, Inc. All Rights Reserved.
+* Copyright (C) 2016-2024 Apple, Inc. All Rights Reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -23,18 +23,22 @@
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// https://w3c.github.io/uievents/#idl-inputevent
+
 [
     Exposed=Window
 ] interface InputEvent : UIEvent {
     constructor([AtomString] DOMString type, optional InputEventInit eventInitDict);
 
     readonly attribute DOMString inputType;
-    readonly attribute DOMString? data;
+    readonly attribute USVString? data;
     [ImplementedAs=isInputMethodComposing] readonly attribute boolean isComposing;
     readonly attribute DataTransfer? dataTransfer;
 
     sequence<StaticRange> getTargetRanges();
 };
+
+// https://w3c.github.io/uievents/#idl-inputeventinit
 
 dictionary InputEventInit : UIEventInit {
     DOMString? data = null;


### PR DESCRIPTION
#### d6d2602cfff3fe9880f243845a21f868166cef0b
<pre>
Sync `InputEvent` and `CompositionEvent` with WebIDL Specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=268707">https://bugs.webkit.org/show_bug.cgi?id=268707</a>

Reviewed by Ryosuke Niwa.

This patch is to align WebKit with Web-Specification:

[1] <a href="https://w3c.github.io/uievents/#idl-inputevent">https://w3c.github.io/uievents/#idl-inputevent</a>
[2] <a href="https://w3c.github.io/uievents/#idl-compositionevent">https://w3c.github.io/uievents/#idl-compositionevent</a>

Only change is to modify `data` in both interfaces to `USVString` as per below:

Web-Spec Issue: <a href="https://github.com/w3c/uievents/issues/352">https://github.com/w3c/uievents/issues/352</a>

* Source/WebCore/dom/InputEvent.idl:
* Source/WebCore/dom/CompositionEvent.idl:

Canonical link: <a href="https://commits.webkit.org/274067@main">https://commits.webkit.org/274067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2262d83944e9f0c8e85f9054e7e3f98f24261d07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40321 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33607 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31964 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12267 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12204 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41581 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34199 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34197 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38089 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12790 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36264 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14202 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8487 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13170 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->