### PR TITLE
Enable WKWebsiteDataStore.proxyConfigurations tests on iOS simulator

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm
@@ -40,14 +40,11 @@
 #import <wtf/SoftLinking.h>
 #import <wtf/text/StringConcatenateNumbers.h>
 
-// FIXME: Try to re-enable on the simulator after rdar://110076935 is resolved
-#if !PLATFORM(IOS_FAMILY_SIMULATOR)
 #if HAVE(NW_PROXY_CONFIG)
 SOFT_LINK_LIBRARY_OPTIONAL(libnetwork)
 SOFT_LINK_OPTIONAL(libnetwork, nw_proxy_config_create_http_connect, nw_proxy_config_t, __cdecl, (nw_endpoint_t, nw_protocol_options_t))
 SOFT_LINK_OPTIONAL(libnetwork, nw_proxy_config_create_socksv5, nw_proxy_config_t, __cdecl, (nw_endpoint_t))
 #endif // HAVE(NW_PROXY_CONFIG)
-#endif // !PLATFORM(IOS_FAMILY_SIMULATOR)
 
 @interface ProxyDelegate : NSObject <WKNavigationDelegate, WKUIDelegate>
 - (NSString *)waitForAlert;
@@ -165,8 +162,6 @@ TEST(WebKit, SOCKS5)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "success!");
 }
 
-// FIXME: Try to re-enable on the simulator after rdar://110076935 is resolved
-#if !PLATFORM(IOS_FAMILY_SIMULATOR)
 #if HAVE(NW_PROXY_CONFIG)
 TEST(WebKit, HTTPSProxyAPI)
 {
@@ -294,7 +289,6 @@ TEST(WebKit, SOCKS5API)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "success!");
 }
 #endif // HAVE(NW_PROXY_CONFIG)
-#endif // !PLATFORM(IOS_FAMILY_SIMULATOR)
 
 static HTTPServer proxyAuthenticationServer()
 {


### PR DESCRIPTION
#### 0c1bf2e5136c5cba56cc4e647169be09861a1a52
<pre>
Enable WKWebsiteDataStore.proxyConfigurations tests on iOS simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=268888">https://bugs.webkit.org/show_bug.cgi?id=268888</a>
<a href="https://rdar.apple.com/122444342">rdar://122444342</a>

Reviewed by Chris Dumez.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm:

Canonical link: <a href="https://commits.webkit.org/274219@main">https://commits.webkit.org/274219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f043e0e88029e86d1c9e25243734a1c40a3956ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40802 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34023 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40473 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14527 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32276 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14511 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12627 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42081 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34778 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38448 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10886 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36642 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/replaced-objects (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14743 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13606 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4985 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->