### PR TITLE
[JSC] Accelerate JSONAtomStringCache

### DIFF
--- a/Source/JavaScriptCore/runtime/JSONAtomStringCache.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCache.h
@@ -33,42 +33,44 @@ class VM;
 
 class JSONAtomStringCache {
 public:
-    static constexpr auto maxStringLengthForCache = 32;
-    static constexpr auto capacity = 512;
-    using Cache = std::array<RefPtr<AtomStringImpl>, capacity>;
+    static constexpr auto maxStringLengthForCache = 27;
+    static constexpr auto capacity = 256;
 
-    enum class Type : bool { Identifier };
-    static constexpr unsigned numberOfTypes = 1;
+    struct Slot {
+        UChar m_buffer[maxStringLengthForCache] { };
+        UChar m_length { 0 };
+        RefPtr<AtomStringImpl> m_impl;
+    };
+    static_assert(sizeof(Slot) <= 64);
+
+    using Cache = std::array<Slot, capacity>;
 
     template<typename CharacterType>
     ALWAYS_INLINE Ref<AtomStringImpl> makeIdentifier(const CharacterType* characters, unsigned length)
     {
-        return make(Type::Identifier, characters, length);
+        return make(characters, length);
     }
 
     ALWAYS_INLINE void clear()
     {
-        for (unsigned i = 0; i < numberOfTypes; ++i)
-            cache(static_cast<Type>(i)).fill({ });
+        m_cache.fill({ });
     }
 
     VM& vm() const;
 
 private:
     template<typename CharacterType>
-    Ref<AtomStringImpl> make(Type, const CharacterType*, unsigned length);
+    Ref<AtomStringImpl> make(const CharacterType*, unsigned length);
 
-    ALWAYS_INLINE RefPtr<AtomStringImpl>& cacheSlot(Type type, UChar firstCharacter, UChar lastCharacter, UChar length)
+    ALWAYS_INLINE Slot& cacheSlot(UChar firstCharacter, UChar lastCharacter, UChar length)
     {
         unsigned hash = (firstCharacter << 6) ^ ((lastCharacter << 14) ^ firstCharacter);
         hash += (hash >> 14) + (length << 14);
         hash ^= hash << 14;
-        return cache(type)[(hash + (hash >> 6)) % capacity];
+        return m_cache[(hash + (hash >> 6)) % capacity];
     }
 
-    ALWAYS_INLINE Cache& cache(Type type) { return m_caches[static_cast<size_t>(type)]; }
-
-    Cache m_caches[numberOfTypes] { };
+    Cache m_cache { };
 };
 
 } // namespace JSC

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -1133,6 +1133,16 @@ inline void copyElements(uint8_t* __restrict destination, const uint64_t* __rest
         *destination++ = *source++;
 }
 
+inline void copyElements(UChar* __restrict destination, const LChar* __restrict source, size_t length)
+{
+    copyElements(bitwise_cast<uint16_t*>(destination), bitwise_cast<const uint8_t*>(source), length);
+}
+
+inline void copyElements(LChar* __restrict destination, const UChar* __restrict source, size_t length)
+{
+    copyElements(bitwise_cast<uint8_t*>(destination), bitwise_cast<const uint16_t*>(source), length);
+}
+
 }
 
 using WTF::equalIgnoringASCIICase;


### PR DESCRIPTION
#### 35a17ac7fc544202144f2d0f1e93be9ee8402ad4
<pre>
[JSC] Accelerate JSONAtomStringCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=269027">https://bugs.webkit.org/show_bug.cgi?id=269027</a>
<a href="https://rdar.apple.com/122590409">rdar://122590409</a>

Reviewed by Mark Lam.

This patch makes JSON parsing faster by embedding small string content itself into the cache.
AtomString is stored in the per-thread hash table. And to get that, we need to do hash-table lookup, which is costly.
These cache can avoid doing that. But still, to check the cache validity, we are still accessing to the string content
of the AtomString. While the input string content is almost always already in CPU cache since we created this input string,
AtomString content is very unlikely in the CPU cache. So if we can put this content in much more CPU friendly place, we can
avoid cache miss much.

In this patch, we leverage the fact that this cache only stores very small strings. So instead of using content inside AtomString,
we also copy the string content into the cache&apos;s slot itself. So string comparison does not encounter cache miss and accelerate
the lookup performance. Good part of AtomString is that, after getting this pointer, we rarely access to the string content of AtomString,
so now, we can avoid access to this string content in majority of cases.

* Source/JavaScriptCore/runtime/JSONAtomStringCache.h:
(JSC::JSONAtomStringCache::makeIdentifier):
(JSC::JSONAtomStringCache::clear):
(JSC::JSONAtomStringCache::cacheSlot):
(JSC::JSONAtomStringCache::cache): Deleted.
* Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h:
(JSC::JSONAtomStringCache::make):
* Source/WTF/wtf/text/StringCommon.h:

Canonical link: <a href="https://commits.webkit.org/274348@main">https://commits.webkit.org/274348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8cf9aceeb7020134fa8869fe92761dc43619c00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38754 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41285 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34407 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32521 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12938 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42561 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/32200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35251 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34915 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38737 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/38377 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36947 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15176 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/45386 "Built successfully") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/14856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9253 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5061 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->