### PR TITLE
[GTK] Build fix for Ubuntu Stable after 274201@main

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -417,7 +417,9 @@ static GtkAccessible* webkitWebViewBaseAccessibleGetFirstAccessibleChild(GtkAcce
 static void
 webkitWebViewBaseAccessibleInterfaceInit(GtkAccessibleInterface* iface)
 {
+#ifdef GTK_ACCESSIBILITY_ATSPI
     iface->get_first_accessible_child = webkitWebViewBaseAccessibleGetFirstAccessibleChild;
+#endif
 }
 #endif
 


### PR DESCRIPTION
#### ef5415e49bdf5f8d84f66b6946d698a4bc298188
<pre>
[GTK] Build fix for Ubuntu Stable after 274201@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=227528">https://bugs.webkit.org/show_bug.cgi?id=227528</a>

Reviewed by NOBODY (OOPS!).

Method &apos;get_first_accessible_child&apos; is only available since GTK 4.10.
Ubuntu Stable (Ubuntu 22.04) features GTK 4.6.9.

Guard code accessing &apos;get_first_accessible_child&apos; under
&apos;ifdef GTK_ACCESSIBILITY_ATSPI&apos;, since other parts of the code also
depend on this guard.

* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseAccessibleInterfaceInit):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef5415e49bdf5f8d84f66b6946d698a4bc298188

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41083 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34225 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/20343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14822 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32407 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14729 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12795 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12778 "Unexpected infrastructure issue, retrying build") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42359 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35013 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38606 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11065 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36812 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14988 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13855 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14462 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->