### PR TITLE
[WebGPU] ShaderModule::createLibrary may produce invalid metal with custom layouts

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.h
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CompilationMessage.h"
 #include <wtf/text/WTFString.h>
 
 namespace WGSL {
@@ -32,6 +33,6 @@ namespace WGSL {
 class CallGraph;
 struct PipelineLayout;
 
-void rewriteGlobalVariables(CallGraph&, const HashMap<String, std::optional<PipelineLayout>>&);
+std::optional<Error> rewriteGlobalVariables(CallGraph&, const HashMap<String, std::optional<PipelineLayout>>&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -232,10 +232,8 @@ struct PrepareResult {
     CompilationScope compilationScope;
 };
 
-// These are not allowed to fail.
-// All failures must have already been caught in check().
-PrepareResult prepare(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>&);
-PrepareResult prepare(ShaderModule&, const String& entryPointName, const std::optional<PipelineLayout>&);
+std::variant<PrepareResult, Error> prepare(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>&);
+std::variant<PrepareResult, Error> prepare(ShaderModule&, const String& entryPointName, const std::optional<PipelineLayout>&);
 
 String generate(const CallGraph&, HashMap<String, ConstantValue>&);
 

--- a/Source/WebGPU/WGSL/wgslc.cpp
+++ b/Source/WebGPU/WGSL/wgslc.cpp
@@ -133,13 +133,19 @@ static int runWGSL(const CommandLine& options)
     String entrypointName = String::fromLatin1(options.entrypoint());
     auto prepareResult = WGSL::prepare(shaderModule, entrypointName, std::nullopt);
 
-    if (entrypointName != "_"_s && !prepareResult.entryPoints.contains(entrypointName)) {
+    if (auto* error = std::get_if<WGSL::Error>(&prepareResult)) {
+        dataLogLn(*error);
+        return EXIT_FAILURE;
+    }
+
+    auto& result = std::get<WGSL::PrepareResult>(prepareResult);
+    if (entrypointName != "_"_s && !result.entryPoints.contains(entrypointName)) {
         dataLogLn("WGSL source does not contain entrypoint named '", entrypointName, "'");
         return EXIT_FAILURE;
     }
 
     HashMap<String, WGSL::ConstantValue> constantValues;
-    auto msl = WGSL::generate(prepareResult.callGraph, constantValues);
+    auto msl = WGSL::generate(result.callGraph, constantValues);
 
     if (options.dumpASTAtEnd())
         WGSL::AST::dumpAST(shaderModule);

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -107,12 +107,15 @@ static RefPtr<ShaderModule> earlyCompileShaderModule(Device& device, std::varian
     }
 
     auto prepareResult = WGSL::prepare(std::get<WGSL::SuccessfulCheck>(checkResult).ast, wgslHints);
+    if (std::holds_alternative<WGSL::Error>(prepareResult))
+        return nullptr;
+    auto& result = std::get<WGSL::PrepareResult>(prepareResult);
     HashMap<String, WGSL::ConstantValue> wgslConstantValues;
-    auto msl = WGSL::generate(prepareResult.callGraph, wgslConstantValues);
+    auto msl = WGSL::generate(result.callGraph, wgslConstantValues);
     auto library = ShaderModule::createLibrary(device.device(), msl, WTFMove(label));
     if (!library)
         return nullptr;
-    return ShaderModule::create(WTFMove(checkResult), WTFMove(hints), WTFMove(prepareResult.entryPoints), library, nil, { }, device);
+    return ShaderModule::create(WTFMove(checkResult), WTFMove(hints), WTFMove(result.entryPoints), library, nil, { }, device);
 }
 
 static const HashSet<String> buildFeatureSet(const Vector<WGPUFeatureName>& features)

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalGenerationTests.cpp
@@ -41,8 +41,10 @@ inline Expected<String, WGSL::FailedCheck> translate(const String& wgsl, const S
         return makeUnexpected(*maybeError);
 
     auto prepareResult = WGSL::prepare(std::get<WGSL::SuccessfulCheck>(result).ast, entryPointName, { });
+    if (auto* maybeError = std::get_if<WGSL::Error>(&prepareResult))
+        return makeUnexpected(WGSL::FailedCheck { { *maybeError }, { } });
     HashMap<String, WGSL::ConstantValue> constantValues;
-    auto msl = WGSL::generate(prepareResult.callGraph, constantValues);
+    auto msl = WGSL::generate(std::get<WGSL::PrepareResult>(prepareResult).callGraph, constantValues);
     return { WTFMove(msl) };
 }
 


### PR DESCRIPTION
#### 920eba11793e61c3988802a8befb005cf895e3e3
<pre>
[WebGPU] ShaderModule::createLibrary may produce invalid metal with custom layouts
<a href="https://bugs.webkit.org/show_bug.cgi?id=268898">https://bugs.webkit.org/show_bug.cgi?id=268898</a>
<a href="https://rdar.apple.com/122256850">rdar://122256850</a>

Reviewed by Mike Wyrzykowski.

The global variable rewriter should return an error when the shader is incompatible with
the user-provided layout, in order to avoid generating invalid Metal code.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::run):
(WGSL::RewriteGlobalVariables::visitEntryPoint):
(WGSL::RewriteGlobalVariables::insertStructs):
(WGSL::rewriteGlobalVariables):
* Source/WebGPU/WGSL/GlobalVariableRewriter.h:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::staticCheck):
(WGSL::prepareImpl):
(WGSL::prepare):
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WGSL/wgslc.cpp:
(runWGSL):
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::earlyCompileShaderModule):

Canonical link: <a href="https://commits.webkit.org/274365@main">https://commits.webkit.org/274365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f768b4e08e5e0b80ae7704f116cdcf5bc6897869

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34343 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32487 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14855 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33619 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12892 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12873 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42497 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35152 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34877 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38706 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13500 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11177 "Found 1 new test failure: http/tests/media/hls/hls-webvtt-style.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36912 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15112 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8703 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13958 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14593 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->