### PR TITLE
Implement parsing support for `field-sizing`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -117,6 +117,7 @@ PASS direction
 PASS display
 PASS dominant-baseline
 PASS empty-cells
+PASS field-sizing
 PASS fill
 PASS fill-opacity
 PASS fill-rule

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/field-sizing-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/field-sizing-computed-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Property field-sizing value 'fixed' assert_true: field-sizing doesn't seem to be supported in the computed style expected true got false
-FAIL Property field-sizing value 'content' assert_true: field-sizing doesn't seem to be supported in the computed style expected true got false
+PASS Property field-sizing value 'fixed'
+PASS Property field-sizing value 'content'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/field-sizing-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/field-sizing-valid-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL e.style['field-sizing'] = "fixed" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['field-sizing'] = "content" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['field-sizing'] = "fixed" should set the property value
+PASS e.style['field-sizing'] = "content" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt
@@ -190,6 +190,9 @@ PASS dominant-baseline: "ideographic" onto "alphabetic"
 PASS empty-cells (type: discrete) has testAccumulation function
 PASS empty-cells: "hide" onto "show"
 PASS empty-cells: "show" onto "hide"
+PASS field-sizing (type: discrete) has testAccumulation function
+PASS field-sizing: "content" onto "fixed"
+PASS field-sizing: "fixed" onto "content"
 PASS fill-opacity (type: opacity) has testAccumulation function
 PASS fill-opacity: [0, 1] number
 PASS fill-opacity: [0, 1] number (clamped)

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt
@@ -190,6 +190,9 @@ PASS dominant-baseline: "ideographic" onto "alphabetic"
 PASS empty-cells (type: discrete) has testAddition function
 PASS empty-cells: "hide" onto "show"
 PASS empty-cells: "show" onto "hide"
+PASS field-sizing (type: discrete) has testAddition function
+PASS field-sizing: "content" onto "fixed"
+PASS field-sizing: "fixed" onto "content"
 PASS fill-opacity (type: opacity) has testAddition function
 PASS fill-opacity: [0, 1] number
 PASS fill-opacity: [0, 1] number (clamped)

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt
@@ -231,6 +231,10 @@ PASS empty-cells (type: discrete) has testInterpolation function
 PASS empty-cells uses discrete animation when animating between "show" and "hide" with linear easing
 PASS empty-cells uses discrete animation when animating between "show" and "hide" with effect easing
 PASS empty-cells uses discrete animation when animating between "show" and "hide" with keyframe easing
+PASS field-sizing (type: discrete) has testInterpolation function
+PASS field-sizing uses discrete animation when animating between "fixed" and "content" with linear easing
+PASS field-sizing uses discrete animation when animating between "fixed" and "content" with effect easing
+PASS field-sizing uses discrete animation when animating between "fixed" and "content" with keyframe easing
 PASS fill-opacity (type: opacity) has testInterpolation function
 PASS fill-opacity supports animating as a [0, 1] number
 PASS fill-rule (type: discrete) has testInterpolation function

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -440,6 +440,12 @@ const gCSSProperties1 = {
       { type: 'discrete', options: [ [ 'show', 'hide' ] ] }
     ]
   },
+  'field-sizing': {
+    // https://drafts.csswg.org/css-ui/#field-sizing
+    types: [
+      { type: 'discrete', options: [ [ 'fixed', 'content' ] ] }
+    ]
+  },
   'fill': {
     // https://svgwg.org/svg2-draft/painting.html#FillProperty
     types: [

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -117,6 +117,7 @@ PASS direction
 PASS display
 PASS dominant-baseline
 PASS empty-cells
+PASS field-sizing
 PASS fill
 PASS fill-opacity
 PASS fill-rule

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -117,6 +117,7 @@ PASS direction
 PASS display
 PASS dominant-baseline
 PASS empty-cells
+PASS field-sizing
 PASS fill
 PASS fill-opacity
 PASS fill-rule

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -116,6 +116,7 @@ PASS direction
 PASS display
 PASS dominant-baseline
 PASS empty-cells
+PASS field-sizing
 PASS fill
 PASS fill-opacity
 PASS fill-rule

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -117,6 +117,7 @@ PASS direction
 PASS display
 PASS dominant-baseline
 PASS empty-cells
+PASS field-sizing
 PASS fill
 PASS fill-opacity
 PASS fill-rule

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1042,6 +1042,20 @@ CSSCustomPropertiesAndValuesEnabled:
     WebCore:
       default: true
 
+CSSFieldSizingEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS field-sizing property"
+  humanReadableDescription: "Enable field-sizing CSS property"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSFontFaceSizeAdjustEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3906,7 +3906,8 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscreteSVGPropertyWrapper<const String&>(CSSPropertyMarkerStart, &SVGRenderStyle::markerStartResource, &SVGRenderStyle::setMarkerStartResource),
         new DiscretePropertyWrapper<const ScrollbarGutter>(CSSPropertyScrollbarGutter, &RenderStyle::scrollbarGutter, &RenderStyle::setScrollbarGutter),
         new DiscretePropertyWrapper<ScrollbarWidth>(CSSPropertyScrollbarWidth, &RenderStyle::scrollbarWidth, &RenderStyle::setScrollbarWidth),
-        new DiscretePropertyWrapper<std::optional<Style::ScopedName>>(CSSPropertyViewTransitionName, &RenderStyle::viewTransitionName, &RenderStyle::setViewTransitionName)
+        new DiscretePropertyWrapper<std::optional<Style::ScopedName>>(CSSPropertyViewTransitionName, &RenderStyle::viewTransitionName, &RenderStyle::setViewTransitionName),
+        new DiscretePropertyWrapper<FieldSizing>(CSSPropertyFieldSizing, &RenderStyle::fieldSizing, &RenderStyle::setFieldSizing)
     };
     const unsigned animatableLonghandPropertiesCount = std::size(animatableLonghandPropertyWrappers);
 

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -411,6 +411,12 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH
 
+#define TYPE FieldSizing
+#define FOR_EACH(CASE) CASE(Fixed) CASE(Content)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
+
 constexpr CSSValueID toCSSValueID(FillAttachment e)
 {
     switch (e) {

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -452,6 +452,17 @@
                 "url": "https://www.w3.org/TR/css-display-3/#the-display-properties"
             }
         },
+        "field-sizing": {
+            "codegen-properties": {
+                "parser-grammar": "fixed | content",
+                "settings-flag": "cssFieldSizingEnabled"
+            },
+            "specification": {
+                "category": "css-ui",
+                "url": "https://drafts.csswg.org/css-ui/#field-sizing"
+            },
+            "status": "in development"
+        },
         "font-family": {
             "inherited": true,
             "values": [

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -3571,6 +3571,8 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         if (style.display() != DisplayType::None && style.hasOutOfFlowPosition())
             return CSSPrimitiveValue::create(CSSValueNone);
         return createConvertingToCSSValueID(style.floating());
+    case CSSPropertyFieldSizing:
+        return createConvertingToCSSValueID(style.fieldSizing());
     case CSSPropertyFont:
         return fontShorthandValue(style, valueType);
     case CSSPropertyFontFamily:

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -1238,6 +1238,8 @@ static constexpr InitialValue initialValueForLonghand(CSSPropertyID longhand)
         return CSSValueNoAutospace;
     case CSSPropertyWhiteSpaceCollapse:
         return CSSValueCollapse;
+    case CSSPropertyFieldSizing:
+        return CSSValueFixed;
     default:
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -3471,6 +3471,21 @@ bool RenderStyle::customPropertiesEqual(const RenderStyle& other) const
         && m_rareInheritedData->customProperties == other.m_rareInheritedData->customProperties;
 }
 
+FieldSizing RenderStyle::fieldSizing() const
+{
+    return m_nonInheritedData->rareData->fieldSizing;
+}
+
+FieldSizing RenderStyle::initialFieldSizing()
+{
+    return FieldSizing::Fixed;
+}
+
+void RenderStyle::setFieldSizing(const FieldSizing sizing)
+{
+    SET_NESTED_VAR(m_nonInheritedData, rareData, fieldSizing, sizing);
+}
+
 const LengthBox& RenderStyle::scrollMargin() const
 {
     return m_nonInheritedData->rareData->scrollMargin;

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -139,6 +139,7 @@ enum class CursorVisibility : bool;
 enum class DisplayType : uint8_t;
 enum class EmptyCell : bool;
 enum class EventListenerRegionType : uint8_t;
+enum class FieldSizing : bool;
 enum class FillAttachment : uint8_t;
 enum class FillBox : uint8_t;
 enum class FillSizeType : uint8_t;
@@ -527,6 +528,8 @@ public:
     Clear clear() const { return static_cast<Clear>(m_nonInheritedFlags.clear); }
     static UsedClear usedClear(const RenderObject&);
     TableLayoutType tableLayout() const { return static_cast<TableLayoutType>(m_nonInheritedFlags.tableLayout); }
+
+    FieldSizing fieldSizing() const;
 
     WEBCORE_EXPORT const FontCascade& fontCascade() const;
     WEBCORE_EXPORT const FontMetrics& metricsOfPrimaryFont() const;
@@ -1215,6 +1218,8 @@ public:
 
     void setClear(Clear v) { m_nonInheritedFlags.clear = static_cast<unsigned>(v); }
     void setTableLayout(TableLayoutType v) { m_nonInheritedFlags.tableLayout = static_cast<unsigned>(v); }
+
+    void setFieldSizing(FieldSizing);
 
     WEBCORE_EXPORT bool setFontDescription(FontCascadeDescription&&);
 
@@ -1990,6 +1995,8 @@ public:
     static WillChangeData* initialWillChange() { return nullptr; }
 
     static constexpr TouchAction initialTouchActions();
+
+    static FieldSizing initialFieldSizing();
 
     static inline Length initialScrollMargin();
     static inline Length initialScrollPadding();

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -458,6 +458,15 @@ TextStream& operator<<(TextStream& ts, EventListenerRegionType listenerType)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, FieldSizing sizing)
+{
+    switch (sizing) {
+    case FieldSizing::Fixed: ts << "fixed"; break;
+    case FieldSizing::Content: ts << "content"; break;
+    }
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, FillAttachment attachment)
 {
     switch (attachment) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1182,6 +1182,11 @@ enum class BlockStepInsert : bool {
     Padding
 };
 
+enum class FieldSizing : bool {
+    Fixed,
+    Content
+};
+
 CSSBoxType transformBoxToCSSBoxType(TransformBox);
 
 constexpr float defaultMiterLimit = 4;
@@ -1303,5 +1308,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, WhiteSpaceCollapse);
 WTF::TextStream& operator<<(WTF::TextStream&, WordBreak);
 WTF::TextStream& operator<<(WTF::TextStream&, MathStyle);
 WTF::TextStream& operator<<(WTF::TextStream&, ContainIntrinsicSizeType);
+WTF::TextStream& operator<<(WTF::TextStream&, FieldSizing);
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -120,6 +120,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , textBoxTrim(static_cast<unsigned>(RenderStyle::initialTextBoxTrim()))
     , overflowAnchor(static_cast<unsigned>(RenderStyle::initialOverflowAnchor()))
     , hasClip(false)
+    , fieldSizing(RenderStyle::initialFieldSizing())
 {
 }
 
@@ -209,6 +210,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , textBoxTrim(o.textBoxTrim)
     , overflowAnchor(o.overflowAnchor)
     , hasClip(o.hasClip)
+    , fieldSizing(o.fieldSizing)
 {
 }
 
@@ -304,7 +306,8 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && textBoxTrim == o.textBoxTrim
         && overflowAnchor == o.overflowAnchor
         && viewTransitionName == o.viewTransitionName
-        && hasClip == o.hasClip;
+        && hasClip == o.hasClip
+        && fieldSizing == o.fieldSizing;
 }
 
 OptionSet<Containment> StyleRareNonInheritedData::effectiveContainment() const

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -232,6 +232,8 @@ public:
 
     bool hasClip : 1;
 
+    FieldSizing fieldSizing { FieldSizing::Fixed };
+
 private:
     StyleRareNonInheritedData();
     StyleRareNonInheritedData(const StyleRareNonInheritedData&);


### PR DESCRIPTION
#### 378cf7aa646dbec394d4fac997df4193b3dbe2cb
<pre>
Implement parsing support for `field-sizing`
<a href="https://bugs.webkit.org/show_bug.cgi?id=268956">https://bugs.webkit.org/show_bug.cgi?id=268956</a>

Reviewed by Tim Nguyen.

Spec: <a href="https://drafts.csswg.org/css-ui/#field-sizing">https://drafts.csswg.org/css-ui/#field-sizing</a>

Grammar for property: fixed | content

This adds the field-sizing property to the CSS parser behind a flag, and updates the relevant expectation files.

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/field-sizing-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/parsing/field-sizing-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::initialValueForLonghand):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::fieldSizing const):
(WebCore::RenderStyle::initialFieldSizing):
(WebCore::RenderStyle::setFieldSizing):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:

Canonical link: <a href="https://commits.webkit.org/274357@main">https://commits.webkit.org/274357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b46def1d2f629990c098cd641d89f92051bb22c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41223 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34345 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40999 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32489 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12896 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42499 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/32138 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34880 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38708 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/38315 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11178 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36914 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15114 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/45324 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8697 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13960 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9244 "Passed tests") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14595 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->