### PR TITLE
[threaded-animation-resolution] add support for blending `opacity` values

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -129,6 +129,7 @@ typedef struct _CARenderContext CARenderContext;
 @interface CAPresentationModifierGroup : NSObject
 + (instancetype)groupWithCapacity:(NSUInteger)capacity;
 - (void)flush;
+- (void)flushWithTransaction;
 @end
 
 @interface CAPresentationModifier : NSObject

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -279,6 +279,85 @@ AcceleratedEffect::AcceleratedEffect(const AcceleratedEffect& source, OptionSet<
     }
 }
 
+static void blend(AcceleratedEffectProperty property, AcceleratedEffectValues& output, const AcceleratedEffectValues& from, const AcceleratedEffectValues& to, const BlendingContext& blendingContext)
+{
+    switch (property) {
+    case AcceleratedEffectProperty::Opacity:
+        output.opacity = blend(from.opacity, to.opacity, blendingContext);
+        break;
+    case AcceleratedEffectProperty::Invalid:
+        ASSERT_NOT_REACHED();
+        break;
+    default:
+        break;
+    }
+}
+
+void AcceleratedEffect::apply(Seconds currentTime, AcceleratedEffectValues& values)
+{
+    auto localTime = [&]() -> Seconds {
+        ASSERT(m_holdTime || m_startTime);
+        if (m_holdTime)
+            return *m_holdTime;
+        return (currentTime - *m_startTime) * m_playbackRate;
+    }();
+
+    auto resolvedTiming = m_timing.resolve(localTime, m_playbackRate);
+    if (!resolvedTiming.transformedProgress)
+        return;
+
+    ASSERT(resolvedTiming.currentIteration);
+    auto progress = *resolvedTiming.transformedProgress;
+
+    // In the case of CSS Transitions we already know that there are only two keyframes, one where offset=0 and one where offset=1,
+    // and only a single CSS property so we can simply blend based on the style available on those keyframes with the provided iteration
+    // progress which already accounts for the transition's timing function.
+    if (m_animationType == WebAnimationType::CSSTransition) {
+        ASSERT(m_animatedProperties.hasExactlyOneBitSet());
+        blend(*m_animatedProperties.begin(), values, m_keyframes.first().values(), m_keyframes.last().values(), { progress, false, m_compositeOperation });
+        return;
+    }
+
+    Keyframe propertySpecificKeyframeWithZeroOffset { 0, values.clone() };
+    Keyframe propertySpecificKeyframeWithOneOffset { 1, values.clone() };
+
+    for (auto animatedProperty : m_animatedProperties) {
+        auto interval = interpolationKeyframes(animatedProperty, progress, propertySpecificKeyframeWithZeroOffset, propertySpecificKeyframeWithOneOffset);
+
+        auto* startKeyframe = interval.endpoints.first();
+        auto* endKeyframe = interval.endpoints.last();
+
+        ASSERT(is<AcceleratedEffect::Keyframe>(startKeyframe) && is<AcceleratedEffect::Keyframe>(endKeyframe));
+        auto startKeyframeValues = downcast<AcceleratedEffect::Keyframe>(startKeyframe)->values();
+        auto endKeyframeValues = downcast<AcceleratedEffect::Keyframe>(endKeyframe)->values();
+
+        KeyframeInterpolation::CompositionCallback composeProperty = [&](const KeyframeInterpolation::Keyframe& keyframe, CompositeOperation compositeOperation) {
+            ASSERT(is<AcceleratedEffect::Keyframe>(keyframe));
+            auto& acceleratedKeyframe = downcast<AcceleratedEffect::Keyframe>(keyframe);
+            if (acceleratedKeyframe.offset() == startKeyframe->offset())
+                blend(animatedProperty, startKeyframeValues, propertySpecificKeyframeWithZeroOffset.values(), acceleratedKeyframe.values(), { 1, false, compositeOperation });
+            else
+                blend(animatedProperty, endKeyframeValues, propertySpecificKeyframeWithZeroOffset.values(), acceleratedKeyframe.values(), { 1, false, compositeOperation });
+        };
+
+        KeyframeInterpolation::AccumulationCallback accumulateProperty = [&](const KeyframeInterpolation::Keyframe&) {
+            // FIXME: implement accumulation.
+        };
+
+        KeyframeInterpolation::InterpolationCallback interpolateProperty = [&](double intervalProgress, double, IterationCompositeOperation) {
+            // FIXME: handle currentIteration and iterationCompositeOperation.
+            blend(animatedProperty, values, startKeyframeValues, endKeyframeValues, { intervalProgress });
+        };
+
+        KeyframeInterpolation::RequiresBlendingForAccumulativeIterationCallback requiresBlendingForAccumulativeIterationCallback = [&]() {
+            // FIXME: implement accumulation.
+            return false;
+        };
+
+        interpolateKeyframes(animatedProperty, interval, progress, *resolvedTiming.currentIteration, m_timing.iterationDuration, composeProperty, accumulateProperty, interpolateProperty, requiresBlendingForAccumulativeIterationCallback);
+    }
+}
+
 bool AcceleratedEffect::animatesTransformRelatedProperty() const
 {
     return m_animatedProperties.containsAny({

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -79,6 +79,8 @@ public:
     WEBCORE_EXPORT Ref<AcceleratedEffect> clone() const;
     WEBCORE_EXPORT Ref<AcceleratedEffect> copyWithProperties(OptionSet<AcceleratedEffectProperty>&) const;
 
+    WEBCORE_EXPORT void apply(Seconds, AcceleratedEffectValues&);
+
     // Encoding and decoding support
     AnimationEffectTiming timing() const { return m_timing; }
     const Vector<Keyframe>& keyframes() const { return m_keyframes; }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h
@@ -27,8 +27,14 @@
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 
+#include <WebCore/AcceleratedEffect.h>
 #include <WebCore/AcceleratedEffectStack.h>
+#include <WebCore/AcceleratedEffectValues.h>
 #include <WebCore/PlatformLayer.h>
+#include <wtf/RetainPtr.h>
+
+OBJC_CLASS CAPresentationModifierGroup;
+OBJC_CLASS CAPresentationModifier;
 
 namespace WebKit {
 
@@ -38,7 +44,7 @@ public:
     static Ref<RemoteAcceleratedEffectStack> create(Seconds);
 
 #if PLATFORM(MAC)
-    void initEffectsFromMainThread(PlatformLayer*, MonotonicTime now);
+    void initEffectsFromScrollingThread(PlatformLayer*, MonotonicTime now);
     void applyEffectsFromScrollingThread(MonotonicTime now) const;
 #endif
 
@@ -49,7 +55,12 @@ public:
 private:
     explicit RemoteAcceleratedEffectStack(Seconds);
 
+    WebCore::AcceleratedEffectValues computeValues(MonotonicTime now) const;
+
     Seconds m_acceleratedTimelineTimeOrigin;
+
+    RetainPtr<CAPresentationModifierGroup> m_presentationModifierGroup;
+    RetainPtr<CAPresentationModifier> m_opacityPresentationModifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -271,7 +271,7 @@ void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::Acce
 #if PLATFORM(IOS_FAMILY)
     m_effectStack->applyEffectsFromMainThread(layer(), host.animationCurrentTime());
 #else
-    m_effectStack->initEffectsFromMainThread(layer(), host.animationCurrentTime());
+    m_effectStack->initEffectsFromScrollingThread(layer(), host.animationCurrentTime());
 #endif
 
     host.animationsWereAddedToNode(*this);


### PR DESCRIPTION
#### c31a0356b67ea73b401b95a0062ea2d393003de9
<pre>
[threaded-animation-resolution] add support for blending `opacity` values
<a href="https://bugs.webkit.org/show_bug.cgi?id=268738">https://bugs.webkit.org/show_bug.cgi?id=268738</a>
<a href="https://rdar.apple.com/122304627">rdar://122304627</a>

Reviewed by Simon Fraser.

In order to add support for blending `opacity` values we make `AcceleratedEffect`
adopt the `KeyframeInterpolation::interpolateKeyframes()` method and its various
callbacks to deal with `AcceleratedEffect::Keyframe` values. We wrap this into
the new `AcceleratedEffect::apply()` method which is called from `RemoteAcceleratedEffectStack`
in the `computeValues()` method.

We compute the blended values in three different places in `RemoteAcceleratedEffectStack`.

When we resolve effects on the main thread (macOS) we have an `initEffectsFromScrollingThread()`
method to initialize the `CAPresentationModifier` objects which will apply the blended
values, and then on subsequent display updates we call `applyEffectsFromScrollingThread()`.

When we resolve effects on the scrolling thread (iOS) there is no initialization step
required and the single `applyEffectsFromScrollingThread()` method suffices.

Future patches will add support for the other transform-related and filter-related
accelerated properties.

* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::blend):
(WebCore::AcceleratedEffect::apply):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm:
(WebKit::RemoteAcceleratedEffectStack::initEffectsFromScrollingThread):
(WebKit::RemoteAcceleratedEffectStack::applyEffectsFromScrollingThread const):
(WebKit::RemoteAcceleratedEffectStack::applyEffectsFromMainThread const):
(WebKit::RemoteAcceleratedEffectStack::computeValues const):
(WebKit::RemoteAcceleratedEffectStack::clear):

Canonical link: <a href="https://commits.webkit.org/274102@main">https://commits.webkit.org/274102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c01c3b45cb899e969af9c1a892fb623530f40cb4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40409 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33689 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39195 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32036 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12337 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12293 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41680 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34356 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38164 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10506 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36341 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14451 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13308 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4916 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13903 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->