### PR TITLE
[CMake] Expand USE_JPEGXL option

### DIFF
--- a/Source/WebCore/platform/ImageDecoders.cmake
+++ b/Source/WebCore/platform/ImageDecoders.cmake
@@ -41,7 +41,7 @@ list(APPEND WebCore_LIBRARIES
     WebP::libwebp
 )
 
-if (JPEGXL_FOUND)
+if (USE_JPEGXL)
     list(APPEND WebCore_LIBRARIES JPEGXL::jxl)
 endif ()
 

--- a/Source/WebKit/WebProcess/EntryPoint/playstation/WebProcessMain.cpp
+++ b/Source/WebKit/WebProcess/EntryPoint/playstation/WebProcessMain.cpp
@@ -61,6 +61,9 @@ int main(int argc, char** argv)
 #if defined(Brotli_LOAD_AT)
     loadLibraryOrExit(Brotli_LOAD_AT);
 #endif
+#if defined(JPEGXL_LOAD_AT)
+    loadLibraryOrExit(JPEGXL_LOAD_AT);
+#endif
     loadLibraryOrExit(Freetype_LOAD_AT);
     loadLibraryOrExit(Fontconfig_LOAD_AT);
     loadLibraryOrExit(HarfBuzz_LOAD_AT);

--- a/Source/cmake/OptionsPlayStation.cmake
+++ b/Source/cmake/OptionsPlayStation.cmake
@@ -279,6 +279,15 @@ if (ENABLE_WEBCORE)
        list(APPEND PlayStationModule_TARGETS LCMS2::LCMS2)
     endif ()
 
+    if (USE_JPEGXL)
+        set(JPEGXL_NAMES SceVshJxl)
+        find_package(JPEGXL 0.7.0)
+        if (NOT JPEGXL_FOUND)
+            message(FATAL_ERROR "libjxl is required for USE_JPEGXL")
+        endif ()
+        list(APPEND PlayStationModule_TARGETS JPEGXL::jxl)
+    endif ()
+
     # See if OpenSSL implementation is BoringSSL
     cmake_push_check_state()
     set(CMAKE_REQUIRED_INCLUDES "${OPENSSL_INCLUDE_DIR}")

--- a/Source/cmake/OptionsWin.cmake
+++ b/Source/cmake/OptionsWin.cmake
@@ -205,7 +205,10 @@ if (USE_LCMS)
 endif ()
 
 if (USE_JPEGXL)
-    find_package(JPEGXL REQUIRED)
+    find_package(JPEGXL 0.7.0)
+    if (NOT JPEGXL_FOUND)
+        message(FATAL_ERROR "libjxl is required for USE_JPEGXL")
+    endif ()
 endif ()
 
 set(bmalloc_LIBRARY_TYPE OBJECT)

--- a/Source/cmake/WebKitFeatures.cmake
+++ b/Source/cmake/WebKitFeatures.cmake
@@ -257,7 +257,7 @@ macro(WEBKIT_OPTION_BEGIN)
     WEBKIT_OPTION_DEFINE(USE_AVIF "Whether to enable support for AVIF images." PRIVATE ON)
     WEBKIT_OPTION_DEFINE(USE_LCMS "Toggle support for image color management using libcms2" PRIVATE ON)
     WEBKIT_OPTION_DEFINE(USE_ISO_MALLOC "Toggle IsoMalloc support" PRIVATE ON)
-    WEBKIT_OPTION_DEFINE(USE_JPEGXL "Whether to enable support for JPEG XL images." PRIVATE ON)
+    WEBKIT_OPTION_DEFINE(USE_JPEGXL "Toggle support for JPEG XL images" PRIVATE ON)
     WEBKIT_OPTION_DEFINE(USE_SYSTEM_MALLOC "Toggle system allocator instead of WebKit's custom allocator" PRIVATE ${USE_SYSTEM_MALLOC_DEFAULT})
 
     WEBKIT_OPTION_CONFLICT(ENABLE_JIT ENABLE_C_LOOP)

--- a/Tools/Scripts/webkitperl/FeatureList.pm
+++ b/Tools/Scripts/webkitperl/FeatureList.pm
@@ -97,6 +97,7 @@ my (
     $iosGestureEventsSupport,
     $iosTouchEventsSupport,
     $jitSupport,
+    $jpegXLSupport,
     $layerBasedSVGEngineSupport,
     $llvmProfileGenerationSupport,
     $legacyCustomProtocolManagerSupport,
@@ -485,6 +486,9 @@ my @features = (
 
     { option => "iso-malloc", desc => "Toggle IsoMalloc support",
       define => "USE_ISO_MALLOC", value => \$isoMallocSupport },
+
+    { option => "jpegxl", desc => "Toggle support for JPEG XL images",
+      define => "USE_JPEGXL", value => \$jpegXLSupport },
 
     { option => "lcms", desc => "Toggle support for image color management using libcms2",
       define => "USE_LCMS", value => \$lcmsSupport },

--- a/Tools/TestWebKitAPI/playstation/main.cpp
+++ b/Tools/TestWebKitAPI/playstation/main.cpp
@@ -50,6 +50,12 @@ int main(int argc, char** argv)
 #if defined(WebP_LOAD_AT)
     loadLibraryOrExit(WebP_LOAD_AT);
 #endif
+#if defined(Brotli_LOAD_AT)
+    loadLibraryOrExit(Brotli_LOAD_AT);
+#endif
+#if defined(JPEGXL_LOAD_AT)
+    loadLibraryOrExit(JPEGXL_LOAD_AT);
+#endif
     loadLibraryOrExit(Fontconfig_LOAD_AT);
     loadLibraryOrExit(Freetype_LOAD_AT);
     loadLibraryOrExit(HarfBuzz_LOAD_AT);


### PR DESCRIPTION
#### a6f41eca20868ff40313c77902ee68cce7229163
<pre>
[CMake] Expand USE_JPEGXL option
<a href="https://bugs.webkit.org/show_bug.cgi?id=269030">https://bugs.webkit.org/show_bug.cgi?id=269030</a>

Reviewed by Fujii Hironori.

Add `--jpegxl` option to `FeatureList.pm`. Look for libjxl on PlayStation when
requested, and handle loading of it as a module. Standardize error messaging
and fix an if statement&apos;s check.

* Source/WebCore/platform/ImageDecoders.cmake:
* Source/WebKit/WebProcess/EntryPoint/playstation/WebProcessMain.cpp:
* Source/cmake/OptionsPlayStation.cmake:
* Source/cmake/OptionsWin.cmake:
* Source/cmake/WebKitFeatures.cmake:
* Tools/Scripts/webkitperl/FeatureList.pm:
* Tools/TestWebKitAPI/playstation/main.cpp:

Canonical link: <a href="https://commits.webkit.org/274341@main">https://commits.webkit.org/274341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45d58860e5b667eaba733512cf5bf2eb2ef3f2ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41306 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15055 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14903 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12939 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42582 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/32221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35201 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38743 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/38398 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13585 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36966 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/45407 "Built successfully") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8687 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/14871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/9260 "Passed tests") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->