### PR TITLE
Unreviewed, reverting 274178@main

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -816,7 +816,7 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
             // referenced by the audioTracks attribute on the HTMLMediaElement.
             m_source->mediaElement()->addAudioTrack(newAudioTrack.copyRef());
 
-            m_audioCodecs.append(audioTrackInfo.description->codec().toAtomString());
+            m_audioCodecs.append(audioTrackInfo.description->codec());
 
             // 5.2.8 Create a new track buffer to store coded frames for this track.
             m_private->addTrackBuffer(audioTrackInfo.track->id(), WTFMove(audioTrackInfo.description));
@@ -852,7 +852,7 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
             // referenced by the videoTracks attribute on the HTMLMediaElement.
             m_source->mediaElement()->addVideoTrack(newVideoTrack.copyRef());
 
-            m_videoCodecs.append(videoTrackInfo.description->codec().toAtomString());
+            m_videoCodecs.append(videoTrackInfo.description->codec());
 
             // 5.3.8 Create a new track buffer to store coded frames for this track.
             m_private->addTrackBuffer(videoTrackInfo.track->id(), WTFMove(videoTrackInfo.description));
@@ -885,7 +885,7 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
             // referenced by the textTracks attribute on the HTMLMediaElement.
             m_source->mediaElement()->addTextTrack(newTextTrack.copyRef());
 
-            m_textCodecs.append(textTrackInfo.description->codec().toAtomString());
+            m_textCodecs.append(textTrackInfo.description->codec());
 
             // 5.4.7 Create a new track buffer to store coded frames for this track.
             m_private->addTrackBuffer(textTrackPrivate.id(), WTFMove(textTrackInfo.description));
@@ -935,36 +935,33 @@ bool SourceBuffer::validateInitializationSegment(const InitializationSegment& se
     // is not enabled, only perform this check if the "pending initialization segment for changeType flag"
     // is not set.)
     for (auto& audioTrackInfo : segment.audioTracks) {
-        auto audioCodec = audioTrackInfo.description->codec().toAtomString();
-        if (m_audioCodecs.contains(audioCodec))
+        if (m_audioCodecs.contains(audioTrackInfo.description->codec()))
             continue;
 
         if (!m_pendingInitializationSegmentForChangeType)
             return false;
 
-        m_audioCodecs.append(WTFMove(audioCodec));
+        m_audioCodecs.append(audioTrackInfo.description->codec());
     }
 
     for (auto& videoTrackInfo : segment.videoTracks) {
-        auto videoCodec = videoTrackInfo.description->codec().toAtomString();
-        if (m_videoCodecs.contains(videoCodec))
+        if (m_videoCodecs.contains(videoTrackInfo.description->codec()))
             continue;
 
         if (!m_pendingInitializationSegmentForChangeType)
             return false;
 
-        m_videoCodecs.append(WTFMove(videoCodec));
+        m_videoCodecs.append(videoTrackInfo.description->codec());
     }
 
     for (auto& textTrackInfo : segment.textTracks) {
-        auto textCodec = textTrackInfo.description->codec().toAtomString();
-        if (m_textCodecs.contains(textCodec))
+        if (m_textCodecs.contains(textTrackInfo.description->codec()))
             continue;
 
         if (!m_pendingInitializationSegmentForChangeType)
             return false;
 
-        m_textCodecs.append(WTFMove(textCodec));
+        m_textCodecs.append(textTrackInfo.description->codec());
     }
 
     return true;

--- a/Source/WebCore/platform/MediaDescription.h
+++ b/Source/WebCore/platform/MediaDescription.h
@@ -27,25 +27,18 @@
 #define MediaDescription_h
 
 #include <wtf/Forward.h>
-#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/RefCounted.h>
 
 namespace WebCore {
 
-class MediaDescription : public ThreadSafeRefCounted<MediaDescription> {
+class MediaDescription : public RefCounted<MediaDescription> {
 public:
-    explicit MediaDescription(String&& codec)
-        : m_codec(WTFMove(codec))
-    {
-        ASSERT(m_codec.isSafeToSendToAnotherThread());
-    }
     virtual ~MediaDescription() = default;
 
-    StringView codec() const { return m_codec; }
+    virtual AtomString codec() const = 0;
     virtual bool isVideo() const = 0;
     virtual bool isAudio() const = 0;
     virtual bool isText() const = 0;
-protected:
-    const String m_codec;
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -166,31 +166,39 @@ public:
     static Ref<MediaDescriptionAVFObjC> create(AVAssetTrack* track) { return adoptRef(*new MediaDescriptionAVFObjC(track)); }
     virtual ~MediaDescriptionAVFObjC() { }
 
-    bool isVideo() const final { return m_isVideo; }
-    bool isAudio() const final { return m_isAudio; }
-    bool isText() const final { return m_isText; }
+    bool isVideo() const override { return m_isVideo; }
+    bool isAudio() const override { return m_isAudio; }
+    bool isText() const override { return m_isText; }
+    AtomString codec() const override
+    {
+        // AtomStrings can only be destroyed from the same thread they're
+        // created in. Since this structure is created in a parser thread
+        // only create the AtomString the first time this function is accessed
+        // which is presumably on the main thread.
+        ASSERT(isMainThread());
+        if (!m_codec)
+            m_codec = AtomString::fromLatin1(m_originalCodec.string().data());
+        return *m_codec;
+    }
 
 private:
     MediaDescriptionAVFObjC(AVAssetTrack* track)
-        : MediaDescription(extractCodecName(track))
-        , m_isVideo([track hasMediaCharacteristic:AVMediaCharacteristicVisual])
+        : m_isVideo([track hasMediaCharacteristic:AVMediaCharacteristicVisual])
         , m_isAudio([track hasMediaCharacteristic:AVMediaCharacteristicAudible])
         , m_isText([track hasMediaCharacteristic:AVMediaCharacteristicLegible])
     {
-    }
-
-    String extractCodecName(AVAssetTrack* track)
-    {
         NSArray* formatDescriptions = [track formatDescriptions];
         CMFormatDescriptionRef description = [formatDescriptions count] ? (__bridge CMFormatDescriptionRef)[formatDescriptions objectAtIndex:0] : 0;
-        if (!description)
-            return emptyString();
-        FourCC originalCodec = PAL::softLink_CoreMedia_CMFormatDescriptionGetMediaSubType(description);
-        CFStringRef originalFormatKey = PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_ProtectedContentOriginalFormat() ? PAL::get_CoreMedia_kCMFormatDescriptionExtension_ProtectedContentOriginalFormat() : CFSTR("CommonEncryptionOriginalFormat");
-        if (auto originalFormat = dynamic_cf_cast<CFNumberRef>(PAL::CMFormatDescriptionGetExtension(description, originalFormatKey)))
-            CFNumberGetValue(originalFormat, kCFNumberSInt32Type, &originalCodec.value);
-        return String::fromLatin1(originalCodec.string().data());
+        if (description) {
+            m_originalCodec = PAL::softLink_CoreMedia_CMFormatDescriptionGetMediaSubType(description);
+            CFStringRef originalFormatKey = PAL::canLoad_CoreMedia_kCMFormatDescriptionExtension_ProtectedContentOriginalFormat() ? PAL::get_CoreMedia_kCMFormatDescriptionExtension_ProtectedContentOriginalFormat() : CFSTR("CommonEncryptionOriginalFormat");
+            if (auto originalFormat = dynamic_cf_cast<CFNumberRef>(PAL::CMFormatDescriptionGetExtension(description, originalFormatKey)))
+                CFNumberGetValue(originalFormat, kCFNumberSInt32Type, &m_originalCodec.value);
+        }
     }
+
+    FourCC m_originalCodec;
+    mutable std::optional<AtomString> m_codec;
     bool m_isVideo;
     bool m_isAudio;
     bool m_isText;

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -449,20 +449,15 @@ public:
     }
 
     MediaDescriptionWebM(webm::TrackEntry&& track)
-        : MediaDescription(extractCodec(track))
-        , m_track { WTFMove(track) }
+        : m_track { WTFMove(track) }
     {
     }
 
-    bool isVideo() const final { return m_track.track_type.is_present() && m_track.track_type.value() == TrackType::kVideo; }
-    bool isAudio() const final { return m_track.track_type.is_present() && m_track.track_type.value() == TrackType::kAudio; }
-    bool isText() const final { return m_track.track_type.is_present() && m_track.track_type.value() == TrackType::kSubtitle; }
-
-    const webm::TrackEntry& track() { return m_track; }
-
-private:
-    String extractCodec(const webm::TrackEntry& track) const
+    AtomString codec() const final
     {
+        if (m_codec)
+            return *m_codec;
+
         // From: https://www.matroska.org/technical/codec_specs.html
         // "Each Codec ID MUST include a Major Codec ID immediately following the Codec ID Prefix.
         // A Major Codec ID MAY be followed by an OPTIONAL Codec ID Suffix to communicate a refinement
@@ -471,18 +466,31 @@ private:
         // ID MUST be composed of only capital letters (A-Z) and numbers (0-9). The Codec ID Suffix MUST
         // be composed of only capital letters (A-Z), numbers (0-9), underscore (“_”), and forward slash (“/”)."
 
-        if (!track.codec_id.is_present())
-            return emptyString();
-        StringView codecID { track.codec_id.value().data(), (unsigned)track.codec_id.value().length() };
-        if (!codecID.startsWith("V_"_s) && !codecID.startsWith("A_"_s) && !codecID.startsWith("S_"_s))
-            return emptyString();
+        if (!m_track.codec_id.is_present()) {
+            m_codec = emptyAtom();
+            return *m_codec;
+        }
+
+        StringView codecID { m_track.codec_id.value().data(), (unsigned)m_track.codec_id.value().length() };
+        if (!codecID.startsWith("V_"_s) && !codecID.startsWith("A_"_s) && !codecID.startsWith("S_"_s)) {
+            m_codec = emptyAtom();
+            return *m_codec;
+        }
 
         auto slashLocation = codecID.find('/');
         auto length = slashLocation == notFound ? codecID.length() - 2 : slashLocation - 2;
-        return codecID.substring(2, length).convertToASCIILowercase();
+        m_codec = codecID.substring(2, length).convertToASCIILowercaseAtom();
+        return *m_codec;
     }
+    bool isVideo() const final { return m_track.track_type.is_present() && m_track.track_type.value() == TrackType::kVideo; }
+    bool isAudio() const final { return m_track.track_type.is_present() && m_track.track_type.value() == TrackType::kAudio; }
+    bool isText() const final { return m_track.track_type.is_present() && m_track.track_type.value() == TrackType::kSubtitle; }
 
-    const webm::TrackEntry m_track;
+    const webm::TrackEntry& track() { return m_track; }
+
+private:
+    mutable std::optional<AtomString> m_codec;
+    webm::TrackEntry m_track;
 };
 
 std::span<const ASCIILiteral> SourceBufferParserWebM::supportedMIMETypes()

--- a/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/GStreamerMediaDescription.h
@@ -26,8 +26,7 @@
 #include "MediaDescription.h"
 
 #include <gst/gst.h>
-#include <wtf/text/StringView.h>
-#include <wtf/text/WTFString.h>
+#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
@@ -40,19 +39,22 @@ public:
 
     virtual ~GStreamerMediaDescription() = default;
 
-    bool isVideo() const final;
-    bool isAudio() const final;
-    bool isText() const final;
+    AtomString codec() const override;
+    bool isVideo() const override;
+    bool isAudio() const override;
+    bool isText() const override;
 
 private:
     GStreamerMediaDescription(const GRefPtr<GstCaps>& caps)
-        : MediaDescription(extractCodecName(caps))
+        : MediaDescription()
         , m_caps(caps)
     {
+        m_codecName = extractCodecName();
     }
 
-    String extractCodecName(const GRefPtr<GstCaps>&) const;
-    const GRefPtr<GstCaps> m_caps;
+    AtomString extractCodecName();
+    GRefPtr<GstCaps> m_caps;
+    AtomString m_codecName;
 };
 
 } // namespace WebCore.

--- a/Source/WebCore/platform/mock/mediasource/MockBox.h
+++ b/Source/WebCore/platform/mock/mediasource/MockBox.h
@@ -74,14 +74,14 @@ public:
 
     int32_t trackID() const { return m_trackID; }
 
-    const String& codec() const { return m_codec; }
+    const AtomString& codec() const { return m_codec; }
 
     enum TrackKind { Audio, Video, Text };
     TrackKind kind() const { return m_kind; }
 
 private:
     uint8_t m_trackID;
-    String m_codec;
+    AtomString m_codec;
     TrackKind m_kind;
 };
 

--- a/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockSourceBufferPrivate.cpp
@@ -108,17 +108,14 @@ public:
     static Ref<MockMediaDescription> create(const MockTrackBox& box) { return adoptRef(*new MockMediaDescription(box)); }
     virtual ~MockMediaDescription() = default;
 
-    bool isVideo() const final { return m_box.kind() == MockTrackBox::Video; }
-    bool isAudio() const final { return m_box.kind() == MockTrackBox::Audio; }
-    bool isText() const final { return m_box.kind() == MockTrackBox::Text; }
+    AtomString codec() const override { return m_box.codec(); }
+    bool isVideo() const override { return m_box.kind() == MockTrackBox::Video; }
+    bool isAudio() const override { return m_box.kind() == MockTrackBox::Audio; }
+    bool isText() const override { return m_box.kind() == MockTrackBox::Text; }
 
 private:
-    MockMediaDescription(const MockTrackBox& box)
-        : MediaDescription(box.codec().isolatedCopy())
-        , m_box(box)
-    {
-    }
-    const MockTrackBox m_box;
+    MockMediaDescription(const MockTrackBox& box) : m_box(box) { }
+    MockTrackBox m_box;
 };
 
 Ref<MockSourceBufferPrivate> MockSourceBufferPrivate::create(MockMediaSourcePrivate& parent)

--- a/Source/WebKit/GPUProcess/media/MediaDescriptionInfo.h
+++ b/Source/WebKit/GPUProcess/media/MediaDescriptionInfo.h
@@ -33,7 +33,7 @@
 namespace WebKit {
 
 struct MediaDescriptionInfo {
-    MediaDescriptionInfo(const String& codec, bool isVideo, bool isAudio, bool isText)
+    MediaDescriptionInfo(const AtomString& codec, bool isVideo, bool isAudio, bool isText)
         : m_codec(codec)
         , m_isVideo(isVideo)
         , m_isAudio(isAudio)
@@ -42,14 +42,14 @@ struct MediaDescriptionInfo {
     }
 
     MediaDescriptionInfo(const WebCore::MediaDescription& description)
-        : m_codec(description.codec().toString())
+        : m_codec(description.codec())
         , m_isVideo(description.isVideo())
         , m_isAudio(description.isAudio())
         , m_isText(description.isText())
     {
     }
 
-    String m_codec;
+    AtomString m_codec;
     bool m_isVideo { false };
     bool m_isAudio { false };
     bool m_isText { false };

--- a/Source/WebKit/GPUProcess/media/MediaDescriptionInfo.serialization.in
+++ b/Source/WebKit/GPUProcess/media/MediaDescriptionInfo.serialization.in
@@ -23,7 +23,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(MEDIA_SOURCE)
 
 struct WebKit::MediaDescriptionInfo {
-    String m_codec;
+    AtomString m_codec;
     bool m_isVideo;
     bool m_isAudio;
     bool m_isText;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaDescription.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaDescription.h
@@ -40,19 +40,21 @@ public:
 
     virtual ~RemoteMediaDescription() = default;
 
+    AtomString codec() const final { return m_codec; }
     bool isVideo() const final { return m_isVideo; }
     bool isAudio() const final { return m_isAudio; }
     bool isText() const final { return m_isText;}
 
 private:
     RemoteMediaDescription(const MediaDescriptionInfo& descriptionInfo)
-        : MediaDescription(descriptionInfo.m_codec.isolatedCopy())
+        : m_codec(descriptionInfo.m_codec)
         , m_isVideo(descriptionInfo.m_isVideo)
         , m_isAudio(descriptionInfo.m_isAudio)
         , m_isText(descriptionInfo.m_isText)
     {
     }
 
+    AtomString m_codec;
     bool m_isVideo { false };
     bool m_isAudio { false };
     bool m_isText { false };


### PR DESCRIPTION
#### fe727222c8274585e37808d7108fa8919b48c9c9
<pre>
Unreviewed, reverting 274178@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=268924">https://bugs.webkit.org/show_bug.cgi?id=268924</a>
<a href="https://rdar.apple.com/122479134">rdar://122479134</a>

Broke TestWebKitAPI.WebKit.MSEHasMediaStreamingActivity and TestWebKitAPI.WebKit.MSEIsPlayingAudio in EWS

Reverted change:

Have MediaDescription stop using AtomString
<a href="https://bugs.webkit.org/show_bug.cgi?id=268728">https://bugs.webkit.org/show_bug.cgi?id=268728</a>
<a href="https://rdar.apple.com/122292724">rdar://122292724</a>
<a href="https://commits.webkit.org/274178@main">https://commits.webkit.org/274178@main</a>

Canonical link: <a href="https://commits.webkit.org/274223@main">https://commits.webkit.org/274223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68c47713e0be5a42dd01fa58c95651639820f0cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/38368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/17311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/40704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/40925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/40660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/20080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/14654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/40925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/38941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/20080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/40704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/40925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/20080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/40704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/42204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/20080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/40704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/42204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/14654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/42204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/40704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/4988 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->