### PR TITLE
Regression(270212@main) XPCConnectionTerminationWatchdog is broken

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h
+++ b/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h
@@ -51,7 +51,7 @@ private:
     XPCConnectionTerminationWatchdog(AuxiliaryProcessProxy&, Seconds interval);
     void watchdogTimerFired();
 
-    WeakPtr<AuxiliaryProcessProxy> m_process;
+    OSObjectPtr<xpc_connection_t> m_xpcConnection;
     RunLoop::Timer m_watchdogTimer;
     Ref<ProcessAndUIAssertion> m_assertion;
 };

--- a/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.mm
+++ b/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.mm
@@ -38,7 +38,7 @@ void XPCConnectionTerminationWatchdog::startConnectionTerminationWatchdog(Auxili
 }
     
 XPCConnectionTerminationWatchdog::XPCConnectionTerminationWatchdog(AuxiliaryProcessProxy& process, Seconds interval)
-    : m_process(process)
+    : m_xpcConnection(process.connection()->xpcConnection())
     , m_watchdogTimer(RunLoop::main(), this, &XPCConnectionTerminationWatchdog::watchdogTimerFired)
     , m_assertion(ProcessAndUIAssertion::create(process, "XPCConnectionTerminationWatchdog"_s, ProcessAssertionType::Background))
 {
@@ -47,8 +47,7 @@ XPCConnectionTerminationWatchdog::XPCConnectionTerminationWatchdog(AuxiliaryProc
     
 void XPCConnectionTerminationWatchdog::watchdogTimerFired()
 {
-    if (m_process && m_process->hasConnection())
-        terminateWithReason(m_process->connection()->xpcConnection(), ReasonCode::WatchdogTimerFired, "XPCConnectionTerminationWatchdog::watchdogTimerFired");
+    terminateWithReason(m_xpcConnection.get(), ReasonCode::WatchdogTimerFired, "XPCConnectionTerminationWatchdog::watchdogTimerFired");
     delete this;
 }
 


### PR DESCRIPTION
#### 0b882fd2de7fc6f68d5664e81a5ae0bbd85b71fb
<pre>
Regression(270212@main) XPCConnectionTerminationWatchdog is broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=268860">https://bugs.webkit.org/show_bug.cgi?id=268860</a>
<a href="https://rdar.apple.com/122343478">rdar://122343478</a>

Reviewed by Per Arne Vollan.

XPCConnectionTerminationWatchdog is broken since 270212@main. As a result,
child processes are no longer getting terminated when they fail to exit
promptly. This means we end up with &quot;zombie&quot; processes that are suspended in
the middle of exit. Worse, when the child process is a GPUProcess, the
connection with existed WebProcesses doesn&apos;t get severed so the WebProcesses
will keep trying to IPC the &quot;old&quot; suspended GPUProcess and will hang on sync
IPC.

The issue was that the XPCConnectionTerminationWatchdog was updated to keep
a WeakPtr to the AuxiliaryProcessProxy instead of a strong pointer to the
XPC connection. After the timeout, it would try and get the XPC connection
from the WeakPtr&lt;AuxiliaryProcessProxy&gt;, which would be null, since nothing
guarantees the proxy object stays alive after we&apos;ve asked it to shut down.

Go back to storing a strong pointer to the XPC connection.

* Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h:
* Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.mm:
(WebKit::XPCConnectionTerminationWatchdog::XPCConnectionTerminationWatchdog):
(WebKit::XPCConnectionTerminationWatchdog::watchdogTimerFired):

Canonical link: <a href="https://commits.webkit.org/274189@main">https://commits.webkit.org/274189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3c5af12e68fc091924596795de81fc852c8e262

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40736 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/33972 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14448 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14435 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12582 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12543 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42014 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34672 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38403 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10814 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36593 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14697 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13557 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4969 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14165 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->