### PR TITLE
[GTK][WPE] Initialize display ID as early as possible

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -2432,6 +2432,8 @@ static void webkitWebViewBaseConstructed(GObject* object)
     };
     g_signal_connect_object(settings, "notify::gtk-theme-name", G_CALLBACK(callback), viewWidget, G_CONNECT_SWAPPED);
     g_signal_connect_object(settings, "notify::gtk-application-prefer-dark-theme", G_CALLBACK(callback), viewWidget, G_CONNECT_SWAPPED);
+
+    priv->displayID = ScreenManager::singleton().primaryDisplayID();
 }
 
 static void webkit_web_view_base_class_init(WebKitWebViewBaseClass* webkitWebViewBaseClass)

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.cpp
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.cpp
@@ -40,8 +40,8 @@ namespace WebKit {
 
 std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitor::create(PlatformDisplayID displayID)
 {
-    const char* forceTimer = getenv("WEBKIT_FORCE_VBLANK_TIMER");
-    if (forceTimer && strcmp(forceTimer, "0"))
+    static const char* forceTimer = getenv("WEBKIT_FORCE_VBLANK_TIMER");
+    if (!displayID || (forceTimer && strcmp(forceTimer, "0")))
         return DisplayVBlankMonitorTimer::create();
 
 #if USE(LIBDRM)

--- a/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.cpp
+++ b/Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.cpp
@@ -42,7 +42,6 @@
 
 #if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
 #include "ScreenManager.h"
-#include <WebCore/PlatformScreen.h>
 #endif
 
 #if PLATFORM(GTK)
@@ -198,7 +197,7 @@ std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitorDRM::create(PlatformDi
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
     PlatformMonitor* monitor = nullptr;
     if (usingWPEPlatformAPI) {
-        monitor = ScreenManager::singleton().monitor(displayID ? displayID : WebCore::primaryScreenDisplayID());
+        monitor = ScreenManager::singleton().monitor(displayID);
         if (!monitor) {
             RELEASE_LOG_FAULT(DisplayLink, "Could not create a vblank monitor for display %u: no monitor found", displayID);
             return nullptr;
@@ -207,7 +206,7 @@ std::unique_ptr<DisplayVBlankMonitor> DisplayVBlankMonitorDRM::create(PlatformDi
 #endif
 
 #if PLATFORM(GTK)
-    auto* monitor = ScreenManager::singleton().monitor(displayID ? displayID : WebCore::primaryScreenDisplayID());
+    auto* monitor = ScreenManager::singleton().monitor(displayID);
     if (!monitor) {
         RELEASE_LOG_FAULT(DisplayLink, "Could not create a vblank monitor for display %u: no monitor found", displayID);
         return nullptr;

--- a/Source/WebKit/UIProcess/glib/ScreenManager.h
+++ b/Source/WebKit/UIProcess/glib/ScreenManager.h
@@ -53,6 +53,7 @@ public:
 
     PlatformDisplayID displayID(PlatformMonitor*) const;
     PlatformMonitor* monitor(PlatformDisplayID) const;
+    PlatformDisplayID primaryDisplayID() const { return m_primaryDisplayID; }
 
     WebCore::ScreenProperties collectScreenProperties() const;
 
@@ -63,10 +64,12 @@ private:
 
     void addMonitor(PlatformMonitor*);
     void removeMonitor(PlatformMonitor*);
+    void updatePrimaryDisplayID();
     void propertiesDidChange() const;
 
     Vector<GRefPtr<PlatformMonitor>, 1> m_monitors;
     HashMap<PlatformMonitor*, PlatformDisplayID> m_monitorToDisplayIDMap;
+    PlatformDisplayID m_primaryDisplayID { 0 };
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### cad5d7e5ed760db4515ca25da8080fe5e85b7e90
<pre>
[GTK][WPE] Initialize display ID as early as possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=268744">https://bugs.webkit.org/show_bug.cgi?id=268744</a>

Reviewed by Adrian Perez de Castro.

In GTK we currently get the display ID when the toplevel window is
realized and gets a monitor assigned. This is happening right after the
web page is initialized, which means we always create the web page with
0 display ID and right after that a window screen change happens.
Because of this we end up creating two display link monitors. We can
avoid this by initializing the web view display id as soon as possible
using the primary display ID, that in most of the cases will be then one
used when the monitor is assigned to the toplevel.

This patch also ensures we never create a DRM vblank monitor when
display ID is 0, since that&apos;s never a valid monitor. We just
fallback to the timer vblank monitor in that case.

* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseConstructed):
* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::m_backend):
* Source/WebKit/UIProcess/glib/DisplayVBlankMonitor.cpp:
(WebKit::DisplayVBlankMonitor::create):
* Source/WebKit/UIProcess/glib/DisplayVBlankMonitorDRM.cpp:
(WebKit::DisplayVBlankMonitorDRM::create):
* Source/WebKit/UIProcess/glib/ScreenManager.h:
(WebKit::ScreenManager::primaryDisplayID const):
* Source/WebKit/UIProcess/gtk/ScreenManagerGtk.cpp:
(WebKit::ScreenManager::ScreenManager):
(WebKit::ScreenManager::updatePrimaryDisplayID):
(WebKit::ScreenManager::collectScreenProperties const):
* Source/WebKit/UIProcess/wpe/ScreenManagerWPE.cpp:
(WebKit::ScreenManager::ScreenManager):
(WebKit::ScreenManager::updatePrimaryDisplayID):
(WebKit::ScreenManager::collectScreenProperties const):

Canonical link: <a href="https://commits.webkit.org/274136@main">https://commits.webkit.org/274136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04ff6500e5ee43805166f40f876eeda406530970

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40412 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33692 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32037 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33183 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12338 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12349 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41683 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34425 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34341 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38163 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12874 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36340 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14453 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13310 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4933 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->