### PR TITLE
[CSS Container Queries][Style queries] Initial parsing support

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-serialization-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL Normalize spaces assert_equals: expected "style(--foo: bar)" but got "style( --foo:bar)"
-FAIL Empty declaration value - spaces assert_equals: expected "style(--foo: )" but got "STyle(--foo: )"
-FAIL Empty declaration value assert_equals: expected "style(--foo: )" but got "STyle(--foo:)"
-FAIL No declaration value assert_equals: expected "style(--foo)" but got "STyle(--foo)"
-FAIL Unknown CSS property after 'or' assert_equals: expected "style((--FOO: BAR) or ( prop: val ))" but got "style( ( --FOO: BAR) OR ( prop: val ) )"
+PASS Normalize spaces
+PASS Empty declaration value - spaces
+PASS Empty declaration value
+PASS No declaration value
+PASS Unknown CSS property after 'or'
 PASS Not a style function with space before '('
 FAIL Spaces preserved in custom property value assert_equals: expected "style(--foo: bar   baz)" but got "style(--foo: bar baz)"
-FAIL Original string number in custom property value assert_equals: expected "style(--foo: 2.100)" but got "style(--foo:2.1 )"
+FAIL Original string number in custom property value assert_equals: expected "style(--foo: 2.100)" but got "style(--foo: 2.1 )"
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1325,6 +1325,20 @@ CSSStartingStyleAtRuleEnabled:
     WebCore:
       default: true
 
+CSSStyleQueriesEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS style queries"
+  humanReadableDescription: "Enable CSS style queries for custom properties"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSTextBoxTrimEnabled:
   type: bool
   status: preview

--- a/Source/WebCore/css/MediaQueryParserContext.cpp
+++ b/Source/WebCore/css/MediaQueryParserContext.cpp
@@ -34,12 +34,14 @@ namespace WebCore {
     
 MediaQueryParserContext::MediaQueryParserContext(const CSSParserContext& context)
     : useSystemAppearance(context.useSystemAppearance)
+    , cssStyleQueriesEnabled(context.cssStyleQueriesEnabled)
     , mode(context.mode)
 {
 }
 
 MediaQueryParserContext::MediaQueryParserContext(const Document& document)
     : useSystemAppearance(document.page() && document.page()->useSystemAppearance())
+    , cssStyleQueriesEnabled(document.settings().cssStyleQueriesEnabled())
 {
 }
 

--- a/Source/WebCore/css/MediaQueryParserContext.h
+++ b/Source/WebCore/css/MediaQueryParserContext.h
@@ -39,6 +39,7 @@ public:
     WEBCORE_EXPORT MediaQueryParserContext(const Document&);
 
     bool useSystemAppearance { false };
+    bool cssStyleQueriesEnabled { false };
     CSSParserMode mode { HTMLStandardMode };
 };
     

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -102,6 +102,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
 #endif
     , cssScopeAtRuleEnabled { document.settings().cssScopeAtRuleEnabled() }
     , cssStartingStyleAtRuleEnabled { document.settings().cssStartingStyleAtRuleEnabled() }
+    , cssStyleQueriesEnabled { document.settings().cssStyleQueriesEnabled() }
     , cssTextUnderlinePositionLeftRightEnabled { document.settings().cssTextUnderlinePositionLeftRightEnabled() }
     , cssWordBreakAutoPhraseEnabled { document.settings().cssWordBreakAutoPhraseEnabled() }
     , popoverAttributeEnabled { document.settings().popoverAttributeEnabled() }

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -93,6 +93,7 @@ struct CSSParserContext {
     bool cssPaintingAPIEnabled : 1 { false };
     bool cssScopeAtRuleEnabled : 1 { false };
     bool cssStartingStyleAtRuleEnabled : 1 { false };
+    bool cssStyleQueriesEnabled : 1 { false };
     bool cssTextUnderlinePositionLeftRightEnabled : 1 { false };
     bool cssWordBreakAutoPhraseEnabled : 1 { false };
     bool popoverAttributeEnabled : 1 { false };

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -161,4 +161,22 @@ const FeatureSchema& orientation()
     return schema;
 }
 
+struct StyleFeatureSchema : public FeatureSchema {
+    StyleFeatureSchema()
+        : FeatureSchema("style"_s, FeatureSchema::Type::Discrete, FeatureSchema::ValueType::CustomProperty)
+    { }
+
+    EvaluationResult evaluate(const MQ::Feature&, const FeatureEvaluationContext&) const override
+    {
+        // FIXME: Implement.
+        return EvaluationResult::Unknown;
+    }
+};
+
+const FeatureSchema& style()
+{
+    static MainThreadNeverDestroyed<StyleFeatureSchema> schema;
+    return schema;
+}
+
 }

--- a/Source/WebCore/css/query/ContainerQueryFeatures.h
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.h
@@ -35,6 +35,8 @@ const MQ::FeatureSchema& inlineSize();
 const MQ::FeatureSchema& blockSize();
 const MQ::FeatureSchema& aspectRatio();
 const MQ::FeatureSchema& orientation();
+const MQ::FeatureSchema& style();
+
 };
 
 }

--- a/Source/WebCore/css/query/ContainerQueryParser.cpp
+++ b/Source/WebCore/css/query/ContainerQueryParser.cpp
@@ -26,8 +26,10 @@
 #include "ContainerQueryParser.h"
 
 #include "CSSPrimitiveValue.h"
+#include "CSSPropertyParser.h"
 #include "CSSPropertyParserHelpers.h"
 #include "ContainerQueryFeatures.h"
+#include "MediaQueryParserContext.h"
 
 namespace WebCore {
 namespace CQ {
@@ -59,6 +61,19 @@ std::optional<ContainerQuery> ContainerQueryParser::consumeContainerQuery(CSSPar
     });
 
     return ContainerQuery { name, *condition, requiredAxes, containsUnknownFeature };
+}
+
+bool ContainerQueryParser::isValidFunctionId(CSSValueID functionId)
+{
+    return functionId == CSSValueStyle;
+}
+
+const MQ::FeatureSchema* ContainerQueryParser::schemaForFeatureName(const AtomString& name, const MediaQueryParserContext& context, State& state)
+{
+    if (state.inFunctionId == CSSValueStyle && context.cssStyleQueriesEnabled)
+        return &Features::style();
+
+    return GenericMediaQueryParser<ContainerQueryParser>::schemaForFeatureName(name, context, state);
 }
 
 Vector<const MQ::FeatureSchema*> ContainerQueryParser::featureSchemas()

--- a/Source/WebCore/css/query/ContainerQueryParser.h
+++ b/Source/WebCore/css/query/ContainerQueryParser.h
@@ -35,6 +35,8 @@ namespace CQ {
 struct ContainerQueryParser : MQ::GenericMediaQueryParser<ContainerQueryParser>  {
     static std::optional<CQ::ContainerQuery> consumeContainerQuery(CSSParserTokenRange&, const MediaQueryParserContext&);
 
+    static bool isValidFunctionId(CSSValueID);
+    static const MQ::FeatureSchema* schemaForFeatureName(const AtomString&, const MediaQueryParserContext&, State&);
     static Vector<const MQ::FeatureSchema*> featureSchemas();
 };
 

--- a/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
+++ b/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
@@ -34,6 +34,8 @@ namespace MQ {
 static void serialize(StringBuilder& builder, const QueryInParens& queryInParens)
 {
     WTF::switchOn(queryInParens, [&](auto& node) {
+        if (node.functionId)
+            builder.append(nameString(*node.functionId));
         builder.append('(');
         serialize(builder, node);
         builder.append(')');

--- a/Source/WebCore/css/query/GenericMediaQueryTypes.h
+++ b/Source/WebCore/css/query/GenericMediaQueryTypes.h
@@ -55,6 +55,8 @@ struct Feature {
     std::optional<Comparison> leftComparison;
     std::optional<Comparison> rightComparison;
 
+    std::optional<CSSValueID> functionId { };
+
     const FeatureSchema* schema { nullptr };
 };
 
@@ -68,6 +70,8 @@ using QueryInParens = std::variant<Condition, Feature, GeneralEnclosed>;
 struct Condition {
     LogicalOperator logicalOperator { LogicalOperator::And };
     Vector<QueryInParens> queries;
+
+    std::optional<CSSValueID> functionId { };
 };
 
 enum class EvaluationResult : uint8_t { False, True, Unknown };
@@ -82,7 +86,7 @@ struct FeatureSchema {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
     enum class Type : uint8_t { Discrete, Range };
-    enum class ValueType : uint8_t { Integer, Number, Length, Ratio, Resolution, Identifier };
+    enum class ValueType : uint8_t { Integer, Number, Length, Ratio, Resolution, Identifier, CustomProperty };
 
     AtomString name;
     Type type;

--- a/Source/WebCore/css/query/MediaQueryParser.cpp
+++ b/Source/WebCore/css/query/MediaQueryParser.cpp
@@ -175,9 +175,9 @@ std::optional<MediaQuery> MediaQueryParser::consumeMediaQuery(CSSParserTokenRang
     return MediaQuery { prefix, mediaType, condition };
 }
 
-const FeatureSchema* MediaQueryParser::schemaForFeatureName(const AtomString& name, const MediaQueryParserContext& context)
+const FeatureSchema* MediaQueryParser::schemaForFeatureName(const AtomString& name, const MediaQueryParserContext& context, State& state)
 {
-    auto* schema = GenericMediaQueryParser<MediaQueryParser>::schemaForFeatureName(name, context);
+    auto* schema = GenericMediaQueryParser<MediaQueryParser>::schemaForFeatureName(name, context, state);
 
     if (schema == &Features::prefersDarkInterface()) {
         if (!context.useSystemAppearance && !isUASheetBehavior(context.mode))

--- a/Source/WebCore/css/query/MediaQueryParser.h
+++ b/Source/WebCore/css/query/MediaQueryParser.h
@@ -39,7 +39,7 @@ struct MediaQueryParser : public GenericMediaQueryParser<MediaQueryParser>  {
     static MediaQueryList consumeMediaQueryList(CSSParserTokenRange&, const MediaQueryParserContext&);
     static std::optional<MediaQuery> consumeMediaQuery(CSSParserTokenRange&, const MediaQueryParserContext&);
 
-    static const FeatureSchema* schemaForFeatureName(const AtomString&, const MediaQueryParserContext&);
+    static const FeatureSchema* schemaForFeatureName(const AtomString&, const MediaQueryParserContext&, State&);
     static Vector<const FeatureSchema*> featureSchemas();
 };
 

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -107,7 +107,7 @@ const Element* ContainerQueryEvaluator::selectContainer(OptionSet<CQ::Axis> axes
                 return false;
             return !axes.contains(principalBox->isHorizontalWritingMode() ? CQ::Axis::Height : CQ::Axis::Width);
         case ContainerType::Normal:
-            return false;
+            return axes.isEmpty();
         }
         RELEASE_ASSERT_NOT_REACHED();
     };


### PR DESCRIPTION
#### bbc81c098ea4d0410dc5c3ee59aeb254324b00a6
<pre>
[CSS Container Queries][Style queries] Initial parsing support
<a href="https://bugs.webkit.org/show_bug.cgi?id=268992">https://bugs.webkit.org/show_bug.cgi?id=268992</a>
<a href="https://rdar.apple.com/122550262">rdar://122550262</a>

Reviewed by Alan Baradlay.

Parse @container style(--custom-property:foo)

<a href="https://drafts.csswg.org/css-contain-3/#container-style-query">https://drafts.csswg.org/css-contain-3/#container-style-query</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/at-container-style-serialization-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Feature flag, off by default.

* Source/WebCore/css/MediaQueryParserContext.cpp:
(WebCore::MediaQueryParserContext::MediaQueryParserContext):
* Source/WebCore/css/MediaQueryParserContext.h:
* Source/WebCore/css/parser/CSSParserContext.cpp:
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/query/ContainerQueryFeatures.cpp:
(WebCore::CQ::Features::StyleFeatureSchema::StyleFeatureSchema):

Add a feature schema for custom property style queries. Evaluation is not yet implemented.

(WebCore::CQ::Features::style):
* Source/WebCore/css/query/ContainerQueryFeatures.h:
* Source/WebCore/css/query/ContainerQueryParser.cpp:
(WebCore::CQ::ContainerQueryParser::isValidFunctionId):

Allow style() functions in container queries.

(WebCore::CQ::ContainerQueryParser::schemaForFeatureName):
* Source/WebCore/css/query/ContainerQueryParser.h:
* Source/WebCore/css/query/GenericMediaQueryParser.cpp:
(WebCore::MQ::consumeFeatureName):
(WebCore::MQ::FeatureParser::consumeBooleanOrPlainFeature):

Consume custom properties as feature names and values.

(WebCore::MQ::FeatureParser::validateFeatureAgainstSchema):

Validate custom property value type.

* Source/WebCore/css/query/GenericMediaQueryParser.h:
(WebCore::MQ::GenericMediaQueryParser::consumeCondition):
(WebCore::MQ::GenericMediaQueryParser::isValidFunctionId):
(WebCore::MQ::GenericMediaQueryParser&lt;ConcreteParser&gt;::consumeCondition):
(WebCore::MQ::GenericMediaQueryParser&lt;ConcreteParser&gt;::consumeQueryInParens):

Add support for function-like productions (`style()`) in the generic query grammar.

(WebCore::MQ::GenericMediaQueryParser&lt;ConcreteParser&gt;::consumeAndValidateFeature):
(WebCore::MQ::GenericMediaQueryParser&lt;ConcreteParser&gt;::validateFeature):
(WebCore::MQ::GenericMediaQueryParser&lt;ConcreteParser&gt;::schemaForFeatureName):
* Source/WebCore/css/query/GenericMediaQuerySerialization.cpp:
(WebCore::MQ::serialize):
* Source/WebCore/css/query/GenericMediaQueryTypes.h:
* Source/WebCore/css/query/MediaQueryParser.cpp:
(WebCore::MQ::MediaQueryParser::schemaForFeatureName):
* Source/WebCore/css/query/MediaQueryParser.h:
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
(WebCore::Style::ContainerQueryEvaluator::selectContainer):

Canonical link: <a href="https://commits.webkit.org/274315@main">https://commits.webkit.org/274315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4bd3afbe544c1d5fbe03801c6fb550d71d2f44a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38686 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41217 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14963 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14849 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12897 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42493 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/32132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35146 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/38309 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13496 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11174 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/36915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/45318 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8673 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9242 "Found unexpected failure with change (failure)") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->