### PR TITLE
hideContentUntilPendingUpdate async IPC call during backgrounding blocks process suspension

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -31,6 +31,7 @@
 #import "LayerProperties.h"
 #import "Logging.h"
 #import "MessageSenderInlines.h"
+#import "ProcessThrottler.h"
 #import "RemoteLayerTreeDrawingAreaProxyMessages.h"
 #import "RemotePageDrawingAreaProxy.h"
 #import "RemotePageProxy.h"
@@ -579,7 +580,9 @@ void RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState(ActivityStat
 
 void RemoteLayerTreeDrawingAreaProxy::hideContentUntilPendingUpdate()
 {
-    m_replyForUnhidingContent = sendWithAsyncReply(Messages::DrawingArea::DispatchAfterEnsuringDrawing(), [] { });
+    // FIXME(rdar://122365213): Rethink whether this needs to use an async reply handler or start a background activity.
+    auto activity = m_webProcessProxy->throttler().backgroundActivity("hideContentUntilPendingUpdate"_s);
+    m_replyForUnhidingContent = m_webProcessProxy->sendWithAsyncReply(Messages::DrawingArea::DispatchAfterEnsuringDrawing(), [timedActivity = makeUnique<ProcessThrottlerTimedActivity>(1_s, WTFMove(activity))] () mutable { }, messageSenderDestinationID(), { }, WebProcessProxy::ShouldStartProcessThrottlerActivity::No);
     m_remoteLayerTreeHost->detachRootLayer();
 }
 


### PR DESCRIPTION
#### f4ce57789de592b5e4d90714e8d0e7c52e01dfa9
<pre>
hideContentUntilPendingUpdate async IPC call during backgrounding blocks process suspension
<a href="https://bugs.webkit.org/show_bug.cgi?id=268799">https://bugs.webkit.org/show_bug.cgi?id=268799</a>
<a href="https://rdar.apple.com/121185956">rdar://121185956</a>

Reviewed by Chris Dumez.

On iOS, when the UIProcess goes into the background, it eventually calls in to
hideContentUntilPendingUpdate through this call stack:

```
WebKit::RemoteLayerTreeDrawingAreaProxy::hideContentUntilPendingUpdate()
WebKit::WebPageProxy::applicationDidFinishSnapshottingAfterEnteringBackground()
WebKit::ApplicationStateTracker::didCompleteSnapshotSequence()
```

The problem is that we recently added an async `DrawingArea::DispatchAfterEnsuringDrawing` IPC with
reply handler call to hideContentUntilPendingUpdate (see 269776@main, 270672@main, 271260@main). An
async IPC with a reply handler in the UIProcess implicitly takes out a background activity which
prevents the WebContent process (and also the UIProcess) from suspending until the reply handler
runs. Unfortunately, since the WebContent process is in the background, presumably it doesn&apos;t
render, so the DispatchAfterEnsuringDrawing reply handler doesn&apos;t run, and the background activity
also never completes. We basically end up blocking process suspension entirely until the 15 second
timer in ProcessStateMonitor expires and forcefully invalidates all background activities for all
processes.

We need to fix this by reworking the logic somehow or by making this DispatchAfterEnsuringDrawing
IPC not create a background activity. Here I&apos;m just trying to make the IPC call not start a
background activity.

Note that there&apos;s also a DispatchAfterEnsuringDrawing call in WebPageProxy that I didn&apos;t touch since
I don&apos;t have evidence that it&apos;s causing a background power regression, but I wonder if that also
should avoid creating a background activity.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::hideContentUntilPendingUpdate):

Canonical link: <a href="https://commits.webkit.org/274157@main">https://commits.webkit.org/274157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5419911e832ad11ef46b5d96e2e1c243d16b4e8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40587 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33837 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32133 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14306 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12480 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12415 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41862 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34526 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38296 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36486 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14569 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8540 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13431 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14019 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->