### PR TITLE
REGRESSION (271747@main): UI-side compositing repaint is broken with DOMGPUP off

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -103,6 +103,7 @@ void RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContent
     }
 
     GraphicsContext& context = m_frontBuffer.imageBuffer->context();
+    GraphicsContextStateSaver outerSaver(context);
 
     // We never need to copy forward when using display list drawing, since we don't do partial repaint.
     // FIXME: Copy forward logic is duplicated in RemoteImageBufferSet, find a good place to share.


### PR DESCRIPTION
#### 39d4937cd4642e7f170a9e38b7f69d2fb07aaa26
<pre>
REGRESSION (271747@main): UI-side compositing repaint is broken with DOMGPUP off
<a href="https://bugs.webkit.org/show_bug.cgi?id=268968">https://bugs.webkit.org/show_bug.cgi?id=268968</a>

Reviewed by Simon Fraser.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContents):
If DOMGPUP is off and UI-side compositing is on, we use RemoteLayerWithInProcessRenderingBackingStore.

This is an uncommon situation to be in; as far as I have been able to determine,
it requires changing default settings on all platforms (turning off DOMGPUP on macOS or iOS,
or turning off dynamic content scaling on visionOS, which happens to accidentally work around this).

The code to apply clipping for partial repaint was hoisted out of RemoteLayerBackingStore
in 271747@main, and sadly was also hoisted past the GraphicsContextStateSaver
that would result in it not persisting forever. Thus, clips end up *accumulating*,
breaking partial repaint.

Put an extra GraphicsContextStateSaver above the clipping.

Canonical link: <a href="https://commits.webkit.org/274312@main">https://commits.webkit.org/274312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad1a5df405da3a7afd8c2181810ed6e44fcc665f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41085 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34227 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32409 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33537 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12797 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12781 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42361 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35016 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34814 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38607 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36813 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/14990 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8674 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13857 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14464 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->