### PR TITLE
[UnifiedPDF] Tracked text selections should be drawn in the page space

### DIFF
--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -654,7 +654,7 @@ public:
     OptionSet<ActivityState> activityState() const { return m_activityState; }
 
     bool isWindowActive() const;
-    bool isVisibleAndActive() const;
+    WEBCORE_EXPORT bool isVisibleAndActive() const;
     WEBCORE_EXPORT void setIsVisible(bool);
     WEBCORE_EXPORT void setIsPrerender();
     bool isVisible() const { return m_activityState.contains(ActivityState::IsVisible); }

--- a/Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h
@@ -30,13 +30,21 @@
 
 #if USE(APPLE_INTERNAL_SDK)
 
-#if HAVE(PDFKIT) && PLATFORM(IOS_FAMILY)
+#if HAVE(PDFKIT)
+
+#if PLATFORM(IOS_FAMILY)
 #import <PDFKit/PDFHostViewController.h>
-#endif // HAVE(PDFKIT) && PLATFORM(IOS_FAMILY)
+#endif // PLATFORM(IOS_FAMILY)
+
+#import <PDFKit/PDFSelectionPriv.h>
+
+#endif // HAVE(PDFKIT)
 
 #else
 
-#if HAVE(PDFKIT) && PLATFORM(IOS_FAMILY)
+#if HAVE(PDFKIT)
+
+#if PLATFORM(IOS_FAMILY)
 #import "UIKitSPI.h"
 
 @interface _UIRemoteViewController : UIViewController
@@ -72,7 +80,13 @@
 - (void) snapshotViewRect: (CGRect) rect snapshotWidth: (NSNumber*) width afterScreenUpdates: (BOOL) afterScreenUpdates withResult: (void (^)(UIImage* image)) completion;
 
 @end
-#endif // HAVE(PDFKIT) && PLATFORM(IOS_FAMILY)
+#endif // PLATFORM(IOS_FAMILY)
+
+@interface PDFSelection (SPI)
+- (void)drawForPage:(PDFPage *)page withBox:(CGPDFBox)box active:(BOOL)active inContext:(CGContextRef)context;
+@end
+
+#endif // HAVE(PDFKIT)
 
 #endif // USE(APPLE_INTERNAL_SDK)
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -211,6 +211,8 @@ public:
 
     void notifySelectionChanged();
 
+    virtual void windowActivityDidChange() { }
+
 private:
     bool documentFinishedLoading() const { return m_documentFinishedLoading; }
     uint64_t streamedBytes() const { return m_streamedBytes; }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -79,6 +79,7 @@ public:
     void focusPreviousAnnotation() final;
 
     void attemptToUnlockPDF(const String& password) final;
+    void windowActivityDidChange() final;
 
     float documentFittingScale() const { return m_documentLayout.scale(); }
 
@@ -179,13 +180,11 @@ private:
         Word,
         Line,
     };
-    enum class SelectionCommitReason : bool { SelectionIsNoLongerActive, ReceivedMouseUp };
 
     SelectionGranularity selectionGranularityForMouseEvent(const WebMouseEvent&) const;
     void beginTrackingSelection(PDFDocumentLayout::PageIndex, const WebCore::IntPoint& pagePoint, SelectionGranularity, OptionSet<WebEventModifier>);
     void continueTrackingSelection(PDFDocumentLayout::PageIndex, const WebCore::IntPoint& pagePoint);
     void setCurrentSelection(RetainPtr<PDFSelection>&&);
-    void commitCurrentSelection(SelectionCommitReason);
 
     String getSelectionString() const override;
     bool existingSelectionContainsPoint(const WebCore::FloatPoint&) const override;
@@ -285,7 +284,6 @@ private:
     struct SelectionTrackingData {
         bool shouldExtendCurrentSelection { false };
         bool shouldMakeMarqueeSelection { false };
-        bool isActive { false };
         SelectionGranularity granularity { SelectionGranularity::Character };
         PDFDocumentLayout::PageIndex startPageIndex;
         WebCore::IntPoint startPagePoint;

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -959,6 +959,11 @@ void PluginView::didChangeSettings()
     m_plugin->didChangeSettings();
 }
 
+void PluginView::windowActivityDidChange()
+{
+    m_plugin->windowActivityDidChange();
+}
+
 } // namespace WebKit
 
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -109,6 +109,8 @@ public:
 
     void didChangeSettings();
 
+    void windowActivityDidChange();
+
 private:
     PluginView(WebCore::HTMLPlugInElement&, const URL&, const String& contentType, bool shouldUseManualLoader, WebPage&);
     virtual ~PluginView();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3942,6 +3942,14 @@ void WebPage::visibilityDidChange()
     }
 }
 
+void WebPage::windowActivityDidChange()
+{
+#if ENABLE(PDF_PLUGIN)
+    for (auto& pluginView : m_pluginViews)
+        pluginView.windowActivityDidChange();
+#endif
+}
+
 void WebPage::setActivityState(OptionSet<ActivityState> activityState, ActivityStateChangeID activityStateChangeID, CompletionHandler<void()>&& callback)
 {
     LOG_WITH_STREAM(ActivityState, stream << "WebPage " << identifier().toUInt64() << " setActivityState to " << activityState);
@@ -3966,6 +3974,9 @@ void WebPage::setActivityState(OptionSet<ActivityState> activityState, ActivityS
 
     if (changed & ActivityState::IsVisible)
         visibilityDidChange();
+
+    if (changed & ActivityState::WindowIsActive)
+        windowActivityDidChange();
 }
 
 void WebPage::setLayerHostingMode(LayerHostingMode layerHostingMode)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1824,6 +1824,7 @@ private:
     void setInitialFocus(bool forward, bool isKeyboardEventValid, const std::optional<WebKeyboardEvent>&, CompletionHandler<void()>&&);
     void updateIsInWindow(bool isInitialState = false);
     void visibilityDidChange();
+    void windowActivityDidChange();
     void setActivityState(OptionSet<WebCore::ActivityState>, ActivityStateChangeID, CompletionHandler<void()>&&);
     void validateCommand(const String&, CompletionHandler<void(bool, int32_t)>&&);
     void executeEditCommand(const String&, const String&);


### PR DESCRIPTION
#### 1c0f305b2a21c9cbf2887b9317afd1e5ac0d6ec5
<pre>
[UnifiedPDF] Tracked text selections should be drawn in the page space
<a href="https://bugs.webkit.org/show_bug.cgi?id=268808">https://bugs.webkit.org/show_bug.cgi?id=268808</a>
<a href="https://rdar.apple.com/122371772">rdar://122371772</a>

Reviewed by Simon Fraser.

Currently, there is no visual indication that we keep track of text
selections on mouse drag. This patch addresses the issue by delegating
the painting of PDFSelection elements to PDFKit, as well as laying some
groundwork to meet that end.

Specifically, this patch does the following:
1. Ask PDFKit to draw the current selection through the PDFSelection SPI
   drawForPage:withBox:active:inContext:. Also provided a forward
   declaration for the interface to keep the build happy.
2. Added hooks to inform the PDF plugin when window activity has
   changed. This allows the PDF plugin to be aware of whether or not the
   window it is in is currently active. This knowledge is vended from
   the plugin to PDFKit to ensure we draw secondary colors when we don&apos;t
   have focus.
3. Drive-by fix: remove the unnecessary concept of &quot;committing&quot; a
   selection, as well as the now redundant &quot;isActive&quot; state. There was
   extra motivation to do this since it may be confusing if it lived
   next to the window activity state.

* Source/WebCore/page/Page.h:
* Source/WebKit/Platform/spi/Cocoa/PDFKitSPI.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::windowActivityDidChange):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::windowActivityDidChange):
(WebKit::UnifiedPDFPlugin::paintPDFContent):
(WebKit::UnifiedPDFPlugin::handleMouseEvent):
(WebKit::UnifiedPDFPlugin::beginTrackingSelection):
(WebKit::UnifiedPDFPlugin::continueTrackingSelection):
(WebKit::UnifiedPDFPlugin::setCurrentSelection):
(WebKit::UnifiedPDFPlugin::commitCurrentSelection): Deleted.
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::windowActivityDidChange):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::windowActivityDidChange):
(WebKit::WebPage::setActivityState):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/274246@main">https://commits.webkit.org/274246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/015877baca7b77d4b297fc269b72a0e18fe9d8d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40941 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40693 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14672 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14627 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33453 "Failed to checkout and rebase branch from PR 23907") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12721 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42220 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/34919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38541 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36742 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14857 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8633 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->