### PR TITLE
WebGLExtensionBase's derived classes are wrongly deleted

### DIFF
--- a/Source/WebCore/html/canvas/WebGLExtension.h
+++ b/Source/WebCore/html/canvas/WebGLExtension.h
@@ -96,6 +96,8 @@ class WebGLExtensionBase : public RefCounted<WebGLExtensionBase> {
 public:
     WebGLExtensionName name() const { return m_name; }
 
+    virtual ~WebGLExtensionBase() = default;
+
 protected:
     WebGLExtensionBase(WebGLExtensionName name)
         : m_name(name)

--- a/Source/WebCore/platform/animation/AcceleratedEffectStack.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectStack.h
@@ -47,6 +47,8 @@ public:
     const AcceleratedEffectValues& baseValues() { return m_baseValues; }
     void setBaseValues(AcceleratedEffectValues&&);
 
+    virtual ~AcceleratedEffectStack() = default;
+
 protected:
     WEBCORE_EXPORT explicit AcceleratedEffectStack();
 


### PR DESCRIPTION
#### aaf9fecff4bd3457d17e16e5dd61afdbd2ca6ba6
<pre>
WebGLExtensionBase&apos;s derived classes are wrongly deleted
<a href="https://bugs.webkit.org/show_bug.cgi?id=268868">https://bugs.webkit.org/show_bug.cgi?id=268868</a>
<a href="https://rdar.apple.com/121954439">rdar://121954439</a>

Reviewed by Mark Lam.

While WebGLExtensionBase has RefCounted&lt;WebGLExtensionBase&gt; and it has many derived classes, it does not have virtual destructor.
This is completely wrong since Ref&lt;DerivedClass&gt; will only invoke ~WebGLExtensionBase() since RefCounted&lt;WebGLExtensionBase&gt;::deref() can only invoke it.
This is totally breaking IsoHeap since we need to call and dispatch derived classes&apos; delete / destructor, but now it is not.
As a result, we are observing IsoHeap related crashes with this. This adds virtual destructor for WebGLExtensionBase.

Also RemoteAcceleratedEffectStack has the exact same bug too. This patch also fixes it.

* Source/WebCore/html/canvas/WebGLExtension.h:

Canonical link: <a href="https://commits.webkit.org/274198@main">https://commits.webkit.org/274198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc7cd60786982f6b6ced88711346d9cc3fbca8ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40786 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34009 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40460 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14511 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14488 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12617 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/34194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42063 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/34744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38437 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13178 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36628 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14730 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13593 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4976 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14194 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->