### PR TITLE
Crash under RenderLayer::calculateClipRects() when going into fullscreen

### DIFF
--- a/LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-dialog-expected.txt
+++ b/LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-dialog-expected.txt
@@ -1,0 +1,2 @@
+x x
+Test passes if it does not crash.

--- a/LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-dialog.html
+++ b/LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-dialog.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .negative-z {
+            position: absolute;
+            top: 20px;
+            left: 20px;
+            z-index: -1;
+            width: 20px;
+            height: 20px;
+            border: 1px solid blue;
+        }
+
+        .transformed {
+            transform: translateZ(0);
+        }
+
+        .relpos {
+            position: relative;
+            height: 500px;
+            height: 600px;
+            margin: 20px 40px;
+            border: 2px solid gray;
+        }
+
+        dialog {
+            position: relative !important;
+            display: block;
+            margin: 0px auto;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0, 0, 0, 0.5);
+            overflow: hidden;
+        }
+
+        .abspos {
+            position: absolute;
+            z-index: 2;
+            width: 500px;
+            height: 200px;
+            background-color: green;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        function showDialog()
+        {
+            let dialog = document.getElementsByTagName('dialog')[0];
+            dialog.showModal();
+        }
+
+        window.addEventListener('load', () => {
+            setTimeout(() => {
+                showDialog();
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            }, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="negative-z">
+        x
+        <div class="negative-z transformed">x</div>
+    </div>
+    <div class="relpos">
+        <dialog>
+            <div class="abspos">Test passes if it does not crash.</div>
+        </dialog>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-fullscreen-expected.txt
+++ b/LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-fullscreen-expected.txt
@@ -1,0 +1,2 @@
+x x
+Test passes if it does not crash.

--- a/LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-fullscreen-variant-expected.txt
+++ b/LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-fullscreen-variant-expected.txt
@@ -1,0 +1,2 @@
+x x
+Test passes if it does not crash..

--- a/LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-fullscreen-variant.html
+++ b/LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-fullscreen-variant.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .negative-z {
+            position: absolute;
+            top: 20px;
+            left: 20px;
+            z-index: -1;
+            width: 20px;
+            height: 20px;
+            border: 1px solid blue;
+        }
+
+        .transformed {
+            transform: translateZ(0);
+        }
+
+        .relpos {
+            position: relative;
+            height: 500px;
+            height: 600px;
+            margin: 20px 40px;
+            border: 2px solid gray;
+        }
+
+        .fullscreen {
+            position: relative;
+            margin: 0px auto;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0, 0, 0, 0.5);
+            overflow: hidden;
+        }
+
+        .abspos {
+            position: absolute;
+            z-index: 2;
+            width: 500px;
+            height: 165px;
+            background-color: green;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        function requestFullscreen()
+        {
+            let fullscreen = document.querySelector('.fullscreen');
+
+            fullscreen.addEventListener("fullscreenchange", () => {
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+
+            internals.withUserGesture(() => {
+                fullscreen.requestFullscreen();
+            });
+        }
+
+        window.addEventListener('load', () => {
+            setTimeout(() => {
+                requestFullscreen();
+            }, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="negative-z">
+        x
+        <div class="negative-z transformed">x</div>
+    </div>
+    <div class="relpos">
+        <div class="fullscreen">
+            <div class="abspos">Test passes if it does not crash..</div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-fullscreen.html
+++ b/LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-fullscreen.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .negative-z {
+            position: absolute;
+            top: 20px;
+            left: 20px;
+            z-index: -1;
+            width: 20px;
+            height: 20px;
+            border: 1px solid blue;
+        }
+
+        .transformed {
+            transform: translateZ(0);
+        }
+
+        .relpos {
+            position: relative;
+            height: 500px;
+            height: 600px;
+            margin: 20px 40px;
+            border: 2px solid gray;
+        }
+
+        .fullscreen {
+            position: relative;
+            margin: 0px auto;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0, 0, 0, 0.5);
+            overflow: hidden;
+        }
+
+        .abspos {
+            position: absolute;
+            z-index: 2;
+            width: 500px;
+            height: 165px;
+            background-color: green;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        function requestFullscreen()
+        {
+            let fullscreen = document.querySelector('.fullscreen');
+
+            fullscreen.addEventListener("fullscreenchange", () => {
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+
+            internals.withUserGesture(() => {
+                fullscreen.requestFullscreen();
+            });
+        }
+
+        window.addEventListener('load', () => {
+            setTimeout(() => {
+                requestFullscreen();
+            }, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="negative-z">
+        x
+        <div class="negative-z transformed">x</div>
+    </div>
+    <div class="relpos">
+        <div class="fullscreen">
+            <div class="abspos">Test passes if it does not crash.</div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-popover-expected.txt
+++ b/LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-popover-expected.txt
@@ -1,0 +1,2 @@
+x x
+Test passes if it does not crash.

--- a/LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-popover.html
+++ b/LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-popover.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .negative-z {
+            position: absolute;
+            top: 20px;
+            left: 20px;
+            z-index: -1;
+            width: 20px;
+            height: 20px;
+            border: 1px solid blue;
+        }
+
+        .transformed {
+            transform: translateZ(0);
+        }
+
+        .relpos {
+            position: relative;
+            height: 650px;
+            height: 770px;
+            margin: 20px 40px;
+            border: 2px solid gray;
+        }
+
+        .popover {
+            position: relative;
+            margin: 0px auto;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0, 0, 0, 0.5);
+            overflow: hidden;
+            display: block;
+        }
+
+        .abspos {
+            position: absolute;
+            z-index: 2;
+            width: 500px;
+            height: 165px;
+            background-color: green;
+        }
+    </style>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        function showPopover()
+        {
+            let popover = document.querySelector('.popover');
+            popover.showPopover();
+        }
+
+        window.addEventListener('load', () => {
+            setTimeout(() => {
+                showPopover();
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            }, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="negative-z">
+        x
+        <div class="negative-z transformed">x</div>
+    </div>
+    <div class="relpos">
+        <div popover class="popover" id="mypopover">
+            <div class="abspos">
+                Test passes if it does not crash.
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4019,6 +4019,8 @@ bool RenderLayer::establishesTopLayer() const
 
 void RenderLayer::establishesTopLayerWillChange()
 {
+    compositor().establishesTopLayerWillChangeForLayer(*this);
+
     if (auto* parentLayer = parent())
         parentLayer->removeChild(*this);
 }
@@ -5299,7 +5301,7 @@ void RenderLayer::repaintIncludingDescendants()
 
 bool RenderLayer::canUseOffsetFromAncestor(const RenderLayer& ancestor) const
 {
-    for (auto* layer = this; layer != &ancestor; layer = layer->parent()) {
+    for (auto* layer = this; layer && layer != &ancestor; layer = layer->parent()) {
         if (!layer->canUseOffsetFromAncestor())
             return false;
     }
@@ -5975,7 +5977,7 @@ void showLayerTree(const WebCore::RenderObject* renderer)
 static void outputPaintOrderTreeLegend(TextStream& stream)
 {
     stream.nextLine();
-    stream << "(S)tacking Context/(F)orced SC/O(P)portunistic SC, (N)ormal flow only, (O)verflow clip, (A)lpha (opacity or mask), has (B)lend mode, (I)solates blending, (T)ransform-ish, (F)ilter, Fi(X)ed position, Behaves as fi(x)ed, (C)omposited, (P)rovides backing/uses (p)rovided backing/paints to (a)ncestor, (c)omposited descendant, (s)scrolling ancestor, (t)transformed ancestor\n"
+    stream << "(T)op layer, (S)tacking Context/(F)orced SC/O(P)portunistic SC, (N)ormal flow only, (O)verflow clip, (A)lpha (opacity or mask), has (B)lend mode, (I)solates blending, (T)ransform-ish, (F)ilter, Fi(X)ed position, Behaves as fi(x)ed, (C)omposited, (P)rovides backing/uses (p)rovided backing/paints to (a)ncestor, (c)omposited descendant, (s)scrolling ancestor, (t)transformed ancestor\n"
         "Dirty (z)-lists, Dirty (n)ormal flow lists\n"
         "Traversal needs: requirements (t)raversal on descendants, (b)acking or hierarchy traversal on descendants, (r)equirements traversal on all descendants, requirements traversal on all (s)ubsequent layers, (h)ierarchy traversal on all descendants, update of paint (o)rder children\n"
         "Update needs:    post-(l)ayout requirements, (g)eometry, (k)ids geometry, (c)onfig, layer conne(x)ion, (s)crolling tree\n"
@@ -5992,6 +5994,7 @@ static void outputIdent(TextStream& stream, unsigned depth)
 
 static void outputPaintOrderTreeRecursive(TextStream& stream, const WebCore::RenderLayer& layer, const char* prefix, unsigned depth = 0)
 {
+    stream << (layer.establishesTopLayer() ? "T" : "-");
     stream << (layer.isCSSStackingContext() ? "S" : (layer.isForcedStackingContext() ? "F" : (layer.isOpportunisticStackingContext() ? "P" : "-")));
     stream << (layer.isNormalFlowOnly() ? "N" : "-");
     stream << (layer.renderer().hasNonVisibleOverflow() ? "O" : "-");

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -244,6 +244,8 @@ public:
 
     void layerStyleChanged(StyleDifference, RenderLayer&, const RenderStyle* oldStyle);
 
+    void establishesTopLayerWillChangeForLayer(RenderLayer&);
+
     // Get the nearest ancestor layer that has overflow or clip, but is not a stacking context
     RenderLayer* enclosingNonStackingClippingLayer(const RenderLayer&) const;
 
@@ -434,6 +436,8 @@ private:
 
     void updateBackingSharingBeforeDescendantTraversal(BackingSharingState&, unsigned depth, const LayerOverlapMap&, RenderLayer&, OverlapExtent&, bool willBeComposited, RenderLayer* stackingContextAncestor);
     void updateBackingSharingAfterDescendantTraversal(BackingSharingState&, unsigned depth, const LayerOverlapMap&, RenderLayer&, OverlapExtent&, const RenderLayer* preDescendantProviderStartLayer, RenderLayer* stackingContextAncestor);
+
+    void clearBackingProviderSequencesInStackingContextOfLayer(RenderLayer&);
 
     void updateCompositingLayersTimerFired();
 


### PR DESCRIPTION
#### 1021d66fe7c33f8661132fbe8803e7bca4e91692
<pre>
Crash under RenderLayer::calculateClipRects() when going into fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=268891">https://bugs.webkit.org/show_bug.cgi?id=268891</a>
<a href="https://rdar.apple.com/121960496">rdar://121960496</a>

Reviewed by Alan Baradlay.

A combination of top layer and compositing backing sharing can cause a null de-ref when entering fullscreen,
or using modal dialogs or popovers.

The issue occurs when the renderer going into top layer participates in a backing sharing sequence, in the
`RenderLayer::paintsIntoProvidedBacking()` sense. What happens in that case is that after the top layer
configuration is changed we do a layout, after which `RenderLayerBacking::updateAfterLayout()` calls
`RenderLayerBacking::updateCompositedBounds()` (this seems like an odd thing to do, because we&apos;re going
to do a compositing update anyway, but a comment explains why we do it). This call requires that we compute
clip rects, which calls `RenderLayer::canUseOffsetFromAncestor()`, which gets confused because the ancestor
layer is no longer an ancestor.

The fix is to clear any relevant backing sharing sequences when going into top layer, where &quot;relevant&quot; means
backing sharing sequences in the stacking context of the layer that&apos;s going into top layer. We do that
by calling into RenderLayerCompositor from `RenderLayer::establishesTopLayerWillChange()`. Normally traversing
layers in a stacking context would walk the z-order lists, and this works for popover and dialog, but fullscreen
triggers a style update before this code runs, which clears the z-order lists. So this stacking context
traversal is written in terms of the RenderLayer tree (like `collectLayers()`).

* LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-dialog-expected.txt: Added.
* LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-dialog.html: Added.
* LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-fullscreen-expected.txt: Added.
* LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-fullscreen-variant-expected.txt: Added.
* LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-fullscreen-variant.html: Added.
* LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-fullscreen.html: Added.
* LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-popover-expected.txt: Added.
* LayoutTests/compositing/shared-backing/top-layer/backing-sharing-split-by-popover.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::establishesTopLayerWillChange):
(WebCore::RenderLayer::calculateClipRects const):
(WebCore::outputPaintOrderTreeLegend):
(WebCore::outputPaintOrderTreeRecursive):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::establishesTopLayerWillChangeForLayer):
(WebCore::clearBackingSharingWithinStackingContext):
(WebCore::RenderLayerCompositor::clearBackingProviderSequencesInStackingContextOfLayer):
* Source/WebCore/rendering/RenderLayerCompositor.h:

Canonical link: <a href="https://commits.webkit.org/274290@main">https://commits.webkit.org/274290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66e06357484a657503bec0bc2d066788700d546f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41049 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34193 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40813 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32384 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14691 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12765 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12745 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34371 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42325 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34972 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34778 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38586 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36790 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/33672 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8653 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13823 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14428 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->