### PR TITLE
REGRESSION(273928@main): [Debug][GStreamer] ASSERTION FAILED: priv->destination

### DIFF
--- a/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
@@ -179,21 +179,30 @@ static void webkit_web_audio_src_class_init(WebKitWebAudioSrcClass* webKitWebAud
     objectClass->set_property = webKitWebAudioSrcSetProperty;
     objectClass->get_property = webKitWebAudioSrcGetProperty;
 
-    GParamFlags flags = static_cast<GParamFlags>(G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE);
     g_object_class_install_property(objectClass,
-                                    PROP_RATE,
-                                    g_param_spec_float("rate",
-                                                       nullptr, nullptr,
-                                                       G_MINDOUBLE, G_MAXDOUBLE,
-                                                       44100.0, flags));
-
-    g_object_class_install_property(objectClass, PROP_DESTINATION, g_param_spec_pointer("destination", "destination", "Destination", G_PARAM_READWRITE));
+        PROP_RATE,
+        g_param_spec_float(
+            "rate",
+            nullptr, nullptr,
+            G_MINDOUBLE, G_MAXDOUBLE,
+            44100.0,
+            static_cast<GParamFlags>(G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE)));
 
     g_object_class_install_property(objectClass,
-                                    PROP_FRAMES,
-                                    g_param_spec_uint("frames",
-                                                      nullptr, nullptr,
-                                                      0, G_MAXUINT8, AudioUtilities::renderQuantumSize, flags));
+        PROP_DESTINATION,
+        g_param_spec_pointer(
+            "destination",
+            nullptr, nullptr,
+            static_cast<GParamFlags>(G_PARAM_CONSTRUCT | G_PARAM_READWRITE)));
+
+    g_object_class_install_property(objectClass,
+        PROP_FRAMES,
+        g_param_spec_uint(
+            "frames",
+            nullptr, nullptr,
+            0, G_MAXUINT8,
+            AudioUtilities::renderQuantumSize,
+            static_cast<GParamFlags>(G_PARAM_CONSTRUCT_ONLY | G_PARAM_READWRITE)));
 }
 
 static void webKitWebAudioSrcConstructed(GObject* object)


### PR DESCRIPTION
#### 8586ce8a975cce32bab4e22e323d53268ae15a40
<pre>
REGRESSION(273928@main): [Debug][GStreamer] ASSERTION FAILED: priv-&gt;destination
<a href="https://bugs.webkit.org/show_bug.cgi?id=268819">https://bugs.webkit.org/show_bug.cgi?id=268819</a>

Reviewed by NOBODY (OOPS!).

The `destination` property of `WebKitWebAudioSrc` spec must include
`G_PARAM_CONSTRUCT` flag.

* Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp:
(webkit_web_audio_src_class_init):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8586ce8a975cce32bab4e22e323d53268ae15a40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/16998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40634 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33874 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40174 "Failed to checkout and rebase branch from PR 23915") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32159 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14358 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33335 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12518 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12473 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41910 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34582 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34527 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38331 "Passed tests") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13057 "Failed to checkout and rebase branch from PR 23915") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36524 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14606 "Failed to checkout and rebase branch from PR 23915") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13470 "Built successfully") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14056 "Failed to checkout and rebase branch from PR 23915") | | | 
<!--EWS-Status-Bubble-End-->