### PR TITLE
UnifiedPDF: Implement link following (external links)

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -28,7 +28,6 @@
 #if ENABLE(LEGACY_PDFKIT_PLUGIN)
 
 #include "PDFPluginBase.h"
-#include "WebMouseEvent.h"
 #include <WebCore/NetscapePlugInStreamLoader.h>
 #include <wtf/HashMap.h>
 #include <wtf/Identified.h>
@@ -202,8 +201,6 @@ private:
     RetainPtr<WKPDFPluginAccessibilityObject> m_accessibilityObject;
     
     RefPtr<PDFPluginPasswordField> m_passwordField;
-
-    std::optional<WebMouseEvent> m_lastMouseEvent;
 
     String m_temporaryPDFUUID;
     String m_lastFoundString;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -31,6 +31,7 @@
 #include "FrameInfoData.h"
 #include "PDFPluginIdentifier.h"
 #include "PDFScriptEvaluator.h"
+#include "WebMouseEvent.h"
 #include <WebCore/AffineTransform.h>
 #include <WebCore/FindOptions.h>
 #include <WebCore/FloatRect.h>
@@ -196,6 +197,8 @@ public:
     virtual void focusNextAnnotation() = 0;
     virtual void focusPreviousAnnotation() = 0;
 
+    void navigateToURL(const URL&);
+
     virtual void attemptToUnlockPDF(const String& password) = 0;
 
 #if HAVE(INCREMENTAL_PDF_APIS)
@@ -260,7 +263,7 @@ protected:
     WebCore::ScrollPosition minimumScrollPosition() const final;
     WebCore::ScrollPosition maximumScrollPosition() const final;
     WebCore::IntSize visibleSize() const final { return m_size; }
-    WebCore::IntPoint lastKnownMousePositionInView() const override { return m_lastMousePositionInPluginCoordinates; }
+    WebCore::IntPoint lastKnownMousePositionInView() const override;
 
     float deviceScaleFactor() const override;
     bool shouldSuspendScrollAnimations() const final { return false; } // If we return true, ScrollAnimatorMac will keep cycling a timer forever, waiting for a good time to animate.
@@ -316,7 +319,7 @@ protected:
     WebCore::AffineTransform m_rootViewToPluginTransform;
 
     WebCore::IntSize m_scrollOffset;
-    WebCore::IntPoint m_lastMousePositionInPluginCoordinates;
+    std::optional<WebMouseEvent> m_lastMouseEvent;
 
     RefPtr<WebCore::Scrollbar> m_horizontalScrollbar;
     RefPtr<WebCore::Scrollbar> m_verticalScrollbar;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -48,7 +48,7 @@ class AnnotationTrackingState {
 public:
     void startAnnotationTracking(RetainPtr<PDFAnnotation>&&, const WebEventType&, const WebMouseEventButton&);
     void finishAnnotationTracking(const WebEventType&, const WebMouseEventButton&);
-    const PDFAnnotation* trackedAnnotation() const { return m_trackedAnnotation.get(); }
+    const PDFAnnotation *trackedAnnotation() const { return m_trackedAnnotation.get(); }
 private:
     void handleMouseDraggedOffTrackedAnnotation();
     RetainPtr<PDFAnnotation> m_trackedAnnotation;
@@ -247,6 +247,8 @@ private:
     void zoomIn() final;
     void zoomOut() final;
 #endif
+
+    void didClickLinkAnnotation(const PDFAnnotation *);
 
     RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(const String& name, WebCore::GraphicsLayer::Type);
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1000,8 +1000,9 @@ auto UnifiedPDFPlugin::pdfElementTypesForPluginPoint(const WebCore::IntPoint& po
 
 bool UnifiedPDFPlugin::handleMouseEvent(const WebMouseEvent& event)
 {
-    m_lastMousePositionInPluginCoordinates = convertFromRootViewToPlugin(event.position());
-    auto pointInDocumentSpace = convertFromPluginToDocument(m_lastMousePositionInPluginCoordinates);
+    m_lastMouseEvent = event;
+
+    auto pointInDocumentSpace = convertFromPluginToDocument(lastKnownMousePositionInView());
     auto pageIndex = pageIndexForDocumentPoint(pointInDocumentSpace);
     if (!pageIndex)
         return false;
@@ -1014,7 +1015,7 @@ bool UnifiedPDFPlugin::handleMouseEvent(const WebMouseEvent& event)
         switch (auto mouseEventButton = event.button()) {
         case WebMouseEventButton::None: {
             auto altKeyIsActive = event.altKey() ? AltKeyIsActive::Yes : AltKeyIsActive::No;
-            auto pdfElementTypes = pdfElementTypesForPluginPoint(m_lastMousePositionInPluginCoordinates);
+            auto pdfElementTypes = pdfElementTypesForPluginPoint(lastKnownMousePositionInView());
             notifyCursorChanged(toWebCoreCursorType(pdfElementTypes, altKeyIsActive));
             if (m_annotationTrackingState.trackedAnnotation()) {
                 m_annotationTrackingState.finishAnnotationTracking(mouseEventType, mouseEventButton);
@@ -1024,6 +1025,7 @@ bool UnifiedPDFPlugin::handleMouseEvent(const WebMouseEvent& event)
         }
         case WebMouseEventButton::Left: {
             if (RetainPtr trackedAnnotation = m_annotationTrackingState.trackedAnnotation(); trackedAnnotation && trackedAnnotation != annotationForRootViewPoint(event.position())) {
+                notifyCursorChanged(toWebCoreCursorType({ }));
                 m_annotationTrackingState.finishAnnotationTracking(mouseEventType, mouseEventButton);
                 updateLayerHierarchy();
                 return true;
@@ -1046,11 +1048,18 @@ bool UnifiedPDFPlugin::handleMouseEvent(const WebMouseEvent& event)
                     setActiveAnnotation(WTFMove(annotation));
                     return true;
                 }
+
                 if ([annotation isKindOfClass:getPDFAnnotationButtonWidgetClass()]) {
                     m_annotationTrackingState.startAnnotationTracking(WTFMove(annotation), mouseEventType, mouseEventButton);
                     updateLayerHierarchy();
                     return true;
                 }
+
+                if ([annotation isKindOfClass:getPDFAnnotationLinkClass()]) {
+                    m_annotationTrackingState.startAnnotationTracking(WTFMove(annotation), mouseEventType, mouseEventButton);
+                    return true;
+                }
+
                 return false;
             }
 
@@ -1066,10 +1075,15 @@ bool UnifiedPDFPlugin::handleMouseEvent(const WebMouseEvent& event)
 
         switch (auto mouseEventButton = event.button()) {
         case WebMouseEventButton::Left:
-            if (m_annotationTrackingState.trackedAnnotation()) {
+            if (RetainPtr trackedAnnotation = m_annotationTrackingState.trackedAnnotation()) {
                 m_annotationTrackingState.finishAnnotationTracking(mouseEventType, mouseEventButton);
+
+                if ([trackedAnnotation isKindOfClass:getPDFAnnotationLinkClass()])
+                    didClickLinkAnnotation(trackedAnnotation.get());
+
                 updateLayerHierarchy();
             }
+
             return false;
         default:
             return false;
@@ -1087,6 +1101,14 @@ bool UnifiedPDFPlugin::handleMouseEnterEvent(const WebMouseEvent&)
 bool UnifiedPDFPlugin::handleMouseLeaveEvent(const WebMouseEvent&)
 {
     return false;
+}
+
+void UnifiedPDFPlugin::didClickLinkAnnotation(const PDFAnnotation *annotation)
+{
+    // FIXME: Handle links with in-document destinations.
+
+    if (NSURL *url = [annotation URL])
+        navigateToURL(url);
 }
 
 #if PLATFORM(MAC)
@@ -1457,8 +1479,7 @@ void AnnotationTrackingState::finishAnnotationTracking(const WebEventType& mouse
                 [m_trackedAnnotation setButtonWidgetState:PDFWidgetCellState::kPDFWidgetOffState];
             else if (currentButtonState == PDFWidgetCellState::kPDFWidgetOffState)
                 [m_trackedAnnotation setButtonWidgetState:PDFWidgetCellState::kPDFWidgetOnState];
-        } else
-            ASSERT_NOT_IMPLEMENTED_YET();
+        }
     } else if (mouseEventType == WebEventType::MouseMove && mouseEventButton == WebMouseEventButton::Left)
         handleMouseDraggedOffTrackedAnnotation();
     m_trackedAnnotation = nullptr;


### PR DESCRIPTION
#### 869c3738830502f32e8eb2b2e2fc7ae1afb773c4
<pre>
UnifiedPDF: Implement link following (external links)
<a href="https://bugs.webkit.org/show_bug.cgi?id=268894">https://bugs.webkit.org/show_bug.cgi?id=268894</a>
<a href="https://rdar.apple.com/118550787">rdar://118550787</a>

Reviewed by Richard Robinson.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
Hoist m_lastMouseEvent to PDFPluginBase.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::clickedLink): Deleted.
Hoist clickedLink up to PDFPluginBase.

(-[WKPDFLayerControllerDelegate pdfLayerController:clickedLinkWithURL:]):
Adopt it in WKPDFLayerControllerDelegate.

(WebKit::PDFPlugin::nsEventForWebMouseEvent):
(WebKit::PDFPlugin::handleMouseEvent):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::lastKnownMousePositionInView const):
Get rid of m_lastMousePositionInPluginCoordinates; since we have to store the
whole event, we&apos;ll just use that instead.

(WebKit::PDFPluginBase::navigateToURL): Hoist!

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
(WebKit::AnnotationTrackingState::trackedAnnotation const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::handleMouseEvent):
Update the cursor to the pointer when we stop tracking an annotation.
We&apos;ll start updating again after the mouseup.

(WebKit::UnifiedPDFPlugin::didClickLinkAnnotation):
Follow the link! Later we&apos;ll follow internal links too.

(WebKit::AnnotationTrackingState::finishAnnotationTracking):
Remove this assertion so we can track other types of annotations that
don&apos;t do anything here.

Canonical link: <a href="https://commits.webkit.org/274205@main">https://commits.webkit.org/274205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d433fbb8c5650667494fccd82c8316275e1e59c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40826 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34042 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14552 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38841 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/14531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12645 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42105 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/34816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38464 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13208 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36661 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14762 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8610 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->