### PR TITLE
[ews-build.webkit.org] Allow S3 uploads to declare content type

### DIFF
--- a/Tools/CISupport/Shared/generate-s3-url
+++ b/Tools/CISupport/Shared/generate-s3-url
@@ -16,12 +16,14 @@ if 'uat' in hostname:
 S3_DEFAULT_BUCKET = f'archives.webkit{custom_suffix}.org'
 S3_EWS_BUCKET = f'ews-archives.webkit{custom_suffix}.org'
 
-def generateS3URL(bucket, identifier, revision):
-    key = '/'.join([identifier, revision + '.zip'])
+def generateS3URL(bucket, identifier, revision, extension=None, content_type=None):
+    key = f"{identifier}/{revision}.{extension or 'zip'}"
     print(f'\tS3 Bucket: {bucket}\n\tS3 Key: {key}')
     config = Config(region_name = 'us-west-2')
     s3 = boto3.client('s3', config=config)
     params = {'Bucket': bucket, 'Key': key}
+    if content_type:
+        params['ContentType'] = content_type
     url = s3.generate_presigned_url(ClientMethod='put_object', Params=params, ExpiresIn=30*60)
     print(f'S3 URL: {url}\n')
     return url
@@ -33,13 +35,18 @@ def main():
     group.add_argument('--revision', action="store", help='Revision number or change identifier for the built archive')
     group.add_argument('--change-id', dest='change_id', action="store", help='patch id or hash of specified change')
     parser.add_argument('--identifier', action="store", required=True, help='S3 destination identifier, in the form of fullPlatform-architecture-configuration. [mac-mojave-x86_64-release]')
+    parser.add_argument('--extension', action='store', required=False, default=None, help='File extension of uploaded file')
+    parser.add_argument('--content-type', action='store', required=False, default=None, help='Content type of file to be uploaded')
     args = parser.parse_args()
 
     s3_bucket = S3_DEFAULT_BUCKET
     if args.change_id:
         s3_bucket = S3_EWS_BUCKET
 
-    url = generateS3URL(s3_bucket, args.identifier, args.revision or args.change_id)
+    url = generateS3URL(
+        s3_bucket, args.identifier, args.revision or args.change_id,
+        extension=args.extension, content_type=args.content_type,
+    )
     return url
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### 46ace4312fd53dbc1730b5598ffd84bfb3ac112d
<pre>
[ews-build.webkit.org] Allow S3 uploads to declare content type
<a href="https://bugs.webkit.org/show_bug.cgi?id=268844">https://bugs.webkit.org/show_bug.cgi?id=268844</a>
<a href="https://rdar.apple.com/122405197">rdar://122405197</a>

Reviewed by Aakash Jain.

* Tools/CISupport/Shared/generate-s3-url:
(generateS3URL): Allow caller to specify file extension and content type.
(main): Accept --extension and --content-type arguments.
* Tools/CISupport/ews-build/steps.py:
(UploadFileToS3.__init__): Allow caller to specify content type to upload with.
(UploadFileToS3.run): Ditto.
(GenerateS3URL.__init__): Allow caller to specify extension and content type of file.
(GenerateS3URL.run): Use specified file extension.
* Tools/CISupport/ews-build/steps_unittest.py:
(TestGenerateS3URL.configureStep):
(TestGenerateS3URL.test_failure_with_extension):
(TestUploadFileToS3.configureStep):
(TestUploadFileToS3.test_success_content_type):

Canonical link: <a href="https://commits.webkit.org/274163@main">https://commits.webkit.org/274163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42cb2a7eb0405465ece3d4d69175daaf73c1f7a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/38159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/17078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/40438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/40708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/33951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/40411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/19802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/14421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/40708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/38733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/19802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/40438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/40708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/19802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/40438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/41986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/19802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/40438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/41986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/14421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/41986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/38202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/40438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->