### PR TITLE
Remove MediaConstraint.m_name

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2170,6 +2170,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/mediastream/DisplayCapturePromptType.h
     platform/mediastream/FillLightMode.h
     platform/mediastream/MDNSRegisterError.h
+    platform/mediastream/MediaConstraintType.h
     platform/mediastream/MediaConstraints.h
     platform/mediastream/MediaSettingsRange.h
     platform/mediastream/MediaStreamPrivate.h

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -400,7 +400,7 @@ void MediaStreamTrack::applyConstraints(const std::optional<MediaTrackConstraint
     m_private->applyConstraints(createMediaConstraints(constraints), [this, protectedThis = Ref { *this }, constraints, promise = WTFMove(promise)](auto&& error) mutable {
         queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [protectedThis = WTFMove(protectedThis), error = WTFMove(error), constraints, promise = WTFMove(promise)]() mutable {
             if (error) {
-                promise.rejectType<IDLInterface<OverconstrainedError>>(OverconstrainedError::create(WTFMove(error->badConstraint), WTFMove(error->message)));
+                promise.rejectType<IDLInterface<OverconstrainedError>>(OverconstrainedError::create(error->invalidConstraint, WTFMove(error->message)));
                 return;
             }
 

--- a/Source/WebCore/Modules/mediastream/MediaTrackConstraints.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaTrackConstraints.cpp
@@ -33,9 +33,9 @@ namespace WebCore {
 
 enum class ConstraintSetType { Mandatory, Advanced };
 
-static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, ASCIILiteral typeAsString, MediaConstraintType type, const ConstrainLong& value)
+static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, MediaConstraintType type, const ConstrainLong& value)
 {
-    IntConstraint constraint(typeAsString, type);
+    IntConstraint constraint(type);
     WTF::switchOn(value,
         [&] (int integer) {
             if (setType == ConstraintSetType::Mandatory)
@@ -57,9 +57,9 @@ static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, ASCI
     map.set(type, WTFMove(constraint));
 }
 
-static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, ASCIILiteral typeAsString, MediaConstraintType type, const ConstrainDouble& value)
+static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, MediaConstraintType type, const ConstrainDouble& value)
 {
-    DoubleConstraint constraint(typeAsString, type);
+    DoubleConstraint constraint(type);
     WTF::switchOn(value,
         [&] (double number) {
             if (setType == ConstraintSetType::Mandatory)
@@ -81,9 +81,9 @@ static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, ASCI
     map.set(type, WTFMove(constraint));
 }
 
-static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, ASCIILiteral typeAsString, MediaConstraintType type, const ConstrainBoolean& value)
+static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, MediaConstraintType type, const ConstrainBoolean& value)
 {
-    BooleanConstraint constraint(typeAsString, type);
+    BooleanConstraint constraint(type);
     WTF::switchOn(value,
         [&] (bool boolean) {
             if (setType == ConstraintSetType::Mandatory)
@@ -101,9 +101,9 @@ static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, ASCI
     map.set(type, WTFMove(constraint));
 }
 
-static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, ASCIILiteral typeAsString, MediaConstraintType type, const ConstrainDOMString& value)
+static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, MediaConstraintType type, const ConstrainDOMString& value)
 {
-    StringConstraint constraint(typeAsString, type);
+    StringConstraint constraint(type);
     WTF::switchOn(value,
         [&] (const String& string) {
             if (setType == ConstraintSetType::Mandatory)
@@ -148,35 +148,35 @@ static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, ASCI
     map.set(type, WTFMove(constraint));
 }
 
-template<typename T> static inline void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, ASCIILiteral typeAsString, MediaConstraintType type, const std::optional<T>& value)
+template<typename T> static inline void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, MediaConstraintType type, const std::optional<T>& value)
 {
     if (!value)
         return;
-    set(map, setType, typeAsString, type, value.value());
+    set(map, setType, type, value.value());
 }
 
 static MediaTrackConstraintSetMap convertToInternalForm(ConstraintSetType setType, const MediaTrackConstraintSet& constraintSet)
 {
     MediaTrackConstraintSetMap result;
-    set(result, setType, "width"_s, MediaConstraintType::Width, constraintSet.width);
-    set(result, setType, "height"_s, MediaConstraintType::Height, constraintSet.height);
-    set(result, setType, "aspectRatio"_s, MediaConstraintType::AspectRatio, constraintSet.aspectRatio);
-    set(result, setType, "frameRate"_s, MediaConstraintType::FrameRate, constraintSet.frameRate);
-    set(result, setType, "facingMode"_s, MediaConstraintType::FacingMode, constraintSet.facingMode);
-    set(result, setType, "volume"_s, MediaConstraintType::Volume, constraintSet.volume);
-    set(result, setType, "sampleRate"_s, MediaConstraintType::SampleRate, constraintSet.sampleRate);
-    set(result, setType, "sampleSize"_s, MediaConstraintType::SampleSize, constraintSet.sampleSize);
-    set(result, setType, "echoCancellation"_s, MediaConstraintType::EchoCancellation, constraintSet.echoCancellation);
+    set(result, setType, MediaConstraintType::Width, constraintSet.width);
+    set(result, setType, MediaConstraintType::Height, constraintSet.height);
+    set(result, setType, MediaConstraintType::AspectRatio, constraintSet.aspectRatio);
+    set(result, setType, MediaConstraintType::FrameRate, constraintSet.frameRate);
+    set(result, setType, MediaConstraintType::FacingMode, constraintSet.facingMode);
+    set(result, setType, MediaConstraintType::Volume, constraintSet.volume);
+    set(result, setType, MediaConstraintType::SampleRate, constraintSet.sampleRate);
+    set(result, setType, MediaConstraintType::SampleSize, constraintSet.sampleSize);
+    set(result, setType, MediaConstraintType::EchoCancellation, constraintSet.echoCancellation);
     // FIXME: add latency
     // FIXME: add channelCount
-    set(result, setType, "deviceId"_s, MediaConstraintType::DeviceId, constraintSet.deviceId);
-    set(result, setType, "groupId"_s, MediaConstraintType::GroupId, constraintSet.groupId);
-    set(result, setType, "displaySurface"_s, MediaConstraintType::DisplaySurface, constraintSet.displaySurface);
-    set(result, setType, "logicalSurface"_s, MediaConstraintType::LogicalSurface, constraintSet.logicalSurface);
+    set(result, setType, MediaConstraintType::DeviceId, constraintSet.deviceId);
+    set(result, setType, MediaConstraintType::GroupId, constraintSet.groupId);
+    set(result, setType, MediaConstraintType::DisplaySurface, constraintSet.displaySurface);
+    set(result, setType, MediaConstraintType::LogicalSurface, constraintSet.logicalSurface);
 
-    set(result, setType, "whiteBalanceMode"_s, MediaConstraintType::WhiteBalanceMode, constraintSet.whiteBalanceMode);
-    set(result, setType, "zoom"_s, MediaConstraintType::Zoom, constraintSet.zoom);
-    set(result, setType, "torch"_s, MediaConstraintType::Torch, constraintSet.torch);
+    set(result, setType, MediaConstraintType::WhiteBalanceMode, constraintSet.whiteBalanceMode);
+    set(result, setType, MediaConstraintType::Zoom, constraintSet.zoom);
+    set(result, setType, MediaConstraintType::Torch, constraintSet.torch);
 
     return result;
 }

--- a/Source/WebCore/Modules/mediastream/OverconstrainedError.h
+++ b/Source/WebCore/Modules/mediastream/OverconstrainedError.h
@@ -30,6 +30,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+#include "MediaConstraintType.h"
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
 
@@ -41,22 +42,39 @@ public:
     {
         return adoptRef(*new OverconstrainedError(constraint, message));
     }
+    static Ref<OverconstrainedError> create(MediaConstraintType invalidConstraint, const String& message)
+    {
+        return adoptRef(*new OverconstrainedError(invalidConstraint, message));
+    }
 
-    String constraint() const { return m_constraint; }
+    String constraint() const;
     String message() const { return m_message; }
     String name() const { return "OverconstrainedError"_s; }
 
 protected:
-    explicit OverconstrainedError(const String& constraint, const String& message)
+    OverconstrainedError(const String& constraint, const String& message)
         : m_constraint(constraint)
+        , m_message(message)
+    {
+    }
+    OverconstrainedError(MediaConstraintType invalidConstraint, const String& message)
+        : m_invalidConstraint(invalidConstraint)
         , m_message(message)
     {
     }
 
 private:
-    String m_constraint;
+    mutable String m_constraint;
+    MediaConstraintType m_invalidConstraint;
     String m_message;
 };
+
+inline String OverconstrainedError::constraint() const
+{
+    if (m_constraint.isNull())
+        m_constraint = convertToString(m_invalidConstraint);
+    return m_constraint;
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.h
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.h
@@ -66,7 +66,7 @@ public:
     WEBCORE_EXPORT void setAllowedMediaDeviceUIDs(const String& audioDeviceUID, const String& videoDeviceUID);
     WEBCORE_EXPORT void allow(CaptureDevice&& audioDevice, CaptureDevice&& videoDevice, MediaDeviceHashSalts&&, CompletionHandler<void()>&&);
 
-    WEBCORE_EXPORT void deny(MediaAccessDenialReason, const String& errorMessage = emptyString());
+    WEBCORE_EXPORT void deny(MediaAccessDenialReason, const String& errorMessage = emptyString(), MediaConstraintType = MediaConstraintType::Unknown);
 
     const Vector<String>& audioDeviceUIDs() const { return m_audioDeviceUIDs; }
     const Vector<String>& videoDeviceUIDs() const { return m_videoDeviceUIDs; }

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2460,6 +2460,7 @@ platform/mediastream/AudioMediaStreamTrackRenderer.cpp
 platform/mediastream/AudioTrackPrivateMediaStream.cpp
 platform/mediastream/CaptureDeviceManager.cpp
 platform/mediastream/MediaConstraints.cpp
+platform/mediastream/MediaConstraintType.cpp
 platform/mediastream/MediaEndpointConfiguration.cpp
 platform/mediastream/MediaStreamPrivate.cpp
 platform/mediastream/MediaStreamTrackDataHolder.cpp

--- a/Source/WebCore/platform/mediastream/MediaConstraintType.cpp
+++ b/Source/WebCore/platform/mediastream/MediaConstraintType.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MediaConstraintType.h"
+
+#if ENABLE(MEDIA_STREAM)
+
+namespace WebCore {
+
+String convertToString(MediaConstraintType type)
+{
+    switch (type) {
+    case MediaConstraintType::Unknown:
+        return ""_s;
+    case MediaConstraintType::Width:
+        return "width"_s;
+    case MediaConstraintType::Height:
+        return "height"_s;
+    case MediaConstraintType::AspectRatio:
+        return "aspectRatio"_s;
+    case MediaConstraintType::FrameRate:
+        return "frameRate"_s;
+    case MediaConstraintType::FacingMode:
+        return "facingMode"_s;
+    case MediaConstraintType::Volume:
+        return "volume"_s;
+    case MediaConstraintType::SampleRate:
+        return "sampleRate"_s;
+    case MediaConstraintType::SampleSize:
+        return "sampleSize"_s;
+    case MediaConstraintType::EchoCancellation:
+        return "echoCancellation"_s;
+    case MediaConstraintType::DeviceId:
+        return "deviceId"_s;
+    case MediaConstraintType::GroupId:
+        return "groupId"_s;
+    case MediaConstraintType::DisplaySurface:
+        return "displaySurface"_s;
+    case MediaConstraintType::LogicalSurface:
+        return "logicalSurface"_s;
+    case MediaConstraintType::FocusDistance:
+        return "focusDistance"_s;
+    case MediaConstraintType::WhiteBalanceMode:
+        return "whiteBalanceMode"_s;
+    case MediaConstraintType::Zoom:
+        return "zoom"_s;
+    case MediaConstraintType::Torch:
+        return "torch"_s;
+    }
+
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/MediaConstraintType.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraintType.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+enum class MediaConstraintType : uint8_t {
+    Unknown,
+    Width,
+    Height,
+    AspectRatio,
+    FrameRate,
+    FacingMode,
+    Volume,
+    SampleRate,
+    SampleSize,
+    EchoCancellation,
+    DeviceId,
+    GroupId,
+    DisplaySurface,
+    LogicalSurface,
+    FocusDistance,
+    WhiteBalanceMode,
+    Zoom,
+    Torch,
+};
+
+#if ENABLE(MEDIA_STREAM)
+
+String convertToString(MediaConstraintType);
+
+#endif // ENABLE(MEDIA_STREAM)
+
+} // namespace WebCore

--- a/Source/WebCore/platform/mediastream/MediaConstraints.cpp
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.cpp
@@ -470,17 +470,17 @@ bool MediaTrackConstraintSetMap::isEmpty() const
 static inline void addDefaultVideoConstraints(MediaTrackConstraintSetMap& videoConstraints, bool addFrameRateConstraint, bool addWidthConstraint, bool addHeightConstraint)
 {
     if (addFrameRateConstraint) {
-        DoubleConstraint frameRateConstraint({ }, MediaConstraintType::FrameRate);
+        DoubleConstraint frameRateConstraint(MediaConstraintType::FrameRate);
         frameRateConstraint.setIdeal(30);
         videoConstraints.set(MediaConstraintType::FrameRate, WTFMove(frameRateConstraint));
     }
     if (addWidthConstraint) {
-        IntConstraint widthConstraint({ }, MediaConstraintType::Width);
+        IntConstraint widthConstraint(MediaConstraintType::Width);
         widthConstraint.setIdeal(640);
         videoConstraints.set(MediaConstraintType::Width, WTFMove(widthConstraint));
     }
     if (addHeightConstraint) {
-        IntConstraint heightConstraint({ }, MediaConstraintType::Height);
+        IntConstraint heightConstraint(MediaConstraintType::Height);
         heightConstraint.setIdeal(480);
         videoConstraints.set(MediaConstraintType::Height, WTFMove(heightConstraint));
     }
@@ -505,7 +505,7 @@ void MediaConstraints::setDefaultAudioConstraints()
     });
 
     if (needsEchoCancellationConstraint) {
-        BooleanConstraint echoCancellationConstraint({ }, MediaConstraintType::EchoCancellation);
+        BooleanConstraint echoCancellationConstraint(MediaConstraintType::EchoCancellation);
         echoCancellationConstraint.setIdeal(true);
         mandatoryConstraints.set(MediaConstraintType::EchoCancellation, WTFMove(echoCancellationConstraint));
     }
@@ -564,7 +564,7 @@ void IntConstraint::logAsInt() const
 
 StringConstraint StringConstraint::isolatedCopy() const
 {
-    return StringConstraint({ name().isolatedCopy(), constraintType(), dataType() }, crossThreadCopy(m_exact), crossThreadCopy(m_ideal));
+    return StringConstraint({ constraintType(), dataType() }, crossThreadCopy(m_exact), crossThreadCopy(m_ideal));
 }
 
 MediaTrackConstraintSetMap MediaTrackConstraintSetMap::isolatedCopy() const

--- a/Source/WebCore/platform/mediastream/MediaConstraints.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.h
@@ -53,13 +53,11 @@ public:
 
     DataType dataType() const { return m_dataType; }
     MediaConstraintType constraintType() const { return m_constraintType; }
-    const String& name() const { return m_name; }
 
     void log() const;
 
-    MediaConstraint(const String& name, MediaConstraintType constraintType, DataType dataType)
-        : m_name(name)
-        , m_constraintType(constraintType)
+    MediaConstraint(MediaConstraintType constraintType, DataType dataType)
+        : m_constraintType(constraintType)
         , m_dataType(dataType)
     {
     }
@@ -68,7 +66,6 @@ protected:
     MediaConstraint() = default;
 
 private:
-    String m_name;
     MediaConstraintType m_constraintType { MediaConstraintType::Unknown };
     DataType m_dataType { DataType::None };
 };
@@ -328,8 +325,8 @@ public:
     bool isMandatory() const { return m_min || m_max || m_exact; }
 
 protected:
-    NumericConstraint(const String& name, MediaConstraintType type, DataType dataType)
-        : MediaConstraint(name, type, dataType)
+    NumericConstraint(MediaConstraintType type, DataType dataType)
+        : MediaConstraint(type, dataType)
     {
     }
     
@@ -378,8 +375,8 @@ protected:
 
 class IntConstraint final : public NumericConstraint<int> {
 public:
-    IntConstraint(const String& name, MediaConstraintType type)
-        : NumericConstraint<int>(name, type, DataType::Integer)
+    explicit IntConstraint(MediaConstraintType type)
+        : NumericConstraint<int>(type, DataType::Integer)
     {
     }
 
@@ -404,8 +401,8 @@ private:
 
 class DoubleConstraint final : public NumericConstraint<double> {
 public:
-    DoubleConstraint(const String& name, MediaConstraintType type)
-        : NumericConstraint<double>(name, type, DataType::Double)
+    explicit DoubleConstraint(MediaConstraintType type)
+        : NumericConstraint<double>(type, DataType::Double)
     {
     }
 
@@ -430,8 +427,8 @@ private:
 
 class BooleanConstraint final : public MediaConstraint {
 public:
-    BooleanConstraint(const String& name, MediaConstraintType type)
-        : MediaConstraint(name, type, DataType::Boolean)
+    explicit BooleanConstraint(MediaConstraintType type)
+        : MediaConstraint(type, DataType::Boolean)
     {
     }
 
@@ -520,8 +517,8 @@ private:
 
 class StringConstraint : public MediaConstraint {
 public:
-    StringConstraint(const String& name, MediaConstraintType type)
-        : MediaConstraint(name, type, DataType::String)
+    explicit StringConstraint(MediaConstraintType type)
+        : MediaConstraint(type, DataType::String)
     {
     }
 
@@ -604,8 +601,8 @@ private:
 
 class UnknownConstraint final : public MediaConstraint {
 public:
-    UnknownConstraint(const String& name, MediaConstraintType type)
-        : MediaConstraint(name, type, DataType::None)
+    UnknownConstraint(MediaConstraintType type)
+        : MediaConstraint(type, DataType::None)
     {
     }
 

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -118,7 +118,7 @@ public:
     {
         auto callbacks = std::exchange(m_applyConstraintsCallbacks, { });
         for (auto& callback : callbacks.values())
-            callback(RealtimeMediaSource::ApplyConstraintsError { "applyConstraint cancelled"_s, ""_s }, { }, { });
+            callback(RealtimeMediaSource::ApplyConstraintsError { MediaConstraintType::Unknown, "applyConstraint cancelled"_s }, { }, { });
     }
 
     using ApplyConstraintsHandler = CompletionHandler<void(std::optional<RealtimeMediaSource::ApplyConstraintsError>&&, RealtimeMediaSourceSettings&&, RealtimeMediaSourceCapabilities&&)>;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
@@ -73,7 +73,7 @@ public:
     WEBCORE_EXPORT static RealtimeMediaSourceCenter& singleton();
 
     using ValidConstraintsHandler = Function<void(Vector<CaptureDevice>&& audioDeviceUIDs, Vector<CaptureDevice>&& videoDeviceUIDs)>;
-    using InvalidConstraintsHandler = Function<void(const String& invalidConstraint)>;
+    using InvalidConstraintsHandler = Function<void(MediaConstraintType)>;
     WEBCORE_EXPORT void validateRequestConstraints(ValidConstraintsHandler&&, InvalidConstraintsHandler&&, const MediaStreamRequest&, MediaDeviceHashSalts&&);
 
     using NewMediaStreamHandler = Function<void(Expected<Ref<MediaStreamPrivate>, CaptureSourceError>&&)>;
@@ -129,8 +129,8 @@ private:
         CaptureDevice device;
     };
 
-    void getDisplayMediaDevices(const MediaStreamRequest&, MediaDeviceHashSalts&&, Vector<DeviceInfo>&, String&);
-    void getUserMediaDevices(const MediaStreamRequest&, MediaDeviceHashSalts&&, Vector<DeviceInfo>& audioDevices, Vector<DeviceInfo>& videoDevices, String&);
+    void getDisplayMediaDevices(const MediaStreamRequest&, MediaDeviceHashSalts&&, Vector<DeviceInfo>&, MediaConstraintType&);
+    void getUserMediaDevices(const MediaStreamRequest&, MediaDeviceHashSalts&&, Vector<DeviceInfo>& audioDevices, Vector<DeviceInfo>& videoDevices, MediaConstraintType&);
     void validateRequestConstraintsAfterEnumeration(ValidConstraintsHandler&&, InvalidConstraintsHandler&&, const MediaStreamRequest&, MediaDeviceHashSalts&&);
     void enumerateDevices(bool shouldEnumerateCamera, bool shouldEnumerateDisplay, bool shouldEnumerateMicrophone, bool shouldEnumerateSpeakers, CompletionHandler<void()>&&);
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h
@@ -32,30 +32,9 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-#include <wtf/text/WTFString.h>
+#include "MediaConstraintType.h"
 
 namespace WebCore {
-
-enum class MediaConstraintType : uint8_t {
-    Unknown,
-    Width,
-    Height,
-    AspectRatio,
-    FrameRate,
-    FacingMode,
-    Volume,
-    SampleRate,
-    SampleSize,
-    EchoCancellation,
-    DeviceId,
-    GroupId,
-    DisplaySurface,
-    LogicalSurface,
-    FocusDistance,
-    WhiteBalanceMode,
-    Zoom,
-    Torch,
-};
 
 class RealtimeMediaSourceSupportedConstraints {
 public:

--- a/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp
@@ -100,7 +100,7 @@ CaptureSourceOrError DisplayCaptureSourceCocoa::create(Expected<UniqueRef<Captur
     auto source = adoptRef(*new DisplayCaptureSourceCocoa(WTFMove(capturer.value()), device, WTFMove(hashSalts), pageIdentifier));
     if (constraints) {
         if (auto result = source->applyConstraints(*constraints))
-            return CaptureSourceOrError({ WTFMove(result->badConstraint), MediaAccessDenialReason::InvalidConstraint });
+            return CaptureSourceOrError(CaptureSourceError { result->invalidConstraint });
     }
 
     return CaptureSourceOrError(WTFMove(source));

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
@@ -75,7 +75,7 @@ CaptureSourceOrError GStreamerAudioCaptureSource::create(String&& deviceID, Medi
 
     if (constraints) {
         if (auto result = source->applyConstraints(*constraints))
-            return CaptureSourceOrError({ WTFMove(result->badConstraint), MediaAccessDenialReason::InvalidConstraint });
+            return CaptureSourceOrError(CaptureSourceError { result->invalidConstraint });
     }
     return CaptureSourceOrError(WTFMove(source));
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -78,7 +78,7 @@ CaptureSourceOrError GStreamerVideoCaptureSource::create(String&& deviceID, Medi
     auto source = adoptRef(*new GStreamerVideoCaptureSource(WTFMove(*device), WTFMove(hashSalts)));
     if (constraints) {
         if (auto result = source->applyConstraints(*constraints))
-            return CaptureSourceOrError({ WTFMove(result->badConstraint), MediaAccessDenialReason::InvalidConstraint });
+            return CaptureSourceOrError(CaptureSourceError { result->invalidConstraint });
     }
     return CaptureSourceOrError(WTFMove(source));
 }
@@ -88,7 +88,7 @@ CaptureSourceOrError GStreamerVideoCaptureSource::createPipewireSource(String&& 
     auto source = adoptRef(*new GStreamerVideoCaptureSource(WTFMove(deviceID), { }, WTFMove(hashSalts), "pipewiresrc", deviceType, nodeAndFd));
     if (constraints) {
         if (auto result = source->applyConstraints(*constraints))
-            return CaptureSourceOrError({ WTFMove(result->badConstraint), MediaAccessDenialReason::InvalidConstraint });
+            return CaptureSourceOrError(CaptureSourceError { result->invalidConstraint });
     }
     return CaptureSourceOrError(WTFMove(source));
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.cpp
@@ -34,7 +34,7 @@ CaptureSourceOrError MockDisplayCaptureSourceGStreamer::create(const CaptureDevi
 
     if (constraints) {
         if (auto error = mockSource->applyConstraints(*constraints))
-            return CaptureSourceOrError({ WTFMove(error->badConstraint), MediaAccessDenialReason::InvalidConstraint });
+            return CaptureSourceOrError(CaptureSourceError { error->invalidConstraint });
     }
 
     Ref<RealtimeMediaSource> source = adoptRef(*new MockDisplayCaptureSourceGStreamer(device, WTFMove(mockSource), WTFMove(hashSalts), pageIdentifier));

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
@@ -64,7 +64,7 @@ CaptureSourceOrError MockRealtimeAudioSource::create(String&& deviceID, AtomStri
     auto source = adoptRef(*new MockRealtimeAudioSourceGStreamer(WTFMove(deviceID), WTFMove(name), WTFMove(hashSalts)));
     if (constraints) {
         if (auto error = source->applyConstraints(*constraints))
-            return CaptureSourceOrError({ WTFMove(error->badConstraint), MediaAccessDenialReason::InvalidConstraint });
+            return CaptureSourceOrError(CaptureSourceError { error->invalidConstraint });
     }
 
     return CaptureSourceOrError(WTFMove(source));

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
@@ -46,7 +46,7 @@ CaptureSourceOrError MockRealtimeVideoSource::create(String&& deviceID, AtomStri
     Ref<RealtimeMediaSource> source = adoptRef(*new MockRealtimeVideoSourceGStreamer(WTFMove(deviceID), WTFMove(name), WTFMove(hashSalts)));
     if (constraints) {
         if (auto error = source->applyConstraints(*constraints))
-            return CaptureSourceOrError({ WTFMove(error->badConstraint), MediaAccessDenialReason::InvalidConstraint });
+            return CaptureSourceOrError(CaptureSourceError { error->invalidConstraint });
     }
 
     return source;

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -229,7 +229,7 @@ CaptureSourceOrError AVVideoCaptureSource::create(const CaptureDevice& device, M
     Ref<RealtimeMediaSource> source = adoptRef(*new AVVideoCaptureSource(avDevice, device, WTFMove(hashSalts), pageIdentifier));
     if (constraints) {
         if (auto result = source->applyConstraints(*constraints))
-            return CaptureSourceOrError({ WTFMove(result->badConstraint), MediaAccessDenialReason::InvalidConstraint });
+            return CaptureSourceOrError(CaptureSourceError { result->invalidConstraint });
     }
 
     return WTFMove(source);

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -74,7 +74,7 @@ static CaptureSourceOrError initializeCoreAudioCaptureSource(Ref<CoreAudioCaptur
 {
     if (constraints) {
         if (auto result = source->applyConstraints(*constraints))
-            return CaptureSourceOrError({ WTFMove(result->badConstraint), MediaAccessDenialReason::InvalidConstraint });
+            return CaptureSourceOrError(CaptureSourceError { result->invalidConstraint });
     }
     return CaptureSourceOrError(WTFMove(source));
 }

--- a/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm
@@ -65,7 +65,7 @@ CaptureSourceOrError MockRealtimeVideoSource::create(String&& deviceID, AtomStri
     Ref<RealtimeMediaSource> source = adoptRef(*new MockRealtimeVideoSourceMac(WTFMove(deviceID), WTFMove(name), WTFMove(hashSalts), pageIdentifier));
     if (constraints) {
         if (auto error = source->applyConstraints(*constraints))
-            return CaptureSourceOrError({ WTFMove(error->badConstraint), MediaAccessDenialReason::InvalidConstraint });
+            return CaptureSourceOrError(CaptureSourceError { error->invalidConstraint });
     }
 
     return source;

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
@@ -65,7 +65,7 @@ CaptureSourceOrError MockRealtimeAudioSource::create(String&& deviceID, String&&
     auto source = adoptRef(*new MockRealtimeAudioSource(WTFMove(deviceID), WTFMove(name), WTFMove(hashSalts)));
     if (constraints) {
         if (auto error = source->applyConstraints(*constraints))
-            return CaptureSourceOrError({ WTFMove(error->badConstraint), MediaAccessDenialReason::InvalidConstraint });
+            return CaptureSourceOrError({ WTFMove(error->invalidConstraint), MediaAccessDenialReason::InvalidConstraint });
     }
 
     return CaptureSourceOrError(WTFMove(source));

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -64,7 +64,7 @@ CaptureSourceOrError MockRealtimeVideoSource::create(String&& deviceID, AtomStri
     auto source = adoptRef(*new MockRealtimeVideoSource(WTFMove(deviceID), WTFMove(name), WTFMove(hashSalts), pageIdentifier));
     if (constraints) {
         if (auto error = source->applyConstraints(*constraints))
-            return CaptureSourceOrError({ WTFMove(error->badConstraint), MediaAccessDenialReason::InvalidConstraint });
+            return CaptureSourceOrError({ WTFMove(error->invalidConstraint), MediaAccessDenialReason::InvalidConstraint });
     }
 
     return CaptureSourceOrError(RealtimeVideoSource::create(WTFMove(source)));

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5060,7 +5060,6 @@ enum class WebCore::MediaConstraintType : uint8_t {
 
 header: <WebCore/MediaConstraints.h>
 [CustomHeader] class WebCore::MediaConstraint {
-    String name();
     WebCore::MediaConstraintType constraintType();
     WebCore::MediaConstraint::DataType dataType();
 };
@@ -6298,6 +6297,7 @@ header: <WebCore/RealtimeMediaSource.h>
 [CustomHeader] struct WebCore::CaptureSourceError {
     String errorMessage;
     WebCore::MediaAccessDenialReason denialReason;
+    WebCore::MediaConstraintType invalidConstraint;
 };
 
 header: <WebCore/FillLightMode.h>

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
@@ -89,7 +89,7 @@ private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
     using CreateSourceCallback = CompletionHandler<void(const WebCore::CaptureSourceError&, const WebCore::RealtimeMediaSourceSettings&, const WebCore::RealtimeMediaSourceCapabilities&)>;
-    void createMediaSourceForCaptureDeviceWithConstraints(WebCore::RealtimeMediaSourceIdentifier, const WebCore::CaptureDevice& deviceID, WebCore::MediaDeviceHashSalts&&, const WebCore::MediaConstraints&, bool shouldUseGPUProcessRemoteFrames, WebCore::PageIdentifier, CreateSourceCallback&&);
+    void createMediaSourceForCaptureDeviceWithConstraints(WebCore::RealtimeMediaSourceIdentifier, const WebCore::CaptureDevice& deviceID, WebCore::MediaDeviceHashSalts&&, WebCore::MediaConstraints&&, bool shouldUseGPUProcessRemoteFrames, WebCore::PageIdentifier, CreateSourceCallback&&);
     void startProducingData(WebCore::RealtimeMediaSourceIdentifier, WebCore::PageIdentifier);
     void stopProducingData(WebCore::RealtimeMediaSourceIdentifier);
     void removeSource(WebCore::RealtimeMediaSourceIdentifier);

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -38,6 +38,7 @@
 #include "WebProcessProxy.h"
 #include "WebsiteDataStore.h"
 #include <WebCore/CaptureDeviceWithCapabilities.h>
+#include <WebCore/MediaConstraintType.h>
 #include <WebCore/MediaConstraints.h>
 #include <WebCore/MockRealtimeMediaSourceCenter.h>
 #include <WebCore/PermissionName.h>
@@ -206,7 +207,17 @@ static uint64_t toWebCore(UserMediaPermissionRequestProxy::UserMediaAccessDenial
 }
 #endif
 
-void UserMediaPermissionRequestManagerProxy::denyRequest(UserMediaPermissionRequestProxy& request, UserMediaPermissionRequestProxy::UserMediaAccessDenialReason reason, const String& invalidConstraint)
+void UserMediaPermissionRequestManagerProxy::denyRequest(UserMediaPermissionRequestProxy& request, UserMediaPermissionRequestProxy::UserMediaAccessDenialReason reason, const String& message)
+{
+    denyRequest(request, reason, message, WebCore::MediaConstraintType::Unknown);
+}
+
+void UserMediaPermissionRequestManagerProxy::denyRequest(UserMediaPermissionRequestProxy& request, WebCore::MediaConstraintType invalidConstraint)
+{
+    denyRequest(request, UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::InvalidConstraint, { }, invalidConstraint);
+}
+
+void UserMediaPermissionRequestManagerProxy::denyRequest(UserMediaPermissionRequestProxy& request, UserMediaPermissionRequestProxy::UserMediaAccessDenialReason reason, const String& message, WebCore::MediaConstraintType invalidConstraint)
 {
     if (!m_page.hasRunningProcess())
         return;
@@ -222,7 +233,7 @@ void UserMediaPermissionRequestManagerProxy::denyRequest(UserMediaPermissionRequ
     }
 
 #if ENABLE(MEDIA_STREAM)
-    m_page.send(Messages::WebPage::UserMediaAccessWasDenied(request.userMediaID(), toWebCore(reason), invalidConstraint));
+    m_page.send(Messages::WebPage::UserMediaAccessWasDenied(request.userMediaID(), toWebCore(reason), message, invalidConstraint));
 #else
     UNUSED_PARAM(reason);
     UNUSED_PARAM(invalidConstraint);
@@ -423,7 +434,7 @@ void UserMediaPermissionRequestManagerProxy::updateStoredRequests(UserMediaPermi
 
 void UserMediaPermissionRequestManagerProxy::rejectionTimerFired()
 {
-    denyRequest(m_pendingRejections.takeFirst(), UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::PermissionDenied, emptyString());
+    denyRequest(m_pendingRejections.takeFirst(), UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::PermissionDenied);
     if (!m_pendingRejections.isEmpty())
         scheduleNextRejection();
 }
@@ -553,7 +564,7 @@ void UserMediaPermissionRequestManagerProxy::processUserMediaPermissionRequest()
         if (!request->isPending())
             return;
 
-        RealtimeMediaSourceCenter::InvalidConstraintsHandler invalidHandler = [this, request](const String& invalidConstraint) {
+        RealtimeMediaSourceCenter::InvalidConstraintsHandler invalidHandler = [this, request](auto invalidConstraint) {
             if (!request->isPending())
                 return;
 
@@ -592,19 +603,19 @@ void UserMediaPermissionRequestManagerProxy::platformValidateUserMediaRequestCon
 }
 #endif
 
-void UserMediaPermissionRequestManagerProxy::processUserMediaPermissionInvalidRequest(const String& invalidConstraint)
+void UserMediaPermissionRequestManagerProxy::processUserMediaPermissionInvalidRequest(MediaConstraintType invalidConstraint)
 {
     ALWAYS_LOG(LOGIDENTIFIER, m_currentUserMediaRequest->userMediaID().toUInt64());
     bool filterConstraint = !m_currentUserMediaRequest->hasPersistentAccess() && !wasGrantedVideoOrAudioAccess(m_currentUserMediaRequest->frameID());
 
-    denyRequest(*m_currentUserMediaRequest, UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::InvalidConstraint, filterConstraint ? String { } : invalidConstraint);
+    denyRequest(*m_currentUserMediaRequest, filterConstraint ? MediaConstraintType::Unknown : invalidConstraint);
 }
 
 void UserMediaPermissionRequestManagerProxy::processUserMediaPermissionValidRequest(Vector<CaptureDevice>&& audioDevices, Vector<CaptureDevice>&& videoDevices, WebCore::MediaDeviceHashSalts&& deviceIdentifierHashSalts)
 {
     ALWAYS_LOG(LOGIDENTIFIER, m_currentUserMediaRequest->userMediaID().toUInt64(), ", video: ", videoDevices.size(), " audio: ", audioDevices.size());
     if (!m_currentUserMediaRequest->requiresDisplayCapture() && videoDevices.isEmpty() && audioDevices.isEmpty()) {
-        denyRequest(*m_currentUserMediaRequest, UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::NoConstraints, emptyString());
+        denyRequest(*m_currentUserMediaRequest, UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::NoConstraints);
         return;
     }
 
@@ -616,7 +627,7 @@ void UserMediaPermissionRequestManagerProxy::processUserMediaPermissionValidRequ
     ALWAYS_LOG(LOGIDENTIFIER, m_currentUserMediaRequest->userMediaID().toUInt64(), ", action: ", action);
 
     if (action == RequestAction::Deny) {
-        denyRequest(*m_currentUserMediaRequest, UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::PermissionDenied, emptyString());
+        denyRequest(*m_currentUserMediaRequest, UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::PermissionDenied);
         return;
     }
 
@@ -674,7 +685,7 @@ void UserMediaPermissionRequestManagerProxy::decidePolicyForUserMediaPermissionR
     auto* webFrame = WebFrameProxy::webFrame(m_currentUserMediaRequest->frameID());
 
     if (!webFrame || !protocolHostAndPortAreEqual(URL(m_page.pageLoadState().activeURL()), m_currentUserMediaRequest->topLevelDocumentSecurityOrigin().data().toURL())) {
-        denyRequest(*m_currentUserMediaRequest, UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::NoConstraints, emptyString());
+        denyRequest(*m_currentUserMediaRequest, UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::NoConstraints);
         return;
     }
 

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
@@ -39,6 +39,7 @@ namespace WebCore {
 class CaptureDevice;
 class SecurityOrigin;
 
+enum class MediaConstraintType : uint8_t;
 enum class PermissionName : uint8_t;
 
 struct CaptureDeviceWithCapabilities;
@@ -82,7 +83,8 @@ public:
     void viewIsBecomingVisible();
 
     void grantRequest(UserMediaPermissionRequestProxy&);
-    void denyRequest(UserMediaPermissionRequestProxy&, UserMediaPermissionRequestProxy::UserMediaAccessDenialReason, const String& invalidConstraint = { });
+    void denyRequest(UserMediaPermissionRequestProxy&, UserMediaPermissionRequestProxy::UserMediaAccessDenialReason, const String& message = { });
+    void denyRequest(UserMediaPermissionRequestProxy&, WebCore::MediaConstraintType);
 
     void enumerateMediaDevicesForFrame(WebCore::FrameIdentifier, Ref<WebCore::SecurityOrigin>&& userMediaDocumentOrigin, Ref<WebCore::SecurityOrigin>&& topLevelDocumentOrigin, CompletionHandler<void(const Vector<WebCore::CaptureDeviceWithCapabilities>&, WebCore::MediaDeviceHashSalts&&)>&&);
 
@@ -134,6 +136,8 @@ private:
     WTFLogChannel& logChannel() const final;
 #endif
 
+    void denyRequest(UserMediaPermissionRequestProxy&, UserMediaPermissionRequestProxy::UserMediaAccessDenialReason, const String& message, WebCore::MediaConstraintType);
+
     Ref<UserMediaPermissionRequestProxy> createPermissionRequest(WebCore::UserMediaRequestIdentifier, WebCore::FrameIdentifier mainFrameID, WebCore::FrameIdentifier, Ref<WebCore::SecurityOrigin>&& userMediaDocumentOrigin, Ref<WebCore::SecurityOrigin>&& topLevelDocumentOrigin, Vector<WebCore::CaptureDevice>&& audioDevices, Vector<WebCore::CaptureDevice>&& videoDevices, WebCore::MediaStreamRequest&&);
 #if ENABLE(MEDIA_STREAM)
     void finishGrantingRequest(UserMediaPermissionRequestProxy&);
@@ -153,7 +157,7 @@ private:
     void platformGetMediaStreamDevices(bool revealIdsAndLabels, CompletionHandler<void(Vector<WebCore::CaptureDeviceWithCapabilities>&&)>&&);
 
     void processUserMediaPermissionRequest();
-    void processUserMediaPermissionInvalidRequest(const String& invalidConstraint);
+    void processUserMediaPermissionInvalidRequest(WebCore::MediaConstraintType invalidConstraint);
     void processUserMediaPermissionValidRequest(Vector<WebCore::CaptureDevice>&& audioDevices, Vector<WebCore::CaptureDevice>&& videoDevices, WebCore::MediaDeviceHashSalts&&);
     void startProcessingUserMediaPermissionRequest(Ref<UserMediaPermissionRequestProxy>&&);
 

--- a/Source/WebKit/UIProcess/glib/UserMediaPermissionRequestManagerProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/UserMediaPermissionRequestManagerProxyGLib.cpp
@@ -23,6 +23,7 @@
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 #include <WebCore/CaptureDeviceWithCapabilities.h>
+#include <WebCore/MediaConstraintType.h>
 #include <WebCore/UserMediaRequest.h>
 
 namespace WebKit {
@@ -30,7 +31,7 @@ using namespace WebCore;
 
 void UserMediaPermissionRequestManagerProxy::platformValidateUserMediaRequestConstraints(RealtimeMediaSourceCenter::ValidConstraintsHandler&& validHandler, RealtimeMediaSourceCenter::InvalidConstraintsHandler&& invalidHandler, WebCore::MediaDeviceHashSalts&& deviceIDHashSalts)
 {
-    m_page.process().connection()->sendWithAsyncReply(Messages::UserMediaCaptureManager::ValidateUserMediaRequestConstraints(m_currentUserMediaRequest->userRequest(), WTFMove(deviceIDHashSalts)), [validHandler = WTFMove(validHandler), invalidHandler = WTFMove(invalidHandler)](std::optional<String> invalidConstraint, Vector<WebCore::CaptureDevice> audioDevices, Vector<WebCore::CaptureDevice> videoDevices) mutable {
+    m_page.process().connection()->sendWithAsyncReply(Messages::UserMediaCaptureManager::ValidateUserMediaRequestConstraints(m_currentUserMediaRequest->userRequest(), WTFMove(deviceIDHashSalts)), [validHandler = WTFMove(validHandler), invalidHandler = WTFMove(invalidHandler)](std::optional<WebCore::MediaConstraintType> invalidConstraint, Vector<WebCore::CaptureDevice> audioDevices, Vector<WebCore::CaptureDevice> videoDevices) mutable {
         if (invalidConstraint)
             invalidHandler(*invalidConstraint);
         else

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
@@ -129,13 +129,13 @@ void UserMediaPermissionRequestManager::userMediaAccessWasGranted(UserMediaReque
     request->allow(WTFMove(audioDevice), WTFMove(videoDevice), WTFMove(deviceIdentifierHashSalts), WTFMove(completionHandler));
 }
 
-void UserMediaPermissionRequestManager::userMediaAccessWasDenied(UserMediaRequestIdentifier requestID, MediaAccessDenialReason reason, String&& invalidConstraint)
+void UserMediaPermissionRequestManager::userMediaAccessWasDenied(UserMediaRequestIdentifier requestID, MediaAccessDenialReason reason, String&& message, MediaConstraintType invalidConstraint)
 {
     auto request = m_ongoingUserMediaRequests.take(requestID);
     if (!request)
         return;
 
-    request->deny(reason, WTFMove(invalidConstraint));
+    request->deny(reason, WTFMove(message),  invalidConstraint);
 }
 
 void UserMediaPermissionRequestManager::enumerateMediaDevices(Document& document, CompletionHandler<void(Vector<CaptureDeviceWithCapabilities>&&, MediaDeviceHashSalts&&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
@@ -53,7 +53,7 @@ public:
     void startUserMediaRequest(WebCore::UserMediaRequest&);
     void cancelUserMediaRequest(WebCore::UserMediaRequest&);
     void userMediaAccessWasGranted(WebCore::UserMediaRequestIdentifier, WebCore::CaptureDevice&& audioDevice, WebCore::CaptureDevice&& videoDevice, WebCore::MediaDeviceHashSalts&&, CompletionHandler<void()>&&);
-    void userMediaAccessWasDenied(WebCore::UserMediaRequestIdentifier, WebCore::MediaAccessDenialReason, String&&);
+    void userMediaAccessWasDenied(WebCore::UserMediaRequestIdentifier, WebCore::MediaAccessDenialReason, String&&, WebCore::MediaConstraintType);
 
     void enumerateMediaDevices(WebCore::Document&, CompletionHandler<void(Vector<WebCore::CaptureDeviceWithCapabilities>&&, WebCore::MediaDeviceHashSalts&&)>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5564,9 +5564,9 @@ void WebPage::userMediaAccessWasGranted(UserMediaRequestIdentifier userMediaID, 
     m_userMediaPermissionRequestManager->userMediaAccessWasGranted(userMediaID, WTFMove(audioDevice), WTFMove(videoDevice), WTFMove(mediaDeviceIdentifierHashSalts), WTFMove(completionHandler));
 }
 
-void WebPage::userMediaAccessWasDenied(UserMediaRequestIdentifier userMediaID, uint64_t reason, String&& invalidConstraint)
+void WebPage::userMediaAccessWasDenied(UserMediaRequestIdentifier userMediaID, uint64_t reason, String&& message, WebCore::MediaConstraintType invalidConstraint)
 {
-    m_userMediaPermissionRequestManager->userMediaAccessWasDenied(userMediaID, static_cast<MediaAccessDenialReason>(reason), WTFMove(invalidConstraint));
+    m_userMediaPermissionRequestManager->userMediaAccessWasDenied(userMediaID, static_cast<MediaAccessDenialReason>(reason), WTFMove(message), invalidConstraint);
 }
 
 void WebPage::captureDevicesChanged()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2020,7 +2020,7 @@ private:
 
 #if ENABLE(MEDIA_STREAM)
     void userMediaAccessWasGranted(WebCore::UserMediaRequestIdentifier, WebCore::CaptureDevice&& audioDeviceUID, WebCore::CaptureDevice&& videoDeviceUID, WebCore::MediaDeviceHashSalts&& mediaDeviceIdentifierHashSalt, Vector<SandboxExtension::Handle>&&, CompletionHandler<void()>&&);
-    void userMediaAccessWasDenied(WebCore::UserMediaRequestIdentifier, uint64_t reason, String&& invalidConstraint);
+    void userMediaAccessWasDenied(WebCore::UserMediaRequestIdentifier, uint64_t reason, String&& message, WebCore::MediaConstraintType);
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -421,7 +421,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 #if ENABLE(MEDIA_STREAM)
     # MediaSteam
     UserMediaAccessWasGranted(WebCore::UserMediaRequestIdentifier userMediaID, WebCore::CaptureDevice audioDevice, WebCore::CaptureDevice videoDevice, struct WebCore::MediaDeviceHashSalts mediaDeviceIdentifierHashSalts, Vector<WebKit::SandboxExtension::Handle> sandboxExtensionHandles) -> ()
-    UserMediaAccessWasDenied(WebCore::UserMediaRequestIdentifier userMediaID, uint64_t reason, String invalidConstraint)
+    UserMediaAccessWasDenied(WebCore::UserMediaRequestIdentifier userMediaID, uint64_t reason, String messsage, enum:uint8_t WebCore::MediaConstraintType invalidConstraint)
     CaptureDevicesChanged()
 #if USE(GSTREAMER)
     SetOrientationForMediaCapture(uint64_t rotation)

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
@@ -48,7 +48,7 @@ public:
     void setSettings(WebCore::RealtimeMediaSourceSettings&&);
 
     void applyConstraintsSucceeded(WebCore::RealtimeMediaSourceSettings&&);
-    void applyConstraintsFailed(String&& failedConstraint, String&& errorMessage) { m_proxy.applyConstraintsFailed(WTFMove(failedConstraint), WTFMove(errorMessage)); }
+    void applyConstraintsFailed(WebCore::MediaConstraintType invalidConstraint, String&& errorMessage) { m_proxy.applyConstraintsFailed(invalidConstraint, WTFMove(errorMessage)); }
 
     void captureStopped(bool didFail);
     void sourceMutedChanged(bool value, bool interrupted);

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
@@ -151,10 +151,10 @@ void RemoteRealtimeMediaSourceProxy::applyConstraintsSucceeded()
     request.first({ });
 }
 
-void RemoteRealtimeMediaSourceProxy::applyConstraintsFailed(String&& failedConstraint, String&& errorMessage)
+void RemoteRealtimeMediaSourceProxy::applyConstraintsFailed(WebCore::MediaConstraintType invalidConstraint, String&& errorMessage)
 {
     auto callback = m_pendingApplyConstraintsRequests.takeFirst().first;
-    callback(RealtimeMediaSource::ApplyConstraintsError { WTFMove(failedConstraint), WTFMove(errorMessage) });
+    callback(RealtimeMediaSource::ApplyConstraintsError { invalidConstraint, WTFMove(errorMessage) });
 }
 
 void RemoteRealtimeMediaSourceProxy::failApplyConstraintCallbacks(const String& errorMessage)

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
@@ -64,7 +64,7 @@ public:
     void createRemoteCloneSource(WebCore::RealtimeMediaSourceIdentifier, WebCore::PageIdentifier);
 
     void applyConstraintsSucceeded();
-    void applyConstraintsFailed(String&& failedConstraint, String&& errorMessage);
+    void applyConstraintsFailed(WebCore::MediaConstraintType, String&& errorMessage);
     void failApplyConstraintCallbacks(const String& errorMessage);
 
     bool isEnded() const { return m_isEnded; }

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
@@ -176,16 +176,16 @@ void UserMediaCaptureManager::applyConstraintsSucceeded(RealtimeMediaSourceIdent
     }, [](std::nullptr_t) { });
 }
 
-void UserMediaCaptureManager::applyConstraintsFailed(RealtimeMediaSourceIdentifier identifier, String&& failedConstraint, String&& message)
+void UserMediaCaptureManager::applyConstraintsFailed(RealtimeMediaSourceIdentifier identifier, WebCore::MediaConstraintType invalidConstraint, String&& message)
 {
     auto iterator = m_sources.find(identifier);
     if (iterator == m_sources.end())
         return;
 
     switchOn(iterator->value, [&](Ref<RemoteRealtimeAudioSource>& source) {
-        source->applyConstraintsFailed(WTFMove(failedConstraint), WTFMove(message));
+        source->applyConstraintsFailed(invalidConstraint, WTFMove(message));
     }, [&](Ref<RemoteRealtimeVideoSource>& source) {
-        source->applyConstraintsFailed(WTFMove(failedConstraint), WTFMove(message));
+        source->applyConstraintsFailed(invalidConstraint, WTFMove(message));
     }, [](std::nullptr_t) { });
 }
 

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
@@ -129,7 +129,7 @@ private:
     void sourceConfigurationChanged(WebCore::RealtimeMediaSourceIdentifier, String&&, WebCore::RealtimeMediaSourceSettings&&, WebCore::RealtimeMediaSourceCapabilities&&);
 
     void applyConstraintsSucceeded(WebCore::RealtimeMediaSourceIdentifier, WebCore::RealtimeMediaSourceSettings&&);
-    void applyConstraintsFailed(WebCore::RealtimeMediaSourceIdentifier, String&&, String&&);
+    void applyConstraintsFailed(WebCore::RealtimeMediaSourceIdentifier, WebCore::MediaConstraintType, String&&);
 
     using Source = std::variant<std::nullptr_t, Ref<RemoteRealtimeAudioSource>, Ref<RemoteRealtimeVideoSource>>;
     HashMap<WebCore::RealtimeMediaSourceIdentifier, Source> m_sources;

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.messages.in
@@ -29,7 +29,7 @@ messages -> UserMediaCaptureManager NotRefCounted {
     SourceSettingsChanged(WebCore::RealtimeMediaSourceIdentifier id, WebCore::RealtimeMediaSourceSettings settings)
     SourceConfigurationChanged(WebCore::RealtimeMediaSourceIdentifier id, String persistentID, WebCore::RealtimeMediaSourceSettings settings, WebCore::RealtimeMediaSourceCapabilities capabilities)
     ApplyConstraintsSucceeded(WebCore::RealtimeMediaSourceIdentifier id, WebCore::RealtimeMediaSourceSettings settings)
-    ApplyConstraintsFailed(WebCore::RealtimeMediaSourceIdentifier id, String failedConstraint, String message)
+    ApplyConstraintsFailed(WebCore::RealtimeMediaSourceIdentifier id, enum:uint8_t WebCore::MediaConstraintType invalidConstraint, String message)
 }
 
 #endif

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp
@@ -51,7 +51,7 @@ UserMediaCaptureManager::~UserMediaCaptureManager()
 void UserMediaCaptureManager::validateUserMediaRequestConstraints(WebCore::MediaStreamRequest request, WebCore::MediaDeviceHashSalts&& deviceIdentifierHashSalts, ValidateUserMediaRequestConstraintsCallback&& completionHandler)
 {
     m_validateUserMediaRequestConstraintsCallback = WTFMove(completionHandler);
-    auto invalidHandler = [this](const String& invalidConstraint) mutable {
+    auto invalidHandler = [this](auto invalidConstraint) mutable {
         Vector<CaptureDevice> audioDevices;
         Vector<CaptureDevice> videoDevices;
         m_validateUserMediaRequestConstraintsCallback(invalidConstraint, audioDevices, videoDevices);

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h
@@ -36,6 +36,8 @@ class CaptureDevice;
 struct CaptureDeviceWithCapabilities;
 struct MediaDeviceHashSalts;
 struct MediaStreamRequest;
+
+enum class MediaConstraintType : uint8_t;
 }
 
 namespace WebKit {
@@ -56,7 +58,7 @@ private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
     // Messages::UserMediaCaptureManager
-    using ValidateUserMediaRequestConstraintsCallback = CompletionHandler<void(std::optional<String> invalidConstraint, Vector<WebCore::CaptureDevice>& audioDevices, Vector<WebCore::CaptureDevice>& videoDevices)>;
+    using ValidateUserMediaRequestConstraintsCallback = CompletionHandler<void(std::optional<WebCore::MediaConstraintType> invalidConstraint, Vector<WebCore::CaptureDevice>& audioDevices, Vector<WebCore::CaptureDevice>& videoDevices)>;
     void validateUserMediaRequestConstraints(WebCore::MediaStreamRequest, WebCore::MediaDeviceHashSalts&&, ValidateUserMediaRequestConstraintsCallback&&);
     ValidateUserMediaRequestConstraintsCallback m_validateUserMediaRequestConstraintsCallback;
 

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.messages.in
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(MEDIA_STREAM)
 
 messages -> UserMediaCaptureManager NotRefCounted {
-    ValidateUserMediaRequestConstraints(struct WebCore::MediaStreamRequest request, struct WebCore::MediaDeviceHashSalts mediaDeviceIdentifierHashSalts) -> (std::optional<String> invalidConstraint, Vector<WebCore::CaptureDevice> audioDevices, Vector<WebCore::CaptureDevice> videoDevices)
+    ValidateUserMediaRequestConstraints(struct WebCore::MediaStreamRequest request, struct WebCore::MediaDeviceHashSalts mediaDeviceIdentifierHashSalts) -> (std::optional<WebCore::MediaConstraintType> invalidConstraint, Vector<WebCore::CaptureDevice> audioDevices, Vector<WebCore::CaptureDevice> videoDevices)
     GetMediaStreamDevices(bool revealIdsAndLabels) -> (Vector<WebCore::CaptureDeviceWithCapabilities> devices)
 }
 


### PR DESCRIPTION
#### cdb9740c25d0bce6fdf85f3e065c64ec960a774e
<pre>
Remove MediaConstraint.m_name
<a href="https://bugs.webkit.org/show_bug.cgi?id=268814">https://bugs.webkit.org/show_bug.cgi?id=268814</a>
<a href="https://rdar.apple.com/122383008">rdar://122383008</a>

Reviewed by Eric Carlson.

MediaConstraint.m_name is redundant with MediaConstraintType.
We now replace wherever String was used by MediaConstraintType, which is both easier to read and more efficient.
We do some refactoring to pass more values as return values instead of out values.
We rename some methods to improve readability.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::applyConstraints):
* Source/WebCore/Modules/mediastream/MediaTrackConstraints.cpp:
(WebCore::set):
(WebCore::convertToInternalForm):
* Source/WebCore/Modules/mediastream/OverconstrainedError.h:
(WebCore::OverconstrainedError::create):
(WebCore::OverconstrainedError::OverconstrainedError):
(WebCore::OverconstrainedError::constraint const):
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::allow):
(WebCore::UserMediaRequest::deny):
* Source/WebCore/Modules/mediastream/UserMediaRequest.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/mediastream/MediaConstraintType.cpp: Added.
(WebCore::convertToString):
* Source/WebCore/platform/mediastream/MediaConstraintType.h: Added.
* Source/WebCore/platform/mediastream/MediaConstraints.cpp:
(WebCore::addDefaultVideoConstraints):
(WebCore::MediaConstraints::setDefaultAudioConstraints):
(WebCore::StringConstraint::isolatedCopy const):
* Source/WebCore/platform/mediastream/MediaConstraints.h:
(WebCore::MediaConstraint::constraintType const):
(WebCore::MediaConstraint::MediaConstraint):
(WebCore::NumericConstraint::NumericConstraint):
(WebCore::StringConstraint::StringConstraint):
(WebCore::MediaConstraint::name const): Deleted.
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivateSourceObserver::close):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::hasInvalidSizeFrameRateAndZoomConstraints):
(WebCore::RealtimeMediaSource::applyConstraint):
(WebCore::RealtimeMediaSource::selectSettings):
(WebCore::RealtimeMediaSource::hasAnyInvalidConstraint):
(WebCore::RealtimeMediaSource::extractVideoFrameSizeConstraints):
(WebCore::RealtimeMediaSource::applyConstraints):
(WebCore::RealtimeMediaSource::supportsConstraints): Deleted.
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
(WebCore::CaptureSourceError::CaptureSourceError):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::createMediaStream):
(WebCore::RealtimeMediaSourceCenter::getDisplayMediaDevices):
(WebCore::RealtimeMediaSourceCenter::getUserMediaDevices):
(WebCore::RealtimeMediaSourceCenter::validateRequestConstraintsAfterEnumeration):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h:
* Source/WebCore/platform/mediastream/cocoa/DisplayCaptureSourceCocoa.cpp:
(WebCore::DisplayCaptureSourceCocoa::create):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp:
(WebCore::GStreamerAudioCaptureSource::create):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
(WebCore::GStreamerVideoCaptureSource::create):
(WebCore::GStreamerVideoCaptureSource::createPipewireSource):
* Source/WebCore/platform/mediastream/gstreamer/MockDisplayCaptureSourceGStreamer.cpp:
(WebCore::MockDisplayCaptureSourceGStreamer::create):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp:
(WebCore::MockRealtimeAudioSource::create):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp:
(WebCore::MockRealtimeVideoSource::create):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::create):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::initializeCoreAudioCaptureSource):
* Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm:
(WebCore::MockRealtimeVideoSource::create):
* Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp:
(WebCore::MockRealtimeAudioSource::create):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::create):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstraints):
(WebKit::UserMediaCaptureManagerProxy::applyConstraints):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::denyRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::rejectionTimerFired):
(WebKit::UserMediaPermissionRequestManagerProxy::processUserMediaPermissionRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::processUserMediaPermissionInvalidRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::processUserMediaPermissionValidRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::decidePolicyForUserMediaPermissionRequest):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h:
(WebKit::UserMediaPermissionRequestManagerProxy::denyRequest):
* Source/WebKit/UIProcess/glib/UserMediaPermissionRequestManagerProxyGLib.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::platformValidateUserMediaRequestConstraints):
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp:
(WebKit::UserMediaPermissionRequestManager::userMediaAccessWasDenied):
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::userMediaAccessWasDenied):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h:
(WebKit::RemoteRealtimeMediaSource::applyConstraintsFailed):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp:
(WebKit::RemoteRealtimeMediaSourceProxy::applyConstraintsFailed):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp:
(WebKit::UserMediaCaptureManager::applyConstraintsFailed):
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.messages.in:
* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp:
(WebKit::UserMediaCaptureManager::validateUserMediaRequestConstraints):
* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h:
* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.messages.in:

Canonical link: <a href="https://commits.webkit.org/274281@main">https://commits.webkit.org/274281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f67254f9505599001d13319fc3517cb809672e8e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41092 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14831 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14739 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12802 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42368 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35023 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38611 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13393 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36820 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14997 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8651 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14471 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->