### PR TITLE
Crash in TIntermAggregate::getConstantValue() when mArguments is an empty std::vector

### DIFF
--- a/Source/ThirdParty/ANGLE/src/compiler/translator/IntermNode.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/IntermNode.cpp
@@ -839,12 +839,11 @@ bool TIntermAggregate::isConstantNullValue() const
 
 const TConstantUnion *TIntermAggregate::getConstantValue() const
 {
-    if (!hasConstantValue())
+    if (!hasConstantValue() || mArguments.empty())
     {
         return nullptr;
     }
     ASSERT(isConstructor());
-    ASSERT(mArguments.size() > 0u);
 
     TConstantUnion *constArray = nullptr;
     if (isArray())


### PR DESCRIPTION
#### 5ecc3851cc3ff2a7220075905235d814a2c42fda
<pre>
Crash in TIntermAggregate::getConstantValue() when mArguments is an empty std::vector
<a href="https://bugs.webkit.org/show_bug.cgi?id=268798">https://bugs.webkit.org/show_bug.cgi?id=268798</a>
&lt;<a href="https://rdar.apple.com/122237051">rdar://122237051</a>&gt;

Reviewed by NOBODY (OOPS!).

* Source/ThirdParty/ANGLE/src/compiler/translator/IntermNode.cpp:
(sh::TIntermAggregate::getConstantValue const):
- Change Debug assertion into runtime check, and return early if
  mArguments is empty.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ecc3851cc3ff2a7220075905235d814a2c42fda

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40571 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33826 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14249 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32123 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14285 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12461 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12403 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41846 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34504 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38279 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10650 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36466 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14558 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14008 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->