### PR TITLE
Sync `munder` & `mover` (font-size: inherit) UA stylesheet rule as per MathML Spec

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1765,7 +1765,6 @@ imported/w3c/web-platform-tests/mathml/presentation-markup/operators/mo-movablel
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/op-dict-8.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/op-dict-9.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/painting-stretchy-operator-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/mover-accent-dynamic-change.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/mprescripts-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/none-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/mathml/presentation-markup/scripts/underover-stretchy-001.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt
@@ -9,9 +9,9 @@ FAIL automatic scriptlevel on munder assert_approx_equals: child 1 expected 71 +
 FAIL automatic scriptlevel on mover assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
 FAIL automatic scriptlevel on munderover assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
 FAIL automatic scriptlevel on mmultiscripts assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munder (accentunder=true) assert_approx_equals: under expected 100 +/- 0.1 but got 75
-FAIL automatic scriptlevel on mover (accent=true) assert_approx_equals: over expected 100 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munderover (accentunder=true) assert_approx_equals: under expected 100 +/- 0.1 but got 75
+PASS automatic scriptlevel on munder (accentunder=true)
+PASS automatic scriptlevel on mover (accent=true)
+FAIL automatic scriptlevel on munderover (accentunder=true) assert_approx_equals: over expected 71 +/- 0.1 but got 75
 FAIL automatic scriptlevel on munderover (accent=true) assert_approx_equals: under expected 71 +/- 0.1 but got 75
 FAIL checking dynamic/case-insensitive accent/accentunder assert_approx_equals: under expected 71 +/- 0.1 but got 75
 0

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt
@@ -9,9 +9,9 @@ FAIL automatic scriptlevel on munder assert_approx_equals: child 1 expected 71 +
 FAIL automatic scriptlevel on mover assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
 FAIL automatic scriptlevel on munderover assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
 FAIL automatic scriptlevel on mmultiscripts assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munder (accentunder=true) assert_approx_equals: under expected 100 +/- 0.1 but got 75
-FAIL automatic scriptlevel on mover (accent=true) assert_approx_equals: over expected 100 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munderover (accentunder=true) assert_approx_equals: under expected 100 +/- 0.1 but got 75
+PASS automatic scriptlevel on munder (accentunder=true)
+PASS automatic scriptlevel on mover (accent=true)
+FAIL automatic scriptlevel on munderover (accentunder=true) assert_approx_equals: over expected 71 +/- 0.1 but got 75
 FAIL automatic scriptlevel on munderover (accent=true) assert_approx_equals: under expected 71 +/- 0.1 but got 75
 FAIL checking dynamic/case-insensitive accent/accentunder assert_approx_equals: under expected 71 +/- 0.1 but got 75
 0

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt
@@ -9,9 +9,9 @@ FAIL automatic scriptlevel on munder assert_approx_equals: child 1 expected 71 +
 FAIL automatic scriptlevel on mover assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
 FAIL automatic scriptlevel on munderover assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
 FAIL automatic scriptlevel on mmultiscripts assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munder (accentunder=true) assert_approx_equals: under expected 100 +/- 0.1 but got 75
-FAIL automatic scriptlevel on mover (accent=true) assert_approx_equals: over expected 100 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munderover (accentunder=true) assert_approx_equals: under expected 100 +/- 0.1 but got 75
+PASS automatic scriptlevel on munder (accentunder=true)
+PASS automatic scriptlevel on mover (accent=true)
+FAIL automatic scriptlevel on munderover (accentunder=true) assert_approx_equals: over expected 71 +/- 0.1 but got 75
 FAIL automatic scriptlevel on munderover (accent=true) assert_approx_equals: under expected 71 +/- 0.1 but got 75
 FAIL checking dynamic/case-insensitive accent/accentunder assert_approx_equals: under expected 71 +/- 0.1 but got 75
 0

--- a/LayoutTests/platform/mac-wk2/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt
+++ b/LayoutTests/platform/mac-wk2/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt
@@ -9,9 +9,9 @@ FAIL automatic scriptlevel on munder assert_approx_equals: child 1 expected 71 +
 FAIL automatic scriptlevel on mover assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
 FAIL automatic scriptlevel on munderover assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
 FAIL automatic scriptlevel on mmultiscripts assert_approx_equals: child 1 expected 71 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munder (accentunder=true) assert_approx_equals: under expected 100 +/- 0.1 but got 75
-FAIL automatic scriptlevel on mover (accent=true) assert_approx_equals: over expected 100 +/- 0.1 but got 75
-FAIL automatic scriptlevel on munderover (accentunder=true) assert_approx_equals: under expected 100 +/- 0.1 but got 75
+PASS automatic scriptlevel on munder (accentunder=true)
+PASS automatic scriptlevel on mover (accent=true)
+FAIL automatic scriptlevel on munderover (accentunder=true) assert_approx_equals: over expected 71 +/- 0.1 but got 75
 FAIL automatic scriptlevel on munderover (accent=true) assert_approx_equals: under expected 71 +/- 0.1 but got 75
 FAIL checking dynamic/case-insensitive accent/accentunder assert_approx_equals: under expected 71 +/- 0.1 but got 75
 0

--- a/Source/WebCore/css/mathml.css
+++ b/Source/WebCore/css/mathml.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc.  All rights reserved.
+ * Copyright (C) 2020-2024 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -258,6 +258,14 @@ mtable[columnlines="solid"] > mtr > mtd + mtd {
 
 mtable[columnlines="dashed"] > mtr > mtd + mtd {
     border-left: dashed thin;
+}
+
+/* Other rules for scriptlevel, displaystyle and math-shift */
+munder[accentunder="true" i] > :nth-child(2),
+mover[accent="true" i] > :nth-child(2),
+munderover[accentunder="true" i] > :nth-child(2),
+munderover[accent="true" i] > :nth-child(3) {
+  font-size: inherit;
 }
 
 #endif


### PR DESCRIPTION
#### 775f16a37adca5f1c20f3739fd39e8086bc3341d
<pre>
Sync `munder` &amp; `mover` (font-size: inherit) UA stylesheet rule as per MathML Spec

<a href="https://bugs.webkit.org/show_bug.cgi?id=268853">https://bugs.webkit.org/show_bug.cgi?id=268853</a>

Reviewed by Frédéric Wang.

This patch is to align WebKit with Web-Specification [1]:

[1] <a href="https://w3c.github.io/mathml-core/#user-agent-stylesheet">https://w3c.github.io/mathml-core/#user-agent-stylesheet</a>

This patch is to sync UA rule of `font-size` as &apos;inherit&apos; for `munder`
and `mover` with accent as `true` with nth-child of certain depth.

* Source/WebCore/css/mathml.css:
* LayoutTests/TestExpectations: Remove now passing test
* LayoutTests/platform/mac-wk2/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt: Rebaselined
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt: Rebaselined
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt: Rebaselined
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mathml/relations/css-styling/scriptlevel-001-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/274212@main">https://commits.webkit.org/274212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b86252740a9c30f2ef9baf193c0f09b2803fae53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40731 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33967 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40424 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14443 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32241 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33399 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12587 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42009 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34766 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38397 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13136 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36587 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14699 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8619 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13552 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14126 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->