### PR TITLE
ASSERT traversing frames under WebExtensionContext::webNavigationTraverseFrameTreeForFrame.

### DIFF
--- a/Source/WebKit/Shared/API/APIFrameHandle.h
+++ b/Source/WebKit/Shared/API/APIFrameHandle.h
@@ -37,10 +37,12 @@ public:
     {
         return adoptRef(*new FrameHandle(frameID, false));
     }
+
     static Ref<FrameHandle> createAutoconverting(WebCore::FrameIdentifier frameID)
     {
         return adoptRef(*new FrameHandle(frameID, true));
     }
+
     static Ref<FrameHandle> create(WebCore::FrameIdentifier frameID, bool autoconverting)
     {
         return adoptRef(*new FrameHandle(frameID, autoconverting));
@@ -50,6 +52,7 @@ public:
         : m_frameID(frameID)
         , m_isAutoconverting(isAutoconverting)
     {
+        ASSERT(m_frameID.object().isValid());
     }
 
     WebCore::FrameIdentifier frameID() const { return m_frameID; }

--- a/Source/WebKit/UIProcess/API/APIFrameInfo.cpp
+++ b/Source/WebKit/UIProcess/API/APIFrameInfo.cpp
@@ -41,7 +41,10 @@ Ref<FrameInfo> FrameInfo::create(WebKit::FrameInfoData&& frameInfoData, RefPtr<W
 
 FrameInfo::FrameInfo(WebKit::FrameInfoData&& data, RefPtr<WebKit::WebPageProxy>&& page)
     : m_data(WTFMove(data))
-    , m_page(WTFMove(page)) { }
+    , m_page(WTFMove(page))
+{
+    ASSERT(m_data.frameID.object().isValid());
+}
 
 FrameInfo::~FrameInfo() = default;
 

--- a/Source/WebKit/UIProcess/API/APIFrameTreeNode.h
+++ b/Source/WebKit/UIProcess/API/APIFrameTreeNode.h
@@ -48,7 +48,10 @@ public:
 private:
     FrameTreeNode(WebKit::FrameTreeNodeData&& data, WebKit::WebPageProxy& page)
         : m_data(WTFMove(data))
-        , m_page(page) { }
+        , m_page(page)
+    {
+        ASSERT(m_data.info.frameID.object().isValid());
+    }
 
     const WebKit::FrameTreeNodeData m_data;
     Ref<WebKit::WebPageProxy> m_page;


### PR DESCRIPTION
#### 23ef211d3842b6d030c4f961ddf26a83a27b56ae
<pre>
ASSERT traversing frames under WebExtensionContext::webNavigationTraverseFrameTreeForFrame.
<a href="https://webkit.org/b/268775">https://webkit.org/b/268775</a>
<a href="https://rdar.apple.com/problem/122331877">rdar://problem/122331877</a>

Reviewed by Alex Christensen.

Add some more ASSERTs to try to catch where these bad frame identifiers are being introduced.

* Source/WebKit/Shared/API/APIFrameHandle.h:
* Source/WebKit/UIProcess/API/APIFrameInfo.cpp:
(API::FrameInfo::FrameInfo):
* Source/WebKit/UIProcess/API/APIFrameTreeNode.h:

Canonical link: <a href="https://commits.webkit.org/274152@main">https://commits.webkit.org/274152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7235351fe28898f654357b09b2befe07027ebba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40513 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33777 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32092 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12415 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12365 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41786 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34447 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38231 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36418 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14517 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13374 "Built successfully") | | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/4946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13969 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->