### PR TITLE
Unify cycle detection logic for legacy & LBSE

### DIFF
--- a/LayoutTests/platform/mac-sonoma-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-sonoma-wk2-lbse-text/TestExpectations
@@ -384,7 +384,6 @@ imported/w3c/web-platform-tests/svg/pservers/reftests/meshgradient-basic-004.svg
 imported/w3c/web-platform-tests/svg/pservers/reftests/meshgradient-basic-005.svg   [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/pservers/reftests/meshgradient-bicubic-001.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/pservers/reftests/meshgradient-complex-001.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/pservers/reftests/meshgradient-basic-001.svg   [ ImageOnlyFailure ]
 
 # Marker problems
 imported/w3c/web-platform-tests/svg/import/imp-path-01-f-manual.svg  [ ImageOnlyFailure ]
@@ -531,7 +530,6 @@ svg/custom/circle-move-invalidation-small-viewBox.svg         [ Pass ]
 svg/custom/use-on-symbol-inside-pattern.svg                   [ Pass ]
 svg/repaint/text-repainting-after-modifying-transform.html    [ Pass ]
 svg/resource-invalidation/mask-resource-invalidation.html     [ Pass ]
-svg/transforms/animated-path-inside-transformed-html.xhtml    [ Pass ]
 svg/transforms/layout-tiny-elements-in-scaled-group.svg       [ Pass ]
 svg/transforms/rotation-origin-in-small-units.svg             [ Pass ]
 svg/transforms/rotation-tiny-element-in-group.svg             [ Pass ]

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2850,11 +2850,7 @@ void RenderLayer::paintSVGResourceLayer(GraphicsContext& context, const AffineTr
     if (!renderer().hasNonVisibleOverflow())
         flags.add(PaintLayerFlag::PaintingOverflowContents);
 
-    {
-        // FIXME: Rename SVGHitTestCycleDetectionScope -> SVGResourceCycleDetectionScope
-        SVGHitTestCycleDetectionScope paintingScope(renderer());
-        paintLayer(context, paintingInfo, flags);
-    }
+    paintLayer(context, paintingInfo, flags);
 
     m_isPaintingSVGResourceLayer = wasPaintingSVGResourceLayer;
 #else

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -105,6 +105,8 @@ public:
     RenderSVGResourceMarker* svgMarkerMidResourceFromStyle() const;
     RenderSVGResourceMarker* svgMarkerEndResourceFromStyle() const;
 
+    bool pointInSVGClippingArea(const FloatPoint&) const;
+
     void paintSVGClippingMask(PaintInfo&, const FloatRect& objectBoundingBox) const;
     void paintSVGMask(PaintInfo&, const LayoutPoint& adjustedPaintOffset) const;
 #endif

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -39,6 +39,7 @@
 #include "SVGMarkerElement.h"
 #include "SVGPathElement.h"
 #include "SVGSubpathData.h"
+#include "SVGVisitedRendererTracking.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -213,10 +214,13 @@ void RenderSVGPath::drawMarkers(PaintInfo& paintInfo)
     if (m_markerPositions.isEmpty())
         return;
 
-    if (SVGHitTestCycleDetectionScope::isVisiting(*this))
+    static NeverDestroyed<SVGVisitedRendererTracking::VisitedSet> s_visitedSet;
+
+    SVGVisitedRendererTracking recursionTracking(s_visitedSet);
+    if (recursionTracking.isVisiting(*this))
         return;
 
-    SVGHitTestCycleDetectionScope paintScope(*this);
+    SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
 
     auto* markerStart = svgMarkerStartResourceFromStyle();
     auto* markerMid = svgMarkerMidResourceFromStyle();
@@ -241,10 +245,13 @@ FloatRect RenderSVGPath::computeMarkerBoundingBox(const SVGBoundingBoxComputatio
     if (m_markerPositions.isEmpty())
         return { };
 
-    if (SVGHitTestCycleDetectionScope::isVisiting(*this))
+    static NeverDestroyed<SVGVisitedRendererTracking::VisitedSet> s_visitedSet;
+
+    SVGVisitedRendererTracking recursionTracking(s_visitedSet);
+    if (recursionTracking.isVisiting(*this))
         return { };
 
-    SVGHitTestCycleDetectionScope queryScope(*this);
+    SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
 
     auto* markerStart = svgMarkerStartResourceFromStyle();
     auto* markerMid = svgMarkerMidResourceFromStyle();

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
- * Copyright (c) 2023 Igalia S.L.
+ * Copyright (c) 2023, 2024 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -27,7 +27,7 @@
 #include "RenderSVGRoot.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGResourceElementClient.h"
-
+#include "SVGVisitedElementTracking.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/SetForScope.h>
 #include <wtf/StackStats.h>
@@ -69,6 +69,23 @@ void RenderSVGResourceContainer::idChanged()
     registerResource();
 }
 
+static inline void notifyResourceChanged(SVGElement& element)
+{
+    static NeverDestroyed<SVGVisitedElementTracking::VisitedSet> s_visitedSet;
+
+    SVGVisitedElementTracking recursionTracking(s_visitedSet);
+    if (recursionTracking.isVisiting(element))
+        return;
+
+    SVGVisitedElementTracking::Scope recursionScope(recursionTracking, element);
+
+    for (auto& cssClient : element.referencingCSSClients()) {
+        if (!cssClient)
+            continue;
+        cssClient->resourceChanged(element);
+    }
+}
+
 void RenderSVGResourceContainer::registerResource()
 {
     auto& treeScope = this->treeScopeForSVGReferences();
@@ -79,24 +96,14 @@ void RenderSVGResourceContainer::registerResource()
     for (auto& element : elements) {
         ASSERT(element->hasPendingResources());
         treeScope.clearHasPendingSVGResourcesIfPossible(element);
-
-        for (auto& cssClient : element->referencingCSSClients()) {
-            if (!cssClient)
-                continue;
-            cssClient->resourceChanged(element.get());
-        }
+        notifyResourceChanged(element.get());
     }
 }
 
 void RenderSVGResourceContainer::repaintAllClients() const
 {
     Ref svgElement = element();
-
-    for (auto& cssClient : svgElement->referencingCSSClients()) {
-        if (!cssClient)
-            continue;
-        cssClient->resourceChanged(svgElement.get());
-    }
+    notifyResourceChanged(svgElement.get());
 }
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -435,8 +435,6 @@ bool RenderSVGRoot::nodeAtPoint(const HitTestRequest& request, HitTestResult& re
 {
     auto adjustedLocation = accumulatedOffset + location();
 
-    ASSERT(SVGHitTestCycleDetectionScope::isEmpty());
-
     auto visualOverflowRect = this->visualOverflowRect();
     visualOverflowRect.moveBy(adjustedLocation);
 
@@ -446,7 +444,6 @@ bool RenderSVGRoot::nodeAtPoint(const HitTestRequest& request, HitTestResult& re
         for (auto* child = lastChild(); child; child = child->previousSibling()) {
             if (!child->hasLayer() && child->nodeAtPoint(request, result, locationInContainer, adjustedLocation, hitTestAction)) {
                 updateHitTestResult(result, locationInContainer.point() - toLayoutSize(adjustedLocation));
-                ASSERT(SVGHitTestCycleDetectionScope::isEmpty());
                 return true;
             }
         }
@@ -461,8 +458,6 @@ bool RenderSVGRoot::nodeAtPoint(const HitTestRequest& request, HitTestResult& re
                 return true;
         }
     }
-
-    ASSERT(SVGHitTestCycleDetectionScope::isEmpty());
 
     return false;
 }

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.h
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.h
@@ -97,17 +97,4 @@ private:
     ~SVGRenderSupport();
 };
 
-class SVGHitTestCycleDetectionScope {
-    WTF_MAKE_NONCOPYABLE(SVGHitTestCycleDetectionScope);
-public:
-    explicit SVGHitTestCycleDetectionScope(const RenderElement&, bool condition = true);
-    ~SVGHitTestCycleDetectionScope();
-    static bool isEmpty();
-    static bool isVisiting(const RenderElement&);
-
-private:
-    static SingleThreadWeakHashSet<RenderElement>& visitedElements();
-    SingleThreadWeakPtr<RenderElement> m_element;
-};
-
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGVisitedRendererTracking.h
+++ b/Source/WebCore/rendering/svg/SVGVisitedRendererTracking.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "RenderElement.h"
+#include <wtf/WeakHashSet.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class SVGVisitedRendererTracking {
+public:
+    using VisitedSet = SingleThreadWeakHashSet<RenderElement>;
+
+    SVGVisitedRendererTracking(VisitedSet& visitedSet)
+        : m_visitedRenderers(visitedSet)
+    {
+    }
+
+    ~SVGVisitedRendererTracking() = default;
+
+    bool isEmpty() const { return m_visitedRenderers.isEmptyIgnoringNullReferences(); }
+    bool isVisiting(const RenderElement& renderer) { return m_visitedRenderers.contains(renderer); }
+
+    class Scope {
+    public:
+        Scope(SVGVisitedRendererTracking& tracking, const RenderElement& renderer)
+            : m_tracking(tracking)
+            , m_renderer(renderer)
+        {
+            m_tracking.addUnique(renderer);
+        }
+
+        ~Scope()
+        {
+            if (m_renderer)
+                m_tracking.removeUnique(*m_renderer);
+        }
+
+    private:
+        SVGVisitedRendererTracking& m_tracking;
+        SingleThreadWeakPtr<RenderElement> m_renderer;
+    };
+
+private:
+    friend class Scope;
+
+    void addUnique(const RenderElement& renderer)
+    {
+        auto result = m_visitedRenderers.add(renderer);
+        ASSERT_UNUSED(result, result.isNewEntry);
+    }
+
+    void removeUnique(const RenderElement& renderer)
+    {
+        bool result = m_visitedRenderers.remove(renderer);
+        ASSERT_UNUSED(result, result);
+    }
+
+    VisitedSet& m_visitedRenderers;
+};
+
+}; // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -481,8 +481,6 @@ bool LegacyRenderSVGRoot::nodeAtPoint(const HitTestRequest& request, HitTestResu
     LayoutPoint pointInParent = locationInContainer.point() - toLayoutSize(accumulatedOffset);
     LayoutPoint pointInBorderBox = pointInParent - toLayoutSize(location());
 
-    ASSERT(SVGHitTestCycleDetectionScope::isEmpty());
-
     // Test SVG content if the point is in our content box or it is inside the visualOverflowRect and the overflow is visible.
     // FIXME: This should be an intersection when rect-based hit tests are supported by nodeAtFloatPoint.
     if (contentBoxRect().contains(pointInBorderBox) || (!shouldApplyViewportClip() && visualOverflowRect().contains(pointInParent))) {
@@ -492,10 +490,8 @@ bool LegacyRenderSVGRoot::nodeAtPoint(const HitTestRequest& request, HitTestResu
             // FIXME: nodeAtFloatPoint() doesn't handle rect-based hit tests yet.
             if (child->nodeAtFloatPoint(request, result, localPoint, hitTestAction)) {
                 updateHitTestResult(result, pointInBorderBox);
-                if (result.addNodeToListBasedTestResult(child->node(), request, locationInContainer) == HitTestProgress::Stop) {
-                    ASSERT(SVGHitTestCycleDetectionScope::isEmpty());
+                if (result.addNodeToListBasedTestResult(child->node(), request, locationInContainer) == HitTestProgress::Stop)
                     return true;
-                }
             }
         }
     }
@@ -513,8 +509,6 @@ bool LegacyRenderSVGRoot::nodeAtPoint(const HitTestRequest& request, HitTestResu
                 return true;
         }
     }
-
-    ASSERT(SVGHitTestCycleDetectionScope::isEmpty());
 
     return false;
 }

--- a/Source/WebCore/svg/SVGVisitedElementTracking.h
+++ b/Source/WebCore/svg/SVGVisitedElementTracking.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "SVGElement.h"
+#include <wtf/WeakHashSet.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class SVGVisitedElementTracking {
+public:
+    using VisitedSet = WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>;
+
+    SVGVisitedElementTracking(VisitedSet& visitedSet)
+        : m_visitedElements(visitedSet)
+    {
+    }
+
+    ~SVGVisitedElementTracking() = default;
+
+    bool isEmpty() const { return m_visitedElements.isEmptyIgnoringNullReferences(); }
+    bool isVisiting(const SVGElement& element) { return m_visitedElements.contains(element); }
+
+    class Scope {
+    public:
+        Scope(SVGVisitedElementTracking& tracking, const SVGElement& element)
+            : m_tracking(tracking)
+            , m_element(element)
+        {
+            m_tracking.addUnique(element);
+        }
+
+        ~Scope()
+        {
+            if (m_element)
+                m_tracking.removeUnique(*m_element);
+        }
+
+    private:
+        SVGVisitedElementTracking& m_tracking;
+        WeakPtr<SVGElement, WeakPtrImplWithEventTargetData> m_element;
+    };
+
+private:
+    friend class Scope;
+
+    void addUnique(const SVGElement& element)
+    {
+        auto result = m_visitedElements.add(element);
+        ASSERT_UNUSED(result, result.isNewEntry);
+    }
+
+    void removeUnique(const SVGElement& element)
+    {
+        bool result = m_visitedElements.remove(element);
+        ASSERT_UNUSED(result, result);
+    }
+
+    VisitedSet& m_visitedElements;
+};
+
+}; // namespace WebCore


### PR DESCRIPTION
#### 3bd5bd5c81f2cb45f09ff2c8d004241544ce69aa
<pre>
Unify cycle detection logic for legacy &amp; LBSE
<a href="https://bugs.webkit.org/show_bug.cgi?id=268909">https://bugs.webkit.org/show_bug.cgi?id=268909</a>

Reviewed by Rob Buis.

Provide one unique way to prevent recursion in SVG: SVGVisitedRendererTracking.
We already had SVGHitTestCycleDetectionScope to prevent cycles in the legacy
SVG engine during hit-testing, and custom code in SVGSMILElement that provided
the same functionality, but SVGElement, not RenderElement based.

Unify the logic in SVGVisitedRenderingTracking / SVGVisitedElementTracking
and make use of them throughout the legacy SVG engine &amp; LBSE.

It&apos;s used like this:

&lt;example&gt;
bool RenderSVGSomething::someMethod()
{
    static NeverDestroyed&lt;SVGVisitedRendererTracking::VisitedSet&gt; s_visitedSet;

    SVGVisitedRendererTracking recursionTracking(s_visitedSet);
    if (recursionTracking.isVisiting(*this))
        return false;

    SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);

    // We can be sure that if someMethod() is entered again - we&apos;ll gracefully exit as
    // SVGVisitedRendererTracking::isVisiting(const RenderElement&amp;) returns true above.
    performActionThatPotententiallyEntersThisMethodAgain();
    return true;
}
&lt;/example&gt;

Unlike SVGHitTestCycleDetectionScope there is no single static HashSet
shared between all instances of SVGVisitedRendererTracking::Scope - instead
it is passed in as reference to the SVGVisitedRendererTracking constructor.
This allows to seperate the different cylce detection scopes in a fine-grained
way, e.g. per method, per type, etc.

Covered by existing tests.

* LayoutTests/platform/mac-sonoma-wk2-lbse-text/TestExpectations:
Some gardening - cleanup duplicated entries so lint passes again.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintSVGResourceLayer):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::pointInSVGClippingArea const):
* Source/WebCore/rendering/RenderLayerModelObject.h:
* Source/WebCore/rendering/svg/RenderSVGContainer.cpp:
(WebCore::RenderSVGContainer::nodeAtPoint):
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::nodeAtPoint):
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::RenderSVGPath::drawMarkers):
(WebCore::RenderSVGPath::computeMarkerBoundingBox const):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::applyMaskClipping):
(WebCore::RenderSVGResourceClipper::hitTestClipContent):
(WebCore::RenderSVGResourceClipper::resourceBoundingBox):
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp:
(WebCore::notifyResourceChanged):
(WebCore::RenderSVGResourceContainer::registerResource):
(WebCore::RenderSVGResourceContainer::repaintAllClients const):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::applyMask):
(WebCore::RenderSVGResourceMasker::resourceBoundingBox):
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
(WebCore::RenderSVGResourcePattern::createTileImage const):
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::nodeAtPoint):
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::nodeAtPoint):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::nodeAtFloatPoint):
(WebCore::RenderSVGText::nodeAtPoint):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::pointInClippingArea):
(WebCore::SVGHitTestCycleDetectionScope::SVGHitTestCycleDetectionScope): Deleted.
(WebCore::SVGHitTestCycleDetectionScope::~SVGHitTestCycleDetectionScope): Deleted.
(WebCore::SVGHitTestCycleDetectionScope::visitedElements): Deleted.
(WebCore::SVGHitTestCycleDetectionScope::isEmpty): Deleted.
(WebCore::SVGHitTestCycleDetectionScope::isVisiting): Deleted.
* Source/WebCore/rendering/svg/SVGRenderSupport.h:
* Source/WebCore/rendering/svg/SVGVisitedRendererTracking.h: Added.
(WebCore::SVGVisitedRendererTracking::SVGVisitedRendererTracking):
(WebCore::SVGVisitedRendererTracking::isEmpty const):
(WebCore::SVGVisitedRendererTracking::isVisiting):
(WebCore::SVGVisitedRendererTracking::Scope::Scope):
(WebCore::SVGVisitedRendererTracking::Scope::~Scope):
(WebCore::SVGVisitedRendererTracking::addUnique):
(WebCore::SVGVisitedRendererTracking::removeUnique):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::nodeAtFloatPoint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::nodeAtFloatPoint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::hitTestClipContent):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::nodeAtPoint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::nodeAtFloatPoint):
* Source/WebCore/svg/SVGVisitedElementTracking.h: Added.
(WebCore::SVGVisitedElementTracking::SVGVisitedElementTracking):
(WebCore::SVGVisitedElementTracking::isEmpty const):
(WebCore::SVGVisitedElementTracking::isVisiting):
(WebCore::SVGVisitedElementTracking::Scope::Scope):
(WebCore::SVGVisitedElementTracking::Scope::~Scope):
(WebCore::SVGVisitedElementTracking::addUnique):
(WebCore::SVGVisitedElementTracking::removeUnique):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::notifyDependentsIntervalChanged):

Canonical link: <a href="https://commits.webkit.org/274392@main">https://commits.webkit.org/274392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b82c5b28013e066b92991a13da5876f1d3e9c54

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41488 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15235 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15070 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13084 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/13049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42765 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35370 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/35039 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38880 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11365 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37102 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15372 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8721 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/15033 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->