### PR TITLE
[GPUP] Add syscall required by Metal

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -773,8 +773,6 @@
 
 (when (defined? 'syscall-unix)
     (deny syscall-unix (with telemetry))
-    (deny syscall-unix (with no-report) (syscall-number
-        SYS_faccessat))
     (when (defined? 'SYS_crossarch_trap)
         (deny syscall-unix (with no-report) (syscall-number
             SYS_crossarch_trap)))
@@ -800,6 +798,7 @@
         SYS_dup
         SYS_dup2
         SYS_exit
+        SYS_faccessat
         SYS_fcntl
         SYS_fcntl_nocancel
         SYS_fileport_makefd


### PR DESCRIPTION
#### cdefe4b2a72a97c50874ef00f5798f89854fc18c
<pre>
[GPUP] Add syscall required by Metal
<a href="https://bugs.webkit.org/show_bug.cgi?id=268718">https://bugs.webkit.org/show_bug.cgi?id=268718</a>
<a href="https://rdar.apple.com/122223847">rdar://122223847</a>

Reviewed by NOBODY (OOPS!).

Add syscall required by Metal in the GPU process on iOS.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdefe4b2a72a97c50874ef00f5798f89854fc18c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40346 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33632 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31984 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14065 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12287 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12224 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41606 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38110 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12814 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36284 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14227 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->