### PR TITLE
Remove runtime check for using extensions when USE(EXTENSIONKIT) is true

### DIFF
--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -66,10 +66,6 @@ static Seconds adjustedTimeoutForThermalState(Seconds timeout)
 #endif
 }
 
-#if USE(EXTENSIONKIT)
-bool AuxiliaryProcessProxy::s_manageProcessesAsExtensions = false;
-#endif
-
 AuxiliaryProcessProxy::AuxiliaryProcessProxy(bool alwaysRunsAtBackgroundPriority, Seconds responsivenessTimeout)
     : m_responsivenessTimer(*this, adjustedTimeoutForThermalState(responsivenessTimeout))
     , m_alwaysRunsAtBackgroundPriority(alwaysRunsAtBackgroundPriority)
@@ -161,12 +157,6 @@ void AuxiliaryProcessProxy::getLaunchOptions(ProcessLauncher::LaunchOptions& lau
 
     platformGetLaunchOptions(launchOptions);
 }
-
-#if !PLATFORM(COCOA)
-void AuxiliaryProcessProxy::platformGetLaunchOptions(ProcessLauncher::LaunchOptions&)
-{
-}
-#endif
 
 void AuxiliaryProcessProxy::connect()
 {

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -193,8 +193,6 @@ public:
 
 #if USE(EXTENSIONKIT)
     RetainPtr<_SEExtensionProcess> extensionProcess() const;
-    static void setManageProcessesAsExtensions(bool manageProcessesAsExtensions) { s_manageProcessesAsExtensions = manageProcessesAsExtensions; }
-    static bool manageProcessesAsExtensions() { return s_manageProcessesAsExtensions; }
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
@@ -212,7 +210,7 @@ protected:
     virtual ASCIILiteral processName() const = 0;
 
     virtual void getLaunchOptions(ProcessLauncher::LaunchOptions&);
-    virtual void platformGetLaunchOptions(ProcessLauncher::LaunchOptions&);
+    virtual void platformGetLaunchOptions(ProcessLauncher::LaunchOptions&) { }
 
     struct PendingMessage {
         UniqueRef<IPC::Encoder> encoder;
@@ -263,9 +261,6 @@ private:
 #endif
 #if ENABLE(EXTENSION_CAPABILITIES)
     ExtensionCapabilityGrantMap m_extensionCapabilityGrants;
-#endif
-#if USE(EXTENSIONKIT)
-    static bool s_manageProcessesAsExtensions;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
@@ -83,13 +83,4 @@ RetainPtr<_SEExtensionProcess> AuxiliaryProcessProxy::extensionProcess() const
 }
 #endif
 
-void AuxiliaryProcessProxy::platformGetLaunchOptions(ProcessLauncher::LaunchOptions& launchOptions)
-{
-#if USE(EXTENSIONKIT)
-    launchOptions.launchAsExtensions = s_manageProcessesAsExtensions;
-#else
-    UNUSED_PARAM(launchOptions);
-#endif
-}
-
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1033,11 +1033,6 @@ void WebPageProxy::setMediaCapability(std::optional<MediaCapability>&& capabilit
 
 void WebPageProxy::updateMediaCapability()
 {
-#if USE(EXTENSIONKIT)
-    if (!AuxiliaryProcessProxy::manageProcessesAsExtensions())
-        return;
-#endif
-
     if (!preferences().mediaCapabilityGrantsEnabled())
         return;
 

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
@@ -93,9 +93,6 @@ public:
         HashMap<String, String> extraInitializationData;
         bool nonValidInjectedCodeAllowed { false };
         bool shouldMakeProcessLaunchFailForTesting { false };
-#if USE(EXTENSIONKIT)
-        bool launchAsExtensions { false };
-#endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
         HashMap<CString, SandboxPermission> extraSandboxPaths;

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -117,6 +117,7 @@ static void launchWithExtensionKit(ProcessLauncher& processLauncher, ProcessLaun
 }
 #endif // USE(EXTENSIONKIT)
 
+#if !USE(EXTENSIONKIT) || !PLATFORM(IOS)
 static const char* webContentServiceName(const ProcessLauncher::LaunchOptions& launchOptions, ProcessLauncher::Client* client)
 {
     if (client && client->shouldEnableLockdownMode())
@@ -142,6 +143,7 @@ static const char* serviceName(const ProcessLauncher::LaunchOptions& launchOptio
 #endif
     }
 }
+#endif // !USE(EXTENSIONKIT) || !PLATFORM(IOS)
 
 void ProcessLauncher::platformDestroy()
 {
@@ -210,14 +212,12 @@ void ProcessLauncher::launchProcess()
         });
     };
 
-    if (m_launchOptions.launchAsExtensions) {
-        launchWithExtensionKit(*this, m_launchOptions.processType, m_client, handler);
-        return;
-    }
-#endif
+    launchWithExtensionKit(*this, m_launchOptions.processType, m_client, handler);
+#else
     const char* name = serviceName(m_launchOptions, m_client);
     m_xpcConnection = adoptOSObject(xpc_connection_create(name, nullptr));
     finishLaunchingProcess(name);
+#endif
 }
 
 void ProcessLauncher::finishLaunchingProcess(const char* name)

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -243,11 +243,6 @@ WebProcessPool::WebProcessPool(API::ProcessPoolConfiguration& configuration)
     , m_audibleActivityTimer(RunLoop::main(), this, &WebProcessPool::clearAudibleActivity)
     , m_webProcessWithMediaStreamingCounter([this](RefCounterEvent) { updateMediaStreamingActivity(); })
 {
-#if USE(EXTENSIONKIT)
-    bool manageProcessesAsExtensions = !CFPreferencesGetAppBooleanValue(CFSTR("disableProcessesAsExtensions"), kCFPreferencesCurrentApplication, nullptr);
-    AuxiliaryProcessProxy::setManageProcessesAsExtensions(manageProcessesAsExtensions);
-#endif
-
     static auto s_needsGlobalStaticInitialization = NeedsGlobalStaticInitialization::Yes;
     auto needsGlobalStaticInitialization = std::exchange(s_needsGlobalStaticInitialization, NeedsGlobalStaticInitialization::No);
     if (needsGlobalStaticInitialization == NeedsGlobalStaticInitialization::Yes) {


### PR DESCRIPTION
#### a869bc0414302a680f5ca9968bf01326f1af76d2
<pre>
Remove runtime check for using extensions when USE(EXTENSIONKIT) is true
<a href="https://bugs.webkit.org/show_bug.cgi?id=268944">https://bugs.webkit.org/show_bug.cgi?id=268944</a>

Reviewed by Per Arne Vollan.

The runtime check is no longer needed.
This also fixes some issues when you use a WKWebsiteDataStore and the network process
before a WKProcessPool has been allocated.

* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::setManageProcessesAsExtensions): Deleted.
(WebKit::AuxiliaryProcessProxy::manageProcessesAsExtensions): Deleted.
* Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm:
(WebKit::AuxiliaryProcessProxy::platformGetLaunchOptions):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::updateMediaCapability):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _setupVisibilityPropagationForWebProcess]):
(-[WKContentView _setupVisibilityPropagationForGPUProcess]):
(-[WKContentView _createVisibilityPropagationView]):

Canonical link: <a href="https://commits.webkit.org/274267@main">https://commits.webkit.org/274267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b385281aa446d5617a682ff8838b08f2c1181a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41046 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14784 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14686 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12762 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42322 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34967 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38581 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11036 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36785 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14953 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5012 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14425 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->