### PR TITLE
[git-webkit] Error message for git webkit commit for non existing issues could be improved.

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -214,6 +214,9 @@ class Tracker(GenericTracker):
             )
             if response.status_code // 100 == 4 and self._logins_left:
                 self._logins_left -= 1
+                if response.json().get('code') == 101:
+                    sys.stderr.write("{}\n".format(response.json().get('message')))
+                    return None
             response = response.json().get('bugs', []) if response.status_code == 200 else None
             if response:
                 response = response[0]

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/commit.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/commit.py
@@ -85,7 +85,7 @@ class Commit(Command):
                 issue = Tracker.instance().issue(int(args.issue))
             else:
                 issue = Tracker.from_string(args.issue)
-            if not issue:
+            if not issue or not issue.title:
                 sys.stderr.write("'{}' cannot be converted to an issue\n".format(args.issue))
                 return 1
 


### PR DESCRIPTION
#### 68b27b7bcabb0a84f5380bfd7d99277960f872d9
<pre>
[git-webkit] Error message for git webkit commit for non existing issues could be improved.
<a href="https://rdar.apple.com/122151119">rdar://122151119</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=268134">https://bugs.webkit.org/show_bug.cgi?id=268134</a>

Reviewed by Jonathan Bedard.

Added reason for failure and cleaned up error.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.populate): If the bug does not exist, populate returns None and prints an error message. This should help future error handling as well.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/commit.py:
(Commit.main):

Canonical link: <a href="https://commits.webkit.org/274756@main">https://commits.webkit.org/274756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1972ec02c4db55b4b7d7792ed82657959ac97ef7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/37979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40524 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32097 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38552 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12425 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/37905 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12370 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/33985 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41797 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34454 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34495 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38239 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/12960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10601 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36428 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/38026 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14526 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8959 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13383 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/13978 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->