### PR TITLE
[Unified Text Replacement] Text replacements do not have their associated document markers properly updated

### DIFF
--- a/Source/WebCore/dom/DocumentMarker.h
+++ b/Source/WebCore/dom/DocumentMarker.h
@@ -103,13 +103,15 @@ public:
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
     struct UnifiedTextReplacementData {
-        enum class ApplyIndicator: bool {
-            No, Yes
+        enum class State: uint8_t {
+            Pending,
+            Committed,
+            Reverted
         };
 
         String originalText;
         WTF::UUID uuid;
-        ApplyIndicator applyIndicator { ApplyIndicator::No };
+        State state { State::Pending };
     };
 #endif
 
@@ -202,8 +204,8 @@ inline String DocumentMarker::description() const
         return *description;
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
-    if (auto* description = std::get_if<DocumentMarker::UnifiedTextReplacementData>(&m_data))
-        return makeString("('", description->originalText, "', indicator: ", description->applyIndicator == DocumentMarker::UnifiedTextReplacementData::ApplyIndicator::Yes, ")");
+    if (auto* data = std::get_if<DocumentMarker::UnifiedTextReplacementData>(&m_data))
+        return makeString("('", data->originalText, "', state: ", enumToUnderlyingType(data->state), ")");
 #endif
 
     return emptyString();

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -56,6 +56,7 @@ public:
 
     WEBCORE_EXPORT void addMarker(const SimpleRange&, DocumentMarker::Type, const DocumentMarker::Data& = { });
     void addMarker(Text&, unsigned startOffset, unsigned length, DocumentMarker::Type, DocumentMarker::Data&& = { });
+    WEBCORE_EXPORT void addMarker(Node&, DocumentMarker&&);
     void addDraggedContentMarker(const SimpleRange&);
 
     void copyMarkers(Node& source, OffsetRange, Node& destination);
@@ -66,7 +67,7 @@ public:
     // remove the marker. If the argument is false, we will adjust the span of the marker so that it retains
     // the portion that is outside of the range.
     WEBCORE_EXPORT void removeMarkers(const SimpleRange&, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
-    void removeMarkers(Node&, OffsetRange, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers(), const Function<FilterMarkerResult(const DocumentMarker&)>& filterFunction = nullptr, RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
+    WEBCORE_EXPORT void removeMarkers(Node&, OffsetRange, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers(), const Function<FilterMarkerResult(const DocumentMarker&)>& filterFunction = nullptr, RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
 
     WEBCORE_EXPORT void filterMarkers(const SimpleRange&, const Function<FilterMarkerResult(const DocumentMarker&)>& filterFunction, OptionSet<DocumentMarker::Type> = DocumentMarker::allMarkers(), RemovePartiallyOverlappingMarker = RemovePartiallyOverlappingMarker::No);
 
@@ -90,13 +91,13 @@ public:
     WeakPtr<DocumentMarker> markerContainingPoint(const LayoutPoint&, DocumentMarker::Type);
     WEBCORE_EXPORT Vector<FloatRect> renderedRectsForMarkers(DocumentMarker::Type);
 
+    WEBCORE_EXPORT void forEachOfTypes(OptionSet<DocumentMarker::Type>, const Function<bool(Node&, RenderedDocumentMarker&)>);
+
 #if ENABLE(TREE_DEBUGGING)
     void showMarkers() const;
 #endif
 
 private:
-    void addMarker(Node&, DocumentMarker&&);
-
     struct TextRange {
         Ref<Node> node;
         OffsetRange range;
@@ -104,7 +105,6 @@ private:
     Vector<TextRange> collectTextRanges(const SimpleRange&);
 
     void forEach(const SimpleRange&, OptionSet<DocumentMarker::Type>, const Function<bool(Node&, RenderedDocumentMarker&)>);
-    void forEachOfTypes(OptionSet<DocumentMarker::Type>, const Function<bool(Node&, RenderedDocumentMarker&)>);
 
     using MarkerMap = HashMap<Ref<Node>, std::unique_ptr<Vector<RenderedDocumentMarker>>>;
 

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -291,6 +291,10 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
         case DocumentMarker::Type::CorrectionIndicator:
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
         case DocumentMarker::Type::UnifiedTextReplacement:
+            if (marker->type() == DocumentMarker::Type::UnifiedTextReplacement && std::get<DocumentMarker::UnifiedTextReplacementData>(marker->data()).state != DocumentMarker::UnifiedTextReplacementData::State::Pending)
+                break;
+
+            BFALLTHROUGH;
 #endif
         case DocumentMarker::Type::DictationAlternatives:
         case DocumentMarker::Type::Grammar:
@@ -302,11 +306,6 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
             auto [clampedStart, clampedEnd] = selectableRange.clamp(marker->startOffset(), marker->endOffset());
 
             auto markedTextType = markedTextTypeForMarkerType(marker->type());
-#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
-            if (marker->type() == DocumentMarker::Type::UnifiedTextReplacement && std::get<DocumentMarker::UnifiedTextReplacementData>(marker->data()).applyIndicator == DocumentMarker::UnifiedTextReplacementData::ApplyIndicator::No)
-                markedTextType = MarkedText::Type::Unmarked;
-#endif
-
             markedTexts.append({ clampedStart, clampedEnd, markedTextType, marker.get() });
             break;
         }

--- a/Source/WebKit/Shared/UnifiedTextReplacement.serialization.in
+++ b/Source/WebKit/Shared/UnifiedTextReplacement.serialization.in
@@ -21,7 +21,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
-[Nested] enum class WebKit::WebTextReplacementData::State : uint8_t {
+header: "WebTextReplacementData.h"
+[CustomHeader] enum class WebKit::WebTextReplacementDataState : uint8_t {
     Pending,
     Active,
     Committed,
@@ -29,7 +30,8 @@
     Invalid
 };
 
-struct WebKit::WebTextReplacementData {
+header: "WebTextReplacementData.h"
+[CustomHeader] struct WebKit::WebTextReplacementData {
     WTF::UUID uuid;
     WebCore::CharacterRange originalRange;
     WTF::String replacement;

--- a/Source/WebKit/Shared/WebTextReplacementData.h
+++ b/Source/WebKit/Shared/WebTextReplacementData.h
@@ -34,14 +34,16 @@
 
 namespace WebKit {
 
+enum class WebTextReplacementDataState : uint8_t {
+    Pending,
+    Active,
+    Committed,
+    Reverted,
+    Invalid,
+};
+
 struct WebTextReplacementData {
-    enum class State : uint8_t {
-        Pending,
-        Active,
-        Committed,
-        Reverted,
-        Invalid,
-    };
+    using State = WebTextReplacementDataState;
 
     WTF::UUID uuid;
     WebCore::CharacterRange originalRange;

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1111,6 +1111,16 @@ void WebPageProxy::textReplacementSessionDidReceiveReplacements(const WTF::UUID&
     send(Messages::WebPage::TextReplacementSessionDidReceiveReplacements(uuid, replacements, context, finished));
 }
 
+void WebPageProxy::textReplacementSessionDidUpdateStateForReplacement(const WTF::UUID& uuid, WebTextReplacementData::State state, const WebTextReplacementData& replacement, const WebUnifiedTextReplacementContextData& context)
+{
+    send(Messages::WebPage::TextReplacementSessionDidUpdateStateForReplacement(uuid, state, replacement, context));
+}
+
+void WebPageProxy::didEndTextReplacementSession(const WTF::UUID& uuid, bool accepted)
+{
+    send(Messages::WebPage::DidEndTextReplacementSession(uuid, accepted));
+}
+
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -485,8 +485,8 @@ struct WebPageProxyIdentifierType;
 struct WebPopupItem;
 struct WebPreferencesStore;
 struct WebSpeechSynthesisVoice;
-struct WebTextReplacementData;
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+struct WebTextReplacementData;
 struct WebUnifiedTextReplacementContextData;
 #endif
 struct WebsitePoliciesData;
@@ -521,6 +521,7 @@ enum class WasNavigationIntercepted : bool;
 enum class WebContentMode : uint8_t;
 enum class WebEventModifier : uint8_t;
 enum class WebEventType : uint8_t;
+enum class WebTextReplacementDataState : uint8_t;
 enum class WindowKind : uint8_t;
 
 template<typename> class MonotonicObjectIdentifier;
@@ -2363,6 +2364,10 @@ public:
     void didBeginTextReplacementSession(const WTF::UUID&, const Vector<WebKit::WebUnifiedTextReplacementContextData>&);
 
     void textReplacementSessionDidReceiveReplacements(const WTF::UUID&, const Vector<WebKit::WebTextReplacementData>&, const WebKit::WebUnifiedTextReplacementContextData&, bool finished);
+
+    void textReplacementSessionDidUpdateStateForReplacement(const WTF::UUID&, WebKit::WebTextReplacementDataState, const WebKit::WebTextReplacementData&, const WebKit::WebUnifiedTextReplacementContextData&);
+
+    void didEndTextReplacementSession(const WTF::UUID&, bool accepted);
 #endif
 
     void addConsoleMessage(WebCore::FrameIdentifier, JSC::MessageSource, JSC::MessageLevel, const String&, std::optional<WebCore::ResourceLoaderIdentifier> = std::nullopt);

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -852,7 +852,7 @@ void WebPage::willBeginTextReplacementSession(const WTF::UUID& uuid, CompletionH
     m_unifiedTextReplacementController->willBeginTextReplacementSession(uuid, WTFMove(completionHandler));
 }
 
-void WebPage::didBeginTextReplacementSession(const WTF::UUID& uuid, const Vector<WebKit::WebUnifiedTextReplacementContextData>& contexts)
+void WebPage::didBeginTextReplacementSession(const WTF::UUID& uuid, const Vector<WebUnifiedTextReplacementContextData>& contexts)
 {
     m_unifiedTextReplacementController->didBeginTextReplacementSession(uuid, contexts);
 }
@@ -861,6 +861,17 @@ void WebPage::textReplacementSessionDidReceiveReplacements(const WTF::UUID& uuid
 {
     m_unifiedTextReplacementController->textReplacementSessionDidReceiveReplacements(uuid, replacements, context, finished);
 }
+
+void WebPage::textReplacementSessionDidUpdateStateForReplacement(const WTF::UUID& uuid, WebTextReplacementData::State state, const WebTextReplacementData& replacement, const WebUnifiedTextReplacementContextData& context)
+{
+    m_unifiedTextReplacementController->textReplacementSessionDidUpdateStateForReplacement(uuid, state, replacement, context);
+}
+
+void WebPage::didEndTextReplacementSession(const WTF::UUID& uuid, bool accepted)
+{
+    m_unifiedTextReplacementController->didEndTextReplacementSession(uuid, accepted);
+}
+
 #endif
 
 std::optional<SimpleRange> WebPage::autocorrectionContextRange()

--- a/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.cpp
@@ -34,6 +34,7 @@
 #include <WebCore/DocumentMarkerController.h>
 #include <WebCore/Editor.h>
 #include <WebCore/HTMLConverter.h>
+#include <WebCore/RenderedDocumentMarker.h>
 #include <WebCore/TextIterator.h>
 
 namespace WebKit {
@@ -53,6 +54,28 @@ static void replaceTextInRange(WebCore::LocalFrame& frame, const SimpleRange& ra
     frame.editor().replaceSelectionWithText(replacementText, WebCore::Editor::SelectReplacement::Yes, WebCore::Editor::SmartReplace::No, WebCore::EditAction::InsertReplacement);
 }
 
+static std::optional<std::tuple<Node&, DocumentMarker&>> findReplacementMarkerByUUID(WebCore::Document& document, const WTF::UUID& replacementUUID)
+{
+    RefPtr<Node> targetNode;
+    WeakPtr<DocumentMarker> targetMarker;
+
+    document.markers().forEachOfTypes({ DocumentMarker::Type::UnifiedTextReplacement }, [&replacementUUID, &targetNode, &targetMarker] (auto& node, auto& marker) mutable {
+        auto data = std::get<DocumentMarker::UnifiedTextReplacementData>(marker.data());
+        if (data.uuid != replacementUUID)
+            return false;
+
+        targetNode = &node;
+        targetMarker = &marker;
+
+        return true;
+    });
+
+    if (targetNode && targetMarker)
+        return { { *targetNode, *targetMarker } };
+
+    return std::nullopt;
+}
+
 UnifiedTextReplacementController::UnifiedTextReplacementController(WebPage& webPage)
     : m_webPage(webPage)
 {
@@ -68,7 +91,7 @@ void UnifiedTextReplacementController::willBeginTextReplacementSession(const WTF
         return;
     }
 
-    auto* corePage = m_webPage->corePage();
+    RefPtr corePage = m_webPage->corePage();
     if (!corePage) {
         ASSERT_NOT_REACHED();
         completionHandler({ });
@@ -105,10 +128,12 @@ void UnifiedTextReplacementController::textReplacementSessionDidReceiveReplaceme
 {
     RELEASE_LOG(UnifiedTextReplacement, "UnifiedTextReplacementController::textReplacementSessionDidReceiveReplacements (%s) [received replacements: %zu, finished: %d]", uuid.toString().utf8().data(), replacements.size(), finished);
 
-    if (!m_webPage)
+    if (!m_webPage) {
+        ASSERT_NOT_REACHED();
         return;
+    }
 
-    auto* corePage = m_webPage->corePage();
+    RefPtr corePage = m_webPage->corePage();
     if (!corePage) {
         ASSERT_NOT_REACHED();
         return;
@@ -140,11 +165,111 @@ void UnifiedTextReplacementController::textReplacementSessionDidReceiveReplaceme
         auto newRangeWithOffset = CharacterRange { locationWithOffset, replacementData.replacement.length() };
         auto newResolvedRange = resolveCharacterRange(*sessionRange, newRangeWithOffset);
 
-        auto markerData = DocumentMarker::UnifiedTextReplacementData { replacementData.originalString.string, replacementData.uuid, DocumentMarker::UnifiedTextReplacementData::ApplyIndicator::Yes };
+        auto markerData = DocumentMarker::UnifiedTextReplacementData { replacementData.originalString.string, replacementData.uuid, DocumentMarker::UnifiedTextReplacementData::State::Pending };
         addMarker(resolvedRange, DocumentMarker::Type::UnifiedTextReplacement, markerData);
 
         additionalOffset += replacementData.replacement.length() - replacementData.originalRange.length;
     }
+}
+
+void UnifiedTextReplacementController::textReplacementSessionDidUpdateStateForReplacement(const WTF::UUID& uuid, WebTextReplacementData::State state, const WebTextReplacementData& replacement, const WebUnifiedTextReplacementContextData& context)
+{
+    RELEASE_LOG(UnifiedTextReplacement, "UnifiedTextReplacementController::textReplacementSessionDidUpdateStateForReplacement (%s) [new state: %hhu, replacement: %s]", uuid.toString().utf8().data(), enumToUnderlyingType(state), replacement.uuid.toString().utf8().data());
+
+    if (!m_webPage) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    RefPtr corePage = m_webPage->corePage();
+    if (!corePage) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    Ref frame = CheckedRef(corePage->focusController())->focusedOrMainFrame();
+    RefPtr document = frame->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    if (state != WebTextReplacementData::State::Committed && state != WebTextReplacementData::State::Reverted)
+        return;
+
+    auto nodeAndMarker = findReplacementMarkerByUUID(*document, replacement.uuid);
+    if (!nodeAndMarker) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    auto& [node, marker] = *nodeAndMarker;
+
+    auto rangeToReplace = makeSimpleRange(node, marker);
+
+    auto oldData = std::get<DocumentMarker::UnifiedTextReplacementData>(marker.data());
+
+    auto offsetRange = OffsetRange { marker.startOffset(), marker.endOffset() };
+    document->markers().removeMarkers(node, offsetRange, { DocumentMarker::Type::UnifiedTextReplacement });
+
+    auto [newText, newState] = [&]() -> std::tuple<String, DocumentMarker::UnifiedTextReplacementData::State> {
+        switch (state) {
+        case WebTextReplacementData::State::Committed:
+            return std::make_tuple(replacement.replacement, DocumentMarker::UnifiedTextReplacementData::State::Committed);
+
+        case WebTextReplacementData::State::Reverted:
+            return std::make_tuple(oldData.originalText, DocumentMarker::UnifiedTextReplacementData::State::Reverted);
+
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+    }();
+
+    replaceTextInRange(frame.get(), rangeToReplace, newText);
+
+    auto newData = DocumentMarker::UnifiedTextReplacementData { oldData.originalText, oldData.uuid, newState };
+    document->markers().addMarker(node, DocumentMarker { DocumentMarker::Type::UnifiedTextReplacement, offsetRange, WTFMove(newData) });
+}
+
+void UnifiedTextReplacementController::didEndTextReplacementSession(const WTF::UUID& uuid, bool accepted)
+{
+    RELEASE_LOG(UnifiedTextReplacement, "UnifiedTextReplacementController::didEndTextReplacementSession (%s) [accepted: %d]", uuid.toString().utf8().data(), accepted);
+
+    if (!m_webPage) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    RefPtr corePage = m_webPage->corePage();
+    if (!corePage) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    Ref frame = CheckedRef(corePage->focusController())->focusedOrMainFrame();
+    RefPtr document = frame->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    // FIXME: Associate the markers with a specific session, and only modify the markers which belong
+    // to this session.
+
+    if (!accepted) {
+        document->markers().forEachOfTypes({ DocumentMarker::Type::UnifiedTextReplacement }, [&frame] (auto& node, auto& marker) mutable {
+            auto data = std::get<DocumentMarker::UnifiedTextReplacementData>(marker.data());
+            if (data.state == DocumentMarker::UnifiedTextReplacementData::State::Reverted)
+                return false;
+
+            auto rangeToReplace = makeSimpleRange(node, marker);
+            replaceTextInRange(frame.get(), rangeToReplace, data.originalText);
+
+            return false;
+        });
+    }
+
+    document->markers().removeMarkers({ DocumentMarker::Type::UnifiedTextReplacement });
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
+++ b/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
@@ -50,7 +50,11 @@ public:
 
     void didBeginTextReplacementSession(const WTF::UUID&, const Vector<WebKit::WebUnifiedTextReplacementContextData>&);
 
-    void textReplacementSessionDidReceiveReplacements(const WTF::UUID&, const Vector<WebKit::WebTextReplacementData>&, const WebKit::WebUnifiedTextReplacementContextData&, bool);
+    void textReplacementSessionDidReceiveReplacements(const WTF::UUID&, const Vector<WebKit::WebTextReplacementData>&, const WebKit::WebUnifiedTextReplacementContextData&, bool finished);
+
+    void textReplacementSessionDidUpdateStateForReplacement(const WTF::UUID&, WebKit::WebTextReplacementData::State, const WebKit::WebTextReplacementData&, const WebKit::WebUnifiedTextReplacementContextData&);
+
+    void didEndTextReplacementSession(const WTF::UUID&, bool accepted);
 
 private:
     WeakPtr<WebPage> m_webPage;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -376,6 +376,7 @@ enum class FindDecorationStyle : uint8_t;
 enum class NavigatingToAppBoundDomain : bool;
 enum class SyntheticEditingCommandType : uint8_t;
 enum class TextRecognitionUpdateResult : uint8_t;
+enum class WebTextReplacementDataState : uint8_t;
 
 struct BackForwardListItemState;
 struct DataDetectionResult;
@@ -401,6 +402,7 @@ struct WebAutocorrectionContext;
 struct WebFoundTextRange;
 struct WebPageCreationParameters;
 struct WebPreferencesStore;
+struct WebTextReplacementData;
 
 #if ENABLE(UI_SIDE_COMPOSITING)
 class VisibleContentRectUpdateInfo;
@@ -2183,6 +2185,10 @@ private:
     void didBeginTextReplacementSession(const WTF::UUID&, const Vector<WebKit::WebUnifiedTextReplacementContextData>&);
 
     void textReplacementSessionDidReceiveReplacements(const WTF::UUID&, const Vector<WebKit::WebTextReplacementData>&, const WebKit::WebUnifiedTextReplacementContextData&, bool finished);
+
+    void textReplacementSessionDidUpdateStateForReplacement(const WTF::UUID&, WebKit::WebTextReplacementDataState, const WebKit::WebTextReplacementData&, const WebKit::WebUnifiedTextReplacementContextData&);
+
+    void didEndTextReplacementSession(const WTF::UUID&, bool accepted);
 #endif
 
     void remotePostMessage(WebCore::FrameIdentifier source, const String& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData>&& targetOrigin, const WebCore::MessageWithMessagePorts&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -765,6 +765,10 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     DidBeginTextReplacementSession(WTF::UUID uuid, Vector<WebKit::WebUnifiedTextReplacementContextData> contexts)
 
     TextReplacementSessionDidReceiveReplacements(WTF::UUID uuid, Vector<WebKit::WebTextReplacementData> replacements, struct WebKit::WebUnifiedTextReplacementContextData context, bool finished)
+
+    TextReplacementSessionDidUpdateStateForReplacement(WTF::UUID uuid, enum:uint8_t WebKit::WebTextReplacementData::State state, struct WebKit::WebTextReplacementData replacement, struct WebKit::WebUnifiedTextReplacementContextData context)
+
+    DidEndTextReplacementSession(WTF::UUID uuid, bool accepted)
 #endif
 
     RemoteViewCoordinatesToRootView(WebCore::FrameIdentifier frameID, WebCore::FloatRect rect) -> (WebCore::FloatRect rect)


### PR DESCRIPTION
#### 3a919dcf057367c9e1ccc0b9be32f581989d7a4e
<pre>
[Unified Text Replacement] Text replacements do not have their associated document markers properly updated
<a href="https://bugs.webkit.org/show_bug.cgi?id=268886">https://bugs.webkit.org/show_bug.cgi?id=268886</a>
<a href="https://rdar.apple.com/120563596">rdar://120563596</a>

Reviewed by Aditya Keerthi.

* Source/WebCore/dom/DocumentMarker.h:
(WebCore::DocumentMarker::description const):
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForDocumentMarkers):
* Source/WebKit/Shared/UnifiedTextReplacement.serialization.in:
* Source/WebKit/Shared/WebTextReplacementData.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::textReplacementSessionDidUpdateStateForReplacement):
(WebKit::WebPageProxy::didEndTextReplacementSession):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::didBeginTextReplacementSession):
(WebKit::WebPage::textReplacementSessionDidUpdateStateForReplacement):
(WebKit::WebPage::didEndTextReplacementSession):
* Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.cpp:
(WebKit::findReplacementMarkerByUUID):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveReplacements):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidUpdateStateForReplacement):
(WebKit::UnifiedTextReplacementController::didEndTextReplacementSession):
* Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/274292@main">https://commits.webkit.org/274292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee17926c0af792e6603e1ba978c164b2bdb93d3e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38640 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17569 "Failed to checkout and rebase branch from PR 23977") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/40965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/41170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/40945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20374 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/14916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/41170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39213 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/14809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/40965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/41170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/40965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/42445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/35103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/40965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/42445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/14916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/42445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/40965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5028 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->