### PR TITLE
Proxy configuration should apply after a network process crash

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -264,7 +264,7 @@ public:
 
 #if HAVE(NW_PROXY_CONFIG)
     virtual void clearProxyConfigData() { }
-    virtual void setProxyConfigData(Vector<std::pair<Vector<uint8_t>, WTF::UUID>>&&) { };
+    virtual void setProxyConfigData(const Vector<std::pair<Vector<uint8_t>, WTF::UUID>>&) { };
 #endif
 
     void setInspectionForServiceWorkersAllowed(bool);

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -133,7 +133,9 @@ struct NetworkSessionCreationParameters {
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     bool isDeclarativeWebPushEnabled { false };
 #endif
-
+#if HAVE(NW_PROXY_CONFIG)
+    std::optional<Vector<std::pair<Vector<uint8_t>, WTF::UUID>>> proxyConfigData;
+#endif
     ResourceLoadStatisticsParameters resourceLoadStatisticsParameters;
 };
 

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
@@ -100,6 +100,8 @@
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     bool isDeclarativeWebPushEnabled;
 #endif
-
+#if HAVE(NW_PROXY_CONFIG)
+    std::optional<Vector<std::pair<Vector<uint8_t>, WTF::UUID>>> proxyConfigData;
+#endif
     WebKit::ResourceLoadStatisticsParameters resourceLoadStatisticsParameters;
 };

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
@@ -151,7 +151,7 @@ public:
     const Vector<RetainPtr<nw_proxy_config_t>> proxyConfigs() const { return m_nwProxyConfigs; }
 
     void clearProxyConfigData() final;
-    void setProxyConfigData(Vector<std::pair<Vector<uint8_t>, WTF::UUID>>&&) final;
+    void setProxyConfigData(const Vector<std::pair<Vector<uint8_t>, WTF::UUID>>&) final;
 
     void applyProxyConfigurationToSessionConfiguration(NSURLSessionConfiguration *);
 #endif

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1517,6 +1517,11 @@ NetworkSessionCocoa::NetworkSessionCocoa(NetworkProcess& networkProcess, const N
 #endif
 
     activateSessionCleanup(*this, parameters);
+
+#if HAVE(NW_PROXY_CONFIG)
+    if (parameters.proxyConfigData)
+        setProxyConfigData(WTFMove(*parameters.proxyConfigData));
+#endif
 }
 
 NetworkSessionCocoa::~NetworkSessionCocoa() = default;
@@ -2183,7 +2188,7 @@ void NetworkSessionCocoa::clearProxyConfigData()
         clearProxies(context);
 }
 
-void NetworkSessionCocoa::setProxyConfigData(Vector<std::pair<Vector<uint8_t>, WTF::UUID>>&& proxyConfigurations)
+void NetworkSessionCocoa::setProxyConfigData(const Vector<std::pair<Vector<uint8_t>, WTF::UUID>>& proxyConfigurations)
 {
     auto* clearProxies = nw_context_clear_proxiesPtr();
     auto* addProxy = nw_context_add_proxyPtr();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1944,6 +1944,9 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     networkSessionParameters.isDeclarativeWebPushEnabled = m_configuration->isDeclarativeWebPushEnabled();
 #endif
+#if HAVE(NW_PROXY_CONFIG)
+    networkSessionParameters.proxyConfigData = m_proxyConfigData;
+#endif
 
     parameters.networkSessionParameters = WTFMove(networkSessionParameters);
     parameters.networkSessionParameters.resourceLoadStatisticsParameters.enabled = m_trackingPreventionEnabled;
@@ -2428,7 +2431,9 @@ void WebsiteDataStore::clearProxyConfigData()
 
 void WebsiteDataStore::setProxyConfigData(Vector<std::pair<Vector<uint8_t>, WTF::UUID>>&& data)
 {
-    protectedNetworkProcess()->send(Messages::NetworkProcess::SetProxyConfigData(m_sessionID, WTFMove(data)), 0);
+    m_proxyConfigData = std::nullopt;
+    protectedNetworkProcess()->send(Messages::NetworkProcess::SetProxyConfigData(m_sessionID, data), 0);
+    m_proxyConfigData = WTFMove(data);
 }
 #endif // HAVE(NW_PROXY_CONFIG)
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -621,6 +621,10 @@ private:
     bool m_isBlobRegistryPartitioningEnabled { false };
 
     HashMap<WebCore::RegistrableDomain, RestrictedOpenerType> m_restrictedOpenerTypesForTesting;
+
+#if HAVE(NW_PROXY_CONFIG)
+    std::optional<Vector<std::pair<Vector<uint8_t>, WTF::UUID>>> m_proxyConfigData;
+#endif
 };
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm
@@ -40,12 +40,6 @@
 #import <wtf/SoftLinking.h>
 #import <wtf/text/StringConcatenateNumbers.h>
 
-#if HAVE(NW_PROXY_CONFIG)
-SOFT_LINK_LIBRARY_OPTIONAL(libnetwork)
-SOFT_LINK_OPTIONAL(libnetwork, nw_proxy_config_create_http_connect, nw_proxy_config_t, __cdecl, (nw_endpoint_t, nw_protocol_options_t))
-SOFT_LINK_OPTIONAL(libnetwork, nw_proxy_config_create_socksv5, nw_proxy_config_t, __cdecl, (nw_endpoint_t))
-#endif // HAVE(NW_PROXY_CONFIG)
-
 @interface ProxyDelegate : NSObject <WKNavigationDelegate, WKUIDelegate>
 - (NSString *)waitForAlert;
 @end
@@ -165,10 +159,6 @@ TEST(WebKit, SOCKS5)
 #if HAVE(NW_PROXY_CONFIG)
 TEST(WebKit, HTTPSProxyAPI)
 {
-    auto* createProxyConfig = nw_proxy_config_create_http_connectPtr();
-    if (!createProxyConfig)
-        return;
-
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]);
     auto delegate = adoptNS([ProxyDelegate new]);
     [webView setNavigationDelegate:delegate.get()];
@@ -189,13 +179,13 @@ TEST(WebKit, HTTPSProxyAPI)
     // 127.0.0.1:1 will never be reachable and will immediately timeout, causing
     // us to fallback to 127.0.0.1:<real port>
     auto endpoint1 = adoptNS(nw_endpoint_create_host("127.0.0.1", "1"));
-    auto proxyConfig1 = adoptNS(createProxyConfig(endpoint1.get(), nil));
+    auto proxyConfig1 = adoptNS(nw_proxy_config_create_http_connect(endpoint1.get(), nil));
 
     auto endpoint2 = adoptNS(nw_endpoint_create_host("127.0.0.1", std::to_string(proxyServer1.port()).c_str()));
-    auto proxyConfig2 = adoptNS(createProxyConfig(endpoint2.get(), nil));
+    auto proxyConfig2 = adoptNS(nw_proxy_config_create_http_connect(endpoint2.get(), nil));
 
     auto endpoint3 = adoptNS(nw_endpoint_create_host("127.0.0.1", std::to_string(proxyServer2.port()).c_str()));
-    auto proxyConfig3 = adoptNS(createProxyConfig(endpoint3.get(), nil));
+    auto proxyConfig3 = adoptNS(nw_proxy_config_create_http_connect(endpoint3.get(), nil));
 
     // Proxy 1 should be ignored as it is unreachable.
     // Proxy 2 should be used.
@@ -224,12 +214,41 @@ TEST(WebKit, HTTPSProxyAPI)
     EXPECT_WK_STREQ([delegate waitForAlert], "non proxy success!");
 }
 
+TEST(WebKit, ProxyAfterNetworkProcessCrash)
+{
+    TestWebKitAPI::HTTPServer proxyServer1({
+        { "/"_s, { "<script>alert('proxy success!')</script>"_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+
+    auto endpoint = adoptNS(nw_endpoint_create_host("127.0.0.1", std::to_string(proxyServer1.port()).c_str()));
+    auto proxyConfig = adoptNS(nw_proxy_config_create_http_connect(endpoint.get(), nil));
+
+    auto dataStore = WKWebsiteDataStore.nonPersistentDataStore;
+    dataStore.proxyConfigurations = @[ proxyConfig.get() ];
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    [configuration setWebsiteDataStore:dataStore];
+
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get()]);
+    auto delegate = adoptNS([ProxyDelegate new]);
+    [webView setNavigationDelegate:delegate.get()];
+    [webView setUIDelegate:delegate.get()];
+
+    NSURLRequest *exampleRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/"]];
+    [webView loadRequest:exampleRequest];
+    EXPECT_WK_STREQ([delegate waitForAlert], "proxy success!");
+
+    pid_t originalNetworkProcessIdentifier = [dataStore _networkProcessIdentifier];
+    EXPECT_NE(originalNetworkProcessIdentifier, 0);
+    kill(originalNetworkProcessIdentifier, 9);
+    while ([dataStore _networkProcessIdentifier])
+        TestWebKitAPI::Util::spinRunLoop();
+    [webView loadRequest:exampleRequest];
+    EXPECT_WK_STREQ([delegate waitForAlert], "proxy success!");
+    EXPECT_NE(originalNetworkProcessIdentifier, [dataStore _networkProcessIdentifier]);
+}
+
 TEST(WebKit, SOCKS5API)
 {
-    auto* createProxyConfig = nw_proxy_config_create_socksv5Ptr();
-    if (!createProxyConfig)
-        return;
-
     constexpr uint8_t socks5Version = 0x5; // https://tools.ietf.org/html/rfc1928#section-3
     constexpr uint8_t noAuthenticationRequired = 0x00; // https://tools.ietf.org/html/rfc1928#section-3
     constexpr uint8_t connect = 0x01; // https://tools.ietf.org/html/rfc1928#section-4
@@ -280,7 +299,7 @@ TEST(WebKit, SOCKS5API)
     });
 
     auto endpoint = adoptNS(nw_endpoint_create_host("127.0.0.1", std::to_string(server.port()).c_str()));
-    auto proxyConfig = adoptNS(createProxyConfig(endpoint.get()));
+    auto proxyConfig = adoptNS(nw_proxy_config_create_socksv5(endpoint.get()));
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]);
     webView.get().configuration.websiteDataStore.proxyConfigurations = @[ proxyConfig.get() ];


### PR DESCRIPTION
#### eb352590aabe6bd659e180e58eaa5fd9b00fe33b
<pre>
Proxy configuration should apply after a network process crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=268952">https://bugs.webkit.org/show_bug.cgi?id=268952</a>
<a href="https://rdar.apple.com/122361008">rdar://122361008</a>

Reviewed by Brady Eidson.

* Source/WebKit/NetworkProcess/NetworkSession.h:
(WebKit::NetworkSession::setProxyConfigData):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
(WebKit::NetworkSessionCocoa::setProxyConfigData):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
(WebKit::WebsiteDataStore::setProxyConfigData):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/274287@main">https://commits.webkit.org/274287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef1f8a551f717b4c5410dea18be764bdbf8cfa83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41068 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34211 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32400 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33514 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12783 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12760 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34376 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42344 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/34991 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38598 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13374 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11055 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36803 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14974 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13841 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5023 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14447 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->