### PR TITLE
REGRESSION(267824@main): Changing HTMLCanvasElement width, height causes intermediate buffer allocations

### DIFF
--- a/LayoutTests/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,3 +1,2 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 

--- a/LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,3 +1,2 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -272,10 +272,10 @@ void CanvasRenderingContext2DBase::reset()
     m_cachedContents.emplace<CachedContentsTransparent>();
 
     clearAccumulatedDirtyRect();
-    resetTransform();
-
-    canvasBase().resetGraphicsContextState();
-    clearCanvas();
+    if (auto* c = canvasBase().existingDrawingContext()) {
+        canvasBase().resetGraphicsContextState();
+        c->clearRect(FloatRect { { }, canvasBase().size() });
+    }
 }
 
 CanvasRenderingContext2DBase::State::State()


### PR DESCRIPTION
#### 26aaa25dcbdc3f17bdf4ebd4067a160adb9e1cad
<pre>
REGRESSION(267824@main): Changing HTMLCanvasElement width, height causes intermediate buffer allocations
<a href="https://bugs.webkit.org/show_bug.cgi?id=268745">https://bugs.webkit.org/show_bug.cgi?id=268745</a>
<a href="https://rdar.apple.com/122309325">rdar://122309325</a>

Reviewed by Simon Fraser.

Resizing is intended to leave the buffer unallocated, so that
sequential width, height assignments will not allocate multiple times.

This intention was nullified by CanvasRenderingContext2DBase::reset().
Calling resetTransform redundantly would recreate the buffer
immediately from width, height attribute setters.

The transform reset is redundant, the context transform is reset when
the context state saver is restored and re-saved.

Clearing the canvas doesn&apos;t need to use public
CanvasRenderingContext2DBase::clearCanvas() that will mutate the context
state. The state is in known state with initial transform, and thus it
doesn&apos;t need transform mutation.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::reset):

Canonical link: <a href="https://commits.webkit.org/274135@main">https://commits.webkit.org/274135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4bdacb7c34c893896e83cc1fd8e3715caf06c78

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40470 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33746 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32067 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33221 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12377 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/37858 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12334 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41742 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/31619 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34407 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38199 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/37622 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12920 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36398 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/37972 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/33280 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/44550 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8527 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13351 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13946 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->