### PR TITLE
[LBSE] Allow tests that pass with the default tolerance

### DIFF
--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/TestExpectations
@@ -356,35 +356,20 @@ svg/as-background-image/background-image-preserveaspectRatio-support.html [ Imag
 svg/as-image/img-preserveAspectRatio-support-1.html                       [ ImageOnlyFailure ]
 
 # Pattern problems
-imported/w3c/web-platform-tests/svg/import/pservers-grad-06-b-manual.svg    [ ImageOnlyFailure ]
 svg/W3C-SVG-1.1/pservers-grad-06-b.svg                                      [ Failure ]
-svg/custom/js-late-pattern-and-object-creation.svg                          [ Failure ]
 svg/custom/js-late-pattern-creation.svg                                     [ Failure ]
 svg/custom/nested-pattern-boundingBoxModeContent.svg                        [ Failure ]
-svg/custom/non-scaling-stroke.svg                                           [ ImageOnlyFailure ]
 svg/custom/pattern-content-inheritance-cycle.svg                            [ ImageOnlyFailure ]
-svg/custom/pattern-deep-referencing.svg                                     [ Failure ]
-svg/custom/pattern-incorrect-tiling.svg                                     [ Failure ]
-svg/custom/pattern-referencing-preserve-aspect-ratio.svg                    [ Failure ]
-svg/custom/pattern-rotate.svg                                               [ Failure ]
-svg/custom/pattern-scaled-pattern-space.svg                                 [ Failure ]
-svg/custom/pattern-scaling.svg                                              [ Failure ]
-svg/custom/pattern-skew-transformed.svg                                     [ Failure ]
 svg/custom/pattern-userSpaceOnUse-userToBaseTransform.xhtml                 [ ImageOnlyFailure ]
-svg/custom/pattern-with-transformation.svg                                  [ Failure ]
 svg/custom/stroked-pattern.svg                                              [ Failure ]
-svg/custom/transformed-pattern-clamp-svg-root.svg                           [ Failure ]
 svg/transforms/text-with-pattern-inside-transformed-html.xhtml              [ Failure ]
 svg/transforms/text-with-pattern-with-svg-transform.svg                     [ Failure ]
 
 # Clipping problems
 css3/masking/reference-clip-path-change-repaint.html                                              [ Failure ]
 imported/w3c/web-platform-tests/svg/import/masking-path-07-b-manual.svg                           [ ImageOnlyFailure ]
-svg/W3C-SVG-1.1/masking-path-04-b.svg                                                             [ ImageOnlyFailure ]
-svg/batik/text/textEffect2.svg                                                                    [ ImageOnlyFailure ]
 svg/batik/text/textProperties.svg                                                                 [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-masking/clip-path-svg-content/clip-path-precision-001.svg [ ImageOnlyFailure ]
-svg/clip-path/clip-path-use-referencing-clipped-text.html                                         [ ImageOnlyFailure ]
 svg/repaint/image-with-clip-path.svg                                                              [ ImageOnlyFailure ]
 
 # Masking problems

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/js-late-pattern-and-object-creation-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/js-late-pattern-and-object-creation-expected.txt
@@ -1,0 +1,32 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGRoot {svg} at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGViewportContainer at (0,0) size 800x600
+layer at (-150,8.80) size 560x219 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
+  RenderSVGTransformableContainer {g} at (-150,8.80) size 559.02x218.20
+layer at (5,5) size 15x16
+  RenderSVGHiddenContainer {pattern} at (155,-3.80) size 15x15
+layer at (5,5) size 10x10
+  RenderSVGRect {rect} at (0,0) size 10x10 [fill={[type=SOLID] [color=#FF0000]}] [x=5.00] [y=5.00] [width=10.00] [height=10.00]
+layer at (10,10) size 10x10
+  RenderSVGRect {rect} at (5,5) size 10x10 [fill={[type=SOLID] [color=#008000]}] [x=10.00] [y=10.00] [width=10.00] [height=10.00]
+layer at (5,5) size 15x16
+  RenderSVGHiddenContainer {pattern} at (155,-3.80) size 15x15
+layer at (5,5) size 10x10
+  RenderSVGRect {rect} at (0,0) size 10x10 [fill={[type=SOLID] [color=#FFFF00]}] [x=5.00] [y=5.00] [width=10.00] [height=10.00]
+layer at (10,10) size 10x10
+  RenderSVGRect {rect} at (5,5) size 10x10 [fill={[type=SOLID] [color=#0000FF]}] [x=10.00] [y=10.00] [width=10.00] [height=10.00]
+layer at (-150,8.80) size 374x78 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
+  RenderSVGText {text} at (0,0) size 374x79 contains 1 chunk(s)
+    RenderSVGInlineText {#text} at (0,0) size 374x79
+      chunk 1 text run 1 at (-150.00,70.00) startOffset 0 endOffset 15 width 373.93: "Pattern on fill"
+layer at (-150,78.80) size 461x78 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
+  RenderSVGText {text} at (0,70) size 461x79 contains 1 chunk(s)
+    RenderSVGInlineText {#text} at (0,0) size 461x79
+      chunk 1 text run 1 at (-150.00,140.00) startOffset 0 endOffset 17 width 460.79: "Pattern on stroke"
+layer at (-150,148.80) size 559x78 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
+  RenderSVGText {text} at (0,140) size 560x79 contains 1 chunk(s)
+    RenderSVGInlineText {#text} at (0,0) size 560x79
+      chunk 1 text run 1 at (-150.00,210.00) startOffset 0 endOffset 22 width 559.01: "Pattern on fill/stroke"

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-deep-referencing-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-deep-referencing-expected.txt
@@ -1,0 +1,22 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGRoot {svg} at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGViewportContainer at (0,0) size 800x600
+layer at (0,0) size 50x30
+  RenderSVGHiddenContainer {pattern} at (0,0) size 50x30
+layer at (0,0) size 50x30
+  RenderSVGRect {rect} at (0,0) size 50x30 [stroke={[type=SOLID] [color=#008000]}] [fill={[type=SOLID] [color=#0000FF]}] [x=0.00] [y=0.00] [width=50.00] [height=30.00]
+layer at (0,0) size 50x30
+  RenderSVGHiddenContainer {pattern} at (0,0) size 50x30
+layer at (0,0) size 50x30
+  RenderSVGRect {rect} at (0,0) size 50x30 [stroke={[type=SOLID] [color=#008000]}] [fill={[type=SOLID] [color=#0000FF]}] [x=0.00] [y=0.00] [width=50.00] [height=30.00]
+layer at (0,0) size 100x100
+  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
+layer at (0,0) size 100x100
+  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
+layer at (10,136) size 443x18
+  RenderSVGText {text} at (10,136) size 444x18 contains 1 chunk(s)
+    RenderSVGInlineText {#text} at (0,0) size 444x18
+      chunk 1 text run 1 at (10.00,150.00) startOffset 0 endOffset 68 width 443.42: "The above two squares should be blue-red patterns and look identical"

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-incorrect-tiling-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-incorrect-tiling-expected.txt
@@ -1,0 +1,16 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGRoot {svg} at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGViewportContainer at (0,0) size 800x600
+layer at (10,40) size 20x20
+  RenderSVGHiddenContainer {pattern} at (10,40) size 20x20
+layer at (10,40) size 20x20
+  RenderSVGEllipse {circle} at (0,0) size 20x20 [fill={[type=SOLID] [color=#000000]}] [cx=20.00] [cy=50.00] [r=10.00]
+layer at (23.83,86) size 352x18
+  RenderSVGText {text} at (23,86) size 354x18 contains 1 chunk(s)
+    RenderSVGInlineText {#text} at (0,0) size 353x18
+      chunk 1 (middle anchor) text run 1 at (23.83,100.00) startOffset 0 endOffset 56 width 352.34: "There should be a black dot in the middle of the ellipse"
+layer at (180,150) size 40x100
+  RenderSVGEllipse {ellipse} at (180,150) size 40x100 [stroke={[type=SOLID] [color=#808080]}] [fill={[type=SOLID] [color=#000000]}] [cx=200.00] [cy=200.00] [rx=20.00] [ry=50.00]

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-referencing-preserve-aspect-ratio-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-referencing-preserve-aspect-ratio-expected.txt
@@ -1,0 +1,24 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGRoot {svg} at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGViewportContainer at (0,0) size 800x600
+layer at (0.50,0.50) size 30x40
+  RenderSVGHiddenContainer {pattern} at (0.50,0.50) size 29x39
+layer at (0.50,0.50) size 29x39
+  RenderSVGRect {rect} at (0,0) size 29x39 [stroke={[type=SOLID] [color=#FF0000]}] [fill={[type=SOLID] [color=#000000]}] [x=0.50] [y=0.50] [width=29.00] [height=39.00]
+layer at (5,5) size 21x21
+  RenderSVGTransformableContainer {g} at (4.50,4.50) size 20x20
+layer at (5,5) size 20x20
+  RenderSVGEllipse {circle} at (0,0) size 20x20 [fill={[type=SOLID] [color=#FFFF00]}] [cx=15.00] [cy=15.00] [r=10.00]
+layer at (10.50,10.50) size 4x4
+  RenderSVGEllipse {circle} at (5.50,5.50) size 3x3 [fill={[type=SOLID] [color=#000000]}] [cx=12.00] [cy=12.00] [r=1.50]
+layer at (15.50,10.50) size 4x4
+  RenderSVGEllipse {circle} at (10.50,5.50) size 3x3 [fill={[type=SOLID] [color=#000000]}] [cx=17.00] [cy=12.00] [r=1.50]
+layer at (10,19) size 10x2
+  RenderSVGPath {path} at (5,14) size 10x1.77 [stroke={[type=SOLID] [color=#000000] [stroke width=2.00]}] [fill={[type=SOLID] [color=#000000]}] [data="M 10 19 C 12.9227 21.34 17.0773 21.34 20 19"]
+layer at (80,0) size 20x80
+  RenderSVGRect {rect} at (80,0) size 20x80 [fill={[type=SOLID] [color=#000000]}] [x=80.00] [y=0.00] [width=20.00] [height=80.00]
+layer at (100,0) size 40x80
+  RenderSVGRect {rect} at (100,0) size 40x80 [fill={[type=SOLID] [color=#000000]}] [x=100.00] [y=0.00] [width=40.00] [height=80.00]

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-rotate-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-rotate-expected.txt
@@ -1,0 +1,49 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGRoot {svg} at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGViewportContainer at (0,0) size 800x600
+layer at (0,0) size 100x100
+  RenderSVGHiddenContainer {defs} at (0,0) size 100x100
+layer at (0.09,0.09) size 1x1
+  RenderSVGHiddenContainer {pattern} at (0.09,0.09) size 0.81x0.81
+layer at (0.09,0.09) size 1x1
+  RenderSVGEllipse {circle} at (0,0) size 0.31x0.31 [fill={[type=SOLID] [color=#FF0000]}] [cx=0.25] [cy=0.25] [r=0.15]
+layer at (0.59,0.09) size 1x1
+  RenderSVGEllipse {circle} at (0.50,0) size 0.31x0.31 [fill={[type=SOLID] [color=#008000]}] [cx=0.75] [cy=0.25] [r=0.15]
+layer at (0.09,0.59) size 1x1
+  RenderSVGEllipse {circle} at (0,0.50) size 0.31x0.31 [fill={[type=SOLID] [color=#0000FF]}] [cx=0.25] [cy=0.75] [r=0.15]
+layer at (0.59,0.59) size 1x1
+  RenderSVGEllipse {circle} at (0.50,0.50) size 0.31x0.31 [fill={[type=SOLID] [color=#800080]}] [cx=0.75] [cy=0.75] [r=0.15]
+layer at (0.44,0.44) size 1x1
+  RenderSVGEllipse {circle} at (0.34,0.34) size 0.13x0.13 [fill={[type=SOLID] [color=#FFA500]}] [cx=0.50] [cy=0.50] [r=0.05]
+layer at (0,0) size 100x100
+  RenderSVGTransformableContainer {g} at (0,0) size 100x100
+layer at (0,0) size 100x100
+  RenderSVGRect {rect} at (0,0) size 100x100 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
+layer at (0,0) size 100x100
+  RenderSVGTransformableContainer {g} at (0,0) size 100x100
+layer at (0,0) size 100x100
+  RenderSVGTransformableContainer {use} at (0,0) size 100x100
+layer at (0,0) size 100x100
+  RenderSVGTransformableContainer {g} at (0,0) size 100x100
+layer at (0,0) size 100x100
+  RenderSVGRect {rect} at (0,0) size 100x100 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
+layer at (0,-11.05) size 296x45 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
+  RenderSVGTransformableContainer {g} at (0,-11.05) size 295.25x44
+layer at (0,-11.05) size 295x44 backgroundClip at (0,0) size 800x600 clip at (0,0) size 800x600
+  RenderSVGText {text} at (0,0) size 296x44 contains 1 chunk(s)
+    RenderSVGTSpan {tspan} at (0,0) size 289x14
+      RenderSVGInlineText {#text} at (0,0) size 289x14
+        chunk 1 text run 1 at (0.00,0.00) startOffset 0 endOffset 40 width 288.05: "For this test case to be successful, the"
+    RenderSVGInlineText {#text} at (288,0) size 8x14
+      chunk 1 text run 1 at (288.05,0.00) startOffset 0 endOffset 1 width 7.20: " "
+    RenderSVGTSpan {tspan} at (0,0) size 281x14
+      RenderSVGInlineText {#text} at (0,15) size 281x14
+        chunk 1 text run 1 at (0.00,15.00) startOffset 0 endOffset 39 width 280.85: "five dots should fit in the rectangle. "
+    RenderSVGInlineText {#text} at (0,0) size 0x0
+    RenderSVGTSpan {tspan} at (0,0) size 65x14
+      RenderSVGInlineText {#text} at (0,30) size 65x14
+        chunk 1 text run 1 at (0.00,30.00) startOffset 0 endOffset 9 width 64.81: "Bug 14924"
+    RenderSVGInlineText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-scaled-pattern-space-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-scaled-pattern-space-expected.txt
@@ -1,0 +1,12 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGRoot {svg} at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGViewportContainer at (0,0) size 800x600
+layer at (0,0) size 5x5
+  RenderSVGHiddenContainer {pattern} at (0,0) size 5x5
+layer at (0,0) size 5x5
+  RenderSVGEllipse {circle} at (0,0) size 5x5 [fill={[type=SOLID] [color=#00FF00]}] [cx=2.50] [cy=2.50] [r=2.50]
+layer at (0,0) size 200x200
+  RenderSVGRect {rect} at (0,0) size 200x200 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=200.00] [height=200.00]

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-scaling-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-scaling-expected.txt
@@ -1,0 +1,70 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGRoot {svg} at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGViewportContainer at (0,0) size 800x600
+layer at (10,10) size 40x40
+  RenderSVGHiddenContainer {defs} at (10,10) size 40x40
+layer at (0,0) size 20x20
+  RenderSVGHiddenContainer {pattern} at (-10,-10) size 20x20
+layer at (0,0) size 10x10
+  RenderSVGRect {rect} at (0,0) size 10x10 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=10.00] [height=10.00]
+layer at (10,10) size 10x10
+  RenderSVGRect {rect} at (10,10) size 10x10 [fill={[type=SOLID] [color=#008000]}] [x=10.00] [y=10.00] [width=10.00] [height=10.00]
+layer at (10,10) size 40x40
+  RenderSVGTransformableContainer {g} at (0,0) size 40x40
+layer at (10,10) size 40x40
+  RenderSVGRect {rect} at (0,0) size 40x40 [fill={[type=SOLID] [color=#FFFF00]}] [x=10.00] [y=10.00] [width=40.00] [height=40.00]
+layer at (10,10) size 40x40
+  RenderSVGRect {rect} at (0,0) size 40x40 [fill={[type=SOLID] [color=#000000]}] [x=10.00] [y=10.00] [width=40.00] [height=40.00]
+layer at (10,10) size 40x40
+  RenderSVGTransformableContainer {g} at (10,10) size 40x40
+layer at (10,10) size 40x40
+  RenderSVGTransformableContainer {use} at (0,0) size 40x40
+layer at (10,10) size 40x40
+  RenderSVGTransformableContainer {g} at (0,0) size 40x40
+layer at (10,10) size 40x40
+  RenderSVGRect {rect} at (0,0) size 40x40 [fill={[type=SOLID] [color=#FFFF00]}] [x=10.00] [y=10.00] [width=40.00] [height=40.00]
+layer at (10,10) size 40x40
+  RenderSVGRect {rect} at (0,0) size 40x40 [fill={[type=SOLID] [color=#000000]}] [x=10.00] [y=10.00] [width=40.00] [height=40.00]
+layer at (10,10) size 40x40
+  RenderSVGTransformableContainer {g} at (10,10) size 40x40
+layer at (10,10) size 40x40
+  RenderSVGTransformableContainer {use} at (0,0) size 40x40
+layer at (10,10) size 40x40
+  RenderSVGTransformableContainer {g} at (0,0) size 40x40
+layer at (10,10) size 40x40
+  RenderSVGRect {rect} at (0,0) size 40x40 [fill={[type=SOLID] [color=#FFFF00]}] [x=10.00] [y=10.00] [width=40.00] [height=40.00]
+layer at (10,10) size 40x40
+  RenderSVGRect {rect} at (0,0) size 40x40 [fill={[type=SOLID] [color=#000000]}] [x=10.00] [y=10.00] [width=40.00] [height=40.00]
+layer at (10,10) size 40x40
+  RenderSVGTransformableContainer {g} at (10,10) size 40x40
+layer at (10,10) size 40x40
+  RenderSVGTransformableContainer {use} at (0,0) size 40x40
+layer at (10,10) size 40x40
+  RenderSVGTransformableContainer {g} at (0,0) size 40x40
+layer at (10,10) size 40x40
+  RenderSVGRect {rect} at (0,0) size 40x40 [fill={[type=SOLID] [color=#FFFF00]}] [x=10.00] [y=10.00] [width=40.00] [height=40.00]
+layer at (10,10) size 40x40
+  RenderSVGRect {rect} at (0,0) size 40x40 [fill={[type=SOLID] [color=#000000]}] [x=10.00] [y=10.00] [width=40.00] [height=40.00]
+layer at (10,10) size 40x40
+  RenderSVGTransformableContainer {g} at (10,10) size 40x40
+layer at (10,10) size 40x40
+  RenderSVGTransformableContainer {use} at (0,0) size 40x40
+layer at (10,10) size 40x40
+  RenderSVGTransformableContainer {g} at (0,0) size 40x40
+layer at (10,10) size 40x40
+  RenderSVGRect {rect} at (0,0) size 40x40 [fill={[type=SOLID] [color=#FFFF00]}] [x=10.00] [y=10.00] [width=40.00] [height=40.00]
+layer at (10,10) size 40x40
+  RenderSVGRect {rect} at (0,0) size 40x40 [fill={[type=SOLID] [color=#000000]}] [x=10.00] [y=10.00] [width=40.00] [height=40.00]
+layer at (10,10) size 40x40
+  RenderSVGTransformableContainer {g} at (10,10) size 40x40
+layer at (10,10) size 40x40
+  RenderSVGTransformableContainer {use} at (0,0) size 40x40
+layer at (10,10) size 40x40
+  RenderSVGTransformableContainer {g} at (0,0) size 40x40
+layer at (10,10) size 40x40
+  RenderSVGRect {rect} at (0,0) size 40x40 [fill={[type=SOLID] [color=#FFFF00]}] [x=10.00] [y=10.00] [width=40.00] [height=40.00]
+layer at (10,10) size 40x40
+  RenderSVGRect {rect} at (0,0) size 40x40 [fill={[type=SOLID] [color=#000000]}] [x=10.00] [y=10.00] [width=40.00] [height=40.00]

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-skew-transformed-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-skew-transformed-expected.txt
@@ -1,0 +1,14 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGRoot {svg} at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGViewportContainer at (0,0) size 800x600
+layer at (0,0) size 110x110
+  RenderSVGHiddenContainer {pattern} at (0,0) size 110x110
+layer at (0,0) size 110x110
+  RenderSVGRect {rect} at (0,0) size 110x110 [fill={[type=SOLID] [color=#0000FF]}] [x=0.00] [y=0.00] [width=110.00] [height=110.00]
+layer at (0,0) size 100x100
+  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#FF0000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
+layer at (0,0) size 100x100
+  RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-with-transformation-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-with-transformation-expected.txt
@@ -1,0 +1,24 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGRoot {svg} at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderSVGViewportContainer at (0,0) size 800x600
+layer at (0,0) size 10x10
+  RenderSVGHiddenContainer {pattern} at (0,0) size 10x10
+layer at (0,0) size 5x5
+  RenderSVGRect {rect} at (0,0) size 5x5 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=5.00] [height=5.00]
+layer at (5,0) size 5x5
+  RenderSVGRect {rect} at (5,0) size 5x5 [fill={[type=SOLID] [color=#FF0000]}] [x=5.00] [y=0.00] [width=5.00] [height=5.00]
+layer at (0,5) size 5x5
+  RenderSVGRect {rect} at (0,5) size 5x5 [fill={[type=SOLID] [color=#0000FF]}] [x=0.00] [y=5.00] [width=5.00] [height=5.00]
+layer at (5,5) size 5x5
+  RenderSVGRect {rect} at (5,5) size 5x5 [fill={[type=SOLID] [color=#FFFF00]}] [x=5.00] [y=5.00] [width=5.00] [height=5.00]
+layer at (10,10) size 120x100
+  RenderSVGTransformableContainer {g} at (10,10) size 120x100
+layer at (10,10) size 120x100
+  RenderSVGRect {rect} at (0,0) size 120x100 [stroke={[type=SOLID] [color=#00000000]}] [fill={[type=SOLID] [color=#FFFFFF]}] [x=10.00] [y=10.00] [width=120.00] [height=100.00]
+layer at (15,24.50) size 86x58
+  RenderSVGText {text} at (5,14) size 87x59 contains 1 chunk(s)
+    RenderSVGInlineText {#text} at (0,0) size 87x58
+      chunk 1 text run 1 at (15.00,70.00) startOffset 0 endOffset 4 width 86.08: "Test"

--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/transformed-pattern-clamp-svg-root-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/transformed-pattern-clamp-svg-root-expected.txt
@@ -1,0 +1,12 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 200x200
+  RenderSVGRoot {svg} at (0,0) size 200x200
+layer at (0,0) size 200x200
+  RenderSVGViewportContainer at (0,0) size 200x200
+layer at (0,0) size 400x400 backgroundClip at (0,0) size 200x200 clip at (0,0) size 200x200
+  RenderSVGHiddenContainer {pattern} at (0,0) size 400x400
+layer at (0,0) size 400x400 backgroundClip at (0,0) size 200x200 clip at (0,0) size 200x200
+  RenderSVGRect {rect} at (0,0) size 400x400 [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=0.00] [width=400.00] [height=400.00]
+layer at (0,100) size 200x200 backgroundClip at (0,0) size 200x200 clip at (0,0) size 200x200
+  RenderSVGRect {rect} at (0,100) size 200x200 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#000000]}] [x=0.00] [y=100.00] [width=200.00] [height=200.00]


### PR DESCRIPTION
#### b2a19bd2cf7ae20372d9131c95c61890c195b3b6
<pre>
[LBSE] Allow tests that pass with the default tolerance
<a href="https://bugs.webkit.org/show_bug.cgi?id=268812">https://bugs.webkit.org/show_bug.cgi?id=268812</a>

Reviewed by Nikolas Zimmermann.

So far tests have been mostly run with tolerance=0, however some tests have only a few pixel
difference and pass with the default tolerance, so allow these. Reasons for pixel differences
imay well be gpu process related.

* LayoutTests/platform/mac-sonoma-wk2-lbse-text/TestExpectations:
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/js-late-pattern-and-object-creation-expected.txt: Added.
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-deep-referencing-expected.txt: Added.
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-incorrect-tiling-expected.txt: Added.
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-referencing-preserve-aspect-ratio-expected.txt: Added.
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-rotate-expected.txt: Added.
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-scaled-pattern-space-expected.txt: Added.
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-scaling-expected.txt: Added.
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-skew-transformed-expected.txt: Added.
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/pattern-with-transformation-expected.txt: Added.
* LayoutTests/platform/mac-sonoma-wk2-lbse-text/svg/custom/transformed-pattern-clamp-svg-root-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/274143@main">https://commits.webkit.org/274143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8099c448bec2d37c85e2293f2ef42a628f2e248b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40618 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33860 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32149 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14344 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12504 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12439 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41894 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34563 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38320 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36512 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14592 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8531 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13456 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->