### PR TITLE
Port DataDetectorElementInfo to the new IPC serialization format

### DIFF
--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
@@ -217,30 +217,6 @@ std::optional<WebCore::FontPlatformData> ArgumentCoder<WebCore::Font>::decodePla
     return WebCore::FontPlatformData(ctFont.get(), *size, *syntheticBold, *syntheticOblique, *orientation, *widthVariant, *textRenderingMode);
 }
 
-#if ENABLE(DATA_DETECTION)
-
-void ArgumentCoder<WebCore::DataDetectorElementInfo>::encode(Encoder& encoder, const WebCore::DataDetectorElementInfo& info)
-{
-    encoder << info.result.get();
-    encoder << info.elementBounds;
-}
-
-std::optional<WebCore::DataDetectorElementInfo> ArgumentCoder<WebCore::DataDetectorElementInfo>::decode(Decoder& decoder)
-{
-    auto result = decoder.decodeWithAllowedClasses<DDScannerResult>();
-    if (!result)
-        return std::nullopt;
-
-    std::optional<WebCore::IntRect> elementBounds;
-    decoder >> elementBounds;
-    if (!elementBounds)
-        return std::nullopt;
-
-    return std::make_optional<WebCore::DataDetectorElementInfo>({ WTFMove(*result), WTFMove(*elementBounds) });
-}
-
-#endif // ENABLE(DATA_DETECTION)
-
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 
 void ArgumentCoder<WebCore::MediaPlaybackTargetContext>::encodePlatformData(Encoder& encoder, const WebCore::MediaPlaybackTargetContext& target)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -193,15 +193,6 @@ template<> struct ArgumentCoder<WebCore::FragmentedSharedBuffer> {
     static std::optional<Ref<WebCore::FragmentedSharedBuffer>> decode(Decoder&);
 };
 
-#if ENABLE(DATA_DETECTION)
-
-template<> struct ArgumentCoder<WebCore::DataDetectorElementInfo> {
-    static void encode(Encoder&, const WebCore::DataDetectorElementInfo&);
-    static std::optional<WebCore::DataDetectorElementInfo> decode(Decoder&);
-};
-
-#endif
-
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
 
 template<> struct ArgumentCoder<RetainPtr<VKCImageAnalysis>> {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7601,6 +7601,14 @@ header: <WebCore/ShareableBitmap.h>
     std::optional<WebCore::ShareableBitmapHandle> createReadOnlyHandle()
 }
 
+#if ENABLE(DATA_DETECTION)
+header: <WebCore/DataDetectorElementInfo.h>
+struct WebCore::DataDetectorElementInfo {
+    RetainPtr<DDScannerResult> result;
+    WebCore::IntRect elementBounds;
+};
+#endif
+
 header: <WebCore/FEComposite.h>
 enum class WebCore::CompositeOperationType : uint8_t {
     FECOMPOSITE_OPERATOR_UNKNOWN,


### PR DESCRIPTION
#### f6d6324f11bc1260c6f174d8c0e178f140226267
<pre>
Port DataDetectorElementInfo to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=268773">https://bugs.webkit.org/show_bug.cgi?id=268773</a>

Reviewed by David Kilzer.

* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::ArgumentCoder&lt;WebCore::DataDetectorElementInfo&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::DataDetectorElementInfo&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/274153@main">https://commits.webkit.org/274153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fa7084100bff8d4f9e2edf16a43a71b92a3163d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40484 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33757 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32079 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12391 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12348 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41757 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34424 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38211 "Found 1 new test failure: media/track/media-element-enqueue-event-crash.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10572 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36395 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14504 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13361 "Built successfully") | | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4945 "Build is being retried. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Checked out pull request; Reviewed by David Kilzer; Canonicalized commit; Pushed commit to WebKit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13956 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->