### PR TITLE
[ews-build.webkit.org] Handle duplicate GitHub hooks

### DIFF
--- a/Tools/CISupport/ews-build/events.py
+++ b/Tools/CISupport/ews-build/events.py
@@ -356,7 +356,27 @@ class GitHubEventHandlerNoEdits(GitHubEventHandler):
     _last_commit_classes_refresh = 0
     COMMIT_CLASSES_REFRESH = 60 * 60 * 24  # Refresh our commit-classes once a day
     COMMIT_CLASSES_URL = f'https://raw.githubusercontent.com/{PUBLIC_REPOS[0]}/main/metadata/commit_classes.json'
+    DUPE_DETECTOR = {}
 
+    # Because buildbot is single-threaded, we can just place event+hash strings in a process-global
+    # record. We create 60 second buckets so that retrying the same event on the same hash will work
+    # manually, but when GitHub duplicates events within a few seconds, we ignore the second event.
+    @classmethod
+    def is_duped(cls, value, bucket=60):
+        bucket = int(time.time() // bucket)
+        next_bucket = bucket + 1
+
+        for key in list(cls.DUPE_DETECTOR.keys()):
+            if key not in (bucket, next_bucket):
+                del cls.DUPE_DETECTOR[key]
+
+        for key in [bucket, next_bucket]:
+            if key not in cls.DUPE_DETECTOR:
+                cls.DUPE_DETECTOR[key] = set()
+            if value in cls.DUPE_DETECTOR[key]:
+                return True
+            cls.DUPE_DETECTOR[key].add(value)
+        return False
 
     @classmethod
     def file_with_status_sign(cls, info):
@@ -512,19 +532,25 @@ class GitHubEventHandlerNoEdits(GitHubEventHandler):
             log.msg(f"PR #{pr_number} ({head_sha}) was updated by '{sender}', ignoring it")
             return defer.returnValue(([], 'git'))
 
-        log.msg(f'Handling PR #{pr_number} with hash: {head_sha}')
         if action == 'labeled' and GitHub.UNSAFE_MERGE_QUEUE_LABEL in labels:
             log.msg(f'PR #{pr_number} ({head_sha}) was labeled for unsafe-merge-queue')
             # 'labeled' is usually an ignored action, override it to force build
             payload['action'] = 'synchronize'
-            yield task.deferLater(reactor, self.LABEL_PROCESS_DELAY, lambda: None)
             event = 'unsafe_merge_queue'
         elif action == 'labeled' and GitHub.MERGE_QUEUE_LABEL in labels:
             log.msg(f'PR #{pr_number} ({head_sha}) was labeled for merge-queue')
             # 'labeled' is usually an ignored action, override it to force build
-            yield task.deferLater(reactor, self.LABEL_PROCESS_DELAY, lambda: None)
             payload['action'] = 'synchronize'
             event = 'merge_queue'
+
+        # We received this exact event in the last 60 seconds, ignore it
+        if self.is_duped(f'{event}-{head_sha}'):
+            log.msg(f'Discarding duplicate for PR #{pr_number} with hash: {head_sha}')
+            return defer.returnValue(([], 'git'))
+
+        log.msg(f'Handling PR #{pr_number} with hash: {head_sha}')
+        if event in ('unsafe_merge_queue', 'merge_queue'):
+            yield task.deferLater(reactor, self.LABEL_PROCESS_DELAY, lambda: None)
 
         result = yield super().handle_pull_request(payload, event)
         changes = result[0]

--- a/Tools/CISupport/ews-build/events_unittest.py
+++ b/Tools/CISupport/ews-build/events_unittest.py
@@ -21,9 +21,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import time
 import unittest
 
-from .events import CommitClassifier
+from .events import CommitClassifier, GitHubEventHandlerNoEdits
 
 
 class TestCommitClassifier(unittest.TestCase):
@@ -92,3 +93,18 @@ class TestCommitClassifier(unittest.TestCase):
 
         self.assertFalse(c.matches('', [], []))
         self.assertFalse(c.matches('', [], ['metadata/contributors.json', 'Makefile']))
+
+    def test_duplicate(self):
+        key_a = 'pull_request-3babd344c6c08255c3ce2db7459b57d99209ae43'
+        key_b = 'merge_queue-3babd344c6c08255c3ce2db7459b57d99209ae43'
+
+        self.assertFalse(GitHubEventHandlerNoEdits.is_duped(key_a, bucket=1))
+        self.assertTrue(GitHubEventHandlerNoEdits.is_duped(key_a, bucket=1))
+        self.assertFalse(GitHubEventHandlerNoEdits.is_duped(key_b, bucket=1))
+
+        time.sleep(.5)
+        self.assertTrue(GitHubEventHandlerNoEdits.is_duped(key_a, bucket=1))
+
+        time.sleep(2)
+        self.assertFalse(GitHubEventHandlerNoEdits.is_duped(key_a, bucket=1))
+        self.assertTrue(len(GitHubEventHandlerNoEdits.DUPE_DETECTOR.keys()), 2)


### PR DESCRIPTION
#### a2343bf6a44c76e9fff85a24d9fb69a559c6cfb4
<pre>
[ews-build.webkit.org] Handle duplicate GitHub hooks
<a href="https://bugs.webkit.org/show_bug.cgi?id=269034">https://bugs.webkit.org/show_bug.cgi?id=269034</a>
<a href="https://rdar.apple.com/122589894">rdar://122589894</a>

Reviewed by Aakash Jain.

Create a process-local record of events from GitHub, and prevent
events duplicated within 60-120 seconds of each over from
triggering duplicate builds.

* Tools/CISupport/ews-build/events.py:
(GitHubEventHandlerNoEdits.is_duped): Check if a value was registered
in the last two 60 second buckets.
(GitHubEventHandlerNoEdits.handle_pull_request): Before dispatching builds,
ensure that the incoming event hasn&apos;t been duplicated in the few minutes.
* Tools/CISupport/ews-build/events_unittest.py:
(TestCommitClassifier.test_duplicate):

Canonical link: <a href="https://commits.webkit.org/274369@main">https://commits.webkit.org/274369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/252b97140d7a7c77f229f48f9f84da8d77798aa9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41437 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/34624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15186 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/32595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/15006 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/33733 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13042 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/12999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/34655 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 7 flakes 1 failures; Uploaded test results; layout-tests (exception)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42714 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35303 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/34994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/38825 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11311 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/37055 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/38954 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/15323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/14986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5072 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/14810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->