### PR TITLE
Convert ews-build.webkit.org to multi-master (to improve responsiveness)

### DIFF
--- a/Tools/CISupport/ews-build-webserver/buildbot.tac
+++ b/Tools/CISupport/ews-build-webserver/buildbot.tac
@@ -1,0 +1,31 @@
+import os
+
+from twisted.application import service
+from buildbot.master import BuildMaster
+
+basedir = '.'
+
+rotateLength = 200000000
+maxRotatedFiles = 20
+configfile = 'master.cfg'
+
+# Default umask for server
+umask = 0o022
+
+# if this is a relocatable tac file, get the directory containing the TAC
+if basedir == '.':
+    basedir = os.path.abspath(os.path.dirname(__file__))
+
+# note: this line is matched against to check that this is a buildmaster
+# directory; do not edit it.
+application = service.Application('buildmaster')
+from twisted.python.logfile import LogFile
+from twisted.python.log import ILogObserver, FileLogObserver
+logfile = LogFile.fromFullPath(os.path.join(basedir, "twistd.log"), rotateLength=rotateLength,
+                                maxRotatedFiles=maxRotatedFiles)
+application.setComponent(ILogObserver, FileLogObserver(logfile).emit)
+
+m = BuildMaster(basedir, configfile, umask)
+m.setServiceParent(application)
+m.log_rotation.rotateLength = rotateLength
+m.log_rotation.maxRotatedFiles = maxRotatedFiles

--- a/Tools/CISupport/ews-build-webserver/master.cfg
+++ b/Tools/CISupport/ews-build-webserver/master.cfg
@@ -1,0 +1,125 @@
+import importlib
+import json
+import os
+import socket
+import sys
+
+from buildbot.plugins import reporters, util
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+loadConfig = importlib.import_module("ews-build.loadConfig")
+events = importlib.import_module("ews-build.events")
+utils = importlib.import_module("ews-build.utils")
+
+
+# This is work-around for Twisted having a small size limit for patches. See https://bugs.webkit.org/show_bug.cgi?id=198851#c5
+from twisted.spread import banana
+banana.SIZE_LIMIT = 100 * 1024 * 1024
+
+# This is work-around for https://bugs.webkit.org/show_bug.cgi?id=222361
+from buildbot.process.buildstep import BuildStep
+BuildStep.warn_deprecated_if_oldstyle_subclass = lambda self, name: None
+
+is_test_mode_enabled = utils.load_password('BUILDBOT_PRODUCTION') is None
+custom_suffix = utils.get_custom_suffix()
+
+# We are using multi-master setup with 2 masters.
+# One master handles UI (web-server), and the other handles the back-end.
+# If test mode is enabled, we use single master setup.
+use_multi_master = not is_test_mode_enabled
+
+c = BuildmasterConfig = {}
+
+if use_multi_master:
+    c['multiMaster'] = True
+    c['mq'] = {
+        'type': 'wamp',
+        'router_url': 'ws://localhost:8080/ws',
+        'realm': 'realm1',
+        'wamp_debug_level': 'info'
+    }
+
+c['www'] = dict(port='tcp:8010:interface=127.0.0.1', allowed_origins=["*"])
+c['www']['custom_templates_dir'] = 'templates'
+c['www']['ui_default_config'] = {
+    'Builders.show_workers_name': True,
+    'Builders.buildFetchLimit': 1000,
+    'Workers.showWorkerBuilders': True,
+}
+
+if not is_test_mode_enabled:
+    c['www']['change_hook_dialects'] = dict(
+        github={
+            'class': events.GitHubEventHandlerNoEdits,
+            'secret': utils.load_password('GITHUB_HOOK_SECRET'),
+            'github_property_whitelist': [
+                'github.number',
+                'github.title',
+                'github.head.ref',
+                'github.head.sha',
+                'github.base.ref',
+                'github.head.repo.full_name',
+                'github.head.user.login',
+            ], 'token': utils.load_password('GITHUB_COM_ACCESS_TOKEN'),
+        },
+    )
+
+    GITHUB_CLIENT_ID = utils.load_password('GITHUB_CLIENT_ID')
+    GITHUB_CLIENT_SECRET = utils.load_password('GITHUB_CLIENT_SECRET')
+    if (not GITHUB_CLIENT_ID) or (not GITHUB_CLIENT_SECRET):
+        print('EWS credentials not found. Please ensure GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET are configured either in env variables or in passwords.json')
+        sys.exit(1)
+
+    # See https://docs.buildbot.net/current/manual/configuration/www.html#example-configs
+    authz = util.Authz(
+        allowRules=[util.AnyEndpointMatcher(role='Buildbot-Administrators', defaultDeny=False),
+                    util.RebuildBuildEndpointMatcher(role='Contributors'),
+                    util.StopBuildEndpointMatcher(role='Committers'),
+                    util.AnyControlEndpointMatcher(role='Buildbot-Administrators')],
+        roleMatchers=[util.RolesFromGroups(groupPrefix='WebKit/')]
+    )
+    auth = util.GitHubAuth(GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, apiVersion=4, getTeamsMembership=True, debug=True)
+    c['www']['auth'] = auth
+    c['www']['authz'] = authz
+
+c['projectName'] = 'WebKit EWS{}'.format(custom_suffix.upper())
+c['projectURL'] = 'https://ews-build.webkit{}.org/'.format(custom_suffix)
+
+if is_test_mode_enabled:
+    c['buildbotURL'] = 'http://localhost:8010/'
+    c['db_url'] = 'sqlite:///state.sqlite?serialize_access=1'
+else:
+    c['buildbotURL'] = 'https://ews-build.webkit{}.org/'.format(custom_suffix)
+    db_url = utils.load_password('DB_URL', None)
+    db_name = utils.load_password('DB_NAME', None)
+    db_username = utils.load_password('DB_USERNAME', None)
+    db_password = utils.load_password('DB_PASSWORD', None)
+    if None in [db_url, db_name, db_username, db_password]:
+        print('Environment variables for DB not found. Please ensure these variables are set.')
+        sys.exit(1)
+    # See https://docs.buildbot.net/1.7.0/manual/configuration/global.html#database-specification
+    c['db_url'] = 'postgresql://{}:{}@{}/{}'.format(db_username, db_password, db_url, db_name)
+
+c['logCompressionMethod'] = 'lz4'
+c['buildbotNetUsageData'] = None
+
+loadConfig.loadBuilderConfig(
+    c, is_test_mode_enabled=is_test_mode_enabled,
+    setup_main_schedulers=True,
+    setup_force_schedulers=True,
+)
+
+c['workers'] = c['builders'] = []
+
+mail_notifier = reporters.MailNotifier(
+    fromaddr='ews-build@webkit{}.org'.format(custom_suffix),
+    sendToInterestedUsers=False,
+    extraRecipients=['webkit-ews-bot-watchers@group.apple.com'],
+    mode=('exception'),
+    addPatch=False)
+
+if not is_test_mode_enabled:
+    hostname =  socket.gethostname().strip()
+    event_reporter = events.Events(master_hostname=hostname, type_prefix='ews')
+    c['services'] = [event_reporter, mail_notifier, util.ProfilerService(wantBuilds=0, basepath='/var/buildbot/profiler-webserver/')]

--- a/Tools/CISupport/ews-build/loadConfig.py
+++ b/Tools/CISupport/ews-build/loadConfig.py
@@ -44,7 +44,7 @@ BUILDER_NAME_LENGTH_LIMIT = 70
 STEP_NAME_LENGTH_LIMIT = 50
 
 
-def loadBuilderConfig(c, is_test_mode_enabled=False, master_prefix_path=os.path.dirname(os.path.abspath(__file__))):
+def loadBuilderConfig(c, is_test_mode_enabled=False, setup_main_schedulers=True, setup_force_schedulers=True, master_prefix_path=os.path.dirname(os.path.abspath(__file__))):
     with open(os.path.join(master_prefix_path, 'config.json')) as config_json:
         config = json.load(config_json)
     if is_test_mode_enabled:
@@ -97,7 +97,8 @@ def loadBuilderConfig(c, is_test_mode_enabled=False, master_prefix_path=os.path.
             scheduler['userpass'] = [(passwords.get('BUILDBOT_TRY_USERNAME', 'sampleuser'), passwords.get('BUILDBOT_TRY_PASSWORD', 'samplepass'))]
         if schedulerClassName == 'AnyBranchScheduler' and schedulerName:
             scheduler['change_filter'] = ChangeFilter(filter_fn=filter_fn)
-        c['schedulers'].append(schedulerClass(**scheduler))
+        if setup_main_schedulers is True:
+            c['schedulers'].append(schedulerClass(**scheduler))
 
     forceScheduler = ForceScheduler(
         name='try_build',
@@ -114,7 +115,8 @@ def loadBuilderConfig(c, is_test_mode_enabled=False, master_prefix_path=os.path.
         properties=[StringParameter(name='patch_id', label='Patch id (not bug number)', regex=r'^[4-9]\d{5}$', required=True, maxsize=6),
                     StringParameter(name='ews_revision', label='WebKit git hash to checkout before trying patch (optional)', required=False, maxsize=40)],
     )
-    c['schedulers'].append(forceScheduler)
+    if setup_force_schedulers is True:
+        c['schedulers'].append(forceScheduler)
 
 
 # Copied from https://github.com/buildbot/buildbot/blob/master/master/buildbot/util/async_sort.py

--- a/Tools/CISupport/ews-build/master.cfg
+++ b/Tools/CISupport/ews-build/master.cfg
@@ -4,7 +4,7 @@ import os
 import socket
 import sys
 
-from buildbot.plugins import reporters, util
+from buildbot.plugins import util
 from datetime import timedelta
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -25,51 +25,30 @@ BuildStep.warn_deprecated_if_oldstyle_subclass = lambda self, name: None
 is_test_mode_enabled = utils.load_password('BUILDBOT_PRODUCTION') is None
 custom_suffix = utils.get_custom_suffix()
 
+# We are using multi-master setup with 2 masters.
+# One master handles UI (web-server), and the other handles the back-end.
+# If test mode is enabled, we use single master setup.
+use_multi_master = not is_test_mode_enabled
+
 c = BuildmasterConfig = {}
 
-c['www'] = dict(port='tcp:8010:interface=127.0.0.1', allowed_origins=["*"])
-c['www']['custom_templates_dir'] = 'templates'
+if use_multi_master:
+    c['multiMaster'] = True
+    c['mq'] = {
+        'type': 'wamp',
+        'router_url': 'ws://localhost:8080/ws',
+        'realm': 'realm1',
+        'wamp_debug_level': 'info'
+    }
 
-c['www']['ui_default_config'] = { 
-    'Builders.show_workers_name': True,
-    'Builders.buildFetchLimit': 1000,
-    'Workers.showWorkerBuilders': True,
-}
-
-if not is_test_mode_enabled:
-    c['www']['change_hook_dialects'] = dict(
-        github={
-            'class': events.GitHubEventHandlerNoEdits,
-            'secret': utils.load_password('GITHUB_HOOK_SECRET'),
-            'github_property_whitelist': [
-                'github.number',
-                'github.title',
-                'github.head.ref',
-                'github.head.sha',
-                'github.base.ref',
-                'github.head.repo.full_name',
-                'github.head.user.login',
-            ], 'token': utils.load_password('GITHUB_COM_ACCESS_TOKEN'),
-        },
-    )
-
-    GITHUB_CLIENT_ID = utils.load_password('GITHUB_CLIENT_ID')
-    GITHUB_CLIENT_SECRET = utils.load_password('GITHUB_CLIENT_SECRET')
-    if (not GITHUB_CLIENT_ID) or (not GITHUB_CLIENT_SECRET):
-        print('EWS credentials not found. Please ensure GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET are configured either in env variables or in passwords.json')
-        sys.exit(1)
-
-    # See https://docs.buildbot.net/current/manual/configuration/www.html#example-configs
-    authz = util.Authz(
-        allowRules=[util.AnyEndpointMatcher(role='Buildbot-Administrators', defaultDeny=False),
-                    util.RebuildBuildEndpointMatcher(role='Contributors'),
-                    util.StopBuildEndpointMatcher(role='Committers'),
-                    util.AnyControlEndpointMatcher(role='Buildbot-Administrators')],
-        roleMatchers=[util.RolesFromGroups(groupPrefix='WebKit/')]
-    )
-    auth = util.GitHubAuth(GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, apiVersion=4, getTeamsMembership=True, debug=True)
-    c['www']['auth'] = auth
-    c['www']['authz'] = authz
+if is_test_mode_enabled:
+    c['www'] = dict(port='tcp:8010:interface=127.0.0.1', allowed_origins=["*"])
+    c['www']['custom_templates_dir'] = 'templates'
+    c['www']['ui_default_config'] = {
+        'Builders.show_workers_name': True,
+        'Builders.buildFetchLimit': 1000,
+        'Workers.showWorkerBuilders': True,
+    }
 
 c['protocols'] = {'pb': {'port': 17000}}
 
@@ -96,16 +75,11 @@ else:
 c['logCompressionMethod'] = 'lz4'
 c['buildbotNetUsageData'] = None
 
-loadConfig.loadBuilderConfig(c, is_test_mode_enabled=is_test_mode_enabled)
-
-mail_notifier = reporters.MailNotifier(
-    fromaddr='ews-build@webkit{}.org'.format(custom_suffix),
-    sendToInterestedUsers=False,
-    extraRecipients=['webkit-ews-bot-watchers@group.apple.com'],
-    mode=('exception'),
-    addPatch=False)
+loadConfig.loadBuilderConfig(
+    c, is_test_mode_enabled=is_test_mode_enabled,
+    setup_main_schedulers=True,
+    setup_force_schedulers=is_test_mode_enabled,
+)
 
 if not is_test_mode_enabled:
-    hostname =  socket.gethostname().strip()
-    event_reporter = events.Events(master_hostname=hostname, type_prefix='ews')
-    c['services'] = [event_reporter, mail_notifier, util.ProfilerService(wantBuilds=0, basepath='/var/buildbot/profiler/')]
+    c['services'] = [util.ProfilerService(wantBuilds=0, basepath='/var/buildbot/profiler/')]


### PR DESCRIPTION
#### 8df1e60d240a30bf4dfc17a6b32663ba946752ab
<pre>
Convert ews-build.webkit.org to multi-master (to improve responsiveness)
<a href="https://bugs.webkit.org/show_bug.cgi?id=268982">https://bugs.webkit.org/show_bug.cgi?id=268982</a>

Reviewed by Ryan Haddad.

* Tools/CISupport/ews-build/master.cfg:
* Tools/CISupport/ews-build/loadConfig.py:
* Tools/CISupport/ews-build-webserver/buildbot.tac: Copied from Tools/CISupport/ews-build/buildbot.tac.
* Tools/CISupport/ews-build-webserver/master.cfg: Copied from Tools/CISupport/ews-build/master.cfg.

Canonical link: <a href="https://commits.webkit.org/274295@main">https://commits.webkit.org/274295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9d05d86077d0f805ecf195cab714d170960b083

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/38636 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/17566 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/40962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/41167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/40941 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/20370 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/14913 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/41167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/39209 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/20370 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/40962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/41167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/20370 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/40962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/42442 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/20370 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/40962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/42442 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/14913 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/42442 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/38685 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/40962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5030 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->