### PR TITLE
[WebAuthn] Implement required CTAP code for SetPinRequest

### DIFF
--- a/Source/WebCore/Modules/webauthn/fido/Pin.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.cpp
@@ -280,6 +280,68 @@ const CryptoKeyAES& TokenRequest::sharedKey() const
     return m_sharedKey;
 }
 
+
+SetPinRequest::SetPinRequest(Ref<WebCore::CryptoKeyAES>&& sharedKey, cbor::CBORValue::MapValue&& coseKey, Vector<uint8_t>&& newPinEnc, Vector<uint8_t>&& pinUvAuthParam)
+    : m_sharedKey(WTFMove(sharedKey))
+    , m_coseKey(WTFMove(coseKey))
+    , m_newPinEnc(WTFMove(newPinEnc))
+    , m_pinUvAuthParam(WTFMove(pinUvAuthParam))
+{
+}
+
+const WebCore::CryptoKeyAES& SetPinRequest::sharedKey() const
+{
+    return m_sharedKey;
+}
+
+std::optional<SetPinRequest> SetPinRequest::tryCreate(const String& inputPin, const WebCore::CryptoKeyEC& peerKey)
+{
+    std::optional<CString> newPin = validateAndConvertToUTF8(inputPin);
+    if (!newPin)
+        return std::nullopt;
+
+    // The following implements Section 5.5.4 Getting sharedSecret from Authenticator.
+    // https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#gettingSharedSecret
+    // 1. Generate a P256 key pair.
+    auto keyPairResult = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, true, CryptoKeyUsageDeriveBits);
+    ASSERT(!keyPairResult.hasException());
+    auto keyPair = keyPairResult.releaseReturnValue();
+
+    // 2. Use ECDH and SHA-256 to compute the shared AES-CBC key.
+    auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), peerKey);
+    if (!sharedKeyResult)
+        return std::nullopt;
+
+    auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
+    crypto->addBytes(sharedKeyResult->data(), sharedKeyResult->size());
+    auto sharedKeyHash = crypto->computeHash();
+
+    auto sharedKey = CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier::AES_CBC, Vector { sharedKeyHash }, true, CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt);
+    ASSERT(sharedKey);
+
+    // The following encodes the public key of the above key pair into COSE format.
+    auto rawPublicKeyResult = downcast<CryptoKeyEC>(*keyPair.publicKey).exportRaw();
+    ASSERT(!rawPublicKeyResult.hasException());
+    auto coseKey = encodeCOSEPublicKey(rawPublicKeyResult.returnValue());
+
+    const size_t minPaddedPinLength = 64;
+    Vector<uint8_t> paddedPin;
+    paddedPin.reserveInitialCapacity(minPaddedPinLength);
+    paddedPin.append(inputPin.utf8().bytes());
+    for (int i = paddedPin.size(); i < 64; i++)
+        paddedPin.append('\0');
+
+    auto hmacKey = CryptoKeyHMAC::importRaw(sharedKeyHash.size() * 8 /* lengthInBits */, CryptoAlgorithmIdentifier::SHA_256, WTFMove(sharedKeyHash), true, CryptoKeyUsageSign);
+
+    auto newPinEnc = CryptoAlgorithmAESCBC::platformEncrypt({ }, *sharedKey, paddedPin, CryptoAlgorithmAESCBC::Padding::No);
+    ASSERT(!newPinEnc.hasException());
+
+    auto pinUvAuthParam = CryptoAlgorithmHMAC::platformSign(*hmacKey, newPinEnc.returnValue());
+    ASSERT(!pinUvAuthParam.hasException());
+
+    return SetPinRequest(sharedKey.releaseNonNull(), WTFMove(coseKey), newPinEnc.releaseReturnValue(), pinUvAuthParam.releaseReturnValue());
+}
+
 Vector<uint8_t> encodeAsCBOR(const TokenRequest& request)
 {
     auto result = CryptoAlgorithmAESCBC::platformEncrypt({ }, request.sharedKey(), request.m_pinHash, CryptoAlgorithmAESCBC::Padding::No);
@@ -288,6 +350,15 @@ Vector<uint8_t> encodeAsCBOR(const TokenRequest& request)
     return encodePinCommand(Subcommand::kGetPinToken, [coseKey = WTFMove(request.m_coseKey), encryptedPin = result.releaseReturnValue()] (CBORValue::MapValue* map) mutable {
         map->emplace(static_cast<int64_t>(RequestKey::kKeyAgreement), WTFMove(coseKey));
         map->emplace(static_cast<int64_t>(RequestKey::kPinHashEnc), WTFMove(encryptedPin));
+    });
+}
+
+Vector<uint8_t> encodeAsCBOR(const SetPinRequest& request)
+{
+    return encodePinCommand(Subcommand::kSetPin, [coseKey = WTFMove(request.m_coseKey), encryptedPin = request.m_newPinEnc, pinUvAuthParam = request.m_pinUvAuthParam] (CBORValue::MapValue* map) mutable {
+        map->emplace(static_cast<int64_t>(RequestKey::kKeyAgreement), WTFMove(coseKey));
+        map->emplace(static_cast<int64_t>(RequestKey::kNewPinEnc), WTFMove(encryptedPin));
+        map->emplace(static_cast<int64_t>(RequestKey::kPinUvAuthParam), WTFMove(pinUvAuthParam));
     });
 }
 

--- a/Source/WebCore/Modules/webauthn/fido/Pin.h
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.h
@@ -67,6 +67,7 @@ enum class RequestKey : uint8_t {
     kPinAuth = 4,
     kNewPinEnc = 5,
     kPinHashEnc = 6,
+    kPinUvAuthParam = 7,
 };
 
 // ResponseKey enumerates the keys in the top-level CBOR map for all PIN
@@ -131,6 +132,22 @@ private:
     explicit KeyAgreementResponse(Ref<WebCore::CryptoKeyEC>&&);
 };
 
+struct SetPinRequest {
+public:
+    WEBCORE_EXPORT const WebCore::CryptoKeyAES& sharedKey() const;
+    WEBCORE_EXPORT static std::optional<SetPinRequest> tryCreate(const String& newPin, const WebCore::CryptoKeyEC&);
+
+    friend Vector<uint8_t> encodeAsCBOR(const SetPinRequest&);
+
+private:
+    Ref<WebCore::CryptoKeyAES> m_sharedKey;
+    mutable cbor::CBORValue::MapValue m_coseKey;
+    Vector<uint8_t> m_newPinEnc;
+    Vector<uint8_t> m_pinUvAuthParam;
+
+    SetPinRequest(Ref<WebCore::CryptoKeyAES>&& sharedKey, cbor::CBORValue::MapValue&& coseKey, Vector<uint8_t>&& m_newPinEnc, Vector<uint8_t>&& m_pinUvAuthParam);
+};
+
 // TokenRequest requests a pin-token from an authenticator. These tokens can be
 // used to show user-verification in other operations, e.g. when getting an
 // assertion.
@@ -177,6 +194,7 @@ private:
 WEBCORE_EXPORT Vector<uint8_t> encodeAsCBOR(const RetriesRequest&);
 WEBCORE_EXPORT Vector<uint8_t> encodeAsCBOR(const KeyAgreementRequest&);
 WEBCORE_EXPORT Vector<uint8_t> encodeAsCBOR(const TokenRequest&);
+WEBCORE_EXPORT Vector<uint8_t> encodeAsCBOR(const SetPinRequest&);
 
 } // namespace pin
 } // namespace fido


### PR DESCRIPTION
#### 66b962b5ff82157ee64fc493c0dfb2d340c3bda2
<pre>
[WebAuthn] Implement required CTAP code for SetPinRequest
<a href="https://bugs.webkit.org/show_bug.cgi?id=268871">https://bugs.webkit.org/show_bug.cgi?id=268871</a>
<a href="https://rdar.apple.com/113573055">rdar://113573055</a>

Reviewed by Pascoe.

Implement the required CTAP code to create a SetPinRequest and associated test

* Source/WebCore/Modules/webauthn/fido/Pin.cpp:
(fido::pin::SetPinRequest::SetPinRequest):
(fido::pin::SetPinRequest::sharedKey const):
(fido::pin::SetPinRequest::tryCreate):
(fido::pin::encodeAsCBOR):
* Source/WebCore/Modules/webauthn/fido/Pin.h:
* Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/274385@main">https://commits.webkit.org/274385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48af982992608ed75b8f99087cc9ef771519fe49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41471 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15219 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13067 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42748 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35341 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38870 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11357 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37091 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8717 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/15018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->