### PR TITLE
Text inserted after a <picture> element ends up inside the element

### DIFF
--- a/LayoutTests/editing/inserting/insert-text-after-picture-expected.txt
+++ b/LayoutTests/editing/inserting/insert-text-after-picture-expected.txt
@@ -1,0 +1,14 @@
+Test text insertion after <picture>.
+
+Initial state:
+| <#selection-anchor>
+| <picture>
+|   <img>
+|     src="../resources/abe.png"
+| <#selection-focus>
+
+After insertion:
+| <picture>
+|   <img>
+|     src="../resources/abe.png"
+| "abe<#selection-caret>"

--- a/LayoutTests/editing/inserting/insert-text-after-picture.html
+++ b/LayoutTests/editing/inserting/insert-text-after-picture.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/dump-as-markup.js"></script>
+<div id="editor" contenteditable><picture><img src="../resources/abe.png"></picture></div>
+<script>
+
+Markup.description('Test text insertion after <picture>.');
+
+var editor = document.getElementById('editor');
+editor.focus();
+document.execCommand('SelectAll', false, null);
+Markup.dump(editor, 'Initial state');
+
+document.getSelection().collapseToEnd();
+document.execCommand('InsertText', false, 'abe');
+
+Markup.dump(editor, 'After insertion');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLPictureElement.h
+++ b/Source/WebCore/html/HTMLPictureElement.h
@@ -42,6 +42,8 @@ public:
     WEBCORE_EXPORT bool isSystemPreviewImage();
 #endif
 
+    bool canContainRangeEndPoint() const override { return false; }
+
 private:
     HTMLPictureElement(const QualifiedName&, Document&);
 };


### PR DESCRIPTION
#### 0c1fbe78b48c6ff69e55d999f9a22492c53406fd
<pre>
Text inserted after a &lt;picture&gt; element ends up inside the element
<a href="https://bugs.webkit.org/show_bug.cgi?id=268895">https://bugs.webkit.org/show_bug.cgi?id=268895</a>
<a href="https://rdar.apple.com/122449003">rdar://122449003</a>

Reviewed by NOBODY (OOPS!).

When attempting to insert text (or any node) after a &lt;picture&gt; element, position
canonicalization results in insertion occuring inside the &lt;picture&gt; element. This
is undesirable, since &lt;picture&gt; elements are only intended to contain an &lt;img&gt; and
one or more &lt;source&gt; elements.

* LayoutTests/editing/inserting/insert-text-after-picture-expected.txt: Added.
* LayoutTests/editing/inserting/insert-text-after-picture.html: Added.
* Source/WebCore/html/HTMLPictureElement.h:

`canContainRangeEndPoint` is used by `canHaveChildrenForEditing`. Ensure that
&lt;picture&gt; cannot gain children from editing, similar to other elements that
behave as a single unit.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c1fbe78b48c6ff69e55d999f9a22492c53406fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40817 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34035 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32286 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14523 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12642 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12622 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42096 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34801 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38460 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13202 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36657 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14755 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/33511 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13615 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14220 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->