### PR TITLE
[UnifiedPDF] Documents should be saved with modified annotations.

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -32,6 +32,8 @@
 #include <WebCore/GraphicsLayer.h>
 #include <wtf/OptionSet.h>
 
+OBJC_CLASS WKPDFFormMutationObserver;
+
 namespace WebCore {
 enum class DelegatedScrollingMode : uint8_t;
 }
@@ -292,6 +294,8 @@ private:
     };
     SelectionTrackingData m_selectionTrackingData;
     RetainPtr<PDFSelection> m_currentSelection;
+
+    RetainPtr<WKPDFFormMutationObserver> m_pdfMutationObserver;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 6ade66019ba329793f0851d597827c5430cefd8a
<pre>
[UnifiedPDF] Documents should be saved with modified annotations.
<a href="https://bugs.webkit.org/show_bug.cgi?id=268923">https://bugs.webkit.org/show_bug.cgi?id=268923</a>
<a href="https://rdar.apple.com/119632592">rdar://119632592</a>

Reviewed by Tim Horton.

When returning the document&apos;s data to save it we have two different
options: we can either return the data from the resource that was loaded
or we returning the data from PDFKit. We would want to return the former
so that documents that cannot be loaded by PDFKit can be saved and the
latter when the PDF was mutated. In order to determine which one we want
to use we need to keep track of when the PDF was mutated. This can be
done by hooking up an observer that will listen for events that are
sent by the PDFDocument when an annotation changed. This observer will
then modify some state to indicate that this occurred and which we will
consult when returning the document data.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(-[WKPDFFormMutationObserver initWithPlguin:]):
(-[WKPDFFormMutationObserver formChanged:]):
(WebKit::UnifiedPDFPlugin::UnifiedPDFPlugin):
(WebKit::mutationObserverNotificationString):
(WebKit::UnifiedPDFPlugin::teardown):
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::liveResourceData const):
(WebKit::UnifiedPDFPlugin::liveData const):

Canonical link: <a href="https://commits.webkit.org/274261@main">https://commits.webkit.org/274261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/066f622c41d8282f5badd3a536634d620c706dba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40798 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/41010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14747 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39032 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/14672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/12750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/42286 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/34955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/36771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14919 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8640 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14391 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->