### PR TITLE
Even more dynamicDowncast<> adoption in editing code

### DIFF
--- a/Source/WebCore/editing/cocoa/AutofillElements.cpp
+++ b/Source/WebCore/editing/cocoa/AutofillElements.cpp
@@ -33,19 +33,16 @@ namespace WebCore {
 
 static inline bool isAutofillableElement(Element& node)
 {
-    if (!is<HTMLInputElement>(node))
-        return false;
-
-    auto inputElement = &downcast<HTMLInputElement>(node);
-    return inputElement->isTextField() || inputElement->isEmailField();
+    auto* inputElement = dynamicDowncast<HTMLInputElement>(node);
+    return inputElement && (inputElement->isTextField() || inputElement->isEmailField());
 }
 
 static inline RefPtr<HTMLInputElement> nextAutofillableElement(Node* startNode, FocusController& focusController)
 {
-    if (!is<Element>(startNode))
+    RefPtr nextElement = dynamicDowncast<Element>(startNode);
+    if (!nextElement)
         return nullptr;
 
-    RefPtr<Element> nextElement = downcast<Element>(startNode);
     do {
         nextElement = focusController.nextFocusableElement(*nextElement.get());
     } while (nextElement && !isAutofillableElement(*nextElement.get()));
@@ -58,10 +55,10 @@ static inline RefPtr<HTMLInputElement> nextAutofillableElement(Node* startNode, 
 
 static inline RefPtr<HTMLInputElement> previousAutofillableElement(Node* startNode, FocusController& focusController)
 {
-    if (!is<Element>(startNode))
+    RefPtr previousElement = dynamicDowncast<Element>(startNode);
+    if (!previousElement)
         return nullptr;
 
-    RefPtr<Element> previousElement = downcast<Element>(startNode);
     do {
         previousElement = focusController.previousFocusableElement(*previousElement.get());
     } while (previousElement && !isAutofillableElement(*previousElement.get()));

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -333,17 +333,19 @@ void Editor::readSelectionFromPasteboard(const String& pasteboardName)
 static void maybeCopyNodeAttributesToFragment(const Node& node, DocumentFragment& fragment)
 {
     // This is only supported for single-Node fragments.
-    RefPtr firstChild = fragment.firstChild();
-    if (!firstChild || firstChild != fragment.lastChild())
+    if (!fragment.hasOneChild())
         return;
 
     // And only supported for HTML elements.
-    if (!node.isHTMLElement() || !firstChild->isHTMLElement())
+    RefPtr oldElement = dynamicDowncast<HTMLElement>(node);
+    if (!oldElement)
+        return;
+
+    RefPtr newElement = dynamicDowncast<HTMLElement>(*fragment.firstChild());
+    if (!newElement)
         return;
 
     // And only if the source Element and destination Element have the same HTML tag name.
-    Ref oldElement = downcast<HTMLElement>(node);
-    Ref newElement = downcast<HTMLElement>(*firstChild);
     if (oldElement->localName() != newElement->localName())
         return;
 

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -360,11 +360,10 @@ static void replaceRichContentWithAttachments(LocalFrame& frame, DocumentFragmen
 
         auto attachment = HTMLAttachmentElement::create(HTMLNames::attachmentTag, fragment.document());
         if (supportsClientSideAttachmentData(frame)) {
-            if (is<HTMLImageElement>(originalElement) && contentTypeIsSuitableForInlineImageRepresentation(info.contentType)) {
-                auto& image = downcast<HTMLImageElement>(originalElement.get());
+            if (RefPtr image = dynamicDowncast<HTMLImageElement>(originalElement); image && contentTypeIsSuitableForInlineImageRepresentation(info.contentType)) {
                 RefPtr document = frame.document();
-                image.setAttributeWithoutSynchronization(HTMLNames::srcAttr, AtomString { DOMURL::createObjectURL(*document, Blob::create(document.get(), info.data->copyData(), info.contentType)) });
-                image.setAttachmentElement(attachment.copyRef());
+                image->setAttributeWithoutSynchronization(HTMLNames::srcAttr, AtomString { DOMURL::createObjectURL(*document, Blob::create(document.get(), info.data->copyData(), info.contentType)) });
+                image->setAttachmentElement(attachment.copyRef());
             } else {
                 attachment->updateAttributes(info.data->size(), AtomString { info.contentType }, AtomString { info.fileName });
                 parent->replaceChild(attachment, WTFMove(originalElement));

--- a/Source/WebCore/editing/mac/EditorMac.mm
+++ b/Source/WebCore/editing/mac/EditorMac.mm
@@ -199,19 +199,19 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 static void getImage(Element& imageElement, RefPtr<Image>& image, CachedImage*& cachedImage)
 {
-    auto* renderer = imageElement.renderer();
-    if (!is<RenderImage>(renderer))
+    CheckedPtr renderImage = dynamicDowncast<RenderImage>(imageElement.renderer());
+    if (!renderImage)
         return;
 
-    CachedImage* tentativeCachedImage = downcast<RenderImage>(*renderer).cachedImage();
+    CachedResourceHandle tentativeCachedImage = renderImage->cachedImage();
     if (!tentativeCachedImage || tentativeCachedImage->errorOccurred())
         return;
 
-    image = tentativeCachedImage->imageForRenderer(renderer);
+    image = tentativeCachedImage->imageForRenderer(renderImage.get());
     if (!image)
         return;
 
-    cachedImage = tentativeCachedImage;
+    cachedImage = tentativeCachedImage.get();
 }
 
 void Editor::selectionWillChange()


### PR DESCRIPTION
#### aebcf656ec82f9901f555ed629e3b40407580dbf
<pre>
Even more dynamicDowncast&lt;&gt; adoption in editing code
<a href="https://bugs.webkit.org/show_bug.cgi?id=268815">https://bugs.webkit.org/show_bug.cgi?id=268815</a>

Reviewed by Chris Dumez.

* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::previousBoundary):
(WebCore::startPositionForLine):
(WebCore::endPositionForLine):
(WebCore::findStartOfParagraph):
(WebCore::findEndOfParagraph):
(WebCore::startOfParagraph):
(WebCore::endOfParagraph):
* Source/WebCore/editing/cocoa/AutofillElements.cpp:
(WebCore::isAutofillableElement):
(WebCore::nextAutofillableElement):
(WebCore::previousAutofillableElement):
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::maybeCopyNodeAttributesToFragment):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::replaceRichContentWithAttachments):
* Source/WebCore/editing/ios/EditorIOS.mm:
(WebCore::Editor::setTextAlignmentForChangedBaseWritingDirection):
(WebCore::getImage):
(WebCore::Editor::setDictationPhrasesAsChildOfElement):
* Source/WebCore/editing/mac/EditorMac.mm:
(WebCore::getImage):

Canonical link: <a href="https://commits.webkit.org/274162@main">https://commits.webkit.org/274162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f33bef9118dac4711b0b9b6b847bab63a086ef34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40626 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33866 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32154 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14347 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12511 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12442 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41902 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34568 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38326 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10715 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36518 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14598 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8546 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13462 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14048 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->