### PR TITLE
[Digital Identity]: implement navigator.identity attribute

### DIFF
--- a/LayoutTests/http/wpt/credential-management/setDigitalIdentityEnable.https.html
+++ b/LayoutTests/http/wpt/credential-management/setDigitalIdentityEnable.https.html
@@ -10,6 +10,10 @@
         testRunner.dumpAsText();
         testRunner.waitUntilDone();
 
+        if (window.navigator.identity !== undefined) {
+            console.log("FAIL: identity must not be exposed by default.");
+        }
+
         if (window.DigitalIdentity !== undefined) {
             console.log(
                 "FAIL: DigitalIdentity interface must not be exposed by default."
@@ -24,6 +28,20 @@
             if (iframeWin.navigator.credentials.requestIdentity) {
                 console.log(
                     "FAIL: navigator.credentials.requestIdentity() was removed from the spec!"
+                );
+            }
+
+            const { identity } = iframeWin.navigator;
+            if (!identity) {
+                console.log(
+                    "FAIL: navigator.identity must be exposed. Was enabled by pref."
+                );
+            }
+            const isInstanceOfCredentialContainer =
+                identity instanceof iframeWin.CredentialsContainer;
+            if (!isInstanceOfCredentialContainer) {
+                console.log(
+                    "FAIL: navigator.identity must be and instance of CredentialsContainer."
                 );
             }
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -374,6 +374,8 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/highlight/Highlight.idl
     Modules/highlight/HighlightRegistry.idl
 
+    Modules/identity/Navigator+Identity.idl
+
     Modules/indexeddb/IDBCursor.idl
     Modules/indexeddb/IDBCursorDirection.idl
     Modules/indexeddb/IDBCursorWithValue.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -504,6 +504,7 @@ $(PROJECT_DIR)/Modules/geolocation/PositionErrorCallback.idl
 $(PROJECT_DIR)/Modules/geolocation/PositionOptions.idl
 $(PROJECT_DIR)/Modules/highlight/Highlight.idl
 $(PROJECT_DIR)/Modules/highlight/HighlightRegistry.idl
+$(PROJECT_DIR)/Modules/identity/Navigator+Identity.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBCursor.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBCursorDirection.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBCursorWithValue.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1980,6 +1980,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Gamepad.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Gamepad.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Geolocation.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Geolocation.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Identity.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Identity.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+IsLoggedIn.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+IsLoggedIn.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+MediaCapabilities.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -375,6 +375,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/geolocation/PositionOptions.idl \
     $(WebCore)/Modules/highlight/HighlightRegistry.idl \
     $(WebCore)/Modules/highlight/Highlight.idl \
+    $(WebCore)/Modules/identity/Navigator+Identity.idl \
     $(WebCore)/Modules/indexeddb/IDBCursor.idl \
     $(WebCore)/Modules/indexeddb/IDBCursorDirection.idl \
     $(WebCore)/Modules/indexeddb/IDBCursorWithValue.idl \

--- a/Source/WebCore/Modules/identity/Navigator+Identity.idl
+++ b/Source/WebCore/Modules/identity/Navigator+Identity.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+//https://wicg.github.io/digital-identities/#extensions-to-the-navigator-interface
+[
+    Conditional=WEB_AUTHN,
+    EnabledBySetting=DigitalIdentityEnabled,
+    ImplementedBy=NavigatorIdentity
+] partial interface Navigator {
+    [SecureContext, SameObject] readonly attribute CredentialsContainer identity;
+};

--- a/Source/WebCore/Modules/identity/NavigatorIdentity.cpp
+++ b/Source/WebCore/Modules/identity/NavigatorIdentity.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "NavigatorIdentity.h"
+
+#if ENABLE(WEB_AUTHN)
+
+#include "Document.h"
+#include "LocalFrame.h"
+#include "Navigator.h"
+
+namespace WebCore {
+
+NavigatorIdentity::NavigatorIdentity() = default;
+
+NavigatorIdentity::~NavigatorIdentity() = default;
+
+ASCIILiteral NavigatorIdentity::supplementName()
+{
+    return "NavigatorIdentity"_s;
+}
+
+CredentialsContainer* NavigatorIdentity::identity(WeakPtr<Document, WeakPtrImplWithEventTargetData>&& document)
+{
+    if (!m_credentialsContainer)
+        m_credentialsContainer = CredentialsContainer::create(WTFMove(document));
+
+    return m_credentialsContainer.get();
+}
+
+CredentialsContainer* NavigatorIdentity::identity(Navigator& navigator)
+{
+    if (!navigator.frame() || !navigator.frame()->document())
+        return nullptr;
+    return NavigatorIdentity::from(&navigator)->identity(*navigator.frame()->document());
+}
+
+NavigatorIdentity* NavigatorIdentity::from(Navigator* navigator)
+{
+    NavigatorIdentity* supplement = static_cast<NavigatorIdentity*>(Supplement<Navigator>::from(navigator, supplementName()));
+    if (!supplement) {
+        auto newSupplement = makeUnique<NavigatorIdentity>();
+        supplement = newSupplement.get();
+        provideTo(navigator, supplementName(), WTFMove(newSupplement));
+    }
+    return supplement;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/identity/NavigatorIdentity.h
+++ b/Source/WebCore/Modules/identity/NavigatorIdentity.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_AUTHN)
+
+#include "CredentialsContainer.h"
+#include "Supplementable.h"
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class WeakPtrImplWithEventTargetData;
+class Navigator;
+
+class NavigatorIdentity final : public Supplement<Navigator> {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    NavigatorIdentity();
+    virtual ~NavigatorIdentity();
+
+    static CredentialsContainer* identity(Navigator&);
+
+private:
+    CredentialsContainer* identity(WeakPtr<Document, WeakPtrImplWithEventTargetData>&&);
+
+    static NavigatorIdentity* from(Navigator*);
+    static ASCIILiteral supplementName();
+
+    RefPtr<CredentialsContainer> m_credentialsContainer;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -146,6 +146,7 @@ Modules/highlight/AppHighlightRangeData.cpp
 Modules/highlight/AppHighlightStorage.cpp
 Modules/highlight/HighlightRegistry.cpp
 Modules/highlight/Highlight.cpp
+Modules/identity/NavigatorIdentity.cpp
 Modules/indexeddb/IDBCursor.cpp
 Modules/indexeddb/IDBCursorWithValue.cpp
 Modules/indexeddb/IDBDatabase.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -316,6 +316,7 @@ namespace WebCore {
     macro(NavigationPreloadManager) \
     macro(NavigationTransition) \
     macro(NavigatorCredentials) \
+    macro(NavigatorIdentity) \
     macro(NavigatorMediaDevices) \
     macro(NavigatorPermissions) \
     macro(NavigatorUserMedia) \


### PR DESCRIPTION
#### dafa992c342e2dc8013708c56750c8b966954bbf
<pre>
[Digital Identity]: implement navigator.identity attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=268726">https://bugs.webkit.org/show_bug.cgi?id=268726</a>
<a href="https://rdar.apple.com/122291807">rdar://122291807</a>

Reviewed by Chris Dumez.

The spec was updated to drop the navigator.credential.requestIdentity() method in favor of having an independent CredentialsContainer for navigator.identity.
See: <a href="https://wicg.github.io/digital-identities/#extensions-to-the-navigator-interface">https://wicg.github.io/digital-identities/#extensions-to-the-navigator-interface</a>

We will need to implement a new CredentialsContainer specifically for navigator.identity as a follow up.

* LayoutTests/http/wpt/credential-management/setDigitalIdentityEnable.https.html:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/identity/Navigator+Identity.idl: Added.
* Source/WebCore/Modules/identity/NavigatorIdentity.cpp: Added.
(WebCore::NavigatorIdentity::supplementName):
(WebCore::NavigatorIdentity::identity):
(WebCore::NavigatorIdentity::from):
* Source/WebCore/Modules/identity/NavigatorIdentity.h: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:

Canonical link: <a href="https://commits.webkit.org/274567@main">https://commits.webkit.org/274567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/486fd0d826be637ee47b34247ee8b854833270fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41881 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/35247 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/21187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15655 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32901 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39921 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/34080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13400 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/13367 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/35020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43159 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35710 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/35350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/39168 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/14159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11670 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37410 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/34298 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8828 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15813 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/15420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->