### PR TITLE
Adopt more smart pointers in Source/WebCore/loader

### DIFF
--- a/Source/WebCore/loader/FormSubmission.cpp
+++ b/Source/WebCore/loader/FormSubmission.cpp
@@ -251,6 +251,11 @@ URL FormSubmission::requestURL() const
     return requestURL;
 }
 
+RefPtr<Event> FormSubmission::protectedEvent() const
+{
+    return m_event;
+}
+
 void FormSubmission::populateFrameLoadRequest(FrameLoadRequest& frameRequest)
 {
     ASSERT(m_method == Method::Post || m_method == Method::Get);

--- a/Source/WebCore/loader/FormSubmission.h
+++ b/Source/WebCore/loader/FormSubmission.h
@@ -92,6 +92,7 @@ public:
     const String boundary() const { return m_boundary; }
     LockHistory lockHistory() const { return m_lockHistory; }
     Event* event() const { return m_event.get(); }
+    RefPtr<Event> protectedEvent() const;
     const String& referrer() const { return m_referrer; }
     const String& origin() const { return m_origin; }
 

--- a/Source/WebCore/loader/NavigationScheduler.h
+++ b/Source/WebCore/loader/NavigationScheduler.h
@@ -36,6 +36,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -78,10 +79,11 @@ private:
 
     void timerFired();
     void schedule(std::unique_ptr<ScheduledNavigation>);
+    Ref<Frame> protectedFrame() const;
 
     static LockBackForwardList mustLockBackForwardList(Frame& targetFrame);
 
-    Frame& m_frame;
+    WeakRef<Frame> m_frame;
     Timer m_timer;
     std::unique_ptr<ScheduledNavigation> m_redirect;
 };


### PR DESCRIPTION
#### 9417ecd0518010c14da6563a1281f5bd288f2591
<pre>
Adopt more smart pointers in Source/WebCore/loader
<a href="https://bugs.webkit.org/show_bug.cgi?id=268892">https://bugs.webkit.org/show_bug.cgi?id=268892</a>

Reviewed by Darin Adler.

* Source/WebCore/loader/FormSubmission.cpp:
(WebCore::FormSubmission::protectedEvent const):
* Source/WebCore/loader/FormSubmission.h:
* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::MediaResourceLoader::~MediaResourceLoader):
(WebCore::MediaResourceLoader::sendH2Ping):
(WebCore::MediaResourceLoader::requestResource):
(WebCore::MediaResourceLoader::removeResource):
(WebCore::MediaResourceLoader::protectedDocument):
(WebCore::MediaResource::create):
(WebCore::MediaResource::MediaResource):
(WebCore::MediaResource::protectedLoader const):
(WebCore::MediaResource::protectedResource const):
(WebCore::MediaResource::~MediaResource):
(WebCore::MediaResource::shutdown):
(WebCore::MediaResource::responseReceived):
(WebCore::MediaResource::shouldCacheResponse):
(WebCore::MediaResource::redirectReceived):
(WebCore::MediaResource::dataSent):
(WebCore::MediaResource::dataReceived):
(WebCore::MediaResource::notifyFinished):
* Source/WebCore/loader/MediaResourceLoader.h:
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::foundMixedContentInFrameTree):
(WebCore::logWarning):
(WebCore::MixedContentChecker::frameAndAncestorsCanDisplayInsecureContent):
(WebCore::MixedContentChecker::frameAndAncestorsCanRunInsecureContent):
(WebCore::MixedContentChecker::checkFormForMixedContent):
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledURLNavigation::protectedInitiatingDocument):
(WebCore::ScheduledURLNavigation::protectedSecurityOrigin const):
(WebCore::NavigationScheduler::protectedFrame const):
(WebCore::NavigationScheduler::clear):
(WebCore::NavigationScheduler::shouldScheduleNavigation const):
(WebCore::NavigationScheduler::scheduleRedirect):
(WebCore::NavigationScheduler::mustLockBackForwardList):
(WebCore::NavigationScheduler::scheduleLocationChange):
(WebCore::NavigationScheduler::scheduleFormSubmission):
(WebCore::NavigationScheduler::scheduleRefresh):
(WebCore::NavigationScheduler::scheduleHistoryNavigation):
(WebCore::NavigationScheduler::timerFired):
(WebCore::NavigationScheduler::schedule):
(WebCore::NavigationScheduler::startTimer):
(WebCore::NavigationScheduler::cancel):
* Source/WebCore/loader/NavigationScheduler.h:

Canonical link: <a href="https://commits.webkit.org/274226@main">https://commits.webkit.org/274226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c24247cf03afbd1628093ba8e072c873b707e11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40809 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34029 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14534 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32282 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14517 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12635 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12616 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42088 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34790 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38456 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36652 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14749 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13610 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4989 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->