### PR TITLE
Implement GC handling for trusted types API

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -725,6 +725,8 @@ bindings/js/JSTextCustom.cpp
 bindings/js/JSTextTrackCueCustom.cpp
 bindings/js/JSTrackCustom.cpp
 bindings/js/JSTreeWalkerCustom.cpp
+bindings/js/JSTrustedTypePolicyCustom.cpp
+bindings/js/JSTrustedTypePolicyFactoryCustom.cpp
 bindings/js/JSCSSStyleValueCustom.cpp
 bindings/js/JSCSSTransformComponentCustom.cpp
 bindings/js/JSUndoItemCustom.cpp

--- a/Source/WebCore/bindings/js/JSTrustedTypePolicyCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTrustedTypePolicyCustom.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSTrustedTypePolicy.h"
+
+#include <JavaScriptCore/SlotVisitorInlines.h>
+
+namespace WebCore {
+
+template<typename Visitor>
+void JSTrustedTypePolicy::visitAdditionalChildren(Visitor& visitor)
+{
+    RefPtr<CreateHTMLCallback> protectedCreateHTML;
+    RefPtr<CreateScriptCallback> protectedCreateScript;
+    RefPtr<CreateScriptURLCallback> protectedCreateScriptURL;
+    {
+        Locker locker { wrapped().lock() };
+        protectedCreateHTML = wrapped().options().createHTML;
+        protectedCreateScript = wrapped().options().createScript;
+        protectedCreateScriptURL = wrapped().options().createScriptURL;
+    }
+    if (protectedCreateHTML)
+        protectedCreateHTML->visitJSFunction(visitor);
+    if (protectedCreateScript)
+        protectedCreateScript->visitJSFunction(visitor);
+    if (protectedCreateScriptURL)
+        protectedCreateScriptURL->visitJSFunction(visitor);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSTrustedTypePolicy);
+
+} // namespace WebCore

--- a/Source/WebCore/bindings/js/JSTrustedTypePolicyFactoryCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTrustedTypePolicyFactoryCustom.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSTrustedTypePolicyFactory.h"
+
+#include <JavaScriptCore/SlotVisitorInlines.h>
+
+namespace WebCore {
+
+template<typename Visitor>
+void JSTrustedTypePolicyFactory::visitAdditionalChildren(Visitor& visitor)
+{
+    addWebCoreOpaqueRoot(visitor, wrapped().defaultPolicyConcurrently());
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSTrustedTypePolicyFactory);
+
+} // namespace WebCore

--- a/Source/WebCore/dom/CreateHTMLCallback.h
+++ b/Source/WebCore/dom/CreateHTMLCallback.h
@@ -36,6 +36,8 @@ class CreateHTMLCallback : public RefCounted<CreateHTMLCallback>, public ActiveD
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    virtual bool hasCallback() const = 0;
+
     virtual CallbackResult<String> handleEvent(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
 };
 

--- a/Source/WebCore/dom/CreateHTMLCallback.idl
+++ b/Source/WebCore/dom/CreateHTMLCallback.idl
@@ -24,5 +24,6 @@
 */
 
 [
-    RethrowException
+    RethrowException,
+    IsWeakCallback
 ] callback CreateHTMLCallback = DOMString? (DOMString input, any... arguments);

--- a/Source/WebCore/dom/CreateScriptCallback.h
+++ b/Source/WebCore/dom/CreateScriptCallback.h
@@ -36,6 +36,8 @@ class CreateScriptCallback : public RefCounted<CreateScriptCallback>, public Act
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    virtual bool hasCallback() const = 0;
+
     virtual CallbackResult<String> handleEvent(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
 };
 

--- a/Source/WebCore/dom/CreateScriptCallback.idl
+++ b/Source/WebCore/dom/CreateScriptCallback.idl
@@ -24,5 +24,6 @@
 */
 
 [
-    RethrowException
+    RethrowException,
+    IsWeakCallback
 ] callback CreateScriptCallback = DOMString? (DOMString input, any... arguments);

--- a/Source/WebCore/dom/CreateScriptURLCallback.h
+++ b/Source/WebCore/dom/CreateScriptURLCallback.h
@@ -36,6 +36,8 @@ class CreateScriptURLCallback : public RefCounted<CreateScriptURLCallback>, publ
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
+    virtual bool hasCallback() const = 0;
+
     virtual CallbackResult<String> handleEvent(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
 };
 

--- a/Source/WebCore/dom/CreateScriptURLCallback.idl
+++ b/Source/WebCore/dom/CreateScriptURLCallback.idl
@@ -24,5 +24,6 @@
 */
 
 [
-    RethrowException
+    RethrowException,
+    IsWeakCallback
 ] callback CreateScriptURLCallback = USVString? (DOMString input, any... arguments);

--- a/Source/WebCore/dom/TrustedTypePolicy.h
+++ b/Source/WebCore/dom/TrustedTypePolicy.h
@@ -30,6 +30,7 @@
 #include "CreateScriptURLCallback.h"
 #include "ExceptionOr.h"
 #include "ScriptWrappable.h"
+#include "TrustedTypePolicyOptions.h"
 #include <JavaScriptCore/Strong.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -41,6 +42,7 @@ class TrustedScript;
 class TrustedScriptURL;
 enum class TrustedType : int8_t;
 struct TrustedTypePolicyOptions;
+class WebCoreOpaqueRoot;
 
 enum class IfMissing : bool { Throw, ReturnNull };
 
@@ -55,13 +57,17 @@ public:
     ExceptionOr<String> getPolicyValue(TrustedType trustedTypeName, const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&&, IfMissing = IfMissing::Throw);
     const String name() const { return m_name; }
 
+    const TrustedTypePolicyOptions& options() const { return m_options; }
+    Lock& lock() WTF_RETURNS_LOCK(m_lock) { return m_lock; }
+
 private:
     TrustedTypePolicy(const String&, const TrustedTypePolicyOptions&);
 
     String m_name;
-    RefPtr<CreateHTMLCallback> m_createHTMLCallback;
-    RefPtr<CreateScriptCallback> m_createScriptCallback;
-    RefPtr<CreateScriptURLCallback> m_createScriptURLCallback;
+    TrustedTypePolicyOptions m_options WTF_GUARDED_BY_LOCK(m_lock);
+    mutable Lock m_lock;
 };
+
+WebCoreOpaqueRoot root(TrustedTypePolicy*);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/TrustedTypePolicy.idl
+++ b/Source/WebCore/dom/TrustedTypePolicy.idl
@@ -25,7 +25,8 @@
 
 [
     EnabledBySetting=TrustedTypesEnabled,
-    Exposed=(Window,Worker)
+    Exposed=(Window,Worker),
+    JSCustomMarkFunction,
 ]
 interface TrustedTypePolicy {
     readonly attribute DOMString name;

--- a/Source/WebCore/dom/TrustedTypePolicyFactory.cpp
+++ b/Source/WebCore/dom/TrustedTypePolicyFactory.cpp
@@ -27,6 +27,7 @@
 #include "TrustedTypePolicyFactory.h"
 
 #include "ContentSecurityPolicy.h"
+#include "ContextDestructionObserver.h"
 #include "HTMLNames.h"
 #include "JSDOMConvertObject.h"
 #include "JSTrustedHTML.h"
@@ -43,10 +44,14 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(TrustedTypePolicyFactory);
 
-Ref<TrustedTypePolicyFactory> TrustedTypePolicyFactory::create()
+Ref<TrustedTypePolicyFactory> TrustedTypePolicyFactory::create(ScriptExecutionContext& context)
 {
-    return adoptRef(*new TrustedTypePolicyFactory());
+    return adoptRef(*new TrustedTypePolicyFactory(context));
 }
+
+TrustedTypePolicyFactory::TrustedTypePolicyFactory(ScriptExecutionContext& context)
+    : ContextDestructionObserver(&context)
+{ }
 
 ExceptionOr<Ref<TrustedTypePolicy>> TrustedTypePolicyFactory::createPolicy(ScriptExecutionContext& context, const String& policyName, const TrustedTypePolicyOptions& options)
 {

--- a/Source/WebCore/dom/TrustedTypePolicyFactory.h
+++ b/Source/WebCore/dom/TrustedTypePolicyFactory.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ContextDestructionObserver.h"
 #include "ScriptWrappable.h"
 #include "TrustedTypePolicy.h"
 #include <wtf/Forward.h>
@@ -39,10 +40,10 @@ class TrustedScript;
 struct TrustedTypePolicyOptions;
 class ScriptExecutionContext;
 
-class TrustedTypePolicyFactory : public ScriptWrappable, public RefCounted<TrustedTypePolicyFactory> {
+class TrustedTypePolicyFactory : public ScriptWrappable, public RefCounted<TrustedTypePolicyFactory>, public ContextDestructionObserver {
     WTF_MAKE_ISO_ALLOCATED(TrustedTypePolicyFactory);
 public:
-    static Ref<TrustedTypePolicyFactory> create();
+    static Ref<TrustedTypePolicyFactory> create(ScriptExecutionContext&);
     ~TrustedTypePolicyFactory() = default;
 
     ExceptionOr<Ref<TrustedTypePolicy>> createPolicy(ScriptExecutionContext&, const String& policyName, const TrustedTypePolicyOptions&);
@@ -56,8 +57,11 @@ public:
     String getPropertyType(const String& tagName, const String& property, const String& elementNamespace) const;
 
     RefPtr<TrustedTypePolicy> defaultPolicy() const { return m_defaultPolicy; }
+    TrustedTypePolicy* defaultPolicyConcurrently() const { return m_defaultPolicy.get(); }
 
 private:
+    TrustedTypePolicyFactory(ScriptExecutionContext&);
+
     RefPtr<TrustedTypePolicy> m_defaultPolicy;
     ListHashSet<String> m_createdPolicyNames;
 };

--- a/Source/WebCore/dom/TrustedTypePolicyFactory.idl
+++ b/Source/WebCore/dom/TrustedTypePolicyFactory.idl
@@ -25,7 +25,9 @@
 
 [
     EnabledBySetting=TrustedTypesEnabled,
-    Exposed=(Window,Worker)
+    Exposed=(Window,Worker),
+    GenerateIsReachable=ImplScriptExecutionContext,
+    JSCustomMarkFunction,
 ]
 interface TrustedTypePolicyFactory {
     [CallWith=CurrentScriptExecutionContext] TrustedTypePolicy createPolicy(DOMString policyName, optional TrustedTypePolicyOptions policyOptions = {});

--- a/Source/WebCore/dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp
+++ b/Source/WebCore/dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp
@@ -71,7 +71,7 @@ DOMWindowTrustedTypes* DOMWindowTrustedTypes::from(LocalDOMWindow& window)
 TrustedTypePolicyFactory* DOMWindowTrustedTypes::trustedTypes() const
 {
     if (!m_trustedTypes)
-        m_trustedTypes = TrustedTypePolicyFactory::create();
+        m_trustedTypes = TrustedTypePolicyFactory::create(*window()->document());
     return m_trustedTypes.get();
 }
 
@@ -115,7 +115,7 @@ WorkerGlobalScopeTrustedTypes* WorkerGlobalScopeTrustedTypes::from(WorkerGlobalS
 TrustedTypePolicyFactory* WorkerGlobalScopeTrustedTypes::trustedTypes() const
 {
     if (!m_trustedTypes)
-        m_trustedTypes = TrustedTypePolicyFactory::create();
+        m_trustedTypes = TrustedTypePolicyFactory::create(m_scope);
     return m_trustedTypes.get();
 }
 

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -158,6 +158,8 @@ void WorkerGlobalScope::prepareForDestruction()
 {
     WorkerOrWorkletGlobalScope::prepareForDestruction();
 
+    removeSupplement("WorkerGlobalScopeTrustedTypes"_s);
+
     if (settingsValues().serviceWorkersEnabled)
         swClientConnection().unregisterServiceWorkerClient(identifier());
 


### PR DESCRIPTION
#### 3fe3c3955914a08964b9c840e2750350e1e8b7af
<pre>
Implement GC handling for trusted types API
<a href="https://bugs.webkit.org/show_bug.cgi?id=268419">https://bugs.webkit.org/show_bug.cgi?id=268419</a>

Reviewed by Ryosuke Niwa.

This patch implements visitAdditionalChildren for TrustedTypePolicy calling visitJSFunction on callbacks.
TrustedTypePolicy is also an opaque root which is added inside of TrustedTypePolicyFactory visitAdditionalChildren.
It also marks TrustedTypePolicyFactory as being reachable via scriptExecutionContext.
The trusted type callbacks are now weak callbacks.
The WorkerGlobalScopeTrustedTypes supplement is now also removed in WorkerGlobalScope::prepareForDestruction,
this is so that teardown happens in the right order.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSTrustedTypePolicyCustom.cpp: Added.
(WebCore::JSTrustedTypePolicy::visitAdditionalChildren):
* Source/WebCore/bindings/js/JSTrustedTypePolicyFactoryCustom.cpp: Added.
(WebCore::JSTrustedTypePolicyFactory::visitAdditionalChildren):
* Source/WebCore/dom/CreateHTMLCallback.h:
* Source/WebCore/dom/CreateHTMLCallback.idl:
* Source/WebCore/dom/CreateScriptCallback.h:
* Source/WebCore/dom/CreateScriptCallback.idl:
* Source/WebCore/dom/CreateScriptURLCallback.h:
* Source/WebCore/dom/CreateScriptURLCallback.idl:
* Source/WebCore/dom/TrustedTypePolicy.cpp:
(WebCore::TrustedTypePolicy::TrustedTypePolicy):
(WebCore::TrustedTypePolicy::getPolicyValue):
(WebCore::root):
* Source/WebCore/dom/TrustedTypePolicy.h:
(WebCore::TrustedTypePolicy::options const):
(WebCore::TrustedTypePolicy::WTF_RETURNS_LOCK):
* Source/WebCore/dom/TrustedTypePolicy.idl:
* Source/WebCore/dom/TrustedTypePolicyFactory.cpp:
(WebCore::TrustedTypePolicyFactory::create):
(WebCore::TrustedTypePolicyFactory::TrustedTypePolicyFactory):
* Source/WebCore/dom/TrustedTypePolicyFactory.h:
(WebCore::TrustedTypePolicyFactory::defaultPolicyConcurrently const):
* Source/WebCore/dom/TrustedTypePolicyFactory.idl:
* Source/WebCore/dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp:
(WebCore::DOMWindowTrustedTypes::trustedTypes const):
(WebCore::WorkerGlobalScopeTrustedTypes::trustedTypes const):
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::prepareForDestruction):

Canonical link: <a href="https://commits.webkit.org/276974@main">https://commits.webkit.org/276974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c89c07202f8aecfb875b580d157fcd4d1900bcfc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48339 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41706 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37396 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18545 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40490 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3715 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41976 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40822 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50089 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20660 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44499 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21965 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43343 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10249 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21654 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->