### PR TITLE
Update `svg/animations` tests to use local `SVGTestCase` and leverage `js-test.js`

### DIFF
--- a/LayoutTests/svg/animations/animate-color-rgba-calcMode-discrete-expected.txt
+++ b/LayoutTests/svg/animations/animate-color-rgba-calcMode-discrete-expected.txt
@@ -5,9 +5,6 @@ Test calcMode discrete with from-to animation on colors with alpha channel. You 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS successfullyParsed is true
-
-TEST COMPLETE
 PASS colors[0] is 0
 PASS colors[1] is 255
 PASS colors[2] is 255

--- a/LayoutTests/svg/animations/animate-color-rgba-calcMode-discrete.html
+++ b/LayoutTests/svg/animations/animate-color-rgba-calcMode-discrete.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <script src="../../resources/js-test.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-elem-03-t-drt.html
+++ b/LayoutTests/svg/animations/animate-elem-03-t-drt.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-elem-04-t-drt.html
+++ b/LayoutTests/svg/animations/animate-elem-04-t-drt.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-elem-05-t-drt.html
+++ b/LayoutTests/svg/animations/animate-elem-05-t-drt.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-elem-06-t-drt.html
+++ b/LayoutTests/svg/animations/animate-elem-06-t-drt.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-elem-07-t-drt.html
+++ b/LayoutTests/svg/animations/animate-elem-07-t-drt.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-elem-08-t-drt.html
+++ b/LayoutTests/svg/animations/animate-elem-08-t-drt.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-elem-09-t-drt.html
+++ b/LayoutTests/svg/animations/animate-elem-09-t-drt.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-elem-10-t-drt.html
+++ b/LayoutTests/svg/animations/animate-elem-10-t-drt.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-elem-11-t-drt.html
+++ b/LayoutTests/svg/animations/animate-elem-11-t-drt.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-elem-12-t-drt.html
+++ b/LayoutTests/svg/animations/animate-elem-12-t-drt.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-elem-13-t-drt.html
+++ b/LayoutTests/svg/animations/animate-elem-13-t-drt.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-end-attribute.html
+++ b/LayoutTests/svg/animations/animate-end-attribute.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-endElement-beginElement.html
+++ b/LayoutTests/svg/animations/animate-endElement-beginElement.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-marker-orient-from-angle-to-autostartreverse.html
+++ b/LayoutTests/svg/animations/animate-marker-orient-from-angle-to-autostartreverse.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-mpath-insert.html
+++ b/LayoutTests/svg/animations/animate-mpath-insert.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-path-animation-Cc-Ss.html
+++ b/LayoutTests/svg/animations/animate-path-animation-Cc-Ss.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-path-animation-Ll-Vv-Hh.html
+++ b/LayoutTests/svg/animations/animate-path-animation-Ll-Vv-Hh.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-path-animation-Qq-Tt.html
+++ b/LayoutTests/svg/animations/animate-path-animation-Qq-Tt.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-path-animation-cC-sS-inverse.html
+++ b/LayoutTests/svg/animations/animate-path-animation-cC-sS-inverse.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-path-animation-lL-vV-hH-inverse.html
+++ b/LayoutTests/svg/animations/animate-path-animation-lL-vV-hH-inverse.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-path-animation-qQ-tT-inverse.html
+++ b/LayoutTests/svg/animations/animate-path-animation-qQ-tT-inverse.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-path-nested-transforms.html
+++ b/LayoutTests/svg/animations/animate-path-nested-transforms.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/animate-path-to-animation.html
+++ b/LayoutTests/svg/animations/animate-path-to-animation.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/change-baseVal-while-animating-fill-freeze-2.html
+++ b/LayoutTests/svg/animations/change-baseVal-while-animating-fill-freeze-2.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/change-baseVal-while-animating-fill-remove-2.html
+++ b/LayoutTests/svg/animations/change-baseVal-while-animating-fill-remove-2.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/change-css-property-while-animating-fill-freeze-expected.txt
+++ b/LayoutTests/svg/animations/change-css-property-while-animating-fill-freeze-expected.txt
@@ -7,9 +7,6 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS parseFloat(getComputedStyle(rect).opacity) is 0
-PASS successfullyParsed is true
-
-TEST COMPLETE
 PASS parseFloat(getComputedStyle(rect).opacity) is 0.25
 PASS parseFloat(getComputedStyle(rect).opacity) is 0.25
 PASS parseFloat(getComputedStyle(rect).opacity) is 0.5

--- a/LayoutTests/svg/animations/change-css-property-while-animating-fill-freeze.html
+++ b/LayoutTests/svg/animations/change-css-property-while-animating-fill-freeze.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <script src="../../resources/js-test.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/change-css-property-while-animating-fill-remove-expected.txt
+++ b/LayoutTests/svg/animations/change-css-property-while-animating-fill-remove-expected.txt
@@ -7,9 +7,6 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS parseFloat(getComputedStyle(rect).opacity) is 0
-PASS successfullyParsed is true
-
-TEST COMPLETE
 PASS parseFloat(getComputedStyle(rect).opacity) is 0.25
 PASS parseFloat(getComputedStyle(rect).opacity) is 0.25
 PASS parseFloat(getComputedStyle(rect).opacity) is 0.5

--- a/LayoutTests/svg/animations/change-css-property-while-animating-fill-remove.html
+++ b/LayoutTests/svg/animations/change-css-property-while-animating-fill-remove.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <script src="../../resources/js-test.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/deferred-insertion-expected.txt
+++ b/LayoutTests/svg/animations/deferred-insertion-expected.txt
@@ -5,6 +5,9 @@ Test for animation on elements inserted programmatically. Should result in a 200
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+PASS successfullyParsed is true
+
+TEST COMPLETE
 PASS rect.width.animVal.value is 200
 PASS rect.width.baseVal.value is 200
 PASS rect.width.animVal.value is 150

--- a/LayoutTests/svg/animations/deferred-insertion.html
+++ b/LayoutTests/svg/animations/deferred-insertion.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="scheduleTest()">

--- a/LayoutTests/svg/animations/fill-remove-support.html
+++ b/LayoutTests/svg/animations/fill-remove-support.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/resources/SVGTestCase.js
+++ b/LayoutTests/svg/animations/resources/SVGTestCase.js
@@ -1,0 +1,55 @@
+// Force activating pixel tests - this variable is used in resources/js-test.js, when calling setDumpAsText().
+window.enablePixelTesting = true;
+
+var svgNS = "http://www.w3.org/2000/svg";
+var xlinkNS = "http://www.w3.org/1999/xlink";
+var xhtmlNS = "http://www.w3.org/1999/xhtml";
+
+var rootSVGElement;
+var iframeElement;
+
+function createSVGElement(name) {
+    return document.createElementNS(svgNS, "svg:" + name);
+}
+
+function createSVGTestCase() {
+    window.jsTestIsAsync = true;
+    rootSVGElement = createSVGElement("svg");
+    rootSVGElement.setAttribute("width", "300");
+    rootSVGElement.setAttribute("height", "300");
+
+    var bodyElement = document.documentElement.lastChild;
+    bodyElement.insertBefore(rootSVGElement, document.getElementById("description"));
+}
+
+function embedSVGTestCase(uri) {
+    window.jsTestIsAsync = true;
+    iframeElement = document.createElement("iframe");
+    iframeElement.setAttribute("style", "width: 300px; height: 300px;");
+    iframeElement.setAttribute("src", uri);
+    iframeElement.setAttribute("onload", "iframeLoaded()");
+
+    var bodyElement = document.documentElement.lastChild;
+    bodyElement.insertBefore(iframeElement, document.getElementById("description"));
+}
+
+function iframeLoaded() {
+    rootSVGElement = iframeElement.getSVGDocument().rootElement;
+}
+
+function clickAt(x, y) {
+    // Translation due to <h1> above us
+    var clientRect = rootSVGElement.getBoundingClientRect();
+    x = x + clientRect.left;
+    y = y + clientRect.top;
+
+    if (window.eventSender) {
+        eventSender.mouseMoveTo(x, y);
+        eventSender.mouseDown();
+        eventSender.mouseUp();
+    }
+}
+
+function completeTest() {
+    finishJSTest();
+}

--- a/LayoutTests/svg/animations/svgPreserveAspectRatio-animation-1.html
+++ b/LayoutTests/svg/animations/svgPreserveAspectRatio-animation-1.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/svglength-additive-by-5.html
+++ b/LayoutTests/svg/animations/svglength-additive-by-5.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/svglength-animation-px-to-exs.html
+++ b/LayoutTests/svg/animations/svglength-animation-px-to-exs.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/svglength-animation-px-to-percentage.html
+++ b/LayoutTests/svg/animations/svglength-animation-px-to-percentage.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/svgpath-animation-1.html
+++ b/LayoutTests/svg/animations/svgpath-animation-1.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/use-animate-transform-and-position.html
+++ b/LayoutTests/svg/animations/use-animate-transform-and-position.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">

--- a/LayoutTests/svg/animations/use-animate-width-and-height-expected.txt
+++ b/LayoutTests/svg/animations/use-animate-width-and-height-expected.txt
@@ -44,6 +44,7 @@ FAIL use.getAttribute('height') should be 135. Was 100.
 PASS useElementTargetClone().width.animVal.value is 135
 PASS useElementTargetClone().height.animVal.value is 135
 PASS successfullyParsed is true
+Some tests failed.
 
 TEST COMPLETE
 

--- a/LayoutTests/svg/animations/use-animate-width-and-height.html
+++ b/LayoutTests/svg/animations/use-animate-width-and-height.html
@@ -1,8 +1,8 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../dynamic-updates/resources/SVGTestCase.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/SVGTestCase.js"></script>
 <script src="resources/SVGAnimationTestCase.js"></script>
 </head>
 <body onload="runSMILTest()">
@@ -25,7 +25,6 @@ rect.setAttribute("y", "10");
 rect.setAttribute("width", "100%");
 rect.setAttribute("height", "100%");
 rect.setAttribute("fill", "green");
-rect.setAttribute("onclick", "executeTest()");
 symbol.appendChild(rect);
 rootSVGElement.appendChild(symbol);
 
@@ -36,6 +35,7 @@ use.setAttribute("x", "0");
 use.setAttribute("y", "0");
 use.setAttribute("width", "100");
 use.setAttribute("height", "100");
+rect.setAttribute("onclick", "executeTest()");
 rootSVGElement.appendChild(use);
 
 var animate = createSVGElement("animate");


### PR DESCRIPTION
#### 0e14d4f96ced357830f7d96e360724fc8a561d86
<pre>
Update `svg/animations` tests to use local `SVGTestCase` and leverage `js-test.js`

<a href="https://bugs.webkit.org/show_bug.cgi?id=268763">https://bugs.webkit.org/show_bug.cgi?id=268763</a>

Reviewed by Nikolas Zimmermann.

This patch aims to leverage `js-test.js` in `svg/animations` by updating helper
script &apos;SVGTestCase.js&apos;.
Similar to Blink, in this patch, we separate &apos;SVGTestCase&apos; from dynamic-updates
and add it as local resources in &apos;svg/animations/resources&apos; folder. It is up-to-date
copy from Blink / Chromium source but I removed unused function to slim it down.

&gt; Script Update:
* LayoutTests/svg/animations/resources/SVGTestCase.js:

&gt; Tests Update:
* LayoutTests/svg/animations/animate-color-rgba-calcMode-discrete.html:
* LayoutTests/svg/animations/animate-elem-03-t-drt.html:
* LayoutTests/svg/animations/animate-elem-04-t-drt.html:
* LayoutTests/svg/animations/animate-elem-05-t-drt.html:
* LayoutTests/svg/animations/animate-elem-06-t-drt.html:
* LayoutTests/svg/animations/animate-elem-07-t-drt.html:
* LayoutTests/svg/animations/animate-elem-08-t-drt.html:
* LayoutTests/svg/animations/animate-elem-09-t-drt.html:
* LayoutTests/svg/animations/animate-elem-10-t-drt.html:
* LayoutTests/svg/animations/animate-elem-11-t-drt.html:
* LayoutTests/svg/animations/animate-elem-12-t-drt.html:
* LayoutTests/svg/animations/animate-elem-13-t-drt.html:
* LayoutTests/svg/animations/animate-end-attribute.html:
* LayoutTests/svg/animations/animate-endElement-beginElement.html:
* LayoutTests/svg/animations/animate-marker-orient-from-angle-to-autostartreverse.html:
* LayoutTests/svg/animations/animate-mpath-insert.html:
* LayoutTests/svg/animations/animate-path-animation-cC-sS-inverse.html:
* LayoutTests/svg/animations/animate-path-animation-Cc-Ss.html:
* LayoutTests/svg/animations/animate-path-animation-lL-vV-hH-inverse.html:
* LayoutTests/svg/animations/animate-path-animation-Ll-Vv-Hh.html:
* LayoutTests/svg/animations/animate-path-animation-qQ-tT-inverse.html:
* LayoutTests/svg/animations/animate-path-animation-Qq-Tt.html:
* LayoutTests/svg/animations/animate-path-nested-transforms.html:
* LayoutTests/svg/animations/animate-path-to-animation.html:
* LayoutTests/svg/animations/change-baseVal-while-animating-fill-freeze-2.html:
* LayoutTests/svg/animations/change-baseVal-while-animating-fill-remove-2.html:
* LayoutTests/svg/animations/change-css-property-while-animating-fill-freeze.html:
* LayoutTests/svg/animations/change-css-property-while-animating-fill-remove.html:
* LayoutTests/svg/animations/deferred-insertion.html:
* LayoutTests/svg/animations/fill-remove-support.html:
* LayoutTests/svg/animations/svglength-additive-by-5.html:
* LayoutTests/svg/animations/svglength-animation-px-to-exs.html:
* LayoutTests/svg/animations/svglength-animation-px-to-percentage.html:
* LayoutTests/svg/animations/svgpath-animation-1.html:
* LayoutTests/svg/animations/svgPreserveAspectRatio-animation-1.html:
* LayoutTests/svg/animations/use-animate-transform-and-position.html:
* LayoutTests/svg/animations/use-animate-width-and-height.html:

&gt; Updated Test Expectations (due to `js-test.js&apos;):
* LayoutTests/svg/animations/use-animate-width-and-height-expected.txt:
* LayoutTests/svg/animations/deferred-insertion-expected.txt:
* LayoutTests/svg/animations/change-css-property-while-animating-fill-remove-expected.txt:
* LayoutTests/svg/animations/change-css-property-while-animating-fill-freeze-expected.txt:
* LayoutTests/svg/animations/animate-color-rgba-calcMode-discrete-expected.txt:

Canonical link: <a href="https://commits.webkit.org/274447@main">https://commits.webkit.org/274447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/962ebcde30ace0adae8586cb9faed56eb0962ccb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/39154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/18114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41688 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34871 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15462 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39728 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/15252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/34875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42965 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/35548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15572 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/34153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5112 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/15058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->