### PR TITLE
Port Credential to the new IPC serialization format

### DIFF
--- a/Source/WebCore/platform/network/Credential.h
+++ b/Source/WebCore/platform/network/Credential.h
@@ -50,6 +50,11 @@ public:
     {
     }
 
+    Credential(NonPlatformData&& data)
+        : CredentialBase(data.user, data.password, data.persistence)
+    {
+    }
+
     Credential(const Credential& original, CredentialPersistence persistence)
         : CredentialBase(original, persistence)
     {

--- a/Source/WebCore/platform/network/CredentialBase.cpp
+++ b/Source/WebCore/platform/network/CredentialBase.cpp
@@ -101,4 +101,13 @@ String CredentialBase::serializationForBasicAuthorizationHeader() const
     return makeString("Basic ", base64Encoded(credentialStringData));
 }
 
+auto CredentialBase::nonPlatformData() const -> NonPlatformData
+{
+    return {
+        user(),
+        password(),
+        persistence()
+    };
 }
+
+} // namespace WebCore

--- a/Source/WebCore/platform/network/CredentialBase.h
+++ b/Source/WebCore/platform/network/CredentialBase.h
@@ -52,6 +52,14 @@ public:
 
     WEBCORE_EXPORT String serializationForBasicAuthorizationHeader() const;
 
+    struct NonPlatformData {
+        String user;
+        String password;
+        CredentialPersistence persistence;
+    };
+
+    WEBCORE_EXPORT NonPlatformData nonPlatformData() const;
+
 protected:
     WEBCORE_EXPORT CredentialBase();
     WEBCORE_EXPORT CredentialBase(const String& user, const String& password, CredentialPersistence);

--- a/Source/WebCore/platform/network/cocoa/CredentialCocoa.h
+++ b/Source/WebCore/platform/network/cocoa/CredentialCocoa.h
@@ -57,6 +57,10 @@ public:
 
     static bool platformCompare(const Credential&, const Credential&);
 
+    using IPCData = std::variant<NonPlatformData, RetainPtr<NSURLCredential>>;
+    WEBCORE_EXPORT static Credential fromIPCData(IPCData&&);
+    WEBCORE_EXPORT IPCData ipcData() const;
+
 private:
     WEBCORE_EXPORT static bool encodingRequiresPlatformData(NSURLCredential *);
 

--- a/Source/WebCore/platform/network/cocoa/CredentialCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CredentialCocoa.mm
@@ -117,4 +117,20 @@ bool Credential::encodingRequiresPlatformData(NSURLCredential *credential)
     return !credential.user;
 }
 
+Credential Credential::fromIPCData(IPCData&& ipcData)
+{
+    return WTF::switchOn(WTFMove(ipcData), [](NonPlatformData&& data) {
+        return Credential { data.user, data.password, data.persistence };
+    }, [](RetainPtr<NSURLCredential>&& credential) {
+        return Credential { credential.get() };
+    });
+}
+
+auto Credential::ipcData() const -> IPCData
+{
+    if (encodingRequiresPlatformData())
+        return m_nsCredential;
+    return nonPlatformData();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/network/soup/CredentialSoup.cpp
+++ b/Source/WebCore/platform/network/soup/CredentialSoup.cpp
@@ -50,4 +50,24 @@ bool Credential::platformCompare(const Credential& a, const Credential& b)
     return a.certificate() == b.certificate();
 }
 
+Credential Credential::fromIPCData(IPCData&& ipcData)
+{
+    return WTF::switchOn(WTFMove(ipcData), [](NonPlatformData&& data) {
+        return Credential { data.user, data.password, data.persistence };
+    }, [](PlatformData&& data) {
+        return Credential { data.certificate.get(), data.persistence };
+    });
+}
+
+auto Credential::ipcData() const -> IPCData
+{
+    if (encodingRequiresPlatformData()) {
+        return PlatformData {
+            m_certificate,
+            persistence()
+        };
+    }
+    return nonPlatformData();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/network/soup/CredentialSoup.h
+++ b/Source/WebCore/platform/network/soup/CredentialSoup.h
@@ -56,6 +56,15 @@ public:
 
     GTlsCertificate* certificate() const { return m_certificate.get(); }
 
+    struct PlatformData {
+        GRefPtr<GTlsCertificate> certificate;
+        CredentialPersistence persistence;
+    };
+
+    using IPCData = std::variant<NonPlatformData, PlatformData>;
+    WEBCORE_EXPORT static Credential fromIPCData(IPCData&&);
+    WEBCORE_EXPORT IPCData ipcData() const;
+
 private:
     GRefPtr<GTlsCertificate> m_certificate;
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -196,44 +196,6 @@ namespace IPC {
 using namespace WebCore;
 using namespace WebKit;
 
-void ArgumentCoder<Credential>::encode(Encoder& encoder, const Credential& credential)
-{
-    if (credential.encodingRequiresPlatformData()) {
-        encoder << true;
-        encodePlatformData(encoder, credential);
-        return;
-    }
-
-    encoder << false;
-    encoder << credential.user() << credential.password();
-    encoder << credential.persistence();
-}
-
-bool ArgumentCoder<Credential>::decode(Decoder& decoder, Credential& credential)
-{
-    bool hasPlatformData;
-    if (!decoder.decode(hasPlatformData))
-        return false;
-
-    if (hasPlatformData)
-        return decodePlatformData(decoder, credential);
-
-    String user;
-    if (!decoder.decode(user))
-        return false;
-
-    String password;
-    if (!decoder.decode(password))
-        return false;
-
-    CredentialPersistence persistence;
-    if (!decoder.decode(persistence))
-        return false;
-    
-    credential = Credential(user, password, persistence);
-    return true;
-}
-
 void ArgumentCoder<WebCore::Font>::encode(Encoder& encoder, const WebCore::Font& font)
 {
     encoder << font.attributes();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -132,13 +132,6 @@ struct Record;
 
 namespace IPC {
 
-template<> struct ArgumentCoder<WebCore::Credential> {
-    static void encode(Encoder&, const WebCore::Credential&);
-    static WARN_UNUSED_RETURN bool decode(Decoder&, WebCore::Credential&);
-    static void encodePlatformData(Encoder&, const WebCore::Credential&);
-    static WARN_UNUSED_RETURN bool decodePlatformData(Decoder&, WebCore::Credential&);
-};
-
 template<> struct ArgumentCoder<WebCore::Font> {
     static void encode(Encoder&, const WebCore::Font&);
     static std::optional<Ref<WebCore::Font>> decode(Decoder&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6016,6 +6016,36 @@ class WebCore::ProtectionSpace {
 #endif
 };
 
+header: <WebCore/Credential.h>
+[Nested] struct WebCore::Credential::NonPlatformData {
+    String user;
+    String password;
+    WebCore::CredentialPersistence persistence;
+}
+
+#if PLATFORM(COCOA)
+[CreateUsing=fromIPCData] class WebCore::Credential {
+    std::variant<WebCore::Credential::NonPlatformData, RetainPtr<NSURLCredential>> ipcData();
+};
+#endif
+
+#if USE(SOUP)
+[Nested] struct WebCore::Credential::PlatformData {
+    GRefPtr<GTlsCertificate> certificate;
+    WebCore::CredentialPersistence persistence;
+};
+
+[CreateUsing=fromIPCData] class WebCore::Credential {
+    std::variant<WebCore::Credential::NonPlatformData, WebCore::Credential::PlatformData> ipcData();
+};
+#endif
+
+#if USE(CURL)
+class WebCore::Credential {
+    WebCore::Credential::NonPlatformData nonPlatformData();
+};
+#endif // USE(CURL)
+
 #if ENABLE(GPU_PROCESS)
 header: <WebCore/BarcodeDetectorOptionsInterface.h>
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::ShapeDetection::BarcodeDetectorOptions {

--- a/Source/WebKit/Shared/curl/WebCoreArgumentCodersCurl.cpp
+++ b/Source/WebKit/Shared/curl/WebCoreArgumentCodersCurl.cpp
@@ -40,17 +40,6 @@ namespace IPC {
 
 using namespace WebCore;
 
-void ArgumentCoder<Credential>::encodePlatformData(Encoder&, const Credential&)
-{
-    ASSERT_NOT_REACHED();
-}
-
-bool ArgumentCoder<Credential>::decodePlatformData(Decoder&, Credential&)
-{
-    ASSERT_NOT_REACHED();
-    return false;
-}
-
 void ArgumentCoder<CurlProxySettings>::encode(Encoder& encoder, const CurlProxySettings& settings)
 {
     encoder << settings.mode();

--- a/Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm
+++ b/Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm
@@ -48,21 +48,6 @@
 
 namespace IPC {
 
-void ArgumentCoder<WebCore::Credential>::encodePlatformData(Encoder& encoder, const WebCore::Credential& credential)
-{
-    NSURLCredential *nsCredential = credential.nsCredential();
-    encoder << nsCredential;
-}
-
-bool ArgumentCoder<WebCore::Credential>::decodePlatformData(Decoder& decoder, WebCore::Credential& credential)
-{
-    std::optional<RetainPtr<NSURLCredential>> nsCredential = decoder.decode<RetainPtr<NSURLCredential>>();
-    if (!nsCredential)
-        return false;
-    credential = WebCore::Credential { nsCredential->get() };
-    return true;
-}
-
 #if ENABLE(VIDEO)
 void ArgumentCoder<WebCore::SerializedPlatformDataCueValue>::encodePlatformData(Encoder& encoder, const WebCore::SerializedPlatformDataCueValue& value)
 {

--- a/Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp
+++ b/Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp
@@ -99,28 +99,6 @@ bool ArgumentCoder<SoupNetworkProxySettings>::decode(Decoder& decoder, SoupNetwo
     return !settings.isEmpty();
 }
 
-void ArgumentCoder<Credential>::encodePlatformData(Encoder& encoder, const Credential& credential)
-{
-    GRefPtr<GTlsCertificate> certificate = credential.certificate();
-    encoder << certificate;
-    encoder << credential.persistence();
-}
-
-bool ArgumentCoder<Credential>::decodePlatformData(Decoder& decoder, Credential& credential)
-{
-    std::optional<GRefPtr<GTlsCertificate>> certificate;
-    decoder >> certificate;
-    if (!certificate)
-        return false;
-
-    CredentialPersistence persistence;
-    if (!decoder.decode(persistence))
-        return false;
-
-    credential = Credential(certificate->get(), persistence);
-    return true;
-}
-
 #if ENABLE(VIDEO)
 void ArgumentCoder<SerializedPlatformDataCueValue>::encodePlatformData(Encoder& encoder, const SerializedPlatformDataCueValue& value)
 {


### PR DESCRIPTION
#### 744114bcfd1094aae2fe74032fdb97ade15c2d03
<pre>
Port Credential to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=268762">https://bugs.webkit.org/show_bug.cgi?id=268762</a>

Reviewed by Alex Christensen.

* Source/WebCore/platform/network/Credential.h:
(WebCore::Credential::Credential):
* Source/WebCore/platform/network/CredentialBase.cpp:
(WebCore::CredentialBase::nonPlatformData const):
* Source/WebCore/platform/network/CredentialBase.h:
* Source/WebCore/platform/network/cocoa/CredentialCocoa.h:
* Source/WebCore/platform/network/cocoa/CredentialCocoa.mm:
(WebCore::Credential::fromIPCData):
(WebCore::Credential::ipcData const):
* Source/WebCore/platform/network/soup/CredentialSoup.cpp:
(WebCore::Credential::fromIPCData):
(WebCore::Credential::ipcData const):
* Source/WebCore/platform/network/soup/CredentialSoup.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;Credential&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;Credential&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/curl/WebCoreArgumentCodersCurl.cpp:
(IPC::ArgumentCoder&lt;Credential&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;Credential&gt;::decodePlatformData): Deleted.
* Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm:
(IPC::ArgumentCoder&lt;WebCore::Credential&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::Credential&gt;::decodePlatformData): Deleted.
* Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp:
(IPC::ArgumentCoder&lt;Credential&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;Credential&gt;::decodePlatformData): Deleted.

Canonical link: <a href="https://commits.webkit.org/274119@main">https://commits.webkit.org/274119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e383be9eaca8755ffc914ebc5efcdc47f0962b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40471 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33747 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39258 "Failed to checkout and rebase branch from PR 23873") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32073 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14182 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12378 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12337 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33959 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41743 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34410 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38201 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10560 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36381 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14495 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13352 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4924 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->