### PR TITLE
[Unified Text Replacement] Replacement document markers do not have their relevant marked text ranges

### DIFF
--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -239,20 +239,29 @@ Vector<FloatRect> DocumentMarkerController::renderedRectsForMarkers(DocumentMark
 
 static bool shouldInsertAsSeparateMarker(const DocumentMarker& marker)
 {
+    switch (marker.type()) {
 #if ENABLE(PLATFORM_DRIVEN_TEXT_CHECKING)
-    if (marker.type() == DocumentMarker::Type::PlatformTextChecking)
+    case DocumentMarker::Type::PlatformTextChecking:
         return true;
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    if (marker.type() == DocumentMarker::Type::DictationPhraseWithAlternatives || marker.type() == DocumentMarker::Type::DictationResult)
+    case DocumentMarker::Type::DictationPhraseWithAlternatives:
+    case DocumentMarker::Type::DictationResult:
         return true;
 #endif
 
-    if (marker.type() == DocumentMarker::Type::DraggedContent)
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    case DocumentMarker::Type::UnifiedTextReplacement:
+        return true;
+#endif
+
+    case DocumentMarker::Type::DraggedContent:
         return is<RenderReplaced>(std::get<RefPtr<Node>>(marker.data())->renderer());
 
-    return false;
+    default:
+        return false;
+    }
 }
 
 // Markers are stored in order sorted by their start offset.


### PR DESCRIPTION
#### 1721c34efc9e0f3b22999abad605d79e2a50d252
<pre>
[Unified Text Replacement] Replacement document markers do not have their relevant marked text ranges
<a href="https://bugs.webkit.org/show_bug.cgi?id=268708">https://bugs.webkit.org/show_bug.cgi?id=268708</a>
<a href="https://rdar.apple.com/122254085">rdar://122254085</a>

Reviewed by Megan Gardner.

* Source/WebCore/dom/DocumentMarker.h:
(WebCore::DocumentMarker::description const):
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::shouldInsertAsSeparateMarker):
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForDocumentMarkers):
* Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.cpp:
(WebKit::replaceTextInRange):
(WebKit::UnifiedTextReplacementController::willBeginTextReplacementSession):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveReplacements):

Canonical link: <a href="https://commits.webkit.org/274193@main">https://commits.webkit.org/274193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2aba47129d56229cbcadc11f2919486ef98579b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16943 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40299 "Hash e2aba471 for PR 23901 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40580 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33832 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32130 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14298 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/40299 "Hash e2aba471 for PR 23901 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12473 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12412 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/40299 "Hash e2aba471 for PR 23901 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41855 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34520 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/40299 "Hash e2aba471 for PR 23901 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38292 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13010 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36482 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14564 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/40299 "Hash e2aba471 for PR 23901 does not build (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13426 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4973 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14014 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->