### PR TITLE
Document markers sometimes get erroneously removed on earlier words when removing text in a later part of the sentence

### DIFF
--- a/LayoutTests/editing/spelling/document-markers-remain-after-removing-text-expected.txt
+++ b/LayoutTests/editing/spelling/document-markers-remain-after-removing-text-expected.txt
@@ -1,0 +1,2 @@
+PASS internals.hasSpellingMarker(0, 4) is true
+aaaa bbbb dddd 

--- a/LayoutTests/editing/spelling/document-markers-remain-after-removing-text.html
+++ b/LayoutTests/editing/spelling/document-markers-remain-after-removing-text.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html><!-- webkit-test-runner [ spellCheckingDots=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+
+<body>
+<div id="editor" contenteditable="true"></div>
+<script>
+
+const incorrectPhrase = "aaaa bbbb cccc dddd";
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+if (window.internals)
+    internals.setContinuousSpellCheckingEnabled(true);
+
+function runTest()
+{
+    var editor = document.getElementById("editor");
+    editor.focus();
+
+    document.execCommand("InsertText", false, incorrectPhrase);
+
+    // Add a word separator so that both spelling and grammar markers will appear.
+    document.execCommand("InsertText", false, " ");
+
+    const first = editor.childNodes[0];
+    const range = document.createRange();
+    range.setStart(first, 9);
+    range.setEnd(first, 14);
+
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    testRunner.execCommand("DeleteBackward");
+
+    shouldBe("internals.hasSpellingMarker(0, 4)", "true");
+
+    editor.blur();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+UIHelper.setSpellCheckerResults({
+    "aaaa bbbb cccc dddd\u00A0" : [
+        { type : "spelling", from : 0, to : 4 },
+    ]
+}).then(runTest);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -644,13 +644,19 @@ void DocumentMarkerController::shiftMarkers(Node& node, unsigned startOffset, in
         // FIXME: No obvious reason this should be iOS-specific. Remove the #if at some point.
         auto targetStartOffset = clampTo<unsigned>(static_cast<int>(marker.startOffset()) + delta);
         auto targetEndOffset = clampTo<unsigned>(static_cast<int>(marker.endOffset()) + delta);
-        if (targetStartOffset >= node.length() || targetEndOffset <= 0) {
-            list->remove(i);
-            continue;
-        }
 #endif
 
         if (marker.startOffset() >= startOffset) {
+            // There is no need to adjust or remove the marker if it's before the start of the
+            // text being removed.
+
+#if PLATFORM(IOS_FAMILY)
+            if (targetStartOffset >= node.length() || targetEndOffset <= 0) {
+                list->remove(i);
+                continue;
+            }
+#endif
+
             ASSERT((int)marker.startOffset() + delta >= 0);
             marker.shiftOffsets(delta);
             didShiftMarker = true;


### PR DESCRIPTION
#### 8e1031fc9a3ad0d3705c50866a49a019e7370363
<pre>
Document markers sometimes get erroneously removed on earlier words when removing text in a later part of the sentence
<a href="https://bugs.webkit.org/show_bug.cgi?id=268778">https://bugs.webkit.org/show_bug.cgi?id=268778</a>
<a href="https://rdar.apple.com/122336557">rdar://122336557</a>

Reviewed by Megan Gardner and Aditya Keerthi.

When a text node (for example, &quot;AAAA BBBB CCCC&quot;) has a document marker on it (for example, a spelling
marker on &quot;AAAA&quot;), and some text is then removed from it (like &quot;CCCC&quot;), the document marker will get
removed accidentally.

This is because the logic in `shiftMarkers` does not guard against markers that occur in the prior
part of the text, which should just be completely ignored and not removed or shifted, since they
would not be affected by the removal of later text.

Fix by checking for such a case and not removing the marker in that case.

* LayoutTests/editing/spelling/document-markers-remain-after-removing-text.html: Added.
* LayoutTests/platform/ios-simulator/editing/spelling/document-markers-remain-after-removing-text-expected.txt: Added.
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::shiftMarkers):

Canonical link: <a href="https://commits.webkit.org/274129@main">https://commits.webkit.org/274129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/115415633a4b16d121659dd41603d64d984747fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40560 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33815 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39767 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14232 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14284 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12453 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12401 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34007 "Build is being retried. Recent messages:OS: Monterey (12.6.8), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 4 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41835 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34490 "Build is being retried. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (warnings)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38263 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12990 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10635 "Build is being retried. Recent messages:OS: Sonoma (14.1), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 4 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36458 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/33345 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8523 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13409 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->