### PR TITLE
[WPE] WPE Platform: use the primary device to allocate buffers when doing direct scanout under wayland

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -164,7 +164,7 @@ std::unique_ptr<PlatformDisplay> PlatformDisplay::createPlatformDisplay()
 #if PLATFORM(WPE)
     if (s_useDMABufForRendering) {
         if (GBMDevice::singleton().isInitialized()) {
-            if (auto* device = GBMDevice::singleton().device())
+            if (auto* device = GBMDevice::singleton().device(GBMDevice::Type::Render))
                 return PlatformDisplayGBM::create(device);
         }
         return PlatformDisplaySurfaceless::create();
@@ -549,7 +549,7 @@ struct gbm_device* PlatformDisplay::gbmDevice()
     if (!device.isInitialized())
         device.initialize(drmRenderNodeFile());
 
-    return device.device();
+    return device.device(GBMDevice::Type::Render);
 }
 
 const Vector<PlatformDisplay::DMABufFormat>& PlatformDisplay::dmabufFormats()

--- a/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp
@@ -79,7 +79,7 @@ static inline bool isBufferFormatSupported(const DMABufFormat& format)
 
 RefPtr<GBMBufferSwapchain::Buffer> GBMBufferSwapchain::getBuffer(const BufferDescription& description)
 {
-    auto* device = GBMDevice::singleton().device();
+    auto* device = GBMDevice::singleton().device(GBMDevice::Type::Render);
     if (!device) {
         WTFLogAlways("Failed to get GBM buffer from swap chain: no GBM device found");
         return nullptr;

--- a/Source/WebCore/platform/graphics/gbm/GBMDevice.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GBMDevice.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2022 Metrological Group B.V.
- * Copyright (C) 2022 Igalia S.L.
+ * Copyright (C) 2022, 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,42 +36,108 @@
 #include <wtf/SafeStrerror.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/WTFString.h>
+#include <xf86drm.h>
 
 namespace WebCore {
+
+GBMDevice::Device::~Device()
+{
+    if (m_gbmDevice.has_value() && m_gbmDevice.value())
+        gbm_device_destroy(m_gbmDevice.value());
+}
+
+struct gbm_device* GBMDevice::Device::device() const
+{
+    RELEASE_ASSERT(m_filename.has_value());
+    if (m_filename->isNull())
+        return nullptr;
+
+    if (m_gbmDevice)
+        return m_gbmDevice.value();
+
+    m_fd = UnixFileDescriptor { open(m_filename->data(), O_RDWR | O_CLOEXEC), UnixFileDescriptor::Adopt };
+    if (m_fd) {
+        m_gbmDevice = gbm_create_device(m_fd.value());
+        if (m_gbmDevice.value())
+            return m_gbmDevice.value();
+
+        WTFLogAlways("Failed to create GBM device for render device: %s: %s", m_filename->data(), safeStrerror(errno).data());
+        m_fd = { };
+    } else {
+        WTFLogAlways("Failed to open DRM render device %s: %s", m_filename->data(), safeStrerror(errno).data());
+        m_gbmDevice = nullptr;
+    }
+
+    return m_gbmDevice.value();
+}
 
 GBMDevice& GBMDevice::singleton()
 {
     static std::unique_ptr<GBMDevice> s_device;
     static std::once_flag s_onceFlag;
-    std::call_once(s_onceFlag,
-        [] {
-            s_device = makeUnique<GBMDevice>();
-        });
+    std::call_once(s_onceFlag, [] {
+        s_device = makeUnique<GBMDevice>();
+    });
     return *s_device;
 }
 
 GBMDevice::~GBMDevice()
 {
-    if (m_device.has_value() && m_device.value())
-        gbm_device_destroy(m_device.value());
 }
 
 void GBMDevice::initialize(const String& deviceFile)
 {
-    RELEASE_ASSERT(!m_device.has_value());
-    if (!deviceFile.isEmpty()) {
-        m_fd = UnixFileDescriptor { open(deviceFile.utf8().data(), O_RDWR | O_CLOEXEC), UnixFileDescriptor::Adopt };
-        if (m_fd) {
-            m_device = gbm_create_device(m_fd.value());
-            if (m_device.value())
-                return;
-
-            WTFLogAlways("Failed to create GBM device for render device: %s: %s", deviceFile.utf8().data(), safeStrerror(errno).data());
-            m_fd = { };
-        } else
-            WTFLogAlways("Failed to open DRM render device %s: %s", deviceFile.utf8().data(), safeStrerror(errno).data());
+    RELEASE_ASSERT(!m_renderDevice.hasFilename());
+    if (deviceFile.isEmpty()) {
+        m_renderDevice.setFilename(nullptr);
+        return;
     }
-    m_device = nullptr;
+
+    drmDevicePtr devices[64];
+    memset(devices, 0, sizeof(devices));
+
+    int numDevices = drmGetDevices2(0, devices, std::size(devices));
+    if (numDevices <= 0) {
+        WTFLogAlways("No DRM devices found");
+        m_renderDevice.setFilename(nullptr);
+        return;
+    }
+
+    drmDevice* device = nullptr;
+    for (int i = 0; i < numDevices && !device; ++i) {
+        for (int j = 0; j < DRM_NODE_MAX && !device; ++j) {
+            if (!(devices[i]->available_nodes & (1 << j)))
+                continue;
+
+            if (String::fromUTF8(devices[i]->nodes[j]) == deviceFile)
+                device = devices[i];
+        }
+    }
+
+    if (device) {
+        RELEASE_ASSERT(device->available_nodes & (1 << DRM_NODE_PRIMARY));
+
+        if (device->available_nodes & (1 << DRM_NODE_RENDER)) {
+            m_renderDevice.setFilename(device->nodes[DRM_NODE_RENDER]);
+            m_displayDevice.setFilename(device->nodes[DRM_NODE_PRIMARY]);
+        } else
+            m_renderDevice.setFilename(device->nodes[DRM_NODE_PRIMARY]);
+    } else {
+        WTFLogAlways("Failed to find DRM device for %s", deviceFile.utf8().data());
+        m_renderDevice.setFilename(nullptr);
+    }
+
+    drmFreeDevices(devices, numDevices);
+}
+
+struct gbm_device* GBMDevice::device(GBMDevice::Type type) const
+{
+    RELEASE_ASSERT(m_renderDevice.hasFilename());
+
+    if (type == Type::Render)
+        return m_renderDevice.device();
+
+    return m_displayDevice.hasFilename() ? m_displayDevice.device() : m_renderDevice.device();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
@@ -110,7 +110,7 @@ void GraphicsContextGLGBM::prepareForDisplay()
 
 bool GraphicsContextGLGBM::platformInitializeContext()
 {
-    auto* device = GBMDevice::singleton().device();
+    auto* device = GBMDevice::singleton().device(GBMDevice::Type::Render);
     if (!device) {
         LOG(WebGL, "Warning: Unable to access the GBM device, we fallback to common GL images, they require a copy, that causes a performance penalty.");
         return false;

--- a/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
@@ -181,7 +181,7 @@ bool webKitDMABufVideoSinkIsEnabled()
     std::call_once(s_flag, [&] {
         const char* value = g_getenv("WEBKIT_GST_DMABUF_SINK_DISABLED");
         s_disabled = value && (equalLettersIgnoringASCIICase(value, "true"_s) || equalLettersIgnoringASCIICase(value, "1"_s));
-        if (!s_disabled && !GBMDevice::singleton().device()) {
+        if (!s_disabled && !GBMDevice::singleton().device(GBMDevice::Type::Render)) {
             WTFLogAlways("Unable to access the GBM device, disabling DMABuf video sink.");
             s_disabled = true;
         }

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -132,7 +132,7 @@ std::unique_ptr<AcceleratedSurfaceDMABuf::RenderTarget> AcceleratedSurfaceDMABuf
         return nullptr;
     }
 
-    auto* device = WebCore::GBMDevice::singleton().device();
+    auto* device = WebCore::GBMDevice::singleton().device(dmabufFormat.usage == DMABufRendererBufferFormat::Usage::Scanout ? WebCore::GBMDevice::Type::Scanout : WebCore::GBMDevice::Type::Render);
     if (!device) {
         WTFLogAlways("Failed to create GBM buffer of size %dx%d: no GBM device found", size.width(), size.height());
         return nullptr;

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -157,7 +157,7 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
         if (m_dmaBufRendererBufferMode.contains(DMABufRendererBufferMode::Hardware)) {
             const char* disableGBM = getenv("WEBKIT_DMABUF_RENDERER_DISABLE_GBM");
             if (!disableGBM || !strcmp(disableGBM, "0")) {
-                if (auto* device = WebCore::GBMDevice::singleton().device())
+                if (auto* device = WebCore::GBMDevice::singleton().device(GBMDevice::Type::Render))
                     m_displayForCompositing = WebCore::PlatformDisplayGBM::create(device);
             }
         }


### PR DESCRIPTION
#### 4756fe12807725f145572d0a0e873a6f517bb3bd
<pre>
[WPE] WPE Platform: use the primary device to allocate buffers when doing direct scanout under wayland
<a href="https://bugs.webkit.org/show_bug.cgi?id=268821">https://bugs.webkit.org/show_bug.cgi?id=268821</a>

Reviewed by Nikolas Zimmermann.

We currently use always the render node, but for scanout we should use
the primary device. GBMDevice has now two devices, render and display,
and only the filename is set during the initialization. We search the
DRM node for the given file and set the filename of the render and
display devices. If they are the same display is not initialized and
render is always used. When the GBM device is requested for the first
time, the device is actually opened and GBM device created, to make sure
we only create the devices if they are really used.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::createPlatformDisplay):
(WebCore::PlatformDisplay::gbmDevice):
* Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp:
(WebCore::GBMBufferSwapchain::getBuffer):
* Source/WebCore/platform/graphics/gbm/GBMDevice.cpp:
(WebCore::GBMDevice::Device::~Device):
(WebCore::GBMDevice::Device::device const):
(WebCore::GBMDevice::singleton):
(WebCore::GBMDevice::~GBMDevice):
(WebCore::GBMDevice::initialize):
(WebCore::GBMDevice::device const):
* Source/WebCore/platform/graphics/gbm/GBMDevice.h:
(WebCore::GBMDevice::isInitialized const):
(WebCore::GBMDevice::Device::setFilename):
(WebCore::GBMDevice::Device::hasFilename const):
(WebCore::GBMDevice::device const): Deleted.
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp:
(WebCore::GraphicsContextGLGBM::platformInitializeContext):
* Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp:
(webKitDMABufVideoSinkIsEnabled):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::create):

Canonical link: <a href="https://commits.webkit.org/274361@main">https://commits.webkit.org/274361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f6e32829f1208a7422166dd87408c84296dca56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40682 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33928 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32213 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33366 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12537 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12494 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [💥 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34097 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41960 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34622 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34553 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38354 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36545 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14642 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13515 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5066 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->