### PR TITLE
Fix sandbox compilation error related to empty parameters

### DIFF
--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -186,13 +186,16 @@
     (home-subpath "/Library/Caches")
     (home-subpath "/Library/Containers")
     (home-subpath "/Library/WebKit")
-    (subpath (param "DARWIN_USER_TEMP_DIR"))
     (subpath "/Library/Frameworks")
     (subpath "/Library/KerberosPlugins")
     (subpath "/System/Library/Frameworks")
     (subpath "/System/Library/KerberosPlugins")
     (subpath "/System/Library/PrivateFrameworks")
     (subpath "/usr/lib"))
+
+(if (positive? (string-length (param "DARWIN_USER_TEMP_DIR")))
+    (allow file-map-executable
+        (subpath (param "DARWIN_USER_TEMP_DIR"))))
 
 (allow file-read-metadata
     (literal "/etc")
@@ -381,9 +384,11 @@
 (read-only-and-issue-extensions (extension "com.apple.app-sandbox.read"))
 (read-write-and-issue-extensions (extension "com.apple.app-sandbox.read-write"))
 
-(allow file-read* file-write* (subpath (param "DARWIN_USER_CACHE_DIR")))
+(if (positive? (string-length (param "DARWIN_USER_CACHE_DIR")))
+    (allow file-read* file-write* (subpath (param "DARWIN_USER_CACHE_DIR"))))
 
-(allow file-read* file-write* (subpath (param "DARWIN_USER_TEMP_DIR")))
+(if (positive? (string-length (param "DARWIN_USER_TEMP_DIR")))
+    (allow file-read* file-write* (subpath (param "DARWIN_USER_TEMP_DIR"))))
 
 ;; IOKit user clients
 (allow IOKIT_OPEN_USER_CLIENT


### PR DESCRIPTION
#### 3fb72872a03ade4008d5c358ebefc6b60e1ea111
<pre>
Fix sandbox compilation error related to empty parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=268916">https://bugs.webkit.org/show_bug.cgi?id=268916</a>
<a href="https://rdar.apple.com/88915314">rdar://88915314</a>

Reviewed by David Kilzer and Brent Fulgham.

On rare occasions, see <a href="https://bugs.webkit.org/show_bug.cgi?id=222233">https://bugs.webkit.org/show_bug.cgi?id=222233</a> for more details, the sandbox string
parameters provided to the Networking process&apos; sandbox can be empty. This will cause the compilation of the
sandbox to fail, and the Networking process will crash on startup being unable to apply the sandbox. We can
guard against this in the sandbox by checking the string length of the parameters. We already do this for
the GPU process and WebContent process.

* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/274228@main">https://commits.webkit.org/274228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81963651ee25a7f44290a81859e12670641b9fe0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40909 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14633 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14597 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12699 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42188 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/34894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38519 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/10974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36720 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14830 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8626 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14294 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->