### PR TITLE
[GCC] Unreviewed, build fix for Debian Stable after 274277@main

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -58,6 +58,7 @@
 #include "GPUSupportedLimits.h"
 #include "GPUTexture.h"
 #include "GPUTextureDescriptor.h"
+#include "GPUTextureFormat.h"
 #include "GPUUncapturedErrorEvent.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSGPUComputePipeline.h"
@@ -162,73 +163,72 @@ ExceptionOr<Ref<GPUBuffer>> GPUDevice::createBuffer(const GPUBufferDescriptor& b
 bool GPUDevice::isSupportedFormat(GPUTextureFormat format) const
 {
     const auto& featureContainer = m_backing->features().features();
-    using enum GPUTextureFormat;
     switch (format) {
-    case Depth32floatStencil8:
+    case GPUTextureFormat::Depth32floatStencil8:
         return featureContainer.contains("depth32float-stencil8"_s);
 
     // BC compressed formats usable if texture-compression-bc is both
     // supported by the device/user agent and enabled in requestDevice.
-    case Bc1RgbaUnorm:
-    case Bc1RgbaUnormSRGB:
-    case Bc2RgbaUnorm:
-    case Bc2RgbaUnormSRGB:
-    case Bc3RgbaUnorm:
-    case Bc3RgbaUnormSRGB:
-    case Bc4RUnorm:
-    case Bc4RSnorm:
-    case Bc5RgUnorm:
-    case Bc5RgSnorm:
-    case Bc6hRgbUfloat:
-    case Bc6hRgbFloat:
-    case Bc7RgbaUnorm:
-    case Bc7RgbaUnormSRGB:
+    case GPUTextureFormat::Bc1RgbaUnorm:
+    case GPUTextureFormat::Bc1RgbaUnormSRGB:
+    case GPUTextureFormat::Bc2RgbaUnorm:
+    case GPUTextureFormat::Bc2RgbaUnormSRGB:
+    case GPUTextureFormat::Bc3RgbaUnorm:
+    case GPUTextureFormat::Bc3RgbaUnormSRGB:
+    case GPUTextureFormat::Bc4RUnorm:
+    case GPUTextureFormat::Bc4RSnorm:
+    case GPUTextureFormat::Bc5RgUnorm:
+    case GPUTextureFormat::Bc5RgSnorm:
+    case GPUTextureFormat::Bc6hRgbUfloat:
+    case GPUTextureFormat::Bc6hRgbFloat:
+    case GPUTextureFormat::Bc7RgbaUnorm:
+    case GPUTextureFormat::Bc7RgbaUnormSRGB:
         return featureContainer.contains("texture-compression-bc"_s);
 
     // ETC2 compressed formats usable if texture-compression-etc2 is both
     // supported by the device/user agent and enabled in requestDevice.
-    case Etc2Rgb8unorm:
-    case Etc2Rgb8unormSRGB:
-    case Etc2Rgb8a1unorm:
-    case Etc2Rgb8a1unormSRGB:
-    case Etc2Rgba8unorm:
-    case Etc2Rgba8unormSRGB:
-    case EacR11unorm:
-    case EacR11snorm:
-    case EacRg11unorm:
-    case EacRg11snorm:
+    case GPUTextureFormat::Etc2Rgb8unorm:
+    case GPUTextureFormat::Etc2Rgb8unormSRGB:
+    case GPUTextureFormat::Etc2Rgb8a1unorm:
+    case GPUTextureFormat::Etc2Rgb8a1unormSRGB:
+    case GPUTextureFormat::Etc2Rgba8unorm:
+    case GPUTextureFormat::Etc2Rgba8unormSRGB:
+    case GPUTextureFormat::EacR11unorm:
+    case GPUTextureFormat::EacR11snorm:
+    case GPUTextureFormat::EacRg11unorm:
+    case GPUTextureFormat::EacRg11snorm:
         return featureContainer.contains("texture-compression-etc2"_s);
 
     // ASTC compressed formats usable if texture-compression-astc is both
     // supported by the device/user agent and enabled in requestDevice.
-    case Astc4x4Unorm:
-    case Astc4x4UnormSRGB:
-    case Astc5x4Unorm:
-    case Astc5x4UnormSRGB:
-    case Astc5x5Unorm:
-    case Astc5x5UnormSRGB:
-    case Astc6x5Unorm:
-    case Astc6x5UnormSRGB:
-    case Astc6x6Unorm:
-    case Astc6x6UnormSRGB:
-    case Astc8x5Unorm:
-    case Astc8x5UnormSRGB:
-    case Astc8x6Unorm:
-    case Astc8x6UnormSRGB:
-    case Astc8x8Unorm:
-    case Astc8x8UnormSRGB:
-    case Astc10x5Unorm:
-    case Astc10x5UnormSRGB:
-    case Astc10x6Unorm:
-    case Astc10x6UnormSRGB:
-    case Astc10x8Unorm:
-    case Astc10x8UnormSRGB:
-    case Astc10x10Unorm:
-    case Astc10x10UnormSRGB:
-    case Astc12x10Unorm:
-    case Astc12x10UnormSRGB:
-    case Astc12x12Unorm:
-    case Astc12x12UnormSRGB:
+    case GPUTextureFormat::Astc4x4Unorm:
+    case GPUTextureFormat::Astc4x4UnormSRGB:
+    case GPUTextureFormat::Astc5x4Unorm:
+    case GPUTextureFormat::Astc5x4UnormSRGB:
+    case GPUTextureFormat::Astc5x5Unorm:
+    case GPUTextureFormat::Astc5x5UnormSRGB:
+    case GPUTextureFormat::Astc6x5Unorm:
+    case GPUTextureFormat::Astc6x5UnormSRGB:
+    case GPUTextureFormat::Astc6x6Unorm:
+    case GPUTextureFormat::Astc6x6UnormSRGB:
+    case GPUTextureFormat::Astc8x5Unorm:
+    case GPUTextureFormat::Astc8x5UnormSRGB:
+    case GPUTextureFormat::Astc8x6Unorm:
+    case GPUTextureFormat::Astc8x6UnormSRGB:
+    case GPUTextureFormat::Astc8x8Unorm:
+    case GPUTextureFormat::Astc8x8UnormSRGB:
+    case GPUTextureFormat::Astc10x5Unorm:
+    case GPUTextureFormat::Astc10x5UnormSRGB:
+    case GPUTextureFormat::Astc10x6Unorm:
+    case GPUTextureFormat::Astc10x6UnormSRGB:
+    case GPUTextureFormat::Astc10x8Unorm:
+    case GPUTextureFormat::Astc10x8UnormSRGB:
+    case GPUTextureFormat::Astc10x10Unorm:
+    case GPUTextureFormat::Astc10x10UnormSRGB:
+    case GPUTextureFormat::Astc12x10Unorm:
+    case GPUTextureFormat::Astc12x10UnormSRGB:
+    case GPUTextureFormat::Astc12x12Unorm:
+    case GPUTextureFormat::Astc12x12UnormSRGB:
         return featureContainer.contains("texture-compression-astc"_s);
 
     default:


### PR DESCRIPTION
#### ed1f614fe8d14d60fe2af3bcf46e6614df2590cd
<pre>
[GCC] Unreviewed, build fix for Debian Stable after 274277@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=267283">https://bugs.webkit.org/show_bug.cgi?id=267283</a>

GCC10.2 doesn&apos;t fully support &quot;using enum&quot;.

* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
(WebCore::GPUDevice::isSupportedFormat const):

Canonical link: <a href="https://commits.webkit.org/274285@main">https://commits.webkit.org/274285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9e9474e02d95c3cafe17f6aafa5be14a33b9ac7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41125 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34256 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14864 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32431 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39162 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/14772 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12827 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42400 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35061 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38634 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/11099 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/36843 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5021 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->