### PR TITLE
Apply SVG paint-order to text-decorations

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7467,5 +7467,4 @@ imported/w3c/web-platform-tests/svg/painting/reftests/marker-units-strokewidth-n
 imported/w3c/web-platform-tests/svg/painting/reftests/markers-orient-002.svg [ Failure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/paint-context-001.svg [ Failure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/paint-context-002.svg [ Failure ]
-imported/w3c/web-platform-tests/svg/painting/reftests/paintorder-text-decorations.svg [ Failure ]
 imported/w3c/web-platform-tests/svg/text/reftests/transform-dynamic-change.html [ Failure ]


### PR DESCRIPTION
#### 9ce832dcb0d37a68a7980d4a4251f92195e864f6
<pre>
Apply SVG paint-order to text-decorations

<a href="https://bugs.webkit.org/show_bug.cgi?id=268825">https://bugs.webkit.org/show_bug.cgi?id=268825</a>

Reviewed by Tim Nguyen.

This patch aligns WebKit with Gecko / Firefox, Blink / Chromium and
Web-Specification [1] &amp; [2]:

[1] <a href="https://svgwg.org/svg2-draft/painting.html#PaintOrder">https://svgwg.org/svg2-draft/painting.html#PaintOrder</a>
[2] <a href="https://svgwg.org/svg2-draft/text.html#TextDecorationProperties">https://svgwg.org/svg2-draft/text.html#TextDecorationProperties</a>

&quot;The paint order of the text decoration itself (fill/stroke) is determined
by the value of the paint-order property at the point where the
text decoration is declared.&quot;

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/72eecba077f756ef4ed254541ff37dcb9baec05a">https://chromium.googlesource.com/chromium/blink/+/72eecba077f756ef4ed254541ff37dcb9baec05a</a>

* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
(SVGInlineTextBox::paintDecoration): &apos;for&apos; loop similar to `paint()` function
* LayoutTests/TestExpectations: Remove passing test

Canonical link: <a href="https://commits.webkit.org/274814@main">https://commits.webkit.org/274814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b8c78c68523798473b7a95f7679f899386aaec4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/42509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/42676 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/36220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/42438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/16472 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/33379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/40705 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/16120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/34658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/13936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/35612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/43954 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/36403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/39701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/14946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/12258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/16565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/16614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5293 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/16209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->