### PR TITLE
Adopt more smart pointers in FrameLoader.cpp

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1029,6 +1029,16 @@ const Editor& Document::editor() const
     return *m_editor;
 }
 
+CheckedRef<Editor> Document::checkedEditor()
+{
+    return editor();
+}
+
+CheckedRef<const Editor> Document::checkedEditor() const
+{
+    return editor();
+}
+
 Editor& Document::ensureEditor()
 {
     ASSERT(m_constructionDidFinish);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1851,6 +1851,8 @@ public:
 
     WEBCORE_EXPORT Editor& editor();
     WEBCORE_EXPORT const Editor& editor() const;
+    CheckedRef<Editor> checkedEditor();
+    CheckedRef<const Editor> checkedEditor() const;
     FrameSelection& selection() { return m_selection; }
     const FrameSelection& selection() const { return m_selection; }
     CheckedRef<FrameSelection> checkedSelection();


### PR DESCRIPTION
#### 1570ab39b14d54197241d8d80b885d2dba341ca9
<pre>
Adopt more smart pointers in FrameLoader.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=268854">https://bugs.webkit.org/show_bug.cgi?id=268854</a>

Reviewed by Darin Adler.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::checkedEditor):
(WebCore::Document::checkedEditor const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::FrameProgressTracker::~FrameProgressTracker):
(WebCore::FrameLoader::FrameProgressTracker::progressStarted):
(WebCore::FrameLoader::FrameProgressTracker::progressCompleted):
(WebCore::FrameLoader::~FrameLoader):
(WebCore::FrameLoader::init):
(WebCore::FrameLoader::initForSynthesizedDocument):
(WebCore::FrameLoader::setDefersLoading):
(WebCore::FrameLoader::submitForm):
(WebCore::FrameLoader::stopLoading):
(WebCore::FrameLoader::closeURL):
(WebCore::FrameLoader::didOpenURL):
(WebCore::FrameLoader::didExplicitOpen):
(WebCore::FrameLoader::clear):
(WebCore::FrameLoader::receivedFirstData):
(WebCore::FrameLoader::didBeginDocument):
(WebCore::FrameLoader::finishedParsing):
(WebCore::FrameLoader::checkCompleted):
(WebCore::FrameLoader::checkCallImplicitClose):
(WebCore::FrameLoader::loadURLIntoChildFrame):
(WebCore::FrameLoader::setOpener):
(WebCore::FrameLoader::provisionalLoadStarted):
(WebCore::FrameLoader::loadInSameDocument):
(WebCore::FrameLoader::completed):
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::stopAllLoaders):
(WebCore::FrameLoader::stopForBackForwardCache):
(WebCore::FrameLoader::isLoading const):
(WebCore::FrameLoader::clearProvisionalLoad):
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::transitionToCommitted):
(WebCore::FrameLoader::willRestoreFromCachedPage):
(WebCore::FrameLoader::handleLoadFailureRecovery):
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
(WebCore::FrameLoader::restoreScrollPositionAndViewStateNowIfNeeded):
(WebCore::FrameLoader::frameLoadCompleted):
(WebCore::FrameLoader::detachFromParent):
(WebCore::FrameLoader::scheduleRefreshIfNeeded):
(WebCore::FrameLoader::loadPostRequest):
(WebCore::FrameLoader::receivedMainResourceError):
(WebCore::FrameLoader::shouldClose):
(WebCore::FrameLoader::dispatchUnloadEvents):
(WebCore::FrameLoader::dispatchBeforeUnloadEvent):
(WebCore::FrameLoader::shouldInterruptLoadForXFrameOptions):
(WebCore::FrameLoader::findFrameForNavigation):
(WebCore::FrameLoader::loadSameDocumentItem):
(WebCore::FrameLoader::loadDifferentDocumentItem):
(WebCore::createWindow):

Canonical link: <a href="https://commits.webkit.org/274194@main">https://commits.webkit.org/274194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0812a654a4d560d397221377ee450d6fbdc8283

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33966 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40423 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14442 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32243 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14430 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12578 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12538 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34146 "Failed to checkout and rebase branch from PR 23951") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42008 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34666 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38413 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36596 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14673 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13551 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4974 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14125 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->