### PR TITLE
[WebGPU] WebCore::GPUCanvasContextCocoa::drawBufferToCanvas crash if WebGPU is not configured

### DIFF
--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -177,7 +177,7 @@ void GPUCanvasContextCocoa::drawBufferToCanvas(SurfaceBuffer)
     // FIXME(https://bugs.webkit.org/show_bug.cgi?id=263957): WebGPU should support obtaining drawing buffer for Web Inspector.
     auto& base = canvasBase();
     base.clearCopiedImage();
-    if (auto buffer = base.buffer()) {
+    if (auto buffer = base.buffer(); m_configuration.has_value()) {
         buffer->flushDrawingContext();
         m_compositorIntegration->paintCompositedResultsToCanvas(*buffer, m_configuration->frameCount);
     }


### PR DESCRIPTION
#### 19c40366c02fd010da9fbf184ac62fdd3aecfcfc
<pre>
[WebGPU] WebCore::GPUCanvasContextCocoa::drawBufferToCanvas crash if WebGPU is not configured
<a href="https://bugs.webkit.org/show_bug.cgi?id=268835">https://bugs.webkit.org/show_bug.cgi?id=268835</a>
&lt;radar://122399779&gt;

Reviewed by Dan Glastonbury.

drawBufferToCanvas should be a no-op if the context is not
configured.

* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::drawBufferToCanvas):

Canonical link: <a href="https://commits.webkit.org/274186@main">https://commits.webkit.org/274186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1e08f60d67c1a3fa25ab8d7b87954a5e9bc173c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40688 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33932 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32212 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14396 "Passed tests") | [💥 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33368 "An unexpected error occured. Recent messages:Failed to print configuration") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12544 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12506 "Passed tests") | [💥 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34101 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41966 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34628 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38380 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36551 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14646 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8600 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13519 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14097 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->