### PR TITLE
[GTK] Only implement GtkAccessible in recent versions

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -384,10 +384,16 @@ struct _WebKitWebViewBasePrivate {
  */
 
 #if USE(GTK4)
+
+#ifdef GTK_ACCESSIBILITY_ATSPI
 static void webkitWebViewBaseAccessibleInterfaceInit(GtkAccessibleInterface*);
 
 WEBKIT_DEFINE_TYPE_WITH_CODE(WebKitWebViewBase, webkit_web_view_base, GTK_TYPE_WIDGET,
     G_IMPLEMENT_INTERFACE(GTK_TYPE_ACCESSIBLE, webkitWebViewBaseAccessibleInterfaceInit))
+#else
+WEBKIT_DEFINE_TYPE(WebKitWebViewBase, webkit_web_view_base, GTK_TYPE_WIDGET)
+#endif // GTK_ACCESSIBILITY_ATSPI
+
 #else
 WEBKIT_DEFINE_TYPE(WebKitWebViewBase, webkit_web_view_base, GTK_TYPE_CONTAINER)
 #endif
@@ -398,15 +404,13 @@ static void webkitWebViewBaseDidExitFullScreen(WebKitWebViewBase*);
 static void webkitWebViewBaseRequestExitFullScreen(WebKitWebViewBase*);
 #endif
 
-#if USE(GTK4)
+#if USE(GTK4) && defined(GTK_ACCESSIBILITY_ATSPI)
 static GtkAccessible* webkitWebViewBaseAccessibleGetFirstAccessibleChild(GtkAccessible* accessible)
 {
     WebKitWebViewBase* webView = WEBKIT_WEB_VIEW_BASE(accessible);
 
-#ifdef GTK_ACCESSIBILITY_ATSPI
     if (webView->priv->socketAccessible)
         return GTK_ACCESSIBLE(g_object_ref(webView->priv->socketAccessible.get()));
-#endif
 
     if (auto* widget = gtk_widget_get_first_child(GTK_WIDGET(webView)))
         return GTK_ACCESSIBLE(g_object_ref(widget));


### PR DESCRIPTION
#### 4aa6d217eac59b49aa4eb0185ea22244c24e1ee9
<pre>
[GTK] Only implement GtkAccessible in recent versions
<a href="https://bugs.webkit.org/show_bug.cgi?id=227528">https://bugs.webkit.org/show_bug.cgi?id=227528</a>

Reviewed by Adrian Perez de Castro.

GtkAccessible is only publicly exposed as an externally implementable
interface since GTK 4.10, but Ubuntu 22.04 ships with GTK4 4.6. This
breaks the build.

Conditionally implement this interface based on the availability of
the GTK_ACCESSIBILITY_ATSPI define.

* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseAccessibleGetFirstAccessibleChild):

Canonical link: <a href="https://commits.webkit.org/274284@main">https://commits.webkit.org/274284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee5991a0ac894620172a4ffcdfe640125aedbace

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41120 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34251 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14859 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14768 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12824 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42395 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35057 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38631 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36840 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15021 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5020 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->