### PR TITLE
Support using Ref / RefPtr with PageClient

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -2362,7 +2362,7 @@ static void webkitWebViewBaseConstructed(GObject* object)
     gtk_widget_set_can_focus(viewWidget, TRUE);
 
     WebKitWebViewBasePrivate* priv = WEBKIT_WEB_VIEW_BASE(object)->priv;
-    priv->pageClient = makeUnique<PageClientImpl>(viewWidget);
+    priv->pageClient = makeUniqueWithoutRefCountedCheck<PageClientImpl>(viewWidget);
     gtk_widget_set_parent(priv->keyBindingTranslator.widget(), viewWidget);
 
 #if ENABLE(DRAG_SUPPORT)

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
@@ -73,7 +73,7 @@ View::View(struct wpe_view_backend* backend, WPEDisplay* display, const API::Pag
 #if ENABLE(TOUCH_EVENTS)
     , m_touchGestureController(makeUnique<TouchGestureController>())
 #endif
-    , m_pageClient(makeUnique<PageClientImpl>(*this))
+    , m_pageClient(makeUniqueWithoutRefCountedCheck<PageClientImpl>(*this))
     , m_size { 800, 600 }
     , m_viewStateFlags { WebCore::ActivityState::WindowIsActive, WebCore::ActivityState::IsFocused, WebCore::ActivityState::IsVisible, WebCore::ActivityState::IsInWindow }
     , m_backend(backend)

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -150,7 +150,7 @@ void WebPageProxy::didCommitLayerTree(const WebKit::RemoteLayerTreeTransaction& 
         }
     }
 
-    pageClient().didCommitLayerTree(layerTreeTransaction);
+    protectedPageClient()->didCommitLayerTree(layerTreeTransaction);
 
     // FIXME: Remove this special mechanism and fold it into the transaction's layout milestones.
     if (internals().observedLayoutMilestones.contains(WebCore::LayoutMilestone::ReachedSessionRestorationRenderTreeSizeThreshold) && !m_hitRenderTreeSizeThreshold
@@ -162,7 +162,7 @@ void WebPageProxy::didCommitLayerTree(const WebKit::RemoteLayerTreeTransaction& 
 
 void WebPageProxy::layerTreeCommitComplete()
 {
-    pageClient().layerTreeCommitComplete();
+    protectedPageClient()->layerTreeCommitComplete();
 }
 
 #if ENABLE(DATA_DETECTION)
@@ -174,7 +174,7 @@ void WebPageProxy::setDataDetectionResult(const DataDetectionResult& dataDetecti
 
 void WebPageProxy::handleClickForDataDetectionResult(const DataDetectorElementInfo& info, const IntPoint& clickLocation)
 {
-    pageClient().handleClickForDataDetectionResult(info, clickLocation);
+    protectedPageClient()->handleClickForDataDetectionResult(info, clickLocation);
 }
 
 #endif
@@ -274,14 +274,14 @@ void WebPageProxy::createSandboxExtensionsIfNeeded(const Vector<String>& files, 
 
 bool WebPageProxy::scrollingUpdatesDisabledForTesting()
 {
-    return pageClient().scrollingUpdatesDisabledForTesting();
+    return protectedPageClient()->scrollingUpdatesDisabledForTesting();
 }
 
 #if ENABLE(DRAG_SUPPORT)
 
 void WebPageProxy::startDrag(const DragItem& dragItem, ShareableBitmap::Handle&& dragImageHandle)
 {
-    pageClient().startDrag(dragItem, WTFMove(dragImageHandle));
+    protectedPageClient()->startDrag(dragItem, WTFMove(dragImageHandle));
 }
 
 #endif
@@ -293,7 +293,7 @@ void WebPageProxy::platformRegisterAttachment(Ref<API::Attachment>&& attachment,
     if (bufferCopy.isEmpty())
         return;
 
-    auto fileWrapper = adoptNS([pageClient().allocFileWrapperInstance() initRegularFileWithContents:bufferCopy.unsafeBuffer()->createNSData().get()]);
+    auto fileWrapper = adoptNS([protectedPageClient()->allocFileWrapperInstance() initRegularFileWithContents:bufferCopy.unsafeBuffer()->createNSData().get()]);
     [fileWrapper setPreferredFilename:preferredFileName];
     attachment->setFileWrapper(fileWrapper.get());
 }
@@ -303,7 +303,7 @@ void WebPageProxy::platformRegisterAttachment(Ref<API::Attachment>&& attachment,
     if (!filePath)
         return;
 
-    auto fileWrapper = adoptNS([pageClient().allocFileWrapperInstance() initWithURL:[NSURL fileURLWithPath:filePath] options:0 error:nil]);
+    auto fileWrapper = adoptNS([protectedPageClient()->allocFileWrapperInstance() initWithURL:[NSURL fileURLWithPath:filePath] options:0 error:nil]);
     attachment->setFileWrapper(fileWrapper.get());
 }
 
@@ -374,7 +374,7 @@ void WebPageProxy::insertDictatedTextAsync(const String& text, const EditingRang
 
     Vector<DictationAlternative> dictationAlternatives;
     for (const auto& alternativeWithRange : dictationAlternativesWithRange) {
-        if (auto context = pageClient().addDictationAlternatives(alternativeWithRange.alternatives.get()))
+        if (auto context = protectedPageClient()->addDictationAlternatives(alternativeWithRange.alternatives.get()))
             dictationAlternatives.append({ alternativeWithRange.range, context });
     }
 
@@ -392,7 +392,7 @@ void WebPageProxy::addDictationAlternative(TextAlternativeWithRange&& alternativ
         return;
 
     auto nsAlternatives = alternative.alternatives.get();
-    auto context = pageClient().addDictationAlternatives(nsAlternatives);
+    auto context = protectedPageClient()->addDictationAlternatives(nsAlternatives);
     sendWithAsyncReply(Messages::WebPage::AddDictationAlternative { nsAlternatives.primaryString, context }, [context, weakThis = WeakPtr { *this }](bool success) {
         if (RefPtr protectedThis = weakThis.get(); protectedThis && !success)
             protectedThis->removeDictationAlternatives(context);
@@ -421,7 +421,7 @@ void WebPageProxy::clearDictationAlternatives(Vector<DictationContext>&& alterna
 
 PlatformTextAlternatives *WebPageProxy::platformDictationAlternatives(WebCore::DictationContext dictationContext)
 {
-    return pageClient().platformDictationAlternatives(dictationContext);
+    return protectedPageClient()->platformDictationAlternatives(dictationContext);
 }
 
 #endif
@@ -512,14 +512,14 @@ void WebPageProxy::Internals::voicesDidChange()
 void WebPageProxy::didCreateContextInWebProcessForVisibilityPropagation(LayerHostingContextID contextID)
 {
     m_contextIDForVisibilityPropagationInWebProcess = contextID;
-    pageClient().didCreateContextInWebProcessForVisibilityPropagation(contextID);
+    protectedPageClient()->didCreateContextInWebProcessForVisibilityPropagation(contextID);
 }
 
 #if ENABLE(GPU_PROCESS)
 void WebPageProxy::didCreateContextInGPUProcessForVisibilityPropagation(LayerHostingContextID contextID)
 {
     m_contextIDForVisibilityPropagationInGPUProcess = contextID;
-    pageClient().didCreateContextInGPUProcessForVisibilityPropagation(contextID);
+    protectedPageClient()->didCreateContextInGPUProcessForVisibilityPropagation(contextID);
 }
 #endif // ENABLE(GPU_PROCESS)
 
@@ -527,7 +527,7 @@ void WebPageProxy::didCreateContextInGPUProcessForVisibilityPropagation(LayerHos
 void WebPageProxy::didCreateContextInModelProcessForVisibilityPropagation(LayerHostingContextID contextID)
 {
     m_contextIDForVisibilityPropagationInModelProcess = contextID;
-    pageClient().didCreateContextInModelProcessForVisibilityPropagation(contextID);
+    protectedPageClient()->didCreateContextInModelProcessForVisibilityPropagation(contextID);
 }
 #endif // ENABLE(MODEL_PROCESS)
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
@@ -573,7 +573,7 @@ void WebPageProxy::didChangeCurrentTime(PlaybackSessionContextIdentifier identif
 
 void WebPageProxy::updateFullscreenVideoTextRecognition()
 {
-    if (!pageClient().isTextRecognitionInFullscreenVideoEnabled())
+    if (!protectedPageClient()->isTextRecognitionInFullscreenVideoEnabled())
         return;
 
     if (internals().currentFullscreenVideoSessionIdentifier && m_playbackSessionManager && m_playbackSessionManager->isPaused(*internals().currentFullscreenVideoSessionIdentifier)) {
@@ -588,7 +588,7 @@ void WebPageProxy::updateFullscreenVideoTextRecognition()
 
 #if PLATFORM(IOS_FAMILY)
     if (RetainPtr controller = m_videoPresentationManager->playerViewController(*internals().currentFullscreenVideoSessionIdentifier))
-        pageClient().cancelTextRecognitionForFullscreenVideo(controller.get());
+        protectedPageClient()->cancelTextRecognitionForFullscreenVideo(controller.get());
 #endif
 }
 
@@ -611,7 +611,7 @@ void WebPageProxy::fullscreenVideoTextRecognitionTimerFired()
 
 #if PLATFORM(IOS_FAMILY)
         if (RetainPtr controller = presentationManager->playerViewController(identifier))
-            protectedThis->pageClient().beginTextRecognitionForFullscreenVideo(WTFMove(*imageHandle), controller.get());
+            protectedThis->protectedPageClient()->beginTextRecognitionForFullscreenVideo(WTFMove(*imageHandle), controller.get());
 #endif
     });
 }
@@ -828,12 +828,12 @@ void WebPageProxy::abortApplePayAMSUISession()
 
 bool WebPageProxy::canHandleContextMenuTranslation() const
 {
-    return pageClient().canHandleContextMenuTranslation();
+    return protectedPageClient()->canHandleContextMenuTranslation();
 }
 
 void WebPageProxy::handleContextMenuTranslation(const TranslationContextMenuInfo& info)
 {
-    return pageClient().handleContextMenuTranslation(info);
+    return protectedPageClient()->handleContextMenuTranslation(info);
 }
 
 #endif // HAVE(TRANSLATION_UI_SERVICES)
@@ -992,7 +992,7 @@ bool WebPageProxy::shouldForceForegroundPriorityForClientNavigation() const
     if (isViewVisible())
         return false;
 
-    bool canTakeForegroundAssertions = pageClient().canTakeForegroundAssertions();
+    bool canTakeForegroundAssertions = protectedPageClient()->canTakeForegroundAssertions();
     WEBPAGEPROXY_RELEASE_LOG(Process, "WebPageProxy::shouldForceForegroundPriorityForClientNavigation() returns %d based on PageClient::canTakeForegroundAssertions()", canTakeForegroundAssertions);
     return canTakeForegroundAssertions;
 }

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -216,6 +216,9 @@ class PageClient : public CanMakeWeakPtr<PageClient> {
 public:
     virtual ~PageClient() { }
 
+    void ref() { refView(); }
+    void deref() { derefView(); }
+
     // Create a new drawing area proxy for the given page.
     virtual std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy(WebProcessProxy&) = 0;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -841,6 +841,7 @@ public:
     void restoreSelectionInFocusedEditableElement();
 
     PageClient& pageClient() const;
+    Ref<PageClient> protectedPageClient() const;
 
     void setViewNeedsDisplay(const WebCore::Region&);
     void requestScroll(const WebCore::FloatPoint& scrollPosition, const WebCore::IntPoint& scrollOrigin, WebCore::ScrollIsAnimated);

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -425,7 +425,7 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
 
     WebKit::InitializeWebKit2();
 
-    _pageClient = makeUnique<WebKit::PageClientImpl>(self, webView);
+    _pageClient = makeUniqueWithoutRefCountedCheck<WebKit::PageClientImpl>(self, webView);
     _webView = webView;
 
     return [self _commonInitializationWithProcessPool:processPool configuration:WTFMove(configuration)];

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -225,12 +225,12 @@ static inline float adjustedUnexposedMaxEdge(float documentEdge, float exposedRe
 WebCore::FloatRect WebPageProxy::computeLayoutViewportRect(const FloatRect& unobscuredContentRect, const FloatRect& unobscuredContentRectRespectingInputViewBounds, const FloatRect& currentLayoutViewportRect, double displayedContentScale, LayoutViewportConstraint constraint) const
 {
     FloatRect constrainedUnobscuredRect = unobscuredContentRect;
-    FloatRect documentRect = pageClient().documentRect();
+    FloatRect documentRect = protectedPageClient()->documentRect();
 
     if (constraint == LayoutViewportConstraint::ConstrainedToDocumentRect)
         constrainedUnobscuredRect.intersect(documentRect);
 
-    double minimumScale = pageClient().minimumZoomScale();
+    double minimumScale = protectedPageClient()->minimumZoomScale();
     bool isBelowMinimumScale = displayedContentScale < minimumScale && !WebKit::scalesAreEssentiallyEqual(displayedContentScale, minimumScale);
     if (isBelowMinimumScale) {
         const CGFloat slope = 12;
@@ -260,22 +260,22 @@ FloatRect WebPageProxy::unconstrainedLayoutViewportRect() const
 
 void WebPageProxy::scrollingNodeScrollViewWillStartPanGesture(ScrollingNodeID nodeID)
 {
-    pageClient().scrollingNodeScrollViewWillStartPanGesture(nodeID);
+    protectedPageClient()->scrollingNodeScrollViewWillStartPanGesture(nodeID);
 }
 
 void WebPageProxy::scrollingNodeScrollViewDidScroll(ScrollingNodeID nodeID)
 {
-    pageClient().scrollingNodeScrollViewDidScroll(nodeID);
+    protectedPageClient()->scrollingNodeScrollViewDidScroll(nodeID);
 }
 
 void WebPageProxy::scrollingNodeScrollWillStartScroll(ScrollingNodeID nodeID)
 {
-    pageClient().scrollingNodeScrollWillStartScroll(nodeID);
+    protectedPageClient()->scrollingNodeScrollWillStartScroll(nodeID);
 }
 
 void WebPageProxy::scrollingNodeScrollDidEndScroll(ScrollingNodeID nodeID)
 {
-    pageClient().scrollingNodeScrollDidEndScroll(nodeID);
+    protectedPageClient()->scrollingNodeScrollDidEndScroll(nodeID);
 }
 
 void WebPageProxy::dynamicViewportSizeUpdate(const DynamicViewportSizeUpdate& target)
@@ -534,7 +534,7 @@ void WebPageProxy::requestAutocorrectionContext()
 
 void WebPageProxy::handleAutocorrectionContext(const WebAutocorrectionContext& context)
 {
-    pageClient().handleAutocorrectionContext(context);
+    protectedPageClient()->handleAutocorrectionContext(context);
 }
 
 void WebPageProxy::getSelectionContext(CompletionHandler<void(const String&, const String&, const String&)>&& callbackFunction)
@@ -559,7 +559,7 @@ void WebPageProxy::selectWithTwoTouches(const WebCore::IntPoint from, const WebC
 
 void WebPageProxy::didReceivePositionInformation(const InteractionInformationAtPosition& info)
 {
-    pageClient().positionInformationDidChange(info);
+    protectedPageClient()->positionInformationDidChange(info);
 }
 
 void WebPageProxy::requestPositionInformation(const InteractionInformationRequest& request)
@@ -611,7 +611,7 @@ void WebPageProxy::saveImageToLibrary(SharedMemory::Handle&& imageHandle, const 
         return;
 
     auto buffer = sharedMemoryBuffer->createSharedBuffer(sharedMemoryBuffer->size());
-    pageClient().saveImageToLibrary(WTFMove(buffer));
+    protectedPageClient()->saveImageToLibrary(WTFMove(buffer));
 }
 
 void WebPageProxy::applicationDidEnterBackground()
@@ -755,7 +755,7 @@ void WebPageProxy::interpretKeyEvent(const EditorState& state, bool isCharEvent,
     if (!hasQueuedKeyEvent())
         completionHandler(false);
     else
-        completionHandler(pageClient().interpretKeyEvent(firstQueuedKeyEvent(), isCharEvent));
+        completionHandler(protectedPageClient()->interpretKeyEvent(firstQueuedKeyEvent(), isCharEvent));
 }
 
 void WebPageProxy::setSmartInsertDeleteEnabled(bool)
@@ -765,19 +765,19 @@ void WebPageProxy::setSmartInsertDeleteEnabled(bool)
 
 void WebPageProxy::registerWebProcessAccessibilityToken(const IPC::DataReference& data)
 {
-    pageClient().accessibilityWebProcessTokenReceived(data);
+    protectedPageClient()->accessibilityWebProcessTokenReceived(data);
 }    
 
 
 void WebPageProxy::relayAccessibilityNotification(const String& notificationName, const IPC::DataReference& data)
 {
     NSData *notificationData = [NSData dataWithBytes:data.data() length:data.size()];
-    pageClient().relayAccessibilityNotification(notificationName, notificationData);
+    protectedPageClient()->relayAccessibilityNotification(notificationName, notificationData);
 }
 
 void WebPageProxy::assistiveTechnologyMakeFirstResponder()
 {
-    pageClient().assistiveTechnologyMakeFirstResponder();
+    protectedPageClient()->assistiveTechnologyMakeFirstResponder();
 }
 
 void WebPageProxy::makeFirstResponder()
@@ -899,24 +899,24 @@ float WebPageProxy::textAutosizingWidth()
 
 void WebPageProxy::couldNotRestorePageState()
 {
-    pageClient().couldNotRestorePageState();
+    protectedPageClient()->couldNotRestorePageState();
 }
 
 void WebPageProxy::restorePageState(std::optional<WebCore::FloatPoint> scrollPosition, const WebCore::FloatPoint& scrollOrigin, const WebCore::FloatBoxExtent& obscuredInsetsOnSave, double scale)
 {
     MESSAGE_CHECK(scale > 0);
-    pageClient().restorePageState(scrollPosition, scrollOrigin, obscuredInsetsOnSave, scale);
+    protectedPageClient()->restorePageState(scrollPosition, scrollOrigin, obscuredInsetsOnSave, scale);
 }
 
 void WebPageProxy::restorePageCenterAndScale(std::optional<WebCore::FloatPoint> center, double scale)
 {
     MESSAGE_CHECK(scale > 0);
-    pageClient().restorePageCenterAndScale(center, scale);
+    protectedPageClient()->restorePageCenterAndScale(center, scale);
 }
 
 void WebPageProxy::didGetTapHighlightGeometries(WebKit::TapIdentifier requestID, const WebCore::Color& color, const Vector<WebCore::FloatQuad>& highlightedQuads, const WebCore::IntSize& topLeftRadius, const WebCore::IntSize& topRightRadius, const WebCore::IntSize& bottomLeftRadius, const WebCore::IntSize& bottomRightRadius, bool nodeHasBuiltInClickHandling)
 {
-    pageClient().didGetTapHighlightGeometries(requestID, color, highlightedQuads, topLeftRadius, topRightRadius, bottomLeftRadius, bottomRightRadius, nodeHasBuiltInClickHandling);
+    protectedPageClient()->didGetTapHighlightGeometries(requestID, color, highlightedQuads, topLeftRadius, topRightRadius, bottomLeftRadius, bottomRightRadius, nodeHasBuiltInClickHandling);
 }
 
 void WebPageProxy::setIsShowingInputViewForFocusedElement(bool showingInputView)
@@ -926,7 +926,7 @@ void WebPageProxy::setIsShowingInputViewForFocusedElement(bool showingInputView)
 
 void WebPageProxy::updateInputContextAfterBlurringAndRefocusingElement()
 {
-    pageClient().updateInputContextAfterBlurringAndRefocusingElement();
+    protectedPageClient()->updateInputContextAfterBlurringAndRefocusingElement();
 }
 
 void WebPageProxy::elementDidFocus(const FocusedElementInformation& information, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState> activityStateChanges, const UserData& userData)
@@ -934,18 +934,18 @@ void WebPageProxy::elementDidFocus(const FocusedElementInformation& information,
     m_pendingInputModeChange = std::nullopt;
 
     API::Object* userDataObject = process().transformHandlesToObjects(userData.object()).get();
-    pageClient().elementDidFocus(information, userIsInteracting, blurPreviousNode, activityStateChanges, userDataObject);
+    protectedPageClient()->elementDidFocus(information, userIsInteracting, blurPreviousNode, activityStateChanges, userDataObject);
 }
 
 void WebPageProxy::elementDidBlur()
 {
     m_pendingInputModeChange = std::nullopt;
-    pageClient().elementDidBlur();
+    protectedPageClient()->elementDidBlur();
 }
 
 void WebPageProxy::updateFocusedElementInformation(const FocusedElementInformation& information)
 {
-    pageClient().updateFocusedElementInformation(information);
+    protectedPageClient()->updateFocusedElementInformation(information);
 }
 
 void WebPageProxy::focusedElementDidChangeInputMode(WebCore::InputMode mode)
@@ -957,7 +957,7 @@ void WebPageProxy::focusedElementDidChangeInputMode(WebCore::InputMode mode)
     }
 #endif
 
-    pageClient().focusedElementDidChangeInputMode(mode);
+    protectedPageClient()->focusedElementDidChangeInputMode(mode);
 }
 
 void WebPageProxy::didReleaseAllTouchPoints()
@@ -965,7 +965,7 @@ void WebPageProxy::didReleaseAllTouchPoints()
     if (!m_pendingInputModeChange)
         return;
 
-    pageClient().focusedElementDidChangeInputMode(*m_pendingInputModeChange);
+    protectedPageClient()->focusedElementDidChangeInputMode(*m_pendingInputModeChange);
     m_pendingInputModeChange = std::nullopt;
 }
 
@@ -976,32 +976,32 @@ void WebPageProxy::autofillLoginCredentials(const String& username, const String
 
 void WebPageProxy::showInspectorHighlight(const WebCore::InspectorOverlay::Highlight& highlight)
 {
-    pageClient().showInspectorHighlight(highlight);
+    protectedPageClient()->showInspectorHighlight(highlight);
 }
 
 void WebPageProxy::hideInspectorHighlight()
 {
-    pageClient().hideInspectorHighlight();
+    protectedPageClient()->hideInspectorHighlight();
 }
 
 void WebPageProxy::showInspectorIndication()
 {
-    pageClient().showInspectorIndication();
+    protectedPageClient()->showInspectorIndication();
 }
 
 void WebPageProxy::hideInspectorIndication()
 {
-    pageClient().hideInspectorIndication();
+    protectedPageClient()->hideInspectorIndication();
 }
 
 void WebPageProxy::enableInspectorNodeSearch()
 {
-    pageClient().enableInspectorNodeSearch();
+    protectedPageClient()->enableInspectorNodeSearch();
 }
 
 void WebPageProxy::disableInspectorNodeSearch()
 {
-    pageClient().disableInspectorNodeSearch();
+    protectedPageClient()->disableInspectorNodeSearch();
 }
 
 void WebPageProxy::focusNextFocusedElement(bool isForward, CompletionHandler<void()>&& callbackFunction)
@@ -1028,49 +1028,49 @@ void WebPageProxy::setFocusedElementSelectedIndex(const WebCore::ElementContext&
 
 void WebPageProxy::didPerformDictionaryLookup(const DictionaryPopupInfo& dictionaryPopupInfo)
 {
-    pageClient().didPerformDictionaryLookup(dictionaryPopupInfo);
+    protectedPageClient()->didPerformDictionaryLookup(dictionaryPopupInfo);
 }
 
 void WebPageProxy::setRemoteLayerTreeRootNode(RemoteLayerTreeNode* rootNode)
 {
-    pageClient().setRemoteLayerTreeRootNode(rootNode);
+    protectedPageClient()->setRemoteLayerTreeRootNode(rootNode);
     m_frozenRemoteLayerTreeHost = nullptr;
 }
 
 void WebPageProxy::showPlaybackTargetPicker(bool hasVideo, const IntRect& elementRect, WebCore::RouteSharingPolicy policy, const String& contextUID)
 {
-    pageClient().showPlaybackTargetPicker(hasVideo, elementRect, policy, contextUID);
+    protectedPageClient()->showPlaybackTargetPicker(hasVideo, elementRect, policy, contextUID);
 }
 
 void WebPageProxy::commitPotentialTapFailed()
 {
-    pageClient().commitPotentialTapFailed();
+    protectedPageClient()->commitPotentialTapFailed();
 }
 
 void WebPageProxy::didNotHandleTapAsClick(const WebCore::IntPoint& point)
 {
-    pageClient().didNotHandleTapAsClick(point);
+    protectedPageClient()->didNotHandleTapAsClick(point);
     m_uiClient->didNotHandleTapAsClick(point);
 }
 
 void WebPageProxy::didHandleTapAsHover()
 {
-    pageClient().didHandleTapAsHover();
+    protectedPageClient()->didHandleTapAsHover();
 }
 
 void WebPageProxy::didCompleteSyntheticClick()
 {
-    pageClient().didCompleteSyntheticClick();
+    protectedPageClient()->didCompleteSyntheticClick();
 }
 
 void WebPageProxy::disableDoubleTapGesturesDuringTapIfNecessary(WebKit::TapIdentifier requestID)
 {
-    pageClient().disableDoubleTapGesturesDuringTapIfNecessary(requestID);
+    protectedPageClient()->disableDoubleTapGesturesDuringTapIfNecessary(requestID);
 }
 
 void WebPageProxy::handleSmartMagnificationInformationForPotentialTap(WebKit::TapIdentifier requestID, const WebCore::FloatRect& renderRect, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale, bool nodeIsRootLevel)
 {
-    pageClient().handleSmartMagnificationInformationForPotentialTap(requestID, renderRect, fitEntireRect, viewportMinimumScale, viewportMaximumScale, nodeIsRootLevel);
+    protectedPageClient()->handleSmartMagnificationInformationForPotentialTap(requestID, renderRect, fitEntireRect, viewportMinimumScale, viewportMaximumScale, nodeIsRootLevel);
 }
 
 size_t WebPageProxy::computePagesForPrintingiOS(FrameIdentifier frameID, const PrintInfo& printInfo)
@@ -1124,7 +1124,7 @@ void WebPageProxy::didUpdateEditorState(const EditorState& oldEditorState, const
     
     // Selection being none is a temporary state when editing. Flipping secure input state too quickly was causing trouble (not fully understood).
     if (couldChangeSecureInputState && !newEditorState.selectionIsNone)
-        pageClient().updateSecureInputState();
+        protectedPageClient()->updateSecureInputState();
     
     if (newEditorState.shouldIgnoreSelectionChanges)
         return;
@@ -1132,7 +1132,7 @@ void WebPageProxy::didUpdateEditorState(const EditorState& oldEditorState, const
     updateFontAttributesAfterEditorStateChange();
     // We always need to notify the client on iOS to make sure the selection is redrawn,
     // even during composition to support phrase boundary gesture.
-    pageClient().selectionDidChange();
+    protectedPageClient()->selectionDidChange();
 }
 
 void WebPageProxy::dispatchDidUpdateEditorState()
@@ -1140,13 +1140,13 @@ void WebPageProxy::dispatchDidUpdateEditorState()
     if (!m_waitingForPostLayoutEditorStateUpdateAfterFocusingElement || !editorState().hasPostLayoutData())
         return;
 
-    pageClient().didUpdateEditorState();
+    protectedPageClient()->didUpdateEditorState();
     m_waitingForPostLayoutEditorStateUpdateAfterFocusingElement = false;
 }
 
 void WebPageProxy::showValidationMessage(const IntRect& anchorClientRect, const String& message)
 {
-    m_validationBubble = pageClient().createValidationBubble(message, { m_preferences->minimumFontSize() });
+    m_validationBubble = protectedPageClient()->createValidationBubble(message, { m_preferences->minimumFontSize() });
     m_validationBubble->setAnchorRect(anchorClientRect, uiClient().presentingViewController());
 
     // If we are currently doing a scrolling / zoom animation, then we'll delay showing the validation
@@ -1224,12 +1224,12 @@ void WebPageProxy::requestDocumentEditingContext(WebKit::DocumentEditingContextR
 
 void WebPageProxy::didHandleDragStartRequest(bool started)
 {
-    pageClient().didHandleDragStartRequest(started);
+    protectedPageClient()->didHandleDragStartRequest(started);
 }
 
 void WebPageProxy::didHandleAdditionalDragItemsRequest(bool added)
 {
-    pageClient().didHandleAdditionalDragItemsRequest(added);
+    protectedPageClient()->didHandleAdditionalDragItemsRequest(added);
 }
 
 void WebPageProxy::requestDragStart(const WebCore::IntPoint& clientPosition, const WebCore::IntPoint& globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
@@ -1254,12 +1254,12 @@ void WebPageProxy::insertDroppedImagePlaceholders(const Vector<IntSize>& imageSi
 
 void WebPageProxy::willReceiveEditDragSnapshot()
 {
-    pageClient().willReceiveEditDragSnapshot();
+    protectedPageClient()->willReceiveEditDragSnapshot();
 }
 
 void WebPageProxy::didReceiveEditDragSnapshot(std::optional<TextIndicatorData> data)
 {
-    pageClient().didReceiveEditDragSnapshot(data);
+    protectedPageClient()->didReceiveEditDragSnapshot(data);
 }
 
 void WebPageProxy::didConcludeDrop()
@@ -1294,7 +1294,7 @@ void WebPageProxy::requestPasswordForQuickLookDocumentInMainFrame(const String& 
 
 void WebPageProxy::requestPasswordForQuickLookDocumentInMainFrameShared(const String& fileName, CompletionHandler<void(const String&)>&& completionHandler)
 {
-    pageClient().requestPasswordForQuickLookDocument(fileName, WTFMove(completionHandler));
+    protectedPageClient()->requestPasswordForQuickLookDocument(fileName, WTFMove(completionHandler));
 }
 
 #endif
@@ -1440,7 +1440,7 @@ bool WebPageProxy::isDesktopClassBrowsingRecommended(const WebCore::ResourceRequ
         return false;
 
 #if !PLATFORM(MACCATALYST)
-    if (!pageClient().hasResizableWindows() && webViewSizeIsNarrow(viewSize()))
+    if (!protectedPageClient()->hasResizableWindows() && webViewSizeIsNarrow(viewSize()))
         return false;
 #endif
 
@@ -1638,17 +1638,17 @@ void WebPageProxy::setDeviceHasAGXCompilerServiceForTesting() const
 
 void WebPageProxy::showDataDetectorsUIForPositionInformation(const InteractionInformationAtPosition& positionInfo)
 {
-    pageClient().showDataDetectorsUIForPositionInformation(positionInfo);
+    protectedPageClient()->showDataDetectorsUIForPositionInformation(positionInfo);
 }
 
 void WebPageProxy::insertionPointColorDidChange()
 {
-    send(Messages::WebPage::SetInsertionPointColor(pageClient().insertionPointColor()));
+    send(Messages::WebPage::SetInsertionPointColor(protectedPageClient()->insertionPointColor()));
 }
 
 Color WebPageProxy::platformUnderPageBackgroundColor() const
 {
-    if (auto contentViewBackgroundColor = pageClient().contentViewBackgroundColor(); contentViewBackgroundColor.isValid())
+    if (auto contentViewBackgroundColor = protectedPageClient()->contentViewBackgroundColor(); contentViewBackgroundColor.isValid())
         return contentViewBackgroundColor;
 
     return WebCore::Color::white;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1151,7 +1151,7 @@ static bool isInRecoveryOS()
 
 WebViewImpl::WebViewImpl(NSView <WebViewImplDelegate> *view, WKWebView *outerWebView, WebProcessPool& processPool, Ref<API::PageConfiguration>&& configuration)
     : m_view(view)
-    , m_pageClient(makeUnique<PageClientImpl>(view, outerWebView))
+    , m_pageClient(makeUniqueWithoutRefCountedCheck<PageClientImpl>(view, outerWebView))
     , m_page(processPool.createWebPage(*m_pageClient, WTFMove(configuration)))
     , m_needsViewFrameInWindowCoordinates(m_page->preferences().pluginsEnabled())
     , m_intrinsicContentSize(CGSizeMake(NSViewNoIntrinsicMetric, NSViewNoIntrinsicMetric))

--- a/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
+++ b/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
@@ -44,7 +44,7 @@ RefPtr<PlayStationWebView> PlayStationWebView::create(struct wpe_view_backend* b
 }
 
 PlayStationWebView::PlayStationWebView(struct wpe_view_backend* backend, const API::PageConfiguration& conf)
-    : m_pageClient(makeUnique<PageClientImpl>(*this))
+    : m_pageClient(makeUniqueWithoutRefCountedCheck<PageClientImpl>(*this))
     , m_viewStateFlags { WebCore::ActivityState::WindowIsActive, WebCore::ActivityState::IsFocused, WebCore::ActivityState::IsVisible, WebCore::ActivityState::IsInWindow }
     , m_backend(backend)
 {
@@ -64,7 +64,7 @@ RefPtr<PlayStationWebView> PlayStationWebView::create(const API::PageConfigurati
 }
 
 PlayStationWebView::PlayStationWebView(const API::PageConfiguration& conf)
-    : m_pageClient(makeUnique<PageClientImpl>(*this))
+    : m_pageClient(makeUniqueWithoutRefCountedCheck<PageClientImpl>(*this))
     , m_viewStateFlags { WebCore::ActivityState::WindowIsActive, WebCore::ActivityState::IsFocused, WebCore::ActivityState::IsVisible, WebCore::ActivityState::IsInWindow }
 {
     auto configuration = conf.copy();

--- a/Source/WebKit/UIProcess/win/WebView.cpp
+++ b/Source/WebKit/UIProcess/win/WebView.cpp
@@ -219,7 +219,7 @@ bool WebView::registerWebViewWindowClass()
 }
 
 WebView::WebView(RECT rect, const API::PageConfiguration& configuration, HWND parentWindow)
-    : m_pageClient(makeUnique<PageClientImpl>(*this))
+    : m_pageClient(makeUniqueWithoutRefCountedCheck<PageClientImpl>(*this))
 {
     registerWebViewWindowClass();
 


### PR DESCRIPTION
#### 29481cad7db8c650d25363a0cdf445d515342a9e
<pre>
Support using Ref / RefPtr with PageClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=268965">https://bugs.webkit.org/show_bug.cgi?id=268965</a>

Reviewed by Darin Adler.

Support using Ref / RefPtr with PageClient and protect it more.

* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseConstructed):
* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::View::View):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::didCommitLayerTree):
(WebKit::WebPageProxy::layerTreeCommitComplete):
(WebKit::WebPageProxy::handleClickForDataDetectionResult):
(WebKit::WebPageProxy::scrollingUpdatesDisabledForTesting):
(WebKit::WebPageProxy::startDrag):
(WebKit::WebPageProxy::platformRegisterAttachment):
(WebKit::WebPageProxy::insertDictatedTextAsync):
(WebKit::WebPageProxy::addDictationAlternative):
(WebKit::WebPageProxy::platformDictationAlternatives):
(WebKit::WebPageProxy::didCreateContextInWebProcessForVisibilityPropagation):
(WebKit::WebPageProxy::didCreateContextInGPUProcessForVisibilityPropagation):
(WebKit::WebPageProxy::didCreateContextInModelProcessForVisibilityPropagation):
(WebKit::WebPageProxy::updateFullscreenVideoTextRecognition):
(WebKit::WebPageProxy::fullscreenVideoTextRecognitionTimerFired):
(WebKit::WebPageProxy::canHandleContextMenuTranslation const):
(WebKit::WebPageProxy::handleContextMenuTranslation):
(WebKit::WebPageProxy::shouldForceForegroundPriorityForClientNavigation const):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::ref):
(WebKit::PageClient::deref):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::m_browsingContextGroup):
(WebKit::WebPageProxy::protectedPageClient const):
(WebKit::WebPageProxy::swapToProvisionalPage):
(WebKit::WebPageProxy::finishAttachingToWebProcess):
(WebKit::WebPageProxy::didAttachToRunningProcess):
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::didChangeBackForwardList):
(WebKit::WebPageProxy::willGoToBackForwardListItem):
(WebKit::WebPageProxy::shouldKeepCurrentBackForwardListItemInList):
(WebKit::WebPageProxy::setTopContentInset):
(WebKit::WebPageProxy::setUnderPageBackgroundColorOverride):
(WebKit::WebPageProxy::setViewNeedsDisplay):
(WebKit::WebPageProxy::requestScroll):
(WebKit::WebPageProxy::viewScrollPosition const):
(WebKit::WebPageProxy::updateActivityState):
(WebKit::WebPageProxy::activityStateDidChange):
(WebKit::WebPageProxy::viewDidEnterWindow):
(WebKit::WebPageProxy::dispatchActivityStateChange):
(WebKit::WebPageProxy::layerHostingModeDidChange):
(WebKit::WebPageProxy::viewSize const):
(WebKit::WebPageProxy::stopMakingViewBlankDueToLackOfRenderingUpdateIfNecessary):
(WebKit::WebPageProxy::makeViewBlankIfUnpaintedSinceLastLoadCommit):
(WebKit::WebPageProxy::performDragOperation):
(WebKit::WebPageProxy::didPerformDragControllerAction):
(WebKit::WebPageProxy::startDrag):
(WebKit::WebPageProxy::setDragCaretRect):
(WebKit::WebPageProxy::processNextQueuedMouseEvent):
(WebKit::WebPageProxy::sendPreventableTouchEvent):
(WebKit::WebPageProxy::handlePreventableTouchEvent):
(WebKit::WebPageProxy::touchEventHandlingCompleted):
(WebKit::WebPageProxy::handleTouchEvent):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::runJavaScriptInFrameInScriptWorld):
(WebKit::WebPageProxy::preferencesDidChange):
(WebKit::WebPageProxy::didCreateMainFrame):
(WebKit::WebPageProxy::didStartProgress):
(WebKit::WebPageProxy::didChangeProgress):
(WebKit::WebPageProxy::didFinishProgress):
(WebKit::WebPageProxy::didDestroyNavigationShared):
(WebKit::WebPageProxy::didStartProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didReceiveServerRedirectForProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::willPerformClientRedirectForFrame):
(WebKit::WebPageProxy::didCancelClientRedirectForFrame):
(WebKit::WebPageProxy::didChangeProvisionalURLForFrameShared):
(WebKit::WebPageProxy::didFailProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::didFinishDocumentLoadForFrame):
(WebKit::WebPageProxy::didFinishLoadForFrame):
(WebKit::WebPageProxy::didFailLoadForFrame):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrame):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrameViaJSHistoryAPI):
(WebKit::WebPageProxy::didReceiveTitleForFrame):
(WebKit::WebPageProxy::didFirstVisuallyNonEmptyLayoutForFrame):
(WebKit::WebPageProxy::didReachLayoutMilestone):
(WebKit::WebPageProxy::didDisplayInsecureContentForFrame):
(WebKit::WebPageProxy::didRunInsecureContentForFrame):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::decidePolicyForNewWindowAction):
(WebKit::WebPageProxy::decidePolicyForResponseShared):
(WebKit::WebPageProxy::didNavigateWithNavigationDataShared):
(WebKit::WebPageProxy::didPerformClientRedirectShared):
(WebKit::WebPageProxy::didPerformServerRedirectShared):
(WebKit::WebPageProxy::didUpdateHistoryTitle):
(WebKit::WebPageProxy::closePage):
(WebKit::WebPageProxy::runModalJavaScriptDialog):
(WebKit::WebPageProxy::setWindowFrame):
(WebKit::WebPageProxy::getWindowFrame):
(WebKit::WebPageProxy::getWindowFrameWithCallback):
(WebKit::WebPageProxy::screenToRootView):
(WebKit::WebPageProxy::rootViewToScreen):
(WebKit::WebPageProxy::syncRootViewToScreen):
(WebKit::WebPageProxy::accessibilityScreenToRootView):
(WebKit::WebPageProxy::rootViewToAccessibilityScreen):
(WebKit::WebPageProxy::didChangeViewportProperties):
(WebKit::WebPageProxy::pageDidScroll):
(WebKit::WebPageProxy::runOpenPanel):
(WebKit::WebPageProxy::showShareSheet):
(WebKit::WebPageProxy::showContactPicker):
(WebKit::WebPageProxy::didChangeContentSize):
(WebKit::WebPageProxy::didChangeIntrinsicContentSize):
(WebKit::WebPageProxy::showColorPicker):
(WebKit::WebPageProxy::showDataListSuggestions):
(WebKit::WebPageProxy::showDateTimePicker):
(WebKit::WebPageProxy::compositionWasCanceled):
(WebKit::WebPageProxy::registerInsertionUndoGrouping):
(WebKit::WebPageProxy::canUndoRedo):
(WebKit::WebPageProxy::executeUndoRedo):
(WebKit::WebPageProxy::clearAllEditCommands):
(WebKit::WebPageProxy::setTextIndicator):
(WebKit::WebPageProxy::clearTextIndicator):
(WebKit::WebPageProxy::setTextIndicatorAnimationProgress):
(WebKit::WebPageProxy::showPopupMenu):
(WebKit::WebPageProxy::showContextMenu):
(WebKit::WebPageProxy::didShowContextMenu):
(WebKit::WebPageProxy::didDismissContextMenu):
(WebKit::WebPageProxy::registerEditCommand):
(WebKit::WebPageProxy::canUndo):
(WebKit::WebPageProxy::canRedo):
(WebKit::WebPageProxy::takeFocus):
(WebKit::WebPageProxy::setToolTip):
(WebKit::WebPageProxy::setCursor):
(WebKit::WebPageProxy::setCursorHiddenUntilMouseMoves):
(WebKit::WebPageProxy::keyEventHandlingCompleted):
(WebKit::WebPageProxy::didReceiveEvent):
(WebKit::WebPageProxy::resetStateAfterProcessTermination):
(WebKit::WebPageProxy::resetState):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
(WebKit::WebPageProxy::creationParameters):
(WebKit::WebPageProxy::enterAcceleratedCompositingMode):
(WebKit::WebPageProxy::didFirstLayerFlush):
(WebKit::WebPageProxy::exitAcceleratedCompositingMode):
(WebKit::WebPageProxy::updateAcceleratedCompositingMode):
(WebKit::WebPageProxy::requestGeolocationPermissionForFrame):
(WebKit::WebPageProxy::requestTextRecognition):
(WebKit::WebPageProxy::computeHasVisualSearchResults):
(WebKit::WebPageProxy::showMediaControlsContextMenu):
(WebKit::WebPageProxy::drawPageBorderForPrinting):
(WebKit::WebPageProxy::recommendedScrollbarStyleDidChange):
(WebKit::WebPageProxy::didChangeScrollOffsetPinningForMainFrame):
(WebKit::WebPageProxy::themeColorChanged):
(WebKit::WebPageProxy::pageExtendedBackgroundColorDidChange):
(WebKit::WebPageProxy::sampledPageTopColorChanged):
(WebKit::WebPageProxy::didFinishLoadingDataForCustomContentProvider):
(WebKit::WebPageProxy::updateBackingStoreDiscardableState):
(WebKit::WebPageProxy::showDictationAlternativeUI):
(WebKit::WebPageProxy::removeDictationAlternatives):
(WebKit::WebPageProxy::dictationAlternatives):
(WebKit::WebPageProxy::showCorrectionPanel):
(WebKit::WebPageProxy::dismissCorrectionPanel):
(WebKit::WebPageProxy::dismissCorrectionPanelSoon):
(WebKit::WebPageProxy::recordAutocorrectionResponse):
(WebKit::WebPageProxy::setEditableElementIsFocused):
(WebKit::WebPageProxy::takeViewSnapshot):
(WebKit::WebPageProxy::wrapCryptoKey):
(WebKit::WebPageProxy::unwrapCryptoKey):
(WebKit::WebPageProxy::navigationGestureDidBegin):
(WebKit::WebPageProxy::navigationGestureWillEnd):
(WebKit::WebPageProxy::navigationGestureDidEnd):
(WebKit::WebPageProxy::willRecordNavigationSnapshot):
(WebKit::WebPageProxy::navigationGestureSnapshotWasRemoved):
(WebKit::WebPageProxy::updatePlayingMediaDidChange):
(WebKit::WebPageProxy::updateReportedMediaCaptureState):
(WebKit::WebPageProxy::videoControlsManagerDidChange):
(WebKit::WebPageProxy::handleControlledElementIDResponse const):
(WebKit::WebPageProxy::didPerformImmediateActionHitTest):
(WebKit::WebPageProxy::immediateActionAnimationControllerForHitTestResult):
(WebKit::WebPageProxy::didHandleAcceptedCandidate):
(WebKit::WebPageProxy::performSwitchHapticFeedback):
(WebKit::WebPageProxy::addPlaybackTargetPickerClient):
(WebKit::WebPageProxy::removePlaybackTargetPickerClient):
(WebKit::WebPageProxy::showPlaybackTargetPicker):
(WebKit::WebPageProxy::playbackTargetPickerClientStateDidChange):
(WebKit::WebPageProxy::setMockMediaPlaybackTargetPickerEnabled):
(WebKit::WebPageProxy::setMockMediaPlaybackTargetPickerState):
(WebKit::WebPageProxy::mockMediaPlaybackTargetPickerDismissPopup):
(WebKit::WebPageProxy::didChangeBackgroundColor):
(WebKit::WebPageProxy::didRestoreScrollPosition):
(WebKit::WebPageProxy::userInterfaceLayoutDirection):
(WebKit::WebPageProxy::useDarkAppearance const):
(WebKit::WebPageProxy::useElevatedUserInterfaceLevel const):
(WebKit::WebPageProxy::dataOwnerForPasteboard const):
(WebKit::WebPageProxy::writePromisedAttachmentToPasteboard):
(WebKit::WebPageProxy::didInvalidateDataForAttachment):
(WebKit::WebPageProxy::didInsertAttachmentWithIdentifier):
(WebKit::WebPageProxy::didRemoveAttachment):
(WebKit::WebPageProxy::storeAppHighlight):
(WebKit::WebPageProxy::webViewDidMoveToWindow):
(WebKit::WebPageProxy::gpuProcessDidFinishLaunching):
(WebKit::WebPageProxy::gpuProcessExited):
(WebKit::WebPageProxy::modelProcessDidFinishLaunching):
(WebKit::WebPageProxy::modelProcessExited):
(WebKit::WebPageProxy::requestScrollToRect):
(WebKit::WebPageProxy::beginTextRecognitionForVideoInElementFullScreen):
(WebKit::WebPageProxy::cancelTextRecognitionForVideoInElementFullScreen):
(WebKit::PageClientProtector::PageClientProtector): Deleted.
(WebKit::PageClientProtector::~PageClientProtector): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::computeLayoutViewportRect const):
(WebKit::WebPageProxy::scrollingNodeScrollViewWillStartPanGesture):
(WebKit::WebPageProxy::scrollingNodeScrollViewDidScroll):
(WebKit::WebPageProxy::scrollingNodeScrollWillStartScroll):
(WebKit::WebPageProxy::scrollingNodeScrollDidEndScroll):
(WebKit::WebPageProxy::handleAutocorrectionContext):
(WebKit::WebPageProxy::didReceivePositionInformation):
(WebKit::WebPageProxy::saveImageToLibrary):
(WebKit::WebPageProxy::interpretKeyEvent):
(WebKit::WebPageProxy::registerWebProcessAccessibilityToken):
(WebKit::WebPageProxy::relayAccessibilityNotification):
(WebKit::WebPageProxy::assistiveTechnologyMakeFirstResponder):
(WebKit::WebPageProxy::couldNotRestorePageState):
(WebKit::WebPageProxy::restorePageState):
(WebKit::WebPageProxy::restorePageCenterAndScale):
(WebKit::WebPageProxy::didGetTapHighlightGeometries):
(WebKit::WebPageProxy::updateInputContextAfterBlurringAndRefocusingElement):
(WebKit::WebPageProxy::elementDidFocus):
(WebKit::WebPageProxy::elementDidBlur):
(WebKit::WebPageProxy::updateFocusedElementInformation):
(WebKit::WebPageProxy::focusedElementDidChangeInputMode):
(WebKit::WebPageProxy::didReleaseAllTouchPoints):
(WebKit::WebPageProxy::showInspectorHighlight):
(WebKit::WebPageProxy::hideInspectorHighlight):
(WebKit::WebPageProxy::showInspectorIndication):
(WebKit::WebPageProxy::hideInspectorIndication):
(WebKit::WebPageProxy::enableInspectorNodeSearch):
(WebKit::WebPageProxy::disableInspectorNodeSearch):
(WebKit::WebPageProxy::didPerformDictionaryLookup):
(WebKit::WebPageProxy::setRemoteLayerTreeRootNode):
(WebKit::WebPageProxy::showPlaybackTargetPicker):
(WebKit::WebPageProxy::commitPotentialTapFailed):
(WebKit::WebPageProxy::didNotHandleTapAsClick):
(WebKit::WebPageProxy::didHandleTapAsHover):
(WebKit::WebPageProxy::didCompleteSyntheticClick):
(WebKit::WebPageProxy::disableDoubleTapGesturesDuringTapIfNecessary):
(WebKit::WebPageProxy::handleSmartMagnificationInformationForPotentialTap):
(WebKit::WebPageProxy::didUpdateEditorState):
(WebKit::WebPageProxy::dispatchDidUpdateEditorState):
(WebKit::WebPageProxy::showValidationMessage):
(WebKit::WebPageProxy::didHandleDragStartRequest):
(WebKit::WebPageProxy::didHandleAdditionalDragItemsRequest):
(WebKit::WebPageProxy::willReceiveEditDragSnapshot):
(WebKit::WebPageProxy::didReceiveEditDragSnapshot):
(WebKit::WebPageProxy::requestPasswordForQuickLookDocumentInMainFrameShared):
(WebKit::WebPageProxy::isDesktopClassBrowsingRecommended const):
(WebKit::WebPageProxy::showDataDetectorsUIForPositionInformation):
(WebKit::WebPageProxy::insertionPointColorDidChange):
(WebKit::WebPageProxy::platformUnderPageBackgroundColor const):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::windowAndViewFramesChanged):
(WebKit::WebPageProxy::setPromisedDataForImage):
(WebKit::WebPageProxy::didPerformDictionaryLookup):
(WebKit::WebPageProxy::registerWebProcessAccessibilityToken):
(WebKit::WebPageProxy::makeFirstResponder):
(WebKit::WebPageProxy::assistiveTechnologyMakeFirstResponder):
(WebKit::WebPageProxy::useFormSemanticContext const):
(WebKit::WebPageProxy::colorSpace):
(WebKit::WebPageProxy::executeSavedCommandBySelector):
(WebKit::WebPageProxy::setRemoteLayerTreeRootNode):
(WebKit::WebPageProxy::acceleratedCompositingRootLayer const):
(WebKit::WebPageProxy::headerBannerLayer const):
(WebKit::WebPageProxy::footerBannerLayer const):
(WebKit::WebPageProxy::showPDFContextMenu):
(WebKit::WebPageProxy::showTelephoneNumberMenu):
(WebKit::WebPageProxy::boundsOfLayerInLayerBackedWindowCoordinates const):
(WebKit::WebPageProxy::didUpdateEditorState):
(WebKit::WebPageProxy::startWindowDrag):
(WebKit::WebPageProxy::rootViewToWindow):
(WebKit::WebPageProxy::showValidationMessage):
(WebKit::WebPageProxy::inspectorAttachmentView):
(WebKit::WebPageProxy::remoteObjectRegistry):
(WebKit::WebPageProxy::createSyntheticEventForContextMenu const):
(WebKit::WebPageProxy::Internals::platformView const):
(WebKit::WebPageProxy::createPDFHUD):
(WebKit::WebPageProxy::removePDFHUD):
(WebKit::WebPageProxy::updatePDFHUDLocation):
(WebKit::WebPageProxy::showImageInQuickLookPreviewPanel):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::WebViewImpl):
* Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp:
(WebKit::PlayStationWebView::PlayStationWebView):
* Source/WebKit/UIProcess/win/WebView.cpp:
(WebKit::WebView::WebView):

Canonical link: <a href="https://commits.webkit.org/274288@main">https://commits.webkit.org/274288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d75efe6266e2044ec62b2338de57bfe018123388

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41076 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34218 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32401 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33524 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12787 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12773 "Found 4 new test failures: imported/w3c/web-platform-tests/beacon/beacon-cors.https.window.html, imported/w3c/web-platform-tests/css/css-flexbox/negative-overflow-002.html, imported/w3c/web-platform-tests/css/css-fonts/font-size-adjust-zero-1.html, imported/w3c/web-platform-tests/webrtc-stats/supported-stats.https.html (failure)") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42352 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35008 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38602 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13381 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11061 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36814 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14981 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13848 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5024 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14455 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->