### PR TITLE
Generate serialization for SecAccessControlRef

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -444,6 +444,7 @@ $(PROJECT_DIR)/Shared/cf/CoreIPCCFArray.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCCFDictionary.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCCGColorSpace.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCNumber.serialization.in
+$(PROJECT_DIR)/Shared/cf/CoreIPCSecAccessControl.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCSecCertificate.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCSecKeychainItem.serialization.in
 $(PROJECT_DIR)/Shared/cf/CoreIPCSecTrust.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -686,6 +686,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/cf/CoreIPCCFDictionary.serialization.in \
 	Shared/cf/CoreIPCCGColorSpace.serialization.in \
 	Shared/cf/CoreIPCNumber.serialization.in \
+	Shared/cf/CoreIPCSecAccessControl.serialization.in \
 	Shared/cf/CoreIPCSecCertificate.serialization.in \
 	Shared/cf/CoreIPCSecKeychainItem.serialization.in \
 	Shared/cf/CoreIPCSecTrust.serialization.in \

--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
@@ -336,33 +336,6 @@ std::optional<RetainPtr<CFCharacterSetRef>> ArgumentCoder<RetainPtr<CFCharacterS
     return WTFMove(characterSet);
 }
 
-#if HAVE(SEC_ACCESS_CONTROL)
-template<typename Encoder>
-void ArgumentCoder<SecAccessControlRef>::encode(Encoder& encoder, SecAccessControlRef accessControl)
-{
-    auto data = adoptCF(SecAccessControlCopyData(accessControl));
-    if (data)
-        encoder << data;
-}
-
-template void ArgumentCoder<SecAccessControlRef>::encode<Encoder>(Encoder&, SecAccessControlRef);
-template void ArgumentCoder<SecAccessControlRef>::encode<StreamConnectionEncoder>(StreamConnectionEncoder&, SecAccessControlRef);
-
-std::optional<RetainPtr<SecAccessControlRef>> ArgumentCoder<RetainPtr<SecAccessControlRef>>::decode(Decoder& decoder)
-{
-    std::optional<RetainPtr<CFDataRef>> data;
-    decoder >> data;
-    if (!data)
-        return std::nullopt;
-
-    auto result = adoptCF(SecAccessControlCreateFromData(kCFAllocatorDefault, data->get(), nullptr));
-    if (!result)
-        return std::nullopt;
-
-    return WTFMove(result);
-}
-#endif
-
 } // namespace IPC
 
 namespace WTF {

--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.h
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.h
@@ -59,13 +59,4 @@ template<> struct ArgumentCoder<RetainPtr<CFCharacterSetRef>> : CFRetainPtrArgum
     static std::optional<RetainPtr<CFCharacterSetRef>> decode(Decoder&);
 };
 
-#if HAVE(SEC_ACCESS_CONTROL)
-template<> struct ArgumentCoder<SecAccessControlRef> {
-    template<typename Encoder> static void encode(Encoder&, SecAccessControlRef);
-};
-template<> struct ArgumentCoder<RetainPtr<SecAccessControlRef>> : CFRetainPtrArgumentCoder<SecAccessControlRef> {
-    static std::optional<RetainPtr<SecAccessControlRef>> decode(Decoder&);
-};
-#endif
-
 } // namespace IPC

--- a/Source/WebKit/Shared/cf/CFTypes.serialization.in
+++ b/Source/WebKit/Shared/cf/CFTypes.serialization.in
@@ -46,15 +46,31 @@
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createCFURL()] CFURLRef wrapped by WebKit::CoreIPCCFURL {
 }
 
+#if HAVE(SEC_ACCESS_CONTROL)
+
+additional_forward_declaration: typedef struct __SecAccessControl *SecAccessControlRef
+[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createSecAccessControl()] SecAccessControlRef wrapped by WebKit::CoreIPCSecAccessControl {
+}
+
+#endif
+
 additional_forward_declaration: typedef struct __SecCertificate *SecCertificateRef
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createSecCertificate()] SecCertificateRef wrapped by WebKit::CoreIPCSecCertificate {
 }
+
+#if HAVE(SEC_KEYCHAIN)
+
+additional_forward_declaration: typedef struct __SecKeychainItem *SecKeychainItemRef
+[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createSecKeychainItem()] SecKeychainItemRef wrapped by WebKit::CoreIPCSecKeychainItem {
+}
+
+#endif
 
 additional_forward_declaration: typedef struct __SecTrust *SecTrustRef
 [WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createSecTrust()] SecTrustRef wrapped by WebKit::CoreIPCSecTrust {
 }
 
-#endif
+#endif // USE(CF)
 
 #if USE(CG)
 
@@ -68,10 +84,3 @@ additional_forward_declaration: typedef struct CF_BRIDGED_TYPE(id) CGColorSpace 
 
 #endif
 
-#if HAVE(SEC_KEYCHAIN)
-
-additional_forward_declaration: typedef struct __SecKeychainItem *SecKeychainItemRef
-[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createSecKeychainItem()] SecKeychainItemRef wrapped by WebKit::CoreIPCSecKeychainItem {
-}
-
-#endif

--- a/Source/WebKit/Shared/cf/CoreIPCSecAccessControl.h
+++ b/Source/WebKit/Shared/cf/CoreIPCSecAccessControl.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(SEC_ACCESS_CONTROL)
+
+#import <wtf/RetainPtr.h>
+#import <wtf/spi/cocoa/SecuritySPI.h>
+
+namespace WebKit {
+
+class CoreIPCSecAccessControl {
+public:
+    CoreIPCSecAccessControl(SecAccessControlRef accessControl)
+        : m_accessControlData(dataFromAccessControl(accessControl))
+    {
+    }
+
+    CoreIPCSecAccessControl(RetainPtr<CFDataRef> data)
+        : m_accessControlData(data)
+    {
+    }
+
+    CoreIPCSecAccessControl(const IPC::DataReference& data)
+        : m_accessControlData(adoptCF(CFDataCreate(kCFAllocatorDefault, data.data(), data.size())))
+    {
+    }
+
+    RetainPtr<SecAccessControlRef> createSecAccessControl() const
+    {
+        auto accessControl = adoptCF(SecAccessControlCreateFromData(kCFAllocatorDefault, m_accessControlData.get(), NULL));
+        ASSERT(accessControl);
+        return accessControl;
+    }
+
+    IPC::DataReference dataReference() const
+    {
+        if (!m_accessControlData)
+            return { };
+        CFDataRef data = m_accessControlData.get();
+        return { CFDataGetBytePtr(data), static_cast<size_t>(CFDataGetLength(data)) };
+    }
+
+private:
+    RetainPtr<CFDataRef> dataFromAccessControl(SecAccessControlRef accessControl) const
+    {
+        ASSERT(accessControl);
+        auto data = adoptCF(SecAccessControlCopyData(accessControl));
+        ASSERT(data);
+        return data;
+    }
+
+    RetainPtr<CFDataRef> m_accessControlData;
+};
+
+} // namespace WebKit
+
+#endif // HAVE(SEC_ACCESS_CONTROL)

--- a/Source/WebKit/Shared/cf/CoreIPCSecAccessControl.serialization.in
+++ b/Source/WebKit/Shared/cf/CoreIPCSecAccessControl.serialization.in
@@ -20,12 +20,12 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#if USE(CF)
+#if HAVE(SEC_ACCESS_CONTROL)
 
-webkit_platform_headers: "CoreIPCSecCertificate.h"
+webkit_platform_headers: "CoreIPCSecAccessControl.h"
 
-[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCSecCertificate {
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCSecAccessControl {
     IPC::DataReference dataReference();
 }
 
-#endif // USE(CF)
+#endif // HAVE(SEC_ACCESS_CONTROL)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1330,6 +1330,7 @@
 		53BA47D11DC2EF5E004DF4AD /* NetworkDataTaskBlob.h in Headers */ = {isa = PBXBuildFile; fileRef = 539EB5471DC2EE40009D48CF /* NetworkDataTaskBlob.h */; };
 		53CFBBC82224D1B500266546 /* TextCheckerCompletion.h in Headers */ = {isa = PBXBuildFile; fileRef = 53CFBBC72224D1B000266546 /* TextCheckerCompletion.h */; };
 		561A54532B61E49E00073A72 /* CoreIPCSecCertificate.h in Headers */ = {isa = PBXBuildFile; fileRef = 561A54512B61E49E00073A72 /* CoreIPCSecCertificate.h */; };
+		561A54542B61E49E00073A72 /* CoreIPCSecAccessControl.serialization.in in Sources */ = {isa = PBXBuildFile; fileRef = 561A54522B61E49E00073A72 /* CoreIPCSecAccessControl.serialization.in */; };
 		561A54612B6438C000073A72 /* CoreIPCSecKeychainItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 561A54602B6438C000073A72 /* CoreIPCSecKeychainItem.h */; };
 		562674F52B69B4C8008BB425 /* CoreIPCSecTrust.h in Headers */ = {isa = PBXBuildFile; fileRef = 562674F32B69B4C7008BB425 /* CoreIPCSecTrust.h */; };
 		570AB8F320AE3BD700B8BE87 /* SecKeyProxyStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 570AB8F220AE3BD700B8BE87 /* SecKeyProxyStore.h */; };
@@ -5663,8 +5664,10 @@
 		550640A324071A6100AAE045 /* RemoteRenderingBackend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteRenderingBackend.h; sourceTree = "<group>"; };
 		550640A424071C2100AAE045 /* RemoteRenderingBackend.messages.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = RemoteRenderingBackend.messages.in; sourceTree = "<group>"; };
 		55AD09422408A02E00DE4D2F /* RemoteImageBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteImageBuffer.h; sourceTree = "<group>"; };
+		560F03DB2B6C47F900F53EE7 /* CoreIPCSecAccessControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCSecAccessControl.h; sourceTree = "<group>"; };
+		560F03DC2B6C480C00F53EE7 /* CoreIPCSecCertificate.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCSecCertificate.serialization.in; sourceTree = "<group>"; };
 		561A54512B61E49E00073A72 /* CoreIPCSecCertificate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCSecCertificate.h; sourceTree = "<group>"; };
-		561A54522B61E49E00073A72 /* CoreIPCSecCertificate.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCSecCertificate.serialization.in; sourceTree = "<group>"; };
+		561A54522B61E49E00073A72 /* CoreIPCSecAccessControl.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCSecAccessControl.serialization.in; sourceTree = "<group>"; };
 		561A545F2B6438BF00073A72 /* CoreIPCSecKeychainItem.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCSecKeychainItem.serialization.in; sourceTree = "<group>"; };
 		561A54602B6438C000073A72 /* CoreIPCSecKeychainItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCSecKeychainItem.h; sourceTree = "<group>"; };
 		562674F32B69B4C7008BB425 /* CoreIPCSecTrust.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCSecTrust.h; sourceTree = "<group>"; };
@@ -9041,8 +9044,10 @@
 				52FB15432B64680B000933CC /* CoreIPCCGColorSpace.serialization.in */,
 				F4EFF36B2AF0267200479AB8 /* CoreIPCNumber.h */,
 				F4EFF36A2AF0267200479AB8 /* CoreIPCNumber.serialization.in */,
+				560F03DB2B6C47F900F53EE7 /* CoreIPCSecAccessControl.h */,
+				561A54522B61E49E00073A72 /* CoreIPCSecAccessControl.serialization.in */,
 				561A54512B61E49E00073A72 /* CoreIPCSecCertificate.h */,
-				561A54522B61E49E00073A72 /* CoreIPCSecCertificate.serialization.in */,
+				560F03DC2B6C480C00F53EE7 /* CoreIPCSecCertificate.serialization.in */,
 				561A54602B6438C000073A72 /* CoreIPCSecKeychainItem.h */,
 				561A545F2B6438BF00073A72 /* CoreIPCSecKeychainItem.serialization.in */,
 				562674F32B69B4C7008BB425 /* CoreIPCSecTrust.h */,
@@ -18611,6 +18616,7 @@
 				E326E357284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm in Sources */,
 				413E5C9229B0CF7C002F4987 /* BackgroundFetchStateCocoa.mm in Sources */,
 				1C62747E288B4C3E00CED3A2 /* CocoaHelpers.mm in Sources */,
+				561A54542B61E49E00073A72 /* CoreIPCSecAccessControl.serialization.in in Sources */,
 				49DC1DE127E5129100C1CB36 /* CSPExtensionUtilities.mm in Sources */,
 				522F792C28D531970069B45B /* CtapAuthenticator.cpp in Sources */,
 				526C5723284ADCBC00E08955 /* CtapCcidDriver.cpp in Sources */,


### PR DESCRIPTION
#### 446cdce9e93b5152ad3b44998d0610e5674b038e
<pre>
Generate serialization for SecAccessControlRef
<a href="https://bugs.webkit.org/show_bug.cgi?id=268571">https://bugs.webkit.org/show_bug.cgi?id=268571</a>
<a href="https://rdar.apple.com/122128719">rdar://122128719</a>

Reviewed by achristensen07 (Alex Christensen).

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/cf/ArgumentCodersCF.cpp:
(IPC::ArgumentCoder&lt;SecAccessControlRef&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;RetainPtr&lt;SecAccessControlRef&gt;&gt;::decode): Deleted.
* Source/WebKit/Shared/cf/ArgumentCodersCF.h:
* Source/WebKit/Shared/cf/CFTypes.serialization.in:
* Source/WebKit/Shared/cf/CoreIPCSecAccessControl.h: Added.
(WebKit::CoreIPCSecAccessControl::CoreIPCSecAccessControl):
(WebKit::CoreIPCSecAccessControl::createSecAccessControl const):
(WebKit::CoreIPCSecAccessControl::dataReference const):
(WebKit::CoreIPCSecAccessControl::dataFromAccessControl const):
* Source/WebKit/Shared/cf/CoreIPCSecAccessControl.serialization.in: Copied from Source/WebKit/Shared/cf/CoreIPCSecCertificate.serialization.in.
* Source/WebKit/Shared/cf/CoreIPCSecCertificate.serialization.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/274242@main">https://commits.webkit.org/274242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/871d0080eaac3b72ca139a2433532b47c2cecdf2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40927 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/40661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14656 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33443 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12712 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42206 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/34911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38533 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/36739 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14843 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4999 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14309 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->