### PR TITLE
[UnifiedPDF] Pinch-to-zoom starts zooming from original scale factor after zooming through the context menu

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1165,7 +1165,7 @@ void UnifiedPDFPlugin::performContextMenuAction(ContextMenuItemTag tag)
         zoomOut();
         break;
     case ContextMenuItemTag::ActualSize:
-        setPageScaleFactor(scaleForActualSize(), std::nullopt);
+        m_view->setPageScaleFactor(scaleForActualSize(), std::nullopt);
         break;
     }
 }
@@ -1372,12 +1372,12 @@ id UnifiedPDFPlugin::accessibilityAssociatedPluginParentForElement(Element*) con
 
 void UnifiedPDFPlugin::zoomIn()
 {
-    setPageScaleFactor(std::clamp(m_scaleFactor * zoomIncrement, minimumZoomScale, maximumZoomScale), std::nullopt);
+    m_view->setPageScaleFactor(std::clamp(m_scaleFactor * zoomIncrement, minimumZoomScale, maximumZoomScale), std::nullopt);
 }
 
 void UnifiedPDFPlugin::zoomOut()
 {
-    setPageScaleFactor(std::clamp(m_scaleFactor / zoomIncrement, minimumZoomScale, maximumZoomScale), std::nullopt);
+    m_view->setPageScaleFactor(std::clamp(m_scaleFactor / zoomIncrement, minimumZoomScale, maximumZoomScale), std::nullopt);
 }
 
 #endif // ENABLE(PDF_HUD)

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -333,12 +333,11 @@ void PluginView::didEndMagnificationGesture()
 
 void PluginView::setPageScaleFactor(double scaleFactor, std::optional<IntPoint> origin)
 {
-    m_webPage->send(Messages::WebPageProxy::PluginScaleFactorDidChange(scaleFactor));
-    m_webPage->send(Messages::WebPageProxy::PluginZoomFactorDidChange(scaleFactor));
-
     if (!m_isInitialized)
         return;
 
+    m_webPage->send(Messages::WebPageProxy::PluginScaleFactorDidChange(scaleFactor));
+    m_webPage->send(Messages::WebPageProxy::PluginZoomFactorDidChange(scaleFactor));
     m_plugin->setPageScaleFactor(scaleFactor, origin);
 }
 


### PR DESCRIPTION
#### 1ba1f5ef79b5665f85d7b57acd3384cd64ae8179
<pre>
[UnifiedPDF] Pinch-to-zoom starts zooming from original scale factor after zooming through the context menu
<a href="https://bugs.webkit.org/show_bug.cgi?id=268764">https://bugs.webkit.org/show_bug.cgi?id=268764</a>
<a href="https://rdar.apple.com/122327672">rdar://122327672</a>

Reviewed by Simon Fraser.

We fail to inform the UIP about a change in the page scale factor
through context menu actions, so when we try a gesture that sends the
PDF plugin a scale factor from the UIP, we receive out-dated
information.

This patch addresses the bug by calling PluginView::setPageScaleFactor,
which sends the PluginScaleFactorDidChange and PluginZoomFactorDidChange
IPC messages to the UIP, and then also calls into
UnifiedPDFPlugin::setPageScaleFactor.

Finally, we move the IPC calls in PluginView::setPageScaleFactor to
after the plugin view initialized check. This ensures that we don&apos;t
communicate a page scale factor change when one hasn&apos;t happened.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::performContextMenuAction):
(WebKit::UnifiedPDFPlugin::zoomIn):
(WebKit::UnifiedPDFPlugin::zoomOut):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::setPageScaleFactor):

Canonical link: <a href="https://commits.webkit.org/274113@main">https://commits.webkit.org/274113@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/402f1811cc2e218ebe2c4a3ad40e7d2abeaaff49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16846 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40482 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33755 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14149 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14191 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12388 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12346 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41755 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34421 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38208 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36394 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8515 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->