### PR TITLE
[Navigation] Implement more of NavigationHistoryEntry

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/current-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/current-basic-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Basic tests for navigation.currentEntry null is not an object (evaluating 'first_entry.index')
+FAIL Basic tests for navigation.currentEntry assert_not_equals: got disallowed value object "[object NavigationHistoryEntry]"
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -231,7 +231,7 @@ Navigation::Result Navigation::traverseTo(const String& key, Options&&, Ref<Defe
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-back
 Navigation::Result Navigation::back(Options&&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
-    if (!m_currentEntryIndex.value_or(0))
+    if (!canGoBack())
         return createErrorResult(committed, finished, ExceptionCode::InvalidStateError, "Cannot go back"_s);
 
     return performTraversal(m_entries[m_currentEntryIndex.value() - 1], committed, finished);
@@ -240,7 +240,7 @@ Navigation::Result Navigation::back(Options&&, Ref<DeferredPromise>&& committed,
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-forward
 Navigation::Result Navigation::forward(Options&&, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished)
 {
-    if (!m_currentEntryIndex || m_currentEntryIndex.value() == m_entries.size())
+    if (!canGoForward())
         return createErrorResult(committed, finished, ExceptionCode::InvalidStateError, "Cannot go forward"_s);
 
     return performTraversal(m_entries[m_currentEntryIndex.value() + 1], committed, finished);
@@ -279,6 +279,5 @@ bool Navigation::hasEntriesAndEventsDisabled() const
         return true;
     return false;
 }
-
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -26,7 +26,11 @@
 #include "config.h"
 #include "NavigationHistoryEntry.h"
 
+#include "FrameLoader.h"
+#include "HistoryController.h"
 #include "JSDOMGlobalObject.h"
+#include "LocalDOMWindow.h"
+#include "Navigation.h"
 #include "ScriptExecutionContext.h"
 #include "SerializedScriptValue.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
@@ -42,6 +46,7 @@ NavigationHistoryEntry::NavigationHistoryEntry(ScriptExecutionContext* context, 
     , m_key(WTF::UUID::createVersion4())
     , m_id(WTF::UUID::createVersion4())
     , m_associatedHistoryItem(historyItem)
+    , m_documentSequenceNumber(historyItem->documentSequenceNumber())
 {
 }
 
@@ -61,6 +66,30 @@ ScriptExecutionContext* NavigationHistoryEntry::scriptExecutionContext() const
 EventTargetInterface NavigationHistoryEntry::eventTargetInterface() const
 {
     return NavigationHistoryEntryEventTargetInterfaceType;
+}
+
+uint64_t NavigationHistoryEntry::index() const
+{
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
+    if (!document || !document->domWindow())
+        return -1;
+    return document->domWindow()->navigation().entries().findIf([this] (auto& entry) {
+        return entry.ptr() == this;
+    });
+}
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationhistoryentry-samedocument
+bool NavigationHistoryEntry::sameDocument() const
+{
+    if (!m_documentSequenceNumber)
+        return false;
+    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
+    if (!document || !document->frame())
+        return false;
+    RefPtr currentItem = document->frame()->loader().history().currentItem();
+    if (!currentItem)
+        return false;
+    return currentItem->documentSequenceNumber() == *m_documentSequenceNumber;
 }
 
 JSC::JSValue NavigationHistoryEntry::getState(JSDOMGlobalObject& globalObject) const

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -39,7 +39,6 @@ class JSValue;
 namespace WebCore {
 
 class SerializedScriptValue;
-class HistoryItem;
 
 class NavigationHistoryEntry final : public RefCounted<NavigationHistoryEntry>, public EventTarget, public ContextDestructionObserver {
     WTF_MAKE_ISO_ALLOCATED(NavigationHistoryEntry);
@@ -53,8 +52,8 @@ public:
     const String& url() const { return m_url.string(); };
     String key() const { return m_key.toString(); };
     String id() const { return m_id.toString(); };
-    uint64_t index() const { return m_index; };
-    bool sameDocument() const { return m_sameDocument; };
+    uint64_t index() const;
+    bool sameDocument() const;
     JSC::JSValue getState(JSDOMGlobalObject&) const;
 
     void setState(RefPtr<SerializedScriptValue>&&);
@@ -71,10 +70,9 @@ private:
     const URL m_url;
     const WTF::UUID m_key;
     const WTF::UUID m_id;
-    uint64_t m_index;
     // TODO: Every entry is supposed to have an associated history item.
     std::optional<Ref<HistoryItem>> m_associatedHistoryItem;
-    bool m_sameDocument;
+    std::optional<long long> m_documentSequenceNumber;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 07ca7d40e32bb25bfc5ba2bc2e41870d0b20e5bc
<pre>
[Navigation] Implement more of NavigationHistoryEntry
<a href="https://bugs.webkit.org/show_bug.cgi?id=268986">https://bugs.webkit.org/show_bug.cgi?id=268986</a>

Reviewed by Alex Christensen.

Implement more of NavigationHistoryEntry according to the specification:
- implement index by looking the NavigationHistoryEntry up in the entries of the associated Navigation object.
- implement sameDocument by checking whether it is same document to the current history item.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/current-basic-expected.txt:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::back):
(WebCore::Navigation::forward):
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::NavigationHistoryEntry):
(WebCore::NavigationHistoryEntry::index const):
(WebCore::NavigationHistoryEntry::sameDocument const):
* Source/WebCore/page/NavigationHistoryEntry.h:

Canonical link: <a href="https://commits.webkit.org/275153@main">https://commits.webkit.org/275153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfc354cac7f670ab8368cc5e93f1ed07d8a7a4b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/40899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/19912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/43277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/43457 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/36990 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/43206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/22918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/17243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/33897 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/41473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/16857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/35254 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/14520 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/14626 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/36244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/44752 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/37111 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/36555 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/40305 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/15714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/12902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/38674 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/17333 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9206 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/17384 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/16977 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->