### PR TITLE
Add Swift bridging types that correspond to TextExtraction::Item and TextExtraction::ItemData

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -423,6 +423,7 @@ UIProcess/Cocoa/WKContactPicker.mm
 UIProcess/Cocoa/WKEditCommand.mm
 UIProcess/Cocoa/WKFullKeyboardAccessWatcher.mm
 UIProcess/Cocoa/WKReloadFrameErrorRecoveryAttempter.mm
+UIProcess/Cocoa/WKTextExtractionUtilities.mm
 UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm
 UIProcess/Cocoa/XPCConnectionTerminationWatchdog.mm
 

--- a/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.h
@@ -23,6 +23,20 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKitSwift/WKSLinearMediaPlayer.h>
-#import <WebKitSwift/WKSLinearMediaTypes.h>
-#import <WebKitSwift/WKTextExtractionItem.h>
+#pragma once
+
+#import <wtf/RetainPtr.h>
+
+@class WKTextExtractionItem;
+
+namespace WebCore {
+namespace TextExtraction {
+struct Item;
+}
+}
+
+namespace WebKit {
+
+RetainPtr<WKTextExtractionItem> createItem(const WebCore::TextExtraction::Item&);
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "WKTextExtractionUtilities.h"
+
+#import <WebCore/TextExtraction.h>
+#import <WebKitSwift/WKTextExtractionItem.h>
+#import <wtf/cocoa/VectorCocoa.h>
+
+#import "WebKitSwiftSoftLink.h"
+
+namespace WebKit {
+using namespace WebCore;
+
+inline static WKTextExtractionContainer containerType(TextExtraction::ContainerType type)
+{
+    switch (type) {
+    case TextExtraction::ContainerType::Root:
+        return WKTextExtractionContainerRoot;
+    case TextExtraction::ContainerType::ViewportConstrained:
+        return WKTextExtractionContainerViewportConstrained;
+    case TextExtraction::ContainerType::Link:
+        return WKTextExtractionContainerLink;
+    case TextExtraction::ContainerType::List:
+        return WKTextExtractionContainerList;
+    case TextExtraction::ContainerType::ListItem:
+        return WKTextExtractionContainerListItem;
+    case TextExtraction::ContainerType::BlockQuote:
+        return WKTextExtractionContainerBlockQuote;
+    case TextExtraction::ContainerType::Article:
+        return WKTextExtractionContainerArticle;
+    case TextExtraction::ContainerType::Section:
+        return WKTextExtractionContainerSection;
+    case TextExtraction::ContainerType::Nav:
+        return WKTextExtractionContainerNav;
+    }
+}
+
+inline static RetainPtr<WKTextExtractionItem> createItemIgnoringChildren(const TextExtraction::Item& item)
+{
+    return WTF::switchOn(item.data,
+        [&](const TextExtraction::TextItemData& data) -> RetainPtr<WKTextExtractionItem> {
+            return adoptNS([allocWKTextExtractionTextItemInstance() initWithContent:data.content rectInRootView:item.rectInRootView]);
+        }, [&](const TextExtraction::ScrollableItemData& data) -> RetainPtr<WKTextExtractionItem> {
+            return adoptNS([allocWKTextExtractionScrollableItemInstance() initWithContentSize:data.contentSize rectInRootView:item.rectInRootView]);
+        }, [&](const TextExtraction::EditableItemData& data) -> RetainPtr<WKTextExtractionItem> {
+            return adoptNS([allocWKTextExtractionEditableItemInstance() initWithIsFocused:data.isFocused rectInRootView:item.rectInRootView]);
+        }, [&](const TextExtraction::ImageItemData& data) -> RetainPtr<WKTextExtractionItem> {
+            return adoptNS([allocWKTextExtractionImageItemInstance() initWithName:data.name altText:data.altText rectInRootView:item.rectInRootView]);
+        }, [&](const TextExtraction::InteractiveItemData& data) -> RetainPtr<WKTextExtractionItem> {
+            return adoptNS([allocWKTextExtractionInteractiveItemInstance() initWithIsEnabled:data.isEnabled rectInRootView:item.rectInRootView]);
+        }, [&](TextExtraction::ContainerType type) -> RetainPtr<WKTextExtractionItem> {
+            return adoptNS([allocWKTextExtractionContainerItemInstance() initWithContainer:containerType(type) rectInRootView:item.rectInRootView]);
+        }
+    );
+}
+
+static RetainPtr<WKTextExtractionItem> createItemRecursive(const TextExtraction::Item& item)
+{
+    auto wkItem = createItemIgnoringChildren(item);
+    [wkItem setChildren:createNSArray(item.children, [](auto& child) {
+        return createItemRecursive(child);
+    }).get()];
+    return wkItem.get();
+}
+
+RetainPtr<WKTextExtractionItem> createItem(const TextExtraction::Item& item)
+{
+    if (!std::holds_alternative<TextExtraction::ContainerType>(item.data)) {
+        ASSERT_NOT_REACHED();
+        return nil;
+    }
+
+    if (std::get<TextExtraction::ContainerType>(item.data) != TextExtraction::ContainerType::Root) {
+        ASSERT_NOT_REACHED();
+        return nil;
+    }
+
+    return createItemRecursive(item);
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.h
+++ b/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.h
@@ -29,3 +29,9 @@
 
 SOFT_LINK_LIBRARY_FOR_HEADER(WebKit, WebKitSwift)
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKGroupSessionObserver)
+SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionContainerItem)
+SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionTextItem)
+SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionScrollableItem)
+SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionEditableItem)
+SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionInteractiveItem)
+SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionImageItem)

--- a/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm
@@ -59,4 +59,9 @@ void* WebKitSwiftLibrary(bool isOptional)
 }
 
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKGroupSessionObserver)
-
+SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionContainerItem)
+SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionTextItem)
+SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionScrollableItem)
+SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionEditableItem)
+SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionInteractiveItem)
+SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionImageItem)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2461,9 +2461,12 @@
 		F451C0FE2703B263002BA03B /* RemoteDisplayListRecorderProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = F48BB8DD26F9635D001C1C40 /* RemoteDisplayListRecorderProxy.h */; };
 		F4648E92296E81FA00744170 /* WebPrivacyHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = F4648E90296E81F500744170 /* WebPrivacyHelpers.h */; };
 		F4660BC225DEF08100E86598 /* PasteboardAccessIntent.h in Headers */ = {isa = PBXBuildFile; fileRef = F4660BC125DEF08100E86598 /* PasteboardAccessIntent.h */; };
+		F47E47112B75DE5A000AF62E /* WKTextExtractionItem.h in Headers */ = {isa = PBXBuildFile; fileRef = F47E47102B75DE5A000AF62E /* WKTextExtractionItem.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F48570A32644BEC500C05F71 /* Timeout.h in Headers */ = {isa = PBXBuildFile; fileRef = F48570A22644BEC400C05F71 /* Timeout.h */; };
 		F48C81E42AE0BA8E00073850 /* CoreIPCData.h in Headers */ = {isa = PBXBuildFile; fileRef = F48C81E32AE0BA6E00073850 /* CoreIPCData.h */; };
 		F48D2A8521583A7E00C6752B /* AppKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F48D2A8421583A0200C6752B /* AppKitSPI.h */; };
+		F48EC3532B75837F00D1B886 /* WKTextExtractionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48EC3522B75837F00D1B886 /* WKTextExtractionItem.swift */; };
+		F48EC3582B75895800D1B886 /* WKTextExtractionUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = F48EC3562B7585A300D1B886 /* WKTextExtractionUtilities.h */; };
 		F496A4311F58A272004C1757 /* DragDropInteractionState.h in Headers */ = {isa = PBXBuildFile; fileRef = F496A42F1F58A272004C1757 /* DragDropInteractionState.h */; };
 		F4974E76265ECBBC00B49B8C /* WKRevealItemPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = F446EDEF265EB2B00031DA8F /* WKRevealItemPresenter.h */; };
 		F4975CF22624B80A003C626E /* WKQuickLookPreviewController.h in Headers */ = {isa = PBXBuildFile; fileRef = F4975CF12624B80A003C626E /* WKQuickLookPreviewController.h */; };
@@ -7961,6 +7964,7 @@
 		F4648E91296E81F500744170 /* WebPrivacyHelpers.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebPrivacyHelpers.mm; sourceTree = "<group>"; };
 		F4660BC125DEF08100E86598 /* PasteboardAccessIntent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PasteboardAccessIntent.h; sourceTree = "<group>"; };
 		F476894628D2B5CD00073641 /* LayerTreeContext.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = LayerTreeContext.serialization.in; sourceTree = "<group>"; };
+		F47E47102B75DE5A000AF62E /* WKTextExtractionItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WKTextExtractionItem.h; path = TextExtraction/WKTextExtractionItem.h; sourceTree = "<group>"; };
 		F48570A22644BEC400C05F71 /* Timeout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Timeout.h; sourceTree = "<group>"; };
 		F488B90F2ACFC67A00792C16 /* RemoteWorkerInitializationData.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteWorkerInitializationData.serialization.in; sourceTree = "<group>"; };
 		F488B9142AD09C9C00792C16 /* DocumentEditingContext.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = DocumentEditingContext.serialization.in; sourceTree = "<group>"; };
@@ -7971,6 +7975,9 @@
 		F48C81E32AE0BA6E00073850 /* CoreIPCData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCData.h; sourceTree = "<group>"; };
 		F48C81E52AE0E1DF00073850 /* CoreIPCData.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCData.serialization.in; sourceTree = "<group>"; };
 		F48D2A8421583A0200C6752B /* AppKitSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppKitSPI.h; sourceTree = "<group>"; };
+		F48EC3522B75837F00D1B886 /* WKTextExtractionItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WKTextExtractionItem.swift; path = TextExtraction/WKTextExtractionItem.swift; sourceTree = "<group>"; };
+		F48EC3542B7585A300D1B886 /* WKTextExtractionUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKTextExtractionUtilities.mm; sourceTree = "<group>"; };
+		F48EC3562B7585A300D1B886 /* WKTextExtractionUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKTextExtractionUtilities.h; sourceTree = "<group>"; };
 		F496A42F1F58A272004C1757 /* DragDropInteractionState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DragDropInteractionState.h; path = ios/DragDropInteractionState.h; sourceTree = "<group>"; };
 		F496A4301F58A272004C1757 /* DragDropInteractionState.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = DragDropInteractionState.mm; path = ios/DragDropInteractionState.mm; sourceTree = "<group>"; };
 		F4975CF12624B80A003C626E /* WKQuickLookPreviewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKQuickLookPreviewController.h; sourceTree = "<group>"; };
@@ -9109,9 +9116,9 @@
 				5C57868D2B6EF92F005D51D5 /* CoreIPCCFArray.h */,
 				5C57868F2B6EF92F005D51D5 /* CoreIPCCFArray.mm */,
 				5C57868E2B6EF92F005D51D5 /* CoreIPCCFArray.serialization.in */,
-                5CFC9C802B717EFA00F8D289 /* CoreIPCCFDictionary.h */,
-                5CFC9C7F2B717EFA00F8D289 /* CoreIPCCFDictionary.mm */,
-                5CFC9C7E2B717EFA00F8D289 /* CoreIPCCFDictionary.serialization.in */,
+				5CFC9C802B717EFA00F8D289 /* CoreIPCCFDictionary.h */,
+				5CFC9C7F2B717EFA00F8D289 /* CoreIPCCFDictionary.mm */,
+				5CFC9C7E2B717EFA00F8D289 /* CoreIPCCFDictionary.serialization.in */,
 				52FB15422B646156000933CC /* CoreIPCCGColorSpace.h */,
 				52FB15432B64680B000933CC /* CoreIPCCGColorSpace.serialization.in */,
 				F4EFF36B2AF0267200479AB8 /* CoreIPCNumber.h */,
@@ -9208,6 +9215,7 @@
 			children = (
 				CDF1B90C266F395E0007EC10 /* GroupActivities */,
 				57FD316B22B3367E008D0E8B /* SOAuthorization */,
+				F48EC3572B7585AC00D1B886 /* TextExtraction */,
 				99C81D551C20DFBE005C4C82 /* AutomationClient.h */,
 				99C81D561C20DFBE005C4C82 /* AutomationClient.mm */,
 				990D28B71C6539A000986977 /* AutomationSessionClient.h */,
@@ -9297,6 +9305,8 @@
 				1DBBB061211CC3CB00502ECC /* WKShareSheet.mm */,
 				7A78FF2E224191750096483E /* WKStorageAccessAlert.h */,
 				7A78FF2F224191760096483E /* WKStorageAccessAlert.mm */,
+				F48EC3562B7585A300D1B886 /* WKTextExtractionUtilities.h */,
+				F48EC3542B7585A300D1B886 /* WKTextExtractionUtilities.mm */,
 				2D7AAFD218C8640600A7ACD4 /* WKWebViewContentProvider.h */,
 				2DC6D9C118C44A610043BAD4 /* WKWebViewContentProviderRegistry.h */,
 				2DC6D9C218C44A610043BAD4 /* WKWebViewContentProviderRegistry.mm */,
@@ -13089,6 +13099,7 @@
 				A1071FAE2B643FB400E9FC57 /* GroupActivities */,
 				A14F9B602B686DAE00AD9C56 /* LinearMediaKit */,
 				A14F9B332B68467F00AD9C56 /* MarketplaceKit */,
+				F48EC3512B75837200D1B886 /* TextExtraction */,
 				A14F9B652B686E0200AD9C56 /* module.modulemap */,
 				A14F9B662B686E0200AD9C56 /* WebKitSwift.h */,
 			);
@@ -15365,6 +15376,22 @@
 			path = mac;
 			sourceTree = "<group>";
 		};
+		F48EC3512B75837200D1B886 /* TextExtraction */ = {
+			isa = PBXGroup;
+			children = (
+				F47E47102B75DE5A000AF62E /* WKTextExtractionItem.h */,
+				F48EC3522B75837F00D1B886 /* WKTextExtractionItem.swift */,
+			);
+			name = TextExtraction;
+			sourceTree = "<group>";
+		};
+		F48EC3572B7585AC00D1B886 /* TextExtraction */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = TextExtraction;
+			sourceTree = "<group>";
+		};
 		F638955A133BF57D008941D5 /* mac */ = {
 			isa = PBXGroup;
 			children = (
@@ -17028,6 +17055,7 @@
 				F43548382AB7C41E00150894 /* WKTapHighlightView.h in Headers */,
 				51F886A61F2C228100C193EF /* WKTestingSupport.h in Headers */,
 				31D755C11D91B81500843BD1 /* WKTextChecker.h in Headers */,
+				F48EC3582B75895800D1B886 /* WKTextExtractionUtilities.h in Headers */,
 				2DD67A351BD861060053B251 /* WKTextFinderClient.h in Headers */,
 				F4D5F51D206087A10038BBA8 /* WKTextInputListViewController.h in Headers */,
 				0FCB4E6818BBE3D9000FCFC9 /* WKTextInputWindowController.h in Headers */,
@@ -17145,6 +17173,7 @@
 				A14F9B672B686E0200AD9C56 /* WebKitSwift.h in Headers */,
 				A14F9B762B68CA6C00AD9C56 /* WKSLinearMediaPlayer.h in Headers */,
 				A14F9B632B686DD300AD9C56 /* WKSLinearMediaTypes.h in Headers */,
+				F47E47112B75DE5A000AF62E /* WKTextExtractionItem.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -19284,6 +19313,7 @@
 				A14F9B772B68CA6C00AD9C56 /* LinearMediaPlayer.swift in Sources */,
 				A14F9B642B686DD300AD9C56 /* LinearMediaTypes.swift in Sources */,
 				EB0FBFA72B66C61E00269CC1 /* MarketplaceKitWrapper.swift in Sources */,
+				F48EC3532B75837F00D1B886 /* WKTextExtractionItem.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/WebKit/WebKitSwift/TextExtraction/WKTextExtractionItem.h
+++ b/Source/WebKit/WebKitSwift/TextExtraction/WKTextExtractionItem.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <CoreGraphics/CoreGraphics.h>
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, WKTextExtractionContainer) {
+    WKTextExtractionContainerRoot,
+    WKTextExtractionContainerViewportConstrained,
+    WKTextExtractionContainerLink,
+    WKTextExtractionContainerList,
+    WKTextExtractionContainerListItem,
+    WKTextExtractionContainerBlockQuote,
+    WKTextExtractionContainerArticle,
+    WKTextExtractionContainerSection,
+    WKTextExtractionContainerNav
+};
+
+@interface WKTextExtractionItem : NSObject
+@property (nonatomic, strong) NSArray<WKTextExtractionItem *> *children;
+@end
+
+@interface WKTextExtractionContainerItem : WKTextExtractionItem
+- (instancetype)initWithContainer:(WKTextExtractionContainer)container rectInRootView:(CGRect)rectInRootView;
+@end
+
+@interface WKTextExtractionTextItem : WKTextExtractionItem
+- (instancetype)initWithContent:(NSString *)content rectInRootView:(CGRect)rectInRootView;
+@end
+
+@interface WKTextExtractionScrollableItem : WKTextExtractionItem
+- (instancetype)initWithContentSize:(CGSize)contentSize rectInRootView:(CGRect)rectInRootView;
+@end
+
+@interface WKTextExtractionEditableItem : WKTextExtractionItem
+- (instancetype)initWithIsFocused:(BOOL)isFocused rectInRootView:(CGRect)rectInRootView;
+@end
+
+@interface WKTextExtractionInteractiveItem : WKTextExtractionItem
+- (instancetype)initWithIsEnabled:(BOOL)isEnabled rectInRootView:(CGRect)rectInRootView;
+@end
+
+@interface WKTextExtractionImageItem : WKTextExtractionItem
+- (instancetype)initWithName:(NSString *)name altText:(NSString *)altText rectInRootView:(CGRect)rectInRootView;
+@end

--- a/Source/WebKit/WebKitSwift/TextExtraction/WKTextExtractionItem.swift
+++ b/Source/WebKit/WebKitSwift/TextExtraction/WKTextExtractionItem.swift
@@ -1,0 +1,109 @@
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+
+@available(iOS 17.0, macOS 12.0, *)
+@objc(WKTextExtractionItem) public class WKTextExtractionItem: NSObject {
+    public let rectInRootView: CGRect
+    @objc public var children: [WKTextExtractionItem] = []
+
+    @objc public init(with rectInRootView: CGRect) {
+        self.rectInRootView = rectInRootView
+    }
+}
+
+@available(iOS 17.0, macOS 12.0, *)
+@objc public enum WKTextExtractionContainer: Int {
+    case root
+    case viewportConstrained
+    case link
+    case list
+    case listItem
+    case blockQuote
+    case article
+    case section
+    case nav
+}
+
+@available(iOS 17.0, macOS 12.0, *)
+@objc(WKTextExtractionContainerItem) public class WKTextExtractionContainerItem: WKTextExtractionItem {
+    public let container: WKTextExtractionContainer
+
+    @objc public init(container: WKTextExtractionContainer, rectInRootView: CGRect) {
+        self.container = container
+        super.init(with: rectInRootView)
+    }
+}
+
+@available(iOS 17.0, macOS 12.0, *)
+@objc(WKTextExtractionTextItem) public class WKTextExtractionTextItem: WKTextExtractionItem {
+    public let content: String
+
+    @objc public init(content: String, rectInRootView: CGRect) {
+        self.content = content
+        super.init(with: rectInRootView)
+    }
+}
+
+@available(iOS 17.0, macOS 12.0, *)
+@objc(WKTextExtractionScrollableItem) public class WKTextExtractionScrollableItem: WKTextExtractionItem {
+    public let contentSize: CGSize
+
+    @objc public init(contentSize: CGSize, rectInRootView: CGRect) {
+        self.contentSize = contentSize
+        super.init(with: rectInRootView)
+    }
+}
+
+@available(iOS 17.0, macOS 12.0, *)
+@objc(WKTextExtractionEditableItem) public class WKTextExtractionEditableItem: WKTextExtractionItem {
+    public let isFocused: Bool
+
+    @objc public init(isFocused: Bool = false, rectInRootView: CGRect) {
+        self.isFocused = isFocused
+        super.init(with: rectInRootView)
+    }
+}
+
+@available(iOS 17.0, macOS 12.0, *)
+@objc(WKTextExtractionInteractiveItem) public class WKTextExtractionInteractiveItem: WKTextExtractionItem {
+    public let isEnabled: Bool
+
+    @objc public init(isEnabled: Bool = false, rectInRootView: CGRect) {
+        self.isEnabled = isEnabled
+        super.init(with: rectInRootView)
+    }
+}
+
+@available(iOS 17.0, macOS 12.0, *)
+@objc(WKTextExtractionImageItem) public class WKTextExtractionImageItem: WKTextExtractionItem {
+    public let name: String
+    public let altText: String
+
+    @objc public init(name: String, altText: String, rectInRootView: CGRect) {
+        self.name = name
+        self.altText = altText
+        super.init(with: rectInRootView)
+    }
+}


### PR DESCRIPTION
#### ebea90b9d06032b0e343f446ce705b1d6ca65094
<pre>
Add Swift bridging types that correspond to TextExtraction::Item and TextExtraction::ItemData
<a href="https://bugs.webkit.org/show_bug.cgi?id=269035">https://bugs.webkit.org/show_bug.cgi?id=269035</a>

Reviewed by Megan Gardner.

Add simple Swift wrappers around the `TextExtraction` C++ structs along with helper functions to
recursively convert a `WebCore::TextExtraction::Item` into a `WKTextExtractionItem` in Objective-C
code (which can eventually be used in Swift code as well).

See below for more details.

* Source/WebKit/SourcesCocoa.txt:

* Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.h: Copied from Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.h.
* Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm: Added.

Add a helper file that contains a new utility function to convert a `WebCore::TextExtraction::Item`
struct into a nested `WKTextExtractionItem`, which will eventually be used in internal Swift code.

(WebKit::containerType):
(WebKit::createItemIgnoringChildren):
(WebKit::createItemRecursive):
(WebKit::createItem):

Add logic to do the conversion above.

* Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.h:
* Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm:

Add the ability to soft-link all of the new Swift/ObjC types in libWebKitSwift.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/UIProcess/Cocoa/WKTextExtractionItem.h: Added.

Create a header file that contains only interface, property and method declarations used in WebKit
to interact with the new Swift types in libWebKitSwift.

* Source/WebKit/WebKitSwift/TextExtraction/WKTextExtractionItem.swift: Added.

Add the new (ObjC-capable) Swift classes to libWebKitSwift.

(WKTextExtractionItem.rectInRootView):
(WKTextExtractionItem.children):
(WKTextExtractionContainerItem.container):
(WKTextExtractionTextItem.content):
(WKTextExtractionScrollableItem.contentSize):
(WKTextExtractionEditableItem.isFocused):
(WKTextExtractionInteractiveItem.isEnabled):
(WKTextExtractionImageItem.name):
(WKTextExtractionImageItem.altText):
* Source/WebKit/WebKitSwift/WebKitSwift.h

Add `WKTextExtractionItem.h` to the umbrella header.

Canonical link: <a href="https://commits.webkit.org/274363@main">https://commits.webkit.org/274363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1aa188191f6bc6b1580f70a6a52e338518c75c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41377 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34499 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15126 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32547 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33682 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/12989 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12958 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42653 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38777 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/36997 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15268 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/8702 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/14926 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14749 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->