### PR TITLE
Lazily initialize more things in Document's constructor

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -35,7 +35,7 @@
 #include "FontSelectorClient.h"
 #include "FrameDestructionObserver.h"
 #include "FrameIdentifier.h"
-#include "OrientationNotifier.h"
+#include "IntDegrees.h"
 #include "PageIdentifier.h"
 #include "PlaybackTargetClientContextIdentifier.h"
 #include "PseudoElementIdentifier.h"
@@ -187,6 +187,7 @@ class MouseEventWithHitTestResults;
 class NodeFilter;
 class NodeIterator;
 class NodeList;
+class OrientationNotifier;
 class Page;
 class PaintWorklet;
 class PaintWorkletGlobalScope;
@@ -1702,10 +1703,10 @@ public:
     void attachToCachedFrame(CachedFrameBase&);
     void detachFromCachedFrame(CachedFrameBase&);
 
-    ConstantPropertyMap& constantProperties() const { return *m_constantPropertyMap; }
+    ConstantPropertyMap& constantProperties() const;
 
     void orientationChanged(IntDegrees orientation);
-    OrientationNotifier& orientationNotifier() { return m_orientationNotifier; }
+    OrientationNotifier& orientationNotifier();
 
     WEBCORE_EXPORT const AtomString& bgColor() const;
     WEBCORE_EXPORT void setBgColor(const AtomString&);
@@ -2325,7 +2326,7 @@ private:
 
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_associatedFormControls;
 
-    OrientationNotifier m_orientationNotifier;
+    std::unique_ptr<OrientationNotifier> m_orientationNotifier;
     mutable RefPtr<Logger> m_logger;
     RefPtr<StringCallback> m_consoleMessageListener;
 

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -124,6 +124,11 @@ ScriptExecutionContext::ScriptExecutionContext(Type type, ScriptExecutionContext
 {
 }
 
+std::unique_ptr<ContentSecurityPolicy> ScriptExecutionContext::makeEmptyContentSecurityPolicy()
+{
+    return makeUnique<ContentSecurityPolicy>(URL { emptyString() }, *this);
+}
+
 void ScriptExecutionContext::regenerateIdentifier()
 {
     Locker locker { allScriptExecutionContextsMapLock };

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -391,6 +391,9 @@ protected:
     void regenerateIdentifier();
 
 private:
+
+    std::unique_ptr<ContentSecurityPolicy> makeEmptyContentSecurityPolicy() final;
+
     // The following addMessage function is deprecated.
     // Callers should try to create the ConsoleMessage themselves.
     virtual void addMessage(MessageSource, MessageLevel, const String& message, const String& sourceURL, unsigned lineNumber, unsigned columnNumber, RefPtr<Inspector::ScriptCallStack>&&, JSC::JSGlobalObject* = nullptr, unsigned long requestIdentifier = 0) = 0;

--- a/Source/WebCore/dom/SecurityContext.h
+++ b/Source/WebCore/dom/SecurityContext.h
@@ -73,7 +73,7 @@ public:
     SandboxFlags creationSandboxFlags() const { return m_creationSandboxFlags; }
 
     SandboxFlags sandboxFlags() const { return m_sandboxFlags; }
-    ContentSecurityPolicy* contentSecurityPolicy() { return m_contentSecurityPolicy.get(); }
+    WEBCORE_EXPORT ContentSecurityPolicy* contentSecurityPolicy();
     CheckedPtr<ContentSecurityPolicy> checkedContentSecurityPolicy();
 
     bool isSecureTransitionTo(const URL&) const;
@@ -83,7 +83,10 @@ public:
 
     bool isSandboxed(SandboxFlags mask) const { return m_sandboxFlags & mask; }
 
-    SecurityOriginPolicy* securityOriginPolicy() const { return m_securityOriginPolicy.get(); }
+    SecurityOriginPolicy* securityOriginPolicy() const;
+
+    bool hasEmptySecurityOriginPolicyAndContentSecurityPolicy() const { return m_hasEmptySecurityOriginPolicy && m_hasEmptyContentSecurityPolicy; }
+    bool hasInitializedSecurityOriginPolicyOrContentSecurityPolicy() const { return m_securityOriginPolicy || m_contentSecurityPolicy; }
 
     // Explicitly override the security origin for this security context.
     // Note: It is dangerous to change the security origin of a script context
@@ -94,6 +97,8 @@ public:
     // Note: It is dangerous to change the content security policy of a script
     //       context that already contains content.
     void setContentSecurityPolicy(std::unique_ptr<ContentSecurityPolicy>&&);
+
+    inline void setEmptySecurityOriginPolicyAndContentSecurityPolicy();
 
     const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy() const { return m_crossOriginEmbedderPolicy; }
     void setCrossOriginEmbedderPolicy(const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy) { m_crossOriginEmbedderPolicy = crossOriginEmbedderPolicy; }
@@ -150,6 +155,7 @@ protected:
 
 private:
     void addSandboxFlags(SandboxFlags);
+    virtual std::unique_ptr<ContentSecurityPolicy> makeEmptyContentSecurityPolicy() = 0;
 
     RefPtr<SecurityOriginPolicy> m_securityOriginPolicy;
     std::unique_ptr<ContentSecurityPolicy> m_contentSecurityPolicy;
@@ -165,6 +171,17 @@ private:
     bool m_isStrictMixedContentMode { false };
     bool m_usedLegacyTLS { false };
     bool m_wasPrivateRelayed { false };
+    bool m_hasEmptySecurityOriginPolicy { false };
+    bool m_hasEmptyContentSecurityPolicy { false };
 };
+
+void SecurityContext::setEmptySecurityOriginPolicyAndContentSecurityPolicy()
+{
+    ASSERT(!m_securityOriginPolicy);
+    ASSERT(!m_contentSecurityPolicy);
+    m_haveInitializedSecurityOrigin = true;
+    m_hasEmptySecurityOriginPolicy = true;
+    m_hasEmptyContentSecurityPolicy = true;
+}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/OrientationNotifier.h
+++ b/Source/WebCore/platform/OrientationNotifier.h
@@ -26,11 +26,13 @@
 #pragma once
 
 #include "IntDegrees.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
-class OrientationNotifier {
+class OrientationNotifier : public CanMakeCheckedPtr {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit OrientationNotifier(IntDegrees orientation) { m_orientation = orientation; }
     ~OrientationNotifier();


### PR DESCRIPTION
#### c44a717752d6769f89ec8cf6cfd9606b2680ab03
<pre>
Lazily initialize more things in Document&apos;s constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=268712">https://bugs.webkit.org/show_bug.cgi?id=268712</a>

Reviewed by Chris Dumez.

This PR delays the initialization of OrientationNotifier in Document and ContentSecurityPolicy
and SecurityOriginPolicy in SecurityContext until they&apos;re used when creating a Document without
a frame (browsing context).

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::initSecurityContext):
(WebCore::Document::constantProperties const):
(WebCore::Document::orientationChanged):
(WebCore::Document::orientationNotifier):
* Source/WebCore/dom/Document.h:
(WebCore::Document::constantProperties const): Deleted.
(WebCore::Document::orientationNotifier): Deleted.
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::makeEmptyContentSecurityPolicy): Added.
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/SecurityContext.cpp:
(WebCore::SecurityContext::setSecurityOriginPolicy):
(WebCore::SecurityContext::contentSecurityPolicy):
(WebCore::SecurityContext::securityOrigin const):
(WebCore::SecurityContext::securityOriginPolicy const):
(WebCore::SecurityContext::setContentSecurityPolicy):
(WebCore::SecurityContext::checkedContentSecurityPolicy):
* Source/WebCore/dom/SecurityContext.h:
(WebCore::SecurityContext::contentSecurityPolicy):
(WebCore::SecurityContext::securityOriginPolicy const):
(WebCore::SecurityContext::hasEmptySecurityOriginPolicyAndContentSecurityPolicy const): Added.
(WebCore::SecurityContext::hasInitializedSecurityOriginPolicyOrContentSecurityPolicy const): Added.
(WebCore::SecurityContext::setEmptySecurityOriginPolicyAndContentSecurityPolicy): Added.
* Source/WebCore/platform/OrientationNotifier.h:

Canonical link: <a href="https://commits.webkit.org/274080@main">https://commits.webkit.org/274080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be432b41d4e7b91df39a0cd29c251a97e047122b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40332 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33618 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31973 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38359 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14050 "Found 1 new test failure: media/video-ended-does-not-hold-sleep-assertion.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12276 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12212 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41592 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34215 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34218 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38098 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12800 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36273 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14213 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13180 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4906 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13523 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->