### PR TITLE
[iOS] run keyboard scrolling animations at a higher frame rate when possible

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -229,6 +229,10 @@ typedef uint32_t CAHighFrameRateReason;
 @interface CAAnimation ()
 @property CAHighFrameRateReason highFrameRateReason;
 @end
+
+@interface CADisplayLink ()
+@property CAHighFrameRateReason highFrameRateReason;
+@end
 #endif // HAVE(CORE_ANIMATION_FRAME_RATE_RANGE)
 
 #endif // __OBJC__

--- a/Source/WebKit/Platform/cocoa/CAFrameRateRangeUtilities.h
+++ b/Source/WebKit/Platform/cocoa/CAFrameRateRangeUtilities.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(CORE_ANIMATION_FRAME_RATE_RANGE)
+
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
+
+namespace WebKit {
+
+#define WEBKIT_HIGH_FRAME_RATE_REASON_COMPONENT 44
+
+static CAFrameRateRange highFrameRateRange()
+{
+    static CAFrameRateRange highFrameRateRange = CAFrameRateRangeMake(80, 120, 120);
+    return highFrameRateRange;
+}
+
+static CAHighFrameRateReason webAnimationHighFrameRateReason = CAHighFrameRateReasonMake(WEBKIT_HIGH_FRAME_RATE_REASON_COMPONENT, 1);
+static CAHighFrameRateReason keyboardScrollingAnimationHighFrameRateReason = CAHighFrameRateReasonMake(WEBKIT_HIGH_FRAME_RATE_REASON_COMPONENT, 2);
+
+}
+
+#endif // HAVE(CORE_ANIMATION_FRAME_RATE_RANGE)

--- a/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
+++ b/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "AccessibilitySupportSPI.h"
+#import "CAFrameRateRangeUtilities.h"
 #import "UIKitSPI.h"
 #import "UIKitUtilities.h"
 #import "WKVelocityTrackingScrollView.h"
@@ -42,6 +43,10 @@
 #import <algorithm>
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakObjCPtr.h>
+
+#if HAVE(CORE_ANIMATION_FRAME_RATE_RANGE)
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
+#endif
 
 @protocol WKKeyboardScrollableInternal <NSObject>
 @required
@@ -434,6 +439,13 @@ static WebCore::FloatPoint farthestPointInDirection(WebCore::FloatPoint a, WebCo
         return;
 
     _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(displayLinkFired:)];
+
+#if HAVE(CORE_ANIMATION_FRAME_RATE_RANGE)
+    // Opt into a higher frame-rate for displays that support higher refresh rates.
+    [_displayLink setPreferredFrameRateRange:WebKit::highFrameRateRange()];
+    [_displayLink setHighFrameRateReason:WebKit::keyboardScrollingAnimationHighFrameRateReason];
+#endif // HAVE(CORE_ANIMATION_FRAME_RATE_RANGE)
+
     [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
 }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1535,6 +1535,7 @@
 		6D9A666E2A27FAE300BD68A0 /* WebTouchEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F4001002527D73C00E91DA7 /* WebTouchEvent.h */; };
 		6EE849C81368D9390038D481 /* WKInspectorPrivateMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EE849C61368D92D0038D481 /* WKInspectorPrivateMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		711725A9228D564300018514 /* WebsiteLegacyOverflowScrollingTouchPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 711725A8228D563A00018514 /* WebsiteLegacyOverflowScrollingTouchPolicy.h */; };
+		7121A3CF2B73728B00C8F7A4 /* CAFrameRateRangeUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 7121A3CE2B73727B00C8F7A4 /* CAFrameRateRangeUtilities.h */; };
 		7134A3DA2603B92500624BD3 /* WKModelInteractionGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7134A3D92603B80E00624BD3 /* WKModelInteractionGestureRecognizer.h */; };
 		7137BA8025F1542000914EE3 /* ModelElementController.h in Headers */ = {isa = PBXBuildFile; fileRef = 7137BA7F25F1540C00914EE3 /* ModelElementController.h */; };
 		71A676A622C62325007D6295 /* WKTouchActionGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A676A422C62318007D6295 /* WKTouchActionGestureRecognizer.h */; };
@@ -6149,6 +6150,7 @@
 		6D8A91A511F0EFD100DD01FE /* com.apple.WebProcess.sb.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = com.apple.WebProcess.sb.in; path = WebProcess/com.apple.WebProcess.sb.in; sourceTree = "<group>"; };
 		6EE849C61368D92D0038D481 /* WKInspectorPrivateMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKInspectorPrivateMac.h; path = mac/WKInspectorPrivateMac.h; sourceTree = "<group>"; };
 		711725A8228D563A00018514 /* WebsiteLegacyOverflowScrollingTouchPolicy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebsiteLegacyOverflowScrollingTouchPolicy.h; sourceTree = "<group>"; };
+		7121A3CE2B73727B00C8F7A4 /* CAFrameRateRangeUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CAFrameRateRangeUtilities.h; sourceTree = "<group>"; };
 		7134A3D82603B80E00624BD3 /* WKModelInteractionGestureRecognizer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WKModelInteractionGestureRecognizer.mm; path = ios/WKModelInteractionGestureRecognizer.mm; sourceTree = "<group>"; };
 		7134A3D92603B80E00624BD3 /* WKModelInteractionGestureRecognizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKModelInteractionGestureRecognizer.h; path = ios/WKModelInteractionGestureRecognizer.h; sourceTree = "<group>"; };
 		71371D1E2B1F89C00092C32D /* RemoteAcceleratedEffectStack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoteAcceleratedEffectStack.h; sourceTree = "<group>"; };
@@ -11608,6 +11610,7 @@
 				07E4BDC62A3A7089000D5509 /* _WKWebViewTextInputNotifications.mm */,
 				A1D615662B06BBAB002D0E19 /* AssertionCapability.h */,
 				A1D615632B06BBAB002D0E19 /* AssertionCapability.mm */,
+				7121A3CE2B73727B00C8F7A4 /* CAFrameRateRangeUtilities.h */,
 				1C62747B288B4C3E00CED3A2 /* CocoaHelpers.h */,
 				1C62747C288B4C3E00CED3A2 /* CocoaHelpers.mm */,
 				4482734624528F6000A95493 /* CocoaImage.h */,
@@ -15641,6 +15644,7 @@
 				935BF8042936BF1A00B41326 /* CacheStorageRecord.h in Headers */,
 				935BF8072936C9FD00B41326 /* CacheStorageRegistry.h in Headers */,
 				935BF7FF2936BF1A00B41326 /* CacheStorageStore.h in Headers */,
+				7121A3CF2B73728B00C8F7A4 /* CAFrameRateRangeUtilities.h in Headers */,
 				57B4B46020B504AC00D4AD79 /* ClientCertificateAuthenticationXPCConstants.h in Headers */,
 				1C62747D288B4C3E00CED3A2 /* CocoaHelpers.h in Headers */,
 				4482734724528F6000A95493 /* CocoaImage.h in Headers */,

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
@@ -27,6 +27,7 @@
 #import "PlatformCAAnimationRemote.h"
 
 #import "ArgumentCoders.h"
+#import "CAFrameRateRangeUtilities.h"
 #import "RemoteLayerTreeHost.h"
 #import "WKAnimationDelegate.h"
 #import "WebCoreArgumentCoders.h"
@@ -45,16 +46,6 @@ static MonotonicTime mediaTimeToCurrentTime(CFTimeInterval t)
 {
     return WTF::MonotonicTime::now() + Seconds(t - CACurrentMediaTime());
 }
-
-#if HAVE(CORE_ANIMATION_FRAME_RATE_RANGE)
-static CAFrameRateRange highFrameRateRange()
-{
-    static CAFrameRateRange highFrameRateRange = CAFrameRateRangeMake(80, 120, 120);
-    return highFrameRateRange;
-}
-
-static CAHighFrameRateReason highFrameRateReason = CAHighFrameRateReasonMake(44, 0);
-#endif // HAVE(CORE_ANIMATION_FRAME_RATE_RANGE)
 
 static NSString * const WKExplicitBeginTimeFlag = @"WKPlatformCAAnimationExplicitBeginTimeFlag";
 
@@ -614,8 +605,8 @@ static RetainPtr<CAAnimation> createAnimation(CALayer *layer, RemoteLayerTreeHos
 
 #if HAVE(CORE_ANIMATION_FRAME_RATE_RANGE)
     // Opt into a higher frame-rate for displays that support higher refresh rates.
-    [caAnimation setPreferredFrameRateRange:highFrameRateRange()];
-    [caAnimation setHighFrameRateReason:highFrameRateReason];
+    [caAnimation setPreferredFrameRateRange:WebKit::highFrameRateRange()];
+    [caAnimation setHighFrameRateReason:WebKit::webAnimationHighFrameRateReason];
 #endif // HAVE(CORE_ANIMATION_FRAME_RATE_RANGE)
 
     return caAnimation;


### PR DESCRIPTION
#### 0eec24ac3eff44a5d415e3617d1cf5abe5c5d496
<pre>
[iOS] run keyboard scrolling animations at a higher frame rate when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=268850">https://bugs.webkit.org/show_bug.cgi?id=268850</a>
<a href="https://rdar.apple.com/122323815">rdar://122323815</a>

Reviewed by Simon Fraser.

In 273122@main we opted into higher frame rate animations when performed by Core Animation on
qualifying hardware. We now do the same with scrolling animations resulting from interacting
with the keyboard (such as pressing the space bar) by setting similar properties on the
`CADisplayLink` created by `WKKeyboardScrollingAnimator`. Because we now have two different
places where we opt into a higher frame rate, we distinguish between the two cases by using
a different `CAHighFrameRateReason` value.

* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
* Source/WebKit/Platform/cocoa/CAFrameRateRangeUtilities.h: Added.
(WebKit::highFrameRateRange):
* Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm:
(-[WKKeyboardScrollingAnimator startDisplayLinkIfNeeded]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm:
(WebKit::createAnimation):
(highFrameRateRange): Deleted.

Canonical link: <a href="https://commits.webkit.org/274234@main">https://commits.webkit.org/274234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adfc6854ed9a441113b7e263142ee37c73081991

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40832 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34046 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14557 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32292 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14535 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12649 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12633 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42110 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34828 "Passed tests") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38469 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13212 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36702 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14766 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13625 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4994 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14231 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->