### PR TITLE
Overlay regions should snap to the scrollview's edges

### DIFF
--- a/LayoutTests/overlay-region/full-page-dynamic-expected.txt
+++ b/LayoutTests/overlay-region/full-page-dynamic-expected.txt
@@ -6,7 +6,6 @@
     (view [class: WKScrollView]
       (scrolling behavior 2)
       (overlay region [x: 0 y: 0 width: 800 height: 50])
-      (overlay region [x: 0 y: 3050 width: 800 height: 50])
       (overlay region [x: 0 y: 50 width: 800 height: 50])
       (overlay region [x: 0 y: 550 width: 800 height: 50])
       (layer bounds [x: 0 y: 0 width: 800 height: 600])

--- a/LayoutTests/overlay-region/full-page-expected.txt
+++ b/LayoutTests/overlay-region/full-page-expected.txt
@@ -6,7 +6,6 @@
     (view [class: WKScrollView]
       (scrolling behavior 2)
       (overlay region [x: 0 y: 0 width: 800 height: 50])
-      (overlay region [x: 0 y: 3050 width: 800 height: 50])
       (overlay region [x: 0 y: 50 width: 800 height: 50])
       (overlay region [x: 0 y: 550 width: 800 height: 50])
       (layer bounds [x: 0 y: 0 width: 800 height: 600])

--- a/LayoutTests/overlay-region/full-page-overflow-expected.txt
+++ b/LayoutTests/overlay-region/full-page-overflow-expected.txt
@@ -44,6 +44,9 @@
                                       (subviews
                                         (view [class: <class not in allowed list of classes>]
                                           (scrolling behavior 2)
+                                          (overlay region [x: 0 y: 0 width: 800 height: 50])
+                                          (overlay region [x: 0 y: 50 width: 800 height: 50])
+                                          (overlay region [x: 0 y: 550 width: 800 height: 50])
                                           (layer bounds [x: 0 y: 0 width: 800 height: 600])
                                           (layer position [x: 400 y: 400])
                                           (subviews

--- a/LayoutTests/overlay-region/full-page-scrolling-expected.txt
+++ b/LayoutTests/overlay-region/full-page-scrolling-expected.txt
@@ -6,7 +6,6 @@
     (view [class: WKScrollView]
       (scrolling behavior 2)
       (overlay region [x: 0 y: 0 width: 800 height: 50])
-      (overlay region [x: 0 y: 1050 width: 800 height: 50])
       (overlay region [x: 0 y: 50 width: 800 height: 50])
       (overlay region [x: 0 y: 550 width: 800 height: 50])
       (layer bounds [x: 0 y: 2000 width: 800 height: 600])

--- a/LayoutTests/overlay-region/many-candidates-expected.txt
+++ b/LayoutTests/overlay-region/many-candidates-expected.txt
@@ -42,12 +42,12 @@
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                       (subviews
                                         (view [class: WKCompositingView]
-                                          (layer bounds [x: 0 y: 0 width: 644 height: 604])
+                                          (layer bounds [x: 0 y: 0 width: 644 height: 424])
                                           (layer position [x: 322 y: 322])
                                           (subviews
                                             (view [class: <class not in allowed list of classes>]
                                               (scrolling behavior 0)
-                                              (layer bounds [x: 0 y: 0 width: 640 height: 600])
+                                              (layer bounds [x: 0 y: 0 width: 640 height: 420])
                                               (layer position [x: 322 y: 322])
                                               (subviews
                                                 (view [class: WKCompositingView]
@@ -70,7 +70,7 @@
                                                           (layer bounds [x: 0 y: 0 width: 640 height: 50])
                                                           (layer position [x: 320 y: 320]))))))
                                                 (view [class: <class not in allowed list of classes>]
-                                                  (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 420])
                                                   (layer position [x: 631 y: 631])
                                                   (layer zPosition 1000)
                                                   (subviews
@@ -78,7 +78,7 @@
                                                       (layer bounds [x: 0 y: 0 width: 32 height: 116])
                                                       (layer position [x: 6 y: 6]))
                                                     (view [class: <class not in allowed list of classes>]
-                                                      (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                      (layer bounds [x: 0 y: 0 width: 12 height: 420])
                                                       (layer position [x: 6 y: 6])
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
@@ -118,12 +118,12 @@
                                       (layer position [x: 192 y: 192])
                                       (subviews
                                         (view [class: WKCompositingView]
-                                          (layer bounds [x: 0 y: 0 width: 644 height: 604])
+                                          (layer bounds [x: 0 y: 0 width: 644 height: 424])
                                           (layer position [x: 322 y: 322])
                                           (subviews
                                             (view [class: <class not in allowed list of classes>]
                                               (scrolling behavior 0)
-                                              (layer bounds [x: 0 y: 0 width: 640 height: 600])
+                                              (layer bounds [x: 0 y: 0 width: 640 height: 420])
                                               (layer position [x: 322 y: 322])
                                               (subviews
                                                 (view [class: WKCompositingView]
@@ -146,7 +146,7 @@
                                                           (layer bounds [x: 0 y: 0 width: 640 height: 50])
                                                           (layer position [x: 320 y: 320]))))))
                                                 (view [class: <class not in allowed list of classes>]
-                                                  (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 420])
                                                   (layer position [x: 631 y: 631])
                                                   (layer zPosition 1000)
                                                   (subviews
@@ -154,7 +154,7 @@
                                                       (layer bounds [x: 0 y: 0 width: 32 height: 116])
                                                       (layer position [x: 6 y: 6]))
                                                     (view [class: <class not in allowed list of classes>]
-                                                      (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                      (layer bounds [x: 0 y: 0 width: 12 height: 420])
                                                       (layer position [x: 6 y: 6])
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
@@ -197,14 +197,13 @@
                                       (layer position [x: 80 y: 80])
                                       (subviews
                                         (view [class: WKCompositingView]
-                                          (layer bounds [x: 0 y: 0 width: 660 height: 604])
+                                          (layer bounds [x: 0 y: 0 width: 660 height: 424])
                                           (layer position [x: 330 y: 330])
                                           (subviews
                                             (view [class: <class not in allowed list of classes>]
                                               (scrolling behavior 2)
-                                              (overlay region [x: 2 y: 2 width: 656 height: 50])
-                                              (overlay region [x: 2 y: 3052 width: 656 height: 50])
-                                              (layer bounds [x: 0 y: 0 width: 656 height: 600])
+                                              (overlay region [x: 0 y: 0 width: 656 height: 50])
+                                              (layer bounds [x: 0 y: 0 width: 656 height: 420])
                                               (layer position [x: 330 y: 330])
                                               (subviews
                                                 (view [class: WKCompositingView]
@@ -227,7 +226,7 @@
                                                           (layer bounds [x: 0 y: 0 width: 656 height: 50])
                                                           (layer position [x: 328 y: 328]))))))
                                                 (view [class: <class not in allowed list of classes>]
-                                                  (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 420])
                                                   (layer position [x: 647 y: 647])
                                                   (layer zPosition 1000)
                                                   (subviews
@@ -235,7 +234,7 @@
                                                       (layer bounds [x: 0 y: 0 width: 32 height: 116])
                                                       (layer position [x: 6 y: 6]))
                                                     (view [class: <class not in allowed list of classes>]
-                                                      (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                      (layer bounds [x: 0 y: 0 width: 12 height: 420])
                                                       (layer position [x: 6 y: 6])
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]

--- a/LayoutTests/overlay-region/many-candidates.html
+++ b/LayoutTests/overlay-region/many-candidates.html
@@ -11,7 +11,7 @@
         #main {
             position: fixed;
             width: 82%;
-            height: 100vh;
+            height: 70vh;
             top: 5%;
             left: 10%;
             overflow: scroll;
@@ -23,14 +23,14 @@
             width: 80%;
             top: 0;
             left: 0;
-            height: 100vh;
+            height: 70vh;
             overflow: scroll;
             border: 2px gray solid;
         }
         #other-after {
             position: fixed;
             width: 80%;
-            height: 100vh;
+            height: 70vh;
             top: 15%;
             left: 24%;
             overflow: scroll;

--- a/LayoutTests/overlay-region/snapping-expected.txt
+++ b/LayoutTests/overlay-region/snapping-expected.txt
@@ -39,33 +39,35 @@
                                   (layer anchorPoint [x: 0 y: 0])
                                   (subviews
                                     (view [class: WKCompositingView]
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                                      (layer position [x: 400 y: 400])
+                                      (layer bounds [x: 0 y: 0 width: 728 height: 540])
+                                      (layer position [x: 436 y: 436])
                                       (subviews
                                         (view [class: <class not in allowed list of classes>]
                                           (scrolling behavior 2)
-                                          (overlay region [x: 0 y: 0 width: 800 height: 50])
-                                          (overlay region [x: 0 y: 50 width: 800 height: 50])
-                                          (overlay region [x: 0 y: 550 width: 800 height: 50])
-                                          (layer bounds [x: 0 y: 4100 width: 800 height: 600])
-                                          (layer position [x: 400 y: 400])
+                                          (overlay region [x: 0 y: 0 width: 50 height: 50])
+                                          (overlay region [x: 0 y: 490 width: 50 height: 50])
+                                          (overlay region [x: 0 y: 50 width: 728 height: 50])
+                                          (overlay region [x: 678 y: 0 width: 50 height: 50])
+                                          (overlay region [x: 678 y: 490 width: 50 height: 50])
+                                          (layer bounds [x: 0 y: 0 width: 728 height: 540])
+                                          (layer position [x: 364 y: 364])
                                           (subviews
                                             (view [class: WKCompositingView]
-                                              (layer bounds [x: 0 y: 0 width: 800 height: 7100])
+                                              (layer bounds [x: 0 y: 0 width: 728 height: 7100])
                                               (layer anchorPoint [x: 0 y: 0])
                                               (subviews
                                                 (view [class: WKCompositingView]
                                                   (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
                                             (view [class: <class not in allowed list of classes>]
-                                              (layer bounds [x: 0 y: 0 width: 12 height: 600])
-                                              (layer position [x: 791 y: 791])
+                                              (layer bounds [x: 0 y: 0 width: 12 height: 540])
+                                              (layer position [x: 719 y: 719])
                                               (layer zPosition 1000)
                                               (subviews
                                                 (view [class: UIView]
                                                   (layer bounds [x: 0 y: 0 width: 32 height: 116])
                                                   (layer position [x: 6 y: 6]))
                                                 (view [class: <class not in allowed list of classes>]
-                                                  (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 540])
                                                   (layer position [x: 6 y: 6])
                                                   (subviews
                                                     (view [class: <class not in allowed list of classes>]
@@ -79,20 +81,20 @@
                                                           (layer bounds [x: 0 y: 0 width: 6 height: 28])
                                                           (layer position [x: 6 y: 6]))))))))
                                             (view [class: <class not in allowed list of classes>]
-                                              (layer bounds [x: 0 y: 0 width: 800 height: 12])
-                                              (layer position [x: 400 y: 400])
+                                              (layer bounds [x: 0 y: 0 width: 728 height: 12])
+                                              (layer position [x: 364 y: 364])
                                               (layer zPosition 1000)
                                               (subviews
                                                 (view [class: UIView]
                                                   (layer bounds [x: 0 y: 0 width: 116 height: 32])
-                                                  (layer position [x: 400 y: 400]))
+                                                  (layer position [x: 364 y: 364]))
                                                 (view [class: <class not in allowed list of classes>]
-                                                  (layer bounds [x: 0 y: 0 width: 800 height: 12])
-                                                  (layer position [x: 400 y: 400])
+                                                  (layer bounds [x: 0 y: 0 width: 728 height: 12])
+                                                  (layer position [x: 364 y: 364])
                                                   (subviews
                                                     (view [class: <class not in allowed list of classes>]
                                                       (layer bounds [x: 0 y: 0 width: 96 height: 12])
-                                                      (layer position [x: 400 y: 400])
+                                                      (layer position [x: 364 y: 364])
                                                       (subviews
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
@@ -101,46 +103,77 @@
                                                           (layer bounds [x: 0 y: 0 width: 90 height: 6])
                                                           (layer position [x: 48 y: 48]))))))))))))
                                     (view [class: WKCompositingView]
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                                      (layer position [x: 400 y: 400])
+                                      (layer bounds [x: 0 y: 0 width: 728 height: 540])
+                                      (layer position [x: 436 y: 436])
                                       (subviews
                                         (view [class: WKCompositingView]
-                                          (layer bounds [x: 0 y: 4100 width: 0 height: 0])
+                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                           (subviews
                                             (view [class: WKTransformView]
                                               (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                               (layer position [x: 0 y: 0])
                                               (subviews
                                                 (view [class: WKCompositingView]
-                                                  (layer bounds [x: 0 y: 0 width: 800 height: 50])
-                                                  (layer position [x: 400 y: 400]))))))))
+                                                  (layer bounds [x: 0 y: 0 width: 728 height: 50])
+                                                  (layer position [x: 364 y: 364]))))))))
                                     (view [class: WKCompositingView]
-                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
-                                      (layer position [x: 400 y: 400])
+                                      (layer bounds [x: 0 y: 0 width: 728 height: 540])
+                                      (layer position [x: 436 y: 436])
                                       (subviews
                                         (view [class: WKCompositingView]
-                                          (layer bounds [x: 0 y: 4100 width: 0 height: 0])
+                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                           (subviews
                                             (view [class: WKTransformView]
                                               (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                               (layer position [x: 0 y: 0])
                                               (subviews
                                                 (view [class: WKCompositingView]
-                                                  (layer bounds [x: 0 y: 0 width: 800 height: 50])
-                                                  (layer position [x: 400 y: 400]))))))))
+                                                  (layer bounds [x: 0 y: 0 width: 728 height: 50])
+                                                  (layer position [x: 364 y: 364]))))))))
                                     (view [class: WKTransformView]
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 73 y: 73])
                                       (subviews
                                         (view [class: WKCompositingView]
-                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
-                                          (layer position [x: 400 y: 400]))))
+                                          (layer bounds [x: 0 y: 0 width: 50 height: 50])
+                                          (layer position [x: 25 y: 25])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 50 height: 50])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
                                     (view [class: WKTransformView]
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                                      (layer position [x: 0 y: 0])
+                                      (layer position [x: 751 y: 751])
                                       (subviews
                                         (view [class: WKCompositingView]
-                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
-                                          (layer position [x: 400 y: 400]))))))))))))))))
+                                          (layer bounds [x: 0 y: 0 width: 50 height: 50])
+                                          (layer position [x: 25 y: 25])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 50 height: 50])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 748 y: 748])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 50 height: 50])
+                                          (layer position [x: 25 y: 25])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 50 height: 50])
+                                              (layer anchorPoint [x: 0 y: 0]))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 71 y: 71])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 50 height: 50])
+                                          (layer position [x: 25 y: 25])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 50 height: 50])
+                                              (layer anchorPoint [x: 0 y: 0]))))))))))))))))))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (view [class: UIView]

--- a/LayoutTests/overlay-region/snapping.html
+++ b/LayoutTests/overlay-region/snapping.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        #test {
+            position: absolute;
+            top: 10vh;
+            left: 12vh;
+            right: 0;
+            bottom: 0;
+            overflow: scroll;
+        }
+        .fixed {
+            position: fixed;
+            width: 50px;
+            height: 50px;
+            background: #F67280;
+            z-index: 100;
+        }
+
+        #top-left {
+            top: calc(10vh - 2px);
+            left: calc(12vh + 1px);
+        }
+        #top-right {
+            top: calc(10vh + 2px);
+            right: -1px;
+        }
+        #bottom-left {
+            bottom: 3px;
+            left: calc(12vh - 1px);
+        }
+        #bottom-right {
+            bottom: -3px;
+            right: 2px;
+        }
+
+        .sticky {
+            position: sticky;
+            top: 50px;
+            height: 50px;
+            background: #6C5B7B;
+            z-index: 10;
+        }
+
+        .long {
+            position: relative;
+            height: 1000px;
+            background: #355C7D;
+        }
+        .long::before {
+            content: "↓";
+            color: white;
+            font-size: 20em;
+            text-align: center;
+            position: absolute;
+            top: 400px;
+            left: 0;
+            right: 0;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div id="top-left" class="fixed">
+    </div>
+    <div id="top-right" class="fixed">
+    </div>
+    <div id="bottom-right" class="fixed">
+    </div>
+    <div id="bottom-left" class="fixed">
+    </div>
+    <h2 class="sticky">This is a sticky header</h2>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <h2 class="sticky">This is another sticky header</h2>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/LayoutTests/overlay-region/split-scrollers-expected.txt
+++ b/LayoutTests/overlay-region/split-scrollers-expected.txt
@@ -117,7 +117,6 @@
                                             (view [class: <class not in allowed list of classes>]
                                               (scrolling behavior 2)
                                               (overlay region [x: 0 y: 0 width: 640 height: 50])
-                                              (overlay region [x: 0 y: 3050 width: 640 height: 50])
                                               (overlay region [x: 0 y: 550 width: 640 height: 50])
                                               (layer bounds [x: 0 y: 0 width: 640 height: 600])
                                               (layer position [x: 320 y: 320])

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1140,6 +1140,28 @@ static void addOverlayEventRegions(WebCore::PlatformLayerIdentifier layerID, con
         addOverlayEventRegions(childLayerID, changedLayerPropertiesMap, overlayRegionsIDs);
 }
 
+static CGRect snapRectToScrollViewEdges(CGRect rect, CGRect viewport)
+{
+    constexpr float edgeSnapThreshold = 4.0;
+
+    auto leftDelta = CGRectGetMinX(rect) - CGRectGetMinX(viewport);
+    auto rightDelta = CGRectGetMaxX(viewport) - CGRectGetMaxX(rect);
+    auto topDelta = CGRectGetMinY(rect) - CGRectGetMinY(viewport);
+    auto bottomDelta = CGRectGetMaxY(viewport) - CGRectGetMaxY(rect);
+
+    if (std::abs(leftDelta) <= edgeSnapThreshold && std::abs(rightDelta) > edgeSnapThreshold)
+        rect.origin.x -= leftDelta;
+    if (std::abs(rightDelta) <= edgeSnapThreshold && std::abs(leftDelta) > edgeSnapThreshold)
+        rect.origin.x += rightDelta;
+
+    if (std::abs(topDelta) <= edgeSnapThreshold && std::abs(bottomDelta) > edgeSnapThreshold)
+        rect.origin.y -= topDelta;
+    if (std::abs(bottomDelta) <= edgeSnapThreshold && std::abs(topDelta) > edgeSnapThreshold)
+        rect.origin.y += bottomDelta;
+
+    return CGRectIntersection(rect, viewport);
+}
+
 static void configureScrollViewWithOverlayRegionsIDs(WKBaseScrollView* scrollView, const WebKit::RemoteLayerTreeHost& host, const HashSet<WebCore::PlatformLayerIdentifier>& overlayRegionsIDs)
 {
     HashSet<WebCore::IntRect> overlayRegionRects;
@@ -1150,6 +1172,8 @@ static void configureScrollViewWithOverlayRegionsIDs(WKBaseScrollView* scrollVie
             continue;
         const auto* uiView = node->uiView();
         if (!uiView)
+            continue;
+        if (uiView == scrollView)
             continue;
 
         WKBaseScrollView* enclosingScrollView = nil;
@@ -1162,13 +1186,34 @@ static void configureScrollViewWithOverlayRegionsIDs(WKBaseScrollView* scrollVie
         if (!enclosingScrollView)
             continue;
 
-        if (enclosingScrollView != scrollView)
+        if (enclosingScrollView != scrollView) {
+            // Overlays on parent scrollViews should still be taken into account.
+            bool overlayFromAncestor = false;
+            for (UIView *view = [scrollView superview]; view; view = [view superview]) {
+                if (view == enclosingScrollView) {
+                    overlayFromAncestor = true;
+                    break;
+                }
+            }
+
+            if (!overlayFromAncestor)
+                continue;
+        }
+
+        // Overlay regions are positioned relative to the viewport of the scrollview,
+        // not the frame (external) nor the bounds (origin moves while scrolling).
+        CGRect rect = [uiView.superview convertRect:uiView.frame toView:scrollView.superview];
+        CGRect offsetRect = CGRectOffset(rect, -scrollView.frame.origin.x, -scrollView.frame.origin.y);
+        CGRect viewport = CGRectOffset(scrollView.frame, -scrollView.frame.origin.x, -scrollView.frame.origin.y);
+        CGRect snappedRect = snapRectToScrollViewEdges(offsetRect, viewport);
+
+        if (!snappedRect.size.width || !snappedRect.size.height)
+            continue;
+        // Filtering out solid background color layers and other larger overlays.
+        if (snappedRect.size.width * snappedRect.size.height >= scrollView.bounds.size.width * scrollView.bounds.size.height * 0.5)
             continue;
 
-        CGRect rect = [uiView convertRect:node->eventRegion().region().bounds() toView:[scrollView superview]];
-        // Filtering out solid background color layers.
-        if (!CGSizeEqualToSize(scrollView.contentSize, rect.size))
-            overlayRegionRects.add(WebCore::enclosingIntRect(rect));
+        overlayRegionRects.add(WebCore::enclosingIntRect(snappedRect));
     }
 
     [scrollView _updateOverlayRegionRects:overlayRegionRects];


### PR DESCRIPTION
#### d8afa9c525866764a23c33a7a7fdd641c53b1a4c
<pre>
Overlay regions should snap to the scrollview&apos;s edges
<a href="https://bugs.webkit.org/show_bug.cgi?id=268984">https://bugs.webkit.org/show_bug.cgi?id=268984</a>
&lt;<a href="https://rdar.apple.com/122495015">rdar://122495015</a>&gt;

Reviewed by Mike Wyrzykowski.

Improve Overlay Regions by making them snap to the ScrollView&apos;s edges
and use the correct coordinate space.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(snapRectToScrollViewEdges):
Introduce a new function to snap/clip the OverlayRegion rects to the
edges of the ScrollView.
(configureScrollViewWithOverlayRegionsIDs):
- Generate Overlay Regions for fixed elements that might be part of a
  ScrollView ancestor.
- Handle the case where the main scroller is itself fixed.
- Position the Overlay Regions relative to the viewport of the
  ScrollView.

* LayoutTests/overlay-region/snapping-expected.txt: Added
* LayoutTests/overlay-region/snapping.html: Added.
Introduce a new test to cover the snapping code.

* LayoutTests/overlay-region/many-candidates.html:
* LayoutTests/overlay-region/many-candidates-expected.txt:
Adjust the scrollers height to cover clipping.

* LayoutTests/overlay-region/full-page-dynamic-expected.txt:
* LayoutTests/overlay-region/full-page-expected.txt:
* LayoutTests/overlay-region/full-page-overflow-expected.txt:
* LayoutTests/overlay-region/full-page-overflow-scrolling-expected.txt:
* LayoutTests/overlay-region/full-page-scrolling-expected.txt:
* LayoutTests/overlay-region/split-scrollers-expected.txt:
Update test expectations for the new rules / coordinate space.

Canonical link: <a href="https://commits.webkit.org/274349@main">https://commits.webkit.org/274349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77ed6f8b89afdcff8906fda1ea0d1b78e80762ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41135 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34265 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32438 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12836 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42410 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38645 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36854 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15035 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/33735 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8693 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13887 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14510 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->