### PR TITLE
IDBRequestData's transaction identifier should not be optional

### DIFF
--- a/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp
@@ -55,7 +55,7 @@ IDBRequestData::IDBRequestData(IDBClient::TransactionOperation& operation)
         m_cursorIdentifier = *operation.cursorIdentifier();
 }
 
-IDBRequestData::IDBRequestData(IDBConnectionIdentifier serverConnectionIdentifier, IDBResourceIdentifier requestIdentifier, std::optional<IDBResourceIdentifier>&& transactionIdentifier, std::optional<IDBResourceIdentifier>&& cursorIdentifier, uint64_t objectStoreIdentifier, uint64_t indexIdentifier, IndexedDB::IndexRecordType indexRecordType, std::optional<IDBDatabaseIdentifier>&& databaseIdentifier, uint64_t requestedVersion, IndexedDB::RequestType requestType)
+IDBRequestData::IDBRequestData(IDBConnectionIdentifier serverConnectionIdentifier, IDBResourceIdentifier requestIdentifier, IDBResourceIdentifier&& transactionIdentifier, std::optional<IDBResourceIdentifier>&& cursorIdentifier, uint64_t objectStoreIdentifier, uint64_t indexIdentifier, IndexedDB::IndexRecordType indexRecordType, std::optional<IDBDatabaseIdentifier>&& databaseIdentifier, uint64_t requestedVersion, IndexedDB::RequestType requestType)
     : m_serverConnectionIdentifier(serverConnectionIdentifier)
     , m_requestIdentifier(requestIdentifier)
     , m_transactionIdentifier(WTFMove(transactionIdentifier))
@@ -123,8 +123,7 @@ IDBResourceIdentifier IDBRequestData::requestIdentifier() const
 
 IDBResourceIdentifier IDBRequestData::transactionIdentifier() const
 {
-    ASSERT(m_transactionIdentifier);
-    return *m_transactionIdentifier;
+    return m_transactionIdentifier;
 }
 
 IDBResourceIdentifier IDBRequestData::cursorIdentifier() const

--- a/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h
@@ -74,12 +74,12 @@ public:
 
 private:
     friend struct IPC::ArgumentCoder<IDBRequestData, void>;
-    WEBCORE_EXPORT IDBRequestData(IDBConnectionIdentifier serverConnectionIdentifier, IDBResourceIdentifier requestIdentifier, std::optional<IDBResourceIdentifier>&& transactionIdentifier, std::optional<IDBResourceIdentifier>&& cursorIdentifier, uint64_t objectStoreIdentifier, uint64_t indexIdentifier, IndexedDB::IndexRecordType, std::optional<IDBDatabaseIdentifier>&&, uint64_t requestedVersion, IndexedDB::RequestType);
+    WEBCORE_EXPORT IDBRequestData(IDBConnectionIdentifier serverConnectionIdentifier, IDBResourceIdentifier requestIdentifier, IDBResourceIdentifier&& transactionIdentifier, std::optional<IDBResourceIdentifier>&& cursorIdentifier, uint64_t objectStoreIdentifier, uint64_t indexIdentifier, IndexedDB::IndexRecordType, std::optional<IDBDatabaseIdentifier>&&, uint64_t requestedVersion, IndexedDB::RequestType);
     static void isolatedCopy(const IDBRequestData& source, IDBRequestData& destination);
 
     IDBConnectionIdentifier m_serverConnectionIdentifier;
     IDBResourceIdentifier m_requestIdentifier;
-    std::optional<IDBResourceIdentifier> m_transactionIdentifier;
+    IDBResourceIdentifier m_transactionIdentifier;
     std::optional<IDBResourceIdentifier> m_cursorIdentifier;
     uint64_t m_objectStoreIdentifier { 0 };
     uint64_t m_indexIdentifier { 0 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -607,7 +607,7 @@ class WebCore::IDBValue {
 class WebCore::IDBRequestData {
     WebCore::IDBConnectionIdentifier m_serverConnectionIdentifier;
     WebCore::IDBResourceIdentifier m_requestIdentifier;
-    std::optional<WebCore::IDBResourceIdentifier> m_transactionIdentifier;
+    WebCore::IDBResourceIdentifier m_transactionIdentifier;
     std::optional<WebCore::IDBResourceIdentifier> m_cursorIdentifier;
     uint64_t m_objectStoreIdentifier;
     uint64_t m_indexIdentifier;


### PR DESCRIPTION
#### 3caa434b53f95970f909ac2be66b45c6e50144e1
<pre>
IDBRequestData&apos;s transaction identifier should not be optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=268829">https://bugs.webkit.org/show_bug.cgi?id=268829</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp:
(WebCore::IDBRequestData::IDBRequestData):
(WebCore::IDBRequestData::transactionIdentifier const):
* Source/WebCore/Modules/indexeddb/shared/IDBRequestData.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre>