### PR TITLE
[GTK] Implement GTK4 accessibility

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
@@ -141,3 +141,7 @@ void webkitWebViewBaseToplevelWindowStateChanged(WebKitWebViewBase*, uint32_t, u
 void webkitWebViewBaseToplevelWindowMonitorChanged(WebKitWebViewBase*, GdkMonitor*);
 
 void webkitWebViewBaseCallAfterNextPresentationUpdate(WebKitWebViewBase*, CompletionHandler<void()>&&);
+
+#if USE(GTK4)
+void webkitWebViewBaseSetPlugID(WebKitWebViewBase*, const String&);
+#endif

--- a/Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp
+++ b/Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp
@@ -173,6 +173,9 @@ static void moveCursorCallback(GtkWidget* widget, GtkMovementStep step, gint cou
 KeyBindingTranslator::KeyBindingTranslator()
     : m_nativeWidget(gtk_text_view_new())
 {
+#if USE(GTK4)
+    gtk_accessible_update_state(GTK_ACCESSIBLE(m_nativeWidget.get()), GTK_ACCESSIBLE_STATE_HIDDEN, TRUE, -1);
+#endif
     g_signal_connect(m_nativeWidget.get(), "backspace", G_CALLBACK(backspaceCallback), this);
     g_signal_connect(m_nativeWidget.get(), "cut-clipboard", G_CALLBACK(cutClipboardCallback), this);
     g_signal_connect(m_nativeWidget.get(), "copy-clipboard", G_CALLBACK(copyClipboardCallback), this);

--- a/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
@@ -54,8 +54,7 @@ GtkWidget* WebPageProxy::viewWidget()
 void WebPageProxy::bindAccessibilityTree(const String& plugID)
 {
 #if USE(GTK4)
-    // FIXME: We need a way to override accessible interface of WebView and send the atspi reference to the web process.
-    ASSERT_NOT_IMPLEMENTED_YET();
+    webkitWebViewBaseSetPlugID(WEBKIT_WEB_VIEW_BASE(viewWidget()), plugID);
 #else
     auto* accessible = gtk_widget_get_accessible(viewWidget());
     atk_socket_embed(ATK_SOCKET(accessible), const_cast<char*>(plugID.utf8().data()));

--- a/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
+++ b/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
@@ -61,9 +61,6 @@ void WebPage::platformInitialize(const WebPageCreationParameters&)
     // entry point to the Web process, and send a message to the UI
     // process to connect the two worlds through the accessibility
     // object there specifically placed for that purpose (the socket).
-#if PLATFORM(GTK) && USE(GTK4)
-    // FIXME: we need a way to connect DOM and app a11y tree in GTK4.
-#else
     if (auto* page = corePage()) {
         m_accessibilityRootObject = AccessibilityRootAtspi::create(*page);
         m_accessibilityRootObject->registerObject([&](const String& plugID) {
@@ -71,7 +68,6 @@ void WebPage::platformInitialize(const WebPageCreationParameters&)
                 send(Messages::WebPageProxy::BindAccessibilityTree(plugID));
         });
     }
-#endif
 #endif
 }
 


### PR DESCRIPTION
#### da96990ed73dce54453c76e87a1ec3a648a8d8ee
<pre>
[GTK] Implement GTK4 accessibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=227528">https://bugs.webkit.org/show_bug.cgi?id=227528</a>

Reviewed by Carlos Garcia Campos.

WebKit maintains a complete AT-SPI accessible tree within the web
process, under a separate D-Bus name. This conflicts with GTK4&apos;s
expectations of having instances of GtkAccessible objects in process
that can be built in an internal tree.

GTK4 recently introduced support for bridging out-of-process AT-SPI
accessible trees using a new GtkAtSpiSocket object that implements
GtkAccessible [1]. The availability of this object is guarded by the
GTK_ACCESSIBILITY_ATSPI ifdef.

Use this new socket object from GTK to bridge the web page accessible
tree, and the UI process&apos; one. Mark the textview widget as hidden from
the accessible tree.

Create the GtkAtSpiSocket accessible when the web page reports to be
ready. Inject the socket accessible as the first GtkAccessible child
of WebKitWebViewBase.

[1] <a href="https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/6827">https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/6827</a>

* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseAccessibleGetFirstAccessibleChild):
(webkitWebViewBaseAccessibleInterfaceInit):
(webkitWebViewBaseSetPlugID):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h:
* Source/WebKit/UIProcess/gtk/KeyBindingTranslator.cpp:
(WebKit::KeyBindingTranslator::KeyBindingTranslator):
* Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp:
(WebKit::WebPageProxy::bindAccessibilityTree):
* Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp:
(WebKit::WebPage::platformInitialize):

Canonical link: <a href="https://commits.webkit.org/274201@main">https://commits.webkit.org/274201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0200806ec10f18906d941ab2b58ce6c2f630fa50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40690 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33934 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14404 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32217 "Build is being retried. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 37 flakes 168 failures 1 missing results; Uploaded test results; 21 flakes 145 failures 1 missing results; compiling; 13 flakes 132 failures 1 missing results; Passed layout tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33370 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12548 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12507 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41968 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34629 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38363 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36554 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14647 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13521 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4978 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14098 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->