### PR TITLE
text-wrap: balance, prefering longer lines at the beginning of block

### DIFF
--- a/LayoutTests/fast/text/whitespace/text-wrap-balance-shape-expected.html
+++ b/LayoutTests/fast/text/whitespace/text-wrap-balance-shape-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#valdef-text-wrap-balance">
+<!-- This tests that we prefer to accumulate longer lines at the beginning of the block, rather than at the end.
+Since specification (see href) doesn't dictates the shape itself, this should not be a general web-platform test, since other UAs might prefer to shape it on a different way. -->
+<style>
+.container {
+  font-family: monospace;
+  font-size: 20px;
+  width: 20ch;
+}
+</style>
+<div class="container">
+  123 567 901 345 789
+  123 567 901 345 789
+  123 123 567 901<br>
+  345 789 123 567<br>
+  901 345 789 123
+</div>

--- a/LayoutTests/fast/text/whitespace/text-wrap-balance-shape.html
+++ b/LayoutTests/fast/text/whitespace/text-wrap-balance-shape.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#valdef-text-wrap-balance">
+<!-- This tests that we prefer to accumulate longer lines at the beginning of the block, rather than at the end.
+Since specification (see href) doesn't dictates the shape itself, this should not be a general web-platform test, since other UAs might prefer to shape it on a different way. -->
+<style>
+.container {
+  font-family: monospace;
+  font-size: 20px;
+  width: 20ch;
+  text-wrap: balance;
+}
+</style>
+<div class="container">
+  123 567 901 345 789
+  123 567 901 345 789 123
+  123 567 901 345 789
+  123 567 901 345 789
+  123
+</div>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp
@@ -29,6 +29,7 @@
 #include "InlineLineBuilder.h"
 #include "RenderStyleInlines.h"
 #include <limits>
+#include <wtf/MathExtras.h>
 
 namespace WebCore {
 namespace Layout {
@@ -292,7 +293,8 @@ std::optional<Vector<LayoutUnit>> InlineContentBalancer::balanceRangeWithLineReq
             // Compute the cost of this line based on the line index
             for (size_t lineIndex = 1; lineIndex <= numberOfLines; lineIndex++) {
                 auto accumulatedCost = candidateLineCost + state[startIndex][lineIndex - 1].accumulatedCost;
-                if (accumulatedCost < state[breakIndex][lineIndex].accumulatedCost) {
+                auto currentAccumulatedCost = state[breakIndex][lineIndex].accumulatedCost;
+                if (accumulatedCost < currentAccumulatedCost || WTF::areEssentiallyEqual(accumulatedCost, currentAccumulatedCost)) {
                     state[breakIndex][lineIndex].accumulatedCost = accumulatedCost;
                     state[breakIndex][lineIndex].previousBreakIndex = startIndex;
                 }


### PR DESCRIPTION
#### 1be1a3ffb5a581913100e29d6296db6c8a7d8899
<pre>
text-wrap: balance, prefering longer lines at the beginning of block
<a href="https://bugs.webkit.org/show_bug.cgi?id=268780">https://bugs.webkit.org/show_bug.cgi?id=268780</a>
<a href="https://rdar.apple.com/122338948">rdar://122338948</a>

Reviewed by Alan Baradlay.

When balancing, there are different results that produce the same score,
i.e.: the overall deviation to the ideal line is the same for different
layout configurations. The current implementation prefers to keep longer
lines at the end of the block, rather than at the beginning. Although
this is not a bug, since specification doesn&apos;t dictates the shape of
balancing, this might look a bit weird for some authors, as we are used
to the Greedy behavior of &quot;wrap&quot;, which will have a shorter line at the
end.

Also, other UAs prefers to have longer lines at the beginning, so, although
it is not a bug, it would make the feature less confusing for authors if we
would match the same behavior.

We are introducing a new test to track the behavior of WebKit shape, but since
this is not dictate by specification, this should not be WPT test.

* LayoutTests/fast/text/whitespace/text-wrap-balance-shape-expected.html: Added.
* LayoutTests/fast/text/whitespace/text-wrap-balance-shape.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp:
(WebCore::Layout::InlineContentBalancer::balanceRangeWithLineRequirement):

Canonical link: <a href="https://commits.webkit.org/274125@main">https://commits.webkit.org/274125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46ce01a4e642ac71c444e9ebc22ff1d1fba88e63

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40541 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33802 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39631 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14211 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14248 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12442 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/34001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41815 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34472 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38254 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12976 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10618 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36450 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14538 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/33332 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8520 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13397 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13990 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->