### PR TITLE
[Buildstream SDK] Vendor an additional libsoup patch

### DIFF
--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -9,6 +9,8 @@ sources:
 - kind: patch
   path: patches/fdo-0003-libsoup-Vendor-patch-needed-for-test-bots.patch
 - kind: patch
+  path: patches/fdo-0004-libsoup-Vendor-another-libsoup-patch.patch
+- kind: patch
   path: patches/fdo-0004-gst-plugins-ugly-Enable-x264-encoder.patch
 - kind: patch
   path: patches/fdo-0005-GStreamer-Bump-to-1.22.9.patch

--- a/Tools/buildstream/patches/fdo-0003-libsoup-Vendor-patch-needed-for-test-bots.patch
+++ b/Tools/buildstream/patches/fdo-0003-libsoup-Vendor-patch-needed-for-test-bots.patch
@@ -3,7 +3,7 @@ From: Philippe Normand <philn@igalia.com>
 Date: Thu, 21 Dec 2023 10:19:01 +0000
 Subject: [PATCH] libsoup: Vendor patch needed for test bots
 
-I suppose that will ship in libsoup 3.4.5.
+I suppose that will ship in libsoup 3.5.0.
 ---
  elements/components/libsoup.bst               |  2 +
  ...ef-of-the-item-when-calling-soup_mes.patch | 54 +++++++++++++++++++

--- a/Tools/buildstream/patches/fdo-0004-libsoup-Vendor-another-libsoup-patch.patch
+++ b/Tools/buildstream/patches/fdo-0004-libsoup-Vendor-another-libsoup-patch.patch
@@ -1,0 +1,82 @@
+From 42f538e7031069d8c2976f3dcc0d87d65f99ea8d Mon Sep 17 00:00:00 2001
+From: Philippe Normand <philn@igalia.com>
+Date: Thu, 8 Feb 2024 12:49:47 +0000
+Subject: [PATCH] libsoup: Vendor another libsoup patch
+
+I suppose that will ship in libsoup 3.5.0.
+---
+ elements/components/libsoup.bst               |  2 +
+ .../libsoup/soup-multipart-input-stream.patch | 51 +++++++++++++++++++
+ 2 files changed, 53 insertions(+)
+ create mode 100644 patches/libsoup/soup-multipart-input-stream.patch
+
+diff --git a/elements/components/libsoup.bst b/elements/components/libsoup.bst
+index c3ecd15..bc0112e 100644
+--- a/elements/components/libsoup.bst
++++ b/elements/components/libsoup.bst
+@@ -40,3 +40,5 @@ sources:
+   ref: 3.4.4-0-gd6133a8e116953dac824b835d4f788e21a3e6565
+ - kind: patch
+   path: patches/libsoup/0001-session-take-a-ref-of-the-item-when-calling-soup_mes.patch
++- kind: patch
++  path: patches/libsoup/soup-multipart-input-stream.patch
+diff --git a/patches/libsoup/soup-multipart-input-stream.patch b/patches/libsoup/soup-multipart-input-stream.patch
+new file mode 100644
+index 0000000..9ac7f72
+--- /dev/null
++++ b/patches/libsoup/soup-multipart-input-stream.patch
+@@ -0,0 +1,51 @@
++From a8bad1ae13df5b865b961410ef134574a0dfb52b Mon Sep 17 00:00:00 2001
++From: Vitaly Dyachkov <vitaly@igalia.com>
++Date: Fri, 2 Feb 2024 15:25:24 +0100
++Subject: [PATCH] soup_multipart_input_stream_next_part: return NULL when EOF
++ is reached
++
++Fixes #372
++---
++ libsoup/soup-multipart-input-stream.c | 5 ++++-
++ tests/multipart-test.c                | 2 +-
++ 2 files changed, 5 insertions(+), 2 deletions(-)
++
++diff --git a/libsoup/soup-multipart-input-stream.c b/libsoup/soup-multipart-input-stream.c
++index 99999ea1..5bbd4bed 100644
++--- a/libsoup/soup-multipart-input-stream.c
+++++ b/libsoup/soup-multipart-input-stream.c
++@@ -376,7 +376,7 @@ soup_multipart_input_stream_read_headers (SoupMultipartInputStream  *multipart,
++ 							    /* blocking */ TRUE, &got_lf, cancellable, error);
++ 
++ 		if (nread <= 0)
++-			break;
+++			return FALSE;
++ 
++ 		g_byte_array_append (priv->meta_buf, read_buf, nread);
++ 
++@@ -468,6 +468,9 @@ soup_multipart_input_stream_new (SoupMessage  *msg,
++  * the part; a new call to this function should be done at that point,
++  * to obtain the next part.
++  *
+++ * @error will only be set if an error happens during a read, %NULL
+++ * is a valid return value otherwise.
+++ *
++  * Returns: (nullable) (transfer full): a new #GInputStream, or
++  *   %NULL if there are no more parts
++  */
++diff --git a/tests/multipart-test.c b/tests/multipart-test.c
++index 8c80265e..2c0e7e96 100644
++--- a/tests/multipart-test.c
+++++ b/tests/multipart-test.c
++@@ -56,7 +56,7 @@ const char *payload = \
++ 	"Content-Type: text/css\r\n" \
++ 	"\r\n" \
++ 	"#soup { background-color: black; }" \
++-        "\r\n--cut-here--";
+++	"\r\n--cut-here\r\n"; /* Tests missing termination .*/
++ 
++ static void
++ server_callback (SoupServer        *server,
++-- 
++GitLab
++
+-- 
+2.43.0
+


### PR DESCRIPTION
#### 272ec53e6d51aff350a6fab8fba1bc4533ca9cc6
<pre>
[Buildstream SDK] Vendor an additional libsoup patch
<a href="https://bugs.webkit.org/show_bug.cgi?id=268979">https://bugs.webkit.org/show_bug.cgi?id=268979</a>

Reviewed by Adrian Perez de Castro.

Vendor <a href="https://gitlab.gnome.org/GNOME/libsoup/-/commit/a8bad1ae13df5b865b961410ef134574a0dfb52b">https://gitlab.gnome.org/GNOME/libsoup/-/commit/a8bad1ae13df5b865b961410ef134574a0dfb52b</a>
until we can bump to libsoup 3.5.0.

* Tools/buildstream/elements/freedesktop-sdk.bst:
* Tools/buildstream/patches/fdo-0003-libsoup-Vendor-patch-needed-for-test-bots.patch:
* Tools/buildstream/patches/fdo-0004-libsoup-Vendor-another-libsoup-patch.patch: Added.

Canonical link: <a href="https://commits.webkit.org/274283@main">https://commits.webkit.org/274283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e99834bb4daf567c109c9daa6a97a827e8e622f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41118 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34249 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14857 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14765 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12823 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42393 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35053 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38628 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36836 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15019 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5019 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14493 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->