### PR TITLE
Fix media/video-ended-does-not-hold-sleep-assertion.html iOS layout test crash

### DIFF
--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
@@ -54,7 +54,7 @@ public:
     void wirelessVideoPlaybackDisabledChanged(bool) override;
     void mutedChanged(bool) override;
     void volumeChanged(double) override;
-    void invalidate();
+    void invalidate() override;
 
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const override;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
@@ -87,7 +87,12 @@ WebAVPlayerController *PlaybackSessionInterfaceAVKit::playerController() const
 
 void PlaybackSessionInterfaceAVKit::invalidate()
 {
+    if (!m_playbackSessionModel)
+        return;
+
     [m_playerController setDelegate:nullptr];
+    m_playbackSessionModel->removeClient(*this);
+    m_playbackSessionModel = nullptr;
 }
 
 void PlaybackSessionInterfaceAVKit::durationChanged(double duration)

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
@@ -69,7 +69,7 @@ public:
     void volumeChanged(double) override = 0;
     void modelDestroyed() override;
 
-    void invalidate();
+    virtual void invalidate() = 0;
 
 #if !RELEASE_LOG_DISABLED
     const void* logIdentifier() const;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm
@@ -50,17 +50,7 @@ PlaybackSessionInterfaceIOS::PlaybackSessionInterfaceIOS(PlaybackSessionModel& m
 
 PlaybackSessionInterfaceIOS::~PlaybackSessionInterfaceIOS()
 {
-    ASSERT(isUIThread());
-    invalidate();
-}
 
-void PlaybackSessionInterfaceIOS::invalidate()
-{
-    if (!m_playbackSessionModel)
-        return;
-
-    m_playbackSessionModel->removeClient(*this);
-    m_playbackSessionModel = nullptr;
 }
 
 PlaybackSessionModel* PlaybackSessionInterfaceIOS::playbackSessionModel() const

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceLMK.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceLMK.h
@@ -48,7 +48,7 @@ public:
     void wirelessVideoPlaybackDisabledChanged(bool) override;
     void mutedChanged(bool) override;
     void volumeChanged(double) override;
-
+    void invalidate() override;
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const override;
 #endif

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -128,6 +128,21 @@ void PlaybackSessionInterfaceLMK::volumeChanged(double)
 
 }
 
+void PlaybackSessionInterfaceLMK::~PlaybackSessionInterfaceLMK()
+{
+    ASSERT(isUIThread());
+    invalidate();
+}
+
+void PlaybackSessionInterfaceLMK::invalidate()
+{
+    if (!m_playbackSessionModel)
+        return;
+
+    m_playbackSessionModel->removeClient(*this);
+    m_playbackSessionModel = nullptr;
+}
+
 #if !RELEASE_LOG_DISABLED
 const char* PlaybackSessionInterfaceLMK::logClassName() const
 {


### PR DESCRIPTION
#### f8e706aae35a22a265f9f8b01a585400f46a748f
<pre>
Fix media/video-ended-does-not-hold-sleep-assertion.html iOS layout test crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=268782">https://bugs.webkit.org/show_bug.cgi?id=268782</a>
<a href="https://rdar.apple.com/122342671">rdar://122342671</a>

Reviewed by Eric Carlson.

Before, destruction logic for PlaybackSessionInterfaceAVKit/LMK was split up between
Their own destructors and the base class PlayBackSessionInterfaceIOS destructor. This
Patch moves all the logic to the derived classes to avoid a crash that was caused
By a virtual function being called indirectly from the base class&apos;s destructor.

* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm:
(WebCore::PlaybackSessionInterfaceAVKit::invalidate):
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm:
(WebCore::PlaybackSessionInterfaceIOS::~PlaybackSessionInterfaceIOS):
(WebCore::PlaybackSessionInterfaceIOS::invalidate): Deleted.
* Source/WebCore/platform/ios/PlaybackSessionInterfaceLMK.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceLMK.mm:
(WebCore::PlaybackSessionInterfaceLMK::~PlaybackSessionInterfaceLMK):
(WebCore::PlaybackSessionInterfaceLMK::invalidate):

Canonical link: <a href="https://commits.webkit.org/274158@main">https://commits.webkit.org/274158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/584ba5c947a8577a098159e86ee95d9ed424cdc8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40529 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33792 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39603 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14197 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32100 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12430 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41803 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34552 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38243 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36438 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14530 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8542 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13388 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13982 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->