### PR TITLE
MediaConstraint::constraintType() is unneeded

### DIFF
--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -188,8 +188,8 @@ static bool hasInvalidGetDisplayMediaConstraint(const MediaConstraints& constrai
         return true;
 
     bool invalid = false;
-    constraints.mandatoryConstraints.filter([&invalid] (const MediaConstraint& constraint) mutable {
-        switch (constraint.constraintType()) {
+    constraints.mandatoryConstraints.filter([&invalid] (auto constraintType, const MediaConstraint& constraint) mutable {
+        switch (constraintType) {
         case MediaConstraintType::Width:
         case MediaConstraintType::Height: {
             auto& intConstraint = downcast<IntConstraint>(constraint);

--- a/Source/WebCore/Modules/mediastream/MediaTrackConstraints.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaTrackConstraints.cpp
@@ -35,7 +35,7 @@ enum class ConstraintSetType { Mandatory, Advanced };
 
 static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, MediaConstraintType type, const ConstrainLong& value)
 {
-    IntConstraint constraint(type);
+    IntConstraint constraint;
     WTF::switchOn(value,
         [&] (int integer) {
             if (setType == ConstraintSetType::Mandatory)
@@ -59,7 +59,7 @@ static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, Medi
 
 static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, MediaConstraintType type, const ConstrainDouble& value)
 {
-    DoubleConstraint constraint(type);
+    DoubleConstraint constraint;
     WTF::switchOn(value,
         [&] (double number) {
             if (setType == ConstraintSetType::Mandatory)
@@ -83,7 +83,7 @@ static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, Medi
 
 static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, MediaConstraintType type, const ConstrainBoolean& value)
 {
-    BooleanConstraint constraint(type);
+    BooleanConstraint constraint;
     WTF::switchOn(value,
         [&] (bool boolean) {
             if (setType == ConstraintSetType::Mandatory)
@@ -103,7 +103,7 @@ static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, Medi
 
 static void set(MediaTrackConstraintSetMap& map, ConstraintSetType setType, MediaConstraintType type, const ConstrainDOMString& value)
 {
-    StringConstraint constraint(type);
+    StringConstraint constraint;
     WTF::switchOn(value,
         [&] (const String& string) {
             if (setType == ConstraintSetType::Mandatory)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -238,7 +238,7 @@ public:
     WEBCORE_EXPORT VideoFrameSizeConstraints extractVideoFrameSizeConstraints(const MediaConstraints&);
 
     std::optional<MediaConstraintType> hasAnyInvalidConstraint(const MediaConstraints&);
-    bool supportsConstraint(const MediaConstraint&);
+    bool supportsConstraint(MediaConstraintType);
 
     virtual bool isMockSource() const { return false; }
     virtual bool isCaptureSource() const { return false; }
@@ -289,8 +289,14 @@ protected:
     virtual void endApplyingConstraints() { }
 
     std::optional<MediaConstraintType> selectSettings(const MediaConstraints&, MediaTrackConstraintSetMap&);
-    double fitnessDistance(const MediaConstraint&);
-    void applyConstraint(const MediaConstraint&);
+
+    double fitnessDistance(MediaConstraintType, const IntConstraint&);
+    double fitnessDistance(MediaConstraintType, const DoubleConstraint&);
+    double fitnessDistance(MediaConstraintType, const StringConstraint&);
+    double fitnessDistance(MediaConstraintType, const BooleanConstraint&);
+    double fitnessDistance(MediaConstraintType, const MediaConstraint&);
+
+    void applyConstraint(MediaConstraintType, const MediaConstraint&);
     void applyConstraints(const MediaTrackConstraintSetMap&);
     VideoFrameSizeConstraints extractVideoFrameSizeConstraints(const MediaTrackConstraintSetMap&);
     std::optional<MediaConstraintType> hasInvalidSizeFrameRateAndZoomConstraints(std::optional<IntConstraint> width, std::optional<IntConstraint> height, std::optional<DoubleConstraint>, std::optional<DoubleConstraint>, double& fitnessDistance);

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -346,7 +346,7 @@ void RealtimeMediaSourceCenter::validateRequestConstraintsAfterEnumeration(Valid
 
     if (request.audioConstraints.isValid && audioDeviceInfo.isEmpty()) {
         WTFLogAlways("Audio capture was requested but no device was found amongst %zu devices", audioCaptureFactory().audioCaptureDeviceManager().captureDevices().size());
-        request.audioConstraints.mandatoryConstraints.forEach([](auto& constraint) { constraint.log(); });
+        request.audioConstraints.mandatoryConstraints.forEach([](auto constraintType, auto& constraint) { constraint.log(constraintType); });
 
         invalidHandler(firstInvalidConstraint);
         return;
@@ -354,7 +354,7 @@ void RealtimeMediaSourceCenter::validateRequestConstraintsAfterEnumeration(Valid
 
     if (request.videoConstraints.isValid && videoDeviceInfo.isEmpty()) {
         WTFLogAlways("Video capture was requested but no device was found amongst %zu devices", videoCaptureFactory().videoCaptureDeviceManager().captureDevices().size());
-        request.videoConstraints.mandatoryConstraints.forEach([](auto& constraint) { constraint.log(); });
+        request.videoConstraints.mandatoryConstraints.forEach([](auto constraintType, auto& constraint) { constraint.log(constraintType); });
 
         invalidHandler(firstInvalidConstraint);
         return;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5031,7 +5031,6 @@ class WebCore::SecurityOriginData {
 #if ENABLE(MEDIA_STREAM)
 
 [Nested] enum class WebCore::MediaConstraint::DataType : uint8_t {
-    None,
     Integer,
     Double,
     Boolean,
@@ -5060,7 +5059,6 @@ enum class WebCore::MediaConstraintType : uint8_t {
 
 header: <WebCore/MediaConstraints.h>
 [CustomHeader] class WebCore::MediaConstraint {
-    WebCore::MediaConstraintType constraintType();
     WebCore::MediaConstraint::DataType dataType();
 };
 


### PR DESCRIPTION
#### ce92687fa9592121aa98ec589334c1069d8b4f55
<pre>
MediaConstraint::constraintType() is unneeded
<a href="https://bugs.webkit.org/show_bug.cgi?id=268978">https://bugs.webkit.org/show_bug.cgi?id=268978</a>
<a href="https://rdar.apple.com/122532646">rdar://122532646</a>

Reviewed by Eric Carlson.

MediaConstraint::constraintType is somehow reduundant with MediaTrackConstraintSetMap member fields.
We therefore remove MediaConstraint::constraintType and instead pass the corresponding MediaConstraintType for each MediaTrackConstraintSetMap member.
We remove MediaConstraint::DataType::None since it is not needed.
Covered by existing tests.

* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::hasInvalidGetDisplayMediaConstraint):
* Source/WebCore/Modules/mediastream/MediaTrackConstraints.cpp:
(WebCore::set):
* Source/WebCore/platform/mediastream/MediaConstraints.cpp:
(WebCore::StringConstraint::merge):
(WebCore::MediaTrackConstraintSetMap::forEach const):
(WebCore::MediaTrackConstraintSetMap::filter const):
(WebCore::MediaTrackConstraintSetMap::merge):
(WebCore::MediaTrackConstraintSetMap::size const):
(WebCore::addDefaultVideoConstraints):
(WebCore::MediaConstraints::setDefaultAudioConstraints):
(WebCore::MediaConstraint::log const):
(WebCore::BooleanConstraint::logAsBoolean const):
(WebCore::DoubleConstraint::logAsDouble const):
(WebCore::IntConstraint::logAsInt const):
(WebCore::StringConstraint::isolatedCopy const):
* Source/WebCore/platform/mediastream/MediaConstraints.h:
(WebCore::MediaConstraint::dataType const):
(WebCore::MediaConstraint::MediaConstraint):
(WebCore::NumericConstraint::NumericConstraint):
(WebCore::StringConstraint::StringConstraint):
(WebCore::MediaConstraint::constraintType const): Deleted.
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::hasInvalidSizeFrameRateAndZoomConstraints):
(WebCore::RealtimeMediaSource::fitnessDistance):
(WebCore::RealtimeMediaSource::applyConstraint):
(WebCore::RealtimeMediaSource::selectSettings):
(WebCore::RealtimeMediaSource::supportsConstraint):
(WebCore::RealtimeMediaSource::hasAnyInvalidConstraint):
(WebCore::RealtimeMediaSource::applyConstraints):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::validateRequestConstraintsAfterEnumeration):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/274294@main">https://commits.webkit.org/274294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ced04332b54d2e9f4e255d5b847fb4fc927f299d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41119 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34250 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32429 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14767 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12825 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42394 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35056 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34829 "Build is in progress. Recent messages:") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38632 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36841 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15020 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8654 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13876 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14494 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->