### PR TITLE
Increase dynamicDowncast<> usage in Editor and some adjacent files

### DIFF
--- a/Source/WebCore/editing/BreakBlockquoteCommand.cpp
+++ b/Source/WebCore/editing/BreakBlockquoteCommand.cpp
@@ -68,10 +68,10 @@ void BreakBlockquoteCommand::doApply()
     // pos is a position equivalent to the caret.  We use downstream() so that pos will 
     // be in the first node that we need to move (there are a few exceptions to this, see below).
     Position pos = endingSelection().start().downstream();
-    
+
     // Find the top-most blockquote from the start.
-    RefPtr topBlockquote = highestEnclosingNodeOfType(pos, isMailBlockquote);
-    if (!topBlockquote || !topBlockquote->parentNode() || !topBlockquote->isElementNode())
+    RefPtr topBlockquote = dynamicDowncast<Element>(highestEnclosingNodeOfType(pos, isMailBlockquote));
+    if (!topBlockquote || !topBlockquote->parentNode())
         return;
 
     auto breakNode = [&]() -> Ref<HTMLElement> {
@@ -152,7 +152,7 @@ void BreakBlockquoteCommand::doApply()
         ancestors.append(node.copyRef());
     
     // Insert a clone of the top blockquote after the break.
-    auto clonedBlockquote = downcast<Element>(*topBlockquote).cloneElementWithoutChildren(document());
+    auto clonedBlockquote = topBlockquote->cloneElementWithoutChildren(document());
     insertNodeAfter(clonedBlockquote.copyRef(), breakNode);
     
     // Clone startNode's ancestors into the cloned blockquote.

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -1301,7 +1301,7 @@ void CompositeEditCommand::cloneParagraphUnderNewElement(const Position& start, 
         appendNode(*lastNode, *blockElement);
     }
 
-    if (start.deprecatedNode() != outerNode && lastNode->isElementNode() && start.anchorNode()->isDescendantOf(outerNode.get())) {
+    if (start.deprecatedNode() != outerNode && is<Element>(*lastNode) && start.anchorNode()->isDescendantOf(outerNode.get())) {
         Vector<RefPtr<Node>> ancestors;
         
         // Insert each node from innerNode to outerNode (excluded) in a list.

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -1366,7 +1366,7 @@ static String loneFontFamilyName(const CSSValue& value)
     auto* list = dynamicDowncast<CSSValueList>(value);
     if (!list || list->length() != 1)
         return { };
-    auto* item = dynamicDowncast<CSSPrimitiveValue>(*downcast<CSSValueList>(value).item(0));
+    auto* item = dynamicDowncast<CSSPrimitiveValue>(list->item(0));
     return item ? item->stringValue() : String();
 }
 

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -305,10 +305,10 @@ VisibleSelection Editor::selectionForCommand(Event* event)
         return selection;
     // If the target is a text control, and the current selection is outside of its shadow tree,
     // then use the saved selection for that text control.
-    if (RefPtr target = event->target(); is<HTMLTextFormControlElement>(target) && downcast<Element>(*target).isTextField()) {
+    if (RefPtr target = dynamicDowncast<HTMLTextFormControlElement>(event->target()); target && target->isTextField()) {
         auto start = selection.start();
-        if (start.isNull() || target != enclosingTextFormControl(start)) {
-            if (auto range = downcast<HTMLTextFormControlElement>(*target).selection())
+        if (start.isNull() || event->target() != enclosingTextFormControl(start)) {
+            if (auto range = target->selection())
                 return { *range, Affinity::Downstream, selection.isDirectional() };
         }
     }
@@ -704,9 +704,8 @@ bool Editor::shouldInsertFragment(DocumentFragment& fragment, const std::optiona
     if (!client())
         return false;
     
-    RefPtr child { fragment.firstChild() };
-    if (is<CharacterData>(child) && fragment.lastChild() == child)
-        return client()->shouldInsertText(downcast<CharacterData>(*child).data(), replacingDOMRange, givenAction);
+    if (RefPtr child = dynamicDowncast<CharacterData>(fragment.firstChild()); child && fragment.lastChild() == fragment.firstChild())
+        return client()->shouldInsertText(child->data(), replacingDOMRange, givenAction);
 
     return client()->shouldInsertNode(fragment, replacingDOMRange, givenAction);
 }
@@ -2044,19 +2043,17 @@ void Editor::setBaseWritingDirection(WritingDirection direction)
         return;
 #endif
 
-    RefPtr focusedElement { document->focusedElement() };
-    if (focusedElement && focusedElement->isTextField()) {
+    if (RefPtr focusedElement = dynamicDowncast<HTMLTextFormControlElement>(document->focusedElement()); focusedElement && focusedElement->isTextField()) {
         if (direction == WritingDirection::Natural)
             return;
 
-        auto& focusedFormElement = downcast<HTMLTextFormControlElement>(*focusedElement);
         auto directionValue = direction == WritingDirection::LeftToRight ? "ltr"_s : "rtl"_s;
         auto writingDirectionInputTypeName = inputTypeNameForEditingAction(EditAction::SetBlockWritingDirection);
-        if (!dispatchBeforeInputEvent(focusedFormElement, writingDirectionInputTypeName, IsInputMethodComposing::No, directionValue))
+        if (!dispatchBeforeInputEvent(*focusedElement, writingDirectionInputTypeName, IsInputMethodComposing::No, directionValue))
             return;
 
-        focusedFormElement.setAttributeWithoutSynchronization(dirAttr, directionValue);
-        dispatchInputEvent(focusedFormElement, writingDirectionInputTypeName, IsInputMethodComposing::No, directionValue);
+        focusedElement->setAttributeWithoutSynchronization(dirAttr, directionValue);
+        dispatchInputEvent(*focusedElement, writingDirectionInputTypeName, IsInputMethodComposing::No, directionValue);
         document->updateStyleIfNeeded();
         return;
     }
@@ -2751,10 +2748,11 @@ void Editor::markMisspellingsAfterTypingToWord(const VisiblePosition& wordStart,
                 break;
 
             RefPtr container = previousPosition.deepEquivalent().downstream().containerNode();
-            if (RefPtr containerElement = is<Element>(container) ? downcast<Element>(container.get()) : container->parentElement()) {
-                if (!containerElement->isSpellCheckingEnabled())
-                    break;
-            }
+            RefPtr containerElement = dynamicDowncast<Element>(container);
+            if (!containerElement)
+                containerElement = container->parentElement();
+            if (containerElement && !containerElement->isSpellCheckingEnabled())
+                break;
 
             spellCheckingStart = previousPosition;
         }
@@ -2852,7 +2850,9 @@ bool Editor::isSpellCheckingEnabledFor(Node* node) const
 {
     if (!node)
         return false;
-    RefPtr element = is<Element>(*node) ? downcast<Element>(node) : node->parentElement();
+    RefPtr element = dynamicDowncast<Element>(*node);
+    if (!element)
+        element = node->parentElement();
     if (!element)
         return false;
     if (element->isInUserAgentShadowTree()) {
@@ -4068,8 +4068,8 @@ static RefPtr<Node> findFirstMarkable(Node* startingNode)
             if (node->renderer()->isRenderTextOrLineBreak())
                 return node;
         }
-        if (is<HTMLTextFormControlElement>(*node) && downcast<Element>(*node).isTextField())
-            node = downcast<HTMLTextFormControlElement>(*node).visiblePositionForIndex(1).deepEquivalent().deprecatedNode();
+        if (RefPtr element = dynamicDowncast<HTMLTextFormControlElement>(*node); element && element->isTextField())
+            node = element->visiblePositionForIndex(1).deepEquivalent().deprecatedNode();
         else if (node->firstChild())
             node = node->firstChild();
         else
@@ -4103,8 +4103,8 @@ OptionSet<TextCheckingType> Editor::resolveTextCheckingTypeMask(const Node& root
 {
 #if USE(AUTOMATIC_TEXT_REPLACEMENT) && !PLATFORM(IOS_FAMILY)
     bool onlyAllowsTextReplacement = false;
-    if (RefPtr host = rootEditableElement.shadowHost())
-        onlyAllowsTextReplacement = is<HTMLInputElement>(host) && downcast<HTMLInputElement>(*host).isSpellcheckDisabledExceptTextReplacement();
+    if (RefPtr host = dynamicDowncast<HTMLInputElement>(rootEditableElement.shadowHost()))
+        onlyAllowsTextReplacement = host->isSpellcheckDisabledExceptTextReplacement();
     if (onlyAllowsTextReplacement)
         textCheckingOptions = textCheckingOptions & TextCheckingType::Replacement;
 #else
@@ -4229,11 +4229,11 @@ static Vector<TextList> editableTextListsAtPositionInDescendingOrder(const Posit
     textLists.reserveInitialCapacity(enclosingLists.size());
     for (auto iterator = enclosingLists.rbegin(); iterator != enclosingLists.rend(); ++iterator) {
         auto& list = iterator->get();
-        bool ordered = is<HTMLOListElement>(list);
+        auto* orderedList = dynamicDowncast<HTMLOListElement>(list);
         if (!list.renderer())
             continue;
         auto style = list.renderer()->style().listStyleType();
-        textLists.append({ style, ordered ? downcast<HTMLOListElement>(list).start() : 1, ordered });
+        textLists.append({ style, orderedList ? orderedList->start() : 1, !!orderedList });
     }
 
     return textLists;
@@ -4319,12 +4319,10 @@ FontAttributes Editor::fontAttributesAtSelectionStart()
 
     RefPtr typingStyle { document().selection().typingStyle() };
     if (typingStyle && typingStyle->style()) {
-        auto value = typingStyle->style()->getPropertyCSSValue(CSSPropertyWebkitTextDecorationsInEffect);
-        if (value && value->isValueList()) {
-            auto& valueList = downcast<CSSValueList>(*value);
-            if (valueList.hasValue(CSSValueLineThrough))
+        if (RefPtr value = dynamicDowncast<CSSValueList>(typingStyle->style()->getPropertyCSSValue(CSSPropertyWebkitTextDecorationsInEffect))) {
+            if (value->hasValue(CSSValueLineThrough))
                 attributes.hasStrikeThrough = true;
-            if (valueList.hasValue(CSSValueUnderline))
+            if (value->hasValue(CSSValueUnderline))
                 attributes.hasUnderline = true;
         }
     } else {
@@ -4347,10 +4345,10 @@ PromisedAttachmentInfo Editor::promisedAttachmentInfo(Element& element)
         return { };
 
     RefPtr<HTMLAttachmentElement> attachment;
-    if (is<HTMLAttachmentElement>(element))
-        attachment = &downcast<HTMLAttachmentElement>(element);
-    else if (is<HTMLImageElement>(element))
-        attachment = downcast<HTMLImageElement>(element).attachmentElement();
+    if (auto* possibleAttachment = dynamicDowncast<HTMLAttachmentElement>(element))
+        attachment = possibleAttachment;
+    else if (auto* image = dynamicDowncast<HTMLImageElement>(element))
+        attachment = image->attachmentElement();
 
     if (!attachment)
         return { };


### PR DESCRIPTION
#### 1747f805fc29521e0bdbdbe663c3d8d838cd569e
<pre>
Increase dynamicDowncast&lt;&gt; usage in Editor and some adjacent files
<a href="https://bugs.webkit.org/show_bug.cgi?id=268809">https://bugs.webkit.org/show_bug.cgi?id=268809</a>

Reviewed by Chris Dumez.

* Source/WebCore/editing/BreakBlockquoteCommand.cpp:
(WebCore::BreakBlockquoteCommand::doApply):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::cloneParagraphUnderNewElement):
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::loneFontFamilyName):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::selectionForCommand):
(WebCore::Editor::shouldInsertFragment):
(WebCore::Editor::setBaseWritingDirection):
(WebCore::Editor::markMisspellingsAfterTypingToWord):
(WebCore::Editor::isSpellCheckingEnabledFor const):
(WebCore::findFirstMarkable):
(WebCore::Editor::resolveTextCheckingTypeMask):
(WebCore::editableTextListsAtPositionInDescendingOrder):
(WebCore::Editor::fontAttributesAtSelectionStart):
(WebCore::Editor::promisedAttachmentInfo):

Canonical link: <a href="https://commits.webkit.org/274208@main">https://commits.webkit.org/274208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7535b80970aebe22def376c66f2f6ed2be7f4511

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40841 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34055 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40530 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14566 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38856 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/14544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12658 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/34227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42119 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/34842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38480 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13220 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36678 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14775 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8615 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14239 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->