### PR TITLE
[WGSL] override expressions as array lengths do not compile

### DIFF
--- a/Source/WebGPU/WGSL/CallGraph.h
+++ b/Source/WebGPU/WGSL/CallGraph.h
@@ -69,6 +69,6 @@ private:
     HashMap<AST::Function*, Vector<Callee>> m_calleeMap;
 };
 
-CallGraph buildCallGraph(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>& pipelineLayouts, PrepareResult&);
+CallGraph buildCallGraph(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>& pipelineLayouts, HashMap<String, Reflection::EntryPointInformation>&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/CompilationScope.h
+++ b/Source/WebGPU/WGSL/CompilationScope.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Apple Inc. All rights reserved.
+ * Copyright (c) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,21 +23,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "ConstantValue.h"
-#import "ShaderModule.h"
+#pragma once
 
-namespace WebGPU {
+#include "ASTBuilder.h"
+
+namespace WGSL {
 
 class ShaderModule;
 
-struct LibraryCreationResult {
-    id<MTLLibrary> library;
-    WGSL::Reflection::EntryPointInformation entryPointInformation; // FIXME(PERFORMANCE): This is big. Don't copy this around.
-    HashMap<String, WGSL::ConstantValue> wgslConstantValues;
+class CompilationScope {
+public:
+    CompilationScope(ShaderModule&);
+    CompilationScope(CompilationScope&&);
+    ~CompilationScope();
+
+private:
+    bool m_invalidated { false };
+    ShaderModule& m_shaderModule;
+    AST::Builder::State m_builderState;
 };
 
-std::optional<LibraryCreationResult> createLibrary(id<MTLDevice>, const ShaderModule&, const PipelineLayout*, const String& entryPointName, NSString *label, uint32_t constantCount, const WGPUConstantEntry* constants);
-
-id<MTLFunction> createFunction(id<MTLLibrary>, const WGSL::Reflection::EntryPointInformation&, NSString *label);
-
-} // namespace WebGPU
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -101,10 +101,11 @@ static ConstantValue zeroValue(const Type* type)
             return result;
         },
         [&](const Types::Array& array) -> ConstantValue {
-            ASSERT(array.size.has_value());
-            ConstantArray result(*array.size);
+            ASSERT(std::holds_alternative<unsigned>(array.size));
+            auto size = std::get<unsigned>(array.size);
+            ConstantArray result(size);
             auto value = zeroValue(array.element);
-            for (unsigned i = 0; i < array.size; ++i)
+            for (unsigned i = 0; i < size; ++i)
                 result.elements[i] = value;
             return result;
         },

--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -70,9 +70,9 @@ class NameManglerVisitor : public AST::ScopedVisitor<MangledName> {
     using Base::visit;
 
 public:
-    NameManglerVisitor(const CallGraph& callGraph, PrepareResult& result)
+    NameManglerVisitor(const CallGraph& callGraph, HashMap<String, Reflection::EntryPointInformation>& entryPoints)
         : m_callGraph(callGraph)
-        , m_result(result)
+        , m_entryPoints(entryPoints)
     {
     }
 
@@ -97,7 +97,7 @@ private:
     void visitVariableDeclaration(AST::Variable&, MangledName::Kind);
 
     const CallGraph& m_callGraph;
-    PrepareResult& m_result;
+    HashMap<String, Reflection::EntryPointInformation>& m_entryPoints;
     HashMap<AST::Structure*, NameMap> m_structFieldMapping;
     uint32_t m_indexPerType[MangledName::numberOfKinds] { 0 };
 };
@@ -111,8 +111,8 @@ void NameManglerVisitor::visit(AST::Function& function)
 {
     String originalName = function.name();
     introduceVariable(function.name(), MangledName::Function);
-    auto it = m_result.entryPoints.find(originalName);
-    if (it != m_result.entryPoints.end()) {
+    auto it = m_entryPoints.find(originalName);
+    if (it != m_entryPoints.end()) {
         it->value.originalName = originalName;
         it->value.mangledName = function.name();
     }
@@ -203,9 +203,9 @@ void NameManglerVisitor::readVariable(AST::Identifier& name) const
         m_callGraph.ast().replace(&name, AST::Identifier::makeWithSpan(name.span(), mangledName->toString()));
 }
 
-void mangleNames(CallGraph& callGraph, PrepareResult& result)
+void mangleNames(CallGraph& callGraph, HashMap<String, Reflection::EntryPointInformation>& entryPoints)
 {
-    NameManglerVisitor(callGraph, result).run();
+    NameManglerVisitor(callGraph, entryPoints).run();
 }
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/MangleNames.h
+++ b/Source/WebGPU/WGSL/MangleNames.h
@@ -25,11 +25,16 @@
 
 #pragma once
 
+#include <wtf/text/WTFString.h>
+
 namespace WGSL {
 
 class CallGraph;
-struct PrepareResult;
 
-void mangleNames(CallGraph&, PrepareResult&);
+namespace Reflection {
+struct EntryPointInformation;
+}
+
+void mangleNames(CallGraph&, HashMap<String, Reflection::EntryPointInformation>&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
@@ -57,12 +57,12 @@ static void dumpMetalCodeIfNeeded(StringBuilder& stringBuilder)
     }
 }
 
-String generateMetalCode(CallGraph& callGraph)
+String generateMetalCode(const CallGraph& callGraph, const HashMap<String, ConstantValue>& constantValues)
 {
     StringBuilder stringBuilder;
     stringBuilder.append(metalCodePrologue());
 
-    Metal::emitMetalFunctions(stringBuilder, callGraph);
+    Metal::emitMetalFunctions(stringBuilder, callGraph, constantValues);
 
     dumpMetalCodeIfNeeded(stringBuilder);
 

--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h
@@ -30,11 +30,12 @@
 namespace WGSL {
 
 class CallGraph;
+struct ConstantValue;
 
 namespace Metal {
 
 // Can't fail. Any failure checks need to be done earlier, in the backend-agnostic part of the compiler.
-String generateMetalCode(CallGraph&);
+String generateMetalCode(const CallGraph&, const HashMap<String, ConstantValue>&);
 
 } // namespace Metal
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h
@@ -30,10 +30,11 @@
 namespace WGSL {
 
 class CallGraph;
+struct ConstantValue;
 
 namespace Metal {
 
-void emitMetalFunctions(StringBuilder&, CallGraph&);
+void emitMetalFunctions(StringBuilder&, const CallGraph&, const HashMap<String, ConstantValue>&);
 
 } // namespace Metal
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Overload.cpp
+++ b/Source/WebGPU/WGSL/Overload.cpp
@@ -209,7 +209,7 @@ const Type* OverloadResolver::materialize(const AbstractType& abstractType) cons
         },
         [&](const AbstractArray& array) -> const Type* {
             if (auto* element = materialize(array.element))
-                return m_types.arrayType(element, std::nullopt);
+                return m_types.arrayType(element, std::monostate { });
             return nullptr;
         },
         [&](const AbstractAtomic& atomic) -> const Type* {
@@ -494,7 +494,7 @@ bool OverloadResolver::unify(const AbstractType& parameter, const Type* argument
         if (!arrayArgument)
             return false;
         // For now, we only support dynamic arrays
-        if (arrayArgument->size.has_value())
+        if (!arrayArgument->isRuntimeSized())
             return false;
         return unify(arrayParameter->element, arrayArgument->element);
     }

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -37,12 +37,19 @@
 #include "Types.h"
 #include "WGSLShaderModule.h"
 #include <wtf/DataLog.h>
+#include <wtf/SetForScope.h>
 #include <wtf/SortedArrayMap.h>
 
 namespace WGSL {
 
 static constexpr bool shouldDumpInferredTypes = false;
 static constexpr bool shouldDumpConstantValues = false;
+
+enum class Evaluation : uint8_t {
+    Constant = 1,
+    Override = 2,
+    Runtime = 3,
+};
 
 struct Binding {
     enum Kind : uint8_t {
@@ -53,6 +60,7 @@ struct Binding {
 
     Kind kind;
     const struct Type* type;
+    Evaluation evaluation;
     std::optional<ConstantValue> constantValue;
 };
 
@@ -65,6 +73,18 @@ static ASCIILiteral bindingKindToString(Binding::Kind kind)
         return "type"_s;
     case Binding::Function:
         return "function"_s;
+    }
+}
+
+static ASCIILiteral evaluationToString(Evaluation evaluation)
+{
+    switch (evaluation) {
+    case Evaluation::Constant:
+        return "constant"_s;
+    case Evaluation::Override:
+        return "override"_s;
+    case Evaluation::Runtime:
+        return "runtime"_s;
     }
 }
 
@@ -150,14 +170,14 @@ private:
     template<typename... Arguments>
     void typeError(InferBottom, const SourceSpan&, Arguments&&...);
 
-    const Type* infer(AST::Expression&);
+    const Type* infer(AST::Expression&, Evaluation);
     const Type* resolve(AST::Expression&);
     const Type* lookupType(const AST::Identifier&);
     void inferred(const Type*);
     bool unify(const Type*, const Type*) WARN_UNUSED_RETURN;
     bool isBottom(const Type*) const;
     void introduceType(const AST::Identifier&, const Type*);
-    void introduceValue(const AST::Identifier&, const Type*, std::optional<ConstantValue> = std::nullopt);
+    void introduceValue(const AST::Identifier&, const Type*, Evaluation = Evaluation::Runtime, std::optional<ConstantValue> = std::nullopt);
     void introduceFunction(const AST::Identifier&, const Type*);
     bool convertValue(const SourceSpan&, const Type*, std::optional<ConstantValue>&);
     bool convertValueImpl(const SourceSpan&, const Type*, ConstantValue&);
@@ -179,6 +199,7 @@ private:
     ShaderModule& m_shaderModule;
     const Type* m_inferredType { nullptr };
     const Type* m_returnType { nullptr };
+    Evaluation m_evaluation { Evaluation::Runtime };
 
     TypeStore& m_types;
     Vector<Error> m_errors;
@@ -379,10 +400,18 @@ void TypeChecker::visit(AST::Structure& structure)
         visitAttributes(member.attributes());
         auto* memberType = resolve(member.type());
 
-        if (UNLIKELY(memberType->containsRuntimeArray() && i != structure.members().size() - 1)) {
-            typeError(InferBottom::No, member.span(), "runtime arrays may only appear as the last member of a struct");
-            introduceType(structure.name(), m_types.bottomType());
-            return;
+        if (UNLIKELY(!memberType->hasCreationFixedFootprint())) {
+            if (!memberType->containsRuntimeArray()) {
+                typeError(InferBottom::No, member.span(), "type '", *memberType, "' cannot be used as a struct member because it does not have creation-fixed footprint");
+                introduceType(structure.name(), m_types.bottomType());
+                return;
+            }
+
+            if (i != structure.members().size() - 1) {
+                typeError(InferBottom::No, member.span(), "runtime arrays may only appear as the last member of a struct");
+                introduceType(structure.name(), m_types.bottomType());
+                return;
+            }
         }
 
         auto result = fields.add(member.name().id(), memberType);
@@ -406,7 +435,7 @@ void TypeChecker::visit(AST::TypeAlias& alias)
 
 void TypeChecker::visit(AST::ConstAssert& assertion)
 {
-    auto* testType = infer(assertion.test());
+    auto* testType = infer(assertion.test(), Evaluation::Constant);
     if (!unify(m_types.boolType(), testType)) {
         typeError(InferBottom::No, assertion.test().span(), "const assertion condition must be a bool, got '", *testType, "'");
         return;
@@ -439,13 +468,19 @@ void TypeChecker::visitVariable(AST::Variable& variable, VariableKind variableKi
 
     const auto& error = [&](auto... arguments) {
         typeError(InferBottom::No, variable.span(), arguments...);
-        introduceValue(variable.name(), m_types.bottomType(), std::nullopt);
+        introduceValue(variable.name(), m_types.bottomType());
     };
+
+    Evaluation evaluation { Evaluation::Runtime };
+    if (variable.flavor() == AST::VariableFlavor::Const)
+        evaluation = Evaluation::Constant;
+    else if (variable.flavor() == AST::VariableFlavor::Override)
+        evaluation = Evaluation::Override;
 
     if (variable.maybeTypeName())
         result = resolve(*variable.maybeTypeName());
     if (variable.maybeInitializer()) {
-        auto* initializerType = infer(*variable.maybeInitializer());
+        auto* initializerType = infer(*variable.maybeInitializer(), evaluation);
         auto& constantValue = variable.maybeInitializer()->m_constantValue;
         if (constantValue.has_value())
             value = &constantValue;
@@ -552,6 +587,8 @@ void TypeChecker::visitVariable(AST::Variable& variable, VariableKind variableKi
             return error("function-scope 'var' declaration must use 'function' address space");
         if ((addressSpace == AddressSpace::Storage || addressSpace == AddressSpace::Uniform || addressSpace == AddressSpace::Handle || addressSpace == AddressSpace::Workgroup) && variable.maybeInitializer())
             return error("variables in the address space '", toString(addressSpace), "' cannot have an initializer");
+        if (addressSpace != AddressSpace::Workgroup && result->containsOverrideArray())
+            return error("array with an 'override' element count can only be used as the store type of a 'var<workgroup>'");
     }
 
     if (value && !isBottom(result))
@@ -573,7 +610,7 @@ void TypeChecker::visitVariable(AST::Variable& variable, VariableKind variableKi
         variable.m_referenceType = &referenceType;
     }
 
-    introduceValue(variable.name(), result, value ? std::optional<ConstantValue>(*value) : std::nullopt);
+    introduceValue(variable.name(), result, evaluation, value ? std::optional<ConstantValue>(*value) : std::nullopt);
 }
 
 void TypeChecker::visit(AST::Function& function)
@@ -607,49 +644,49 @@ void TypeChecker::visit(AST::Function& function)
 // Attributes
 void TypeChecker::visit(AST::AlignAttribute& attribute)
 {
-    auto* type = infer(attribute.alignment());
+    auto* type = infer(attribute.alignment(), Evaluation::Constant);
     if (!satisfies(type, Constraints::ConcreteInteger))
         typeError(InferBottom::No, attribute.span(), "@align must be an i32 or u32 value");
 }
 
 void TypeChecker::visit(AST::BindingAttribute& attribute)
 {
-    auto* type = infer(attribute.binding());
+    auto* type = infer(attribute.binding(), Evaluation::Constant);
     if (!satisfies(type, Constraints::ConcreteInteger))
         typeError(InferBottom::No, attribute.span(), "@binding must be an i32 or u32 value");
 }
 
 void TypeChecker::visit(AST::GroupAttribute& attribute)
 {
-    auto* type = infer(attribute.group());
+    auto* type = infer(attribute.group(), Evaluation::Constant);
     if (!satisfies(type, Constraints::ConcreteInteger))
         typeError(InferBottom::No, attribute.span(), "@group must be an i32 or u32 value");
 }
 
 void TypeChecker::visit(AST::IdAttribute& attribute)
 {
-    auto* type = infer(attribute.value());
+    auto* type = infer(attribute.value(), Evaluation::Constant);
     if (!satisfies(type, Constraints::ConcreteInteger))
         typeError(InferBottom::No, attribute.span(), "@id must be an i32 or u32 value");
 }
 
 void TypeChecker::visit(AST::LocationAttribute& attribute)
 {
-    auto* type = infer(attribute.location());
+    auto* type = infer(attribute.location(), Evaluation::Constant);
     if (!satisfies(type, Constraints::ConcreteInteger))
         typeError(InferBottom::No, attribute.span(), "@location must be an i32 or u32 value");
 }
 
 void TypeChecker::visit(AST::SizeAttribute& attribute)
 {
-    auto* type = infer(attribute.size());
+    auto* type = infer(attribute.size(), Evaluation::Constant);
     if (!satisfies(type, Constraints::ConcreteInteger))
         typeError(InferBottom::No, attribute.span(), "@size must be an i32 or u32 value");
 }
 
 void TypeChecker::visit(AST::WorkgroupSizeAttribute& attribute)
 {
-    auto* xType = infer(attribute.x());
+    auto* xType = infer(attribute.x(), Evaluation::Override);
     if (!satisfies(xType, Constraints::ConcreteInteger)) {
         typeError(InferBottom::No, attribute.span(), "@workgroup_size x dimension must be an i32 or u32 value");
         return;
@@ -658,14 +695,14 @@ void TypeChecker::visit(AST::WorkgroupSizeAttribute& attribute)
     const Type* yType = nullptr;
     const Type* zType = nullptr;
     if (auto* y = attribute.maybeY()) {
-        yType = infer(*y);
+        yType = infer(*y, Evaluation::Override);
         if (!satisfies(yType, Constraints::ConcreteInteger)) {
             typeError(InferBottom::No, attribute.span(), "@workgroup_size y dimension must be an i32 or u32 value");
             return;
         }
 
         if (auto* z = attribute.maybeZ()) {
-            zType = infer(*z);
+            zType = infer(*z, Evaluation::Override);
             if (!satisfies(zType, Constraints::ConcreteInteger)) {
                 typeError(InferBottom::No, attribute.span(), "@workgroup_size z dimension must be an i32 or u32 value");
                 return;
@@ -687,8 +724,8 @@ void TypeChecker::visit(AST::WorkgroupSizeAttribute& attribute)
 // Statements
 void TypeChecker::visit(AST::AssignmentStatement& statement)
 {
-    auto* lhs = infer(statement.lhs());
-    auto* rhs = infer(statement.rhs());
+    auto* lhs = infer(statement.lhs(), Evaluation::Runtime);
+    auto* rhs = infer(statement.rhs(), Evaluation::Runtime);
 
     if (isBottom(lhs))
         return;
@@ -715,7 +752,7 @@ void TypeChecker::visit(AST::AssignmentStatement& statement)
 
 void TypeChecker::visit(AST::CallStatement& statement)
 {
-    auto* result = infer(statement.call());
+    auto* result = infer(statement.call(), Evaluation::Runtime);
     // FIXME: this should check if the function has a must_use attribute
     UNUSED_PARAM(result);
 }
@@ -724,8 +761,8 @@ void TypeChecker::visit(AST::CompoundAssignmentStatement& statement)
 {
     // FIXME: Implement type checking - infer is called to avoid ASSERT in
     // TypeChecker::visit(AST::Expression&)
-    infer(statement.leftExpression());
-    infer(statement.rightExpression());
+    infer(statement.leftExpression(), Evaluation::Runtime);
+    infer(statement.rightExpression(), Evaluation::Runtime);
 
     const char* operationName = nullptr;
     if (statement.operation() == AST::BinaryOperation::Divide)
@@ -750,7 +787,7 @@ void TypeChecker::visit(AST::CompoundAssignmentStatement& statement)
 
 void TypeChecker::visit(AST::DecrementIncrementStatement& statement)
 {
-    auto* expression = infer(statement.expression());
+    auto* expression = infer(statement.expression(), Evaluation::Runtime);
     if (isBottom(expression))
         return;
 
@@ -779,7 +816,7 @@ void TypeChecker::visit(AST::DecrementIncrementStatement& statement)
 
 void TypeChecker::visit(AST::IfStatement& statement)
 {
-    auto* test = infer(statement.test());
+    auto* test = infer(statement.test(), Evaluation::Runtime);
 
     if (!unify(test, m_types.boolType()))
         typeError(statement.test().span(), "expected 'bool', found ", *test);
@@ -791,7 +828,7 @@ void TypeChecker::visit(AST::IfStatement& statement)
 
 void TypeChecker::visit(AST::PhonyAssignmentStatement& statement)
 {
-    infer(statement.rhs());
+    infer(statement.rhs(), Evaluation::Runtime);
     // There is nothing to unify with since result of the right-hand side is
     // discarded.
 }
@@ -801,7 +838,7 @@ void TypeChecker::visit(AST::ReturnStatement& statement)
     const Type* type;
     auto* expression = statement.maybeExpression();
     if (expression)
-        type = infer(*expression);
+        type = infer(*expression, Evaluation::Runtime);
     else
         type = m_types.voidType();
 
@@ -821,7 +858,7 @@ void TypeChecker::visit(AST::ForStatement& statement)
         Base::visit(*initializer);
 
     if (auto* test = statement.maybeTest()) {
-        auto* testType = infer(*test);
+        auto* testType = infer(*test, Evaluation::Runtime);
         if (!unify(m_types.boolType(), testType))
             typeError(InferBottom::No, test->span(), "for-loop condition must be bool, got ", *testType);
     }
@@ -846,7 +883,7 @@ void TypeChecker::visit(AST::LoopStatement& statement)
 
 void TypeChecker::visit(AST::WhileStatement& statement)
 {
-    auto* testType = infer(statement.test());
+    auto* testType = infer(statement.test(), Evaluation::Runtime);
     if (!unify(m_types.boolType(), testType))
         typeError(InferBottom::No, statement.test().span(), "while condition must be bool, got ", *testType);
 
@@ -855,7 +892,7 @@ void TypeChecker::visit(AST::WhileStatement& statement)
 
 void TypeChecker::visit(AST::SwitchStatement& statement)
 {
-    auto* valueType = infer(statement.value());
+    auto* valueType = infer(statement.value(), Evaluation::Runtime);
     if (!satisfies(valueType, Constraints::ConcreteInteger)) {
         typeError(InferBottom::No, statement.value().span(), "switch selector must be of type i32 or u32");
         valueType = m_types.bottomType();
@@ -863,7 +900,7 @@ void TypeChecker::visit(AST::SwitchStatement& statement)
 
     const auto& visitClause = [&](AST::SwitchClause& clause) {
         for (auto& selector : clause.selectors) {
-            auto* selectorType = infer(selector);
+            auto* selectorType = infer(selector, Evaluation::Runtime);
             if (unify(valueType, selectorType)) {
                 // If the selectorType can satisfy the value type, we're good to go.
                 // e.g. valueType is i32 or u32 and the selector is a literal of type AbstractInt
@@ -938,7 +975,7 @@ void TypeChecker::visit(AST::FieldAccessExpression& access)
         return nullptr;
     };
 
-    auto* baseType = infer(access.base());
+    auto* baseType = infer(access.base(), m_evaluation);
     if (const auto* reference = std::get_if<Types::Reference>(baseType)) {
         bool canBeReference = true;
         if (const Type* result = accessImpl(reference->element, &canBeReference)) {
@@ -999,8 +1036,8 @@ void TypeChecker::visit(AST::IndexAccessExpression& access)
         return result;
     };
 
-    auto* base = infer(access.base());
-    auto* index = infer(access.index());
+    auto* base = infer(access.base(), m_evaluation);
+    auto* index = infer(access.index(), m_evaluation);
 
     if (!unify(m_types.i32Type(), index) && !unify(m_types.u32Type(), index) && !unify(m_types.abstractIntType(), index)) {
         typeError(access.span(), "index must be of type 'i32' or 'u32', found: '", *index, "'");
@@ -1058,6 +1095,11 @@ void TypeChecker::visit(AST::IdentifierExpression& identifier)
         return;
     }
 
+    if (binding->evaluation > m_evaluation) {
+        typeError(identifier.span(), "cannot use ", evaluationToString(binding->evaluation), " value in ", evaluationToString(m_evaluation), " expression");
+        return;
+    }
+
     inferred(binding->type);
     if (binding->constantValue.has_value())
         setConstantValue(identifier, binding->type, *binding->constantValue);
@@ -1096,7 +1138,7 @@ void TypeChecker::visit(AST::CallExpression& call)
                         auto& argument = call.arguments()[i];
                         auto& member = structType->structure.members()[i];
                         auto* fieldType = structType->fields.get(member.name());
-                        auto* argumentType = infer(argument);
+                        auto* argumentType = infer(argument, m_evaluation);
                         if (!unify(fieldType, argumentType)) {
                             typeError(argument.span(), "type in struct initializer does not match struct member type: expected '", *fieldType, "', found '", *argumentType, "'");
                             return;
@@ -1140,6 +1182,11 @@ void TypeChecker::visit(AST::CallExpression& call)
                 auto& functionType = std::get<Types::Function>(*targetBinding->type);
                 auto numberOfArguments = call.arguments().size();
                 auto numberOfParameters = functionType.parameters.size();
+                if (m_evaluation < Evaluation::Runtime) {
+                    typeError(call.span(), "cannot call function from ", evaluationToString(m_evaluation), " context");
+                    return;
+                }
+
                 if (numberOfArguments != numberOfParameters) {
                     const char* errorKind = numberOfArguments < numberOfParameters ? "few" : "many";
                     typeError(call.span(), "funtion call has too ", errorKind, " arguments: expected ", String::number(numberOfParameters), ", found ", String::number(numberOfArguments));
@@ -1149,7 +1196,7 @@ void TypeChecker::visit(AST::CallExpression& call)
                 for (unsigned i = 0; i < numberOfArguments; ++i) {
                     auto& argument = call.arguments()[i];
                     auto* parameterType = functionType.parameters[i];
-                    auto* argumentType = infer(argument);
+                    auto* argumentType = infer(argument, m_evaluation);
                     if (!unify(parameterType, argumentType)) {
                         typeError(argument.span(), "type in function call does not match parameter type: expected '", *parameterType, "', found '", *argumentType, "'");
                         return;
@@ -1217,7 +1264,7 @@ void TypeChecker::visit(AST::CallExpression& call)
                 return;
             }
             elementType = resolve(*array.maybeElementType());
-            auto* elementCountType = infer(*array.maybeElementCount());
+            auto* elementCountType = infer(*array.maybeElementCount(), m_evaluation);
 
             if (isBottom(elementType) || isBottom(elementCountType)) {
                 inferred(m_types.bottomType());
@@ -1248,7 +1295,7 @@ void TypeChecker::visit(AST::CallExpression& call)
                 return;
             }
             for (auto& argument : call.arguments()) {
-                auto* argumentType = infer(argument);
+                auto* argumentType = infer(argument, m_evaluation);
                 if (!unify(elementType, argumentType)) {
                     typeError(argument.span(), "'", *argumentType, "' cannot be used to construct an array of '", *elementType, "'");
                     return;
@@ -1264,12 +1311,12 @@ void TypeChecker::visit(AST::CallExpression& call)
             }
             for (auto& argument : call.arguments()) {
                 if (!elementType) {
-                    elementType = infer(argument);
+                    elementType = infer(argument, m_evaluation);
                     if (auto* reference = std::get_if<Types::Reference>(elementType))
                         elementType = reference->element;
                     continue;
                 }
-                auto* argumentType = infer(argument);
+                auto* argumentType = infer(argument, m_evaluation);
                 if (unify(elementType, argumentType))
                     continue;
                 if (unify(argumentType, elementType)) {
@@ -1318,7 +1365,7 @@ void TypeChecker::bitcast(AST::CallExpression& call, const Vector<const Type*>& 
     }
 
     auto& argument = call.arguments()[0];
-    auto* sourceType = infer(argument);
+    auto* sourceType = infer(argument, m_evaluation);
     auto* destinationType = typeArguments[0];
 
     if (isBottom(sourceType) || isBottom(destinationType)) {
@@ -1438,21 +1485,19 @@ void TypeChecker::visit(AST::ArrayTypeExpression& array)
         return;
     }
 
-    std::optional<unsigned> size;
+    Types::Array::Size size;
     if (array.maybeElementCount()) {
-        auto elementCountType = infer(*array.maybeElementCount());
+        auto elementCountType = infer(*array.maybeElementCount(), Evaluation::Override);
         if (!unify(m_types.i32Type(), elementCountType) && !unify(m_types.u32Type(), elementCountType)) {
             typeError(array.span(), "array count must be an i32 or u32 value, found '", *elementCountType, "'");
             return;
         }
 
         auto value = array.maybeElementCount()->constantValue();
-        if (!value.has_value()) {
-            typeError(array.span(), "array count must evaluate to a constant integer expression or override variable");
-            return;
-        }
-
-        size = value->integerValue();
+        if (value.has_value())
+            size = { static_cast<unsigned>(value->integerValue()) };
+        else
+            size = { array.maybeElementCount() };
     }
 
     inferred(m_types.arrayType(elementType, size));
@@ -1507,7 +1552,7 @@ void TypeChecker::visit(AST::Continuing& continuing)
         Base::visit(statement);
 
     if (auto* breakIf = continuing.breakIf) {
-        auto* type = infer(*breakIf);
+        auto* type = infer(*breakIf, Evaluation::Runtime);
         if (!unify(m_types.boolType(), type))
             typeError(InferBottom::No, breakIf->span(), "expected 'bool', found ", *type);
     }
@@ -1602,7 +1647,7 @@ const Type* TypeChecker::chooseOverload(const char* kind, AST::Expression& expre
     Vector<const Type*> valueArguments;
     valueArguments.reserveInitialCapacity(callArguments.size());
     for (unsigned i = 0; i < callArguments.size(); ++i) {
-        auto* type = infer(callArguments[i]);
+        auto* type = infer(callArguments[i], m_evaluation);
         if (isBottom(type)) {
             inferred(m_types.bottomType());
             return m_types.bottomType();
@@ -1634,7 +1679,13 @@ const Type* TypeChecker::chooseOverload(const char* kind, AST::Expression& expre
                 arguments[i] = *value;
         }
 
-        if (auto constantFunction = it->value.constantFunction; isConstant && constantFunction) {
+        auto constantFunction = it->value.constantFunction;
+        if (!constantFunction && m_evaluation < Evaluation::Runtime) {
+            typeError(InferBottom::No, expression.span(), "cannot call function from ", evaluationToString(m_evaluation), " context");
+            return m_types.bottomType();
+        }
+
+        if (isConstant && constantFunction) {
             auto result = constantFunction(overload->result, WTFMove(arguments));
             if (!result)
                 typeError(InferBottom::No, expression.span(), result.error());
@@ -1669,8 +1720,9 @@ const Type* TypeChecker::chooseOverload(const char* kind, AST::Expression& expre
     return m_types.bottomType();
 }
 
-const Type* TypeChecker::infer(AST::Expression& expression)
+const Type* TypeChecker::infer(AST::Expression& expression, Evaluation evaluation)
 {
+    auto evaluationScope = SetForScope(m_evaluation, evaluation);
     ASSERT(!m_inferredType);
     Base::visit(expression);
     ASSERT(m_inferredType);
@@ -1748,7 +1800,7 @@ bool TypeChecker::isBottom(const Type* type) const
 void TypeChecker::introduceType(const AST::Identifier& name, const Type* type)
 {
     ASSERT(type);
-    if (!introduceVariable(name, { Binding::Type, type, std::nullopt }))
+    if (!introduceVariable(name, { Binding::Type, type, Evaluation::Runtime, std::nullopt }))
         typeError(InferBottom::No, name.span(), "redeclaration of '", name, "'");
 }
 
@@ -1939,19 +1991,19 @@ bool TypeChecker::convertValueImpl(const SourceSpan& span, const Type* type, Con
         });
 }
 
-void TypeChecker::introduceValue(const AST::Identifier& name, const Type* type, std::optional<ConstantValue> value)
+void TypeChecker::introduceValue(const AST::Identifier& name, const Type* type, Evaluation evaluation, std::optional<ConstantValue> value)
 {
     ASSERT(type);
     if (shouldDumpConstantValues && value.has_value())
         dataLogLn("> Assigning value: ", name, " => ", value);
-    if (!introduceVariable(name, { Binding::Value, type , value }))
+    if (!introduceVariable(name, { Binding::Value, type, evaluation, value }))
         typeError(InferBottom::No, name.span(), "redeclaration of '", name, "'");
 }
 
 void TypeChecker::introduceFunction(const AST::Identifier& name, const Type* type)
 {
     ASSERT(type);
-    if (!introduceVariable(name, { Binding::Function, type , std::nullopt }))
+    if (!introduceVariable(name, { Binding::Function, type, Evaluation::Runtime , std::nullopt }))
         typeError(InferBottom::No, name.span(), "redeclaration of '", name, "'");
 }
 
@@ -2017,7 +2069,7 @@ void TypeChecker::allocateTextureStorageConstructor(ASCIILiteral name, Types::Te
 
 std::optional<TexelFormat> TypeChecker::texelFormat(AST::Expression& expression)
 {
-    auto* formatType = infer(expression);
+    auto* formatType = infer(expression, Evaluation::Runtime);
     if (isBottom(formatType))
         return std::nullopt;
 
@@ -2036,7 +2088,7 @@ std::optional<TexelFormat> TypeChecker::texelFormat(AST::Expression& expression)
 
 std::optional<AccessMode> TypeChecker::accessMode(AST::Expression& expression)
 {
-    auto* accessType = infer(expression);
+    auto* accessType = infer(expression, Evaluation::Runtime);
     if (isBottom(accessType))
         return std::nullopt;
 
@@ -2055,7 +2107,7 @@ std::optional<AccessMode> TypeChecker::accessMode(AST::Expression& expression)
 
 std::optional<AddressSpace> TypeChecker::addressSpace(AST::Expression& expression)
 {
-    auto* addressSpaceType = infer(expression);
+    auto* addressSpaceType = infer(expression, Evaluation::Runtime);
     if (isBottom(addressSpaceType))
         return std::nullopt;
 

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -93,7 +93,7 @@ public:
     const Type* textureDepthMultisampled2dType() const { return m_textureDepthMultisampled2d; }
 
     const Type* structType(AST::Structure&, HashMap<String, const Type*>&& = { });
-    const Type* arrayType(const Type*, std::optional<unsigned>);
+    const Type* arrayType(const Type*, Types::Array::Size);
     const Type* vectorType(uint8_t, const Type*);
     const Type* matrixType(uint8_t columns, uint8_t rows, const Type*);
     const Type* textureType(Types::Texture::Kind, const Type*);

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -133,8 +133,17 @@ struct Matrix {
 };
 
 struct Array {
+    // std::monostate represents a runtime-sized array
+    // unsigned represents a creation fixed array (constant size)
+    // AST::Expression* represents a fixed array (override size)
+    using Size = std::variant<std::monostate, unsigned, AST::Expression*>;
+
     const Type* element;
-    std::optional<unsigned> size;
+    Size size;
+
+    bool isRuntimeSized() const { return std::holds_alternative<std::monostate>(size); }
+    bool isCreationFixed() const { return std::holds_alternative<unsigned>(size); }
+    bool isOverrideSized() const { return std::holds_alternative<AST::Expression*>(size); }
 };
 
 struct Struct {
@@ -275,7 +284,9 @@ struct Type : public std::variant<
     bool isStorable() const;
     bool isHostShareable() const;
     bool hasFixedFootprint() const;
+    bool hasCreationFixedFootprint() const;
     bool containsRuntimeArray() const;
+    bool containsOverrideArray() const;
 };
 
 using ConversionRank = Markable<unsigned, IntegralMarkableTraits<unsigned, std::numeric_limits<unsigned>::max()>>;

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -25,7 +25,9 @@
 
 #pragma once
 
+#include "CallGraph.h"
 #include "CompilationMessage.h"
+#include "CompilationScope.h"
 #include "ConstantValue.h"
 #include "WGSLEnums.h"
 #include <cinttypes>
@@ -46,6 +48,7 @@ namespace WGSL {
 //
 
 class ShaderModule;
+class CompilationScope;
 
 namespace AST {
 class Expression;
@@ -224,14 +227,17 @@ struct EntryPointInformation {
 } // namespace Reflection
 
 struct PrepareResult {
-    String msl;
+    CallGraph callGraph;
     HashMap<String, Reflection::EntryPointInformation> entryPoints;
+    CompilationScope compilationScope;
 };
 
 // These are not allowed to fail.
 // All failures must have already been caught in check().
 PrepareResult prepare(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>&);
 PrepareResult prepare(ShaderModule&, const String& entryPointName, const std::optional<PipelineLayout>&);
+
+String generate(const CallGraph&, HashMap<String, ConstantValue>&);
 
 ConstantValue evaluate(const AST::Expression&, const HashMap<String, ConstantValue>&);
 

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -234,25 +234,6 @@ public:
         m_replacements.clear();
     }
 
-    class Compilation {
-    public:
-        Compilation(ShaderModule& shaderModule)
-            : m_shaderModule(shaderModule)
-            , m_builderState(shaderModule.astBuilder().saveCurrentState())
-        {
-        }
-
-        ~Compilation()
-        {
-            m_shaderModule.revertReplacements();
-            m_shaderModule.astBuilder().restore(WTFMove(m_builderState));
-        }
-
-    private:
-        ShaderModule& m_shaderModule;
-        AST::Builder::State m_builderState;
-    };
-
     OptionSet<Extension>& enabledExtensions() { return m_enabledExtensions; }
     OptionSet<LanguageFeature> requiredFeatures() { return m_requiredFeatures; }
     bool containsOverride(uint32_t idValue) const

--- a/Source/WebGPU/WGSL/wgslc.cpp
+++ b/Source/WebGPU/WGSL/wgslc.cpp
@@ -138,11 +138,14 @@ static int runWGSL(const CommandLine& options)
         return EXIT_FAILURE;
     }
 
+    HashMap<String, WGSL::ConstantValue> constantValues;
+    auto msl = WGSL::generate(prepareResult.callGraph, constantValues);
+
     if (options.dumpASTAtEnd())
         WGSL::AST::dumpAST(shaderModule);
 
     if (options.dumpGeneratedCode())
-        printf("%s", prepareResult.msl.utf8().data());
+        printf("%s", msl.utf8().data());
 
     return EXIT_SUCCESS;
 }

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -135,6 +135,8 @@
 		9776BE732992A236002D6D93 /* Overload.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9776BE712992A236002D6D93 /* Overload.cpp */; };
 		9776BE742992A236002D6D93 /* Overload.h in Headers */ = {isa = PBXBuildFile; fileRef = 9776BE722992A236002D6D93 /* Overload.h */; };
 		9776BE7629957E12002D6D93 /* WGSLShaderModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 9776BE7529957E12002D6D93 /* WGSLShaderModule.h */; };
+		977F5AC02B73057700D05129 /* CompilationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 977F5ABE2B73057700D05129 /* CompilationScope.h */; };
+		977F5AC12B73057700D05129 /* CompilationScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 977F5ABF2B73057700D05129 /* CompilationScope.cpp */; };
 		97835C9329F7C9C600939EBA /* ASTBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 97835C9229F7C9C600939EBA /* ASTBuilder.h */; };
 		97835C9529F7D85A00939EBA /* ASTBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97835C9429F7D85A00939EBA /* ASTBuilder.cpp */; };
 		9789C31A297EA105009E9006 /* CallGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9789C318297EA105009E9006 /* CallGraph.cpp */; };
@@ -426,6 +428,8 @@
 		9776BE712992A236002D6D93 /* Overload.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Overload.cpp; sourceTree = "<group>"; };
 		9776BE722992A236002D6D93 /* Overload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Overload.h; sourceTree = "<group>"; };
 		9776BE7529957E12002D6D93 /* WGSLShaderModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WGSLShaderModule.h; sourceTree = "<group>"; };
+		977F5ABE2B73057700D05129 /* CompilationScope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompilationScope.h; sourceTree = "<group>"; };
+		977F5ABF2B73057700D05129 /* CompilationScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CompilationScope.cpp; sourceTree = "<group>"; };
 		97835C9229F7C9C600939EBA /* ASTBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTBuilder.h; sourceTree = "<group>"; };
 		97835C9429F7D85A00939EBA /* ASTBuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASTBuilder.cpp; sourceTree = "<group>"; };
 		9789C318297EA105009E9006 /* CallGraph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CallGraph.cpp; sourceTree = "<group>"; };
@@ -624,6 +628,8 @@
 				9789C319297EA105009E9006 /* CallGraph.h */,
 				33EA186727BC1B1400A1DD52 /* CompilationMessage.cpp */,
 				33EA186527BC1AD500A1DD52 /* CompilationMessage.h */,
+				977F5ABF2B73057700D05129 /* CompilationScope.cpp */,
+				977F5ABE2B73057700D05129 /* CompilationScope.h */,
 				1CEBD8042716BFAB00A5254D /* config.h */,
 				97E21C962A2512F7009CEB0E /* ConstantFunctions.h */,
 				97E21C942A2512F7009CEB0E /* ConstantValue.cpp */,
@@ -903,6 +909,7 @@
 				3A12AEB228FCE94C00C1B975 /* ASTWorkgroupSizeAttribute.h in Headers */,
 				97A448A12AE3544800A4E147 /* AttributeValidator.h in Headers */,
 				33EA186627BC1AD500A1DD52 /* CompilationMessage.h in Headers */,
+				977F5AC02B73057700D05129 /* CompilationScope.h in Headers */,
 				97E21C992A2512F7009CEB0E /* ConstantFunctions.h in Headers */,
 				97E21C982A2512F7009CEB0E /* ConstantValue.h in Headers */,
 				97C36CFE29F1730100CFB379 /* Constraints.h in Headers */,
@@ -1140,6 +1147,7 @@
 				97A448A22AE3544800A4E147 /* AttributeValidator.cpp in Sources */,
 				9789C31A297EA105009E9006 /* CallGraph.cpp in Sources */,
 				339B7B1E27D816270072BF9A /* CompilationMessage.cpp in Sources */,
+				977F5AC12B73057700D05129 /* CompilationScope.cpp in Sources */,
 				97E21C972A2512F7009CEB0E /* ConstantValue.cpp in Sources */,
 				97C36CFF29F1730100CFB379 /* Constraints.cpp in Sources */,
 				979240C929769AC00050EA2C /* EntryPointRewriter.cpp in Sources */,

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -107,7 +107,9 @@ static RefPtr<ShaderModule> earlyCompileShaderModule(Device& device, std::varian
     }
 
     auto prepareResult = WGSL::prepare(std::get<WGSL::SuccessfulCheck>(checkResult).ast, wgslHints);
-    auto library = ShaderModule::createLibrary(device.device(), prepareResult.msl, WTFMove(label));
+    HashMap<String, WGSL::ConstantValue> wgslConstantValues;
+    auto msl = WGSL::generate(prepareResult.callGraph, wgslConstantValues);
+    auto library = ShaderModule::createLibrary(device.device(), msl, WTFMove(label));
     if (!library)
         return nullptr;
     return ShaderModule::create(WTFMove(checkResult), WTFMove(hints), WTFMove(prepareResult.entryPoints), library, nil, { }, device);

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
@@ -40,9 +40,10 @@ inline Expected<String, WGSL::FailedCheck> translate(const String& wgsl, const S
     if (auto* maybeError = std::get_if<WGSL::FailedCheck>(&result))
         return makeUnexpected(*maybeError);
 
-    auto preparedResults = WGSL::prepare(std::get<WGSL::SuccessfulCheck>(result).ast, entryPointName, { });
-
-    return { WTFMove(preparedResults.msl) };
+    auto prepareResult = WGSL::prepare(std::get<WGSL::SuccessfulCheck>(result).ast, entryPointName, { });
+    HashMap<String, WGSL::ConstantValue> constantValues;
+    auto msl = WGSL::generate(prepareResult.callGraph, constantValues);
+    return { WTFMove(msl) };
 }
 
 TEST(WGSLMetalGenerationTests, RedFrag)


### PR DESCRIPTION
#### 2e6c189562a8c6a3c3bc460f399d45ae801a0bd2
<pre>
[WGSL] override expressions as array lengths do not compile
<a href="https://bugs.webkit.org/show_bug.cgi?id=268425">https://bugs.webkit.org/show_bug.cgi?id=268425</a>
<a href="https://rdar.apple.com/121971104">rdar://121971104</a>

Reviewed by Mike Wyrzykowski.

Allow overrides to be used as array length. This required a series of changes:
- validating that runtime expressions aren&apos;t used in a constant/override context
- breaking the compiler API into 3 parts to expose the necessary information to
  the API so it can feed the constants back to the compiler
- changing the type representation for arrays so it can encode 1) fixed-sized arrays,
  2) override-sized arrays and 3) runtime-sized arrays

* Source/WebGPU/WGSL/CallGraph.cpp:
(WGSL::CallGraphBuilder::CallGraphBuilder):
(WGSL::CallGraphBuilder::initializeMappings):
(WGSL::buildCallGraph):
* Source/WebGPU/WGSL/CallGraph.h:
* Source/WebGPU/WGSL/CompilationScope.cpp: Copied from Source/WebGPU/WGSL/MangleNames.h.
(WGSL::CompilationScope::CompilationScope):
(WGSL::CompilationScope::~CompilationScope):
* Source/WebGPU/WGSL/CompilationScope.h: Copied from Source/WebGPU/WGSL/MangleNames.h.
* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::zeroValue):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::collectGlobals):
(WGSL::RewriteGlobalVariables::storeInitialValue):
(WGSL::RewriteGlobalVariables::containsRuntimeArray): Deleted.
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::NameManglerVisitor):
(WGSL::NameManglerVisitor::visit):
(WGSL::mangleNames):
* Source/WebGPU/WGSL/MangleNames.h:
* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp:
(WGSL::Metal::generateMetalCode):
* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.h:
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::FunctionDefinitionWriter):
(WGSL::Metal::FunctionDefinitionWriter::visitGlobal):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::emitMetalFunctions):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.h:
* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::materialize const):
(WGSL::OverloadResolver::unify):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::evaluationToString):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::visitVariable):
(WGSL::TypeChecker::bitcast):
(WGSL::TypeChecker::chooseOverload):
(WGSL::TypeChecker::infer):
(WGSL::TypeChecker::introduceType):
(WGSL::TypeChecker::introduceValue):
(WGSL::TypeChecker::introduceFunction):
(WGSL::TypeChecker::texelFormat):
(WGSL::TypeChecker::accessMode):
(WGSL::TypeChecker::addressSpace):
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::ArrayKey::encode const):
(WGSL::TypeStore::arrayType):
* Source/WebGPU/WGSL/TypeStore.h:
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::dump const):
(WGSL::Type::size const):
(WGSL::Type::isConstructible const):
(WGSL::Type::isStorable const):
(WGSL::Type::isHostShareable const):
(WGSL::Type::hasFixedFootprint const):
(WGSL::Type::hasCreationFixedFootprint const):
(WGSL::Type::containsRuntimeArray const):
(WGSL::Type::containsOverrideArray const):
* Source/WebGPU/WGSL/Types.h:
(WGSL::Types::Array::isRuntimeSized const):
(WGSL::Types::Array::isCreationFixed const):
(WGSL::Types::Array::isOverrideSized const):
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::prepareImpl):
(WGSL::generate):
(WGSL::evaluate):
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::Compilation::Compilation): Deleted.
(WGSL::ShaderModule::Compilation::~Compilation): Deleted.
* Source/WebGPU/WGSL/wgslc.cpp:
(runWGSL):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::Device::createComputePipeline):
* Source/WebGPU/WebGPU/Pipeline.h:
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):
(WebGPU::createFunction):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::earlyCompileShaderModule):

Canonical link: <a href="https://commits.webkit.org/274296@main">https://commits.webkit.org/274296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91fc819d294a22443184f8b7ba05fe6242c6a411

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41130 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34261 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40899 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32435 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14779 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33566 "Build is being retried. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; api tests running") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12832 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12810 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42405 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35069 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38640 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13423 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36849 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15030 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8656 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14505 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->