### PR TITLE
[upload-file-to-url] Add Content-Type

### DIFF
--- a/Tools/Scripts/upload-file-to-url
+++ b/Tools/Scripts/upload-file-to-url
@@ -34,7 +34,7 @@ import os
 import requests
 
 
-def upload(filename, url, max_attempts=2):
+def upload(filename, url, max_attempts=2, content_type=None):
     if not os.path.isfile(filename):
         sys.stderr.write(f'ERROR: File not found: {filename}\n')
         return -1
@@ -44,7 +44,10 @@ def upload(filename, url, max_attempts=2):
         return -1
 
     filesize = os.stat(filename).st_size / 1024 / 1024;
-    sys.stderr.write(f'Uploading {filename}, size: {filesize:.2f} MB\n')
+    sys.stderr.write(f'Uploading {filename}, size: {filesize:.2f} MB')
+    if content_type:
+        sys.stderr.write(f', content-type {content_type}')
+    sys.stderr.write('\n')
 
     with open(filename, 'rb') as f:
         try:
@@ -55,7 +58,10 @@ def upload(filename, url, max_attempts=2):
 
         for attempt in range(1, max_attempts + 1):
             try:
-                response = requests.put(url, data=data, timeout=15*60)
+                headers = None
+                if content_type:
+                    headers={'Content-Type': content_type}
+                response = requests.put(url, data=data, headers=headers, timeout=15*60)
                 sys.stderr.write(f'Response: {response}, status_code: {response.status_code}, {response.reason}\n')
                 if response and response.status_code // 100 == 2:
                     return 0
@@ -72,9 +78,10 @@ def main():
     parser = argparse.ArgumentParser(add_help=True)
     parser.add_argument('--filename', action="store", required=True, help='Path to the file. [path/to/123456.zip]')
     parser.add_argument('--url', action="store", required=False, help='url to upload to')
+    parser.add_argument('--content-type', action='store', required=False, default=None, help='Content type of uploaded file')
     args = parser.parse_args()
     url = args.url or os.getenv('UPLOAD_URL')
-    rc = upload(args.filename, url)
+    rc = upload(args.filename, url, content_type=args.content_type)
     return rc
 
 


### PR DESCRIPTION
#### b563a072516871064db1992ea7d9395bcb570556
<pre>
[upload-file-to-url] Add Content-Type
<a href="https://bugs.webkit.org/show_bug.cgi?id=268827">https://bugs.webkit.org/show_bug.cgi?id=268827</a>
<a href="https://rdar.apple.com/122390338">rdar://122390338</a>

Reviewed by Aakash Jain.

* Tools/Scripts/upload-file-to-url:
(upload): If content_type is specified, include it in the headers of the uploaded file.
(main): Add --content-type argument.

Canonical link: <a href="https://commits.webkit.org/274156@main">https://commits.webkit.org/274156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/641ad3e38206f14342b7bb8bacbbb4a673637bdd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40678 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33923 "Failed to checkout and rebase branch from PR 23922") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/40340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14388 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14386 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12536 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/34095 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41956 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34618 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38353 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10764 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36544 "Found 1 new API test failure: /WebKitGTK/TestSSL:/webkit/WebKitWebView/tls-errors-redirect-to-http (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4949 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->