### PR TITLE
Remove FlattenedConstraints

### DIFF
--- a/Source/WebCore/platform/mediastream/MediaConstraints.cpp
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.cpp
@@ -122,65 +122,6 @@ void StringConstraint::merge(const MediaConstraint& other)
     }
 }
 
-void FlattenedConstraint::set(const MediaConstraint& constraint)
-{
-    if (find(constraint.constraintType()))
-        return;
-
-    append(constraint);
-}
-
-void FlattenedConstraint::merge(const MediaConstraint& constraint)
-{
-    for (auto& variant : *this) {
-        if (variant.constraintType() != constraint.constraintType())
-            continue;
-
-        switch (variant.dataType()) {
-        case MediaConstraint::DataType::Integer:
-            ASSERT(constraint.isInt());
-            downcast<const IntConstraint>(variant).merge(downcast<const IntConstraint>(constraint));
-            return;
-        case MediaConstraint::DataType::Double:
-            ASSERT(constraint.isDouble());
-            downcast<const DoubleConstraint>(variant).merge(downcast<const DoubleConstraint>(constraint));
-            return;
-        case MediaConstraint::DataType::Boolean:
-            ASSERT(constraint.isBoolean());
-            downcast<const BooleanConstraint>(variant).merge(downcast<const BooleanConstraint>(constraint));
-            return;
-        case MediaConstraint::DataType::String:
-            ASSERT(constraint.isString());
-            downcast<const StringConstraint>(variant).merge(downcast<const StringConstraint>(constraint));
-            return;
-        case MediaConstraint::DataType::None:
-            ASSERT_NOT_REACHED();
-            return;
-        }
-    }
-
-    append(constraint);
-}
-
-void FlattenedConstraint::append(const MediaConstraint& constraint)
-{
-#if ASSERT_ENABLED
-    ++m_generation;
-#endif
-
-    m_variants.append(ConstraintHolder::create(constraint));
-}
-
-const MediaConstraint* FlattenedConstraint::find(MediaConstraintType type) const
-{
-    for (auto& variant : m_variants) {
-        if (variant.constraintType() == type)
-            return &variant.constraint();
-    }
-
-    return nullptr;
-}
-
 void MediaTrackConstraintSetMap::forEach(Function<void(const MediaConstraint&)>&& callback) const
 {
     filter([callback = WTFMove(callback)] (const MediaConstraint& constraint) mutable {
@@ -362,6 +303,149 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     case MediaConstraintType::FocusDistance:
     case MediaConstraintType::Zoom:
     case MediaConstraintType::Torch:
+    case MediaConstraintType::Unknown:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+}
+
+void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, const MediaConstraint& constraint)
+{
+    switch (constraint.dataType()) {
+    case MediaConstraint::DataType::Integer:
+        set(constraintType, std::make_optional(downcast<const IntConstraint>(constraint)));
+        return;
+    case MediaConstraint::DataType::Double:
+        set(constraintType, std::make_optional(downcast<const DoubleConstraint>(constraint)));
+        return;
+    case MediaConstraint::DataType::Boolean:
+        set(constraintType, std::make_optional(downcast<const BooleanConstraint>(constraint)));
+        return;
+    case MediaConstraint::DataType::String:
+        set(constraintType, std::make_optional(downcast<const StringConstraint>(constraint)));
+        return;
+    case MediaConstraint::DataType::None:
+        ASSERT_NOT_REACHED();
+        return;
+    }
+}
+
+void MediaTrackConstraintSetMap::merge(const MediaConstraint& constraint)
+{
+    switch (constraint.constraintType()) {
+    case MediaConstraintType::FacingMode:
+        ASSERT(constraint.dataType() == MediaConstraint::DataType::String);
+        if (!m_facingMode)
+            m_facingMode = downcast<const StringConstraint>(constraint);
+        else
+            m_facingMode->merge(downcast<const StringConstraint>(constraint));
+        break;
+    case MediaConstraintType::DeviceId:
+        ASSERT(constraint.dataType() == MediaConstraint::DataType::String);
+        if (!m_deviceId)
+            m_deviceId = downcast<const StringConstraint>(constraint);
+        else
+            m_deviceId->merge(downcast<const StringConstraint>(constraint));
+        break;
+    case MediaConstraintType::GroupId:
+        ASSERT(constraint.dataType() == MediaConstraint::DataType::String);
+        if (!m_groupId)
+            m_groupId = downcast<const StringConstraint>(constraint);
+        else
+            m_groupId->merge(downcast<const StringConstraint>(constraint));
+        break;
+    case MediaConstraintType::WhiteBalanceMode:
+        ASSERT(constraint.dataType() == MediaConstraint::DataType::String);
+        if (!m_whiteBalanceMode)
+            m_whiteBalanceMode = downcast<const StringConstraint>(constraint);
+        else
+            m_whiteBalanceMode->merge(downcast<const StringConstraint>(constraint));
+        break;
+    case MediaConstraintType::Width:
+        ASSERT(constraint.dataType() == MediaConstraint::DataType::Integer);
+        if (!m_width)
+            m_width = downcast<const IntConstraint>(constraint);
+        else
+            m_width->merge(downcast<const IntConstraint>(constraint));
+        break;
+    case MediaConstraintType::Height:
+        ASSERT(constraint.dataType() == MediaConstraint::DataType::Integer);
+        if (!m_height)
+            m_height = downcast<const IntConstraint>(constraint);
+        else
+            m_height->merge(downcast<const IntConstraint>(constraint));
+        break;
+    case MediaConstraintType::SampleRate:
+        ASSERT(constraint.dataType() == MediaConstraint::DataType::Integer);
+        if (!m_sampleRate)
+            m_sampleRate = downcast<const IntConstraint>(constraint);
+        else
+            m_sampleRate->merge(downcast<const IntConstraint>(constraint));
+        break;
+    case MediaConstraintType::SampleSize:
+        ASSERT(constraint.dataType() == MediaConstraint::DataType::Integer);
+        if (!m_sampleSize)
+            m_sampleSize = downcast<const IntConstraint>(constraint);
+        else
+            m_sampleSize->merge(downcast<const IntConstraint>(constraint));
+        break;
+    case MediaConstraintType::AspectRatio:
+        ASSERT(constraint.dataType() == MediaConstraint::DataType::Double);
+        if (!m_aspectRatio)
+            m_aspectRatio = downcast<const DoubleConstraint>(constraint);
+        else
+            m_aspectRatio->merge(downcast<const DoubleConstraint>(constraint));
+        break;
+    case MediaConstraintType::FrameRate:
+        ASSERT(constraint.dataType() == MediaConstraint::DataType::Double);
+        if (!m_frameRate)
+            m_frameRate = downcast<const DoubleConstraint>(constraint);
+        else
+            m_frameRate->merge(downcast<const DoubleConstraint>(constraint));
+        break;
+    case MediaConstraintType::Volume:
+        ASSERT(constraint.dataType() == MediaConstraint::DataType::Double);
+        if (!m_volume)
+            m_volume = downcast<const DoubleConstraint>(constraint);
+        else
+            m_volume->merge(downcast<const DoubleConstraint>(constraint));
+        break;
+    case MediaConstraintType::Zoom:
+        ASSERT(constraint.dataType() == MediaConstraint::DataType::Double);
+        if (!m_zoom)
+            m_zoom = downcast<const DoubleConstraint>(constraint);
+        else
+            m_zoom->merge(downcast<const DoubleConstraint>(constraint));
+        break;
+    case MediaConstraintType::EchoCancellation:
+        ASSERT(constraint.dataType() == MediaConstraint::DataType::Boolean);
+        if (!m_echoCancellation)
+            m_echoCancellation = downcast<const BooleanConstraint>(constraint);
+        else
+            m_echoCancellation->merge(downcast<const BooleanConstraint>(constraint));
+        break;
+    case MediaConstraintType::DisplaySurface:
+        ASSERT(constraint.dataType() == MediaConstraint::DataType::Boolean);
+        if (!m_displaySurface)
+            m_displaySurface = downcast<const BooleanConstraint>(constraint);
+        else
+            m_displaySurface->merge(downcast<const BooleanConstraint>(constraint));
+        break;
+    case MediaConstraintType::LogicalSurface:
+        ASSERT(constraint.dataType() == MediaConstraint::DataType::Boolean);
+        if (!m_logicalSurface)
+            m_logicalSurface = downcast<const BooleanConstraint>(constraint);
+        else
+            m_logicalSurface->merge(downcast<const BooleanConstraint>(constraint));
+        break;
+    case MediaConstraintType::Torch:
+        ASSERT(constraint.dataType() == MediaConstraint::DataType::Boolean);
+        if (!m_torch)
+            m_torch = downcast<const BooleanConstraint>(constraint);
+        else
+            m_torch->merge(downcast<const BooleanConstraint>(constraint));
+        break;
+    case MediaConstraintType::FocusDistance:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -288,11 +288,11 @@ protected:
     virtual void startApplyingConstraints() { }
     virtual void endApplyingConstraints() { }
 
-    bool selectSettings(const MediaConstraints&, FlattenedConstraint&, String&);
+    bool selectSettings(const MediaConstraints&, MediaTrackConstraintSetMap&, String&);
     double fitnessDistance(const MediaConstraint&);
     void applyConstraint(const MediaConstraint&);
-    void applyConstraints(const FlattenedConstraint&);
-    VideoFrameSizeConstraints extractVideoFrameSizeConstraints(const FlattenedConstraint&);
+    void applyConstraints(const MediaTrackConstraintSetMap&);
+    VideoFrameSizeConstraints extractVideoFrameSizeConstraints(const MediaTrackConstraintSetMap&);
     bool supportsSizeFrameRateAndZoom(std::optional<IntConstraint> width, std::optional<IntConstraint> height, std::optional<DoubleConstraint>, std::optional<DoubleConstraint>, String&, double& fitnessDistance);
 
     virtual bool supportsSizeFrameRateAndZoom(std::optional<int> width, std::optional<int> height, std::optional<double>, std::optional<double>);


### PR DESCRIPTION
#### 59e2ed56406e4f89e2011b3e51f0cec271c6241a
<pre>
Remove FlattenedConstraints
<a href="https://bugs.webkit.org/show_bug.cgi?id=268813">https://bugs.webkit.org/show_bug.cgi?id=268813</a>
<a href="https://rdar.apple.com/122375936">rdar://122375936</a>

Reviewed by Eric Carlson.

FlattenedConstraints can be replaced by MediaTrackConstraintSetMap which has the benefit of being typed.

* Source/WebCore/platform/mediastream/MediaConstraints.cpp:
(WebCore::MediaTrackConstraintSetMap::set):
(WebCore::MediaTrackConstraintSetMap::merge):
(WebCore::FlattenedConstraint::set): Deleted.
(WebCore::FlattenedConstraint::merge): Deleted.
(WebCore::FlattenedConstraint::append): Deleted.
(WebCore::FlattenedConstraint::find const): Deleted.
* Source/WebCore/platform/mediastream/MediaConstraints.h:
(WebCore::MediaTrackConstraintSetMap::width const):
(WebCore::MediaTrackConstraintSetMap::height const):
(WebCore::MediaTrackConstraintSetMap::sampleRate const):
(WebCore::MediaTrackConstraintSetMap::sampleSize const):
(WebCore::MediaTrackConstraintSetMap::aspectRatio const):
(WebCore::MediaTrackConstraintSetMap::frameRate const):
(WebCore::MediaTrackConstraintSetMap::volume const):
(WebCore::MediaTrackConstraintSetMap::echoCancellation const):
(WebCore::MediaTrackConstraintSetMap::displaySurface const):
(WebCore::MediaTrackConstraintSetMap::logicalSurface const):
(WebCore::MediaTrackConstraintSetMap::facingMode const):
(WebCore::MediaTrackConstraintSetMap::deviceId const):
(WebCore::MediaTrackConstraintSetMap::groupId const):
(WebCore::MediaTrackConstraintSetMap::whiteBalanceMode const):
(WebCore::MediaTrackConstraintSetMap::zoom const):
(WebCore::MediaTrackConstraintSetMap::torch const):
(WebCore::FlattenedConstraint::isEmpty const): Deleted.
(WebCore::FlattenedConstraint::iterator::iterator): Deleted.
(WebCore::FlattenedConstraint::iterator::operator* const): Deleted.
(WebCore::FlattenedConstraint::iterator::operator++): Deleted.
(WebCore::FlattenedConstraint::iterator::operator== const): Deleted.
(WebCore::FlattenedConstraint::begin const): Deleted.
(WebCore::FlattenedConstraint::end const): Deleted.
(WebCore::FlattenedConstraint::ConstraintHolder::create): Deleted.
(WebCore::FlattenedConstraint::ConstraintHolder::~ConstraintHolder): Deleted.
(WebCore::FlattenedConstraint::ConstraintHolder::ConstraintHolder): Deleted.
(WebCore::FlattenedConstraint::ConstraintHolder::constraint const): Deleted.
(WebCore::FlattenedConstraint::ConstraintHolder::dataType const): Deleted.
(WebCore::FlattenedConstraint::ConstraintHolder::constraintType const): Deleted.
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::selectSettings):
(WebCore::RealtimeMediaSource::supportsConstraints):
(WebCore::RealtimeMediaSource::extractVideoFrameSizeConstraints):
(WebCore::RealtimeMediaSource::applyConstraints):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:

Canonical link: <a href="https://commits.webkit.org/274204@main">https://commits.webkit.org/274204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49de318c0b6185f23cc7b8cf6bfb884e22fb64a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40621 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33862 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32152 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14343 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33328 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12509 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12438 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41897 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34562 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34522 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38323 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36520 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14594 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8613 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13458 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14044 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->