### PR TITLE
Generate serialization of SerializedPlatformDataCueValue

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -311,6 +311,7 @@ platform/cocoa/PublicSuffixCocoa.mm
 platform/cocoa/RemoteCommandListenerCocoa.mm
 platform/cocoa/RuntimeApplicationChecksCocoa.mm
 platform/cocoa/SearchPopupMenuCocoa.mm
+platform/cocoa/SerializedPlatformDataCueValue.mm @no-unify
 platform/cocoa/SharedBufferCocoa.mm
 platform/cocoa/SharedMemoryCocoa.cpp
 platform/cocoa/SystemVersion.mm

--- a/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
+++ b/Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SerializedPlatformDataCueValue.h"
+
+#import <AVFoundation/AVMetadataItem.h>
+#import <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+SerializedPlatformDataCueValue::SerializedPlatformDataCueValue(AVMetadataItem *item)
+{
+    if (!item)
+        return;
+
+    m_data = Data { };
+
+    auto dictionary = adoptNS([[NSMutableDictionary alloc] init]);
+    NSDictionary *extras = [item extraAttributes];
+
+    for (id key in [extras keyEnumerator]) {
+        if (![key isKindOfClass:[NSString class]])
+            continue;
+        NSString *value = [extras objectForKey:key];
+        if (![value isKindOfClass:NSString.class])
+            continue;
+        NSString *keyString = key;
+
+        if ([key isEqualToString:@"MIMEtype"])
+            keyString = @"type";
+        else if ([key isEqualToString:@"dataTypeNamespace"] || [key isEqualToString:@"pictureType"])
+            continue;
+        else if ([key isEqualToString:@"dataType"]) {
+            id dataTypeNamespace = [extras objectForKey:@"dataTypeNamespace"];
+            if (!dataTypeNamespace || ![dataTypeNamespace isKindOfClass:[NSString class]] || ![dataTypeNamespace isEqualToString:@"org.iana.media-type"])
+                continue;
+            keyString = @"type";
+        } else {
+            if (![value length])
+                continue;
+            keyString = [key lowercaseString];
+        }
+
+        if ([keyString isEqualToString:@"type"])
+            m_data->type = value;
+        else
+            m_data->otherAttributes.add(keyString, value);
+    }
+
+    if ([item.key isKindOfClass:NSString.class])
+        m_data->key = (NSString *)item.key;
+
+    if (item.locale)
+        m_data->locale = item.locale;
+
+    if ([item.value isKindOfClass:NSString.class])
+        m_data->value = (NSString *)item.value;
+    else if ([item.value isKindOfClass:NSData.class])
+        m_data->value = (NSData *)item.value;
+    else if ([item.value isKindOfClass:NSDate.class])
+        m_data->value = (NSDate *)item.value;
+    else if ([item.value isKindOfClass:NSNumber.class])
+        m_data->value = (NSNumber *)item.value;
+}
+
+RetainPtr<NSDictionary> SerializedPlatformDataCueValue::toNSDictionary() const
+{
+    if (!m_data)
+        return nullptr;
+
+    auto dictionary = adoptNS([NSMutableDictionary new]);
+
+    if (!m_data->type.isNull())
+        [dictionary setObject:m_data->type forKey:@"type"];
+
+    for (auto& pair : m_data->otherAttributes)
+        [dictionary setObject:pair.value forKey:pair.key];
+
+    if (m_data->locale)
+        [dictionary setObject:m_data->locale.get() forKey:@"locale"];
+
+    if (!m_data->key.isNull())
+        [dictionary setObject:m_data->key forKey:@"key"];
+
+    WTF::switchOn(m_data->value, [] (std::nullptr_t) {
+    }, [&] (RetainPtr<NSString> string) {
+        [dictionary setValue:string.get() forKey:@"data"];
+    }, [&] (RetainPtr<NSNumber> number) {
+        [dictionary setValue:number.get() forKey:@"data"];
+    }, [&] (RetainPtr<NSData> data) {
+        [dictionary setValue:data.get() forKey:@"data"];
+    }, [&] (RetainPtr<NSDate> date) {
+        [dictionary setValue:date.get() forKey:@"data"];
+    });
+
+    return dictionary;
+}
+
+bool SerializedPlatformDataCueValue::operator==(const SerializedPlatformDataCueValue& other) const
+{
+    if (!m_data || !other.m_data)
+        return false;
+
+    return *m_data == *other.m_data;
+}
+
+bool SerializedPlatformDataCueValue::Data::operator==(const Data& other) const
+{
+    return type == other.type
+        && otherAttributes == other.otherAttributes
+        && [locale isEqual:other.locale.get()]
+        && key == other.key
+        && value.index() == other.value.index()
+        && WTF::switchOn(value, [] (std::nullptr_t) {
+            return true;
+        }, [&] (RetainPtr<NSString> string) {
+            return !![string isEqual:std::get<RetainPtr<NSString>>(other.value).get()];
+        }, [&] (RetainPtr<NSNumber> number) {
+            return !![number isEqual:std::get<RetainPtr<NSNumber>>(other.value).get()];
+        }, [&] (RetainPtr<NSData> data) {
+            return !![data isEqual:std::get<RetainPtr<NSData>>(other.value).get()];
+        }, [&] (RetainPtr<NSDate> date) {
+            return !![date isEqual:std::get<RetainPtr<NSDate>>(other.value).get()];
+        });
+}
+
+}

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -3707,7 +3707,7 @@ void MediaPlayerPrivateAVFoundationObjC::metadataDidArrive(const RetainPtr<NSArr
         if (item.keySpace)
             type = metadataType(item.keySpace);
 
-        m_metadataTrack->addDataCue(start, end, SerializedPlatformDataCue::create({ WebCore::SerializedPlatformDataCueValue::PlatformType::ObjC, item }), type);
+        m_metadataTrack->addDataCue(start, end, SerializedPlatformDataCue::create(SerializedPlatformDataCueValue { item }), type);
     }
 #endif
 }

--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h
@@ -28,6 +28,7 @@
 #if ENABLE(VIDEO) && ENABLE(DATACUE_VALUE)
 
 #include "SerializedPlatformDataCue.h"
+#include "SerializedPlatformDataCueValue.h"
 #include <wtf/HashSet.h>
 
 namespace WebCore {
@@ -45,13 +46,10 @@ public:
 
     WEBCORE_EXPORT SerializedPlatformDataCueValue encodableValue() const final;
 
-    id nativeValue() const { return m_nativeValue.get(); }
-
     WEBCORE_EXPORT static const HashSet<Class>& allowedClassesForNativeValues();
 
 private:
-
-    RetainPtr<id> m_nativeValue;
+    SerializedPlatformDataCueValue m_value;
 };
 
 SerializedPlatformDataCueMac* toSerializedPlatformDataCueMac(SerializedPlatformDataCue*);

--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
@@ -48,7 +48,6 @@ static JSValue *jsValueWithArrayInContext(NSArray *, JSContext *);
 static JSValue *jsValueWithDictionaryInContext(NSDictionary *, JSContext *);
 static JSValue *jsValueWithAVMetadataItemInContext(AVMetadataItem *, JSContext *);
 static JSValue *jsValueWithValueInContext(id, JSContext *);
-static RetainPtr<NSDictionary> NSDictionaryWithAVMetadataItem(AVMetadataItem *);
 #endif
 
 Ref<SerializedPlatformDataCue> SerializedPlatformDataCue::create(SerializedPlatformDataCueValue&& value)
@@ -58,9 +57,8 @@ Ref<SerializedPlatformDataCue> SerializedPlatformDataCue::create(SerializedPlatf
 
 SerializedPlatformDataCueMac::SerializedPlatformDataCueMac(SerializedPlatformDataCueValue&& value)
     : SerializedPlatformDataCue()
-    , m_nativeValue(value.nativeValue())
+    , m_value(WTFMove(value))
 {
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(value.platformType() == SerializedPlatformDataCueValue::PlatformType::ObjC);
 }
 
 RefPtr<ArrayBuffer> SerializedPlatformDataCueMac::data() const
@@ -71,12 +69,13 @@ RefPtr<ArrayBuffer> SerializedPlatformDataCueMac::data() const
 JSC::JSValue SerializedPlatformDataCueMac::deserialize(JSC::JSGlobalObject* lexicalGlobalObject) const
 {
 #if JSC_OBJC_API_ENABLED
-    if (!m_nativeValue)
+    auto dictionary = m_value.toNSDictionary();
+    if (!dictionary)
         return JSC::jsNull();
 
     JSGlobalContextRef jsGlobalContextRef = toGlobalRef(lexicalGlobalObject);
     JSContext *jsContext = [JSContext contextWithJSGlobalContextRef:jsGlobalContextRef];
-    JSValue *serializedValue = jsValueWithValueInContext(m_nativeValue.get(), jsContext);
+    JSValue *serializedValue = jsValueWithValueInContext(dictionary.get(), jsContext);
 
     return toJS(lexicalGlobalObject, [serializedValue JSValueRef]);
 #else
@@ -87,15 +86,7 @@ JSC::JSValue SerializedPlatformDataCueMac::deserialize(JSC::JSGlobalObject* lexi
 
 bool SerializedPlatformDataCueMac::isEqual(const SerializedPlatformDataCue& other) const
 {
-    if (other.platformType() != PlatformType::ObjC)
-        return false;
-
-    const SerializedPlatformDataCueMac* otherObjC = toSerializedPlatformDataCueMac(&other);
-
-    if (!m_nativeValue || !otherObjC->nativeValue())
-        return false;
-
-    return [m_nativeValue isEqual:otherObjC->nativeValue()];
+    return m_value == toSerializedPlatformDataCueMac(&other)->m_value;
 }
 
 SerializedPlatformDataCueMac* toSerializedPlatformDataCueMac(SerializedPlatformDataCue* rep)
@@ -105,7 +96,6 @@ SerializedPlatformDataCueMac* toSerializedPlatformDataCueMac(SerializedPlatformD
 
 const SerializedPlatformDataCueMac* toSerializedPlatformDataCueMac(const SerializedPlatformDataCue* rep)
 {
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(rep->platformType() == SerializedPlatformDataCue::PlatformType::ObjC);
     return static_cast<const SerializedPlatformDataCueMac*>(rep);
 }
 
@@ -117,10 +107,7 @@ const HashSet<Class>& SerializedPlatformDataCueMac::allowedClassesForNativeValue
 
 SerializedPlatformDataCueValue SerializedPlatformDataCueMac::encodableValue() const
 {
-    if ([m_nativeValue isKindOfClass:PAL::getAVMetadataItemClass()])
-        return { SerializedPlatformDataCueValue::PlatformType::ObjC, NSDictionaryWithAVMetadataItem(m_nativeValue.get()).get() };
-
-    return { SerializedPlatformDataCueValue::PlatformType::ObjC, m_nativeValue.get() };
+    return m_value;
 }
 
 #if JSC_OBJC_API_ENABLED
@@ -206,48 +193,7 @@ static JSValue *jsValueWithDictionaryInContext(NSDictionary *dictionary, JSConte
 
 static JSValue *jsValueWithAVMetadataItemInContext(AVMetadataItem *item, JSContext *context)
 {
-    return jsValueWithDictionaryInContext(NSDictionaryWithAVMetadataItem(item).get(), context);
-}
-
-static RetainPtr<NSDictionary> NSDictionaryWithAVMetadataItem(AVMetadataItem *item)
-{
-    auto dictionary = adoptNS([[NSMutableDictionary alloc] init]);
-    NSDictionary *extras = [item extraAttributes];
-
-    for (id key in [extras keyEnumerator]) {
-        if (![key isKindOfClass:[NSString class]])
-            continue;
-        id value = [extras objectForKey:key];
-        NSString *keyString = key;
-
-        if ([key isEqualToString:@"MIMEtype"])
-            keyString = @"type";
-        else if ([key isEqualToString:@"dataTypeNamespace"] || [key isEqualToString:@"pictureType"])
-            continue;
-        else if ([key isEqualToString:@"dataType"]) {
-            id dataTypeNamespace = [extras objectForKey:@"dataTypeNamespace"];
-            if (!dataTypeNamespace || ![dataTypeNamespace isKindOfClass:[NSString class]] || ![dataTypeNamespace isEqualToString:@"org.iana.media-type"])
-                continue;
-            keyString = @"type";
-        } else if ([value isKindOfClass:[NSString class]]) {
-            if (![value length])
-                continue;
-            keyString = [key lowercaseString];
-        }
-
-        [dictionary setObject:value forKey:keyString];
-    }
-
-    if (item.key)
-        [dictionary setObject:item.key forKey:@"key"];
-
-    if (item.locale)
-        [dictionary setObject:item.locale forKey:@"locale"];
-
-    if (item.value)
-        [dictionary setObject:item.value forKey:@"data"];
-
-    return WTFMove(dictionary);
+    return jsValueWithDictionaryInContext(SerializedPlatformDataCueValue(item).toNSDictionary().get(), context);
 }
 #endif
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -376,35 +376,6 @@ bool ArgumentCoder<MediaPlaybackTargetContext>::decode(Decoder& decoder, MediaPl
 }
 #endif
 
-#if ENABLE(VIDEO)
-void ArgumentCoder<WebCore::SerializedPlatformDataCueValue>::encode(Encoder& encoder, const SerializedPlatformDataCueValue& value)
-{
-    bool hasPlatformData = value.encodingRequiresPlatformData();
-    encoder << hasPlatformData;
-
-    encoder << value.platformType();
-    if (hasPlatformData)
-        encodePlatformData(encoder, value);
-}
-
-std::optional<SerializedPlatformDataCueValue> ArgumentCoder<WebCore::SerializedPlatformDataCueValue>::decode(IPC::Decoder& decoder)
-{
-    bool hasPlatformData;
-    if (!decoder.decode(hasPlatformData))
-        return std::nullopt;
-
-    WebCore::SerializedPlatformDataCueValue::PlatformType type;
-    if (!decoder.decode(type))
-        return std::nullopt;
-
-    if (hasPlatformData)
-        return decodePlatformData(decoder, type);
-
-    return { SerializedPlatformDataCueValue() };
-
-}
-#endif
-
 constexpr bool useUnixDomainSockets()
 {
 #if USE(UNIX_DOMAIN_SOCKETS)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -188,15 +188,6 @@ template<> struct ArgumentCoder<WebCore::MediaPlaybackTargetContext> {
 };
 #endif
 
-#if ENABLE(VIDEO)
-template<> struct ArgumentCoder<WebCore::SerializedPlatformDataCueValue> {
-    static void encode(Encoder&, const WebCore::SerializedPlatformDataCueValue&);
-    static std::optional<WebCore::SerializedPlatformDataCueValue> decode(Decoder&);
-    static void encodePlatformData(Encoder&, const WebCore::SerializedPlatformDataCueValue&);
-    static std::optional<WebCore::SerializedPlatformDataCueValue> decodePlatformData(Decoder&, WebCore::SerializedPlatformDataCueValue::PlatformType);
-};
-#endif
-
 template<> struct ArgumentCoder<WebCore::FragmentedSharedBuffer> {
     static void encode(Encoder&, const WebCore::FragmentedSharedBuffer&);
     static std::optional<Ref<WebCore::FragmentedSharedBuffer>> decode(Decoder&);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7727,3 +7727,17 @@ header: <WebCore/FilterFunction.h>
     SourceAlpha,
     SourceGraphic
 };
+
+class WebCore::SerializedPlatformDataCueValue {
+    std::optional<WebCore::SerializedPlatformDataCueValue::Data> data()
+}
+
+[Nested] struct WebCore::SerializedPlatformDataCueValue::Data {
+#if PLATFORM(COCOA)
+    String type;
+    HashMap<String, String> otherAttributes;
+    String key;
+    RetainPtr<NSLocale> locale;
+    std::variant<std::nullptr_t, RetainPtr<NSString>, RetainPtr<NSDate>, RetainPtr<NSNumber>, RetainPtr<NSData>> value;
+#endif
+};

--- a/Source/WebKit/Shared/curl/WebCoreArgumentCodersCurl.cpp
+++ b/Source/WebKit/Shared/curl/WebCoreArgumentCodersCurl.cpp
@@ -70,17 +70,4 @@ std::optional<CurlProxySettings> ArgumentCoder<CurlProxySettings>::decode(Decode
     return CurlProxySettings { WTFMove(url), WTFMove(ignoreHosts) };
 }
 
-#if ENABLE(VIDEO)
-void ArgumentCoder<SerializedPlatformDataCueValue>::encodePlatformData(Encoder& encoder, const SerializedPlatformDataCueValue& value)
-{
-    ASSERT_NOT_REACHED();
-}
-
-std::optional<SerializedPlatformDataCueValue>  ArgumentCoder<SerializedPlatformDataCueValue>::decodePlatformData(Decoder& decoder, WebCore::SerializedPlatformDataCueValue::PlatformType platformType)
-{
-    ASSERT_NOT_REACHED();
-    return std::nullopt;
-}
-#endif
-
 }

--- a/Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm
+++ b/Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm
@@ -48,29 +48,6 @@
 
 namespace IPC {
 
-#if ENABLE(VIDEO)
-void ArgumentCoder<WebCore::SerializedPlatformDataCueValue>::encodePlatformData(Encoder& encoder, const WebCore::SerializedPlatformDataCueValue& value)
-{
-    ASSERT(value.platformType() == WebCore::SerializedPlatformDataCueValue::PlatformType::ObjC);
-    if (value.platformType() == WebCore::SerializedPlatformDataCueValue::PlatformType::ObjC)
-        encodeObjectWithWrapper(encoder, value.nativeValue().get());
-}
-
-std::optional<WebCore::SerializedPlatformDataCueValue>  ArgumentCoder<WebCore::SerializedPlatformDataCueValue>::decodePlatformData(Decoder& decoder, WebCore::SerializedPlatformDataCueValue::PlatformType platformType)
-{
-    ASSERT(platformType == WebCore::SerializedPlatformDataCueValue::PlatformType::ObjC);
-
-    if (platformType != WebCore::SerializedPlatformDataCueValue::PlatformType::ObjC)
-        return std::nullopt;
-
-    auto object = decodeObjectFromWrapper(decoder, WebCore::SerializedPlatformDataCueMac::allowedClassesForNativeValues());
-    if (!object)
-        return std::nullopt;
-
-    return WebCore::SerializedPlatformDataCueValue { platformType, object.value().get() };
-}
-#endif
-
 #if USE(APPKIT)
 
 template<typename Encoder>

--- a/Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp
+++ b/Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp
@@ -99,17 +99,4 @@ bool ArgumentCoder<SoupNetworkProxySettings>::decode(Decoder& decoder, SoupNetwo
     return !settings.isEmpty();
 }
 
-#if ENABLE(VIDEO)
-void ArgumentCoder<SerializedPlatformDataCueValue>::encodePlatformData(Encoder& encoder, const SerializedPlatformDataCueValue& value)
-{
-    ASSERT_NOT_REACHED();
-}
-
-std::optional<SerializedPlatformDataCueValue>  ArgumentCoder<SerializedPlatformDataCueValue>::decodePlatformData(Decoder& decoder, SerializedPlatformDataCueValue::PlatformType platformType)
-{
-    ASSERT_NOT_REACHED();
-    return std::nullopt;
-}
-#endif
-
 }


### PR DESCRIPTION
#### b0bcfd764ea406c4eea381e0a0191977fc06ad81
<pre>
Generate serialization of SerializedPlatformDataCueValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=268805">https://bugs.webkit.org/show_bug.cgi?id=268805</a>

Reviewed by Eric Carlson.

Before this change, SerializedPlatformDataCueValue was a strange abstraction that contained
a RetainPtr&lt;id&gt; that was either a AVMetadataItem or an NSDictionary extracted from it, and
there wasn&apos;t a good way to tell if that extraction had happened from the abstraction itself.
Also, the NSDictionary had a generous allowance for the types of contents it would allow to
be serialized across IPC.

This changes SerializedPlatformDataCueValue to be a container for strictly typed data that
is extracted from an AVMetadataItem.  I made a few assumptions to make this possible:

1. AVMetadataItem.extraAttributes contains only keys and values we care about that have a
   type of NSString.  Others will now be ignored.  Non-String keys were already ignored.
   AVMetadataItem.h pointed to AVMetadataFormat.h which seems to indicate this is a reasonable
   assumption.
2. AVMetadataItem.key contains only an NSString if we care about it.  The API indicates it
   is a id&lt;NSObject, NSCopying&gt; but I don&apos;t think we support anything useful that isn&apos;t an
   NSString.
3. AVMetadataItem.value is either nil, a number, a string, an NSDate, or an NSData.
   The existence of stringValue, numberValue, dateValue, and dataValue selectors on
   AVMetadataItem objects seems to indicate that these are the valid values.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/SerializedPlatformDataCueValue.h:
(WebCore::SerializedPlatformDataCueValue::SerializedPlatformDataCueValue):
(WebCore::SerializedPlatformDataCueValue::data const):
(WebCore::SerializedPlatformDataCueValue::platformType const): Deleted.
(WebCore::SerializedPlatformDataCueValue::nativeValue const): Deleted.
(WebCore::SerializedPlatformDataCueValue::encodingRequiresPlatformData const): Deleted.
(): Deleted.
* Source/WebCore/platform/cocoa/SerializedPlatformDataCueValue.mm: Added.
(WebCore::SerializedPlatformDataCueValue::SerializedPlatformDataCueValue):
(WebCore::SerializedPlatformDataCueValue::toNSDictionary const):
(WebCore::SerializedPlatformDataCueValue::operator== const):
(WebCore::SerializedPlatformDataCueValue::Data::operator== const):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::metadataDidArrive):
* Source/WebCore/platform/mac/SerializedPlatformDataCueMac.h:
* Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm:
(WebCore::SerializedPlatformDataCueMac::SerializedPlatformDataCueMac):
(WebCore::SerializedPlatformDataCueMac::deserialize const):
(WebCore::SerializedPlatformDataCueMac::isEqual const):
(WebCore::toSerializedPlatformDataCueMac):
(WebCore::SerializedPlatformDataCueMac::encodableValue const):
(WebCore::jsValueWithAVMetadataItemInContext):
(WebCore::NSDictionaryWithAVMetadataItem): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;WebCore::SerializedPlatformDataCueValue&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::SerializedPlatformDataCueValue&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/mac/WebCoreArgumentCodersMac.mm:
(IPC::ArgumentCoder&lt;WebCore::SerializedPlatformDataCueValue&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::SerializedPlatformDataCueValue&gt;::decodePlatformData): Deleted.

Canonical link: <a href="https://commits.webkit.org/274146@main">https://commits.webkit.org/274146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dc166a44fb114f4ea3cfe46be377442ae863c69

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40598 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33843 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/39937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32136 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14322 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12486 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41874 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34539 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38303 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13026 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36494 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14575 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13439 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4936 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14025 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->