### PR TITLE
[Wasm-GC] Fix handling of bottom type in struct ops

### DIFF
--- a/JSTests/wasm/gc/arrays.js
+++ b/JSTests/wasm/gc/arrays.js
@@ -330,6 +330,24 @@ function testArrayGet() {
     );
   }
 
+  // Bottom is type valid but throws due to null.
+  {
+    let m = instantiate(`
+      (module
+        (type (array i32))
+        (func (export "f") (result i32)
+          (ref.null none)
+          (i32.const 3)
+          (array.get 0))
+      )
+    `);
+    assert.throws(
+      () => { m.exports.f(); },
+      WebAssembly.RuntimeError,
+      "array.get to a null reference"
+    );
+  }
+
   // Should trap on index out of bounds.
   {
     let m = instantiate(`
@@ -503,6 +521,22 @@ function testArraySet() {
     );
   }
 
+  // Bottom is type valid but throws due to null.
+  {
+    let m = instantiate(`
+      (module
+        (type (array (mut i32)))
+        (func (export "f")
+          (array.set 0 (ref.null none) (i32.const 3) (i32.const 42)))
+      )
+    `);
+    assert.throws(
+      () => { m.exports.f(); },
+      WebAssembly.RuntimeError,
+      "array.set to a null reference"
+    );
+  }
+
   // Should trap on index out of bounds.
   {
     let m = instantiate(`
@@ -555,6 +589,23 @@ function testArrayLen() {
         (type (array i32))
         (func (export "f") (result i32)
           (ref.null 0)
+          (array.len))
+      )
+    `);
+    assert.throws(
+      () => { m.exports.f(); },
+      WebAssembly.RuntimeError,
+      "array.len to a null reference"
+    );
+  }
+
+  // Bottom is type valid but throws on null.
+  {
+    let m = instantiate(`
+      (module
+        (type (array i32))
+        (func (export "f") (result i32)
+          (ref.null none)
           (array.len))
       )
     `);


### PR DESCRIPTION
#### d27f9e79585db8efbc87fb4832a1f2a3c15021ff
<pre>
[Wasm-GC] Fix handling of bottom type in struct ops
<a href="https://bugs.webkit.org/show_bug.cgi?id=268870">https://bugs.webkit.org/show_bug.cgi?id=268870</a>

Reviewed by Justin Michaud.

The parsing of struct types for the reference argument of various struct
operations relied on checking for a type index in the type to check validity.
This is too conservative, as the bottom type exists and values of bottom
inhabit all types in the hiearchy.

This patch corrects the validation check to accommodate bottom.

* JSTests/wasm/gc/arrays.js:
(testArrayGet):
* JSTests/wasm/gc/structs.js:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseStructFieldManipulation):

Canonical link: <a href="https://commits.webkit.org/274556@main">https://commits.webkit.org/274556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fd54308b9e8d51864511eceb6573ace7c864381

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/40945 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34130 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14676 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32351 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/38961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14630 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33456 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12726 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12703 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42224 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/31949 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34717 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38543 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/38056 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11001 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36757 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14861 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/45010 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8819 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13767 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9203 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14327 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->