### PR TITLE
REGRESSION(272969@main): Null-deref crash in SourceBufferPrivateAVFObjC::trackDidChangeEnabled

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -215,7 +215,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     StdUnorderedMap<TrackID, RetainPtr<AVSampleBufferAudioRenderer>> m_audioRenderers;
 ALLOW_NEW_API_WITHOUT_GUARDS_END
-    RefPtr<WebAVSampleBufferListener> m_listener;
+    Ref<WebAVSampleBufferListener> m_listener;
 #if PLATFORM(IOS_FAMILY)
     bool m_displayLayerWasInterrupted { false };
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -143,6 +143,7 @@ SourceBufferPrivateAVFObjC::~SourceBufferPrivateAVFObjC()
     destroyStreamDataParser();
     destroyRenderers();
     clearTracks();
+    m_listener->invalidate();
 
     abort();
 }
@@ -502,11 +503,6 @@ void SourceBufferPrivateAVFObjC::destroyRenderers()
         if (m_cdmInstance && shouldAddContentKeyRecipients())
             [m_cdmInstance->contentKeySession() removeContentKeyRecipient:renderer.get()];
 #endif
-    }
-
-    if (m_listener) {
-        m_listener->invalidate();
-        m_listener = nullptr;
     }
 
     m_audioRenderers.clear();
@@ -1249,7 +1245,6 @@ void SourceBufferPrivateAVFObjC::setVideoLayer(AVSampleBufferDisplayLayer* layer
     ASSERT(!layer || !m_decompressionSession || hasSelectedVideo());
 
     if (m_videoLayer) {
-        ASSERT(m_listener);
         m_videoLayer->flush();
         m_videoLayer->stopRequestingMediaData();
         m_listener->stopObservingLayer(m_videoLayer->displayLayer());


### PR DESCRIPTION
#### 56b164c3ab85e41d500f1ebe5868247c0aeb81f1
<pre>
REGRESSION(272969@main): Null-deref crash in SourceBufferPrivateAVFObjC::trackDidChangeEnabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=268921">https://bugs.webkit.org/show_bug.cgi?id=268921</a>
<a href="https://rdar.apple.com/122444388">rdar://122444388</a>

Reviewed by Eric Carlson.

The WebAVSampleBufferListener m_listener is invalidated and destroyed in SourceBufferPrivateAVFObjC::destroyRenderers(),
and is never recreated. It is subsequently used without nil-checking the next time a renderer is recreated. Rather than
destroying and re-creating whenever renderers are destroyed and created, make it a Ref&lt;&gt; object whose lifetime is the same
(or longer) as the object which owns it.

* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::~SourceBufferPrivateAVFObjC):
(WebCore::SourceBufferPrivateAVFObjC::destroyRenderers):

Canonical link: <a href="https://commits.webkit.org/274323@main">https://commits.webkit.org/274323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/476ba38952df3b65d37f44a9a0d7fa630e4f6d34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41160 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34288 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14906 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32466 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39202 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14806 "Build is being retried. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 2 new passes 9 flakes 2 failures; Uploaded test results; layout-tests running") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12846 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34463 "Build is being retried. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests running") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42435 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35099 "Build is being retried. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (warnings)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34852 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38680 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11151 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36876 "Build is being retried. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (failure); 3 api tests failed or timed out; compiling") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15055 "Build is being retried. Recent messages:OS: Sonoma (14.0), Xcode: 15.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; compiling") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8679 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14533 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->