### PR TITLE
[JSC] Remove unused macros from ClassInfo.h

### DIFF
--- a/Source/JavaScriptCore/runtime/ClassInfo.h
+++ b/Source/JavaScriptCore/runtime/ClassInfo.h
@@ -127,25 +127,6 @@ struct MethodTable {
 
 #undef METHOD_TABLE_ENTRY
 
-#define CREATE_MEMBER_CHECKER(member) \
-    template <typename T> \
-    struct MemberCheck##member { \
-        struct Fallback { \
-            void member(...); \
-        }; \
-        struct Derived : T, Fallback { }; \
-        template <typename U, U> struct Check; \
-        typedef char Yes[2]; \
-        typedef char No[1]; \
-        template <typename U> \
-        static No &func(Check<void (Fallback::*)(...), &U::member>*); \
-        template <typename U> \
-        static Yes &func(...); \
-        enum { has = sizeof(func<Derived>(0)) == sizeof(Yes) }; \
-    }
-
-#define HAS_MEMBER_NAMED(klass, name) (MemberCheck##name<klass>::has)
-
 #define CREATE_METHOD_TABLE(ClassName) \
     JSCastingHelpers::InheritsTraits<ClassName>::typeRange, \
     { \


### PR DESCRIPTION
#### 701ede139f2da1f652987f24bcdf7ed52d66e2d8
<pre>
[JSC] Remove unused macros from ClassInfo.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=268899">https://bugs.webkit.org/show_bug.cgi?id=268899</a>
&lt;<a href="https://rdar.apple.com/problem/122450501">rdar://problem/122450501</a>&gt;

Reviewed by Mark Lam.

CREATE_MEMBER_CHECKER and HAS_MEMBER_NAMED are unused and quite weird.

* Source/JavaScriptCore/runtime/ClassInfo.h:

Canonical link: <a href="https://commits.webkit.org/274237@main">https://commits.webkit.org/274237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ae046b24492234e81ea0e14744ff858e4a07f49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40822 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34040 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32290 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14591 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12646 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42101 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/31872 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34889 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38463 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/37943 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13206 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/10918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36660 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14760 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/44891 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13619 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9181 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4997 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14225 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->