### PR TITLE
[Digital Identity]: DigitalCredential interface is now DigitalIdentity

### DIFF
--- a/LayoutTests/http/wpt/credential-management/setDigitalCredentialsEnabled.https.html
+++ b/LayoutTests/http/wpt/credential-management/setDigitalCredentialsEnabled.https.html
@@ -14,9 +14,9 @@
             console.log("FAIL: requestIdentity() must not be exposed by default.");
         }
 
-        if (window.DigitalCredential !== undefined) {
+        if (window.DigitalIdentity !== undefined) {
             console.log(
-                "FAIL: DigitalCredential interface must not be exposed by default."
+                "FAIL: DigitalIdentity interface must not be exposed by default."
             );
         }
 
@@ -31,12 +31,12 @@
                 );
             }
 
-            const isInstanceOfDigitalCredential =
-                iframeWin.DigitalCredential.prototype instanceof
+            const isInstanceOfDigitalIdentity =
+                iframeWin.DigitalIdentity.prototype instanceof
                 iframeWin.Credential;
-            if (!isInstanceOfDigitalCredential) {
+            if (!isInstanceOfDigitalIdentity) {
                 console.log(
-                    "FAIL: DigitalCredential's prototype interface must be an instance of Credential."
+                    "FAIL: DigitalIdentity's prototype interface must be an instance of Credential."
                 );
             }
             console.log("Test finished");

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -311,7 +311,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/credentialmanagement/CredentialMediationRequirement.idl
     Modules/credentialmanagement/CredentialRequestOptions.idl
     Modules/credentialmanagement/CredentialsContainer.idl
-    Modules/credentialmanagement/DigitalCredential.idl
+    Modules/credentialmanagement/DigitalIdentity.idl
     Modules/credentialmanagement/DigitalCredentialRequestOptions.idl
     Modules/credentialmanagement/IdentityCredentialProtocol.idl
     Modules/credentialmanagement/IdentityRequestProvider.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -433,7 +433,7 @@ $(PROJECT_DIR)/Modules/credentialmanagement/CredentialCreationOptions.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/CredentialMediationRequirement.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/CredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/CredentialsContainer.idl
-$(PROJECT_DIR)/Modules/credentialmanagement/DigitalCredential.idl
+$(PROJECT_DIR)/Modules/credentialmanagement/DigitalIdentity.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/DigitalCredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/IdentityCredentialProtocol.idl
 $(PROJECT_DIR)/Modules/credentialmanagement/IdentityRequestProvider.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -839,8 +839,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceOrientationEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceOrientationEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceOrientationOrMotionPermissionState.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDeviceOrientationOrMotionPermissionState.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredential.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredential.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalIdentity.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalIdentity.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialRequestOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialRequestOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDistanceModelType.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -307,7 +307,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/credentialmanagement/CredentialMediationRequirement.idl \
     $(WebCore)/Modules/credentialmanagement/CredentialRequestOptions.idl \
     $(WebCore)/Modules/credentialmanagement/CredentialsContainer.idl \
-    $(WebCore)/Modules/credentialmanagement/DigitalCredential.idl \
+    $(WebCore)/Modules/credentialmanagement/DigitalIdentity.idl \
     $(WebCore)/Modules/credentialmanagement/DigitalCredentialRequestOptions.idl \
     $(WebCore)/Modules/credentialmanagement/IdentityRequestProvider.idl \
     $(WebCore)/Modules/credentialmanagement/IdentityCredentialProtocol.idl \

--- a/Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp
@@ -46,8 +46,8 @@ BasicCredential::~BasicCredential() = default;
 String BasicCredential::type() const
 {
     switch (m_type) {
-    case Type::DigitalCredential:
-        return "digital-credential"_s;
+    case Type::DigitalIdentity:
+        return "digital-identity"_s;
 
     case Type::PublicKey:
         return "public-key"_s;

--- a/Source/WebCore/Modules/credentialmanagement/BasicCredential.h
+++ b/Source/WebCore/Modules/credentialmanagement/BasicCredential.h
@@ -39,7 +39,7 @@ namespace WebCore {
 class BasicCredential : public RefCounted<BasicCredential> {
 public:
     enum class Type {
-        DigitalCredential,
+        DigitalIdentity,
         PublicKey,
     };
 

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
@@ -32,12 +32,12 @@
 #include "AbortSignal.h"
 #include "CredentialCreationOptions.h"
 #include "CredentialRequestOptions.h"
-#include "DigitalCredential.h"
 #include "DigitalCredentialRequestOptions.h"
+#include "DigitalIdentity.h"
 #include "Document.h"
 #include "ExceptionOr.h"
 #include "JSDOMPromiseDeferred.h"
-#include "JSDigitalCredential.h"
+#include "JSDigitalIdentity.h"
 #include "Page.h"
 #include "SecurityOrigin.h"
 #include "WebAuthenticationConstants.h"
@@ -144,7 +144,7 @@ void CredentialsContainer::preventSilentAccess(DOMPromiseDeferred<void>&& promis
     promise.resolve();
 }
 
-void CredentialsContainer::requestIdentity(DigitalCredentialRequestOptions&& options, DigitalCredentialPromise&& promise)
+void CredentialsContainer::requestIdentity(DigitalCredentialRequestOptions&& options, DigitalIdentityPromise&& promise)
 {
     if (options.signal && options.signal->aborted()) {
         promise.reject(Exception { ExceptionCode::AbortError, "Aborted by AbortSignal."_s });
@@ -152,7 +152,7 @@ void CredentialsContainer::requestIdentity(DigitalCredentialRequestOptions&& opt
     }
     std::span<uint8_t> emptySpan;
     Ref<ArrayBuffer> emptyArrayBuffer = ArrayBuffer::create(emptySpan);
-    promise.resolve(DigitalCredential::create(WTFMove(emptyArrayBuffer)));
+    promise.resolve(DigitalIdentity::create(WTFMove(emptyArrayBuffer)));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h
@@ -29,7 +29,7 @@
 #if ENABLE(WEB_AUTHN)
 
 #include "AuthenticatorCoordinator.h"
-#include "DigitalCredential.h"
+#include "DigitalIdentity.h"
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 
@@ -39,7 +39,7 @@ enum class Scope;
 
 namespace WebCore {
 
-class DigitalCredential;
+class DigitalIdentity;
 class Document;
 class WeakPtrImplWithEventTargetData;
 struct CredentialCreationOptions;
@@ -58,7 +58,7 @@ public:
 
     void preventSilentAccess(DOMPromiseDeferred<void>&&) const;
 
-    void requestIdentity(DigitalCredentialRequestOptions&&, DigitalCredentialPromise&&);
+    void requestIdentity(DigitalCredentialRequestOptions&&, DigitalIdentityPromise&&);
 
 private:
     CredentialsContainer(WeakPtr<Document, WeakPtrImplWithEventTargetData>&&);

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl
@@ -34,5 +34,5 @@
     Promise<BasicCredential> store(BasicCredential credential);
     Promise<BasicCredential?> create(optional CredentialCreationOptions options);
     Promise<undefined> preventSilentAccess();
-    [EnabledBySetting=DigitalCredentialsEnabled] Promise<DigitalCredential> requestIdentity(DigitalCredentialRequestOptions options);
+    [EnabledBySetting=DigitalCredentialsEnabled] Promise<DigitalIdentity> requestIdentity(DigitalCredentialRequestOptions options);
 };

--- a/Source/WebCore/Modules/credentialmanagement/DigitalIdentity.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalIdentity.cpp
@@ -23,11 +23,26 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Exposed=Window,
-    SecureContext,
-    EnabledBySetting=DigitalCredentialsEnabled,
-    Conditional=WEB_AUTHN,
-] interface DigitalCredential : BasicCredential {
-    [SameObject] readonly attribute ArrayBuffer data;
-};
+#include "config.h"
+#include "DigitalIdentity.h"
+
+#if ENABLE(WEB_AUTHN)
+
+namespace WebCore {
+
+Ref<DigitalIdentity> DigitalIdentity::create(Ref<ArrayBuffer>&& data)
+{
+    return adoptRef(*new DigitalIdentity(WTFMove(data)));
+}
+
+DigitalIdentity::~DigitalIdentity() = default;
+
+DigitalIdentity::DigitalIdentity(Ref<ArrayBuffer>&& data)
+    : BasicCredential(base64URLEncodeToString(data->data(), data->byteLength()), Type::DigitalIdentity, Discovery::CredentialStore)
+    , m_data(WTFMove(data))
+{
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/DigitalIdentity.h
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalIdentity.h
@@ -35,16 +35,16 @@
 
 namespace WebCore {
 
-class DigitalCredential;
+class DigitalIdentity;
 template<typename IDLType> class DOMPromiseDeferred;
 
-using DigitalCredentialPromise = DOMPromiseDeferred<IDLInterface<DigitalCredential>>;
+using DigitalIdentityPromise = DOMPromiseDeferred<IDLInterface<DigitalIdentity>>;
 
-class DigitalCredential final : public BasicCredential {
+class DigitalIdentity final : public BasicCredential {
 public:
-    static Ref<DigitalCredential> create(Ref<ArrayBuffer>&& data);
+    static Ref<DigitalIdentity> create(Ref<ArrayBuffer>&& data);
 
-    virtual ~DigitalCredential();
+    virtual ~DigitalIdentity();
 
     ArrayBuffer* data() const
     {
@@ -52,15 +52,15 @@ public:
     };
 
 private:
-    DigitalCredential(Ref<ArrayBuffer>&& data);
+    DigitalIdentity(Ref<ArrayBuffer>&& data);
 
-    Type credentialType() const final { return Type::DigitalCredential; }
+    Type credentialType() const final { return Type::DigitalIdentity; }
 
     RefPtr<ArrayBuffer> m_data;
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BASIC_CREDENTIAL(DigitalCredential, BasicCredential::Type::DigitalCredential)
+SPECIALIZE_TYPE_TRAITS_BASIC_CREDENTIAL(DigitalIdentity, BasicCredential::Type::DigitalIdentity)
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/credentialmanagement/DigitalIdentity.idl
+++ b/Source/WebCore/Modules/credentialmanagement/DigitalIdentity.idl
@@ -23,26 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "DigitalCredential.h"
-
-#if ENABLE(WEB_AUTHN)
-
-namespace WebCore {
-
-Ref<DigitalCredential> DigitalCredential::create(Ref<ArrayBuffer>&& data)
-{
-    return adoptRef(*new DigitalCredential(WTFMove(data)));
-}
-
-DigitalCredential::~DigitalCredential() = default;
-
-DigitalCredential::DigitalCredential(Ref<ArrayBuffer>&& data)
-    : BasicCredential(base64URLEncodeToString(data->data(), data->byteLength()), Type::DigitalCredential, Discovery::CredentialStore)
-    , m_data(WTFMove(data))
-{
-}
-
-} // namespace WebCore
-
-#endif // ENABLE(WEB_AUTHN)
+[
+    Exposed=Window,
+    SecureContext,
+    EnabledBySetting=DigitalCredentialsEnabled,
+    Conditional=WEB_AUTHN,
+] interface DigitalIdentity : BasicCredential {
+    [SameObject] readonly attribute ArrayBuffer data;
+};

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -112,7 +112,7 @@ Modules/cookie-store/CookieStore.cpp
 Modules/cookie-store/CookieStoreManager.cpp
 Modules/credentialmanagement/BasicCredential.cpp
 Modules/credentialmanagement/CredentialsContainer.cpp
-Modules/credentialmanagement/DigitalCredential.cpp
+Modules/credentialmanagement/DigitalIdentity.cpp
 Modules/credentialmanagement/NavigatorCredentials.cpp
 Modules/entriesapi/DOMFileSystem.cpp
 Modules/entriesapi/ErrorCallback.cpp
@@ -3468,7 +3468,7 @@ JSDetectedText.cpp
 JSDeviceMotionEvent.cpp
 JSDeviceOrientationEvent.cpp
 JSDeviceOrientationOrMotionPermissionState.cpp
-JSDigitalCredential.cpp
+JSDigitalIdentity.cpp
 JSDigitalCredentialRequestOptions.cpp
 JSDistanceModelType.cpp
 JSDocument.cpp

--- a/Source/WebCore/bindings/js/JSBasicCredentialCustom.cpp
+++ b/Source/WebCore/bindings/js/JSBasicCredentialCustom.cpp
@@ -29,7 +29,7 @@
 #if ENABLE(WEB_AUTHN)
 
 #include "JSDOMBinding.h"
-#include "JSDigitalCredential.h"
+#include "JSDigitalIdentity.h"
 #include "JSPublicKeyCredential.h"
 
 namespace WebCore {
@@ -39,8 +39,8 @@ JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, 
 {
     if (is<PublicKeyCredential>(credential))
         return createWrapper<PublicKeyCredential>(globalObject, WTFMove(credential));
-    if (is<DigitalCredential>(credential))
-        return createWrapper<DigitalCredential>(globalObject, WTFMove(credential));
+    if (is<DigitalIdentity>(credential))
+        return createWrapper<DigitalIdentity>(globalObject, WTFMove(credential));
     return createWrapper<BasicCredential>(globalObject, WTFMove(credential));
 }
 

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -182,7 +182,7 @@ namespace WebCore {
     macro(DecompressionStreamTransform) \
     macro(DelayNode) \
     macro(DeprecationReportBody) \
-    macro(DigitalCredential) \
+    macro(DigitalIdentity) \
     macro(DocumentTimeline) \
     macro(DynamicsCompressorNode) \
     macro(ElementInternals) \


### PR DESCRIPTION
#### 60339678878a0cc06b7ba3b5c5bc574d59f821a1
<pre>
[Digital Identity]: DigitalCredential interface is now DigitalIdentity
<a href="https://bugs.webkit.org/show_bug.cgi?id=268883">https://bugs.webkit.org/show_bug.cgi?id=268883</a>
<a href="https://rdar.apple.com/122444474">rdar://122444474</a>

Reviewed by Anne van Kesteren.

Renames instances of DigitalCredential to DigitalIdentity, to match the spec change:
<a href="https://wicg.github.io/digital-identities/#the-digitalidentity-interface">https://wicg.github.io/digital-identities/#the-digitalidentity-interface</a>

* LayoutTests/http/wpt/credential-management/setDigitalCredentialsEnabled.https.html:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/credentialmanagement/BasicCredential.cpp:
(WebCore::BasicCredential::type const):
* Source/WebCore/Modules/credentialmanagement/BasicCredential.h:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
(WebCore::CredentialsContainer::requestIdentity):
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.h:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl:
* Source/WebCore/Modules/credentialmanagement/DigitalIdentity.cpp: Renamed from Source/WebCore/Modules/credentialmanagement/DigitalCredential.cpp.
(WebCore::DigitalIdentity::create):
(WebCore::DigitalIdentity::DigitalIdentity):
* Source/WebCore/Modules/credentialmanagement/DigitalIdentity.h: Renamed from Source/WebCore/Modules/credentialmanagement/DigitalCredential.h.
* Source/WebCore/Modules/credentialmanagement/DigitalIdentity.idl: Renamed from Source/WebCore/Modules/credentialmanagement/DigitalCredential.idl.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSBasicCredentialCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:

Canonical link: <a href="https://commits.webkit.org/274209@main">https://commits.webkit.org/274209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e71f6ac8295b9e61eed91c2586883d0d3af774b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40803 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34024 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14528 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32279 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14512 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12631 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42082 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34780 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38450 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13192 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36644 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/33505 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8616 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->