### PR TITLE
[visionOS] Safari can become unresponsive to pinches/gestures after exiting fullscreen

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1853,6 +1853,9 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 
                 for (MRUIPlatterOrnament *ornament in [originalState ornamentProperties])
                     ornament.offset2D = [[[originalState ornamentProperties] objectForKey:ornament] offset2D];
+
+                // Dismiss the fullscreen view controller on exit to ensure hit-test redirection does not occur.
+                [controller->_fullscreenViewController dismissViewControllerAnimated:NO completion:nil];
             }
 
             scene.mrui_placement.preferredChromeOptions = [originalState sceneChromeOptions];


### PR DESCRIPTION
#### db96b72c4ad369670bdc82166e0d9517fca2aa16
<pre>
[visionOS] Safari can become unresponsive to pinches/gestures after exiting fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=268970">https://bugs.webkit.org/show_bug.cgi?id=268970</a>
<a href="https://rdar.apple.com/121572842">rdar://121572842</a>

Reviewed by Wenson Hsieh.

Hit-test redirection is applied by the system whenever a view controller with
a custom presentation style, such as WebKit&apos;s fullscreen view controller, is
presented.

Unlike on iOS, WebKit does not explicitly dismiss the view controller, since
window hiding is used for the exit transition. In most cases, this is fine,
since the `UIWindow` will also be deallocated on exit. However, there is no
guarantee that `UIWindow` deallocation will occur, and its object lifetime
cannot be relied upon for correctness. In this case, the system will still
attempt to redirect hit-testing to the presented view controller. Consequently,
pinches and gestures may get redirected to a hidden view controller, rather
than the visible Safari window, resulting in unresponsiveness.

Fix by explicitly dismissing the presented view controller on fullscreen exit.
In the longer term, hit-test redirection logic should be updated by the system,
to avoid hidden windows. However, as that is a riskier change, and dismissing
the fullscreen view controller is good cleanup, that is the immediate solution.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/274309@main">https://commits.webkit.org/274309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0452991a5afba34ce146bf69af1f24397e99a8e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38613 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/40943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41147 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34282 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14890 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32464 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14794 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33595 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12853 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12838 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42423 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35085 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38677 "Passed tests") | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36866 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15045 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8669 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13896 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14521 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->