### PR TITLE
Adopt more smart pointers for SVGDocumentExtensions

### DIFF
--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -818,8 +818,8 @@ void ContainerNode::stringReplaceAll(String&& string)
 inline void ContainerNode::rebuildSVGExtensionsElementsIfNecessary()
 {
     RefAllowingPartiallyDestroyed<Document> document = this->document();
-    if (document->svgExtensions() && !is<SVGUseElement>(shadowHost()))
-        document->accessSVGExtensions().rebuildElements();
+    if (document->svgExtensionsIfExists() && !is<SVGUseElement>(shadowHost()))
+        document->checkedSVGExtensions()->rebuildElements();
 }
 
 // this differs from other remove functions because it forcibly removes all the children,

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -865,8 +865,8 @@ void Document::commonTeardown()
         fullscreenManager->emptyEventQueue();
 #endif
 
-    if (svgExtensions())
-        accessSVGExtensions().pauseAnimations();
+    if (CheckedPtr svgExtensions = svgExtensionsIfExists())
+        svgExtensions->pauseAnimations();
 
     clearScriptedAnimationController();
 
@@ -3772,8 +3772,8 @@ void Document::implicitClose()
             HTMLStyleElement::dispatchPendingLoadEvents(currentPage.get());
         }
 
-        if (svgExtensions())
-            accessSVGExtensions().dispatchLoadEventToOutermostSVGElements();
+        if (CheckedPtr svgExtensions = svgExtensionsIfExists())
+            svgExtensions->dispatchLoadEventToOutermostSVGElements();
     }
 
     dispatchWindowLoadEvent();
@@ -3832,8 +3832,8 @@ void Document::implicitClose()
     }
 #endif
 
-    if (svgExtensions())
-        accessSVGExtensions().startAnimations();
+    if (CheckedPtr svgExtensions = svgExtensionsIfExists())
+        svgExtensions->startAnimations();
 }
 
 void Document::setParsing(bool b)
@@ -7061,11 +7061,16 @@ ExceptionOr<Ref<Attr>> Document::createAttributeNS(const AtomString& namespaceUR
     return Attr::create(*this, parsedName, emptyAtom());
 }
 
-SVGDocumentExtensions& Document::accessSVGExtensions()
+SVGDocumentExtensions& Document::svgExtensions()
 {
     if (!m_svgExtensions)
         m_svgExtensions = makeUnique<SVGDocumentExtensions>(*this);
     return *m_svgExtensions;
+}
+
+CheckedRef<SVGDocumentExtensions> Document::checkedSVGExtensions()
+{
+    return svgExtensions();
 }
 
 bool Document::hasSVGRootNode() const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1341,8 +1341,9 @@ public:
 
     void removeAllEventListeners() final;
 
-    const SVGDocumentExtensions* svgExtensions() { return m_svgExtensions.get(); }
-    WEBCORE_EXPORT SVGDocumentExtensions& accessSVGExtensions();
+    SVGDocumentExtensions* svgExtensionsIfExists() { return m_svgExtensions.get(); }
+    WEBCORE_EXPORT SVGDocumentExtensions& svgExtensions();
+    WEBCORE_EXPORT CheckedRef<SVGDocumentExtensions> checkedSVGExtensions();
 
     void initSecurityContext();
     void initContentSecurityPolicy();

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -112,8 +112,8 @@ void CachedFrameBase::restore()
         if (localFrame)
             m_cachedFrameScriptData->restore(*localFrame);
 
-        if (document->svgExtensions())
-            document->accessSVGExtensions().unpauseAnimations();
+        if (CheckedPtr svgExtensions = document->svgExtensionsIfExists())
+            svgExtensions->unpauseAnimations();
 
         document->resume(ReasonForSuspension::BackForwardCache);
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2887,8 +2887,8 @@ void Page::setIsVisibleInternal(bool isVisible)
         }
 
         forEachDocument([] (Document& document) {
-            if (document.svgExtensions())
-                document.accessSVGExtensions().unpauseAnimations();
+            if (CheckedPtr svgExtensions = document.svgExtensionsIfExists())
+                svgExtensions->unpauseAnimations();
         });
 
         resumeAnimatingImages();
@@ -2908,8 +2908,8 @@ void Page::setIsVisibleInternal(bool isVisible)
         }
 
         forEachDocument([] (Document& document) {
-            if (document.svgExtensions())
-                document.accessSVGExtensions().pauseAnimations();
+            if (CheckedPtr svgExtensions = document.svgExtensionsIfExists())
+                svgExtensions->pauseAnimations();
         });
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
@@ -89,7 +89,7 @@ static inline SVGResourcesCache& resourcesCacheFromRenderer(const RenderElement&
         RELEASE_ASSERT_NOT_REACHED();
 #endif
 
-    return renderer.document().accessSVGExtensions().resourcesCache();
+    return renderer.document().svgExtensions().resourcesCache();
 }
 
 SVGResources* SVGResourcesCache::cachedResourcesForRenderer(const RenderElement& renderer)

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -201,8 +201,8 @@ const Settings& Resolver::settings() const
 
 void Resolver::addCurrentSVGFontFaceRules()
 {
-    if (document().svgExtensions()) {
-        auto& svgFontFaceElements = document().svgExtensions()->svgFontFaceElements();
+    if (document().svgExtensionsIfExists()) {
+        auto& svgFontFaceElements = document().svgExtensionsIfExists()->svgFontFaceElements();
         for (auto& svgFontFaceElement : svgFontFaceElements)
             document().fontSelector().addFontFaceRule(svgFontFaceElement.fontFaceRule(), svgFontFaceElement.isInUserAgentShadowTree());
     }

--- a/Source/WebCore/svg/SVGDocumentExtensions.h
+++ b/Source/WebCore/svg/SVGDocumentExtensions.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
@@ -37,7 +38,7 @@ class SVGSVGElement;
 class SVGUseElement;
 class WeakPtrImplWithEventTargetData;
 
-class SVGDocumentExtensions {
+class SVGDocumentExtensions : public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(SVGDocumentExtensions); WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit SVGDocumentExtensions(Document&);

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -70,7 +70,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
             m_orderX->setBaseValInternal(result->first);
             m_orderY->setBaseValInternal(result->second);
         } else
-            document().accessSVGExtensions().reportWarning("feConvolveMatrix: problem parsing order=\"" + newValue + "\". Filtered element will not be displayed.");
+            protectedDocument()->checkedSVGExtensions()->reportWarning("feConvolveMatrix: problem parsing order=\"" + newValue + "\". Filtered element will not be displayed.");
         break;
     }
     case AttributeNames::edgeModeAttr: {
@@ -78,7 +78,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
         if (propertyValue != EdgeModeType::Unknown)
             m_edgeMode->setBaseValInternal<EdgeModeType>(propertyValue);
         else
-            document().accessSVGExtensions().reportWarning("feConvolveMatrix: problem parsing edgeMode=\"" + newValue + "\". Filtered element will not be displayed.");
+            protectedDocument()->checkedSVGExtensions()->reportWarning("feConvolveMatrix: problem parsing edgeMode=\"" + newValue + "\". Filtered element will not be displayed.");
         break;
     }
     case AttributeNames::kernelMatrixAttr:
@@ -88,7 +88,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
         if (float divisor = newValue.toFloat())
             m_divisor->setBaseValInternal(divisor);
         else
-            document().accessSVGExtensions().reportWarning("feConvolveMatrix: problem parsing divisor=\"" + newValue + "\". Filtered element will not be displayed.");
+            protectedDocument()->checkedSVGExtensions()->reportWarning("feConvolveMatrix: problem parsing divisor=\"" + newValue + "\". Filtered element will not be displayed.");
         break;
     case AttributeNames::biasAttr:
         m_bias->setBaseValInternal(newValue.toFloat());
@@ -105,7 +105,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
             m_kernelUnitLengthX->setBaseValInternal(result->first);
             m_kernelUnitLengthY->setBaseValInternal(result->second);
         } else
-            document().accessSVGExtensions().reportWarning("feConvolveMatrix: problem parsing kernelUnitLength=\"" + newValue + "\". Filtered element will not be displayed.");
+            protectedDocument()->checkedSVGExtensions()->reportWarning("feConvolveMatrix: problem parsing kernelUnitLength=\"" + newValue + "\". Filtered element will not be displayed.");
         break;
     }
     case AttributeNames::preserveAlphaAttr:
@@ -114,7 +114,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
         else if (newValue == falseAtom())
             m_preserveAlpha->setBaseValInternal(false);
         else
-            document().accessSVGExtensions().reportWarning("feConvolveMatrix: problem parsing preserveAlphaAttr=\"" + newValue + "\". Filtered element will not be displayed.");
+            protectedDocument()->checkedSVGExtensions()->reportWarning("feConvolveMatrix: problem parsing preserveAlphaAttr=\"" + newValue + "\". Filtered element will not be displayed.");
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -74,7 +74,7 @@ void SVGFEGaussianBlurElement::attributeChanged(const QualifiedName& name, const
         if (propertyValue != EdgeModeType::Unknown)
             m_edgeMode->setBaseValInternal<EdgeModeType>(propertyValue);
         else
-            document().accessSVGExtensions().reportWarning("feGaussianBlur: problem parsing edgeMode=\"" + newValue + "\". Filtered element will not be displayed.");
+            protectedDocument()->checkedSVGExtensions()->reportWarning("feGaussianBlur: problem parsing edgeMode=\"" + newValue + "\". Filtered element will not be displayed.");
         break;
     }
     default:

--- a/Source/WebCore/svg/SVGFitToViewBox.cpp
+++ b/Source/WebCore/svg/SVGFitToViewBox.cpp
@@ -114,29 +114,29 @@ template<typename CharacterType> std::optional<FloatRect> SVGFitToViewBox::parse
     auto height = parseNumber(buffer, SuffixSkippingPolicy::DontSkip);
 
     if (validate) {
-        Document& document = m_viewBox->contextElement()->document();
+        Ref document = m_viewBox->contextElement()->document();
 
         if (!x || !y || !width || !height) {
-            document.accessSVGExtensions().reportWarning(makeString("Problem parsing viewBox=\"", stringToParse, "\""));
+            document->checkedSVGExtensions()->reportWarning(makeString("Problem parsing viewBox=\"", stringToParse, "\""));
             return std::nullopt;
         }
 
         // Check that width is positive.
         if (*width < 0.0) {
-            document.accessSVGExtensions().reportError("A negative value for ViewBox width is not allowed"_s);
+            document->checkedSVGExtensions()->reportError("A negative value for ViewBox width is not allowed"_s);
             return std::nullopt;
         }
 
         // Check that height is positive.
         if (*height < 0.0) {
-            document.accessSVGExtensions().reportError("A negative value for ViewBox height is not allowed"_s);
+            document->checkedSVGExtensions()->reportError("A negative value for ViewBox height is not allowed"_s);
             return std::nullopt;
         }
 
         // Nothing should come after the last, fourth number.
         skipOptionalSVGSpaces(buffer);
         if (buffer.hasCharactersRemaining()) {
-            document.accessSVGExtensions().reportWarning(makeString("Problem parsing viewBox=\"", stringToParse, "\""));
+            document->checkedSVGExtensions()->reportWarning(makeString("Problem parsing viewBox=\"", stringToParse, "\""));
             return std::nullopt;
         }
     }

--- a/Source/WebCore/svg/SVGFontFaceElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceElement.cpp
@@ -303,7 +303,7 @@ Node::InsertedIntoAncestorResult SVGFontFaceElement::insertedIntoAncestor(Insert
         ASSERT(!m_fontElement);
         return InsertedIntoAncestorResult::Done;
     }
-    document().accessSVGExtensions().registerSVGFontFaceElement(*this);
+    protectedDocument()->svgExtensions().registerSVGFontFaceElement(*this);
 
     rebuildFontFace();
     return result;
@@ -315,13 +315,14 @@ void SVGFontFaceElement::removedFromAncestor(RemovalType removalType, ContainerN
 
     if (removalType.disconnectedFromDocument) {
         m_fontElement = nullptr;
-        document().accessSVGExtensions().unregisterSVGFontFaceElement(*this);
-        auto& fontFaceSet = document().fontSelector().cssFontFaceSet();
+        RefAllowingPartiallyDestroyed<Document> document = this->document();
+        document->svgExtensions().unregisterSVGFontFaceElement(*this);
+        auto& fontFaceSet = document->fontSelector().cssFontFaceSet();
         if (auto* fontFace = fontFaceSet.lookUpByCSSConnection(m_fontFaceRule))
             fontFaceSet.remove(*fontFace);
         m_fontFaceRule->mutableProperties().clear();
 
-        document().styleScope().didChangeStyleSheetEnvironment();
+        document->checkedStyleScope()->didChangeStyleSheetEnvironment();
     } else
         ASSERT(!m_fontElement);
 }

--- a/Source/WebCore/svg/SVGGeometryElement.cpp
+++ b/Source/WebCore/svg/SVGGeometryElement.cpp
@@ -137,7 +137,7 @@ void SVGGeometryElement::attributeChanged(const QualifiedName& name, const AtomS
     if (name == SVGNames::pathLengthAttr) {
         m_pathLength->setBaseValInternal(newValue.toFloat());
         if (m_pathLength->baseVal() < 0)
-            document().accessSVGExtensions().reportError("A negative value for path attribute <pathLength> is not allowed"_s);
+            protectedDocument()->checkedSVGExtensions()->reportError("A negative value for path attribute <pathLength> is not allowed"_s);
     }
 
     SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -118,7 +118,7 @@ void SVGPathElement::attributeChanged(const QualifiedName& name, const AtomStrin
         else if (m_pathSegList->baseVal()->parse(newValue))
             cache.add(newValue, m_pathSegList->baseVal()->existingPathByteStream().data());
         else
-            document().accessSVGExtensions().reportError("Problem parsing d=\"" + newValue + "\"");
+            protectedDocument()->checkedSVGExtensions()->reportError("Problem parsing d=\"" + newValue + "\"");
     }
 
     SVGGeometryElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/svg/SVGPolyElement.cpp
+++ b/Source/WebCore/svg/SVGPolyElement.cpp
@@ -47,7 +47,7 @@ void SVGPolyElement::attributeChanged(const QualifiedName& name, const AtomStrin
 {
     if (name == SVGNames::pointsAttr) {
         if (!m_points->baseVal()->parse(newValue))
-            document().accessSVGExtensions().reportError("Problem parsing points=\"" + newValue + "\"");
+            protectedDocument()->checkedSVGExtensions()->reportError("Problem parsing points=\"" + newValue + "\"");
     }
 
     SVGGeometryElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -330,7 +330,7 @@ Path SVGUseElement::toClipPath()
 
     if (!isDirectReference(*targetClone)) {
         // Spec: Indirect references are an error (14.3.5)
-        document().accessSVGExtensions().reportError("Not allowed to use indirect reference in <clip-path>"_s);
+        protectedDocument()->checkedSVGExtensions()->reportError("Not allowed to use indirect reference in <clip-path>"_s);
         return { };
     }
 


### PR DESCRIPTION
#### dccc78696b925690bc34339f8c17ce3d05f572a1
<pre>
Adopt more smart pointers for SVGDocumentExtensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=269001">https://bugs.webkit.org/show_bug.cgi?id=269001</a>

Reviewed by Ryosuke Niwa.

Adopt more smart pointers for SVGDocumentExtensions:
1. Rename `Document::svgExtensions()` to `Document::svgExtensionsIfExists()`
   and `Document::accessSVGExtensions()` to `Document::svgExtensions()` for
   consistency with our usual naming conventions.
2. Introduce `Document::checkedSVGExtensions()` which returns a `CheckedRef&lt;&gt;`
   and adopt where appropriate.
3. Update call site to make sure the `Document` is protected during the scope
   of the SVGDocumentExtensions variable, since it owns it.

* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::rebuildSVGExtensionsElementsIfNecessary):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::commonTeardown):
(WebCore::Document::implicitClose):
(WebCore::Document::svgExtensions):
(WebCore::Document::checkedSVGExtensions):
(WebCore::Document::accessSVGExtensions): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::svgExtensionsIfExists):
(WebCore::Document::svgExtensions): Deleted.
* Source/WebCore/history/CachedFrame.cpp:
(WebCore::CachedFrameBase::restore):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setIsVisibleInternal):
* Source/WebCore/rendering/svg/SVGResourcesCache.cpp:
(WebCore::resourcesCacheFromRenderer):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::addCurrentSVGFontFaceRules):
* Source/WebCore/svg/SVGDocumentExtensions.h:
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::~SVGElement):
(WebCore::SVGElement::reportAttributeParsingError):
(WebCore::SVGElement::removedFromAncestor):
(WebCore::SVGElement::attributeChanged):
* Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp:
(WebCore::SVGFEConvolveMatrixElement::attributeChanged):
* Source/WebCore/svg/SVGFEGaussianBlurElement.cpp:
(WebCore::SVGFEGaussianBlurElement::attributeChanged):
* Source/WebCore/svg/SVGFitToViewBox.cpp:
(WebCore::SVGFitToViewBox::parseViewBoxGeneric):
* Source/WebCore/svg/SVGFontFaceElement.cpp:
(WebCore::SVGFontFaceElement::insertedIntoAncestor):
(WebCore::SVGFontFaceElement::removedFromAncestor):
* Source/WebCore/svg/SVGGeometryElement.cpp:
(WebCore::SVGGeometryElement::attributeChanged):
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::attributeChanged):
* Source/WebCore/svg/SVGPolyElement.cpp:
(WebCore::SVGPolyElement::attributeChanged):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::~SVGSVGElement):
(WebCore::SVGSVGElement::insertedIntoAncestor):
(WebCore::SVGSVGElement::removedFromAncestor):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::toClipPath):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::areSVGAnimationsPaused const):
(WebCore::Internals::svgAnimationsInterval const):
(WebCore::Internals::allSVGSVGElements const):

Canonical link: <a href="https://commits.webkit.org/274316@main">https://commits.webkit.org/274316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa064f8c090d3d85477621bc4b5b8cbb5ea452b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41196 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34318 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14942 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14841 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12883 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42472 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35138 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38696 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13475 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36902 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15087 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13933 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5044 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14568 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->