### PR TITLE
[JSC] emitReturn() should load `this` value from arrow function lexical environment prior to TDZ check

### DIFF
--- a/JSTests/stress/regress-268864.js
+++ b/JSTests/stress/regress-268864.js
@@ -1,0 +1,34 @@
+function assert(x) {
+  if (!x)
+    throw new Error("Bad assertion!");
+}
+
+(function() {
+  class C extends class {} {
+    constructor() {
+      var f = () => { super(); };
+      f();
+      return;
+    }
+  }
+
+  for (var i = 0; i < 5000; i++) {
+    var c = new C();
+    assert(c instanceof C);
+  }
+})();
+
+(function() {
+  class C extends class {} {
+    constructor() {
+      var f = () => { super(); };
+      f();
+      return undefined;
+    }
+  }
+
+  for (var i = 0; i < 5000; i++) {
+    var c = new C();
+    assert(typeof c === "object");
+  }
+})();

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1105,15 +1105,6 @@ test/language/statements/class/elements/privatefieldset-evaluation-order-1.js:
 test/language/statements/class/subclass/default-constructor-spread-override.js:
   default: 'Test262Error: @@iterator invoked'
   strict mode: 'Test262Error: @@iterator invoked'
-test/language/statements/class/subclass/derived-class-return-override-catch-finally-arrow.js:
-  default: "ReferenceError: 'super()' must be called in derived constructor before accessing |this| or returning non-object."
-  strict mode: "ReferenceError: 'super()' must be called in derived constructor before accessing |this| or returning non-object."
-test/language/statements/class/subclass/derived-class-return-override-finally-super-arrow.js:
-  default: "ReferenceError: 'super()' must be called in derived constructor before accessing |this| or returning non-object."
-  strict mode: "ReferenceError: 'super()' must be called in derived constructor before accessing |this| or returning non-object."
-test/language/statements/class/subclass/derived-class-return-override-for-of-arrow.js:
-  default: "ReferenceError: 'super()' must be called in derived constructor before accessing |this| or returning non-object."
-  strict mode: "ReferenceError: 'super()' must be called in derived constructor before accessing |this| or returning non-object."
 test/language/statements/const/dstr/ary-init-iter-get-err-array-prototype.js:
   default: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a TypeError to be thrown but no exception was thrown at all'

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -853,8 +853,7 @@ namespace JSC {
         RegisterID* emitGetTemplateObject(RegisterID* dst, TaggedTemplateNode*);
         RegisterID* emitGetGlobalPrivate(RegisterID* dst, const Identifier& property);
 
-        enum class ReturnFrom { Normal, Finally };
-        RegisterID* emitReturn(RegisterID* src, ReturnFrom = ReturnFrom::Normal);
+        RegisterID* emitReturn(RegisterID* src);
         RegisterID* emitEnd(RegisterID* src);
 
         RegisterID* emitConstruct(RegisterID* dst, RegisterID* func, RegisterID* lazyThis, ExpectedFunction, CallArguments&, const JSTextPosition& divot, const JSTextPosition& divotStart, const JSTextPosition& divotEnd);

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -5136,12 +5136,9 @@ void FunctionNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
 
         // If there is no return we must automatically insert one.
         if (!returnNode) {
-            if (generator.constructorKind() == ConstructorKind::Extends && generator.needsToUpdateArrowFunctionContext() && generator.isSuperCallUsedInInnerArrowFunction())
-                generator.emitLoadThisFromArrowFunctionLexicalEnvironment(); // Arrow function can invoke 'super' in constructor and before leave constructor we need load 'this' from lexical arrow function environment
-            
             RegisterID* r0 = nullptr;
             if (generator.isConstructor() && generator.constructorKind() != ConstructorKind::Naked)
-                r0 = generator.thisRegister();
+                r0 = generator.ensureThis();
             else
                 r0 = generator.emitLoad(nullptr, jsUndefined());
             generator.emitProfileType(r0, ProfileTypeBytecodeFunctionReturnStatement); // Do not emit expression info for this profile because it's not in the user's source code.


### PR DESCRIPTION
#### 26302cf8d239273b6b659e4e746829b8322a83b5
<pre>
[JSC] emitReturn() should load `this` value from arrow function lexical environment prior to TDZ check
<a href="https://bugs.webkit.org/show_bug.cgi?id=268864">https://bugs.webkit.org/show_bug.cgi?id=268864</a>
&lt;<a href="https://rdar.apple.com/problem/122430056">rdar://problem/122430056</a>&gt;

Reviewed by Justin Michaud.

This change:

  1) Hoists first TDZ check of emitReturn() up to FunctionNode::emitBytecode(), and refactors it
     leveraging semantically equivalent ensureThis(), which makes automatically-inserted return
     equivalent to `return this`.
     I confirmed this to be the only call site of emitReturn() with unchecked thisRegister() as `src`.
     This is non-observable.

  2) Adds missing emitLoadThisFromArrowFunctionLexicalEnvironment() before second TDZ check, and
     refactors it using ensureThis().
     This is an observable change that prevents ReferenceError being thrown on totally valid and
     rather sane code of calling super() inside an arrow function before explicit `return`.
     Aligns JSC with the spec [1], V8, and SpiderMonkey.

  3) Since when `from == ReturnFrom::Finally` is true, `src` is always completionValueRegister(),
     meaning the check ^^ is useless. Removes it altogether with BytecodeGenerator::ReturnFrom.

[1]: <a href="https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget">https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget</a> (step 12)

* JSTests/stress/regress-268864.js: Added.
* JSTests/test262/expectations.yaml: Mark 6 tests as passing.
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitReturn):
(JSC::BytecodeGenerator::emitFinallyCompletion):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::FunctionNode::emitBytecode):

Canonical link: <a href="https://commits.webkit.org/275425@main">https://commits.webkit.org/275425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18cf617a31174554250e29814250e981a833c740

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/41827 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/20841 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/44209 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/44407 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/37921 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/23993 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/18172 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/44407 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/42401 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/23993 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/44209 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/44407 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/23993 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/44209 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/45805 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/35280 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/23993 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/44209 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/45805 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/41453 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/16642 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/18172 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/45805 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/18261 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/44209 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/48464 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/18319 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/48464 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5599 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/17905 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->