### PR TITLE
Destructuring exception shouldn't crash

### DIFF
--- a/JSTests/stress/destructuring-class-in-constructor-exception.js
+++ b/JSTests/stress/destructuring-class-in-constructor-exception.js
@@ -1,0 +1,13 @@
+try {
+    class C0 {
+        constructor(a2, a3) {
+            const v4 = this.e;
+            let {...v5} = this;
+            let [...v6] = v4;
+        }
+    }
+    new C0();
+} catch {
+
+}
+

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -582,9 +582,15 @@ namespace JSC {
         }
 
         void emitExpressionInfo(const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd)
-        {            
+        {
+            ASSERT(divot && divotStart && divotEnd);
             ASSERT(divot.offset >= divotStart.offset);
             ASSERT(divotEnd.offset >= divot.offset);
+
+            // Don't emit expression info if the data could cause us to crash later.
+            // In this case we'll just use the wrong info for an error message, not crash.
+            if (!divot || !divotStart || !divotEnd)
+                return;
 
             if (m_isBuiltinFunction)
                 return;

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -1027,7 +1027,7 @@ public:
     {
         return new (m_parserArena) ObjectPatternNode();
     }
-    
+
     void appendObjectPatternEntry(ObjectPattern node, const JSTokenLocation& location, bool wasString, const Identifier& identifier, DestructuringPattern pattern, ExpressionNode* defaultValue)
     {
         node->appendEntry(location, identifier, wasString, pattern, defaultValue, ObjectPatternNode::BindingType::Element);
@@ -1053,6 +1053,11 @@ public:
     void setContainsComputedProperty(ObjectPattern node, bool containsComputedProperty)
     {
         node->setContainsComputedProperty(containsComputedProperty);
+    }
+
+    void finishObjectPattern(ObjectPattern node, const JSTextPosition& divotStart, const JSTextPosition& divot, const JSTextPosition& divotEnd)
+    {
+        setExceptionLocation(node, divotStart, divot, divotEnd);
     }
 
     BindingPattern createBindingLocation(const JSTokenLocation&, const Identifier& boundProperty, const JSTextPosition& start, const JSTextPosition& end, AssignmentContext context)
@@ -1122,6 +1127,7 @@ private:
 
     static void setExceptionLocation(ThrowableExpressionData* node, const JSTextPosition& divotStart, const JSTextPosition& divot, const JSTextPosition& divotEnd)
     {
+        ASSERT(divot && divotStart && divotEnd);
         ASSERT(divot.offset >= divot.lineStartOffset);
         node->setExceptionSourceCode(divot, divotStart, divotEnd);
     }

--- a/Source/JavaScriptCore/parser/ParserTokens.h
+++ b/Source/JavaScriptCore/parser/ParserTokens.h
@@ -218,6 +218,7 @@ struct JSTextPosition {
     JSTextPosition operator-(unsigned adjustment) const { return *this + (- static_cast<int>(adjustment)); }
 
     operator int() const { return offset; }
+    explicit operator bool() const { return *this != JSTextPosition(); }
 
     friend bool operator==(const JSTextPosition&, const JSTextPosition&) = default;
 

--- a/Source/JavaScriptCore/parser/SyntaxChecker.h
+++ b/Source/JavaScriptCore/parser/SyntaxChecker.h
@@ -384,6 +384,9 @@ public:
     void setContainsComputedProperty(ObjectPattern, bool)
     {
     }
+    void finishObjectPattern(ObjectPattern, const JSTextPosition&, const JSTextPosition&, const JSTextPosition&)
+    {
+    }
 
     DestructuringPattern createBindingLocation(const JSTokenLocation&, const Identifier&, const JSTextPosition&, const JSTextPosition&, AssignmentContext)
     {


### PR DESCRIPTION
#### 5a241c1e2822e6ad1b32aca9db53babb28e0b375
<pre>
Destructuring exception shouldn&apos;t crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=268849">https://bugs.webkit.org/show_bug.cgi?id=268849</a>
<a href="https://rdar.apple.com/121869296">rdar://121869296</a>

Reviewed by Yusuke Suzuki.

We recently changed how we saved expression info for exceptions, which saved a bunch of memory.
The new system exposed some places where we were not setting JSTextPositions properly. This
patch fixes that and adds some asserts that the expression info is initialized. We also now
return early rather than emit bad expression info if not all parts are initialized in production.
This means users will see the wrong expression in their stack trace but we won&apos;t crash.

* JSTests/stress/destructuring-class-in-constructor-exception.js: Added.
(try.C0):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::BytecodeGenerator::emitExpressionInfo):
* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::finishObjectPattern):
(JSC::ASTBuilder::setExceptionLocation):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseDestructuringPattern):
(JSC::Parser&lt;LexerType&gt;::parseForStatement):
* Source/JavaScriptCore/parser/ParserTokens.h:
(JSC::JSTextPosition::operator bool const):
* Source/JavaScriptCore/parser/SyntaxChecker.h:
(JSC::SyntaxChecker::operatorStackPop):

Canonical link: <a href="https://commits.webkit.org/274213@main">https://commits.webkit.org/274213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c81bf45a7e4e1ba89c7fa9aa91c00a19842c424

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40722 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33961 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14434 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32238 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12573 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12535 "Passed tests") | [💥 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34136 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/41999 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/31801 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34659 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34579 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38394 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/37850 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36584 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14668 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/44789 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8618 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13546 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9174 "Found 2 new JSC stress test failures: stress/array-flatmap.js.dfg-eager, wasm.yaml/wasm/gc/extern.js.wasm-bbq (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14120 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->