### PR TITLE
Don't fire window or tab events until the browser calls didOpenTab: and didOpenWindow:.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -603,7 +603,7 @@ static inline NSArray *toAPI(const WebKit::WebExtensionContext::WindowVector& wi
 
     NSMutableArray *result = [[NSMutableArray alloc] initWithCapacity:windows.size()];
 
-    for (auto& window : windows) {
+    for (Ref window : windows) {
         if (auto delegate = window->delegate())
             [result addObject:delegate];
     }
@@ -621,14 +621,14 @@ static inline NSArray *toAPI(const WebKit::WebExtensionContext::WindowVector& wi
     return toAPI(_webExtensionContext->focusedWindow(WebKit::WebExtensionContext::IgnoreExtensionAccess::Yes));
 }
 
-static inline NSSet *toAPI(const WebKit::WebExtensionContext::TabMapValueIterator& tabs)
+static inline NSSet *toAPI(const WebKit::WebExtensionContext::TabVector& tabs)
 {
     if (tabs.isEmpty())
         return [NSSet set];
 
     NSMutableSet *result = [[NSMutableSet alloc] initWithCapacity:tabs.size()];
 
-    for (auto& tab : tabs) {
+    for (Ref tab : tabs) {
         if (auto delegate = tab->delegate())
             [result addObject:delegate];
     }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm
@@ -195,7 +195,8 @@ RefPtr<WebExtensionTab> WebExtensionWindow::activeTab() const
         return nullptr;
 
     THROW_UNLESS([activeTab conformsToProtocol:@protocol(_WKWebExtensionTab)], @"Object returned by activeTabForWebExtensionContext: does not conform to the _WKWebExtensionTab protocol");
-    auto result = m_extensionContext->getOrCreateTab(activeTab);
+
+    Ref result = m_extensionContext->getOrCreateTab(activeTab);
 
     auto *tabs = [m_delegate tabsForWebExtensionContext:m_extensionContext->wrapper()];
     THROW_UNLESS([tabs isKindOfClass:NSArray.class], @"Object returned by tabsForWebExtensionContext: is not an array");
@@ -296,6 +297,11 @@ void WebExtensionWindow::setState(WebExtensionWindow::State state, CompletionHan
 
         completionHandler(std::nullopt);
     }).get()];
+}
+
+bool WebExtensionWindow::isOpen() const
+{
+    return m_isOpen && isValid();
 }
 
 bool WebExtensionWindow::isFocused() const

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -135,6 +135,10 @@ public:
 
     String title() const;
 
+    bool isOpen() const;
+    void didOpen() { ASSERT(!m_isOpen); m_isOpen = true; }
+    void didClose() { ASSERT(m_isOpen); m_isOpen = false; }
+
     bool isActive() const;
     bool isSelected() const;
     bool isPrivate() const;
@@ -201,6 +205,7 @@ private:
     RefPtr<WebExtensionMatchPattern> m_temporaryPermissionMatchPattern;
     OptionSet<ChangedProperties> m_changedProperties;
     bool m_activeUserGesture : 1 { false };
+    bool m_isOpen : 1 { false };
     mutable bool m_private : 1 { false };
     mutable bool m_cachedPrivate : 1 { false };
     bool m_respondsToWindow : 1 { false };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -111,6 +111,10 @@ public:
     State state() const;
     void setState(State, CompletionHandler<void(Error)>&&);
 
+    bool isOpen() const;
+    void didOpen() { ASSERT(!m_isOpen); m_isOpen = true; }
+    void didClose() { ASSERT(m_isOpen); m_isOpen = false; }
+
     bool isFocused() const;
     bool isFrontmost() const;
     void focus(CompletionHandler<void(Error)>&&);
@@ -138,6 +142,7 @@ private:
     WebExtensionWindowIdentifier m_identifier;
     WeakPtr<WebExtensionContext> m_extensionContext;
     WeakObjCPtr<_WKWebExtensionWindow> m_delegate;
+    bool m_isOpen : 1 { false };
     mutable bool m_private : 1 { false };
     mutable bool m_cachedPrivate : 1 { false };
     bool m_respondsToTabs : 1 { false };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -553,40 +553,42 @@ TEST(WKWebExtensionAPITabs, Query)
 {
     auto *backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
-        @"const windowIdOne = allWindows[0].id",
-        @"const windowIdTwo = allWindows[1].id",
+        @"browser.test.assertEq(allWindows?.length, 2, 'There should be 2 windows')",
 
-        @"const tabIdOne = allWindows[0].tabs[0].id",
-        @"const tabIdTwo = allWindows[0].tabs[1].id",
-        @"const tabIdThree = allWindows[1].tabs[0].id",
-        @"const tabIdFour = allWindows[1].tabs[1].id",
-        @"const tabIdFive = allWindows[1].tabs[2].id",
+        @"const windowIdOne = allWindows?.[0]?.id",
+        @"const windowIdTwo = allWindows?.[1]?.id",
+
+        @"const tabIdOne = allWindows?.[0]?.tabs?.[0]?.id",
+        @"const tabIdTwo = allWindows?.[0]?.tabs?.[1]?.id",
+        @"const tabIdThree = allWindows?.[1]?.tabs?.[0]?.id",
+        @"const tabIdFour = allWindows?.[1]?.tabs?.[1]?.id",
+        @"const tabIdFive = allWindows?.[1]?.tabs?.[2]?.id",
 
         @"const tabsInWindowOne = await browser.tabs.query({ windowId: windowIdOne })",
         @"const tabsInWindowTwo = await browser.tabs.query({ windowId: windowIdTwo })",
-        @"browser.test.assertEq(tabsInWindowOne.length, 2, 'There should be 2 tabs in the first window')",
-        @"browser.test.assertEq(tabsInWindowTwo.length, 3, 'There should be 3 tabs in the second window')",
+        @"browser.test.assertEq(tabsInWindowOne?.length, 2, 'There should be 2 tabs in the first window')",
+        @"browser.test.assertEq(tabsInWindowTwo?.length, 3, 'There should be 3 tabs in the second window')",
 
         @"const thirdTab = await browser.tabs.query({ index: 0, windowId: windowIdTwo })",
-        @"browser.test.assertEq(thirdTab[0].id, tabIdThree, 'Third tab ID should match the first tab of the second window')",
+        @"browser.test.assertEq(thirdTab?.[0]?.id, tabIdThree, 'Third tab ID should match the first tab of the second window')",
 
         @"const activeTabs = await browser.tabs.query({ active: true })",
-        @"browser.test.assertEq(activeTabs.length, 2, 'There should be 2 active tabs across all windows')",
+        @"browser.test.assertEq(activeTabs?.length, 2, 'There should be 2 active tabs across all windows')",
 
         @"const hiddenTabs = await browser.tabs.query({ hidden: true })",
-        @"browser.test.assertEq(hiddenTabs.length, 3, 'There should be 3 hidden tabs across all windows')",
+        @"browser.test.assertEq(hiddenTabs?.length, 3, 'There should be 3 hidden tabs across all windows')",
 
         @"const lastFocusedTabs = await browser.tabs.query({ lastFocusedWindow: true })",
-        @"browser.test.assertEq(lastFocusedTabs.length, 2, 'There should be 2 tabs in the last focused window')",
+        @"browser.test.assertEq(lastFocusedTabs?.length, 2, 'There should be 2 tabs in the last focused window')",
 
         @"const pinnedTabs = await browser.tabs.query({ pinned: true })",
-        @"browser.test.assertEq(pinnedTabs.length, 0, 'There should be no pinned tabs')",
+        @"browser.test.assertEq(pinnedTabs?.length, 0, 'There should be no pinned tabs')",
 
         @"const loadingTabs = await browser.tabs.query({ status: 'loading' })",
-        @"browser.test.assertEq(loadingTabs.length, 0, 'There should be no tabs loading')",
+        @"browser.test.assertEq(loadingTabs?.length, 0, 'There should be no tabs loading')",
 
         @"const completeTabs = await browser.tabs.query({ status: 'complete' })",
-        @"browser.test.assertEq(completeTabs.length, 5, 'There should be 5 tabs with loading complete')",
+        @"browser.test.assertEq(completeTabs?.length, 5, 'There should be 5 tabs with loading complete')",
 
         @"browser.test.notifyPass()"
     ]);
@@ -616,40 +618,49 @@ TEST(WKWebExtensionAPITabs, QueryWithPrivateAccess)
 {
     auto *backgroundScript = Util::constructScript(@[
         @"const allWindows = await browser.windows.getAll({ populate: true })",
-        @"const windowIdOne = allWindows[0].id",
-        @"const windowIdTwo = allWindows[1].id",
+        @"const normalWindows = allWindows.filter(window => !window.incognito)",
+        @"const incognitoWindows = allWindows.filter(window => window.incognito)",
 
-        @"const tabIdOne = allWindows[0].tabs[0].id",
-        @"const tabIdTwo = allWindows[0].tabs[1].id",
-        @"const tabIdThree = allWindows[1].tabs[0].id",
-        @"const tabIdFour = allWindows[1].tabs[1].id",
-        @"const tabIdFive = allWindows[1].tabs[2].id",
+        @"const windowIdOne = normalWindows?.[0]?.id",
+        @"const windowIdTwo = normalWindows?.[1]?.id",
+        @"const incognitoWindowId = incognitoWindows?.[0]?.id",
+
+        @"const tabIdOne = normalWindows?.[0]?.tabs?.[0]?.id",
+        @"const tabIdTwo = normalWindows?.[0]?.tabs?.[1]?.id",
+        @"const tabIdThree = normalWindows?.[1]?.tabs?.[0]?.id",
+        @"const tabIdFour = normalWindows?.[1]?.tabs?.[1]?.id",
+        @"const tabIdFive = normalWindows?.[1]?.tabs?.[2]?.id",
+        @"const incognitoTabIdOne = incognitoWindows?.[0]?.tabs?.[0]?.id",
+        @"const incognitoTabIdTwo = incognitoWindows?.[0]?.tabs?.[1]?.id",
 
         @"const tabsInWindowOne = await browser.tabs.query({ windowId: windowIdOne })",
         @"const tabsInWindowTwo = await browser.tabs.query({ windowId: windowIdTwo })",
-        @"browser.test.assertEq(tabsInWindowOne.length, 2, 'There should be 2 tabs in the first window')",
-        @"browser.test.assertEq(tabsInWindowTwo.length, 3, 'There should be 3 tabs in the second window')",
+        @"const tabsInIncognitoWindow = await browser.tabs.query({ windowId: incognitoWindowId })",
+
+        @"browser.test.assertEq(tabsInWindowOne?.length, 2, 'There should be 2 tabs in the first normal window')",
+        @"browser.test.assertEq(tabsInWindowTwo?.length, 3, 'There should be 3 tabs in the second normal window')",
+        @"browser.test.assertEq(tabsInIncognitoWindow?.length, 2, 'There should be 2 tabs in the incognito window')",
 
         @"const thirdTab = await browser.tabs.query({ index: 0, windowId: windowIdTwo })",
-        @"browser.test.assertEq(thirdTab[0].id, tabIdThree, 'Third tab ID should match the first tab of the second window')",
+        @"browser.test.assertEq(thirdTab?.[0]?.id, tabIdThree, 'Third tab ID should match the first tab of the second window')",
 
         @"const activeTabs = await browser.tabs.query({ active: true })",
-        @"browser.test.assertEq(activeTabs.length, 3, 'There should be 3 active tabs across all windows')",
+        @"browser.test.assertEq(activeTabs?.length, 3, 'There should be 3 active tabs across all windows')",
 
         @"const hiddenTabs = await browser.tabs.query({ hidden: true })",
-        @"browser.test.assertEq(hiddenTabs.length, 4, 'There should be 4 hidden tabs across all windows')",
+        @"browser.test.assertEq(hiddenTabs?.length, 4, 'There should be 4 hidden tabs across all windows')",
 
         @"const lastFocusedTabs = await browser.tabs.query({ lastFocusedWindow: true })",
-        @"browser.test.assertEq(lastFocusedTabs.length, 2, 'There should be 2 tabs in the last focused window')",
+        @"browser.test.assertEq(lastFocusedTabs?.length, 2, 'There should be 2 tabs in the last focused window')",
 
         @"const pinnedTabs = await browser.tabs.query({ pinned: true })",
-        @"browser.test.assertEq(pinnedTabs.length, 0, 'There should be no pinned tabs')",
+        @"browser.test.assertEq(pinnedTabs?.length, 0, 'There should be no pinned tabs')",
 
         @"const loadingTabs = await browser.tabs.query({ status: 'loading' })",
-        @"browser.test.assertEq(loadingTabs.length, 0, 'There should be no tabs loading')",
+        @"browser.test.assertEq(loadingTabs?.length, 0, 'There should be no tabs loading')",
 
         @"const completeTabs = await browser.tabs.query({ status: 'complete' })",
-        @"browser.test.assertEq(completeTabs.length, 7, 'There should be 7 tabs with loading complete')",
+        @"browser.test.assertEq(completeTabs?.length, 7, 'There should be 7 tabs with loading complete')",
 
         @"browser.test.notifyPass()"
     ]);


### PR DESCRIPTION
#### 1e7cb6de6869907b5b840532a65c37783bf9b41e
<pre>
Don&apos;t fire window or tab events until the browser calls didOpenTab: and didOpenWindow:.
<a href="https://webkit.org/b/268671">https://webkit.org/b/268671</a>
<a href="https://rdar.apple.com/122143707">rdar://122143707</a>

Reviewed by Brian Weinstein.

Be more protective of when we fire window and tab events, so we never fire events
if the window or tab hasn&apos;t fired the onCreated event. Also add more smart pointer
use, assertions, and error logging to catch misuse.

While fixing this, I discovered the WKWebExtensionAPITabs.QueryWithPrivateAccess
test was not correct and was missing the tests for the incognito windows. Fixed
things up there, and added optional chaining to avoid exceptions when things are
incorrectly undefined / null.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(toAPI):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::postAsyncNotification):
(WebKit::WebExtensionContext::removeGrantedPermissionMatchPatterns):
(WebKit::WebExtensionContext::getOrCreateWindow const):
(WebKit::WebExtensionContext::getWindow const):
(WebKit::WebExtensionContext::forgetWindow const):
(WebKit::WebExtensionContext::getOrCreateTab const):
(WebKit::WebExtensionContext::getTab const):
(WebKit::WebExtensionContext::getCurrentTab const):
(WebKit::WebExtensionContext::forgetTab const):
(WebKit::WebExtensionContext::populateWindowsAndTabs):
(WebKit::WebExtensionContext::isValidWindow):
(WebKit::WebExtensionContext::isValidTab):
(WebKit::WebExtensionContext::openWindows const):
(WebKit::WebExtensionContext::openTabs const):
(WebKit::WebExtensionContext::frontmostWindow const):
(WebKit::WebExtensionContext::didOpenWindow):
(WebKit::WebExtensionContext::didCloseWindow):
(WebKit::WebExtensionContext::didFocusWindow):
(WebKit::WebExtensionContext::didOpenTab):
(WebKit::WebExtensionContext::didCloseTab):
(WebKit::WebExtensionContext::didActivateTab):
(WebKit::WebExtensionContext::didSelectOrDeselectTabs):
(WebKit::WebExtensionContext::didMoveTab):
(WebKit::WebExtensionContext::didReplaceTab):
(WebKit::WebExtensionContext::didChangeTabProperties):
(WebKit::WebExtensionContext::resourceLoadDidSendRequest):
(WebKit::WebExtensionContext::resourceLoadDidPerformHTTPRedirection):
(WebKit::WebExtensionContext::resourceLoadDidReceiveChallenge):
(WebKit::WebExtensionContext::resourceLoadDidReceiveResponse):
(WebKit::WebExtensionContext::resourceLoadDidCompleteWithError):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::parameters const):
(WebKit::WebExtensionTab::index const):
(WebKit::WebExtensionTab::parentTab const):
(WebKit::WebExtensionTab::mainWebView const):
(WebKit::WebExtensionTab::webViews const):
(WebKit::WebExtensionTab::isOpen const):
(WebKit::WebExtensionTab::isActive const):
(WebKit::WebExtensionTab::isPrivate const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm:
(WebKit::WebExtensionWindow::activeTab const):
(WebKit::WebExtensionWindow::isOpen const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::openTabs const): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
(WebKit::WebExtensionTab::didOpen):
(WebKit::WebExtensionTab::didClose):
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h:
(WebKit::WebExtensionWindow::didOpen):
(WebKit::WebExtensionWindow::didClose):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/274103@main">https://commits.webkit.org/274103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8669f6fe3051776101a898b5776b4f1787697f03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37903 "Failed to checkout and rebase branch from PR 23841") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/16811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/40165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/40446 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39233 "Failed to checkout and rebase branch from PR 23841") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/19506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/14111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/40446 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/38475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/19506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/40446 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/19506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/33894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/41718 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/19506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/41718 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/12902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/14111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/41718 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4917 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->