### PR TITLE
Generate serialization for NSPresentationIntent

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -233,6 +233,7 @@ $(PROJECT_DIR)/Shared/Cocoa/CoreIPCNSCFObject.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCNSValue.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPassKit.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPersonNameComponents.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCPresentationIntent.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCSecureCoding.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCString.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCURL.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -558,6 +558,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/CoreIPCNSValue.serialization.in \
 	Shared/Cocoa/CoreIPCPassKit.serialization.in \
 	Shared/Cocoa/CoreIPCPersonNameComponents.serialization.in \
+	Shared/Cocoa/CoreIPCPresentationIntent.serialization.in \
 	Shared/Cocoa/CoreIPCSecureCoding.serialization.in \
 	Shared/Cocoa/CoreIPCString.serialization.in \
 	Shared/Cocoa/CoreIPCURL.serialization.in \

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -87,6 +87,7 @@ enum class NSType : uint8_t {
     Locale,
     Number,
     PersonNameComponents,
+    PresentationIntent,
     SecureCoding,
     String,
     URL,

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -352,6 +352,8 @@ NSType typeFromObject(id object)
         return NSType::NSValue;
     if ([object isKindOfClass:[NSPersonNameComponents class]])
         return NSType::PersonNameComponents;
+    if ([object isKindOfClass:[NSPresentationIntent class]])
+        return NSType::PresentationIntent;
     if ([object isKindOfClass:[NSString class]])
         return NSType::String;
     if ([object isKindOfClass:[NSURL class]])
@@ -552,10 +554,6 @@ static constexpr bool haveSecureActionContext = false;
 #endif
     if (allowedClasses.contains(NSParagraphStyle.class))
         return haveStrictDecodableNSTextTable;
-
-    // rdar://109121874
-    if (allowedClasses.contains(NSPresentationIntent.class))
-        return true;
 
     // rdar://107553194, Don't reintroduce rdar://108339450
     if (allowedClasses.contains(NSMutableURLRequest.class))

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -85,6 +85,7 @@ using ObjectValue = std::variant<
     CoreIPCNSValue,
     CoreIPCNumber,
     CoreIPCPersonNameComponents,
+    CoreIPCPresentationIntent,
     CoreIPCSecureCoding,
     CoreIPCString,
     CoreIPCURL

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -98,6 +98,8 @@ static ObjectValue valueFromID(id object)
         return CoreIPCNumber(bridge_cast((NSNumber *)object));
     case IPC::NSType::PersonNameComponents:
         return CoreIPCPersonNameComponents((NSPersonNameComponents *)object);
+    case IPC::NSType::PresentationIntent:
+        return CoreIPCPresentationIntent((NSPresentationIntent *)object);
     case IPC::NSType::SecureCoding:
         return CoreIPCSecureCoding((NSObject<NSSecureCoding> *)object);
     case IPC::NSType::String:

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(COCOA)
+
+#include <wtf/ArgumentCoder.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+OBJC_CLASS NSPresentationIntent;
+
+namespace WebKit {
+
+class CoreIPCPresentationIntent {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    CoreIPCPresentationIntent(NSPresentationIntent *);
+
+    RetainPtr<id> toID() const;
+
+private:
+    friend struct IPC::ArgumentCoder<CoreIPCPresentationIntent, void>;
+
+    CoreIPCPresentationIntent(int64_t intentKind, int64_t identity, std::unique_ptr<CoreIPCPresentationIntent>&& parentIntent, int64_t column, Vector<int64_t>&& columnAlignments, int64_t columnCount, int64_t headerLevel, const String& languageHint, int64_t ordinal, int64_t row)
+        : m_intentKind(intentKind)
+        , m_identity(identity)
+        , m_parentIntent(WTFMove(parentIntent))
+        , m_column(column)
+        , m_columnAlignments(WTFMove(columnAlignments))
+        , m_columnCount(columnCount)
+        , m_headerLevel(headerLevel)
+        , m_languageHint(languageHint)
+        , m_ordinal(ordinal)
+        , m_row(row)
+    {
+    }
+
+    int64_t m_intentKind { 0 };
+    int64_t m_identity { 0 };
+    std::unique_ptr<CoreIPCPresentationIntent> m_parentIntent;
+
+    int64_t m_column { 0 };
+    Vector<int64_t> m_columnAlignments;
+    int64_t m_columnCount { 0 };
+    int64_t m_headerLevel { 0 };
+    String m_languageHint;
+    int64_t m_ordinal { 0 };
+    int64_t m_row { 0 };
+};
+
+} // namespace WebKit
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.mm
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "CoreIPCPresentationIntent.h"
+
+#if PLATFORM(COCOA)
+
+#import <Foundation/Foundation.h>
+#import <wtf/RetainPtr.h>
+
+namespace WebKit {
+
+CoreIPCPresentationIntent::CoreIPCPresentationIntent(NSPresentationIntent *intent)
+    : m_intentKind(intent.intentKind)
+    , m_identity(intent.identity)
+{
+    if (intent.parentIntent)
+        m_parentIntent = makeUnique<CoreIPCPresentationIntent>(intent.parentIntent);
+
+    switch (m_intentKind) {
+    case NSPresentationIntentKindHeader:
+        m_headerLevel = intent.headerLevel;
+        break;
+    case NSPresentationIntentKindListItem:
+        m_ordinal = intent.ordinal;
+        break;
+    case NSPresentationIntentKindCodeBlock:
+        m_languageHint = { intent.languageHint };
+        break;
+    case NSPresentationIntentKindTable:
+        for (NSNumber *alignment in intent.columnAlignments)
+            m_columnAlignments.append(alignment.unsignedIntegerValue);
+        m_columnCount = intent.columnCount;
+        break;
+    case NSPresentationIntentKindTableRow:
+        m_row = intent.row;
+        break;
+    case NSPresentationIntentKindTableCell:
+        m_column = intent.column;
+        break;
+    case NSPresentationIntentKindParagraph:
+    case NSPresentationIntentKindOrderedList:
+    case NSPresentationIntentKindUnorderedList:
+    case NSPresentationIntentKindBlockQuote:
+    case NSPresentationIntentKindThematicBreak:
+    case NSPresentationIntentKindTableHeaderRow:
+        break;
+    }
+}
+
+RetainPtr<id> CoreIPCPresentationIntent::toID() const
+{
+    auto parent = (m_parentIntent ? m_parentIntent->toID(): nullptr);
+    switch (m_intentKind) {
+    case NSPresentationIntentKindParagraph:
+        return [NSPresentationIntent paragraphIntentWithIdentity:m_identity nestedInsideIntent:parent.get()];
+    case NSPresentationIntentKindHeader:
+        return [NSPresentationIntent headerIntentWithIdentity:m_identity level:m_headerLevel nestedInsideIntent:parent.get()];
+    case NSPresentationIntentKindOrderedList:
+        return [NSPresentationIntent orderedListIntentWithIdentity:m_identity nestedInsideIntent:parent.get()];
+    case NSPresentationIntentKindUnorderedList:
+        return [NSPresentationIntent unorderedListIntentWithIdentity:m_identity nestedInsideIntent:parent.get()];
+    case NSPresentationIntentKindListItem:
+        return [NSPresentationIntent listItemIntentWithIdentity:m_identity ordinal:m_ordinal nestedInsideIntent:parent.get()];
+    case NSPresentationIntentKindCodeBlock:
+        return [NSPresentationIntent codeBlockIntentWithIdentity:m_identity languageHint:m_languageHint nestedInsideIntent:parent.get()];
+    case NSPresentationIntentKindBlockQuote:
+        return [NSPresentationIntent blockQuoteIntentWithIdentity:m_identity nestedInsideIntent:parent.get()];
+    case NSPresentationIntentKindThematicBreak:
+        return [NSPresentationIntent thematicBreakIntentWithIdentity:m_identity nestedInsideIntent:parent.get()];
+    case NSPresentationIntentKindTable: {
+        auto columnAlignments = adoptNS([[NSMutableArray alloc] initWithCapacity:m_columnAlignments.size()]);
+        for (int64_t alignment : m_columnAlignments)
+            [columnAlignments.get() addObject:@(alignment)];
+        return [NSPresentationIntent tableIntentWithIdentity:m_identity columnCount:m_columnCount alignments:columnAlignments.get() nestedInsideIntent:parent.get()];
+    }
+    case NSPresentationIntentKindTableHeaderRow:
+        return [NSPresentationIntent tableHeaderRowIntentWithIdentity:m_identity nestedInsideIntent:parent.get()];
+    case NSPresentationIntentKindTableRow:
+        return [NSPresentationIntent tableRowIntentWithIdentity:m_identity row:m_row nestedInsideIntent:parent.get()];
+    case NSPresentationIntentKindTableCell:
+        return [NSPresentationIntent tableCellIntentWithIdentity:m_identity column:m_column nestedInsideIntent:parent.get()];
+    }
+
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+} // namespace WebKit
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.serialization.in
@@ -1,0 +1,40 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(COCOA)
+
+webkit_platform_headers: "CoreIPCPresentationIntent.h"
+
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCPresentationIntent {
+    int64_t m_intentKind;
+    int64_t m_identity;
+    std::unique_ptr<WebKit::CoreIPCPresentationIntent> m_parentIntent;
+    int64_t m_column;
+    Vector<int64_t> m_columnAlignments;
+    int64_t m_columnCount;
+    int64_t m_headerLevel;
+    String m_languageHint;
+    int64_t m_ordinal;
+    int64_t m_row;
+}
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCTypes.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCTypes.h
@@ -39,6 +39,7 @@
 #import "CoreIPCNumber.h"
 #import "CoreIPCPassKit.h"
 #import "CoreIPCPersonNameComponents.h"
+#import "CoreIPCPresentationIntent.h"
 #import "CoreIPCSecureCoding.h"
 #import "CoreIPCString.h"
 #import "CoreIPCURL.h"

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1332,6 +1332,8 @@
 		561A54532B61E49E00073A72 /* CoreIPCSecCertificate.h in Headers */ = {isa = PBXBuildFile; fileRef = 561A54512B61E49E00073A72 /* CoreIPCSecCertificate.h */; };
 		561A54612B6438C000073A72 /* CoreIPCSecKeychainItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 561A54602B6438C000073A72 /* CoreIPCSecKeychainItem.h */; };
 		562674F52B69B4C8008BB425 /* CoreIPCSecTrust.h in Headers */ = {isa = PBXBuildFile; fileRef = 562674F32B69B4C7008BB425 /* CoreIPCSecTrust.h */; };
+		564599972B71C3B700BC59E6 /* CoreIPCPresentationIntent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 564599952B71BBC300BC59E6 /* CoreIPCPresentationIntent.mm */; };
+		564599992B71C3D100BC59E6 /* CoreIPCPresentationIntent.h in Headers */ = {isa = PBXBuildFile; fileRef = 564599942B71BBB200BC59E6 /* CoreIPCPresentationIntent.h */; };
 		570AB8F320AE3BD700B8BE87 /* SecKeyProxyStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 570AB8F220AE3BD700B8BE87 /* SecKeyProxyStore.h */; };
 		570DAAAE23026F5C00E8FC04 /* NfcService.h in Headers */ = {isa = PBXBuildFile; fileRef = 570DAAAC23026F5C00E8FC04 /* NfcService.h */; };
 		570DAAC22303730300E8FC04 /* NfcConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 570DAAC02303730300E8FC04 /* NfcConnection.h */; };
@@ -5669,6 +5671,9 @@
 		561A54602B6438C000073A72 /* CoreIPCSecKeychainItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCSecKeychainItem.h; sourceTree = "<group>"; };
 		562674F32B69B4C7008BB425 /* CoreIPCSecTrust.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCSecTrust.h; sourceTree = "<group>"; };
 		562674F42B69B4C8008BB425 /* CoreIPCSecTrust.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCSecTrust.serialization.in; sourceTree = "<group>"; };
+		564599932B71BBA000BC59E6 /* CoreIPCPresentationIntent.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCPresentationIntent.serialization.in; sourceTree = "<group>"; };
+		564599942B71BBB200BC59E6 /* CoreIPCPresentationIntent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCPresentationIntent.h; sourceTree = "<group>"; };
+		564599952B71BBC300BC59E6 /* CoreIPCPresentationIntent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCPresentationIntent.mm; sourceTree = "<group>"; };
 		570AB8F220AE3BD700B8BE87 /* SecKeyProxyStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SecKeyProxyStore.h; sourceTree = "<group>"; };
 		570AB90020B2517400B8BE87 /* AuthenticationChallengeProxyCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AuthenticationChallengeProxyCocoa.mm; sourceTree = "<group>"; };
 		570AB90320B2541C00B8BE87 /* SecKeyProxyStore.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SecKeyProxyStore.mm; sourceTree = "<group>"; };
@@ -11333,6 +11338,9 @@
 				51AD568D2B1C46EF001A0ECB /* CoreIPCPersonNameComponents.h */,
 				51AD568E2B1C46EF001A0ECB /* CoreIPCPersonNameComponents.mm */,
 				51AD568F2B1C46F0001A0ECB /* CoreIPCPersonNameComponents.serialization.in */,
+				564599942B71BBB200BC59E6 /* CoreIPCPresentationIntent.h */,
+				564599952B71BBC300BC59E6 /* CoreIPCPresentationIntent.mm */,
+				564599932B71BBA000BC59E6 /* CoreIPCPresentationIntent.serialization.in */,
 				5C5786912B6EFFFF005D51D5 /* CoreIPCRetainPtr.h */,
 				5197FAD92AFD33B2009180C5 /* CoreIPCSecureCoding.h */,
 				5197FADA2AFD33B2009180C5 /* CoreIPCSecureCoding.mm */,
@@ -15675,6 +15683,7 @@
 				F4EFF36D2AF0267300479AB8 /* CoreIPCNumber.h in Headers */,
 				5157AE0A2B23E96A00C0E095 /* CoreIPCPassKit.h in Headers */,
 				51AD56912B1C4704001A0ECB /* CoreIPCPersonNameComponents.h in Headers */,
+				564599992B71C3D100BC59E6 /* CoreIPCPresentationIntent.h in Headers */,
 				5C5786922B6EFFFF005D51D5 /* CoreIPCRetainPtr.h in Headers */,
 				561A54532B61E49E00073A72 /* CoreIPCSecCertificate.h in Headers */,
 				5197FAE92AFD33CF009180C5 /* CoreIPCSecureCoding.h in Headers */,
@@ -18532,6 +18541,7 @@
 				51ACFFE02B048829001331A2 /* CoreIPCNSValue.mm in Sources */,
 				5157AE0B2B23E97400C0E095 /* CoreIPCPassKit.mm in Sources */,
 				51AD56902B1C46FE001A0ECB /* CoreIPCPersonNameComponents.mm in Sources */,
+				564599972B71C3B700BC59E6 /* CoreIPCPresentationIntent.mm in Sources */,
 				5197FAED2AFD33FF009180C5 /* CoreIPCSecureCoding.mm in Sources */,
 				5131D5462AE9D5230016EF39 /* CoreTextHelpers.mm in Sources */,
 				51AD56862B1AB839001A0ECB /* GeneratedWebKitSecureCoding.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -366,6 +366,7 @@ struct ObjCHolderForTesting {
         RetainPtr<AVOutputContext>,
 #endif
         RetainPtr<NSPersonNameComponents>,
+        RetainPtr<NSPresentationIntent>,
 #if USE(PASSKIT) && !PLATFORM(WATCHOS)
         RetainPtr<CNPhoneNumber>,
         RetainPtr<CNPostalAddress>,
@@ -953,6 +954,44 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         NSNull.null : NSData.data,
         url : (id)trust.get()
     } });
+
+    // NSPresentationIntent
+    NSInteger intentID = 1;
+    NSPresentationIntent *paragraphIntent = [NSPresentationIntent paragraphIntentWithIdentity:intentID++ nestedInsideIntent:nil];
+    runTestNS({ paragraphIntent });
+
+    NSPresentationIntent *headingIntent = [NSPresentationIntent headerIntentWithIdentity:intentID++ level:1 nestedInsideIntent:nil];
+    runTestNS({ headingIntent });
+
+    NSPresentationIntent *codeBlockIntent = [NSPresentationIntent codeBlockIntentWithIdentity:intentID++ languageHint:@"Swift" nestedInsideIntent:paragraphIntent];
+    runTestNS({ codeBlockIntent });
+
+    NSPresentationIntent *thematicBreakIntent = [NSPresentationIntent thematicBreakIntentWithIdentity:intentID++ nestedInsideIntent:nil];
+    runTestNS({ thematicBreakIntent });
+
+    NSPresentationIntent *orderedListIntent = [NSPresentationIntent orderedListIntentWithIdentity:intentID++ nestedInsideIntent:paragraphIntent];
+    runTestNS({ orderedListIntent });
+
+    NSPresentationIntent *unorderedListIntent = [NSPresentationIntent unorderedListIntentWithIdentity:intentID++ nestedInsideIntent:paragraphIntent];
+    runTestNS({ unorderedListIntent });
+
+    NSPresentationIntent *listItemIntent = [NSPresentationIntent listItemIntentWithIdentity:intentID++ ordinal:1 nestedInsideIntent:orderedListIntent];
+    runTestNS({ listItemIntent });
+
+    NSPresentationIntent *blockQuoteIntent = [NSPresentationIntent blockQuoteIntentWithIdentity:intentID++ nestedInsideIntent:paragraphIntent];
+    runTestNS({ blockQuoteIntent });
+
+    NSPresentationIntent *tableIntent = [NSPresentationIntent tableIntentWithIdentity:intentID++ columnCount:2 alignments:@[@(NSPresentationIntentTableColumnAlignmentLeft), @(NSPresentationIntentTableColumnAlignmentRight)] nestedInsideIntent:unorderedListIntent];
+    runTestNS({ tableIntent });
+
+    NSPresentationIntent *tableHeaderRowIntent = [NSPresentationIntent tableHeaderRowIntentWithIdentity:intentID++ nestedInsideIntent:tableIntent];
+    runTestNS({ tableHeaderRowIntent });
+
+    NSPresentationIntent *tableRowIntent = [NSPresentationIntent tableRowIntentWithIdentity:intentID++ row:1 nestedInsideIntent:tableIntent];
+    runTestNS({ tableRowIntent });
+
+    NSPresentationIntent *tableCellIntent = [NSPresentationIntent tableCellIntentWithIdentity:intentID++ column:1 nestedInsideIntent:tableRowIntent];
+    runTestNS({ tableCellIntent });
 }
 
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 089245fbdcadc21c8ef020e0a1ea4dd297355b4e
<pre>
Generate serialization for NSPresentationIntent
<a href="https://bugs.webkit.org/show_bug.cgi?id=268779">https://bugs.webkit.org/show_bug.cgi?id=268779</a>
<a href="https://rdar.apple.com/109121874">rdar://109121874</a>

Reviewed by achristensen07 (Alex Christensen).

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::typeFromObject):
(IPC::shouldEnableStrictMode):
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::valueFromID):
* Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.h: Added.
(WebKit::CoreIPCPresentationIntent::CoreIPCPresentationIntent):
* Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.mm: Added.
(WebKit::CoreIPCPresentationIntent::CoreIPCPresentationIntent):
(WebKit::CoreIPCPresentationIntent::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCPresentationIntent.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCTypes.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/274269@main">https://commits.webkit.org/274269@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dd1fd2476454a738622e7288d0cd79a7213c4f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41051 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14789 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39082 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14690 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12767 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42327 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34971 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38584 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36788 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14958 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5014 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14430 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->