### PR TITLE
Generate project-specific results with clang static analyzer

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -190,8 +190,11 @@ testing t: force
 analyze:
 	@$(call set_webkit_configuration,--debug)
 	@$(call invoke_xcode,analyze,$(ANALYZER_XCODE_SETTINGS)) || true
-	find $(ANALYZER_OUTPUT) -name 'report-*.html' -exec mv {} $(ANALYZER_OUTPUT)/ \;
-	$(PATH_TO_SCAN_BUILD) --generate-index-only $(ANALYZER_OUTPUT)
+	@for dir in $$(ls -d $(ANALYZER_OUTPUT)/StaticAnalyzer/*); do \
+		mkdir -p $$dir/StaticAnalyzerReports; \
+		find $$dir -name 'report-*.html' -exec mv {} $$dir/StaticAnalyzerReports/ \;; \
+		$(PATH_TO_SCAN_BUILD) --generate-index-only $$dir; \
+	done
 
 clean:
 ifndef XCODE_TARGET

--- a/Tools/Scripts/build-and-analyze
+++ b/Tools/Scripts/build-and-analyze
@@ -140,7 +140,7 @@ def main(args):
 
     commands = [
         make_command,
-        [generate_static_analysis_archive_path, '--count', '--output-root', output_dir],
+        [generate_static_analysis_archive_path, '--count', '--output-root', output_dir, '--id-string', 'WebKit Build'],
     ]
 
     # FIXME: Handle Ctrl-C interrupts gracefully so subprocess jobs actually stop.

--- a/Tools/Scripts/generate-static-analysis-archive
+++ b/Tools/Scripts/generate-static-analysis-archive
@@ -54,23 +54,14 @@ def parse_command_line(args):
     return parser.parse_args(args)
 
 
-def get_project_name(output_root, analysis_dir):
-    static_analyzer_dir = os.path.join(output_root, analysis_dir, 'StaticAnalyzer')
-    if os.path.exists(static_analyzer_dir):
-        subdirs = filter(lambda x: x[0] != '.' and x != 'PAL', os.listdir(static_analyzer_dir))
-        return os.path.basename(subdirs[0])
-
-
-def generate_results_page(project_dict, id_string, output_root):
+def generate_results_page(project_dirs, id_string, output_root, static_analysis_dir):
     project_list = ''
-    for project_name in sorted(project_dict.keys()):
-        if project_name:
-            project_path = project_dict[project_name]
-            static_analyzer_index_path = os.path.join(output_root, project_path, INDEX_HTML)
-            project_list = project_list + PROJECT_TEMPLATE.format(
-                    project_file_url=project_path + '/' + INDEX_HTML,
-                    project_issue_count=get_project_issue_count_as_string(static_analyzer_index_path),
-                    project_name=project_name)
+    for project_name in sorted(project_dirs):
+        static_analyzer_index_path = os.path.join(static_analysis_dir, project_name, INDEX_HTML)
+        project_list = project_list + PROJECT_TEMPLATE.format(
+                project_file_url=os.path.relpath(static_analyzer_index_path, output_root),
+                project_issue_count=get_project_issue_count_as_string(static_analyzer_index_path),
+                project_name=project_name)
 
     return INDEX_TEMPLATE.format(
         heading='Results for {}'.format(id_string),
@@ -79,36 +70,30 @@ def generate_results_page(project_dict, id_string, output_root):
     )
 
 
-def get_total_issue_count(project_dict, output_root):
+def get_total_issue_count(project_dirs, static_analysis_dir):
     total_issue_count = 0
-    for project_name in sorted(project_dict.keys()):
-        if project_name:
-            project_path = project_dict[project_name]
-            static_analyzer_index_path = os.path.join(output_root, project_path, INDEX_HTML)
-            try:
-                issue_count = int(get_project_issue_count_as_string(static_analyzer_index_path))
-                total_issue_count = total_issue_count + issue_count
-            except ValueError:
-                pass
+    for project_name in sorted(project_dirs):
+        static_analyzer_index_path = os.path.join(static_analysis_dir, project_name, INDEX_HTML)
+        try:
+            issue_count = int(get_project_issue_count_as_string(static_analyzer_index_path))
+            total_issue_count = total_issue_count + issue_count
+        except ValueError:
+            pass
     return total_issue_count
 
 
 def main(options):
     output_root = options.output_root
-    project_dict = {}
-    subdirs = []
+    static_analysis_dir = output_root
 
-    if os.path.isdir(os.path.join(output_root, 'StaticAnalyzer')):
-        # Current: scan-build was not used to build & analyze.
-        subdirs = ['.']
-        project_dict = {'Everything': '.'}
-    else:
-        # Legacy: scan-build was used to build & analyze.
-        subdirs = filter(lambda x: x[0] != '.', os.listdir(output_root))
-        project_dict = dict(map(lambda x: (get_project_name(output_root, x), x), subdirs))
+    if os.path.isdir(os.path.join(static_analysis_dir, 'StaticAnalyzer')):
+        static_analysis_dir = os.path.join(static_analysis_dir, 'StaticAnalyzer')
+
+    project_dirs = list(filter(lambda x: x[0] != '.' and os.path.isdir(os.path.join(static_analysis_dir, x)),
+                                         os.listdir(static_analysis_dir)))
 
     if options.id_string:
-        results_page = generate_results_page(project_dict, options.id_string, output_root)
+        results_page = generate_results_page(project_dirs, options.id_string, output_root, static_analysis_dir)
         f = open(output_root + '/results.html', 'w')
         f.write(results_page)
         f.close()
@@ -116,10 +101,10 @@ def main(options):
     if options.destination:
         if os.path.isfile(options.destination):
             subprocess.check_call(['/bin/rm', options.destination])
-        subprocess.check_call(['/usr/bin/zip', '-r', options.destination, output_root])
+        subprocess.check_call(['/usr/bin/zip', '-9', '-r', options.destination, output_root, '-x', '*.d'])
 
     if options.count:
-        total_issue_count = get_total_issue_count(project_dict, output_root)
+        total_issue_count = get_total_issue_count(project_dirs, static_analysis_dir)
         print('Total issue count: {}'.format(total_issue_count))
 
     return 0


### PR DESCRIPTION
#### 669a4a405828283a61660a6b2d41fdd12f39db7e
<pre>
Generate project-specific results with clang static analyzer
<a href="https://bugs.webkit.org/show_bug.cgi?id=269017">https://bugs.webkit.org/show_bug.cgi?id=269017</a>
&lt;<a href="https://rdar.apple.com/122578881">rdar://122578881</a>&gt;

Reviewed by Jonathan Bedard.

* Makefile.shared:
(analyze):
- Instead of de-duping issues across all projects, only de-dupe issues
  within each project by creating a StaticAnalyzerReports folder and
  moving all the reports into it.
* Tools/Scripts/build-and-analyze:
(main):
- Add --id-string argument to the generate-static-analysis-archive
  command so that a results.html file is generated.
* Tools/Scripts/generate-static-analysis-archive:
(get_project_name): Delete.
- This is no longer needed because we don&apos;t need to map a UUID folder to
  a project name.
(generate_results_page):
- Pass in both output_root and static_analysis_dir so that a relative
  path from the results.html file to each index.html file (generated by
  scan-build) can be created.
- Simplify logic since we just pass an array of project names instead of
  a dictionary that might contain None values.
(get_total_issue_count):
- Pass in static_analysis_dir instead of output_root since the project
  folders are all under that path.
- Simplify logic since we just pass an array of project names instead of
  a dictionary that might contain None values.
(main):
- Split the concept of output_root (where results.html is written) and
  static_analysis_dir (the folder where the project folders exist).
- Generate list of project names (folders) instead of a dictionary.
  Wrap filter() output in list() for python3.
- Update calls to generate_results_page() and get_total_issue_count()
  per above.
- Shrink size of zip file by passing &apos;-9&apos; and &apos;-x *.d&apos; switches to use
  maximum compression and to ignore *.d output files.

Canonical link: <a href="https://commits.webkit.org/274397@main">https://commits.webkit.org/274397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7859a601991c55fbb30dd908a328fbe160134fe5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41250 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34372 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/14996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32504 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33636 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12915 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42526 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/32165 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35170 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38721 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/38342 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11191 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36934 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15141 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/45351 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/14842 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9248 "Found unexpected failure with change (failure)") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5087 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14622 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->