### PR TITLE
Make HTMLConverter::_processText() accept CDATASection and Text nodes

### DIFF
--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -235,7 +235,7 @@ private:
     void _addTableForElement(Element* tableElement);
     void _addTableCellForElement(Element* tableCellElement);
     void _addMarkersToList(NSTextList *list, NSRange range);
-    void _processText(CharacterData&);
+    void _processText(Text&);
     void _adjustTrailingNewline();
 };
 
@@ -2033,24 +2033,24 @@ void HTMLConverter::_exitElement(Element& element, NSInteger depth, NSUInteger s
         _exitBlockquote();
 }
 
-void HTMLConverter::_processText(CharacterData& characterData)
+void HTMLConverter::_processText(Text& text)
 {
-    if (m_ignoreUserSelectNoneContent && m_userSelectNoneStateCache.nodeOnlyContainsUserSelectNone(characterData))
+    if (m_ignoreUserSelectNoneContent && m_userSelectNoneStateCache.nodeOnlyContainsUserSelectNone(text))
         return;
     NSUInteger textLength = [_attrStr length];
     unichar lastChar = (textLength > 0) ? [[_attrStr string] characterAtIndex:textLength - 1] : '\n';
     BOOL suppressLeadingSpace = ((_flags.isSoft && lastChar == ' ') || lastChar == '\n' || lastChar == '\r' || lastChar == '\t' || lastChar == NSParagraphSeparatorCharacter || lastChar == NSLineSeparatorCharacter || lastChar == NSFormFeedCharacter || lastChar == WebNextLineCharacter);
     NSRange rangeToReplace = NSMakeRange(textLength, 0);
 
-    String originalString = characterData.data();
+    String originalString = text.data();
     unsigned startOffset = 0;
     unsigned endOffset = originalString.length();
-    if (&characterData == m_start.containerNode()) {
+    if (&text == m_start.containerNode()) {
         startOffset = m_start.offsetInContainerNode();
         _domRangeStartIndex = [_attrStr length];
         _flags.reachedStart = YES;
     }
-    if (&characterData == m_end.containerNode()) {
+    if (&text == m_end.containerNode()) {
         endOffset = m_end.offsetInContainerNode();
         _flags.reachedEnd = YES;
     }
@@ -2060,7 +2060,7 @@ void HTMLConverter::_processText(CharacterData& characterData)
 
     // FIXME: Use RenderText's content instead.
     bool wasSpace = false;
-    if (_caches->propertyValueForNode(characterData, CSSPropertyWhiteSpace).startsWith("pre"_s)) {
+    if (_caches->propertyValueForNode(text, CSSPropertyWhiteSpace).startsWith("pre"_s)) {
         if (textLength && originalString.length() && _flags.isSoft) {
             unichar c = originalString.characterAt(0);
             if (c == '\n' || c == '\r' || c == NSParagraphSeparatorCharacter || c == NSLineSeparatorCharacter || c == NSFormFeedCharacter || c == WebNextLineCharacter)
@@ -2083,7 +2083,7 @@ void HTMLConverter::_processText(CharacterData& characterData)
                     builder.append(c);
                 else {
                     if (!noBreakSpaceRepresentation)
-                        noBreakSpaceRepresentation = _caches->propertyValueForNode(characterData, CSSPropertyWebkitNbspMode) == "space"_s ? ' ' : noBreakSpace;
+                        noBreakSpaceRepresentation = _caches->propertyValueForNode(text, CSSPropertyWebkitNbspMode) == "space"_s ? ' ' : noBreakSpace;
                     builder.append(noBreakSpaceRepresentation);
                 }
                 wasSpace = false;
@@ -2096,7 +2096,7 @@ void HTMLConverter::_processText(CharacterData& characterData)
     }
 
     if (outputString.length()) {
-        String textTransform = _caches->propertyValueForNode(characterData, CSSPropertyTextTransform);
+        String textTransform = _caches->propertyValueForNode(text, CSSPropertyTextTransform);
         if (textTransform == "capitalize"_s)
             outputString = capitalize(outputString, ' '); // FIXME: Needs to take locale into account to work correctly.
         else if (textTransform == "uppercase"_s)
@@ -2107,7 +2107,7 @@ void HTMLConverter::_processText(CharacterData& characterData)
         [_attrStr replaceCharactersInRange:rangeToReplace withString:outputString];
         rangeToReplace.length = outputString.length();
         if (rangeToReplace.length)
-            [_attrStr setAttributes:aggregatedAttributesForAncestors(characterData) range:rangeToReplace];
+            [_attrStr setAttributes:aggregatedAttributesForAncestors(text) range:rangeToReplace];
         _flags.isSoft = wasSpace;
     }
 }
@@ -2171,8 +2171,8 @@ void HTMLConverter::_traverseNode(Node& node, unsigned depth, bool embedded)
                 _exitElement(*element, depth, std::min(startIndex, [_attrStr length]));
             }
         }
-    } else if (node.nodeType() == Node::TEXT_NODE)
-        _processText(downcast<CharacterData>(node));
+    } else if (RefPtr text = dynamicDowncast<Text>(node))
+        _processText(*text);
 
     if (isEnd)
         _flags.reachedEnd = YES;


### PR DESCRIPTION
#### affd64b09f15ac2e708c4ef3a74dedbd4270f606
<pre>
Make HTMLConverter::_processText() accept CDATASection and Text nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=268446">https://bugs.webkit.org/show_bug.cgi?id=268446</a>
<a href="https://rdar.apple.com/122072235">rdar://122072235</a>

Reviewed by Chris Dumez.

Except for certain edge cases noted in the DOM Standard, CDATASection
and Text nodes are generally to be treated as interchangeable.

(This is a redo of 273887@main (backed out in 274099@main) as an
intentional change in behavior rather than an accidental one.)

* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::_processText):
(HTMLConverter::_traverseNode):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewGetContents.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/274324@main">https://commits.webkit.org/274324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05322394feb5feb03a310c3aa715636fb7383896

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41136 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34266 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32459 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12839 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12831 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42411 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35072 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34838 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38646 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13428 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11109 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36855 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15036 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8677 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13888 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14511 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->