### PR TITLE
[Cocoa] Netflix.com key renewal fails, causes playback errors, stuttering.

### DIFF
--- a/LayoutTests/http/tests/media/fairplay/fps-mse-multi-key-renewal-expected.txt
+++ b/LayoutTests/http/tests/media/fairplay/fps-mse-multi-key-renewal-expected.txt
@@ -1,0 +1,28 @@
+Initiate a multi-key key request and verify that a renewal does not revoke any usable keys.
+PROMISE: requestMediaKeySystemAccess resolved
+PROMISE: createMediaKeys resolved
+FETCH: server certificate recieved
+PROMISE: arrayBuffer resolved
+PROMISE: setServerCertificate resolved
+
+Issue a multi-key request
+EVENT(message)
+Requesting key.
+PROMISE: licenseResponse resolved
+Requesting key.
+PROMISE: licenseResponse resolved
+Requesting key.
+PROMISE: licenseResponse resolved
+Requesting key.
+PROMISE: licenseResponse resolved
+PROMISE: session.update() resolved
+EXPECTED (session.keyStatuses.size == '4') OK
+
+Issue a single key renewal
+EVENT(message)
+Requesting key.
+PROMISE: licenseResponse resolved
+PROMISE: session.update() resolved
+EXPECTED (session.keyStatuses.size == '4') OK
+END OF TEST
+

--- a/LayoutTests/http/tests/media/fairplay/fps-mse-multi-key-renewal.html
+++ b/LayoutTests/http/tests/media/fairplay/fps-mse-multi-key-renewal.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>fps-mse-multi-key-renewal</title>
+    <script src=../../../media-resources/video-test.js></script>
+    <script src=support.js></script>
+    <script src="eme2016.js"></script>
+    <script>
+    window.addEventListener('load', async event => {
+        startTest().then(endTest).catch(failTest);
+    });
+
+    async function startTest() {
+        consoleWrite('Initiate a multi-key key request and verify that a renewal does not revoke any usable keys.')
+
+        var access = await navigator.requestMediaKeySystemAccess("com.apple.fps", [{
+            initDataTypes: ['cenc'],
+            videoCapabilities: [{ contentType: 'video/mp4', robustness: '' }],
+            distinctiveIdentifier: 'not-allowed',
+            persistentState: 'not-allowed',
+            sessionTypes: ['temporary'],
+        }]);
+
+        consoleWrite('PROMISE: requestMediaKeySystemAccess resolved');
+        var keys = await access.createMediaKeys();
+
+        consoleWrite('PROMISE: createMediaKeys resolved');
+        var certificateResponse = await fetch('resources/cert.der');
+
+        consoleWrite('FETCH: server certificate recieved');
+        var arrayBuffer = await certificateResponse.arrayBuffer();
+
+        consoleWrite('PROMISE: arrayBuffer resolved');
+        await keys.setServerCertificate(arrayBuffer);
+
+        consoleWrite('PROMISE: setServerCertificate resolved');
+        window.session = keys.createSession();
+
+        let keyIDs = [];
+
+        let handleCencMessage = async event => {
+            let messageString = uInt8ArrayToString(new Uint8Array(event.message));
+            let messageObject = JSON.parse(messageString);
+            let responses = [];
+
+            for (let message of messageObject) {
+                consoleWrite('Requesting key.');
+                keyIDs.push(message.keyID);
+                let id = base64DecodeUint8Array(message.keyID)[15];
+
+                var licenseResponse = await fetch('resources/index.py', {
+                    method: 'POST',
+                    headers: new Headers({'Content-type': 'application/x-www-form-urlencoded'}),
+                    body: JSON.stringify({
+                        "fairplay-streaming-request" : {
+                            "version" : 1,
+                            "streaming-keys" : [{
+                                id: id,
+                                uri: 'skd://twelve',
+                                spc: message.payload,
+                            }],
+                        }
+                    }),
+                });
+                consoleWrite('PROMISE: licenseResponse resolved');
+                var license = await licenseResponse.text();
+
+                responseObject = JSON.parse(license.trim());
+                responses.push({ keyID: message.keyID, payload: responseObject["fairplay-streaming-response"]["streaming-keys"][0].ckc });
+            }
+
+            let response = stringToUInt8Array(JSON.stringify(responses));
+            await session.update(response.buffer);
+            consoleWrite('PROMISE: session.update() resolved');
+        }
+
+
+        let handleRenewalMessage = async event => {
+            consoleWrite('Requesting key.');
+            let keyID = keyIDs.at(-1);
+            let id = base64DecodeUint8Array(keyID)[15];
+
+            var licenseResponse = await fetch('resources/index.py', {
+                method: 'POST',
+                headers: new Headers({'Content-type': 'application/x-www-form-urlencoded'}),
+                body: JSON.stringify({
+                    "fairplay-streaming-request" : {
+                        "version" : 1,
+                        "streaming-keys" : [{
+                            id: id,
+                            uri: 'skd://twelve',
+                            spc: base64EncodeUint8Array(new Uint8Array(event.message)),
+                        }],
+                    }
+                }),
+            });
+            consoleWrite('PROMISE: licenseResponse resolved');
+            var license = await licenseResponse.text();
+
+            responseObject = JSON.parse(license.trim());
+            responses = [{ keyID: keyID, payload: responseObject["fairplay-streaming-response"]["streaming-keys"][0].ckc }];
+
+            let response = stringToUInt8Array(JSON.stringify(responses));
+            await session.update(response.buffer);
+            consoleWrite('PROMISE: session.update() resolved');
+        }
+
+        consoleWrite('');
+        consoleWrite('Issue a multi-key request');
+
+        var initData = base64DecodeUint8Array(`AAABuHBzc2gAAAAAlM6G+wf/T0OtuJPS+paMogAAAZgAAAGYZnBzZAAAABBmcHNpAAAAAGNlbmMAAABgZnBzawAAABxma3JpAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAYZmthaQAAAAAAAAAAAAAAAAAAAAEAAAAYZmtjeAAAAAAAAAAAAAAAAAAAAAEAAAAMZmt2bAEAAAAAAABgZnBzawAAABxma3JpAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAYZmthaQAAAAAAAAAAAAAAAAAAAAIAAAAYZmtjeAAAAAAAAAAAAAAAAAAAAAIAAAAMZmt2bAEAAAAAAABgZnBzawAAABxma3JpAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAYZmthaQAAAAAAAAAAAAAAAAAAAAMAAAAYZmtjeAAAAAAAAAAAAAAAAAAAAAMAAAAMZmt2bAEAAAAAAABgZnBzawAAABxma3JpAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAYZmthaQAAAAAAAAAAAAAAAAAAAAQAAAAYZmtjeAAAAAAAAAAAAAAAAAAAAAQAAAAMZmt2bAEAAAA=`);
+
+        session.generateRequest('cenc', initData);
+        let event = await waitFor(session, 'message');
+
+        await handleCencMessage(event);
+
+        testExpected('session.keyStatuses.size', 4);
+
+        consoleWrite('');
+        consoleWrite('Issue a single key renewal');
+        session.update(stringToUInt8Array('renew'));    
+        event = await waitFor(session, 'message');
+
+        await handleRenewalMessage(event);
+        
+        testExpected('session.keyStatuses.size', 4);
+    }
+    </script>
+</head>
+</html>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -1374,7 +1374,17 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRenewingRequest(AVCon
         return;
     }
 
-    m_requests[renewingIndex] = *m_currentRequest;
+    auto replaceRequest = [](Vector<RetainPtr<AVContentKeyRequest>>& requests, AVContentKeyRequest* replacementRequest) {
+        for (auto& request : requests) {
+            if (![[request contentKeySpecifier].identifier isEqual:replacementRequest.contentKeySpecifier.identifier])
+                continue;
+
+            request = replacementRequest;
+            return;
+        }
+    };
+
+    replaceRequest(m_requests[renewingIndex].requests, request);
     m_renewingRequest = std::nullopt;
 
     RetainPtr<NSData> appIdentifier;


### PR DESCRIPTION
#### 8c14e2cb82142e26dd1de6f1dcb42d2460b3d047
<pre>
[Cocoa] Netflix.com key renewal fails, causes playback errors, stuttering.
<a href="https://bugs.webkit.org/show_bug.cgi?id=268830">https://bugs.webkit.org/show_bug.cgi?id=268830</a>
<a href="https://rdar.apple.com/121931039">rdar://121931039</a>

Reviewed by Andy Estes.

When adding a workaround for a platform change in behavior in the modern AVContentKeySession path,
a behavior was introduced which narrowly affects the way Netflix.com preloads keys. Previously,
a &quot;renew&quot; message would result in the resulting AVContentKeyRequest replacing the entire set of
pre-loaded keys from the previous request, some of which were in use by Netflix.

Rather than replace the entire set, replace only the AVContentKeyRequest within the batch of requests
whose contentKeySpecifier has a maching identifier to the replacement.

* LayoutTests/http/tests/media/fairplay/fps-mse-multi-key-renewal-expected.txt: Added.
* LayoutTests/http/tests/media/fairplay/fps-mse-multi-key-renewal.html: Added.
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRenewingRequest):

Canonical link: <a href="https://commits.webkit.org/274172@main">https://commits.webkit.org/274172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9937f6ec69c7dbae6f0f4b660c3b5d26f19e356

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40408 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40668 "Build is being retried. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33906 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14389 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/40668 "Build is being retried. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14387 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/40668 "Build is being retried. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Failed to compile WebKit") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12491 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34096 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41947 "Failed to compile WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34619 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/41947 "Failed to compile WebKit") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10761 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/41947 "Failed to compile WebKit") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14636 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/33431 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8553 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13510 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14087 "Build was cancelled. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | 
<!--EWS-Status-Bubble-End-->