### PR TITLE
Adopt even more smart pointers in Source/WebCore/loader

### DIFF
--- a/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
+++ b/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
@@ -68,7 +68,7 @@ NetscapePlugInStreamLoader::~NetscapePlugInStreamLoader() = default;
 
 void NetscapePlugInStreamLoader::create(LocalFrame& frame, NetscapePlugInStreamLoaderClient& client, ResourceRequest&& request, CompletionHandler<void(RefPtr<NetscapePlugInStreamLoader>&&)>&& completionHandler)
 {
-    auto loader(adoptRef(*new NetscapePlugInStreamLoader(frame, client)));
+    Ref loader = adoptRef(*new NetscapePlugInStreamLoader(frame, client));
     loader->init(WTFMove(request), [loader, completionHandler = WTFMove(completionHandler)] (bool initialized) mutable {
         if (!initialized)
             return completionHandler(nullptr);
@@ -93,7 +93,7 @@ void NetscapePlugInStreamLoader::init(ResourceRequest&& request, CompletionHandl
         if (!success)
             return completionHandler(false);
         ASSERT(!reachedTerminalState());
-        m_documentLoader->addPlugInStreamLoader(*this);
+        protectedDocumentLoader()->addPlugInStreamLoader(*this);
         m_isInitialized = true;
         completionHandler(true);
     });
@@ -137,13 +137,13 @@ void NetscapePlugInStreamLoader::didReceiveResponse(const ResourceResponse& resp
 
         // Status code can be null when serving from a Web archive.
         if (response.httpStatusCode() && (response.httpStatusCode() < 100 || response.httpStatusCode() >= 400))
-            cancel(frameLoader()->client().fileDoesNotExistError(response));
+            cancel(checkedFrameLoader()->client().fileDoesNotExistError(response));
     });
 }
 
 void NetscapePlugInStreamLoader::didReceiveData(const SharedBuffer& buffer, long long encodedDataLength, DataPayloadType dataPayloadType)
 {
-    Ref<NetscapePlugInStreamLoader> protectedThis(*this);
+    Ref protectedThis { *this };
 
     if (m_client)
         m_client->didReceiveData(this, buffer);
@@ -153,7 +153,7 @@ void NetscapePlugInStreamLoader::didReceiveData(const SharedBuffer& buffer, long
 
 void NetscapePlugInStreamLoader::didFinishLoading(const NetworkLoadMetrics& networkLoadMetrics)
 {
-    Ref<NetscapePlugInStreamLoader> protectedThis(*this);
+    Ref protectedThis { *this };
 
     notifyDone();
 
@@ -164,7 +164,7 @@ void NetscapePlugInStreamLoader::didFinishLoading(const NetworkLoadMetrics& netw
 
 void NetscapePlugInStreamLoader::didFail(const ResourceError& error)
 {
-    Ref<NetscapePlugInStreamLoader> protectedThis(*this);
+    Ref protectedThis { *this };
 
     notifyDone();
 
@@ -189,7 +189,7 @@ void NetscapePlugInStreamLoader::notifyDone()
     if (!m_isInitialized)
         return;
 
-    m_documentLoader->removePlugInStreamLoader(*this);
+    protectedDocumentLoader()->removePlugInStreamLoader(*this);
 }
 
 

--- a/Source/WebCore/loader/PolicyChecker.h
+++ b/Source/WebCore/loader/PolicyChecker.h
@@ -95,7 +95,9 @@ private:
     URLKeepingBlobAlive extendBlobURLLifetimeIfNecessary(const ResourceRequest&, const Document&, PolicyDecisionMode = PolicyDecisionMode::Asynchronous) const;
     std::optional<HitTestResult> hitTestResult(const NavigationAction&);
 
-    LocalFrame& m_frame;
+    Ref<LocalFrame> protectedFrame() const;
+
+    WeakRef<LocalFrame> m_frame;
 
     uint64_t m_javaScriptURLPolicyCheckIdentifier { 0 };
     bool m_delegateIsDecidingNavigationPolicy;

--- a/Source/WebCore/loader/PrivateClickMeasurement.cpp
+++ b/Source/WebCore/loader/PrivateClickMeasurement.cpp
@@ -290,7 +290,7 @@ URL PrivateClickMeasurement::attributionReportClickDestinationURL() const
 
 Ref<JSON::Object> PrivateClickMeasurement::attributionReportJSON() const
 {
-    auto reportDetails = JSON::Object::create();
+    Ref reportDetails = JSON::Object::create();
     if (!m_attributionTriggerData || !isValid())
         return reportDetails;
 
@@ -366,7 +366,7 @@ const std::optional<const URL> PrivateClickMeasurement::tokenSignatureURL() cons
 
 Ref<JSON::Object> PrivateClickMeasurement::tokenSignatureJSON() const
 {
-    auto reportDetails = JSON::Object::create();
+    Ref reportDetails = JSON::Object::create();
     if (!m_ephemeralSourceNonce || !m_ephemeralSourceNonce->isValid())
         return reportDetails;
 
@@ -383,7 +383,7 @@ Ref<JSON::Object> PrivateClickMeasurement::tokenSignatureJSON() const
 
 Ref<JSON::Object> PCM::AttributionTriggerData::tokenSignatureJSON() const
 {
-    auto reportDetails = JSON::Object::create();
+    Ref reportDetails = JSON::Object::create();
     if (!ephemeralDestinationNonce || !ephemeralDestinationNonce->isValid())
         return reportDetails;
 

--- a/Source/WebCore/loader/ProgressTracker.h
+++ b/Source/WebCore/loader/ProgressTracker.h
@@ -34,6 +34,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/RefPtr.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -51,7 +52,7 @@ public:
 
     ProgressTrackerClient& client() { return m_client.get(); }
 
-    WEBCORE_EXPORT double estimatedProgress() const;
+    double estimatedProgress() const { return m_progressValue; }
 
     void progressStarted(LocalFrame&);
     void progressCompleted(LocalFrame&);
@@ -71,8 +72,9 @@ private:
     void progressEstimateChanged(LocalFrame&);
 
     void progressHeartbeatTimerFired();
+    Ref<Page> protectedPage() const;
 
-    Page& m_page;
+    SingleThreadWeakRef<Page> m_page;
     UniqueRef<ProgressTrackerClient> m_client;
     RefPtr<LocalFrame> m_originatingProgressFrame;
     HashMap<ResourceLoaderIdentifier, std::unique_ptr<ProgressItem>> m_progressItems;

--- a/Source/WebCore/loader/ResourceLoadNotifier.cpp
+++ b/Source/WebCore/loader/ResourceLoadNotifier.cpp
@@ -52,6 +52,11 @@ ResourceLoadNotifier::ResourceLoadNotifier(LocalFrame& frame)
 {
 }
 
+Ref<LocalFrame> ResourceLoadNotifier::protectedFrame() const
+{
+    return m_frame.get();
+}
+
 void ResourceLoadNotifier::didReceiveAuthenticationChallenge(ResourceLoader* loader, const AuthenticationChallenge& currentWebChallenge)
 {
     didReceiveAuthenticationChallenge(loader->identifier(), loader->documentLoader(), currentWebChallenge);
@@ -59,65 +64,65 @@ void ResourceLoadNotifier::didReceiveAuthenticationChallenge(ResourceLoader* loa
 
 void ResourceLoadNotifier::didReceiveAuthenticationChallenge(ResourceLoaderIdentifier identifier, DocumentLoader* loader, const AuthenticationChallenge& currentWebChallenge)
 {
-    m_frame.loader().client().dispatchDidReceiveAuthenticationChallenge(loader, identifier, currentWebChallenge);
+    protectedFrame()->checkedLoader()->client().dispatchDidReceiveAuthenticationChallenge(loader, identifier, currentWebChallenge);
 }
 
 void ResourceLoadNotifier::willSendRequest(ResourceLoader* loader, ResourceRequest& clientRequest, const ResourceResponse& redirectResponse)
 {
-    m_frame.loader().applyUserAgentIfNeeded(clientRequest);
+    protectedFrame()->checkedLoader()->applyUserAgentIfNeeded(clientRequest);
 
-    dispatchWillSendRequest(loader->documentLoader(), loader->identifier(), clientRequest, redirectResponse, loader->cachedResource(), loader);
+    dispatchWillSendRequest(loader->protectedDocumentLoader().get(), loader->identifier(), clientRequest, redirectResponse, loader->protectedCachedResource().get(), loader);
 }
 
 void ResourceLoadNotifier::didReceiveResponse(ResourceLoader* loader, const ResourceResponse& r)
 {
     loader->documentLoader()->addResponse(r);
 
-    if (Page* page = m_frame.page())
-        page->progress().incrementProgress(loader->identifier(), r);
+    if (RefPtr page = m_frame->page())
+        page->checkedProgress()->incrementProgress(loader->identifier(), r);
 
-    dispatchDidReceiveResponse(loader->documentLoader(), loader->identifier(), r, loader);
+    dispatchDidReceiveResponse(loader->protectedDocumentLoader().get(), loader->identifier(), r, loader);
 }
 
 void ResourceLoadNotifier::didReceiveData(ResourceLoader* loader, const SharedBuffer& buffer, int encodedDataLength)
 {
-    if (Page* page = m_frame.page())
-        page->progress().incrementProgress(loader->identifier(), buffer.size());
+    if (RefPtr page = m_frame->page())
+        page->checkedProgress()->incrementProgress(loader->identifier(), buffer.size());
 
-    dispatchDidReceiveData(loader->documentLoader(), loader->identifier(), &buffer, buffer.size(), encodedDataLength);
+    dispatchDidReceiveData(loader->protectedDocumentLoader().get(), loader->identifier(), &buffer, buffer.size(), encodedDataLength);
 }
 
 void ResourceLoadNotifier::didFinishLoad(ResourceLoader* loader, const NetworkLoadMetrics& networkLoadMetrics)
 {    
-    if (Page* page = m_frame.page())
-        page->progress().completeProgress(loader->identifier());
+    if (RefPtr page = m_frame->page())
+        page->checkedProgress()->completeProgress(loader->identifier());
 
-    dispatchDidFinishLoading(loader->documentLoader(), loader->identifier(), networkLoadMetrics, loader);
+    dispatchDidFinishLoading(loader->protectedDocumentLoader().get(), loader->identifier(), networkLoadMetrics, loader);
 }
 
 void ResourceLoadNotifier::didFailToLoad(ResourceLoader* loader, const ResourceError& error)
 {
-    if (Page* page = m_frame.page())
-        page->progress().completeProgress(loader->identifier());
+    if (RefPtr page = m_frame->page())
+        page->checkedProgress()->completeProgress(loader->identifier());
 
     // Notifying the LocalFrameLoaderClient may cause the frame to be destroyed.
-    Ref protectedFrame { m_frame };
+    Ref frame = m_frame.get();
     if (!error.isNull())
-        m_frame.loader().client().dispatchDidFailLoading(loader->documentLoader(), loader->identifier(), error);
+        frame->checkedLoader()->client().dispatchDidFailLoading(loader->protectedDocumentLoader().get(), loader->identifier(), error);
 
-    InspectorInstrumentation::didFailLoading(&m_frame, loader->documentLoader(), loader->identifier(), error);
+    InspectorInstrumentation::didFailLoading(frame.ptr(), loader->protectedDocumentLoader().get(), loader->identifier(), error);
 }
 
 void ResourceLoadNotifier::assignIdentifierToInitialRequest(ResourceLoaderIdentifier identifier, DocumentLoader* loader, const ResourceRequest& request)
 {
     bool pageIsProvisionallyLoading = false;
-    if (auto* frameLoader = loader ? loader->frameLoader() : nullptr)
+    if (CheckedPtr frameLoader = loader ? loader->frameLoader() : nullptr)
         pageIsProvisionallyLoading = frameLoader->provisionalDocumentLoader() == loader;
 
     if (pageIsProvisionallyLoading)
         m_initialRequestIdentifier = identifier;
 
-    m_frame.loader().client().assignIdentifierToInitialRequest(identifier, loader, request);
+    protectedFrame()->checkedLoader()->client().assignIdentifierToInitialRequest(identifier, loader, request);
 }
 
 void ResourceLoadNotifier::dispatchWillSendRequest(DocumentLoader* loader, ResourceLoaderIdentifier identifier, ResourceRequest& request, const ResourceResponse& redirectResponse, const CachedResource* cachedResource, ResourceLoader* resourceLoader)
@@ -130,55 +135,54 @@ void ResourceLoadNotifier::dispatchWillSendRequest(DocumentLoader* loader, Resou
 
     String oldRequestURL = request.url().string();
 
-    ASSERT(m_frame.loader().documentLoader());
-    if (m_frame.loader().documentLoader())
-        m_frame.loader().documentLoader()->didTellClientAboutLoad(request.url().string());
+    Ref frame = m_frame.get();
+    ASSERT(frame->loader().documentLoader());
+    if (RefPtr documentLoader = m_frame->loader().documentLoader())
+        documentLoader->didTellClientAboutLoad(request.url().string());
 
-    // Notifying the LocalFrameLoaderClient may cause the frame to be destroyed.
-    Ref protectedFrame { m_frame };
-    m_frame.loader().client().dispatchWillSendRequest(loader, identifier, request, redirectResponse);
+    frame->checkedLoader()->client().dispatchWillSendRequest(loader, identifier, request, redirectResponse);
 
     // If the URL changed, then we want to put that new URL in the "did tell client" set too.
-    if (!request.isNull() && oldRequestURL != request.url().string() && m_frame.loader().documentLoader())
-        m_frame.loader().documentLoader()->didTellClientAboutLoad(request.url().string());
+    if (!request.isNull() && oldRequestURL != request.url().string() && frame->loader().documentLoader())
+        frame->loader().protectedDocumentLoader()->didTellClientAboutLoad(request.url().string());
 
-    InspectorInstrumentation::willSendRequest(&m_frame, identifier, loader, request, redirectResponse, cachedResource, resourceLoader);
+    InspectorInstrumentation::willSendRequest(frame.ptr(), identifier, loader, request, redirectResponse, cachedResource, resourceLoader);
 }
 
 void ResourceLoadNotifier::dispatchDidReceiveResponse(DocumentLoader* loader, ResourceLoaderIdentifier identifier, const ResourceResponse& r, ResourceLoader* resourceLoader)
 {
     // Notifying the LocalFrameLoaderClient may cause the frame to be destroyed.
-    Ref protectedFrame { m_frame };
-    m_frame.loader().client().dispatchDidReceiveResponse(loader, identifier, r);
+    Ref frame = m_frame.get();
+    frame->checkedLoader()->client().dispatchDidReceiveResponse(loader, identifier, r);
 
-    InspectorInstrumentation::didReceiveResourceResponse(m_frame, identifier, loader, r, resourceLoader);
+    InspectorInstrumentation::didReceiveResourceResponse(frame, identifier, loader, r, resourceLoader);
 }
 
 void ResourceLoadNotifier::dispatchDidReceiveData(DocumentLoader* loader, ResourceLoaderIdentifier identifier, const SharedBuffer* buffer, int expectedDataLength, int encodedDataLength)
 {
     // Notifying the LocalFrameLoaderClient may cause the frame to be destroyed.
-    Ref protectedFrame { m_frame };
-    m_frame.loader().client().dispatchDidReceiveContentLength(loader, identifier, expectedDataLength);
+    Ref frame = m_frame.get();
+    frame->checkedLoader()->client().dispatchDidReceiveContentLength(loader, identifier, expectedDataLength);
 
-    InspectorInstrumentation::didReceiveData(&m_frame, identifier, buffer, encodedDataLength);
+    InspectorInstrumentation::didReceiveData(frame.ptr(), identifier, buffer, encodedDataLength);
 }
 
 void ResourceLoadNotifier::dispatchDidFinishLoading(DocumentLoader* loader, ResourceLoaderIdentifier identifier, const NetworkLoadMetrics& networkLoadMetrics, ResourceLoader* resourceLoader)
 {
     // Notifying the LocalFrameLoaderClient may cause the frame to be destroyed.
-    Ref protectedFrame { m_frame };
-    m_frame.loader().client().dispatchDidFinishLoading(loader, identifier);
+    Ref frame = m_frame.get();
+    frame->checkedLoader()->client().dispatchDidFinishLoading(loader, identifier);
 
-    InspectorInstrumentation::didFinishLoading(&m_frame, loader, identifier, networkLoadMetrics, resourceLoader);
+    InspectorInstrumentation::didFinishLoading(frame.ptr(), loader, identifier, networkLoadMetrics, resourceLoader);
 }
 
 void ResourceLoadNotifier::dispatchDidFailLoading(DocumentLoader* loader, ResourceLoaderIdentifier identifier, const ResourceError& error)
 {
     // Notifying the LocalFrameLoaderClient may cause the frame to be destroyed.
-    Ref protectedFrame { m_frame };
-    m_frame.loader().client().dispatchDidFailLoading(loader, identifier, error);
+    Ref frame = m_frame.get();
+    frame->checkedLoader()->client().dispatchDidFailLoading(loader, identifier, error);
 
-    InspectorInstrumentation::didFailLoading(&m_frame, loader, identifier, error);
+    InspectorInstrumentation::didFailLoading(frame.ptr(), loader, identifier, error);
 }
 
 void ResourceLoadNotifier::sendRemainingDelegateMessages(DocumentLoader* loader, ResourceLoaderIdentifier identifier, const ResourceRequest& request, const ResourceResponse& response, const SharedBuffer* buffer, int expectedDataLength, int encodedDataLength, const ResourceError& error)

--- a/Source/WebCore/loader/ResourceLoadNotifier.h
+++ b/Source/WebCore/loader/ResourceLoadNotifier.h
@@ -32,6 +32,7 @@
 #include "ResourceLoaderIdentifier.h"
 #include <optional>
 #include <wtf/Noncopyable.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -75,7 +76,9 @@ public:
     }
 
 private:
-    LocalFrame& m_frame;
+    Ref<LocalFrame> protectedFrame() const;
+
+    WeakRef<LocalFrame> m_frame;
     std::optional<ResourceLoaderIdentifier> m_initialRequestIdentifier;
 };
 

--- a/Source/WebCore/loader/ResourceTimingInformation.cpp
+++ b/Source/WebCore/loader/ResourceTimingInformation.cpp
@@ -58,22 +58,22 @@ void ResourceTimingInformation::addResourceTiming(CachedResource& resource, Docu
     if (info.added == Added)
         return;
 
-    Document* initiatorDocument = &document;
+    RefPtr initiatorDocument = &document;
     if (resource.type() == CachedResource::Type::MainResource && document.frame() && document.frame()->loader().shouldReportResourceTimingToParentFrame()) {
         initiatorDocument = document.parentDocument();
         if (initiatorDocument)
-            resourceTiming.updateExposure(initiatorDocument->securityOrigin());
+            resourceTiming.updateExposure(initiatorDocument->protectedSecurityOrigin());
     }
     if (!initiatorDocument)
         return;
 
-    auto* initiatorWindow = initiatorDocument->domWindow();
+    RefPtr initiatorWindow = initiatorDocument->domWindow();
     if (!initiatorWindow)
         return;
 
     resourceTiming.overrideInitiatorType(info.type);
 
-    initiatorWindow->performance().addResourceTiming(WTFMove(resourceTiming));
+    initiatorWindow->protectedPerformance()->addResourceTiming(WTFMove(resourceTiming));
 
     info.added = Added;
 }

--- a/Source/WebCore/loader/TextTrackLoader.cpp
+++ b/Source/WebCore/loader/TextTrackLoader.cpp
@@ -55,27 +55,25 @@ TextTrackLoader::TextTrackLoader(TextTrackLoaderClient& client, Document& docume
 
 TextTrackLoader::~TextTrackLoader()
 {
-    if (m_resource)
-        m_resource->removeClient(*this);
+    if (CachedResourceHandle resource = m_resource)
+        resource->removeClient(*this);
 }
 
 void TextTrackLoader::cueLoadTimerFired()
 {
     if (m_newCuesAvailable) {
         m_newCuesAvailable = false;
-        m_client.newCuesAvailable(*this);
+        m_client->newCuesAvailable(*this);
     }
 
     if (m_state >= Finished)
-        m_client.cueLoadingCompleted(*this, m_state == Failed);
+        m_client->cueLoadingCompleted(*this, m_state == Failed);
 }
 
 void TextTrackLoader::cancelLoad()
 {
-    if (m_resource) {
-        m_resource->removeClient(*this);
-        m_resource = nullptr;
-    }
+    if (CachedResourceHandle resource = std::exchange(m_resource, nullptr))
+        resource->removeClient(*this);
 }
 
 void TextTrackLoader::processNewCueData(CachedResource& resource)
@@ -85,12 +83,12 @@ void TextTrackLoader::processNewCueData(CachedResource& resource)
     if (m_state == Failed || !m_resource->resourceBuffer())
         return;
 
-    auto* buffer = m_resource->resourceBuffer();
+    Ref buffer = *m_resource->resourceBuffer();
     if (m_parseOffset == buffer->size())
         return;
 
     if (!m_cueParser)
-        m_cueParser = makeUnique<WebVTTParser>(static_cast<WebVTTParserClient&>(*this), m_document);
+        m_cueParser = makeUnique<WebVTTParser>(static_cast<WebVTTParserClient&>(*this), protectedDocument());
 
     while (m_parseOffset < buffer->size()) {
         auto data = buffer->getSomeData(m_parseOffset);
@@ -107,13 +105,13 @@ void TextTrackLoader::deprecatedDidReceiveCachedResource(CachedResource& resourc
     if (!m_resource->resourceBuffer())
         return;
 
-    processNewCueData(*m_resource);
+    processNewCueData(*protectedResource());
 }
 
 void TextTrackLoader::corsPolicyPreventedLoad()
 {
     static NeverDestroyed<String> consoleMessage(MAKE_STATIC_STRING_IMPL("Cross-origin text track load denied by Cross-Origin Resource Sharing policy."));
-    m_document.addConsoleMessage(MessageSource::Security, MessageLevel::Error, consoleMessage);
+    protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, consoleMessage);
     m_state = Failed;
 }
 
@@ -128,11 +126,12 @@ void TextTrackLoader::notifyFinished(CachedResource& resource, const NetworkLoad
         m_state = Failed;
 
     if (m_state != Failed) {
-        processNewCueData(*m_resource);
+        CachedResourceHandle resource = m_resource;
+        processNewCueData(*resource);
         if (m_cueParser)
             m_cueParser->fileFinished();
         if (m_state != Failed)
-            m_state = m_resource->errorOccurred() ? Failed : Finished;
+            m_state = resource->errorOccurred() ? Failed : Finished;
     }
 
     if (m_state == Finished && m_cueParser)
@@ -151,18 +150,20 @@ bool TextTrackLoader::load(const URL& url, HTMLTrackElement& element)
     ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
     options.contentSecurityPolicyImposition = element.isInUserAgentShadowTree() ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
 
+    Ref document = m_document.get();
     // FIXME: Do we really need to call completeURL here?
-    ResourceRequest resourceRequest(m_document.completeURL(url.string()));
+    ResourceRequest resourceRequest(document->completeURL(url.string()));
 
-    if (auto mediaElement = element.mediaElement())
+    if (RefPtr mediaElement = element.mediaElement())
         resourceRequest.setInspectorInitiatorNodeIdentifier(InspectorInstrumentation::identifierForNode(*mediaElement));
 
-    auto cueRequest = createPotentialAccessControlRequest(WTFMove(resourceRequest), WTFMove(options), m_document, element.mediaElementCrossOriginAttribute());
-    m_resource = m_document.cachedResourceLoader().requestTextTrack(WTFMove(cueRequest)).value_or(nullptr);
-    if (!m_resource)
-        return false;
-    m_resource->addClient(*this);
-    return true;
+    auto cueRequest = createPotentialAccessControlRequest(WTFMove(resourceRequest), WTFMove(options), document, element.mediaElementCrossOriginAttribute());
+    m_resource = document->protectedCachedResourceLoader()->requestTextTrack(WTFMove(cueRequest)).value_or(nullptr);
+    if (CachedResourceHandle resource = m_resource) {
+        resource->addClient(*this);
+        return true;
+    }
+    return false;
 }
 
 void TextTrackLoader::newCuesParsed()
@@ -176,12 +177,12 @@ void TextTrackLoader::newCuesParsed()
 
 void TextTrackLoader::newRegionsParsed()
 {
-    m_client.newRegionsAvailable(*this);
+    m_client->newRegionsAvailable(*this);
 }
 
 void TextTrackLoader::newStyleSheetsParsed()
 {
-    m_client.newStyleSheetsAvailable(*this);
+    m_client->newStyleSheetsAvailable(*this);
 }
 
 void TextTrackLoader::fileFailedToParse()
@@ -203,7 +204,7 @@ Vector<Ref<VTTCue>> TextTrackLoader::getNewCues()
         return { };
 
     return m_cueParser->takeCues().map([this](auto& cueData) {
-        return VTTCue::create(m_document, cueData);
+        return VTTCue::create(protectedDocument(), cueData);
     });
 }
 
@@ -223,6 +224,16 @@ Vector<String> TextTrackLoader::getNewStyleSheets()
     return m_cueParser->takeStyleSheets();
 }
 
+Ref<Document> TextTrackLoader::protectedDocument() const
+{
+    return m_document.get();
 }
+
+CachedResourceHandle<CachedTextTrack> TextTrackLoader::protectedResource() const
+{
+    return m_resource.get();
+}
+
+} // namespace WebCore
 
 #endif

--- a/Source/WebCore/loader/TextTrackLoader.h
+++ b/Source/WebCore/loader/TextTrackLoader.h
@@ -33,6 +33,7 @@
 #include "Timer.h"
 #include "WebVTTParser.h"
 #include <memory>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -42,7 +43,7 @@ class HTMLTrackElement;
 class TextTrackLoader;
 class VTTCue;
 
-class TextTrackLoaderClient {
+class TextTrackLoaderClient : public CanMakeWeakPtr<TextTrackLoaderClient> {
 public:
     virtual ~TextTrackLoaderClient() = default;
     
@@ -81,12 +82,15 @@ private:
     void cueLoadTimerFired();
     void corsPolicyPreventedLoad();
 
+    Ref<Document> protectedDocument() const;
+    CachedResourceHandle<CachedTextTrack> protectedResource() const;
+
     enum State { Idle, Loading, Finished, Failed };
 
-    TextTrackLoaderClient& m_client;
+    WeakRef<TextTrackLoaderClient> m_client;
     std::unique_ptr<WebVTTParser> m_cueParser;
     CachedResourceHandle<CachedTextTrack> m_resource;
-    Document& m_document;
+    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     Timer m_cueLoadTimer;
     State m_state { Idle };
     unsigned m_parseOffset { 0 };

--- a/Source/WebCore/loader/ThreadableLoader.cpp
+++ b/Source/WebCore/loader/ThreadableLoader.cpp
@@ -151,15 +151,15 @@ void ThreadableLoader::logError(ScriptExecutionContext& context, const ResourceE
     if (error.domain() != errorDomainWebKitInternal && error.domain() != errorDomainWebKitServiceWorker && !error.isAccessControl())
         return;
 
-    const char* messageStart;
+    ASCIILiteral messageStart;
     if (initiatorType == cachedResourceRequestInitiatorTypes().eventsource)
-        messageStart = "EventSource cannot load ";
+        messageStart = "EventSource cannot load "_s;
     else if (initiatorType == cachedResourceRequestInitiatorTypes().fetch)
-        messageStart = "Fetch API cannot load ";
+        messageStart = "Fetch API cannot load "_s;
     else if (initiatorType == cachedResourceRequestInitiatorTypes().xmlhttprequest)
-        messageStart = "XMLHttpRequest cannot load ";
+        messageStart = "XMLHttpRequest cannot load "_s;
     else
-        messageStart = "Cannot load ";
+        messageStart = "Cannot load "_s;
 
     String messageEnd = error.isAccessControl() ? " due to access control checks."_s : "."_s;
     context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString(messageStart, error.failingURL().string(), messageEnd));

--- a/Source/WebCore/loader/ThreadableLoaderClient.h
+++ b/Source/WebCore/loader/ThreadableLoaderClient.h
@@ -33,6 +33,7 @@
 #include "LoaderMalloc.h"
 #include "ResourceLoaderIdentifier.h"
 #include <wtf/CheckedRef.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -42,7 +43,7 @@ class ResourceResponse;
 class ResourceTiming;
 class SharedBuffer;
 
-class ThreadableLoaderClient : public CanMakeThreadSafeCheckedPtr {
+class ThreadableLoaderClient : public CanMakeWeakPtr<ThreadableLoaderClient>, public CanMakeThreadSafeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(ThreadableLoaderClient); WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     virtual void didSendData(unsigned long long /*bytesSent*/, unsigned long long /*totalBytesToBeSent*/) { }

--- a/Source/WebCore/loader/ThreadableLoaderClientWrapper.h
+++ b/Source/WebCore/loader/ThreadableLoaderClientWrapper.h
@@ -103,13 +103,13 @@ public:
 protected:
     explicit ThreadableLoaderClientWrapper(ThreadableLoaderClient&, const String&);
 
-    ThreadableLoaderClient* m_client;
+    WeakPtr<ThreadableLoaderClient> m_client;
     String m_initiator;
     bool m_done { false };
 };
 
 inline ThreadableLoaderClientWrapper::ThreadableLoaderClientWrapper(ThreadableLoaderClient& client, const String& initiator)
-    : m_client(&client)
+    : m_client(client)
     , m_initiator(initiator.isolatedCopy())
 {
 }

--- a/Source/WebCore/loader/WorkerThreadableLoader.h
+++ b/Source/WebCore/loader/WorkerThreadableLoader.h
@@ -101,6 +101,7 @@ private:
     private:
         // Executed on the worker context's thread.
         void clearClientWrapper();
+        RefPtr<ThreadableLoaderClientWrapper> protectedWorkerClientWrapper() const;
 
         // All executed on the main thread.
         void didSendData(unsigned long long bytesSent, unsigned long long totalBytesToBeSent) override;
@@ -120,7 +121,7 @@ private:
         RefPtr<ThreadableLoaderClientWrapper> m_workerClientWrapper;
 
         // May be used on either thread.
-        WorkerLoaderProxy* m_loaderProxy;
+        WorkerLoaderProxy* m_loaderProxy; // FIXME: Use a smart pointer.
 
         // For use on the main thread.
         String m_taskMode;
@@ -134,7 +135,7 @@ private:
     void computeIsDone() final;
 
     Ref<ThreadableLoaderClientWrapper> m_workerClientWrapper;
-    MainThreadBridge& m_bridge;
+    MainThreadBridge& m_bridge; // FIXME: Use a smart pointer.
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -55,6 +55,10 @@ public:
     static ExceptionOr<Ref<EventSource>> create(ScriptExecutionContext&, const String& url, const Init&);
     virtual ~EventSource();
 
+    using EventTarget::weakPtrFactory;
+    using EventTarget::WeakValueType;
+    using EventTarget::WeakPtrImplType;
+
     const String& url() const;
     bool withCredentials() const;
 

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -517,6 +517,11 @@ Performance& WorkerGlobalScope::performance() const
     return *m_performance;
 }
 
+Ref<Performance> WorkerGlobalScope::protectedPerformance() const
+{
+    return *m_performance;
+}
+
 WorkerCacheStorageConnection& WorkerGlobalScope::cacheStorageConnection()
 {
     if (!m_cacheStorageConnection)

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -141,6 +141,7 @@ public:
 
     Crypto& crypto();
     Performance& performance() const;
+    Ref<Performance> protectedPerformance() const;
     ReportingScope& reportingScope() const { return m_reportingScope.get(); }
 
     void prepareForDestruction() override;


### PR DESCRIPTION
#### 0e63180ecc2609db0bec2a06de3d988610d1d150
<pre>
Adopt even more smart pointers in Source/WebCore/loader
<a href="https://bugs.webkit.org/show_bug.cgi?id=268932">https://bugs.webkit.org/show_bug.cgi?id=268932</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/loader/NetscapePlugInStreamLoader.cpp:
(WebCore::NetscapePlugInStreamLoader::create):
(WebCore::NetscapePlugInStreamLoader::init):
(WebCore::NetscapePlugInStreamLoader::didReceiveResponse):
(WebCore::NetscapePlugInStreamLoader::didReceiveData):
(WebCore::NetscapePlugInStreamLoader::didFinishLoading):
(WebCore::NetscapePlugInStreamLoader::didFail):
(WebCore::NetscapePlugInStreamLoader::notifyDone):
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::processContentRuleListsForLoad):
(WebCore::PingLoader::loadImage):
(WebCore::PingLoader::sendPing):
(WebCore::PingLoader::sendViolationReport):
(WebCore::PingLoader::startPingLoad):
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::FrameLoader::PolicyChecker::checkNavigationPolicy):
(WebCore::FrameLoader::PolicyChecker::extendBlobURLLifetimeIfNecessary const):
(WebCore::FrameLoader::PolicyChecker::protectedFrame const):
(WebCore::FrameLoader::PolicyChecker::hitTestResult):
(WebCore::FrameLoader::PolicyChecker::checkNewWindowPolicy):
(WebCore::FrameLoader::PolicyChecker::stopCheck):
(WebCore::FrameLoader::PolicyChecker::cannotShowMIMEType):
(WebCore::FrameLoader::PolicyChecker::handleUnimplementablePolicy):
* Source/WebCore/loader/PolicyChecker.h:
* Source/WebCore/loader/PrivateClickMeasurement.cpp:
(WebCore::PrivateClickMeasurement::attributionReportJSON const):
(WebCore::PrivateClickMeasurement::tokenSignatureJSON const):
(WebCore::PCM::AttributionTriggerData::tokenSignatureJSON const):
* Source/WebCore/loader/ProgressTracker.cpp:
(WebCore::ProgressTracker::protectedPage const):
(WebCore::ProgressTracker::progressStarted):
(WebCore::ProgressTracker::progressEstimateChanged):
(WebCore::ProgressTracker::finalProgressComplete):
(WebCore::ProgressTracker::progressHeartbeatTimerFired):
(WebCore::ProgressTracker::estimatedProgress const): Deleted.
* Source/WebCore/loader/ProgressTracker.h:
(WebCore::ProgressTracker::estimatedProgress const):
* Source/WebCore/loader/ResourceLoadNotifier.cpp:
(WebCore::ResourceLoadNotifier::protectedFrame const):
(WebCore::ResourceLoadNotifier::didReceiveAuthenticationChallenge):
(WebCore::ResourceLoadNotifier::willSendRequest):
(WebCore::ResourceLoadNotifier::didReceiveResponse):
(WebCore::ResourceLoadNotifier::didReceiveData):
(WebCore::ResourceLoadNotifier::didFinishLoad):
(WebCore::ResourceLoadNotifier::didFailToLoad):
(WebCore::ResourceLoadNotifier::assignIdentifierToInitialRequest):
(WebCore::ResourceLoadNotifier::dispatchWillSendRequest):
(WebCore::ResourceLoadNotifier::dispatchDidReceiveResponse):
(WebCore::ResourceLoadNotifier::dispatchDidReceiveData):
(WebCore::ResourceLoadNotifier::dispatchDidFinishLoading):
(WebCore::ResourceLoadNotifier::dispatchDidFailLoading):
* Source/WebCore/loader/ResourceLoadNotifier.h:
* Source/WebCore/loader/ResourceTimingInformation.cpp:
(WebCore::ResourceTimingInformation::addResourceTiming):
* Source/WebCore/loader/TextTrackLoader.cpp:
(WebCore::TextTrackLoader::~TextTrackLoader):
(WebCore::TextTrackLoader::cueLoadTimerFired):
(WebCore::TextTrackLoader::cancelLoad):
(WebCore::TextTrackLoader::processNewCueData):
(WebCore::TextTrackLoader::deprecatedDidReceiveCachedResource):
(WebCore::TextTrackLoader::corsPolicyPreventedLoad):
(WebCore::TextTrackLoader::notifyFinished):
(WebCore::TextTrackLoader::load):
(WebCore::TextTrackLoader::newRegionsParsed):
(WebCore::TextTrackLoader::newStyleSheetsParsed):
(WebCore::TextTrackLoader::getNewCues):
(WebCore::TextTrackLoader::protectedDocument const):
(WebCore::TextTrackLoader::protectedResource const):
* Source/WebCore/loader/TextTrackLoader.h:
* Source/WebCore/loader/ThreadableLoader.cpp:
(WebCore::ThreadableLoader::logError):
* Source/WebCore/loader/ThreadableLoaderClient.h:
* Source/WebCore/loader/ThreadableLoaderClientWrapper.h:
(WebCore::ThreadableLoaderClientWrapper::ThreadableLoaderClientWrapper):
* Source/WebCore/loader/WorkerThreadableLoader.cpp:
(WebCore::WorkerThreadableLoader::loadResourceSynchronously):
(WebCore::m_contextIdentifier):
(WebCore::WorkerThreadableLoader::MainThreadBridge::destroy):
(WebCore::WorkerThreadableLoader::MainThreadBridge::cancel):
(WebCore::WorkerThreadableLoader::MainThreadBridge::computeIsDone):
(WebCore::WorkerThreadableLoader::MainThreadBridge::clearClientWrapper):
(WebCore::WorkerThreadableLoader::MainThreadBridge::protectedWorkerClientWrapper const):
(WebCore::WorkerThreadableLoader::MainThreadBridge::didFinishTiming):
* Source/WebCore/loader/WorkerThreadableLoader.h:
* Source/WebCore/page/EventSource.h:
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::protectedPerformance const):
* Source/WebCore/workers/WorkerGlobalScope.h:

Canonical link: <a href="https://commits.webkit.org/274286@main">https://commits.webkit.org/274286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db4120780f4a427922b0919da45be2b4fa6ecd56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41059 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34203 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32394 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12777 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12752 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42335 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34980 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34769 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38596 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11049 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36801 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14966 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13833 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5022 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14438 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->