### PR TITLE
More dynamicDowncast<> adoption in editing code

### DIFF
--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -95,9 +95,10 @@ static LocalFrame* targetFrame(LocalFrame& frame, Event* event)
 {
     if (!event)
         return &frame;
-    if (!is<Node>(event->target()))
+    auto* node = dynamicDowncast<Node>(event->target());
+    if (!node)
         return &frame;
-    return downcast<Node>(*event->target()).document().frame();
+    return node->document().frame();
 }
 
 static bool applyCommandToFrame(LocalFrame& frame, EditorCommandSource source, EditAction action, Ref<EditingStyle>&& style)
@@ -220,13 +221,13 @@ static unsigned verticalScrollDistance(LocalFrame& frame)
     RefPtr focusedElement = frame.document()->focusedElement();
     if (!focusedElement)
         return 0;
-    CheckedPtr renderer = focusedElement->renderer();
-    if (!is<RenderBox>(renderer.get()))
+    CheckedPtr renderBox = dynamicDowncast<RenderBox>(focusedElement->renderer());
+    if (!renderBox)
         return 0;
-    const RenderStyle& style = renderer->style();
+    const RenderStyle& style = renderBox->style();
     if (!(style.overflowY() == Overflow::Scroll || style.overflowY() == Overflow::Auto || focusedElement->hasEditableStyle()))
         return 0;
-    int height = std::min<int>(downcast<RenderBox>(*renderer).clientHeight(), frame.view()->visibleHeight());
+    int height = std::min<int>(renderBox->clientHeight(), frame.view()->visibleHeight());
     return static_cast<unsigned>(Scrollbar::pageStep(height));
 }
 

--- a/Source/WebCore/editing/InsertListCommand.cpp
+++ b/Source/WebCore/editing/InsertListCommand.cpp
@@ -80,14 +80,13 @@ Ref<HTMLElement> InsertListCommand::mergeWithNeighboringLists(HTMLElement& list)
     if (canMergeLists(previousList.get(), &list))
         mergeIdenticalElements(*previousList, list);
 
-    RefPtr sibling = ElementTraversal::nextSibling(list);
-    if (!is<HTMLElement>(sibling))
+    RefPtr sibling = dynamicDowncast<HTMLElement>(ElementTraversal::nextSibling(list));
+    if (!sibling)
         return protectedList;
 
-    Ref<HTMLElement> nextList = downcast<HTMLElement>(*sibling);
-    if (canMergeLists(&list, nextList.ptr())) {
-        mergeIdenticalElements(list, nextList);
-        return nextList;
+    if (canMergeLists(&list, sibling.get())) {
+        mergeIdenticalElements(list, *sibling);
+        return sibling.releaseNonNull();
     }
     return protectedList;
 }

--- a/Source/WebCore/editing/SimplifyMarkupCommand.cpp
+++ b/Source/WebCore/editing/SimplifyMarkupCommand.cpp
@@ -70,8 +70,8 @@ void SimplifyMarkupCommand::doApply()
             if (!currentNode)
                 break;
 
-            CheckedPtr renderer = currentNode->renderer();
-            if (!is<RenderInline>(renderer.get()) || downcast<RenderInline>(*renderer).mayAffectLayout())
+            CheckedPtr renderInline = dynamicDowncast<RenderInline>(currentNode->renderer());
+            if (!renderInline || renderInline->mayAffectLayout())
                 continue;
             
             if (currentNode->firstChild() != currentNode->lastChild()) {

--- a/Source/WebCore/editing/SpellChecker.cpp
+++ b/Source/WebCore/editing/SpellChecker.cpp
@@ -152,8 +152,8 @@ bool SpellChecker::isCheckable(const SimpleRange& range) const
     }
     if (!foundRenderer)
         return false;
-    Ref node = range.start.container.get();
-    return !is<Element>(node) || downcast<Element>(node.get()).isSpellCheckingEnabled();
+    RefPtr element = dynamicDowncast<Element>(range.start.container.get());
+    return !element || element->isSpellCheckingEnabled();
 }
 
 void SpellChecker::requestCheckingFor(Ref<SpellCheckRequest>&& request)

--- a/Source/WebCore/editing/SplitTextNodeContainingElementCommand.cpp
+++ b/Source/WebCore/editing/SplitTextNodeContainingElementCommand.cpp
@@ -55,10 +55,10 @@ void SplitTextNodeContainingElementCommand::doApply()
     CheckedPtr parentRenderer = parent->renderer();
     if (!parentRenderer || !parentRenderer->isInline()) {
         wrapContentsInDummySpan(*parent);
-        RefPtr firstChild = parent->firstChild();
-        if (!is<Element>(firstChild))
+        RefPtr firstChild = dynamicDowncast<Element>(parent->firstChild());
+        if (!firstChild)
             return;
-        parent = downcast<Element>(WTFMove(firstChild));
+        parent = WTFMove(firstChild);
     }
 
     splitElement(*parent, m_text);

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -683,8 +683,8 @@ Node* VisibleSelection::nonBoundaryShadowTreeRootNode() const
 
 bool VisibleSelection::isInPasswordField() const
 {
-    RefPtr textControl = enclosingTextFormControl(start());
-    return is<HTMLInputElement>(textControl) && downcast<HTMLInputElement>(*textControl).isPasswordField();
+    RefPtr textControl = dynamicDowncast<HTMLInputElement>(enclosingTextFormControl(start()));
+    return textControl && textControl->isPasswordField();
 }
 
 bool VisibleSelection::isInAutoFilledAndViewableField() const


### PR DESCRIPTION
#### 31313f2c893f34e7e345f815f1a4ccdc9b6b5024
<pre>
More dynamicDowncast&lt;&gt; adoption in editing code
<a href="https://bugs.webkit.org/show_bug.cgi?id=268811">https://bugs.webkit.org/show_bug.cgi?id=268811</a>

Reviewed by Chris Dumez.

* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::targetFrame):
(WebCore::verticalScrollDistance):
* Source/WebCore/editing/FormatBlockCommand.cpp:
(WebCore::isElementForFormatBlock):
(WebCore::FormatBlockCommand::elementForFormatBlockCommand):
(WebCore::enclosingBlockToSplitTreeTo):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::removingNodeRemovesPosition):
(WebCore::CaretBase::paintCaret const):
(WebCore::FrameSelection::selectAll):
(WebCore::scanForForm):
* Source/WebCore/editing/InsertListCommand.cpp:
(WebCore::InsertListCommand::mergeWithNeighboringLists):
* Source/WebCore/editing/SimplifyMarkupCommand.cpp:
(WebCore::SimplifyMarkupCommand::doApply):
* Source/WebCore/editing/SpellChecker.cpp:
(WebCore::SpellChecker::isCheckable const):
* Source/WebCore/editing/SplitTextNodeContainingElementCommand.cpp:
(WebCore::SplitTextNodeContainingElementCommand::doApply):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::isInPasswordField const):

Canonical link: <a href="https://commits.webkit.org/274221@main">https://commits.webkit.org/274221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61a32ef70681f3100378ff11d5c153d1628f06bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40908 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40601 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14632 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38924 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12698 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/34275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42187 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38518 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36719 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14829 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8624 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->