### PR TITLE
Adopt more smart pointers in WebCore/loader

### DIFF
--- a/Source/WebCore/loader/ApplicationManifestLoader.cpp
+++ b/Source/WebCore/loader/ApplicationManifestLoader.cpp
@@ -54,7 +54,7 @@ ApplicationManifestLoader::~ApplicationManifestLoader()
 bool ApplicationManifestLoader::startLoading()
 {
     ASSERT(!m_resource);
-    auto* frame = m_documentLoader->frame();
+    RefPtr frame = m_documentLoader->frame();
     if (!frame)
         return false;
 
@@ -87,10 +87,10 @@ bool ApplicationManifestLoader::startLoading()
     options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
     CachedResourceRequest request(WTFMove(resourceRequest), options);
 
-    auto cachedResource = frame->document()->cachedResourceLoader().requestApplicationManifest(WTFMove(request));
+    auto cachedResource = frame->document()->protectedCachedResourceLoader()->requestApplicationManifest(WTFMove(request));
     m_resource = cachedResource.value_or(nullptr);
-    if (m_resource)
-        m_resource->addClient(*this);
+    if (CachedResourceHandle resource = m_resource)
+        resource->addClient(*this);
     else {
         LOG_ERROR("Failed to start load for application manifest at url %s (error: %s)", resourceRequestURL.string().ascii().data(), cachedResource.error().localizedDescription().utf8().data());
         return false;
@@ -101,20 +101,20 @@ bool ApplicationManifestLoader::startLoading()
 
 void ApplicationManifestLoader::stopLoading()
 {
-    if (m_resource) {
-        m_resource->removeClient(*this);
-        m_resource = nullptr;
-    }
+    if (CachedResourceHandle resource = std::exchange(m_resource, nullptr))
+        resource->removeClient(*this);
 }
 
 std::optional<ApplicationManifest>& ApplicationManifestLoader::processManifest()
 {
-    if (!m_processedManifest && m_resource) {
-        auto manifestURL = m_url;
-        auto documentURL = m_documentLoader->url();
-        auto frame = m_documentLoader->frame();
-        auto document = frame ? frame->document() : nullptr;
-        m_processedManifest = m_resource->process(manifestURL, documentURL, document);
+    if (!m_processedManifest) {
+        if (CachedResourceHandle resource = m_resource) {
+            auto manifestURL = m_url;
+            auto documentURL = m_documentLoader->url();
+            auto frame = m_documentLoader->frame();
+            RefPtr document = frame ? frame->document() : nullptr;
+            m_processedManifest = resource->process(manifestURL, documentURL, document.get());
+        }
     }
     return m_processedManifest;
 }
@@ -122,7 +122,7 @@ std::optional<ApplicationManifest>& ApplicationManifestLoader::processManifest()
 void ApplicationManifestLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
 {
     ASSERT_UNUSED(resource, &resource == m_resource);
-    m_documentLoader->finishedLoadingApplicationManifest(*this);
+    Ref { m_documentLoader.get() }->finishedLoadingApplicationManifest(*this);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/ContentFilter.h
+++ b/Source/WebCore/loader/ContentFilter.h
@@ -95,11 +95,13 @@ private:
     void didDecide(State);
     void deliverResourceData(const SharedBuffer&, size_t encodedDataLength = 0);
     void deliverStoredResourceData();
+
+    Ref<ContentFilterClient> protectedClient() const;
     
     URL url();
     
     Container m_contentFilters;
-    ContentFilterClient& m_client;
+    WeakRef<ContentFilterClient> m_client;
     URL m_mainResourceURL;
     struct ResourceDataItem {
         RefPtr<const SharedBuffer> buffer;
@@ -107,7 +109,7 @@ private:
     };
     Vector<ResourceDataItem> m_buffers;
     CachedResourceHandle<CachedRawResource> m_mainResource;
-    const PlatformContentFilter* m_blockingContentFilter { nullptr };
+    WeakPtr<const PlatformContentFilter> m_blockingContentFilter;
     State m_state { State::Stopped };
     ResourceError m_blockedError;
     bool m_isLoadingBlockedPage { false };

--- a/Source/WebCore/loader/ContentFilterClient.h
+++ b/Source/WebCore/loader/ContentFilterClient.h
@@ -28,6 +28,7 @@
 #if ENABLE(CONTENT_FILTERING)
 
 #include <wtf/Forward.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -36,7 +37,7 @@ class ResourceError;
 class SharedBuffer;
 class SubstituteData;
 
-class ContentFilterClient {
+class ContentFilterClient : public CanMakeWeakPtr<ContentFilterClient> {
 public:
     virtual ~ContentFilterClient() = default;
     virtual void ref() const = 0;

--- a/Source/WebCore/loader/CookieJar.cpp
+++ b/Source/WebCore/loader/CookieJar.cpp
@@ -49,7 +49,7 @@ namespace WebCore {
 
 static ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking(const Document& document)
 {
-    if (auto* page = document.page())
+    if (RefPtr page = document.page())
         return page->shouldRelaxThirdPartyCookieBlocking();
     return ShouldRelaxThirdPartyCookieBlocking::No;
 }
@@ -68,11 +68,11 @@ SameSiteInfo CookieJar::sameSiteInfo(const Document& document, IsForDOMCookieAcc
 {
     RefPtr frame = document.frame();
     if (frame && frame->loader().client().isRemoteWorkerFrameLoaderClient()) {
-        auto domain = RegistrableDomain(document.securityOrigin().data());
+        RegistrableDomain domain(document.securityOrigin().data());
         return { domain.matches(document.firstPartyForCookies()), false, true };
     }
 
-    if (auto* loader = document.loader())
+    if (RefPtr loader = document.loader())
         return SameSiteInfo::create(loader->request(), isAccessForDOM);
     return { };
 }

--- a/Source/WebCore/loader/CrossOriginAccessControl.cpp
+++ b/Source/WebCore/loader/CrossOriginAccessControl.cpp
@@ -123,7 +123,7 @@ ResourceRequest createAccessControlPreflightRequest(const ResourceRequest& reque
     }
 
     if (includeFetchMetadata) {
-        auto requestOrigin = SecurityOrigin::create(request.url());
+        Ref requestOrigin = SecurityOrigin::create(request.url());
         if (requestOrigin->isPotentiallyTrustworthy()) {
             preflightRequest.setHTTPHeaderField(HTTPHeaderName::SecFetchMode, "cors"_s);
             preflightRequest.setHTTPHeaderField(HTTPHeaderName::SecFetchDest, "empty"_s);
@@ -156,7 +156,7 @@ CachedResourceRequest createPotentialAccessControlRequest(ResourceRequest&& requ
         }
     }
 
-    if (auto* documentLoader = document.loader())
+    if (RefPtr documentLoader = document.loader())
         request.setIsAppInitiated(documentLoader->lastNavigationWasAppInitiated());
 
     if (crossOriginAttribute.isNull()) {

--- a/Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp
+++ b/Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp
@@ -112,14 +112,14 @@ void CrossOriginEmbedderPolicy::addPolicyHeadersTo(ResourceResponse& response) c
 // https://html.spec.whatwg.org/multipage/origin.html#queue-a-cross-origin-embedder-policy-inheritance-violation
 void sendCOEPInheritenceViolation(ReportingClient& reportingClient, const URL& embedderURL, const String& endpoint, COEPDisposition disposition, const String& type, const URL& blockedURL)
 {
-    auto reportBody = COEPInheritenceViolationReportBody::create(disposition, blockedURL, AtomString { type });
-    auto report = Report::create("coep"_s, embedderURL.string(), WTFMove(reportBody));
+    Ref reportBody = COEPInheritenceViolationReportBody::create(disposition, blockedURL, AtomString { type });
+    Ref report = Report::create("coep"_s, embedderURL.string(), WTFMove(reportBody));
     reportingClient.notifyReportObservers(WTFMove(report));
 
     if (endpoint.isEmpty())
         return;
 
-    auto reportFormData = Report::createReportFormDataForViolation("coep"_s, embedderURL, reportingClient.httpUserAgent(), endpoint, [&](auto& body) {
+    Ref reportFormData = Report::createReportFormDataForViolation("coep"_s, embedderURL, reportingClient.httpUserAgent(), endpoint, [&](auto& body) {
         body.setString("disposition"_s, disposition == COEPDisposition::Reporting ? "reporting"_s : "enforce"_s);
         body.setString("type"_s, type);
         body.setString("blockedURL"_s, PingLoader::sanitizeURLForReport(blockedURL));
@@ -130,14 +130,14 @@ void sendCOEPInheritenceViolation(ReportingClient& reportingClient, const URL& e
 // https://fetch.spec.whatwg.org/#queue-a-cross-origin-embedder-policy-corp-violation-report
 void sendCOEPCORPViolation(ReportingClient& reportingClient, const URL& embedderURL, const String& endpoint, COEPDisposition disposition, FetchOptions::Destination destination, const URL& blockedURL)
 {
-    auto reportBody = CORPViolationReportBody::create(disposition, blockedURL, destination);
-    auto report = Report::create("coep"_s, embedderURL.string(), WTFMove(reportBody));
+    Ref reportBody = CORPViolationReportBody::create(disposition, blockedURL, destination);
+    Ref report = Report::create("coep"_s, embedderURL.string(), WTFMove(reportBody));
     reportingClient.notifyReportObservers(WTFMove(report));
 
     if (endpoint.isEmpty())
         return;
 
-    auto reportFormData = Report::createReportFormDataForViolation("coep"_s, embedderURL, reportingClient.httpUserAgent(), endpoint, [&](auto& body) {
+    Ref reportFormData = Report::createReportFormDataForViolation("coep"_s, embedderURL, reportingClient.httpUserAgent(), endpoint, [&](auto& body) {
         body.setString("disposition"_s, disposition == COEPDisposition::Reporting ? "reporting"_s : "enforce"_s);
         body.setString("type"_s, "corp"_s);
         body.setString("blockedURL"_s, PingLoader::sanitizeURLForReport(blockedURL));

--- a/Source/WebCore/loader/CrossOriginOpenerPolicy.cpp
+++ b/Source/WebCore/loader/CrossOriginOpenerPolicy.cpp
@@ -80,7 +80,7 @@ static void sendViolationReportWhenNavigatingToCOOPResponse(ReportingClient& rep
     if (endpoint.isEmpty())
         return;
 
-    auto report = Report::createReportFormDataForViolation("coop"_s, coopURL, reportingClient.httpUserAgent(), endpoint, [&](auto& body) {
+    Ref report = Report::createReportFormDataForViolation("coop"_s, coopURL, reportingClient.httpUserAgent(), endpoint, [&](auto& body) {
         body.setString("disposition"_s, disposition == COOPDisposition::Reporting ? "reporting"_s : "enforce"_s);
         body.setString("effectivePolicy"_s, crossOriginOpenerPolicyValueToEffectivePolicyString(disposition == COOPDisposition::Reporting ? coop.reportOnlyValue : coop.value));
         body.setString("previousResponseURL"_s, coopOrigin.isSameOriginAs(previousResponseOrigin) ? PingLoader::sanitizeURLForReport(previousResponseURL) : String());
@@ -97,7 +97,7 @@ static void sendViolationReportWhenNavigatingAwayFromCOOPResponse(ReportingClien
     if (endpoint.isEmpty())
         return;
 
-    auto report = Report::createReportFormDataForViolation("coop"_s, coopURL, reportingClient.httpUserAgent(), endpoint, [&](auto& body) {
+    Ref report = Report::createReportFormDataForViolation("coop"_s, coopURL, reportingClient.httpUserAgent(), endpoint, [&](auto& body) {
         body.setString("disposition"_s, disposition == COOPDisposition::Reporting ? "reporting"_s : "enforce"_s);
         body.setString("effectivePolicy"_s, crossOriginOpenerPolicyValueToEffectivePolicyString(disposition == COOPDisposition::Reporting ? coop.reportOnlyValue : coop.value));
         body.setString("nextResponseURL"_s, coopOrigin.isSameOriginAs(nextResponseOrigin) || isCOOPResponseNavigationSource ? PingLoader::sanitizeURLForReport(nextResponseURL) : String());

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.h
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.h
@@ -59,8 +59,9 @@ private:
 
     static void handleLoadingFailure(DocumentThreadableLoader&, unsigned long, const ResourceError&);
     static void validatePreflightResponse(DocumentThreadableLoader&, ResourceRequest&&, ResourceLoaderIdentifier, const ResourceResponse&);
+    Ref<DocumentThreadableLoader> protectedLoader() const;
 
-    DocumentThreadableLoader& m_loader;
+    SingleThreadWeakRef<DocumentThreadableLoader> m_loader;
     CachedResourceHandle<CachedRawResource> m_resource;
     ResourceRequest m_request;
 };

--- a/Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.mm
+++ b/Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.mm
@@ -115,7 +115,7 @@ DiskCacheMonitor::DiskCacheMonitor(const ResourceRequest& request, PAL::SessionI
 
 void DiskCacheMonitor::resourceBecameFileBacked(SharedBuffer& fileBackedBuffer)
 {
-    auto* resource = MemoryCache::singleton().resourceForRequest(m_resourceRequest, m_sessionID);
+    CachedResourceHandle resource = MemoryCache::singleton().resourceForRequest(m_resourceRequest, m_sessionID);
     if (!resource)
         return;
 

--- a/Source/WebCore/loader/icon/IconLoader.cpp
+++ b/Source/WebCore/loader/icon/IconLoader.cpp
@@ -60,7 +60,7 @@ void IconLoader::startLoading()
     if (m_resource)
         return;
 
-    auto* frame = m_documentLoader->frame();
+    RefPtr frame = m_documentLoader->frame();
     if (!frame)
         return;
 
@@ -91,18 +91,16 @@ void IconLoader::startLoading()
 
     auto cachedResource = frame->document()->cachedResourceLoader().requestIcon(WTFMove(request));
     m_resource = cachedResource.value_or(nullptr);
-    if (m_resource)
-        m_resource->addClient(*this);
+    if (CachedResourceHandle resource = m_resource)
+        resource->addClient(*this);
     else
         LOG_ERROR("Failed to start load for icon at url %s (error: %s)", resourceRequestURL.string().ascii().data(), cachedResource.error().localizedDescription().utf8().data());
 }
 
 void IconLoader::stopLoading()
 {
-    if (m_resource) {
-        m_resource->removeClient(*this);
-        m_resource = nullptr;
-    }
+    if (CachedResourceHandle resource = std::exchange(m_resource, nullptr))
+        resource->removeClient(*this);
 }
 
 void IconLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&)
@@ -111,7 +109,7 @@ void IconLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetri
 
     // If we got a status code indicating an invalid response, then lets
     // ignore the data and not try to decode the error page as an icon.
-    auto* data = m_resource->resourceBuffer();
+    RefPtr data = m_resource->resourceBuffer();
     int status = m_resource->response().httpStatusCode();
     if (status && (status < 200 || status > 299))
         data = nullptr;
@@ -126,7 +124,7 @@ void IconLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetri
 
     // DocumentLoader::finishedLoadingIcon destroys this IconLoader as it finishes. This will automatically
     // trigger IconLoader::stopLoading() during destruction, so we should just return here.
-    m_documentLoader->finishedLoadingIcon(*this, data);
+    Ref { m_documentLoader.get() }->finishedLoadingIcon(*this, data.get());
 }
 
 }

--- a/Source/WebCore/loader/ios/LegacyPreviewLoader.h
+++ b/Source/WebCore/loader/ios/LegacyPreviewLoader.h
@@ -67,6 +67,9 @@ private:
     void provideMainResourceForPreviewConverter(PreviewConverter&, CompletionHandler<void(Ref<FragmentedSharedBuffer>&&)>&&) final;
     void providePasswordForPreviewConverter(PreviewConverter&, Function<void(const String&)>&&) final;
 
+    RefPtr<PreviewConverter> protectedConverter() const;
+    Ref<LegacyPreviewLoaderClient> protectedClient() const;
+
     RefPtr<PreviewConverter> m_converter;
     Ref<LegacyPreviewLoaderClient> m_client;
     SharedBufferBuilder m_originalData;

--- a/Source/WebCore/loader/mac/DocumentLoaderMac.cpp
+++ b/Source/WebCore/loader/mac/DocumentLoaderMac.cpp
@@ -35,20 +35,20 @@ namespace WebCore {
 
 static void scheduleAll(const ResourceLoaderMap& loaders, SchedulePair& pair)
 {
-    for (auto& loader : copyToVector(loaders.values()))
+    for (RefPtr loader : copyToVector(loaders.values()))
         loader->schedule(pair);
 }
 
 static void unscheduleAll(const ResourceLoaderMap& loaders, SchedulePair& pair)
 {
-    for (auto& loader : copyToVector(loaders.values()))
+    for (RefPtr loader : copyToVector(loaders.values()))
         loader->unschedule(pair);
 }
 
 void DocumentLoader::schedule(SchedulePair& pair)
 {
-    if (mainResourceLoader())
-        mainResourceLoader()->schedule(pair);
+    if (RefPtr loader = mainResourceLoader())
+        loader->schedule(pair);
     scheduleAll(m_subresourceLoaders, pair);
     scheduleAll(m_plugInStreamLoaders, pair);
     scheduleAll(m_multipartSubresourceLoaders, pair);
@@ -56,8 +56,8 @@ void DocumentLoader::schedule(SchedulePair& pair)
 
 void DocumentLoader::unschedule(SchedulePair& pair)
 {
-    if (mainResourceLoader())
-        mainResourceLoader()->unschedule(pair);
+    if (RefPtr loader = mainResourceLoader())
+        loader->unschedule(pair);
     unscheduleAll(m_subresourceLoaders, pair);
     unscheduleAll(m_plugInStreamLoaders, pair);
     unscheduleAll(m_multipartSubresourceLoaders, pair);

--- a/Source/WebCore/loader/mac/LoaderNSURLExtras.mm
+++ b/Source/WebCore/loader/mac/LoaderNSURLExtras.mm
@@ -91,7 +91,7 @@ NSString *suggestedFilenameWithMIMEType(NSURL *url, const String& mimeType)
 
 NSString *filenameByFixingIllegalCharacters(NSString *string)
 {
-    auto filename = adoptNS([string mutableCopy]);
+    RetainPtr filename = adoptNS([string mutableCopy]);
 
     // Strip null characters.
     unichar nullChar = 0;

--- a/Source/WebCore/loader/mac/ResourceLoaderMac.mm
+++ b/Source/WebCore/loader/mac/ResourceLoaderMac.mm
@@ -29,6 +29,7 @@
 #import "config.h"
 #import "ResourceLoader.h"
 
+#import "DocumentLoader.h"
 #import "FrameLoader.h"
 #import "LocalFrameLoaderClient.h"
 #import <wtf/CompletionHandler.h>
@@ -39,7 +40,7 @@ void ResourceLoader::willCacheResponseAsync(ResourceHandle*, NSCachedURLResponse
 {
     if (m_options.sendLoadCallbacks == SendCallbackPolicy::DoNotSendCallbacks)
         return completionHandler(nullptr);
-    frameLoader()->client().willCacheResponse(documentLoader(), identifier(), response, WTFMove(completionHandler));
+    checkedFrameLoader()->client().willCacheResponse(protectedDocumentLoader().get(), identifier(), response, WTFMove(completionHandler));
 }
 
 }

--- a/Source/WebCore/platform/PlatformContentFilter.h
+++ b/Source/WebCore/platform/PlatformContentFilter.h
@@ -28,6 +28,7 @@
 
 #include "SharedBuffer.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -38,7 +39,7 @@ class ResourceRequest;
 class ResourceResponse;
 class SharedBuffer;
 
-class PlatformContentFilter {
+class PlatformContentFilter : public CanMakeWeakPtr<PlatformContentFilter> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(PlatformContentFilter);
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -83,9 +83,10 @@ class NetworkResourceLoader final
     , public WebCore::CrossOriginAccessControlCheckDisabler
 #if ENABLE(CONTENT_FILTERING)
     , public WebCore::ContentFilterClient
+#else
+    , public CanMakeWeakPtr<NetworkResourceLoader>
 #endif
-    , public WebCore::ReportingClient
-    , public CanMakeWeakPtr<NetworkResourceLoader> {
+    , public WebCore::ReportingClient {
 public:
     static Ref<NetworkResourceLoader> create(NetworkResourceLoadParameters&& parameters, NetworkConnectionToWebProcess& connection, CompletionHandler<void(const WebCore::ResourceError&, const WebCore::ResourceResponse, Vector<uint8_t>&&)>&& reply = nullptr)
     {


### PR DESCRIPTION
#### 5ee1e908b6ed778eca6b6a72997648b10d4bcbf4
<pre>
Adopt more smart pointers in WebCore/loader
<a href="https://bugs.webkit.org/show_bug.cgi?id=268722">https://bugs.webkit.org/show_bug.cgi?id=268722</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/loader/ApplicationManifestLoader.cpp:
(WebCore::ApplicationManifestLoader::startLoading):
(WebCore::ApplicationManifestLoader::stopLoading):
(WebCore::ApplicationManifestLoader::processManifest):
(WebCore::ApplicationManifestLoader::notifyFinished):
* Source/WebCore/loader/ContentFilter.cpp:
(WebCore::ContentFilter::continueAfterWillSendRequest):
(WebCore::ContentFilter::startFilteringMainResource):
(WebCore::ContentFilter::continueAfterResponseReceived):
(WebCore::ContentFilter::continueAfterDataReceived):
(WebCore::ContentFilter::continueAfterNotifyFinished):
(WebCore::ContentFilter::forEachContentFilterUntilBlocked):
(WebCore::ContentFilter::didDecide):
(WebCore::ContentFilter::protectedClient const):
(WebCore::ContentFilter::deliverResourceData):
(WebCore::ContentFilter::handleProvisionalLoadFailure):
* Source/WebCore/loader/ContentFilter.h:
* Source/WebCore/loader/ContentFilterClient.h:
* Source/WebCore/loader/CookieJar.cpp:
(WebCore::shouldRelaxThirdPartyCookieBlocking):
(WebCore::CookieJar::sameSiteInfo):
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::createAccessControlPreflightRequest):
(WebCore::createPotentialAccessControlRequest):
* Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp:
(WebCore::sendCOEPInheritenceViolation):
(WebCore::sendCOEPCORPViolation):
* Source/WebCore/loader/CrossOriginOpenerPolicy.cpp:
(WebCore::sendViolationReportWhenNavigatingToCOOPResponse):
(WebCore::sendViolationReportWhenNavigatingAwayFromCOOPResponse):
* Source/WebCore/loader/CrossOriginPreflightChecker.cpp:
(WebCore::CrossOriginPreflightChecker::~CrossOriginPreflightChecker):
(WebCore::CrossOriginPreflightChecker::validatePreflightResponse):
(WebCore::CrossOriginPreflightChecker::notifyFinished):
(WebCore::CrossOriginPreflightChecker::protectedLoader const):
(WebCore::CrossOriginPreflightChecker::redirectReceived):
(WebCore::CrossOriginPreflightChecker::startPreflight):
(WebCore::CrossOriginPreflightChecker::doPreflight):
(WebCore::CrossOriginPreflightChecker::setDefersLoading):
* Source/WebCore/loader/CrossOriginPreflightChecker.h:
* Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.mm:
(WebCore::DiskCacheMonitor::resourceBecameFileBacked):
* Source/WebCore/loader/icon/IconLoader.cpp:
(WebCore::IconLoader::startLoading):
(WebCore::IconLoader::stopLoading):
(WebCore::IconLoader::notifyFinished):
* Source/WebCore/loader/ios/LegacyPreviewLoader.h:
* Source/WebCore/loader/ios/LegacyPreviewLoader.mm:
(WebCore::makeClient):
(WebCore::LegacyPreviewLoader::protectedConverter const):
(WebCore::LegacyPreviewLoader::protectedClient const):
(WebCore::LegacyPreviewLoader::didReceiveData):
(WebCore::LegacyPreviewLoader::didFinishLoading):
(WebCore::LegacyPreviewLoader::didFail):
(WebCore::LegacyPreviewLoader::previewConverterDidStartConverting):
(WebCore::LegacyPreviewLoader::previewConverterDidReceiveData):
(WebCore::LegacyPreviewLoader::previewConverterDidFinishConverting):
(WebCore::LegacyPreviewLoader::previewConverterDidFailUpdating):
(WebCore::LegacyPreviewLoader::previewConverterDidFailConverting):
(WebCore::LegacyPreviewLoader::providePasswordForPreviewConverter):
* Source/WebCore/loader/mac/DocumentLoaderMac.cpp:
(WebCore::scheduleAll):
(WebCore::unscheduleAll):
(WebCore::DocumentLoader::schedule):
(WebCore::DocumentLoader::unschedule):
* Source/WebCore/loader/mac/LoaderNSURLExtras.mm:
(filenameByFixingIllegalCharacters):
* Source/WebCore/loader/mac/ResourceLoaderMac.mm:
(WebCore::ResourceLoader::willCacheResponseAsync):
* Source/WebCore/platform/PlatformContentFilter.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:

Canonical link: <a href="https://commits.webkit.org/274084@main">https://commits.webkit.org/274084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b35bcdbd5b7d56b3009597a0de635ef1dd4848a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40353 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33639 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/13983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/31990 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33132 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12293 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12238 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33807 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41613 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38118 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10439 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36292 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14236 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13205 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4909 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13544 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->