### PR TITLE
[WebGPU] default limit for maxBufferSize is incorrect

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp
@@ -207,40 +207,7 @@ void AdapterImpl::requestDevice(const DeviceDescriptor& descriptor, CompletionHa
         return convertToBackingContext.convertToBacking(featureName);
     });
 
-    auto limits = WGPULimits {
-        .maxTextureDimension1D =    8192,
-        .maxTextureDimension2D =    8192,
-        .maxTextureDimension3D =    2048,
-        .maxTextureArrayLayers =    256,
-        .maxBindGroups =    4,
-        .maxBindGroupsPlusVertexBuffers = 24,
-        .maxBindingsPerBindGroup =    1000,
-        .maxDynamicUniformBuffersPerPipelineLayout =    8,
-        .maxDynamicStorageBuffersPerPipelineLayout =    4,
-        .maxSampledTexturesPerShaderStage =    16,
-        .maxSamplersPerShaderStage =    16,
-        .maxStorageBuffersPerShaderStage =    8,
-        .maxStorageTexturesPerShaderStage =    4,
-        .maxUniformBuffersPerShaderStage =    12,
-        .maxUniformBufferBindingSize =    65536,
-        .maxStorageBufferBindingSize =    134217728,
-        .minUniformBufferOffsetAlignment =    256,
-        .minStorageBufferOffsetAlignment =    256,
-        .maxVertexBuffers =    8,
-        .maxBufferSize =    268435456,
-        .maxVertexAttributes =    16,
-        .maxVertexBufferArrayStride =    2048,
-        .maxInterStageShaderComponents =    60,
-        .maxInterStageShaderVariables =    16,
-        .maxColorAttachments =    8,
-        .maxColorAttachmentBytesPerSample = 32,
-        .maxComputeWorkgroupStorageSize =    16384,
-        .maxComputeInvocationsPerWorkgroup =    256,
-        .maxComputeWorkgroupSizeX =    256,
-        .maxComputeWorkgroupSizeY =    256,
-        .maxComputeWorkgroupSizeZ =    64,
-        .maxComputeWorkgroupsPerDimension =    65535,
-    };
+    auto limits = wgpuDefaultLimits();
 
     auto& supportedLimits = this->limits();
 

--- a/Source/WebGPU/WebGPU/HardwareCapabilities.mm
+++ b/Source/WebGPU/WebGPU/HardwareCapabilities.mm
@@ -43,7 +43,7 @@ static constexpr auto tier1LimitForBuffersAndTextures = 1;
 static constexpr auto tier2LimitForBuffersAndTextures = 4;
 static constexpr auto tier1LimitForSamplers = 1;
 static constexpr auto tier2LimitForSamplers = 2;
-static constexpr uint64_t defaultMaxBufferSize = 134217728;
+static constexpr uint64_t defaultMaxBufferSize = 268435456;
 
 static constexpr auto multipleOf4(auto input)
 {
@@ -683,7 +683,7 @@ WGPULimits defaultLimits()
         .maxInterStageShaderVariables = 16,
         .maxColorAttachments = 8,
         .maxColorAttachmentBytesPerSample = 32,
-        .maxComputeWorkgroupStorageSize =    16352,
+        .maxComputeWorkgroupStorageSize =    16384,
         .maxComputeInvocationsPerWorkgroup =    256,
         .maxComputeWorkgroupSizeX =    256,
         .maxComputeWorkgroupSizeY =    256,
@@ -711,3 +711,8 @@ bool isValid(const WGPULimits& limits)
 }
 
 } // namespace WebGPU
+
+WGPULimits wgpuDefaultLimits()
+{
+    return WebGPU::defaultLimits();
+}

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -134,6 +134,7 @@ WGPU_EXPORT void wgpuRenderBundleEncoderSetBindGroupWithDynamicOffsets(WGPURende
 #endif
 WGPU_EXPORT void wgpuExternalTextureDestroy(WGPUExternalTexture texture) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuExternalTextureUndestroy(WGPUExternalTexture texture) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT WGPULimits wgpuDefaultLimits() WGPU_FUNCTION_ATTRIBUTE;
 
 #endif  // !defined(WGPU_SKIP_DECLARATIONS)
 


### PR DESCRIPTION
#### 5e7cc9ef56943415773f731b5dd81679bc25732e
<pre>
[WebGPU] default limit for maxBufferSize is incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=269005">https://bugs.webkit.org/show_bug.cgi?id=269005</a>
&lt;radar://122561559&gt;

Reviewed by Tadeu Zagallo.

The limit was raised to 256MB, but we were still reporting 128MB.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp:
(WebCore::WebGPU::AdapterImpl::requestDevice):
Use the same default limits as WebGPU.framework.

* Source/WebGPU/WebGPU/HardwareCapabilities.mm:
(WebGPU::defaultLimits):
(wgpuDefaultLimits):
* Source/WebGPU/WebGPU/WebGPUExt.h:

Canonical link: <a href="https://commits.webkit.org/274336@main">https://commits.webkit.org/274336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cddea574a153b389df6b76bdec07ba355ab9a7e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41203 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34325 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/40979 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32480 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33623 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12881 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12865 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42479 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35139 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34867 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38698 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11169 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36904 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15094 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8683 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/13940 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14575 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->