### PR TITLE
Adopt more smart pointers in Page.cpp

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -788,6 +788,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     contentextensions/ContentExtensionParser.h
     contentextensions/ContentExtensionRule.h
     contentextensions/ContentExtensionStringSerialization.h
+    contentextensions/ContentExtensionStyleSheet.h
     contentextensions/ContentExtensionsBackend.h
     contentextensions/ContentExtensionsDebugging.h
     contentextensions/ContentRuleListResults.h
@@ -972,6 +973,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/ExceptionCode.h
     dom/ExceptionData.h
     dom/ExceptionOr.h
+    dom/ExtensionStyleSheets.h
     dom/FocusOptions.h
     dom/FragmentDirectiveParser.h
     dom/FragmentDirectiveRangeFinder.h

--- a/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.h
@@ -34,7 +34,7 @@ class AccessibilityObjectAtspi;
 class Page;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AccessibilityRootAtspi);
-class AccessibilityRootAtspi final : public RefCounted<AccessibilityRootAtspi> {
+class AccessibilityRootAtspi final : public RefCounted<AccessibilityRootAtspi>, public CanMakeWeakPtr<AccessibilityRootAtspi> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(AccessibilityRootAtspi);
 public:
     static Ref<AccessibilityRootAtspi> create(Page&);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -667,7 +667,8 @@ public:
     CheckedRef<const Style::Scope> checkedStyleScope() const;
 
     ExtensionStyleSheets* extensionStyleSheetsIfExists() { return m_extensionStyleSheets.get(); }
-    inline ExtensionStyleSheets& extensionStyleSheets();
+    inline ExtensionStyleSheets& extensionStyleSheets(); // Defined in DocumentInlines.h.
+    inline CheckedRef<ExtensionStyleSheets> checkedExtensionStyleSheets(); // Defined in DocumentInlines.h.
 
     const Style::CustomPropertyRegistry& customPropertyRegistry() const;
     const CSSCounterStyleRegistry& counterStyleRegistry() const;

--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -31,6 +31,7 @@
 #include "DocumentMarkerController.h"
 #include "DocumentParser.h"
 #include "Element.h"
+#include "ExtensionStyleSheets.h"
 #include "FocusOptions.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FullscreenManager.h"
@@ -73,6 +74,11 @@ inline ExtensionStyleSheets& Document::extensionStyleSheets()
     if (!m_extensionStyleSheets)
         return ensureExtensionStyleSheets();
     return *m_extensionStyleSheets;
+}
+
+inline CheckedRef<ExtensionStyleSheets> Document::checkedExtensionStyleSheets()
+{
+    return extensionStyleSheets();
 }
 
 inline VisitedLinkState& Document::visitedLinkState() const

--- a/Source/WebCore/dom/VisitedLinkState.h
+++ b/Source/WebCore/dom/VisitedLinkState.h
@@ -31,6 +31,7 @@
 #include "Element.h"
 #include "RenderStyleConstants.h"
 #include "SharedStringHash.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashSet.h>
 #include <wtf/WeakRef.h>
 
@@ -38,7 +39,7 @@ namespace WebCore {
 
 class Document;
 
-class VisitedLinkState {
+class VisitedLinkState : public CanMakeCheckedPtr {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit VisitedLinkState(Document&);

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
@@ -36,7 +37,7 @@ class BackForwardClient;
 class HistoryItem;
 class Page;
 
-class BackForwardController {
+class BackForwardController : public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(BackForwardController); WTF_MAKE_FAST_ALLOCATED;
 public:
     BackForwardController(Page&, Ref<BackForwardClient>&&);

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5751,6 +5751,11 @@ RenderView* LocalFrameView::renderView() const
     return m_frame->contentRenderer();
 }
 
+CheckedPtr<RenderView> LocalFrameView::checkedRenderView() const
+{
+    return renderView();
+}
+
 int LocalFrameView::mapFromLayoutToCSSUnits(LayoutUnit value) const
 {
     return value / (m_frame->pageZoomFactor() * m_frame->frameScaleFactor());

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -108,6 +108,7 @@ public:
     Ref<LocalFrame> protectedFrame() const;
 
     WEBCORE_EXPORT RenderView* renderView() const;
+    CheckedPtr<RenderView> checkedRenderView() const;
 
     int mapFromLayoutToCSSUnits(LayoutUnit) const;
     LayoutUnit mapFromCSSToLayoutUnits(int) const;

--- a/Source/WebCore/page/PageGroup.h
+++ b/Source/WebCore/page/PageGroup.h
@@ -36,7 +36,7 @@ class Page;
 class CaptionUserPreferences;
 #endif
 
-class PageGroup {
+class PageGroup : public CanMakeWeakPtr<PageGroup> {
     WTF_MAKE_NONCOPYABLE(PageGroup); WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT explicit PageGroup(const String& name);

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.h
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.h
@@ -30,6 +30,7 @@
 #include "WorkerThreadType.h"
 #include <JavaScriptCore/Debugger.h>
 #include <JavaScriptCore/JSRunLoopTimer.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/Lock.h>
 #include <wtf/MessageQueue.h>
@@ -52,7 +53,7 @@ class WorkerConsoleClient;
 class WorkerOrWorkletGlobalScope;
 class WorkerScriptFetcher;
 
-class WorkerOrWorkletScriptController {
+class WorkerOrWorkletScriptController : public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(WorkerOrWorkletScriptController);
     WTF_MAKE_FAST_ALLOCATED;
 public:


### PR DESCRIPTION
#### dd3340d4fb22789ac7195998a5d71ef882a82139
<pre>
Adopt more smart pointers in Page.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=268938">https://bugs.webkit.org/show_bug.cgi?id=268938</a>

Reviewed by Brent Fulgham.

* Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.h:
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentInlines.h:
(WebCore::Document::checkedExtensionStyleSheets):
* Source/WebCore/dom/VisitedLinkState.h:
* Source/WebCore/history/BackForwardController.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::checkedRenderView const):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::forEachPage):
(WebCore::networkStateChanged):
(WebCore::m_historyItemClient):
(WebCore::Page::~Page):
(WebCore::Page::checkedBackForward):
(WebCore::Page::clearPreviousItemFromAllPages):
(WebCore::Page::renderTreeSize const):
(WebCore::Page::disabledAdaptations const):
(WebCore::viewportDocumentForFrame):
(WebCore::Page::viewportArguments const):
(WebCore::Page::setOverrideViewportArguments):
(WebCore::Page::scrollingCoordinator):
(WebCore::Page::scrollingStateTreeAsText):
(WebCore::Page::synchronousScrollingReasonsAsText):
(WebCore::Page::nonFastScrollableRectsForTesting):
(WebCore::Page::touchEventRectsForEventForTesting):
(WebCore::Page::passiveTouchEventListenerRectsForTesting):
(WebCore::Page::accessibilityTreeData const):
(WebCore::Page::progressEstimateChanged const):
(WebCore::Page::progressFinished const):
(WebCore::Page::goToItem):
(WebCore::Page::updateStyleAfterChangeInEnvironment):
(WebCore::Page::updateStyleForAllPagesAfterGlobalChangeInEnvironment):
(WebCore::Page::setNeedsRecalcStyleInAllFrames):
(WebCore::Page::refreshPlugins):
(WebCore::Page::findString):
(WebCore::Page::findTextMatches):
(WebCore::Page::rangeOfString):
(WebCore::Page::findMatchesForText):
(WebCore::replaceRanges):
(WebCore::Page::replaceSelectionWithText):
(WebCore::Page::setEditableRegionEnabled):
(WebCore::Page::editableElementsInRect const):
(WebCore::Page::checkedFocusController const):
(WebCore::Page::setInteractionRegionsEnabled):
(WebCore::Page::selection const):
(WebCore::Page::setDefersLoading):
(WebCore::Page::setZoomedOutPageScaleFactor):
(WebCore::Page::setPageScaleFactor):
(WebCore::Page::setDeviceScaleFactor):
(WebCore::Page::windowScreenDidChange):
(WebCore::Page::setTopContentInset):
(WebCore::Page::lockAllOverlayScrollbarsToHidden):
(WebCore::Page::group):
(WebCore::Page::setVerticalScrollElasticity):
(WebCore::Page::setHorizontalScrollElasticity):
(WebCore::Page::pageCount const):
(WebCore::Page::pageCountAssumingLayoutIsUpToDate const):
(WebCore::Page::setIsInWindowInternal):
(WebCore::Page::layoutIfNeeded):
(WebCore::Page::didScheduleRenderingUpdate):
(WebCore::Page::updateRendering):
(WebCore::Page::doAfterUpdateRendering):
(WebCore::Page::finalizeRenderingUpdateForRootFrame):
(WebCore::Page::renderingUpdateCompleted):
(WebCore::Page::protectedOpportunisticTaskScheduler const):
(WebCore::Page::willStartRenderingUpdateDisplay):
(WebCore::Page::didCompleteRenderingUpdateDisplay):
(WebCore::Page::didCompleteRenderingFrame):
(WebCore::Page::prioritizeVisibleResources):
(WebCore::Page::shouldUpdateAccessibilityRegions const):
(WebCore::Page::timelineControllerMaximumAnimationFrameRateDidChange):
(WebCore::Page::preferredRenderingUpdateFramesPerSecond const):
(WebCore::Page::setIsVisuallyIdleInternal):
(WebCore::Page::handleLowPowerModeChange):
(WebCore::Page::userStyleSheetLocationChanged):
(WebCore::Page::userStyleSheet const):
(WebCore::Page::userAgentChanged):
(WebCore::Page::invalidateStylesForAllLinks):
(WebCore::Page::invalidateStylesForLink):
(WebCore::Page::setDebugger):
(WebCore::Page::setMemoryCacheClientCallsEnabled):
(WebCore::Page::resumeAnimatingImages):
(WebCore::Page::setActivityState):
(WebCore::Page::stopKeyboardScrollAnimation):
(WebCore::Page::setIsVisibleInternal):
(WebCore::Page::setHeaderHeight):
(WebCore::Page::setFooterHeight):
(WebCore::Page::pageExtendedBackgroundColor const):
(WebCore::Page::setUnderPageBackgroundColorOverride):
(WebCore::Page::addRelevantRepaintedObject):
(WebCore::Page::suspendActiveDOMObjectsAndAnimations):
(WebCore::Page::resumeActiveDOMObjectsAndAnimations):
(WebCore::Page::hiddenPageCSSAnimationSuspensionStateChanged):
(WebCore::Page::protectedStorageNamespaceProvider const):
(WebCore::Page::protectedPluginInfoProvider const):
(WebCore::Page::setUserContentProvider):
(WebCore::Page::protectedVisitedLinkStore):
(WebCore::Page::setVisitedLinkStore):
(WebCore::Page::setSessionID):
(WebCore::Page::clearWheelEventTestMonitor):
(WebCore::Page::startMonitoringWheelEvents):
(WebCore::Page::accessibilitySettingsDidChange):
(WebCore::Page::appearanceDidChange):
(WebCore::Page::hasLocalDataForURL):
(WebCore::dispatchPrintEvent):
(WebCore::Page::dispatchBeforePrintEvent):
(WebCore::Page::dispatchAfterPrintEvent):
(WebCore::Page::startApplePayAMSUISession):
(WebCore::Page::setMediaSessionCoordinator):
(WebCore::Page::invalidateMediaSessionCoordinator):
(WebCore::Page::didFinishLoadingImageForElement):
(WebCore::Page::recomputeTextAutoSizingInAllFrames):
(WebCore::Page::revealCurrentSelection):
(WebCore::Page::injectUserStyleSheet):
(WebCore::Page::removeInjectedUserStyleSheet):
(WebCore::Page::mainFrameDidChangeToNonInitialEmptyDocument):
(WebCore::Page::updateElementsWithTextRecognitionResults):
(WebCore::Page::serviceWorkerGlobalObject):
(WebCore::Page::setupForRemoteWorker):
(WebCore::Page::forceRepaintAllFrames):
(WebCore::Page::updatePlayStateForAllAnimations):
(WebCore::Page::reloadExecutionContextsForOrigin const):
(WebCore::Page::accessibilityRootObject const):
(WebCore::Page::setAccessibilityRootObject):
* Source/WebCore/page/Page.h:
(WebCore::Page::accessibilityRootObject const): Deleted.
(WebCore::Page::setAccessibilityRootObject): Deleted.
(WebCore::Page::group): Deleted.
* Source/WebCore/page/PageGroup.h:

Canonical link: <a href="https://commits.webkit.org/274301@main">https://commits.webkit.org/274301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f677778d54c8c46ce1f8b0db0c258d27e9846ba0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41146 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34274 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14889 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32447 "Build is being retried. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests running") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39185 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14792 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12850 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42422 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35083 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38665 "Build is being retried. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests running") | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11119 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36878 "Build is being retried. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15044 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5034 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->