### PR TITLE
[JSC] Rest parameter should be evaluated before VariableEnvironment is set

### DIFF
--- a/JSTests/stress/regress-268274.js
+++ b/JSTests/stress/regress-268274.js
@@ -1,0 +1,71 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+(function() {
+    var obj = {};
+
+    function foo(a, b, [foo = function() { return e; }], ...[e, {d = foo()}]) { 
+        var d;
+        assert(d === 20);
+        return d;
+    }
+
+    noInline(foo);
+
+    for (var i = 0; i < 5000; i++) {
+        assert(foo(null, obj, [], 20, {}) === 20);
+    }
+})();
+
+(function() {
+    function foo(f1 = function(x) { b = x; }, ...[f2 = function() { return b; }, {b}]) {
+        var b;
+        assert(b === 34);
+        assert(f2() === 34);
+        f1(50);
+        assert(b === 34);
+        assert(f2() === 50);
+    }
+
+    noInline(foo);
+
+    for (var i = 0; i < 5000; i++) {
+        foo(undefined, undefined, {b: 34});
+    }
+})();
+
+(function() {
+    var outer = "outer";
+
+    function foo(...[a = outer, b = function() { return a; }, c = function(v) { a = v; }]) {
+        var a;
+        assert(a === "outer");
+        a = 20;
+        assert(a === 20);
+        assert(b() === "outer");
+        c("hello");
+        assert(b() === "hello");
+    }
+
+    function bar(a = outer, b = function() { return a; }, ...[c = function(v) { a = v; }]) {
+        with ({}) {
+            var a;
+            assert(a === "outer");
+            a = 20;
+            assert(a === 20);
+            assert(b() === "outer");
+            c("hello");
+            assert(b() === "hello");
+        }
+    }
+
+    noInline(foo);
+    noInline(bar);
+
+    for (var i = 0; i < 2500; i++) {
+        foo();
+        bar();
+    }
+})();

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -857,8 +857,6 @@ test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-p
   default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«param», «undefined») to be true'
 test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign.js:
   default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«param», «undefined») to be true'
-test/language/expressions/arrow-function/scope-param-rest-elem-var-open.js:
-  default: 'Test262Error: Expected SameValue(«outside», «inside») to be true'
 test/language/expressions/assignment/S11.13.1_A7_T3.js:
   default: 'Test262Error: Expected a DummyError but got a Test262Error'
   strict mode: 'Test262Error: Expected a DummyError but got a Test262Error'
@@ -1015,10 +1013,6 @@ test/language/expressions/dynamic-import/import-assertions/2nd-param-assert-valu
 test/language/expressions/dynamic-import/import-assertions/2nd-param-get-assert-error.js:
   default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected an error, but observed no error'
   strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Expected an error, but observed no error'
-test/language/expressions/function/scope-param-rest-elem-var-open.js:
-  default: 'Test262Error: Expected SameValue(«outside», «inside») to be true'
-test/language/expressions/generators/scope-param-rest-elem-var-open.js:
-  default: 'Test262Error: Expected SameValue(«outside», «inside») to be true'
 test/language/expressions/instanceof/prototype-getter-with-primitive.js:
   default: "Test262Error: getter for 'prototype' called"
   strict mode: "Test262Error: getter for 'prototype' called"
@@ -1031,10 +1025,6 @@ test/language/expressions/logical-assignment/lgcl-or-assignment-operator-non-sim
 test/language/expressions/new/non-ctor-err-realm.js:
   default: 'Test262Error: production including Arguments Expected a TypeError but got a different error constructor with the same name'
   strict mode: 'Test262Error: production including Arguments Expected a TypeError but got a different error constructor with the same name'
-test/language/expressions/object/scope-gen-meth-param-rest-elem-var-open.js:
-  default: 'Test262Error: Expected SameValue(«outside», «inside») to be true'
-test/language/expressions/object/scope-meth-param-rest-elem-var-open.js:
-  default: 'Test262Error: Expected SameValue(«outside», «inside») to be true'
 test/language/expressions/postfix-decrement/S11.3.2_A6_T3.js:
   default: 'Test262Error: Expected true but got false'
   strict mode: 'Test262Error: Expected true but got false'
@@ -1268,10 +1258,6 @@ test/language/statements/for/dstr/var-ary-ptrn-elem-id-iter-val-array-prototype.
   strict mode: 'Test262Error: Expected SameValue(«3», «42») to be true'
 test/language/statements/for/head-lhs-let.js:
   default: "SyntaxError: Unexpected token ';'. Expected a parameter pattern or a ')' in parameter list."
-test/language/statements/function/scope-param-rest-elem-var-open.js:
-  default: 'Test262Error: Expected SameValue(«outside», «inside») to be true'
-test/language/statements/generators/scope-param-rest-elem-var-open.js:
-  default: 'Test262Error: Expected SameValue(«outside», «inside») to be true'
 test/language/statements/let/dstr/ary-init-iter-get-err-array-prototype.js:
   default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -200,14 +200,6 @@ ParserError BytecodeGenerator::generate(unsigned& size)
         if (m_needToInitializeArguments)
             initializeVariable(variable(propertyNames().arguments), m_argumentsRegister);
 
-        if (m_restParameter) {
-            // We should move moving m_restParameter->emit(*this) to initializeDefaultParameterValuesAndSetupFunctionScopeStack
-            // as an optimization if we can prove that change has no side effect.
-            asyncFuncParametersTryCatchWrap([&] {
-                m_restParameter->emit(*this);
-            });
-        }
-
         {
             bool shouldHoistInEval = m_codeType == EvalCode && !m_ecmaMode.isStrict();
             RefPtr<RegisterID> temp = newTemporary();
@@ -1184,6 +1176,9 @@ void BytecodeGenerator::initializeDefaultParameterValuesAndSetupFunctionScopeSta
 
             parameter.first->bindValue(*this, temp.get());
         }
+
+        if (m_restParameter)
+            m_restParameter->emit(*this);
 
         // Final act of weirdness for default parameters. If a "var" also
         // has the same name as a parameter, it should start out as the


### PR DESCRIPTION
#### c0dd368287d55af9c01a3ac187167581e95e5c5b
<pre>
[JSC] Rest parameter should be evaluated before VariableEnvironment is set
<a href="https://bugs.webkit.org/show_bug.cgi?id=268274">https://bugs.webkit.org/show_bug.cgi?id=268274</a>
&lt;<a href="https://rdar.apple.com/problem/121961421">rdar://problem/121961421</a>&gt;

Reviewed by Mark Lam.

If a function has non-simple parameter list, a separate Environment Record is created (step 28.c of [1])
to ensure that a closure, created in default value expression, don&apos;t have visibility of declarations
in the function body. This is also the environment where direct eval() declare variables.

Moreover, if there is a `var` by the same name as parameter, it should start out with the value of
that parameter (step 28.c of [1]), but have a distinct binding.

All parameters, including the ...rest one, are evaluated during steps 25-26 of [1].
This change moves rest parameter evaluation to come before VariableEnvironment is created &amp; set,
which matches the steps order in the spec [1] and aligns JSC with V8 and SpiderMonkey.

From userland perspective, this patch fixes a handful of bugs:
  * direct eval() in default value expression inside rest parameter creates variable in environment
    of the function rather than the separate one of the parameters;
  * ReferenceError is thrown when accessing a binding, which is defined inside rest parameter,
    in eval() / closure created in default value expression of a preceding parameter, but only
    if there is a `var` binding by the same name;
  * a closure, created in default value expression inside rest parameter, is created in different
    VariableEnvironment (of the function) than its counterparts in preceding parameters, which causes
    incorrect environment to be consulted when querying / modifying parameter names that are
    &quot;shadowed&quot; by `var` bindings.

With this change, all parameters are evaluated inside a single try / catch wrapper, which reduces
the number of bytecodes, emitted for an async function with rest parameter, by 2.

[1]: <a href="https://tc39.es/ecma262/#sec-functiondeclarationinstantiation">https://tc39.es/ecma262/#sec-functiondeclarationinstantiation</a>

* JSTests/stress/regress-268274.js: Added.
* JSTests/test262/expectations.yaml: Mark 7 tests as passing.
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::generate):
(JSC::BytecodeGenerator::initializeDefaultParameterValuesAndSetupFunctionScopeStack):

Canonical link: <a href="https://commits.webkit.org/274109@main">https://commits.webkit.org/274109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de57da299a759ed6880b215b88373d6abece854b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/37920 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/16828 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/40179 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/40463 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33739 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/19523 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/14129 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/40463 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/38492 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/19523 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/40179 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/40463 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/19523 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/40179 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/41735 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/31612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/19523 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/40179 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/41735 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/37615 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/12913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/14129 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/41735 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/40179 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/44543 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/44543 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4919 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->