### PR TITLE
[GStreamer] Potential dangling pipeline pointer usage in connectSimpleBusMessageCallback

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -44,8 +44,10 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/PrintStream.h>
 #include <wtf/Scope.h>
+#include <wtf/glib/GThreadSafeWeakPtr.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/RunLoopSourcePriority.h>
+#include <wtf/glib/WTFGType.h>
 #include <wtf/text/StringHash.h>
 
 #if USE(GSTREAMER_MPEGTS)
@@ -529,41 +531,45 @@ static GQuark customMessageHandlerQuark()
 
 void disconnectSimpleBusMessageCallback(GstElement* pipeline)
 {
-    if (!g_object_get_qdata(G_OBJECT(pipeline), customMessageHandlerQuark()))
+    auto handler = GPOINTER_TO_UINT(g_object_get_qdata(G_OBJECT(pipeline), customMessageHandlerQuark()));
+    if (!handler)
         return;
 
     auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(pipeline)));
-    g_signal_handlers_disconnect_by_data(bus.get(), pipeline);
+    g_signal_handler_disconnect(bus.get(), handler);
     gst_bus_remove_signal_watch(bus.get());
+    g_object_set_qdata(G_OBJECT(pipeline), customMessageHandlerQuark(), nullptr);
 }
 
-struct CustomMessageHandlerHolder {
-    explicit CustomMessageHandlerHolder(Function<void(GstMessage*)>&& handler)
-    {
-        this->handler = WTFMove(handler);
-    }
+struct MessageBusData {
+    GThreadSafeWeakPtr<GstElement> pipeline;
     Function<void(GstMessage*)> handler;
 };
+WEBKIT_DEFINE_ASYNC_DATA_STRUCT(MessageBusData)
 
 void connectSimpleBusMessageCallback(GstElement* pipeline, Function<void(GstMessage*)>&& customHandler)
 {
     auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(pipeline)));
     gst_bus_add_signal_watch_full(bus.get(), RunLoopSourcePriority::RunLoopDispatcher);
 
-    g_object_set_qdata_full(G_OBJECT(pipeline), customMessageHandlerQuark(), new CustomMessageHandlerHolder(WTFMove(customHandler)), [](gpointer data) {
-        delete reinterpret_cast<CustomMessageHandlerHolder*>(data);
-    });
+    auto data = createMessageBusData();
+    data->pipeline.reset(pipeline);
+    data->handler = WTFMove(customHandler);
+    auto handler = g_signal_connect_data(bus.get(), "message", G_CALLBACK(+[](GstBus*, GstMessage* message, gpointer userData) {
+        auto data = reinterpret_cast<MessageBusData*>(userData);
+        auto pipeline = data->pipeline.get();
+        if (!pipeline)
+            return;
 
-    g_signal_connect(bus.get(), "message", G_CALLBACK(+[](GstBus*, GstMessage* message, GstElement* pipeline) {
         switch (GST_MESSAGE_TYPE(message)) {
         case GST_MESSAGE_ERROR: {
-            GST_ERROR_OBJECT(pipeline, "Got message: %" GST_PTR_FORMAT, message);
-            auto dotFileName = makeString(GST_OBJECT_NAME(pipeline), "_error");
-            GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(pipeline), GST_DEBUG_GRAPH_SHOW_ALL, dotFileName.utf8().data());
+            GST_ERROR_OBJECT(pipeline.get(), "Got message: %" GST_PTR_FORMAT, message);
+            auto dotFileName = makeString(GST_OBJECT_NAME(pipeline.get()), "_error"_s);
+            GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(pipeline.get()), GST_DEBUG_GRAPH_SHOW_ALL, dotFileName.utf8().data());
             break;
         }
         case GST_MESSAGE_STATE_CHANGED: {
-            if (GST_MESSAGE_SRC(message) != GST_OBJECT_CAST(pipeline))
+            if (GST_MESSAGE_SRC(message) != GST_OBJECT_CAST(pipeline.get()))
                 break;
 
             GstState oldState;
@@ -571,26 +577,25 @@ void connectSimpleBusMessageCallback(GstElement* pipeline, Function<void(GstMess
             GstState pending;
             gst_message_parse_state_changed(message, &oldState, &newState, &pending);
 
-            GST_INFO_OBJECT(pipeline, "State changed (old: %s, new: %s, pending: %s)", gst_element_state_get_name(oldState),
+            GST_INFO_OBJECT(pipeline.get(), "State changed (old: %s, new: %s, pending: %s)", gst_element_state_get_name(oldState),
                 gst_element_state_get_name(newState), gst_element_state_get_name(pending));
 
-            auto dotFileName = makeString(GST_OBJECT_NAME(pipeline), '_', gst_element_state_get_name(oldState), '_', gst_element_state_get_name(newState));
-            GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(pipeline), GST_DEBUG_GRAPH_SHOW_ALL, dotFileName.utf8().data());
+            auto dotFileName = makeString(GST_OBJECT_NAME(pipeline.get()), '_', gst_element_state_get_name(oldState), '_', gst_element_state_get_name(newState));
+            GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(pipeline.get()), GST_DEBUG_GRAPH_SHOW_ALL, dotFileName.utf8().data());
             break;
         }
         case GST_MESSAGE_LATENCY:
-            gst_bin_recalculate_latency(GST_BIN_CAST(pipeline));
+            gst_bin_recalculate_latency(GST_BIN_CAST(pipeline.get()));
             break;
         default:
             break;
         }
 
-        auto* holder = reinterpret_cast<CustomMessageHandlerHolder*>(g_object_get_qdata(G_OBJECT(pipeline), customMessageHandlerQuark()));
-        if (!holder)
-            return;
-
-        holder->handler(message);
-    }), pipeline);
+        data->handler(message);
+    }), data, reinterpret_cast<GClosureNotify>(+[](gpointer data, GClosure*) {
+        destroyMessageBusData(reinterpret_cast<MessageBusData*>(data));
+    }), static_cast<GConnectFlags>(0));
+    g_object_set_qdata(G_OBJECT(pipeline), customMessageHandlerQuark(), GUINT_TO_POINTER(handler));
 }
 
 template<>


### PR DESCRIPTION
#### 48c8f103137941a9b9829778fe480226392dd571
<pre>
[GStreamer] Potential dangling pipeline pointer usage in connectSimpleBusMessageCallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=268747">https://bugs.webkit.org/show_bug.cgi?id=268747</a>

Reviewed by Xabier Rodriguez-Calvar.

There was no guarantee the raw pipeline pointer passed as user-data to the signal would remain
valid. So we now pass a custom structure pointer that has the same lifetime as the signal handler.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::disconnectSimpleBusMessageCallback):
(WebCore::connectSimpleBusMessageCallback):
(WebCore::CustomMessageHandlerHolder::CustomMessageHandlerHolder): Deleted.

Canonical link: <a href="https://commits.webkit.org/274139@main">https://commits.webkit.org/274139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36397c3a20a51ad1b1343b161d9b4a3fb77889a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40414 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33694 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32039 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38441 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33186 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12340 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12301 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41685 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34365 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38166 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36343 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14455 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8529 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13312 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->