### PR TITLE
Have MediaDescription stop using AtomString

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -816,7 +816,7 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
             // referenced by the audioTracks attribute on the HTMLMediaElement.
             m_source->mediaElement()->addAudioTrack(newAudioTrack.copyRef());
 
-            m_audioCodecs.append(audioTrackInfo.description->codec());
+            m_audioCodecs.append(audioTrackInfo.description->codec().toAtomString());
 
             // 5.2.8 Create a new track buffer to store coded frames for this track.
             m_private->addTrackBuffer(audioTrackInfo.track->id(), WTFMove(audioTrackInfo.description));
@@ -852,7 +852,7 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
             // referenced by the videoTracks attribute on the HTMLMediaElement.
             m_source->mediaElement()->addVideoTrack(newVideoTrack.copyRef());
 
-            m_videoCodecs.append(videoTrackInfo.description->codec());
+            m_videoCodecs.append(videoTrackInfo.description->codec().toAtomString());
 
             // 5.3.8 Create a new track buffer to store coded frames for this track.
             m_private->addTrackBuffer(videoTrackInfo.track->id(), WTFMove(videoTrackInfo.description));
@@ -885,7 +885,7 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
             // referenced by the textTracks attribute on the HTMLMediaElement.
             m_source->mediaElement()->addTextTrack(newTextTrack.copyRef());
 
-            m_textCodecs.append(textTrackInfo.description->codec());
+            m_textCodecs.append(textTrackInfo.description->codec().toAtomString());
 
             // 5.4.7 Create a new track buffer to store coded frames for this track.
             m_private->addTrackBuffer(textTrackPrivate.id(), WTFMove(textTrackInfo.description));
@@ -935,33 +935,36 @@ bool SourceBuffer::validateInitializationSegment(const InitializationSegment& se
     // is not enabled, only perform this check if the "pending initialization segment for changeType flag"
     // is not set.)
     for (auto& audioTrackInfo : segment.audioTracks) {
-        if (m_audioCodecs.contains(audioTrackInfo.description->codec()))
+        auto audioCodec = audioTrackInfo.description->codec().toAtomString();
+        if (m_audioCodecs.contains(audioCodec))
             continue;
 
         if (!m_pendingInitializationSegmentForChangeType)
             return false;
 
-        m_audioCodecs.append(audioTrackInfo.description->codec());
+        m_audioCodecs.append(WTFMove(audioCodec));
     }
 
     for (auto& videoTrackInfo : segment.videoTracks) {
-        if (m_videoCodecs.contains(videoTrackInfo.description->codec()))
+        auto videoCodec = videoTrackInfo.description->codec().toAtomString();
+        if (m_videoCodecs.contains(videoCodec))
             continue;
 
         if (!m_pendingInitializationSegmentForChangeType)
             return false;
 
-        m_videoCodecs.append(videoTrackInfo.description->codec());
+        m_videoCodecs.append(WTFMove(videoCodec));
     }
 
     for (auto& textTrackInfo : segment.textTracks) {
-        if (m_textCodecs.contains(textTrackInfo.description->codec()))
+        auto textCodec = textTrackInfo.description->codec().toAtomString();
+        if (m_textCodecs.contains(textCodec))
             continue;
 
         if (!m_pendingInitializationSegmentForChangeType)
             return false;
 
-        m_textCodecs.append(textTrackInfo.description->codec());
+        m_textCodecs.append(WTFMove(textCodec));
     }
 
     return true;

--- a/Source/WebCore/platform/MediaDescription.h
+++ b/Source/WebCore/platform/MediaDescription.h
@@ -27,18 +27,25 @@
 #define MediaDescription_h
 
 #include <wtf/Forward.h>
-#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
 
-class MediaDescription : public RefCounted<MediaDescription> {
+class MediaDescription : public ThreadSafeRefCounted<MediaDescription> {
 public:
+    explicit MediaDescription(String&& codec)
+        : m_codec(WTFMove(codec))
+    {
+        ASSERT(m_codec.isSafeToSendToAnotherThread());
+    }
     virtual ~MediaDescription() = default;
 
-    virtual AtomString codec() const = 0;
+    StringView codec() const { return m_codec; }
     virtual bool isVideo() const = 0;
     virtual bool isAudio() const = 0;
     virtual bool isText() const = 0;
+protected:
+    const String m_codec;
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -166,39 +166,31 @@ public:
     static Ref<MediaDescriptionAVFObjC> create(AVAssetTrack* track) { return adoptRef(*new MediaDescriptionAVFObjC(track)); }
     virtual ~MediaDescriptionAVFObjC() { }
 
-    bool isVideo() const override { return m_isVideo; }
-    bool isAudio() const override { return m_isAudio; }
-    bool isText() const override { return m_isText; }
-    AtomString codec() const override
-    {
-        // AtomStrings can only be destroyed from the same thread they're
-        // created in. Since this structure is created in a parser thread
-        // only create the AtomString the first time this function is accessed
-        // which is presumably on the main thread.
-        ASSERT(isMainThread());
-        if (!m_codec)
-            m_codec = AtomString::fromLatin1(m_originalCodec.string().data());
-        return *m_codec;
-    }
+    bool isVideo() const final { return m_isVideo; }
+    bool isAudio() const final { return m_isAudio; }
+    bool isText() const final { return m_isText; }
 
 private:
     MediaDescriptionAVFObjC(AVAssetTrack* track)
-        : m_isVideo([track hasMediaCharacteristic:AVMediaCharacteristicVisual])
+        : MediaDescription(extractCodecName(track))
+        , m_isVideo([track hasMediaCharacteristic:AVMediaCharacteristicVisual])
         , m_isAudio([track hasMediaCharacteristic:AVMediaCharacteristicAudible])
         , m_isText([track hasMediaCharacteristic:AVMediaCharacteristicLegible])
     {
-        NSArray* formatDescriptions = [track formatDescriptions];
-        CMFormatDescriptionRef description = [formatDescriptions count] ? (__bridge CMFormatDescriptionRef)[formatDescriptions objectAtIndex:0] : 0;
-        if (description) {
-            m_originalCodec = PAL::softLink_CoreMedia_CMFormatDescriptionGetMediaSubType(description);
-            CFStringRef originalFormatKey = PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_ProtectedContentOriginalFormat() ? PAL::get_CoreMedia_kCMFormatDescriptionExtension_ProtectedContentOriginalFormat() : CFSTR("CommonEncryptionOriginalFormat");
-            if (auto originalFormat = dynamic_cf_cast<CFNumberRef>(PAL::CMFormatDescriptionGetExtension(description, originalFormatKey)))
-                CFNumberGetValue(originalFormat, kCFNumberSInt32Type, &m_originalCodec.value);
-        }
     }
 
-    FourCC m_originalCodec;
-    mutable std::optional<AtomString> m_codec;
+    String extractCodecName(AVAssetTrack* track)
+    {
+        NSArray* formatDescriptions = [track formatDescriptions];
+        CMFormatDescriptionRef description = [formatDescriptions count] ? (__bridge CMFormatDescriptionRef)[formatDescriptions objectAtIndex:0] : 0;
+        if (!description)
+            return emptyString();
+        FourCC originalCodec = PAL::softLink_CoreMedia_CMFormatDescriptionGetMediaSubType(description);
+        CFStringRef originalFormatKey = PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_ProtectedContentOriginalFormat() ? PAL::get_CoreMedia_kCMFormatDescriptionExtension_ProtectedContentOriginalFormat() : CFSTR("CommonEncryptionOriginalFormat");
+        if (auto originalFormat = dynamic_cf_cast<CFNumberRef>(PAL::CMFormatDescriptionGetExtension(description, originalFormatKey)))
+            CFNumberGetValue(originalFormat, kCFNumberSInt32Type, &originalCodec.value);
+        return String::fromLatin1(originalCodec.string().data());
+    }
     bool m_isVideo;
     bool m_isAudio;
     bool m_isText;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp
@@ -23,17 +23,10 @@
 #include "GStreamerCommon.h"
 
 #include <gst/pbutils/pbutils.h>
-#include <wtf/text/AtomString.h>
-#include <wtf/text/WTFString.h>
 
 #if ENABLE(VIDEO) && USE(GSTREAMER) && ENABLE(MEDIA_SOURCE)
 
 namespace WebCore {
-
-AtomString GStreamerMediaDescription::codec() const
-{
-    return m_codecName;
-}
 
 bool GStreamerMediaDescription::isVideo() const
 {
@@ -51,16 +44,16 @@ bool GStreamerMediaDescription::isText() const
     return false;
 }
 
-AtomString GStreamerMediaDescription::extractCodecName()
+String GStreamerMediaDescription::extractCodecName(const GRefPtr<GstCaps>& caps) const
 {
-    GRefPtr<GstCaps> originalCaps = m_caps;
+    GRefPtr<GstCaps> originalCaps = caps;
 
     if (areEncryptedCaps(originalCaps.get())) {
         originalCaps = adoptGRef(gst_caps_copy(originalCaps.get()));
         GstStructure* structure = gst_caps_get_structure(originalCaps.get(), 0);
 
         if (!gst_structure_has_field(structure, "original-media-type"))
-            return AtomString();
+            return String();
 
         gst_structure_set_name(structure, gst_structure_get_string(structure, "original-media-type"));
         // Remove the DRM related fields from the caps.
@@ -74,7 +67,7 @@ AtomString GStreamerMediaDescription::extractCodecName()
     }
 
     GUniquePtr<gchar> description(gst_pb_utils_get_codec_description(originalCaps.get()));
-    auto codecName = AtomString::fromLatin1(description.get());
+    auto codecName = String::fromLatin1(description.get());
 
     // Report "H.264 (Main Profile)" and "H.264 (High Profile)" just as "H.264" to allow changes between both variants
     // go unnoticed to the SourceBuffer layer.
@@ -83,7 +76,7 @@ AtomString GStreamerMediaDescription::extractCodecName()
         size_t braceEnd = codecName.find(')', braceStart + 1);
         if (braceStart != notFound && braceEnd != notFound) {
             StringView codecNameView { codecName };
-            codecName = makeAtomString(codecNameView.left(braceStart), codecNameView.substring(braceEnd + 1));
+            codecName = makeString(codecNameView.left(braceStart), codecNameView.substring(braceEnd + 1));
         }
     }
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.h
@@ -26,7 +26,8 @@
 #include "MediaDescription.h"
 
 #include <gst/gst.h>
-#include <wtf/text/AtomString.h>
+#include <wtf/text/StringView.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -39,22 +40,19 @@ public:
 
     virtual ~GStreamerMediaDescription() = default;
 
-    AtomString codec() const override;
-    bool isVideo() const override;
-    bool isAudio() const override;
-    bool isText() const override;
+    bool isVideo() const final;
+    bool isAudio() const final;
+    bool isText() const final;
 
 private:
     GStreamerMediaDescription(const GRefPtr<GstCaps>& caps)
-        : MediaDescription()
+        : MediaDescription(extractCodecName(caps))
         , m_caps(caps)
     {
-        m_codecName = extractCodecName();
     }
 
-    AtomString extractCodecName();
-    GRefPtr<GstCaps> m_caps;
-    AtomString m_codecName;
+    String extractCodecName(const GRefPtr<GstCaps>&) const;
+    const GRefPtr<GstCaps> m_caps;
 };
 
 } // namespace WebCore.

--- a/Source/WebCore/platform/mock/mediasource/MockBox.h
+++ b/Source/WebCore/platform/mock/mediasource/MockBox.h
@@ -74,14 +74,14 @@ public:
 
     int32_t trackID() const { return m_trackID; }
 
-    const AtomString& codec() const { return m_codec; }
+    const String& codec() const { return m_codec; }
 
     enum TrackKind { Audio, Video, Text };
     TrackKind kind() const { return m_kind; }
 
 private:
     uint8_t m_trackID;
-    AtomString m_codec;
+    String m_codec;
     TrackKind m_kind;
 };
 

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
@@ -108,14 +108,17 @@ public:
     static Ref<MockMediaDescription> create(const MockTrackBox& box) { return adoptRef(*new MockMediaDescription(box)); }
     virtual ~MockMediaDescription() = default;
 
-    AtomString codec() const override { return m_box.codec(); }
-    bool isVideo() const override { return m_box.kind() == MockTrackBox::Video; }
-    bool isAudio() const override { return m_box.kind() == MockTrackBox::Audio; }
-    bool isText() const override { return m_box.kind() == MockTrackBox::Text; }
+    bool isVideo() const final { return m_box.kind() == MockTrackBox::Video; }
+    bool isAudio() const final { return m_box.kind() == MockTrackBox::Audio; }
+    bool isText() const final { return m_box.kind() == MockTrackBox::Text; }
 
 private:
-    MockMediaDescription(const MockTrackBox& box) : m_box(box) { }
-    MockTrackBox m_box;
+    MockMediaDescription(const MockTrackBox& box)
+        : MediaDescription(box.codec().isolatedCopy())
+        , m_box(box)
+    {
+    }
+    const MockTrackBox m_box;
 };
 
 Ref<MockSourceBufferPrivate> MockSourceBufferPrivate::create(MockMediaSourcePrivate& parent)

--- a/Source/WebKit/GPUProcess/media/MediaDescriptionInfo.h
+++ b/Source/WebKit/GPUProcess/media/MediaDescriptionInfo.h
@@ -33,7 +33,7 @@
 namespace WebKit {
 
 struct MediaDescriptionInfo {
-    MediaDescriptionInfo(const AtomString& codec, bool isVideo, bool isAudio, bool isText)
+    MediaDescriptionInfo(const String& codec, bool isVideo, bool isAudio, bool isText)
         : m_codec(codec)
         , m_isVideo(isVideo)
         , m_isAudio(isAudio)
@@ -42,14 +42,14 @@ struct MediaDescriptionInfo {
     }
 
     MediaDescriptionInfo(const WebCore::MediaDescription& description)
-        : m_codec(description.codec())
+        : m_codec(description.codec().toString())
         , m_isVideo(description.isVideo())
         , m_isAudio(description.isAudio())
         , m_isText(description.isText())
     {
     }
 
-    AtomString m_codec;
+    String m_codec;
     bool m_isVideo { false };
     bool m_isAudio { false };
     bool m_isText { false };

--- a/Source/WebKit/GPUProcess/media/MediaDescriptionInfo.serialization.in
+++ b/Source/WebKit/GPUProcess/media/MediaDescriptionInfo.serialization.in
@@ -23,7 +23,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)
 
 struct WebKit::MediaDescriptionInfo {
-    AtomString m_codec;
+    String m_codec;
     bool m_isVideo;
     bool m_isAudio;
     bool m_isText;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaDescription.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaDescription.h
@@ -40,21 +40,19 @@ public:
 
     virtual ~RemoteMediaDescription() = default;
 
-    AtomString codec() const final { return m_codec; }
     bool isVideo() const final { return m_isVideo; }
     bool isAudio() const final { return m_isAudio; }
     bool isText() const final { return m_isText;}
 
 private:
     RemoteMediaDescription(const MediaDescriptionInfo& descriptionInfo)
-        : m_codec(descriptionInfo.m_codec)
+        : MediaDescription(descriptionInfo.m_codec.isolatedCopy())
         , m_isVideo(descriptionInfo.m_isVideo)
         , m_isAudio(descriptionInfo.m_isAudio)
         , m_isText(descriptionInfo.m_isText)
     {
     }
 
-    AtomString m_codec;
     bool m_isVideo { false };
     bool m_isAudio { false };
     bool m_isText { false };


### PR DESCRIPTION
#### 8904da90987b4e0a99d4ea716053ee65a613e15b
<pre>
Have MediaDescription stop using AtomString
<a href="https://bugs.webkit.org/show_bug.cgi?id=268728">https://bugs.webkit.org/show_bug.cgi?id=268728</a>
<a href="https://rdar.apple.com/122292724">rdar://122292724</a>

Reviewed by Youenn Fablet.

Sub-task of 265982.

To be used in WorkQueues, MediaDescription needs to stop using AtomString.
Instead we make this object use ThreadSafeRefCount, and return a StringView
which explicitly enforce that you can&apos;t extend the lifetime of the string
outside the lifetime of the MediaDescription container.

No change in observable behaviour.

* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment):
(WebCore::SourceBuffer::validateInitializationSegment):
* Source/WebCore/platform/MediaDescription.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
* Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp:
(WebCore::GStreamerMediaDescription::codec const):
(WebCore::GStreamerMediaDescription::extractCodecName const):
(WebCore::GStreamerMediaDescription::extractCodecName): Deleted.
* Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.h:
(WebCore::GStreamerMediaDescription::GStreamerMediaDescription):
* Source/WebCore/platform/mock/mediasource/MockBox.h:
* Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp:
* Source/WebKit/GPUProcess/media/MediaDescriptionInfo.h:
(WebKit::MediaDescriptionInfo::MediaDescriptionInfo):
* Source/WebKit/GPUProcess/media/MediaDescriptionInfo.serialization.in:
* Source/WebKit/GPUProcess/media/RemoteMediaDescription.h:
(WebKit::RemoteMediaDescription::RemoteMediaDescription):

Canonical link: <a href="https://commits.webkit.org/274178@main">https://commits.webkit.org/274178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa57b851f2273d98ac01b385253a28adbdcbeb91

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40620 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33861 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14319 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32150 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38647 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14342 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33331 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12506 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12437 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34062 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41896 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34561 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34512 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38322 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10708 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36514 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14593 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8558 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13457 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14043 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->