### PR TITLE
Crash when closing page while extension is waiting on storage callback.

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
@@ -526,7 +526,7 @@ void WebExtensionAPIAction::setPopup(NSDictionary *details, Ref<WebExtensionCall
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPIAction::openPopup(WebPage* page, NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIAction::openPopup(WebPage& page, NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/openPopup
 
@@ -535,7 +535,7 @@ void WebExtensionAPIAction::openPopup(WebPage* page, NSDictionary *details, Ref<
     if (!parseActionDetails(details, windowIdentifier, tabIdentifier, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionOpenPopup(page->webPageProxyIdentifier(), windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::ActionOpenPopup(page.webPageProxyIdentifier(), windowIdentifier, tabIdentifier), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> error) {
         if (error) {
             callback->reportError(error.value());
             return;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm
@@ -79,20 +79,16 @@ void WebExtensionAPIEvent::invokeListenersWithArgument(id argument1, id argument
         listener->call(argument1, argument2, argument3);
 }
 
-void WebExtensionAPIEvent::addListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener)
+void WebExtensionAPIEvent::addListener(WebPage& page, RefPtr<WebExtensionCallbackHandler> listener)
 {
-    ASSERT(page);
-
-    m_pageProxyIdentifier = page->webPageProxyIdentifier();
+    m_pageProxyIdentifier = page.webPageProxyIdentifier();
     m_listeners.append(listener);
 
-    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(page->webPageProxyIdentifier(), m_type, contentWorldType()), extensionContext().identifier());
+    WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(page.webPageProxyIdentifier(), m_type, contentWorldType()), extensionContext().identifier());
 }
 
-void WebExtensionAPIEvent::removeListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener)
+void WebExtensionAPIEvent::removeListener(WebPage& page, RefPtr<WebExtensionCallbackHandler> listener)
 {
-    ASSERT(page);
-
     auto removedCount = m_listeners.removeAllMatching([&](auto& entry) {
         return entry->callbackFunction() == listener->callbackFunction();
     });
@@ -100,7 +96,7 @@ void WebExtensionAPIEvent::removeListener(WebPage* page, RefPtr<WebExtensionCall
     if (!removedCount)
         return;
 
-    ASSERT(page->webPageProxyIdentifier() == m_pageProxyIdentifier);
+    ASSERT(page.webPageProxyIdentifier() == m_pageProxyIdentifier);
 
     WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(m_pageProxyIdentifier, m_type, contentWorldType(), removedCount), extensionContext().identifier());
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
@@ -154,11 +154,11 @@ NSArray *WebExtensionAPIExtension::getViews(JSContextRef context, NSDictionary *
     return [result copy];
 }
 
-bool WebExtensionAPIExtension::isInIncognitoContext(WebPage* page)
+bool WebExtensionAPIExtension::isInIncognitoContext(WebPage& page)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/inIncognitoContext
 
-    return page->usesEphemeralSession();
+    return page.usesEphemeralSession();
 }
 
 void WebExtensionAPIExtension::isAllowedFileSchemeAccess(Ref<WebExtensionCallbackHandler>&& callback)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -291,11 +291,11 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
     return true;
 }
 
-id WebExtensionAPIMenus::createMenu(WebPage* page, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+id WebExtensionAPIMenus::createMenu(WebPage& page, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/create
 
-    m_pageProxyIdentifier = page->webPageProxyIdentifier();
+    m_pageProxyIdentifier = page.webPageProxyIdentifier();
 
     std::optional<WebExtensionMenuItemParameters> parameters;
     RefPtr<WebExtensionCallbackHandler> clickCallback;
@@ -324,11 +324,11 @@ id WebExtensionAPIMenus::createMenu(WebPage* page, NSDictionary *properties, Ref
     return toMenuIdentifierWebAPI(parameters.value().identifier);
 }
 
-void WebExtensionAPIMenus::update(WebPage* page, id identifier, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIMenus::update(WebPage& page, id identifier, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/menus/update
 
-    m_pageProxyIdentifier = page->webPageProxyIdentifier();
+    m_pageProxyIdentifier = page.webPageProxyIdentifier();
 
     if (!validateObject(identifier, @"identifier", [NSOrderedSet orderedSetWithObjects:NSString.class, NSNumber.class, nil], outExceptionString))
         return;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm
@@ -113,7 +113,7 @@ void WebExtensionAPIPort::setError(JSValue *error)
     m_error = error;
 }
 
-void WebExtensionAPIPort::postMessage(WebFrame *frame, NSString *message, NSString **outExceptionString)
+void WebExtensionAPIPort::postMessage(WebFrame& frame, NSString *message, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port#postmessage
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -247,7 +247,7 @@ double WebExtensionAPIRuntime::getFrameId(JSValue *target)
     if (!target)
         return WebExtensionFrameConstants::None;
 
-    auto frame = WebFrame::contentFrameForWindowOrFrameElement(target.context.JSGlobalContextRef, target.JSValueRef);
+    RefPtr frame = WebFrame::contentFrameForWindowOrFrameElement(target.context.JSGlobalContextRef, target.JSValueRef);
     if (!frame)
         return WebExtensionFrameConstants::None;
 
@@ -293,7 +293,7 @@ JSValue *WebExtensionAPIRuntime::lastError()
     return m_lastError.get();
 }
 
-void WebExtensionAPIRuntime::sendMessage(WebFrame *frame, NSString *extensionID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIRuntime::sendMessage(WebFrame& frame, NSString *extensionID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage
 
@@ -307,10 +307,10 @@ void WebExtensionAPIRuntime::sendMessage(WebFrame *frame, NSString *extensionID,
     WebExtensionMessageSenderParameters sender {
         extensionContext().uniqueIdentifier(),
         std::nullopt, // tabParameters
-        toWebExtensionFrameIdentifier(*frame),
-        frame->page()->webPageProxyIdentifier(),
+        toWebExtensionFrameIdentifier(frame),
+        frame.page()->webPageProxyIdentifier(),
         contentWorldType(),
-        frame->url(),
+        frame.url(),
     };
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::RuntimeSendMessage(extensionID, messageJSON, sender), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> replyJSON, std::optional<String> error) {
@@ -328,7 +328,7 @@ void WebExtensionAPIRuntime::sendMessage(WebFrame *frame, NSString *extensionID,
     }, extensionContext().identifier());
 }
 
-RefPtr<WebExtensionAPIPort> WebExtensionAPIRuntime::connect(WebFrame* frame, JSContextRef context, NSString *extensionID, NSDictionary *options, NSString **outExceptionString)
+RefPtr<WebExtensionAPIPort> WebExtensionAPIRuntime::connect(WebFrame& frame, JSContextRef context, NSString *extensionID, NSDictionary *options, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/connect
 
@@ -341,10 +341,10 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPIRuntime::connect(WebFrame* frame, JSC
     WebExtensionMessageSenderParameters sender {
         extensionContext().uniqueIdentifier(),
         std::nullopt, // tabParameters
-        toWebExtensionFrameIdentifier(*frame),
-        frame->page()->webPageProxyIdentifier(),
+        toWebExtensionFrameIdentifier(frame),
+        frame.page()->webPageProxyIdentifier(),
         contentWorldType(),
-        frame->url(),
+        frame.url(),
     };
 
     auto port = WebExtensionAPIPort::create(forMainWorld(), runtime(), extensionContext(), WebExtensionContentWorldType::Main, resolvedName, sender);
@@ -360,7 +360,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPIRuntime::connect(WebFrame* frame, JSC
     return port;
 }
 
-void WebExtensionAPIRuntime::sendNativeMessage(WebFrame* frame, NSString *applicationID, NSString *messageJSON, Ref<WebExtensionCallbackHandler>&& callback)
+void WebExtensionAPIRuntime::sendNativeMessage(WebFrame& frame, NSString *applicationID, NSString *messageJSON, Ref<WebExtensionCallbackHandler>&& callback)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendNativeMessage
 
@@ -379,7 +379,7 @@ void WebExtensionAPIRuntime::sendNativeMessage(WebFrame* frame, NSString *applic
     }, extensionContext().identifier());
 }
 
-RefPtr<WebExtensionAPIPort> WebExtensionAPIRuntime::connectNative(WebFrame* frame, JSContextRef context, NSString *applicationID)
+RefPtr<WebExtensionAPIPort> WebExtensionAPIRuntime::connectNative(WebFrame& frame, JSContextRef context, NSString *applicationID)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/connectNative
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -64,7 +64,7 @@ bool WebExtensionAPIStorageArea::isPropertyAllowed(ASCIILiteral propertyName, We
     return false;
 }
 
-void WebExtensionAPIStorageArea::get(WebPage* page, id items, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIStorageArea::get(WebPage& page, id items, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get
 
@@ -104,7 +104,7 @@ void WebExtensionAPIStorageArea::get(WebPage* page, id items, Ref<WebExtensionCa
         keysVector = { key };
     }
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGet(page->webPageProxyIdentifier(), m_type, keysVector), [&, keysWithDefaultValues, protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> dataJSON, WebKit::WebExtensionContext::ErrorString error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGet(page.webPageProxyIdentifier(), m_type, keysVector), [&, keysWithDefaultValues, protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> dataJSON, WebKit::WebExtensionContext::ErrorString error) {
         if (error)
             callback->reportError(error.value());
         else {
@@ -119,7 +119,7 @@ void WebExtensionAPIStorageArea::get(WebPage* page, id items, Ref<WebExtensionCa
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIStorageArea::getBytesInUse(WebPage* page, id keys, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIStorageArea::getBytesInUse(WebPage& page, id keys, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse
 
@@ -135,7 +135,7 @@ void WebExtensionAPIStorageArea::getBytesInUse(WebPage* page, id keys, Ref<WebEx
     else if (NSString *key = dynamic_objc_cast<NSString>(keys))
         keysVector = { key };
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGetBytesInUse(page->webPageProxyIdentifier(), m_type, keysVector), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<size_t> size, WebKit::WebExtensionContext::ErrorString error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGetBytesInUse(page.webPageProxyIdentifier(), m_type, keysVector), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<size_t> size, WebKit::WebExtensionContext::ErrorString error) {
         if (error)
             callback->reportError(error.value());
         else
@@ -143,7 +143,7 @@ void WebExtensionAPIStorageArea::getBytesInUse(WebPage* page, id keys, Ref<WebEx
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIStorageArea::set(WebPage* page, NSDictionary *items, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIStorageArea::set(WebPage& page, NSDictionary *items, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set
 
@@ -179,7 +179,7 @@ void WebExtensionAPIStorageArea::set(WebPage* page, NSDictionary *items, Ref<Web
         return;
     }
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageSet(page->webPageProxyIdentifier(), m_type, encodeJSONString(serializedData)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebKit::WebExtensionContext::ErrorString error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageSet(page.webPageProxyIdentifier(), m_type, encodeJSONString(serializedData)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebKit::WebExtensionContext::ErrorString error) {
         if (error)
             callback->reportError(error.value());
         else
@@ -187,7 +187,7 @@ void WebExtensionAPIStorageArea::set(WebPage* page, NSDictionary *items, Ref<Web
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIStorageArea::remove(WebPage* page, id keys, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIStorageArea::remove(WebPage& page, id keys, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/remove
 
@@ -196,7 +196,7 @@ void WebExtensionAPIStorageArea::remove(WebPage* page, id keys, Ref<WebExtension
 
     Vector<String> keysVector = [keys isKindOfClass:NSArray.class] ? makeVector<String>((NSArray *)keys) : Vector<String> { keys };
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageRemove(page->webPageProxyIdentifier(), m_type, keysVector), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebKit::WebExtensionContext::ErrorString error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageRemove(page.webPageProxyIdentifier(), m_type, keysVector), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebKit::WebExtensionContext::ErrorString error) {
         if (error)
             callback->reportError(error.value());
         else
@@ -204,9 +204,9 @@ void WebExtensionAPIStorageArea::remove(WebPage* page, id keys, Ref<WebExtension
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIStorageArea::clear(WebPage* page, Ref<WebExtensionCallbackHandler>&& callback)
+void WebExtensionAPIStorageArea::clear(WebPage& page, Ref<WebExtensionCallbackHandler>&& callback)
 {
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageClear(page->webPageProxyIdentifier(), m_type), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebKit::WebExtensionContext::ErrorString error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageClear(page.webPageProxyIdentifier(), m_type), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebKit::WebExtensionContext::ErrorString error) {
         if (error)
             callback->reportError(error.value());
         else
@@ -214,7 +214,7 @@ void WebExtensionAPIStorageArea::clear(WebPage* page, Ref<WebExtensionCallbackHa
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIStorageArea::setAccessLevel(WebPage* page, NSDictionary *accessOptions, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIStorageArea::setAccessLevel(WebPage& page, NSDictionary *accessOptions, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     static auto *requiredKeys = @[
         accessLevelKey,
@@ -235,7 +235,7 @@ void WebExtensionAPIStorageArea::setAccessLevel(WebPage* page, NSDictionary *acc
 
     WebExtensionStorageAccessLevel accessLevel = [accessLevelString isEqualToString:accessLevelTrustedContexts] ? WebExtensionStorageAccessLevel::TrustedContexts : WebExtensionStorageAccessLevel::TrustedAndUntrustedContexts;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageSetAccessLevel(page->webPageProxyIdentifier(), m_type, accessLevel), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebKit::WebExtensionContext::ErrorString error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageSetAccessLevel(page.webPageProxyIdentifier(), m_type, accessLevel), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebKit::WebExtensionContext::ErrorString error) {
         if (error)
             callback->reportError(error.value());
         else

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -554,7 +554,7 @@ bool WebExtensionAPITabs::isPropertyAllowed(ASCIILiteral name, WebPage*)
     return false;
 }
 
-void WebExtensionAPITabs::createTab(WebPage* page, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::createTab(WebPage& page, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create
 
@@ -562,7 +562,7 @@ void WebExtensionAPITabs::createTab(WebPage* page, NSDictionary *properties, Ref
     if (!parseTabCreateOptions(properties, parameters, @"properties", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsCreate(page->webPageProxyIdentifier(), WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionTabParameters> tabParameters, WebExtensionTab::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsCreate(page.webPageProxyIdentifier(), WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionTabParameters> tabParameters, WebExtensionTab::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;
@@ -577,7 +577,7 @@ void WebExtensionAPITabs::createTab(WebPage* page, NSDictionary *properties, Ref
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPITabs::query(WebPage* page, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::query(WebPage& page, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query
 
@@ -585,7 +585,7 @@ void WebExtensionAPITabs::query(WebPage* page, NSDictionary *options, Ref<WebExt
     if (!parseTabQueryOptions(options, parameters, @"info", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsQuery(page->webPageProxyIdentifier(), WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Vector<WebExtensionTabParameters> tabs, WebExtensionTab::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsQuery(page.webPageProxyIdentifier(), WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Vector<WebExtensionTabParameters> tabs, WebExtensionTab::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;
@@ -622,11 +622,11 @@ void WebExtensionAPITabs::get(double tabID, Ref<WebExtensionCallbackHandler>&& c
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPITabs::getCurrent(WebPage* page, Ref<WebExtensionCallbackHandler>&& callback)
+void WebExtensionAPITabs::getCurrent(WebPage& page, Ref<WebExtensionCallbackHandler>&& callback)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getCurrent
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGetCurrent(page->webPageProxyIdentifier()), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionTabParameters> tabParameters, WebExtensionTab::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGetCurrent(page.webPageProxyIdentifier()), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionTabParameters> tabParameters, WebExtensionTab::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;
@@ -641,7 +641,7 @@ void WebExtensionAPITabs::getCurrent(WebPage* page, Ref<WebExtensionCallbackHand
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPITabs::getSelected(WebPage* page, double windowID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::getSelected(WebPage& page, double windowID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getSelected
 
@@ -653,7 +653,7 @@ void WebExtensionAPITabs::getSelected(WebPage* page, double windowID, Ref<WebExt
     parameters.windowIdentifier = windowIdentifer.value_or(WebExtensionWindowConstants::CurrentIdentifier);
     parameters.active = true;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsQuery(page->webPageProxyIdentifier(), WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Vector<WebExtensionTabParameters> tabs, WebExtensionTab::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsQuery(page.webPageProxyIdentifier(), WTFMove(parameters)), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Vector<WebExtensionTabParameters> tabs, WebExtensionTab::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;
@@ -697,7 +697,7 @@ void WebExtensionAPITabs::duplicate(double tabID, NSDictionary *properties, Ref<
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPITabs::update(WebPage* page, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::update(WebPage& page, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/update
 
@@ -765,7 +765,7 @@ void WebExtensionAPITabs::remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandl
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPITabs::reload(WebPage* page, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::reload(WebPage& page, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/reload
 
@@ -785,7 +785,7 @@ void WebExtensionAPITabs::reload(WebPage* page, double tabID, NSDictionary *prop
     NSNumber *bypassCacheNumber = objectForKey<NSNumber>(properties, bypassCacheKey);
     ReloadFromOrigin reloadFromOrigin = bypassCacheNumber.boolValue ? ReloadFromOrigin::Yes : ReloadFromOrigin::No;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsReload(page->webPageProxyIdentifier(), tabIdentifer, reloadFromOrigin), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebExtensionTab::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsReload(page.webPageProxyIdentifier(), tabIdentifer, reloadFromOrigin), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebExtensionTab::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;
@@ -795,7 +795,7 @@ void WebExtensionAPITabs::reload(WebPage* page, double tabID, NSDictionary *prop
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPITabs::goBack(WebPage* page, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::goBack(WebPage& page, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/goBack
 
@@ -803,7 +803,7 @@ void WebExtensionAPITabs::goBack(WebPage* page, double tabID, Ref<WebExtensionCa
     if (tabIdentifer && !isValid(tabIdentifer, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGoBack(page->webPageProxyIdentifier(), tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebExtensionTab::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGoBack(page.webPageProxyIdentifier(), tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebExtensionTab::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;
@@ -813,7 +813,7 @@ void WebExtensionAPITabs::goBack(WebPage* page, double tabID, Ref<WebExtensionCa
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPITabs::goForward(WebPage* page, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::goForward(WebPage& page, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/goForward
 
@@ -821,7 +821,7 @@ void WebExtensionAPITabs::goForward(WebPage* page, double tabID, Ref<WebExtensio
     if (tabIdentifer && !isValid(tabIdentifer, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGoForward(page->webPageProxyIdentifier(), tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebExtensionTab::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGoForward(page.webPageProxyIdentifier(), tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebExtensionTab::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;
@@ -831,7 +831,7 @@ void WebExtensionAPITabs::goForward(WebPage* page, double tabID, Ref<WebExtensio
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPITabs::getZoom(WebPage* page, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::getZoom(WebPage& page, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getZoom
 
@@ -839,7 +839,7 @@ void WebExtensionAPITabs::getZoom(WebPage* page, double tabID, Ref<WebExtensionC
     if (tabIdentifer && !isValid(tabIdentifer, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGetZoom(page->webPageProxyIdentifier(), tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<double> zoomFactor, WebExtensionTab::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsGetZoom(page.webPageProxyIdentifier(), tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<double> zoomFactor, WebExtensionTab::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;
@@ -851,7 +851,7 @@ void WebExtensionAPITabs::getZoom(WebPage* page, double tabID, Ref<WebExtensionC
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPITabs::setZoom(WebPage* page, double tabID, double zoomFactor, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::setZoom(WebPage& page, double tabID, double zoomFactor, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/setZoom
 
@@ -859,7 +859,7 @@ void WebExtensionAPITabs::setZoom(WebPage* page, double tabID, double zoomFactor
     if (tabIdentifer && !isValid(tabIdentifer, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsSetZoom(page->webPageProxyIdentifier(), tabIdentifer, zoomFactor), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebExtensionTab::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsSetZoom(page.webPageProxyIdentifier(), tabIdentifer, zoomFactor), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebExtensionTab::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;
@@ -869,7 +869,7 @@ void WebExtensionAPITabs::setZoom(WebPage* page, double tabID, double zoomFactor
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPITabs::detectLanguage(WebPage* page, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::detectLanguage(WebPage& page, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/detectLanguage
 
@@ -877,7 +877,7 @@ void WebExtensionAPITabs::detectLanguage(WebPage* page, double tabID, Ref<WebExt
     if (tabIdentifer && !isValid(tabIdentifer, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsDetectLanguage(page->webPageProxyIdentifier(), tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> language, WebExtensionTab::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsDetectLanguage(page.webPageProxyIdentifier(), tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> language, WebExtensionTab::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;
@@ -892,7 +892,7 @@ void WebExtensionAPITabs::detectLanguage(WebPage* page, double tabID, Ref<WebExt
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPITabs::toggleReaderMode(WebPage* page, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::toggleReaderMode(WebPage& page, double tabID, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/toggleReaderMode
 
@@ -900,7 +900,7 @@ void WebExtensionAPITabs::toggleReaderMode(WebPage* page, double tabID, Ref<WebE
     if (tabIdentifer && !isValid(tabIdentifer, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsToggleReaderMode(page->webPageProxyIdentifier(), tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebExtensionTab::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsToggleReaderMode(page.webPageProxyIdentifier(), tabIdentifer), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebExtensionTab::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;
@@ -910,7 +910,7 @@ void WebExtensionAPITabs::toggleReaderMode(WebPage* page, double tabID, Ref<WebE
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPITabs::captureVisibleTab(WebPage* page, double windowID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::captureVisibleTab(WebPage& page, double windowID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/captureVisibleTab
 
@@ -924,7 +924,7 @@ void WebExtensionAPITabs::captureVisibleTab(WebPage* page, double windowID, NSDi
     if (!parseCaptureVisibleTabOptions(options, imageFormat, imageQuality, @"options", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsCaptureVisibleTab(page->webPageProxyIdentifier(), windowIdentifier, imageFormat, imageQuality), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<URL> imageDataURL, WebExtensionTab::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsCaptureVisibleTab(page.webPageProxyIdentifier(), windowIdentifier, imageFormat, imageQuality), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<URL> imageDataURL, WebExtensionTab::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;
@@ -939,7 +939,7 @@ void WebExtensionAPITabs::captureVisibleTab(WebPage* page, double windowID, NSDi
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPITabs::sendMessage(WebFrame *frame, double tabID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPITabs::sendMessage(WebFrame& frame, double tabID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/sendMessage
 
@@ -959,10 +959,10 @@ void WebExtensionAPITabs::sendMessage(WebFrame *frame, double tabID, NSString *m
     WebExtensionMessageSenderParameters sender {
         extensionContext().uniqueIdentifier(),
         std::nullopt, // tabParameters
-        toWebExtensionFrameIdentifier(*frame),
-        frame->page()->webPageProxyIdentifier(),
+        toWebExtensionFrameIdentifier(frame),
+        frame.page()->webPageProxyIdentifier(),
         contentWorldType(),
-        frame->url(),
+        frame.url(),
     };
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsSendMessage(tabIdentifer.value(), messageJSON, targetFrameIdentifier, sender), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String> replyJSON, WebExtensionTab::Error error) {
@@ -980,7 +980,7 @@ void WebExtensionAPITabs::sendMessage(WebFrame *frame, double tabID, NSString *m
     }, extensionContext().identifier());
 }
 
-RefPtr<WebExtensionAPIPort> WebExtensionAPITabs::connect(WebFrame* frame, JSContextRef context, double tabID, NSDictionary *options, NSString **outExceptionString)
+RefPtr<WebExtensionAPIPort> WebExtensionAPITabs::connect(WebFrame& frame, JSContextRef context, double tabID, NSDictionary *options, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/connect
 
@@ -998,10 +998,10 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPITabs::connect(WebFrame* frame, JSCont
     WebExtensionMessageSenderParameters sender {
         extensionContext().uniqueIdentifier(),
         std::nullopt, // tabParameters
-        toWebExtensionFrameIdentifier(*frame),
-        frame->page()->webPageProxyIdentifier(),
+        toWebExtensionFrameIdentifier(frame),
+        frame.page()->webPageProxyIdentifier(),
         contentWorldType(),
-        frame->url(),
+        frame.url(),
     };
 
     auto port = WebExtensionAPIPort::create(forMainWorld(), runtime(), extensionContext(), WebExtensionContentWorldType::ContentScript, resolvedName, sender);
@@ -1017,7 +1017,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPITabs::connect(WebFrame* frame, JSCont
     return port;
 }
 
-void WebExtensionAPITabs::executeScript(WebPage *page, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler> && callback, NSString **outExceptionString)
+void WebExtensionAPITabs::executeScript(WebPage& page, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler> && callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript
 
@@ -1029,7 +1029,7 @@ void WebExtensionAPITabs::executeScript(WebPage *page, double tabID, NSDictionar
     if (options && !parseScriptOptions(options, parameters, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsExecuteScript(page->webPageProxyIdentifier(), tabIdentifier, parameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<Vector<WebKit::WebExtensionScriptInjectionResultParameters>> results, WebExtensionTab::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsExecuteScript(page.webPageProxyIdentifier(), tabIdentifier, parameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<Vector<WebKit::WebExtensionScriptInjectionResultParameters>> results, WebExtensionTab::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;
@@ -1039,7 +1039,7 @@ void WebExtensionAPITabs::executeScript(WebPage *page, double tabID, NSDictionar
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::insertCSS(WebPage *page, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler> && callback, NSString **outExceptionString)
+void WebExtensionAPITabs::insertCSS(WebPage& page, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler> && callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/insertCSS
 
@@ -1051,7 +1051,7 @@ void WebExtensionAPITabs::insertCSS(WebPage *page, double tabID, NSDictionary *o
     if (options && !parseScriptOptions(options, parameters, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsInsertCSS(page->webPageProxyIdentifier(), tabIdentifier, parameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebExtensionTab::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsInsertCSS(page.webPageProxyIdentifier(), tabIdentifier, parameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebExtensionTab::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;
@@ -1061,7 +1061,7 @@ void WebExtensionAPITabs::insertCSS(WebPage *page, double tabID, NSDictionary *o
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPITabs::removeCSS(WebPage *page, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler> && callback, NSString **outExceptionString)
+void WebExtensionAPITabs::removeCSS(WebPage& page, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler> && callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/removeCSS
 
@@ -1073,7 +1073,7 @@ void WebExtensionAPITabs::removeCSS(WebPage *page, double tabID, NSDictionary *o
     if (options && !parseScriptOptions(options, parameters, outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsRemoveCSS(page->webPageProxyIdentifier(), tabIdentifier, parameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebExtensionTab::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsRemoveCSS(page.webPageProxyIdentifier(), tabIdentifier, parameters), [protectedThis = Ref { *this }, callback = WTFMove(callback)](WebExtensionTab::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
@@ -72,7 +72,7 @@ static NSArray<NSDictionary *> *toWebAPI(Vector<WebExtensionFrameParameters> all
     }).get();
 }
 
-void WebExtensionAPIWebNavigation::getAllFrames(WebPage* webPage, NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIWebNavigation::getAllFrames(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/getAllFrames
 
@@ -99,7 +99,7 @@ void WebExtensionAPIWebNavigation::getAllFrames(WebPage* webPage, NSDictionary *
     }, extensionContext().identifier());
 }
 
-void WebExtensionAPIWebNavigation::getFrame(WebPage* webPage, NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIWebNavigation::getFrame(NSDictionary *details, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/getFrame
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm
@@ -54,10 +54,8 @@ void WebExtensionAPIWebNavigationEvent::invokeListenersWithArgument(id argument,
     }
 }
 
-void WebExtensionAPIWebNavigationEvent::addListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener, NSDictionary *filter, NSString **outExceptionString)
+void WebExtensionAPIWebNavigationEvent::addListener(WebPage& page, RefPtr<WebExtensionCallbackHandler> listener, NSDictionary *filter, NSString **outExceptionString)
 {
-    ASSERT(page);
-
     _WKWebExtensionWebNavigationURLFilter *parsedFilter;
     if (filter) {
         parsedFilter = [[_WKWebExtensionWebNavigationURLFilter alloc] initWithDictionary:filter outErrorMessage:outExceptionString];
@@ -65,16 +63,14 @@ void WebExtensionAPIWebNavigationEvent::addListener(WebPage* page, RefPtr<WebExt
             return;
     }
 
-    m_pageProxyIdentifier = page->webPageProxyIdentifier();
+    m_pageProxyIdentifier = page.webPageProxyIdentifier();
     m_listeners.append({ listener, parsedFilter });
 
     WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(m_pageProxyIdentifier, m_type, contentWorldType()), extensionContext().identifier());
 }
 
-void WebExtensionAPIWebNavigationEvent::removeListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener)
+void WebExtensionAPIWebNavigationEvent::removeListener(WebPage& page, RefPtr<WebExtensionCallbackHandler> listener)
 {
-    ASSERT(page);
-
     auto removedCount = m_listeners.removeAllMatching([&](auto& entry) {
         return entry.first->callbackFunction() == listener->callbackFunction();
     });
@@ -82,7 +78,7 @@ void WebExtensionAPIWebNavigationEvent::removeListener(WebPage* page, RefPtr<Web
     if (!removedCount)
         return;
 
-    ASSERT(page->webPageProxyIdentifier() == m_pageProxyIdentifier);
+    ASSERT(page.webPageProxyIdentifier() == m_pageProxyIdentifier);
 
     WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(m_pageProxyIdentifier, m_type, contentWorldType(), removedCount), extensionContext().identifier());
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm
@@ -60,10 +60,8 @@ void WebExtensionAPIWebRequestEvent::invokeListenersWithArgument(NSDictionary *a
     }
 }
 
-void WebExtensionAPIWebRequestEvent::addListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener, NSDictionary *filter, id extraInfoSpec, NSString **outExceptionString)
+void WebExtensionAPIWebRequestEvent::addListener(WebPage& page, RefPtr<WebExtensionCallbackHandler> listener, NSDictionary *filter, id extraInfoSpec, NSString **outExceptionString)
 {
-    ASSERT(page);
-
     _WKWebExtensionWebRequestFilter *parsedFilter;
     if (filter) {
         parsedFilter = [[_WKWebExtensionWebRequestFilter alloc] initWithDictionary:filter outErrorMessage:outExceptionString];
@@ -71,16 +69,14 @@ void WebExtensionAPIWebRequestEvent::addListener(WebPage* page, RefPtr<WebExtens
             return;
     }
 
-    m_pageProxyIdentifier = page->webPageProxyIdentifier();
+    m_pageProxyIdentifier = page.webPageProxyIdentifier();
     m_listeners.append({ listener, parsedFilter });
 
     WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(m_pageProxyIdentifier, m_type, contentWorldType()), extensionContext().identifier());
 }
 
-void WebExtensionAPIWebRequestEvent::removeListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener)
+void WebExtensionAPIWebRequestEvent::removeListener(WebPage& page, RefPtr<WebExtensionCallbackHandler> listener)
 {
-    ASSERT(page);
-
     auto removedCount = m_listeners.removeAllMatching([&](auto& entry) {
         return entry.first->callbackFunction() == listener->callbackFunction();
     });
@@ -88,7 +84,7 @@ void WebExtensionAPIWebRequestEvent::removeListener(WebPage* page, RefPtr<WebExt
     if (!removedCount)
         return;
 
-    ASSERT(page->webPageProxyIdentifier() == m_pageProxyIdentifier);
+    ASSERT(page.webPageProxyIdentifier() == m_pageProxyIdentifier);
 
     WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(m_pageProxyIdentifier, m_type, contentWorldType(), removedCount), extensionContext().identifier());
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -410,7 +410,7 @@ void WebExtensionAPIWindows::createWindow(NSDictionary *data, Ref<WebExtensionCa
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPIWindows::get(WebPage* page, double windowID, NSDictionary *info, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIWindows::get(WebPage& page, double windowID, NSDictionary *info, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/get
 
@@ -423,7 +423,7 @@ void WebExtensionAPIWindows::get(WebPage* page, double windowID, NSDictionary *i
     if (!parseWindowGetOptions(info, populate, filter, @"info", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGet(page->webPageProxyIdentifier(), windowIdentifer.value(), filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionWindowParameters> windowParameters, WebExtensionWindow::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGet(page.webPageProxyIdentifier(), windowIdentifer.value(), filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionWindowParameters> windowParameters, WebExtensionWindow::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;
@@ -438,7 +438,7 @@ void WebExtensionAPIWindows::get(WebPage* page, double windowID, NSDictionary *i
     }, extensionContext().identifier().toUInt64());
 }
 
-void WebExtensionAPIWindows::getCurrent(WebPage* page, NSDictionary *info, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
+void WebExtensionAPIWindows::getCurrent(WebPage& page, NSDictionary *info, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/windows/getCurrent
 
@@ -447,7 +447,7 @@ void WebExtensionAPIWindows::getCurrent(WebPage* page, NSDictionary *info, Ref<W
     if (!parseWindowGetOptions(info, populate, filter, @"info", outExceptionString))
         return;
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGet(page->webPageProxyIdentifier(), WebExtensionWindowConstants::CurrentIdentifier, filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionWindowParameters> windowParameters, WebExtensionWindow::Error error) {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::WindowsGet(page.webPageProxyIdentifier(), WebExtensionWindowConstants::CurrentIdentifier, filter, populate), [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<WebExtensionWindowParameters> windowParameters, WebExtensionWindow::Error error) {
         if (error) {
             callback->reportError(error.value());
             return;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm
@@ -55,27 +55,20 @@ void WebExtensionAPIWindowsEvent::invokeListenersWithArgument(id argument, Optio
     }
 }
 
-void WebExtensionAPIWindowsEvent::addListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener, NSDictionary *filter, NSString **outExceptionString)
+void WebExtensionAPIWindowsEvent::addListener(WebPage& page, RefPtr<WebExtensionCallbackHandler> listener, NSDictionary *filter, NSString **outExceptionString)
 {
-    ASSERT(page);
-
     OptionSet<WindowTypeFilter> windowTypeFilter;
     if (!WebExtensionAPIWindows::parseWindowTypesFilter(filter, windowTypeFilter, @"filters", outExceptionString))
         return;
 
-    m_pageProxyIdentifier = page->webPageProxyIdentifier();
+    m_pageProxyIdentifier = page.webPageProxyIdentifier();
     m_listeners.append({ listener, windowTypeFilter });
-
-    if (!page)
-        return;
 
     WebProcess::singleton().send(Messages::WebExtensionContext::AddListener(m_pageProxyIdentifier, m_type, contentWorldType()), extensionContext().identifier());
 }
 
-void WebExtensionAPIWindowsEvent::removeListener(WebPage* page, RefPtr<WebExtensionCallbackHandler> listener)
+void WebExtensionAPIWindowsEvent::removeListener(WebPage& page, RefPtr<WebExtensionCallbackHandler> listener)
 {
-    ASSERT(page);
-
     auto removedCount = m_listeners.removeAllMatching([&](auto& entry) {
         return entry.first->callbackFunction() == listener->callbackFunction();
     });
@@ -83,7 +76,7 @@ void WebExtensionAPIWindowsEvent::removeListener(WebPage* page, RefPtr<WebExtens
     if (!removedCount)
         return;
 
-    ASSERT(page->webPageProxyIdentifier() == m_pageProxyIdentifier);
+    ASSERT(page.webPageProxyIdentifier() == m_pageProxyIdentifier);
 
     WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(m_pageProxyIdentifier, m_type, contentWorldType(), removedCount), extensionContext().identifier());
 }

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h
@@ -58,7 +58,7 @@ public:
 
     void getPopup(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void setPopup(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void openPopup(WebPage*, NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void openPopup(WebPage&, NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     WebExtensionAPIEvent& onClicked();
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
@@ -50,8 +50,8 @@ public:
 
     const ListenerVector& listeners() const { return m_listeners; }
 
-    void addListener(WebPage*, RefPtr<WebExtensionCallbackHandler>);
-    void removeListener(WebPage*, RefPtr<WebExtensionCallbackHandler>);
+    void addListener(WebPage&, RefPtr<WebExtensionCallbackHandler>);
+    void removeListener(WebPage&, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
     void removeAllListeners();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIExtension.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIExtension.h
@@ -49,7 +49,7 @@ public:
 #if PLATFORM(COCOA)
     bool isPropertyAllowed(ASCIILiteral propertyName, WebPage*);
 
-    bool isInIncognitoContext(WebPage*);
+    bool isInIncognitoContext(WebPage&);
     void isAllowedFileSchemeAccess(Ref<WebExtensionCallbackHandler>&&);
     void isAllowedIncognitoAccess(Ref<WebExtensionCallbackHandler>&&);
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h
@@ -44,8 +44,8 @@ public:
 #if PLATFORM(COCOA)
     using ClickHandlerMap = HashMap<String, Ref<WebExtensionCallbackHandler>>;
 
-    id createMenu(WebPage*, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void update(WebPage*, id identifier, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    id createMenu(WebPage&, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void update(WebPage&, id identifier, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     void remove(id identifier, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void removeAll(Ref<WebExtensionCallbackHandler>&&);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
@@ -51,7 +51,7 @@ public:
     WebExtensionContentWorldType targetContentWorldType() const { return m_targetContentWorldType; }
     WebExtensionPortChannelIdentifier channelIdentifier() const { return m_channelIdentifier; }
 
-    void postMessage(WebFrame*, NSString *, NSString **outExceptionString);
+    void postMessage(WebFrame&, NSString *, NSString **outExceptionString);
     void disconnect();
 
     bool disconnected() const { return m_disconnected; }

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
@@ -79,11 +79,11 @@ public:
 
     JSValue *lastError();
 
-    void sendMessage(WebFrame*, NSString *extensionID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    RefPtr<WebExtensionAPIPort> connect(WebFrame*, JSContextRef, NSString *extensionID, NSDictionary *options, NSString **outExceptionString);
+    void sendMessage(WebFrame&, NSString *extensionID, NSString *messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    RefPtr<WebExtensionAPIPort> connect(WebFrame&, JSContextRef, NSString *extensionID, NSDictionary *options, NSString **outExceptionString);
 
-    void sendNativeMessage(WebFrame*, NSString *applicationID, NSString *messageJSON, Ref<WebExtensionCallbackHandler>&&);
-    RefPtr<WebExtensionAPIPort> connectNative(WebFrame*, JSContextRef, NSString *applicationID);
+    void sendNativeMessage(WebFrame&, NSString *applicationID, NSString *messageJSON, Ref<WebExtensionCallbackHandler>&&);
+    RefPtr<WebExtensionAPIPort> connectNative(WebFrame&, JSContextRef, NSString *applicationID);
 
     WebExtensionAPIEvent& onConnect();
     WebExtensionAPIEvent& onInstalled();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
@@ -42,16 +42,16 @@ public:
 #if PLATFORM(COCOA)
     bool isPropertyAllowed(ASCIILiteral propertyName, WebPage*);
 
-    void get(WebPage*, id items, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void getBytesInUse(WebPage*, id keys, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void set(WebPage*, NSDictionary *items, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void remove(WebPage*, id keys, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void clear(WebPage*, Ref<WebExtensionCallbackHandler>&&);
+    void get(WebPage&, id items, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getBytesInUse(WebPage&, id keys, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void set(WebPage&, NSDictionary *items, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void remove(WebPage&, id keys, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void clear(WebPage&, Ref<WebExtensionCallbackHandler>&&);
 
     double quotaBytes();
 
     // Exposed only by storage.session.
-    void setAccessLevel(WebPage*, NSDictionary * , Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void setAccessLevel(WebPage&, NSDictionary *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     // Exposed only by storage.sync.
     double quotaBytesPerItem();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
@@ -50,35 +50,35 @@ public:
 #if PLATFORM(COCOA)
     bool isPropertyAllowed(ASCIILiteral propertyName, WebPage*);
 
-    void createTab(WebPage*, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void createTab(WebPage&, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void query(WebPage*, NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void query(WebPage&, NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     void get(double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void getCurrent(WebPage*, Ref<WebExtensionCallbackHandler>&&);
-    void getSelected(WebPage*, double windowID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getCurrent(WebPage&, Ref<WebExtensionCallbackHandler>&&);
+    void getSelected(WebPage&, double windowID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     void duplicate(double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void update(WebPage*, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void update(WebPage&, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void remove(NSObject *tabIDs, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void reload(WebPage*, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void goBack(WebPage*, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void goForward(WebPage*, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void reload(WebPage&, double tabID, NSDictionary *properties, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void goBack(WebPage&, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void goForward(WebPage&, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void getZoom(WebPage*, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void setZoom(WebPage*, double tabID, double zoomFactor, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getZoom(WebPage&, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void setZoom(WebPage&, double tabID, double zoomFactor, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void detectLanguage(WebPage*, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void toggleReaderMode(WebPage*, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void captureVisibleTab(WebPage*, double windowID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void detectLanguage(WebPage&, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void toggleReaderMode(WebPage&, double tabID, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void captureVisibleTab(WebPage&, double windowID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void sendMessage(WebFrame*, double tabID, NSString *message, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    RefPtr<WebExtensionAPIPort> connect(WebFrame*, JSContextRef, double tabID, NSDictionary *options, NSString **outExceptionString);
+    void sendMessage(WebFrame&, double tabID, NSString *message, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    RefPtr<WebExtensionAPIPort> connect(WebFrame&, JSContextRef, double tabID, NSDictionary *options, NSString **outExceptionString);
 
-    void executeScript(WebPage*, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void insertCSS(WebPage*, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void removeCSS(WebPage*, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void executeScript(WebPage&, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void insertCSS(WebPage&, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void removeCSS(WebPage&, double tabID, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     double tabIdentifierNone() const { return -1; }
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigation.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigation.h
@@ -46,8 +46,8 @@ public:
     WebExtensionAPIWebNavigationEvent& onCompleted();
     WebExtensionAPIWebNavigationEvent& onErrorOccurred();
 
-    void getAllFrames(WebPage*, NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void getFrame(WebPage*, NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getAllFrames(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getFrame(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
 private:
     RefPtr<WebExtensionAPIWebNavigationEvent> m_onBeforeNavigateEvent;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
@@ -52,8 +52,8 @@ public:
 
     const ListenerVector& listeners() const { return m_listeners; }
 
-    void addListener(WebPage*, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, NSString **outExceptionString);
-    void removeListener(WebPage*, RefPtr<WebExtensionCallbackHandler>);
+    void addListener(WebPage&, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, NSString **outExceptionString);
+    void removeListener(WebPage&, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
     void removeAllListeners();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
@@ -50,8 +50,8 @@ public:
 
     const ListenerVector& listeners() const { return m_listeners; }
 
-    void addListener(WebPage*, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, id extraInfoSpec, NSString **outExceptionString);
-    void removeListener(WebPage*, RefPtr<WebExtensionCallbackHandler>);
+    void addListener(WebPage&, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, id extraInfoSpec, NSString **outExceptionString);
+    void removeListener(WebPage&, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
     void invokeListenersWithArgument(NSDictionary *argument, WebExtensionTabIdentifier, WebExtensionWindowIdentifier, const ResourceLoadInfo&);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h
@@ -52,8 +52,8 @@ public:
 
     void createWindow(NSDictionary *data, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void get(WebPage*, double windowID, NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
-    void getCurrent(WebPage*, NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void get(WebPage&, double windowID, NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void getCurrent(WebPage&, NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void getLastFocused(NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void getAll(NSDictionary *info, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
@@ -49,8 +49,8 @@ public:
 
     const ListenerVector& listeners() const { return m_listeners; }
 
-    void addListener(WebPage*, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, NSString **outExceptionString);
-    void removeListener(WebPage*, RefPtr<WebExtensionCallbackHandler>);
+    void addListener(WebPage&, RefPtr<WebExtensionCallbackHandler>, NSDictionary *filter, NSString **outExceptionString);
+    void removeListener(WebPage&, RefPtr<WebExtensionCallbackHandler>);
     bool hasListener(RefPtr<WebExtensionCallbackHandler>);
 
     void removeAllListeners();

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigation.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigation.idl
@@ -26,7 +26,6 @@
 [
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,
-    NeedsPageWithCallbackHandler,
     ReturnsPromiseWhenCallbackIsOmitted,
 ] interface WebExtensionAPIWebNavigation {
 

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequest.idl
@@ -26,7 +26,6 @@
 [
     Conditional=WK_WEB_EXTENSIONS,
     MainWorldOnly,
-    NeedsPageWithCallbackHandler,
     ReturnsPromiseWhenCallbackIsOmitted,
 ] interface WebExtensionAPIWebRequest {
 


### PR DESCRIPTION
#### 8dabe5207fb4cd442388423dc0aa823e34b3a4a9
<pre>
Crash when closing page while extension is waiting on storage callback.
<a href="https://webkit.org/b/268767">https://webkit.org/b/268767</a>
<a href="https://rdar.apple.com/problem/122328331">rdar://problem/122328331</a>

Reviewed by Brian Weinstein.

Teach the Web Extension code generator to pass references for the page and frame
to the implementation after null checking them. This avoids all the clients needing
to check, and makes the implementations safer. Log an error if they are null, and
return undefined to JavaScript. An exception would not be useful here, since the
page is being destroyed already.

Also use RefPtr for the impl, page, and frame pointers so the lifetime is guaranteed
for the current call duration.

Also stop setting ObjC types to nil by default, since the generated code is ARC.
Do similar for RefPtr types, since they also default to nullptr.

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm:
(WebKit::WebExtensionAPIAction::openPopup):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIEventCocoa.mm:
(WebKit::WebExtensionAPIEvent::addListener):
(WebKit::WebExtensionAPIEvent::removeListener):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm:
(WebKit::WebExtensionAPIExtension::isInIncognitoContext):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::WebExtensionAPIMenus::createMenu):
(WebKit::WebExtensionAPIMenus::update):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPortCocoa.mm:
(WebKit::WebExtensionAPIPort::postMessage):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::getFrameId):
(WebKit::WebExtensionAPIRuntime::sendMessage):
(WebKit::WebExtensionAPIRuntime::connect):
(WebKit::WebExtensionAPIRuntime::sendNativeMessage):
(WebKit::WebExtensionAPIRuntime::connectNative):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::get):
(WebKit::WebExtensionAPIStorageArea::getBytesInUse):
(WebKit::WebExtensionAPIStorageArea::set):
(WebKit::WebExtensionAPIStorageArea::remove):
(WebKit::WebExtensionAPIStorageArea::clear):
(WebKit::WebExtensionAPIStorageArea::setAccessLevel):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::createTab):
(WebKit::WebExtensionAPITabs::query):
(WebKit::WebExtensionAPITabs::getCurrent):
(WebKit::WebExtensionAPITabs::getSelected):
(WebKit::WebExtensionAPITabs::update):
(WebKit::WebExtensionAPITabs::reload):
(WebKit::WebExtensionAPITabs::goBack):
(WebKit::WebExtensionAPITabs::goForward):
(WebKit::WebExtensionAPITabs::getZoom):
(WebKit::WebExtensionAPITabs::setZoom):
(WebKit::WebExtensionAPITabs::detectLanguage):
(WebKit::WebExtensionAPITabs::toggleReaderMode):
(WebKit::WebExtensionAPITabs::captureVisibleTab):
(WebKit::WebExtensionAPITabs::sendMessage):
(WebKit::WebExtensionAPITabs::connect):
(WebKit::WebExtensionAPITabs::executeScript):
(WebKit::WebExtensionAPITabs::insertCSS):
(WebKit::WebExtensionAPITabs::removeCSS):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm:
(WebKit::WebExtensionAPIWebNavigation::getAllFrames):
(WebKit::WebExtensionAPIWebNavigation::getFrame):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationEventCocoa.mm:
(WebKit::WebExtensionAPIWebNavigationEvent::addListener):
(WebKit::WebExtensionAPIWebNavigationEvent::removeListener):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestEventCocoa.mm:
(WebKit::WebExtensionAPIWebRequestEvent::addListener):
(WebKit::WebExtensionAPIWebRequestEvent::removeListener):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::WebExtensionAPIWindows::get):
(WebKit::WebExtensionAPIWindows::getCurrent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm:
(WebKit::WebExtensionAPIWindowsEvent::addListener):
(WebKit::WebExtensionAPIWindowsEvent::removeListener):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIExtension.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigation.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h:
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateImplementationFile):
(_platformTypeVariableDeclaration):
(_dynamicAttributesImplementation):
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebNavigation.idl:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIWebRequest.idl:

Canonical link: <a href="https://commits.webkit.org/274114@main">https://commits.webkit.org/274114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7af7130b29f74034c16e515a2abf3e36006b0b28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/37964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16871 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/40219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40509 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33773 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19569 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/14174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/38537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/14215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/40219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12410 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/40219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41782 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/34441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/40219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/12947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/14174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/36413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/40219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4921 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/13967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->