### PR TITLE
[CSS Container Queries] Queries with unknown features should not select a container

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-selection-unknown-features-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-selection-unknown-features-expected.txt
@@ -3,7 +3,7 @@ Green
 Green
 Green
 
-FAIL width query with (foo: bar) assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
-FAIL width query with foo(bar) assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS width query with (foo: bar)
+PASS width query with foo(bar)
 PASS style query with (foo: bar)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/query-evaluation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/query-evaluation-expected.txt
@@ -28,10 +28,10 @@ PASS ((height) or (height))
 PASS ((height) or (width) or (width))
 PASS ((width) or (height) or (width))
 PASS ((width) or (width) or (height))
-FAIL ((unknown) or (width) or (width)) assert_equals: expected "false" but got "true"
-FAIL ((width) or (unknown) or (width)) assert_equals: expected "false" but got "true"
-FAIL ((width) or (width) or (unknown)) assert_equals: expected "false" but got "true"
-FAIL ((unknown) or (height) or (width)) assert_equals: expected "false" but got "true"
+PASS ((unknown) or (width) or (width))
+PASS ((width) or (unknown) or (width))
+PASS ((width) or (width) or (unknown))
+PASS ((unknown) or (height) or (width))
 PASS (not ((width) and (width)))
 PASS (not ((width) and (height)))
 PASS ((width) and (not ((height) or (width))))

--- a/Source/WebCore/css/ContainerQuery.h
+++ b/Source/WebCore/css/ContainerQuery.h
@@ -53,10 +53,13 @@ enum class Axis : uint8_t {
 };
 OptionSet<Axis> requiredAxesForFeature(const MQ::Feature&);
 
+enum class ContainsUnknownFeature : bool { No, Yes };
+
 struct ContainerQuery {
     AtomString name;
-    OptionSet<CQ::Axis> axisFilter;
     MQ::Condition condition;
+    OptionSet<CQ::Axis> requiredAxes;
+    ContainsUnknownFeature containsUnknownFeature;
 };
 
 void serialize(StringBuilder&, const ContainerQuery&);

--- a/Source/WebCore/css/ContainerQueryParser.h
+++ b/Source/WebCore/css/ContainerQueryParser.h
@@ -40,13 +40,10 @@ public:
     static Vector<const MQ::FeatureSchema*> featureSchemas();
 
     std::optional<CQ::ContainerQuery> consumeContainerQuery(CSSParserTokenRange&);
-    std::optional<MQ::Feature> consumeFeature(CSSParserTokenRange&);
 
 private:
     ContainerQueryParser(const MediaQueryParserContext& context)
         : GenericMediaQueryParser(context) { }
-
-    OptionSet<CQ::Axis> m_requiredAxes;
 };
 
 }

--- a/Source/WebCore/css/query/GenericMediaQueryTypes.h
+++ b/Source/WebCore/css/query/GenericMediaQueryTypes.h
@@ -110,7 +110,8 @@ void traverseFeatures(const QueryInParens& queryInParens, TraverseFunction&& fun
     }, [&](const MQ::Feature& feature) {
         function(feature);
     }, [&](const MQ::GeneralEnclosed&) {
-        return;
+        MQ::Feature dummy { };
+        function(dummy);
     });
 }
 

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -65,9 +65,13 @@ auto ContainerQueryEvaluator::featureEvaluationContextForQuery(const CQ::Contain
     // considered to just those with a matching query container name."
     // https://drafts.csswg.org/css-contain-3/#container-rule
 
+    // "If the <container-query> contains unknown or unsupported container features, no query container will be selected."
+    if (containerQuery.containsUnknownFeature == CQ::ContainsUnknownFeature::Yes)
+        return { };
+
     auto* cachedQueryContainers = m_selectorMatchingState ? &m_selectorMatchingState->queryContainers : nullptr;
 
-    auto* container = selectContainer(containerQuery.axisFilter, containerQuery.name, m_element.get(), m_selectionMode, m_scopeOrdinal, cachedQueryContainers);
+    auto* container = selectContainer(containerQuery.requiredAxes, containerQuery.name, m_element.get(), m_selectionMode, m_scopeOrdinal, cachedQueryContainers);
     if (!container)
         return { };
 


### PR DESCRIPTION
#### 39f36da26b7671d55bc256f852cc652255d1328b
<pre>
[CSS Container Queries] Queries with unknown features should not select a container
<a href="https://bugs.webkit.org/show_bug.cgi?id=268741">https://bugs.webkit.org/show_bug.cgi?id=268741</a>
<a href="https://rdar.apple.com/122307175">rdar://122307175</a>

Reviewed by Alan Baradlay.

<a href="https://github.com/w3c/csswg-drafts/issues/7551">https://github.com/w3c/csswg-drafts/issues/7551</a> changed the behavior for unknown features:

&quot;If the &lt;container-query&gt; contains unknown or unsupported container features, no query container will be selected.&quot;

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-selection-unknown-features-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/query-evaluation-expected.txt:
* Source/WebCore/css/ContainerQuery.h:
* Source/WebCore/css/ContainerQueryParser.cpp:
(WebCore::ContainerQueryParser::consumeContainerQuery):

Traverse the features and see if we have anything unknown along with collecting the axis requirements.

(WebCore::ContainerQueryParser::consumeFeature): Deleted.

Traverse after consuming instead.

* Source/WebCore/css/ContainerQueryParser.h:
(WebCore::ContainerQueryParser::ContainerQueryParser):
* Source/WebCore/css/query/GenericMediaQueryTypes.h:
(WebCore::MQ::traverseFeatures):

Also traverse GeneralEnclosed which is what unknown features turn into.

* Source/WebCore/style/ContainerQueryEvaluator.cpp:
(WebCore::Style::ContainerQueryEvaluator::featureEvaluationContextForQuery const):

Bail out for unknown features.

Canonical link: <a href="https://commits.webkit.org/274098@main">https://commits.webkit.org/274098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0468bd7651444bfb49704d1da66d08203dfcdeea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40408 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33688 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39194 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14062 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32038 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33179 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12339 "Found 1 new API test failure: /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/languages (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12295 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33860 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41679 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34358 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38161 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10508 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36338 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14450 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8505 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->