### PR TITLE
REGRESSION (271770@main): visionOS: Significant regression on MotionMark

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -519,6 +519,7 @@ platform/graphics/mac/controls/TextFieldMac.mm
 platform/graphics/mac/controls/ToggleButtonMac.mm
 platform/graphics/mac/controls/WebControlView.mm
 platform/graphics/opentype/OpenTypeCG.cpp
+platform/graphics/re/DynamicContentScalingResourceCache.mm
 platform/image-decoders/avif/AVIFImageDecoder.cpp
 platform/image-decoders/avif/AVIFImageReader.cpp
 platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -38,6 +38,14 @@
 #include <wtf/RefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+#include "DynamicContentScalingResourceCache.h"
+#endif
+
+#if HAVE(IOSURFACE)
+#include "IOSurface.h"
+#endif
+
 namespace WTF {
 class TextStream;
 }
@@ -49,7 +57,6 @@ class DynamicContentScalingDisplayList;
 class Filter;
 class GraphicsClient;
 #if HAVE(IOSURFACE)
-class IOSurface;
 class IOSurfacePool;
 #endif
 class ScriptExecutionContext;
@@ -66,9 +73,12 @@ struct ImageBufferCreationContext {
     IOSurfacePool* surfacePool { nullptr };
     PlatformDisplayID displayID { 0 };
 #endif
-    WebCore::ProcessIdentity resourceOwner;
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+    DynamicContentScalingResourceCache dynamicContentScalingResourceCache;
+#endif
+    ProcessIdentity resourceOwner;
 
-    ImageBufferCreationContext() = default; // To guarantee order in presence of ifdefs, use individual .property to initialize them.
+    ImageBufferCreationContext() = default;
 };
 
 struct ImageBufferParameters {

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -44,6 +44,10 @@
 #include <cairo.h>
 #endif
 
+#if HAVE(IOSURFACE)
+#include "IOSurface.h"
+#endif
+
 namespace WTF {
 class TextStream;
 }
@@ -54,7 +58,6 @@ struct ImageBufferCreationContext;
 class GraphicsContext;
 class GraphicsContextGL;
 #if HAVE(IOSURFACE)
-class IOSurface;
 class IOSurfacePool;
 #endif
 class Image;

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -30,7 +30,7 @@
 #include "DestinationColorSpace.h"
 #include "IntSize.h"
 #include "ProcessIdentity.h"
-#include <CoreGraphics/CGImage.h>
+#include <CoreGraphics/CoreGraphics.h>
 #include <objc/objc.h>
 #include <wtf/spi/cocoa/IOSurfaceSPI.h>
 

--- a/Source/WebCore/platform/graphics/re/DynamicContentScalingResourceCache.h
+++ b/Source/WebCore/platform/graphics/re/DynamicContentScalingResourceCache.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+class DynamicContentScalingResourceCache : public RetainPtr<id> {
+public:
+    WEBCORE_EXPORT static DynamicContentScalingResourceCache create();
+
+    DynamicContentScalingResourceCache()
+        : RetainPtr<id>()
+    {
+    }
+
+    DynamicContentScalingResourceCache(RetainPtr<id>&& object)
+        : RetainPtr<id>(WTFMove(object))
+    {
+    }
+};
+
+}
+
+#endif

--- a/Source/WebCore/platform/graphics/re/DynamicContentScalingResourceCache.mm
+++ b/Source/WebCore/platform/graphics/re/DynamicContentScalingResourceCache.mm
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import "config.h"
+#import "DynamicContentScalingResourceCache.h"
+
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+
+#import <CoreRE/RECGCommandsContext.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
+
+namespace WebCore {
+
+DynamicContentScalingResourceCache DynamicContentScalingResourceCache::create()
+{
+    return bridge_id_cast(adoptCF(RECGCommandsCacheCreate(nullptr)));
+}
+
+}
+
+#endif

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm
@@ -29,6 +29,7 @@
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
 
 #import "DynamicContentScalingImageBufferBackend.h"
+#import <CoreRE/RECGCommandsContext.h>
 #import <WebCore/BifurcatedGraphicsContext.h>
 #import <WebCore/DynamicContentScalingDisplayList.h>
 #import <wtf/MachSendRight.h>

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm
@@ -87,9 +87,13 @@ std::unique_ptr<DynamicContentScalingImageBufferBackend> DynamicContentScalingIm
 
 DynamicContentScalingImageBufferBackend::DynamicContentScalingImageBufferBackend(const Parameters& parameters, const WebCore::ImageBufferCreationContext& creationContext, WebCore::RenderingMode renderingMode)
     : ImageBufferCGBackend { parameters }
-    , m_resourceCache(bridge_id_cast(adoptCF(RECGCommandsCacheCreate(nullptr))))
+    , m_resourceCache(creationContext.dynamicContentScalingResourceCache)
     , m_renderingMode(renderingMode)
 {
+    // FIXME: We should make callers always specify a cache and have an assertion here instead
+    // of making a temporary one. RemoteLayerWithRemoteRenderingBackingStore currently does not.
+    if (!m_resourceCache)
+        m_resourceCache = bridge_id_cast(adoptCF(RECGCommandsCacheCreate(nullptr)));
 }
 
 std::optional<ImageBufferBackendHandle> DynamicContentScalingImageBufferBackend::createBackendHandle(WebCore::SharedMemory::Protection) const

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "RemoteLayerBackingStore.h"
+#include <WebCore/DynamicContentScalingResourceCache.h>
 
 namespace WebKit {
 
@@ -53,13 +54,17 @@ public:
     void dump(WTF::TextStream&) const final;
 
 private:
-    RefPtr<WebCore::ImageBuffer> allocateBuffer() const;
+    RefPtr<WebCore::ImageBuffer> allocateBuffer();
     SwapBuffersDisplayRequirement prepareBuffers();
     WebCore::SetNonVolatileResult swapToValidFrontBuffer();
 
     void ensureFrontBuffer();
     bool hasFrontBuffer() const final;
     bool frontBufferMayBeVolatile() const final;
+
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+    DynamicContentScalingResourceCache ensureDynamicContentScalingResourceCache();
+#endif
 
     struct Buffer {
         RefPtr<WebCore::ImageBuffer> imageBuffer;
@@ -82,6 +87,10 @@ private:
     Buffer m_frontBuffer;
     Buffer m_backBuffer;
     Buffer m_secondaryBackBuffer;
+
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+    WebCore::DynamicContentScalingResourceCache m_dynamicContentScalingResourceCache;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
@@ -93,6 +93,13 @@ std::optional<ImageBufferBackendHandle> RemoteLayerWithInProcessRenderingBacking
         return frontBuffer->dynamicContentScalingDisplayList();
     return std::nullopt;
 }
+
+DynamicContentScalingResourceCache RemoteLayerWithInProcessRenderingBackingStore::ensureDynamicContentScalingResourceCache()
+{
+    if (!m_dynamicContentScalingResourceCache)
+        m_dynamicContentScalingResourceCache = DynamicContentScalingResourceCache::create();
+    return m_dynamicContentScalingResourceCache;
+}
 #endif
 
 void RemoteLayerWithInProcessRenderingBackingStore::createContextAndPaintContents()
@@ -254,15 +261,17 @@ static RefPtr<ImageBuffer> allocateBufferInternal(RemoteLayerBackingStore::Type 
     }
 }
 
-RefPtr<WebCore::ImageBuffer> RemoteLayerWithInProcessRenderingBackingStore::allocateBuffer() const
+RefPtr<WebCore::ImageBuffer> RemoteLayerWithInProcessRenderingBackingStore::allocateBuffer()
 {
     auto purpose = m_layer->containsBitmapOnly() ? WebCore::RenderingPurpose::BitmapOnlyLayerBacking : WebCore::RenderingPurpose::LayerBacking;
     ImageBufferCreationContext creationContext;
     creationContext.surfacePool = &WebCore::IOSurfacePool::sharedPool();
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-    if (m_parameters.includeDisplayList == IncludeDisplayList::Yes)
+    if (m_parameters.includeDisplayList == IncludeDisplayList::Yes) {
+        creationContext.dynamicContentScalingResourceCache = ensureDynamicContentScalingResourceCache();
         return allocateBufferInternal<DynamicContentScalingBifurcatedImageBuffer>(type(), size(), purpose, scale(), colorSpace(), pixelFormat(), creationContext);
+    }
 #endif
 
     return allocateBufferInternal<ImageBuffer>(type(), size(), purpose, scale(), colorSpace(), pixelFormat(), creationContext);


### PR DESCRIPTION
#### 03a60be8929d23706595fd8fcaa834e3839912ae
<pre>
REGRESSION (271770@main): visionOS: Significant regression on MotionMark
<a href="https://bugs.webkit.org/show_bug.cgi?id=269010">https://bugs.webkit.org/show_bug.cgi?id=269010</a>
<a href="https://rdar.apple.com/122127093">rdar://122127093</a>

Reviewed by Simon Fraser.

Before 271770@main, the dynamic content scaling image buffer was a sidecar, outside
of the normal flow of the front/back buffer swapping. After that commit, it was moved
inside the main image buffer, and thus is swapped like the base scale rendering.

This had one unintended consequence: when we&apos;re discarding the back buffer
(e.g. because it contains an IOSurface that is still in-use and can&apos;t be recycled),
we will now *also* discard the dynamic content scaling image buffer, and, critically,
its resource cache.

The whole point of the resource cache is to maintain state between frames, so this is
wildly counterproductive. Once you get into a state where you are discarding
back buffers (which comes up frequently under load, like MotionMark), you&apos;re also
losing all resource caching.

Instead of trying to rearchitect the discarding code to avoid dropping the display
list image buffer, just maintain the dynamic content scaling resource cache
in a sidecar on the RemoteLayerBackingStore, like it was before, and pass it
down to the image buffer.

A subsequent patch will make a similar change for the remote rendering case.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/re/DynamicContentScalingResourceCache.h: Added.
(WebCore::DynamicContentScalingResourceCache::DynamicContentScalingResourceCache):
* Source/WebCore/platform/graphics/re/DynamicContentScalingResourceCache.mm: Added.
(WebCore::DynamicContentScalingResourceCache::create):
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm:
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm:
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::ensureDynamicContentScalingResourceCache):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::allocateBuffer):
(WebKit::RemoteLayerWithInProcessRenderingBackingStore::allocateBuffer const): Deleted.

* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
Note that it is not safe in a unified-sources world to forward-declare WebCore::IOSurface
because of the name conflict with ::IOSurface; we need to strictly order the declarations,
which is easiest to achieve by just importing our header.

Canonical link: <a href="https://commits.webkit.org/274319@main">https://commits.webkit.org/274319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa850181fbb4a9b7258686e250d1e58537eae58b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38698 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41229 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41005 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14975 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39271 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14856 "Found 1 new test failure: fast/events/ios/select-all-with-existing-selection.html (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12901 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/34503 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42505 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35153 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38710 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/13508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36916 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/8676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/13966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5046 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->