### PR TITLE
[Perf Dashboard] AsyncTaskWorker is buggy

### DIFF
--- a/PerformanceTests/JetStream2/worker/async-task.js
+++ b/PerformanceTests/JetStream2/worker/async-task.js
@@ -522,7 +522,8 @@ class AsyncTaskWorker {
         var worker = this._makeWorkerEventuallyAvailable();
         if (worker)
             callback(worker);
-        this._queue.push(callback);
+        else
+            this._queue.push(callback);
     }
 
     static _makeWorkerEventuallyAvailable()
@@ -537,6 +538,8 @@ class AsyncTaskWorker {
 
         if (this._latestStartTime > Date.now() - 50) {
             setTimeout(function () {
+                if (!AsyncTaskWorker._queue.length)
+                    return;
                 var worker = AsyncTaskWorker._findAvailableWorker();
                 if (worker)
                     AsyncTaskWorker._queue.pop()(worker);

--- a/PerformanceTests/JetStream2/worker/segmentation.js
+++ b/PerformanceTests/JetStream2/worker/segmentation.js
@@ -522,7 +522,8 @@ class AsyncTaskWorker {
         var worker = this._makeWorkerEventuallyAvailable();
         if (worker)
             callback(worker);
-        this._queue.push(callback);
+        else
+            this._queue.push(callback);
     }
 
     static _makeWorkerEventuallyAvailable()
@@ -537,6 +538,8 @@ class AsyncTaskWorker {
 
         if (this._latestStartTime > Date.now() - 50) {
             setTimeout(function () {
+                if (!AsyncTaskWorker._queue.length)
+                    return;
                 var worker = AsyncTaskWorker._findAvailableWorker();
                 if (worker)
                     AsyncTaskWorker._queue.pop()(worker);

--- a/Websites/perf.webkit.org/public/v3/async-task.js
+++ b/Websites/perf.webkit.org/public/v3/async-task.js
@@ -45,7 +45,8 @@ class AsyncTaskWorker {
         var worker = this._makeWorkerEventuallyAvailable();
         if (worker)
             callback(worker);
-        this._queue.push(callback);
+        else
+            this._queue.push(callback);
     }
 
     static _makeWorkerEventuallyAvailable()
@@ -60,6 +61,8 @@ class AsyncTaskWorker {
 
         if (this._latestStartTime > Date.now() - 50) {
             setTimeout(function () {
+                if (!AsyncTaskWorker._queue.length)
+                    return;
                 var worker = AsyncTaskWorker._findAvailableWorker();
                 if (worker)
                     AsyncTaskWorker._queue.pop()(worker);


### PR DESCRIPTION
#### dde5760b8dbf355dc9e872edd85a14be5a96313c
<pre>
[Perf Dashboard] AsyncTaskWorker is buggy
<a href="https://bugs.webkit.org/show_bug.cgi?id=268962">https://bugs.webkit.org/show_bug.cgi?id=268962</a>
<a href="https://rdar.apple.com/121879117">rdar://121879117</a>

Reviewed by Ryosuke Niwa.

There are two issues.

1. Even we found a worker and calling a callback, we are still pushing it into the queue. This makes scheduling this callback twice.
2. In setTimeout&apos;s task, we are not checking length of the _queue. This may be zero since existing workers are continuously consuming tasks.
   So we should first check the length before popping the task from that.

* PerformanceTests/JetStream2/worker/async-task.js:
(AsyncTaskWorker.waitForAvailableWorker):
(AsyncTaskWorker._makeWorkerEventuallyAvailable):
* PerformanceTests/JetStream2/worker/segmentation.js:
(AsyncTaskWorker.waitForAvailableWorker):
(AsyncTaskWorker._makeWorkerEventuallyAvailable):
* Websites/perf.webkit.org/public/v3/async-task.js:
(AsyncTaskWorker.waitForAvailableWorker):
(AsyncTaskWorker._makeWorkerEventuallyAvailable):

Canonical link: <a href="https://commits.webkit.org/274265@main">https://commits.webkit.org/274265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a744252da33671a4a0712f0ee1591c4d59679993

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38530 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/17462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/40859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/41069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20246 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/14807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/41069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39103 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/14713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/40859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/41069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/40859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/42345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/34997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/40859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/42345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/14807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/42345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/14975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/40859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5010 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->