### PR TITLE
Sync `DataTransfer*` with IDL Web Specification

### DIFF
--- a/Source/WebCore/dom/DataTransfer.idl
+++ b/Source/WebCore/dom/DataTransfer.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,8 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://html.spec.whatwg.org/multipage/dnd.html#the-datatransfer-interface
+
 [
     SkipVTableValidation,
     Exposed=Window
@@ -39,6 +41,7 @@
 
     undefined setDragImage(Element image, long x, long y);
 
+    /* old interface */
     readonly attribute FrozenArray<DOMString> types;
     [CallWith=CurrentDocument] DOMString getData(DOMString format);
     [CallWith=CurrentDocument] undefined setData(DOMString format, DOMString data);

--- a/Source/WebCore/dom/DataTransferItem.idl
+++ b/Source/WebCore/dom/DataTransferItem.idl
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,6 +29,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://html.spec.whatwg.org/multipage/dnd.html#the-datatransferitem-interface
+
 [
     EnabledBySetting=DataTransferItemsEnabled,
     Exposed=Window
@@ -37,7 +39,7 @@
     readonly attribute DOMString type;
 
     [CallWith=CurrentDocument] undefined getAsString(StringCallback? callback);
-    File getAsFile();
+    File? getAsFile();
 
     // https://wicg.github.io/entries-api/#html-data
     [CallWith=CurrentScriptExecutionContext, ImplementedAs=getAsEntry] FileSystemEntry? webkitGetAsEntry();

--- a/Source/WebCore/dom/DataTransferItemList.idl
+++ b/Source/WebCore/dom/DataTransferItemList.idl
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Google Inc. All rights reserved.
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,18 +29,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://html.spec.whatwg.org/multipage/dnd.html#the-datatransferitemlist-interface
+
 [
     EnabledBySetting=DataTransferItemsEnabled,
     JSGenerateToNativeObject,
     JSGenerateToJSObject,
     Exposed=Window
 ] interface DataTransferItemList {
-    readonly attribute long length;
-    getter DataTransferItem item(unsigned long index);
-
+    readonly attribute unsigned long length;
+    getter DataTransferItem (unsigned long index);
     [CallWith=CurrentDocument] DataTransferItem? add(DOMString data, DOMString type);
     DataTransferItem? add(File file);
-
     undefined remove(unsigned long index);
 
     undefined clear();


### PR DESCRIPTION
<pre>
Sync `DataTransfer*` with IDL Web Specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=266893">https://bugs.webkit.org/show_bug.cgi?id=266893</a>
rdar://problem/120376716

Reviewed by NOBODY (OOPS!).

This patch is to align WebKit with Web-Specifications:

[1] <a href="https://html.spec.whatwg.org/multipage/dnd.html#the-datatransferitemlist-interface">https://html.spec.whatwg.org/multipage/dnd.html#the-datatransferitemlist-interface</a>
[2] <a href="https://html.spec.whatwg.org/multipage/dnd.html#the-datatransferitem-interface">https://html.spec.whatwg.org/multipage/dnd.html#the-datatransferitem-interface</a>
[3] <a href="https://html.spec.whatwg.org/multipage/dnd.html#the-datatransfer-interface">https://html.spec.whatwg.org/multipage/dnd.html#the-datatransfer-interface</a>

This patch adds links for quick reference and add missing '?' to make it nullable,
remove `item()` and change to 'unsigned' as needed.

* Source/WebCore/dom/DataTransfer.idl:
* Source/WebCore/dom/DataTransferItem.idl:
* Source/WebCore/dom/DataTransferItemList.idl:
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdaa77f83b5368d4d144a798624c4b645e58d6ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40322 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33608 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39109 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13910 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31963 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33070 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12266 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12198 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41582 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34189 "Found 2 new API test failures: TestWebKitAPI.DragAndDropTests.ExternalSourceDataTransferItemGetPlainTextFileAsEntry, TestWebKitAPI.DragAndDropTests.ExternalSourceDataTransferItemGetFolderAsEntry (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38090 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10368 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36265 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14203 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13171 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13514 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->