### PR TITLE
[WebGPU] ShaderModule::createLibrary may produce invalid metal with custom layouts

### DIFF
--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -55,7 +55,7 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
 
     auto prepareResult = WGSL::prepare(*ast, entryPoint, wgslPipelineLayout);
 
-    auto library = ShaderModule::createLibrary(device, prepareResult.msl, label);
+    auto library = ShaderModule::createLibrary(device, prepareResult.msl, label, pipelineLayout && !pipelineLayout->isAutoLayout());
 
     auto iterator = prepareResult.entryPoints.find(entryPoint);
     if (iterator == prepareResult.entryPoints.end())

--- a/Source/WebGPU/WebGPU/ShaderModule.h
+++ b/Source/WebGPU/WebGPU/ShaderModule.h
@@ -64,7 +64,7 @@ public:
     bool isValid() const { return std::holds_alternative<WGSL::SuccessfulCheck>(m_checkResult); }
 
     static WGSL::PipelineLayout convertPipelineLayout(const PipelineLayout&);
-    static id<MTLLibrary> createLibrary(id<MTLDevice>, const String& msl, String&& label);
+    static id<MTLLibrary> createLibrary(id<MTLDevice>, const String& msl, String&& label, bool generatedMetalMightBeInvalid);
 
     WGSL::ShaderModule* ast() const;
 


### PR DESCRIPTION
#### ebfd093aa1f0cb1f3c803431e37f3f6d2bca0da3
<pre>
[WebGPU] ShaderModule::createLibrary may produce invalid metal with custom layouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=268898">https://bugs.webkit.org/show_bug.cgi?id=268898</a>
&lt;radar://122256850&gt;

Reviewed by NOBODY (OOPS!).

This is accounting for over 50% of fuzzing crashes, it is because a custom
pipeline layout will impact metal source generation and the combination
may not be valid. So we should only assert in fuzzer builds when auto layout
is used.

Otherwise we return an invalid shader module, which is correct because an
incompatible pipeline layout was used.

* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):
* Source/WebGPU/WebGPU/ShaderModule.h:
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::ShaderModule::createLibrary):
(WebGPU::earlyCompileShaderModule):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebfd093aa1f0cb1f3c803431e37f3f6d2bca0da3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40818 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34036 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/19961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32287 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14524 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12643 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12623 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42097 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34802 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38529 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10912 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36662 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14756 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13616 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14221 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->