### PR TITLE
Remove deprecated collation types "big5han" and "gb2312" from JSTests expectations

### DIFF
--- a/JSTests/stress/intl-enumeration.js
+++ b/JSTests/stress/intl-enumeration.js
@@ -5,6 +5,15 @@ function shouldBe(actual, expected) {
         throw new Error(`expected ${expected} but got ${actual}`);
 }
 
+const icuVersion = $vm.icuVersion();
+function shouldBeForICUVersion(minimumVersion, actual, expected) {
+    if (icuVersion < minimumVersion)
+        return;
+
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
 function shouldThrow(func, errorType) {
     let error;
     try {
@@ -21,7 +30,7 @@ let calendars = Intl.supportedValuesOf("calendar");
 shouldBe(JSON.stringify(calendars), `["buddhist","chinese","coptic","dangi","ethioaa","ethiopic","gregory","hebrew","indian","islamic","islamic-civil","islamic-rgsa","islamic-tbla","islamic-umalqura","iso8601","japanese","persian","roc"]`);
 
 let collations = Intl.supportedValuesOf("collation");
-shouldBe(JSON.stringify(collations), `["big5han","compat","dict","emoji","eor","gb2312","phonebk","phonetic","pinyin","reformed","searchjl","stroke","trad","unihan","zhuyin"]`);
+shouldBeForICUVersion(74, JSON.stringify(collations), `["compat","dict","emoji","eor","phonebk","phonetic","pinyin","reformed","searchjl","stroke","trad","unihan","zhuyin"]`);
 
 let currencies = Intl.supportedValuesOf("currency");
 shouldBe(JSON.stringify(currencies), `["ADP","AED","AFA","AFN","ALK","ALL","AMD","ANG","AOA","AOK","AON","AOR","ARA","ARL","ARM","ARP","ARS","ATS","AUD","AWG","AZM","AZN","BAD","BAM","BAN","BBD","BDT","BEC","BEF","BEL","BGL","BGM","BGN","BGO","BHD","BIF","BMD","BND","BOB","BOL","BOP","BOV","BRB","BRC","BRE","BRL","BRN","BRR","BRZ","BSD","BTN","BUK","BWP","BYB","BYN","BYR","BZD","CAD","CDF","CHE","CHF","CHW","CLE","CLF","CLP","CNH","CNX","CNY","COP","COU","CRC","CSD","CSK","CUC","CUP","CVE","CYP","CZK","DDM","DEM","DJF","DKK","DOP","DZD","ECS","ECV","EEK","EGP","ERN","ESA","ESB","ESP","ETB","EUR","FIM","FJD","FKP","FRF","GBP","GEK","GEL","GHC","GHS","GIP","GMD","GNF","GNS","GQE","GRD","GTQ","GWE","GWP","GYD","HKD","HNL","HRD","HRK","HTG","HUF","IDR","IEP","ILP","ILR","ILS","INR","IQD","IRR","ISJ","ISK","ITL","JMD","JOD","JPY","KES","KGS","KHR","KMF","KPW","KRH","KRO","KRW","KWD","KYD","KZT","LAK","LBP","LKR","LRD","LSL","LTL","LTT","LUC","LUF","LUL","LVL","LVR","LYD","MAD","MAF","MCF","MDC","MDL","MGA","MGF","MKD","MKN","MLF","MMK","MNT","MOP","MRO","MRU","MTL","MTP","MUR","MVP","MVR","MWK","MXN","MXP","MXV","MYR","MZE","MZM","MZN","NAD","NGN","NIC","NIO","NLG","NOK","NPR","NZD","OMR","PAB","PEI","PEN","PES","PGK","PHP","PKR","PLN","PLZ","PTE","PYG","QAR","RHD","ROL","RON","RSD","RUB","RUR","RWF","SAR","SBD","SCR","SDD","SDG","SDP","SEK","SGD","SHP","SIT","SKK","SLL","SOS","SRD","SRG","SSP","STD","STN","SUR","SVC","SYP","SZL","THB","TJR","TJS","TMM","TMT","TND","TOP","TPE","TRL","TRY","TTD","TWD","TZS","UAH","UAK","UGS","UGX","USD","USN","USS","UYI","UYP","UYU","UYW","UZS","VEB","VEF","VES","VND","VNN","VUV","WST","XAF","XAG","XAU","XBA","XBB","XBC","XBD","XCD","XDR","XEU","XFO","XFU","XOF","XPD","XPF","XPT","XRE","XSU","XTS","XUA","XXX","YDD","YER","YUD","YUM","YUN","YUR","ZAL","ZAR","ZMK","ZMW","ZRN","ZRZ","ZWD","ZWL","ZWR"]`);

--- a/JSTests/stress/intl-locale-info.js
+++ b/JSTests/stress/intl-locale-info.js
@@ -3,6 +3,15 @@ function shouldBe(actual, expected) {
         throw new Error(`expected ${expected} but got ${actual}`);
 }
 
+const icuVersion = $vm.icuVersion();
+function shouldBeForICUVersion(minimumVersion, actual, expected) {
+    if (icuVersion < minimumVersion)
+        return;
+
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
 function shouldBeOneOf(actual, expectedArray) {
     if (!expectedArray.some((value) => value === actual))
         throw new Error('bad value: ' + actual + ' expected values: ' + expectedArray);
@@ -91,7 +100,7 @@ function shouldBeOneOf(actual, expectedArray) {
 {
     let locale = new Intl.Locale("zh")
     shouldBe(JSON.stringify(locale.getCalendars()), `["gregory","chinese"]`);
-    shouldBe(JSON.stringify(locale.getCollations()), `["pinyin","big5han","gb2312","stroke","unihan","zhuyin","emoji","eor"]`);
+    shouldBeForICUVersion(74, JSON.stringify(locale.getCollations()), `["pinyin","stroke","unihan","zhuyin","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
     shouldBeOneOf(JSON.stringify(locale.getHourCycles()), [ `["h23"]`, `["h12"]` ]);
     shouldBe(JSON.stringify(locale.getNumberingSystems()), `["latn"]`);
@@ -100,7 +109,7 @@ function shouldBeOneOf(actual, expectedArray) {
 {
     let locale = new Intl.Locale("zh-TW")
     shouldBe(JSON.stringify(locale.getCalendars()), `["gregory","roc","chinese"]`);
-    shouldBe(JSON.stringify(locale.getCollations()), `["stroke","big5han","gb2312","pinyin","unihan","zhuyin","emoji","eor"]`);
+    shouldBeForICUVersion(74, JSON.stringify(locale.getCollations()), `["stroke","pinyin","unihan","zhuyin","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
     shouldBe(JSON.stringify(locale.getHourCycles()), `["h12"]`);
     shouldBe(JSON.stringify(locale.getNumberingSystems()), `["latn"]`);
@@ -109,7 +118,7 @@ function shouldBeOneOf(actual, expectedArray) {
 {
     let locale = new Intl.Locale("zh-HK")
     shouldBe(JSON.stringify(locale.getCalendars()), `["gregory","chinese"]`);
-    shouldBe(JSON.stringify(locale.getCollations()), `["stroke","big5han","gb2312","pinyin","unihan","zhuyin","emoji","eor"]`);
+    shouldBeForICUVersion(74, JSON.stringify(locale.getCollations()), `["stroke","pinyin","unihan","zhuyin","emoji","eor"]`);
     shouldBe(locale.hourCycle, undefined);
     shouldBe(JSON.stringify(locale.getHourCycles()), `["h12"]`);
     shouldBe(JSON.stringify(locale.getNumberingSystems()), `["latn"]`);


### PR DESCRIPTION
#### bc9716f4ee6360017237a4b85426cc3b56fd8b66
<pre>
Remove deprecated collation types &quot;big5han&quot; and &quot;gb2312&quot; from JSTests expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=268879">https://bugs.webkit.org/show_bug.cgi?id=268879</a>
&lt;<a href="https://rdar.apple.com/problem/122437088">rdar://problem/122437088</a>&gt;

Reviewed by Yusuke Suzuki and Mark Lam.

These collation types were deprecated for a long time and not available in Chrome / Firefox [1],
and finally removed in ICU 74 [2].

[1]: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCollations#supported_collation_types">https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCollations#supported_collation_types</a>
[2]: <a href="https://github.com/unicode-org/icu/pull/2365">https://github.com/unicode-org/icu/pull/2365</a>

* JSTests/stress/intl-enumeration.js:
* JSTests/stress/intl-locale-info.js:

Canonical link: <a href="https://commits.webkit.org/274236@main">https://commits.webkit.org/274236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19fe9610b88eaa74f1fdfac54ca9b7cec2178625

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40783 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34006 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14508 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14485 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12612 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12584 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42060 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/31845 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34741 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38433 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/37905 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13176 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36624 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14728 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/44848 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13592 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9178 "Found 3 new JSC stress test failures: wasm.yaml/wasm/gc/bug266056.js.wasm-eager, wasm.yaml/wasm/gc/bug266127.js.wasm-eager, wasm.yaml/wasm/gc/call_ref.js.wasm-eager (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4996 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14192 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->